### PR TITLE
[WebProfilerBundle] Fix using URL objects with `EventSource`

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -299,7 +299,7 @@
                 var oldEventSource = window.EventSource;
                 window.EventSource = function (url, options) {
                     var es = new oldEventSource(url, options);
-                    if (!url.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                    if (!url.toString().match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
                         var stackElement = {
                             error: false,
                             url: url,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62729
| License       | MIT

`toString()` will work with both `string` and `URL`.