### PR TITLE
[Messenger] Fix processing batches

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -20,6 +20,10 @@ trait BatchHandlerTrait
 
     public function flush(bool $force): void
     {
+        if (!$force && !$this->shouldFlush()) {
+            return;
+        }
+
         if ($jobs = $this->jobs) {
             $this->jobs = [];
             $this->process($jobs);

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Exception\NoSenderForMessageException;
+use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
@@ -45,7 +46,9 @@ class SendMessageMiddleware implements MiddlewareInterface
 
         if ($envelope->all(ReceivedStamp::class)) {
             // it's a received message, do not send it back
-            $this->logger?->info('Received message {class}', $context);
+            if (!$envelope->all(FlushBatchHandlersStamp::class)) {
+                $this->logger?->info('Received message {class}', $context);
+            }
         } else {
             $shouldDispatchEvent = true;
             $senders = $this->sendersLocator->getSenders($envelope);

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -321,6 +321,54 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $this->assertSame([$message], $handler->processedMessages);
     }
 
+    public function testBatchHandlerFlushFalseDoesNotFlushPartialBatch()
+    {
+        $handler = new class implements BatchHandlerInterface {
+            public array $processedMessages = [];
+
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function getBatchSize(): int
+            {
+                return 3;
+            }
+
+            private function process(array $jobs): void
+            {
+                $this->processedMessages = array_column($jobs, 0);
+
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $ack = static function () {};
+
+        $message = new DummyMessage('Hey');
+        $envelope = $middleware->handle(new Envelope($message, [new AckStamp($ack)]), new StackMiddleware());
+
+        $this->assertEmpty($handler->processedMessages);
+        $this->assertCount(1, $envelope->all(NoAutoAckStamp::class));
+
+        $handler->flush(false);
+
+        $this->assertEmpty($handler->processedMessages);
+
+        $handler->flush(true);
+
+        $this->assertSame([$message], $handler->processedMessages);
+    }
+
     public function testHandlerArgumentsStamp()
     {
         $message = new DummyMessage('Hey');

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -532,14 +532,14 @@ class WorkerTest extends TestCase
             static $i = 0;
             if (1 < ++$i) {
                 $event->getWorker()->stop();
-                $this->assertSame(1, $receiver->getAcknowledgeCount());
-            } else {
-                $this->assertSame(0, $receiver->getAcknowledgeCount());
             }
+            $this->assertSame(0, $receiver->getAcknowledgeCount());
         });
 
         $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
         $worker->run();
+
+        $this->assertSame(1, $receiver->getAcknowledgeCount());
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
     }
@@ -606,7 +606,7 @@ class WorkerTest extends TestCase
         $unacks = $unacksProperty->getValue($worker);
         $dummyHandler = new DummyBatchHandler();
         $envelopeWithNoAutoAck = $envelope->with(new NoAutoAckStamp(new HandlerDescriptor($dummyHandler)));
-        $unacks[$dummyHandler] = [$envelopeWithNoAutoAck, 'transport'];
+        $unacks[$dummyHandler] = [$envelopeWithNoAutoAck, 'transport', false];
 
         $worker->run();
 

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -165,7 +165,7 @@ class Worker
         if (!$acked && !$noAutoAckStamp) {
             $this->acks[] = [$transportName, $envelope, $e];
         } elseif ($noAutoAckStamp) {
-            $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName];
+            $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName, &$acked];
         }
 
         $this->ack();
@@ -254,13 +254,23 @@ class Worker
         $this->unacks = new \SplObjectStorage();
 
         foreach ($unacks as $batchHandler) {
-            [$envelope, $transportName] = $unacks[$batchHandler];
+            [$envelope, $transportName, $acked] = $unacks[$batchHandler];
             try {
+                $e = null;
                 $this->bus->dispatch($envelope->with(new FlushBatchHandlersStamp($force)));
                 unset($unacks[$batchHandler], $batchHandler);
             } catch (\Throwable $e) {
                 $envelope = $envelope->withoutAll(NoAutoAckStamp::class);
                 $this->acks[] = [$transportName, $envelope, $e];
+                continue;
+            }
+
+            $noAutoAckStamp = $envelope->last(NoAutoAckStamp::class);
+
+            if (!$acked && !$noAutoAckStamp) {
+                $this->acks[] = [$transportName, $envelope, $e];
+            } elseif ($noAutoAckStamp) {
+                $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName, &$acked];
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes ?
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61292, #54600
| License       | MIT

The reason batches can contain a random number of elements, as described in the issue, is that during idle periods (when no new messages arrive) the worker flushes all remaining batches regardless of whether they have reached the batch size limit. When messages are queued one by one, a race condition may occur where the worker checks for new messages before a message is queued and flushes the batch prematurely.

This PR changes the behavior so that the `$force` parameter is respected and batches are flushed only when `$force` is `true`.

This change introduces a downside: if a batch has not reached its size limit and no new messages arrive, the existing messages will not be flushed until the batch is filled or the worker shuts down. This can cause messages to remain "stuck" in a batch indefinitely.

Because of this, I'm not sure whether the original behavior is a bug or intended.