### PR TITLE
[Cache] Fix namespace of chained pools when using another chain as template

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -99,7 +99,7 @@ class CachePoolPass implements CompilerPassInterface
                 $adapters = [];
                 foreach ($providers['index_0'] ?? $providers[0] as $provider => $adapter) {
                     if ($adapter instanceof ChildDefinition) {
-                        $chainedPool = $adapter;
+                        $chainedPool = clone $adapter;
                     } else {
                         $chainedPool = $adapter = new ChildDefinition($adapter);
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62634
| License       | MIT

Oopsy