### PR TITLE
[PropertyInfo] Fix: prioritize property access over getter methods in reflection ext…

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -326,6 +326,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             }
         }
 
+        if ($hasProperty && (($r = $reflClass->getProperty($property))->getModifiers() & $this->propertyReflectionFlags)) {
+            return new PropertyReadInfo(PropertyReadInfo::TYPE_PROPERTY, $property, $this->getReadVisibilityForProperty($r), $r->isStatic(), true);
+        }
+
         if ($allowGetterSetter && $reflClass->hasMethod($getsetter) && ($reflClass->getMethod($getsetter)->getModifiers() & $this->methodReflectionFlags)) {
             $method = $reflClass->getMethod($getsetter);
             // Only consider jQuery-style accessors when they don't require parameters
@@ -336,10 +340,6 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         if ($allowMagicGet && $reflClass->hasMethod('__get') && (($r = $reflClass->getMethod('__get'))->getModifiers() & $this->methodReflectionFlags)) {
             return new PropertyReadInfo(PropertyReadInfo::TYPE_PROPERTY, $property, PropertyReadInfo::VISIBILITY_PUBLIC, false, $r->returnsReference());
-        }
-
-        if ($hasProperty && (($r = $reflClass->getProperty($property))->getModifiers() & $this->propertyReflectionFlags)) {
-            return new PropertyReadInfo(PropertyReadInfo::TYPE_PROPERTY, $property, $this->getReadVisibilityForProperty($r), $r->isStatic(), true);
         }
 
         if ($allowMagicCall && $reflClass->hasMethod('__call') && ($reflClass->getMethod('__call')->getModifiers() & $this->methodReflectionFlags)) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php7ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php82Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\PropertyNameConflictDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\UnderscoreDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\VirtualProperties;
@@ -693,6 +694,23 @@ class ReflectionExtractorTest extends TestCase
         yield ['false', Type::false()];
         yield ['true', Type::true()];
         yield ['someCollection', Type::union(Type::intersection(Type::object(\Traversable::class), Type::object(\Countable::class)), Type::null())];
+    }
+
+    #[DataProvider('propertyNameConflictProvider')]
+    public function testPropertyNameConflicts(string $property, ?Type $type, mixed $value)
+    {
+        $this->assertEquals($type, $this->extractor->getType(PropertyNameConflictDummy::class, $property));
+        $this->assertSame($value, new PropertyNameConflictDummy()->{$property});
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: ?Type, 2: mixed}>
+     */
+    public static function propertyNameConflictProvider(): iterable
+    {
+        yield ['string', Type::string(), 'string'];
+        yield ['boolean', Type::bool(), false];
+        yield ['unchanged', Type::int(), 42];
     }
 
     #[DataProvider('defaultValueProvider')]

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PropertyNameConflictDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PropertyNameConflictDummy.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * Fixture class for testing property name conflicts with method names.
+ */
+class PropertyNameConflictDummy
+{
+    public bool $boolean = false;
+
+    public string $string = 'string';
+
+    public int $unchanged = 42;
+
+    public function setValue(): void
+    {
+        $this->boolean = true;
+    }
+
+    public function setString(): void
+    {
+        $this->string = 'changed';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4, 7.3, 7.4, 8.0, 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix 62871

When a property and getter method have conflicting names, the property should be accessed directly instead of attempting to call the getter method. This change reorders the property check before the getter/setter method check to ensure direct property access takes precedence.

Includes new test fixture and test cases to verify proper handling of property name conflicts with method names.