### PR TITLE
[Translation] Add ResetInterface and reset method to DataCollectorTranslator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_debug.php
@@ -18,6 +18,7 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('translator.data_collector', DataCollectorTranslator::class)
             ->args([service('translator.data_collector.inner')])
+            ->tag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore'])
 
         ->set('data_collector.translation', TranslationDataCollector::class)
             ->args([service('translator.data_collector')])

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation;
 
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -20,7 +21,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * @final since Symfony 7.1
  */
-class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInterface, LocaleAwareInterface, WarmableInterface
+class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInterface, LocaleAwareInterface, WarmableInterface, ResetInterface
 {
     public const MESSAGE_DEFINED = 0;
     public const MESSAGE_MISSING = 1;
@@ -31,6 +32,11 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     public function __construct(
         private TranslatorInterface&TranslatorBagInterface&LocaleAwareInterface $translator,
     ) {
+    }
+
+    public function reset(): void
+    {
+        $this->messages = [];
     }
 
     public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string


### PR DESCRIPTION
Memory growth in long-running Symfony apps: DataCollectorTranslator accumulates messages across requests (no reset)

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

When running Symfony in a long-lived process (e.g. Workerman/RoadRunner/Swoole/any worker mode), memory usage grows slowly over time in dev due to Symfony\Component\Translation\DataCollectorTranslator accumulating translated messages across requests.

DataCollectorTranslator stores every call to trans() in its private $messages array via collectMessage(), but it has no built-in reset/clear mechanism. In classic PHP-FPM this is not visible because the process lifecycle ends per request; in long-running workers the array grows indefinitely.

## Expected behavior
In long-running runtimes, dev tooling collectors should not retain per-request data indefinitely. The collected messages should be cleared between requests (e.g. via kernel.reset/services_resetter).

## Actual behavior
Memory and the internal message list continuously increase with repeated requests in dev, even when the same route is hit repeatedly.

Example symptom (repeated /login requests):

- The collector list grows consistently per request (e.g. translator::$messages increases by a fixed delta).
- Process RSS increases slowly over time.

Root cause
Symfony\Component\Translation\DataCollectorTranslator appends entries to $messages on every trans() call:

- File: src/Symfony/Component/Translation/DataCollectorTranslator.php
- Field: private array $messages = [];
- Method: collectMessage() uses $this->messages[] = [...]

There is no reset() or other lifecycle hook to clear $messages between requests, so the service retains all entries for the lifetime of the worker.

## Why this matters
Symfony increasingly supports long-running runtimes and worker modes. Dev-only collectors that are safe under PHP-FPM can become memory leaks in a worker context unless they implement a reset mechanism.

## Proposed fix
Implement Symfony\Contracts\Service\ResetInterface on DataCollectorTranslator and clear $messages in reset(). With autoconfiguration (kernel.reset tag), services_resetter will call reset() between requests in long-running mode, preventing unbounded growth.

## Additional context
This only affects dev (or when the data-collector translator is enabled). Production translator implementations are not impacted.
