### PR TITLE
[AssetMapper] Add type annotations for extensionsMap

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapperDevServerSubscriber.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperDevServerSubscriber.php
@@ -100,8 +100,15 @@ final class AssetMapperDevServerSubscriber implements EventSubscriberInterface
     ];
 
     private readonly string $publicPrefix;
+
+    /**
+     * @var array<string, string>
+     */
     private array $extensionsMap;
 
+    /**
+     * @param array<string, string> $extensionsMap
+     */
     public function __construct(
         private readonly AssetMapperInterface $assetMapper,
         string $publicPrefix = '/assets/',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT


Add a PHPDoc type annotations for the `extensionsMap` property and the constructor `extensionsMap` parameter to improve code clarity.

This is a non-breaking change that improves code quality without altering functionality.