### PR TITLE
[ObjectMapper] Fix mapping for missing source properties

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -155,6 +155,10 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
 
             if (!$mappings && $targetRefl->hasProperty($propertyName)) {
+                if (!$this->isReadable($source, $propertyName)) {
+                    continue;
+                }
+
                 $sourceProperty = $refl->getProperty($propertyName);
                 if ($refl->isInstance($source) && !$sourceProperty->isInitialized($source)) {
                     continue;

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -654,4 +654,25 @@ final class ObjectMapperTest extends TestCase
         $this->assertSame('foo', $out->var1);
         $this->assertSame('bar', $out->b->var2);
     }
+
+    public function testMissingSourcePropertiesAreIgnored()
+    {
+        $mapper = new ObjectMapper();
+        $source = new class {
+            public string $name = 'test';
+        };
+        $target = $mapper->map($source, new class {
+            public string $name;
+            public bool $withDefault = true;
+            public string $withoutDefault;
+        });
+
+        $this->assertSame('test', $target->name);
+        $this->assertTrue($target->withDefault);
+
+        $this->assertFalse(
+            (new \ReflectionProperty($target, 'withoutDefault'))->isInitialized($target),
+            'Property without default value should remain uninitialized'
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62842
| License       | MIT

Fix ObjectMapper plain mapping to ignore missing source properties.
Only readable source properties are mapped, preserving target defaults and leaving
other properties untouched.
