### PR TITLE
[Messenger] Add regex support for transport name matching in `messenger:consume` command

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add regex support for transport name patterns in the `messenger:consume` command
+
 8.0
 ---
 

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -66,7 +66,7 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
         $this
             ->setDefinition([
-                new InputArgument('receivers', InputArgument::IS_ARRAY, 'Names of the receivers/transports to consume in order of priority', $defaultReceiverName ? [$defaultReceiverName] : []),
+                new InputArgument('receivers', InputArgument::IS_ARRAY, 'Names or regular expression patterns of the receivers/transports to consume in order of priority', $defaultReceiverName ? [$defaultReceiverName] : []),
                 new InputOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Limit the number of received messages'),
                 new InputOption('failure-limit', 'f', InputOption::VALUE_REQUIRED, 'The number of failed messages the worker can consume'),
                 new InputOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'The memory limit the worker can consume'),
@@ -84,9 +84,15 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
                     <info>php %command.full_name% <receiver-name></info>
 
-                To receive from multiple transports, pass each name:
+                You can specify a single receiver name or use a regular expression to match
+                multiple receivers. When a regular expression matches multiple transport names,
+                the order of the receivers will match their order in the configuration:
 
-                    <info>php %command.full_name% receiver1 receiver2</info>
+                    <info>php %command.full_name% "receiver1|receiver2"</info>
+
+                To get a different order, pass each name or regular expression as a separate argument:
+
+                    <info>php %command.full_name% receiver2 receiver1</info>
 
                 Use the <info>--limit</info> option to limit the number of messages received:
 
@@ -183,7 +189,16 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
         $receivers = [];
         $rateLimiters = [];
-        $receiverNames = $input->getOption('all') ? $this->receiverNames : $input->getArgument('receivers');
+        if ($input->getOption('all')) {
+            $receiverNames = $this->receiverNames;
+        } else {
+            $receiverNames = [];
+            foreach ($input->getArgument('receivers') as $receiver) {
+                $receiverNames = array_merge($receiverNames, preg_grep(\sprintf('{^%s$}', $receiver), $this->receiverNames));
+            }
+            $receiverNames = $receiverNames ?: $input->getArgument('receivers');
+            $receiverNames = array_unique($receiverNames);
+        }
 
         if ($input->getOption('all') && $excludedTransports = $input->getOption('exclude-receivers')) {
             $receiverNames = array_diff($receiverNames, $excludedTransports);

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -524,4 +524,52 @@ class ConsumeMessagesCommandTest extends TestCase
             '--exclude-receivers' => ['dummy-receiver1', 'dummy-receiver2'],
         ]);
     }
+
+    #[DataProvider('provideReceiversForCaseInsensitiveMatching')]
+    public function testCaseInsensitiveReceiverMatching(array $receiverNames, array $receivers, array $expectedReceivers)
+    {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
+
+        $receiver = $this->createStub(ReceiverInterface::class);
+        $receiver->method('get')->willReturn([$envelope]);
+
+        $receiverLocator = new Container();
+        foreach ($receiverNames as $receiverName) {
+            $receiverLocator->set($receiverName, $receiver);
+        }
+
+        $bus = $this->createStub(MessageBusInterface::class);
+
+        $busLocator = new Container();
+        $busLocator->set('dummy-bus', $bus);
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher(), receiverNames: $receiverNames);
+
+        $application = new Application();
+        $application->addCommand($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+        $tester->execute([
+            'receivers' => $receivers,
+            '--limit' => 1,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString(
+            \sprintf(
+                '[OK] Consuming messages from %s "%s"',
+                1 === \count($expectedReceivers) ? 'transport' : 'transports',
+                implode(', ', $expectedReceivers)
+            ),
+            $tester->getDisplay()
+        );
+    }
+
+    public static function provideReceiversForCaseInsensitiveMatching(): \Traversable
+    {
+        yield [['one', 'one_second', 'second', 'pone'], ['one.*'], ['one', 'one_second']];
+        yield [['one', 'one_second', 'second'], ['one'], ['one']];
+        yield [['one', 'one_second', 'second', 'SECOND'], ['(?i)second'], ['second', 'SECOND']];
+        yield [['one', 'one_second', 'second', 'SECOND', 'ssecond'], ['one', 'one.*', 'second.*'], ['one', 'one_second', 'second']];
+        yield [['pone'], ['.*one'], ['pone']];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61259
| License       | MIT

### Overview:
This PR adds support for regex patterns in the `messenger:consume` command, allowing devs to match transport names dynamically (e.g., scheduler_.*).

### Key Changes:
* Introduced regex matching for transport names.


### Example Usage:
* `php bin/console messenger:consume '(?i)THIRD.*' second.*` – Match multiple transports using regex patterns.
* `php bin/console messenger:consume second.*` – Match transports starting with second.
* `php bin/console messenger:consume one.* normal` – Match using both a regex (one.*) and a specific name (normal).

### Note:
This feature does not work when the `messenger:consume` command is run in interactive mode.