### PR TITLE
[Cache] Fix DSN auth not passed to clusters in RedisTrait

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -37,6 +37,7 @@ trait RedisTrait
 {
     private static array $defaultConnectionOptions = [
         'class' => null,
+        'auth' => null,
         'persistent' => 0,
         'persistent_id' => null,
         'timeout' => 30,
@@ -99,6 +100,7 @@ trait RedisTrait
             throw new CacheException('Cannot find the "redis" extension nor the "relay" extension nor the "predis/predis" package.');
         }
 
+        $auth = null;
         $params = preg_replace_callback('#^'.$scheme.':(//)?(?:(?:(?<user>[^:@]*+):)?(?<password>[^@]*+)@)?#', function ($m) use (&$auth) {
             if (isset($m['password'])) {
                 if (\in_array($m['user'], ['', 'default'], true)) {
@@ -173,6 +175,7 @@ trait RedisTrait
         }
 
         $params += $query + $options + self::$defaultConnectionOptions;
+        $params['auth'] ??= $auth;
 
         if (isset($params['redis_sentinel']) && !class_exists(\Predis\Client::class) && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
             throw new CacheException('Redis Sentinel support requires one of: "predis/predis", "ext-redis >= 5.2", "ext-relay".');
@@ -217,7 +220,7 @@ trait RedisTrait
                 do {
                     $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
                     $port = $hosts[$hostIndex]['port'] ?? 0;
-                    $passAuth = isset($params['auth']) && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
+                    $passAuth = null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     $address = false;
 
                     if (isset($hosts[$hostIndex]['host']) && $tls) {
@@ -229,7 +232,7 @@ trait RedisTrait
                     }
 
                     try {
-                        if (version_compare(phpversion('redis'), '6.0.0', '>=') && $isRedisExt) {
+                        if ($isRedisExt && version_compare(phpversion('redis'), '6.0.0', '>=')) {
                             $options = [
                                 'host' => $host,
                                 'port' => $port,
@@ -281,7 +284,7 @@ trait RedisTrait
                         }
                     }
 
-                    if (isset($params['auth'])) {
+                    if (null !== $params['auth']) {
                         $extra['auth'] = $params['auth'];
                     }
                     @$redis->{$connect}($host, $port, (float) $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...\defined('Redis::SCAN_PREFIX') || !$isRedisExt ? [$extra] : []);
@@ -297,7 +300,7 @@ trait RedisTrait
                         throw new InvalidArgumentException('Redis connection failed: '.$error.'.');
                     }
 
-                    if ((null !== $auth && !$redis->auth($auth))
+                    if ((null !== $auth && $isRedisExt && version_compare(phpversion('redis'), '5.3', '<') && !$redis->auth($auth))
                         // Due to a bug in phpredis we must always select the dbindex if persistent pooling is enabled
                         // @see https://github.com/phpredis/phpredis/issues/1920
                         // @see https://github.com/symfony/symfony/issues/51578
@@ -389,14 +392,12 @@ trait RedisTrait
             if ($params['dbindex']) {
                 $params['parameters']['database'] = $params['dbindex'];
             }
-            if (null !== $auth) {
-                if (\is_array($auth)) {
-                    // ACL
-                    $params['parameters']['username'] = $auth[0];
-                    $params['parameters']['password'] = $auth[1];
-                } else {
-                    $params['parameters']['password'] = $auth;
-                }
+            if (\is_array($params['auth'])) {
+                // ACL
+                $params['parameters']['username'] = $params['auth'][0];
+                $params['parameters']['password'] = $params['auth'][1];
+            } elseif (null !== $params['auth']) {
+                $params['parameters']['password'] = $params['auth'];
             }
 
             if (isset($params['ssl'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #62765
| License       | MIT

This fix enables `symfony/cache` Redis-type cluster connections to use authentication from DSN.
The cluster connections use `$params['auth']` instead of `$auth` in `RedisTrait::createConnection()`.
The values that are extracted from the DSN in `$auth` are never merged into the `$params`.

As this is a trait that is used in a connection factory, it's impossible to unit-test this.
It can be reproduced with a redis-cluster that has no default-user or that has a password protected default user and then connecting to it using a DSN like `rediss://user:pass@redis-cluster:6379`.
I've just tested it on an aws memoryDb cluster.

Here's my research thread using deepwiki:
https://deepwiki.com/search/in-redistraitphp-why-is-params_8008d228-37f0-42cb-8e6c-74a2c419d33a?mode=fast
(note how it fails telling me which branch to target 🔢)