### PR TITLE
[AssetMapper] Update return type annotation for all() method

### DIFF
--- a/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
@@ -97,7 +97,7 @@ class AssetMapperRepository
      *
      * Key is the logical path, value is the absolute path.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function all(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Update a PHPDoc return type annotation for `AssetMapperRepository::all()` method to improve code clarity.

This is a non-breaking change that improves code quality without altering functionality.