### PR TITLE
[TypeInfo] Allow resolving object shapes

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `ObjectShapeType` to represent the exact shape of an anonymous object
+
 8.0
 ---
 

--- a/src/Symfony/Component/TypeInfo/Tests/Type/ObjectShapeTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/ObjectShapeTypeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectShapeType;
+
+class ObjectShapeTypeTest extends TestCase
+{
+    public function testAccepts()
+    {
+        $type = new ObjectShapeType([
+            'foo' => ['type' => Type::bool(), 'optional' => false],
+            'bar' => ['type' => Type::string(), 'optional' => true],
+        ]);
+
+        $this->assertFalse($type->accepts('string'));
+        $this->assertFalse($type->accepts((object) []));
+        $this->assertFalse($type->accepts((object) ['foo' => 'string']));
+        $this->assertFalse($type->accepts((object) ['foo' => true, 'other' => 'string']));
+        $this->assertFalse($type->accepts(['foo' => true]));
+        $this->assertFalse($type->accepts(['foo' => true, 'bar' => 'string']));
+
+        $this->assertTrue($type->accepts((object) ['foo' => true]));
+        $this->assertTrue($type->accepts((object) ['foo' => true, 'bar' => 'string']));
+    }
+
+    public function testToString()
+    {
+        $type = new ObjectShapeType([1 => ['type' => Type::bool(), 'optional' => false]]);
+        $this->assertSame("object{'1': bool}", (string) $type);
+
+        $type = new ObjectShapeType([
+            2 => ['type' => Type::int(), 'optional' => true],
+            1 => ['type' => Type::bool(), 'optional' => false],
+        ]);
+        $this->assertSame("object{'1': bool, '2'?: int}", (string) $type);
+
+        $type = new ObjectShapeType([
+            'foo' => ['type' => Type::bool(), 'optional' => false],
+            'bar' => ['type' => Type::string(), 'optional' => true],
+        ]);
+        $this->assertSame("object{'bar'?: string, 'foo': bool}", (string) $type);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\TypeInfo\Type\EnumType;
 use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\IntersectionType;
 use Symfony\Component\TypeInfo\Type\NullableType;
+use Symfony\Component\TypeInfo\Type\ObjectShapeType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\TemplateType;
 use Symfony\Component\TypeInfo\Type\UnionType;
@@ -228,6 +229,13 @@ class TypeFactoryTest extends TestCase
     {
         $arrayShape = new ArrayShapeType(['substr' => ['type' => Type::string(), 'optional' => false]]);
         $this->assertEquals(Type::string(), $arrayShape->getCollectionKeyType());
+    }
+
+    public function testCreateObjectShape()
+    {
+        $this->assertEquals(new ObjectShapeType(['foo' => ['type' => Type::bool(), 'optional' => true]]), Type::objectShape(['foo' => ['type' => Type::bool(), 'optional' => true]]));
+        $this->assertEquals(new ObjectShapeType(['foo' => ['type' => Type::bool(), 'optional' => false]]), Type::objectShape(['foo' => Type::bool()]));
+        $this->assertEquals(new ObjectShapeType(['substr' => ['type' => Type::bool(), 'optional' => false]]), Type::objectShape(['substr' => Type::bool()]));
     }
 
     public function testCreateArrayKey()

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -89,8 +89,12 @@ class StringTypeResolverTest extends TestCase
         yield [Type::arrayShape(['foo' => Type::bool()], extraValueType: Type::int()), 'array{foo: bool, ...<int>}'];
         yield [Type::arrayShape(['foo' => Type::union(Type::bool(), Type::float(), Type::int(), Type::null(), Type::string()), 'bar' => Type::string()]), 'array{foo: scalar|null, bar: string}'];
 
+        // object
+        yield [Type::object(), 'object'];
+
         // object shape
-        yield [Type::object(), 'object{foo: true, bar: false}'];
+        yield [Type::objectShape(['foo' => Type::true(), 'bar' => Type::false()]), 'object{foo: true, bar: false}'];
+        yield [Type::objectShape(['foo' => ['type' => Type::bool(), 'optional' => true]]), 'object{foo?: bool}'];
 
         // this
         yield [Type::object(Dummy::class), '$this', $typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class)];

--- a/src/Symfony/Component/TypeInfo/Type/ObjectShapeType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectShapeType.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Type;
+
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Represents the exact shape of an anonymous object.
+ *
+ * @author Benjamin Franzke <ben@bnf.dev>
+ */
+final class ObjectShapeType extends Type
+{
+    /**
+     * @var array<string, array{type: Type, optional: bool}>
+     */
+    private readonly array $shape;
+
+    /**
+     * @param array<string, array{type: Type, optional: bool}> $shape
+     */
+    public function __construct(
+        array $shape,
+    ) {
+        $sortedShape = $shape;
+        ksort($sortedShape);
+
+        $this->shape = $sortedShape;
+    }
+
+    public function getTypeIdentifier(): TypeIdentifier
+    {
+        return TypeIdentifier::OBJECT;
+    }
+
+    /**
+     * @return array<string, array{type: Type, optional: bool}>
+     */
+    public function getShape(): array
+    {
+        return $this->shape;
+    }
+
+    public function accepts(mixed $value): bool
+    {
+        if (!\is_object($value)) {
+            return false;
+        }
+
+        foreach ($this->shape as $key => $shapeValue) {
+            if (!($shapeValue['optional'] ?? false) && !property_exists($value, $key)) {
+                return false;
+            }
+        }
+
+        foreach (get_object_vars($value) as $key => $itemValue) {
+            $valueType = $this->shape[$key]['type'] ?? false;
+            if (!$valueType) {
+                return false;
+            }
+
+            if (!$valueType->accepts($itemValue)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function __toString(): string
+    {
+        $items = [];
+
+        foreach ($this->shape as $key => $value) {
+            $itemKey = \sprintf("'%s'", $key);
+            if ($value['optional'] ?? false) {
+                $itemKey = \sprintf('%s?', $itemKey);
+            }
+
+            $items[] = \sprintf('%s: %s', $itemKey, $value['type']);
+        }
+
+        return \sprintf('object{%s}', implode(', ', $items));
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -19,6 +19,7 @@ use Symfony\Component\TypeInfo\Type\EnumType;
 use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\IntersectionType;
 use Symfony\Component\TypeInfo\Type\NullableType;
+use Symfony\Component\TypeInfo\Type\ObjectShapeType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\TemplateType;
 use Symfony\Component\TypeInfo\Type\UnionType;
@@ -227,6 +228,20 @@ trait TypeFactoryTrait
     public static function object(?string $className = null): BuiltinType|ObjectType
     {
         return null !== $className ? new ObjectType($className) : new BuiltinType(TypeIdentifier::OBJECT);
+    }
+
+    /**
+     * @param array<string, array{type: Type, optional?: bool}|Type> $shape
+     */
+    public static function objectShape(array $shape): ObjectShapeType
+    {
+        $shape = array_map(static function (array|Type $item): array {
+            return $item instanceof Type
+                ? ['type' => $item, 'optional' => false]
+                : ['type' => $item['type'], 'optional' => $item['optional'] ?? false];
+        }, $shape);
+
+        return new ObjectShapeType($shape);
     }
 
     /**

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -127,7 +127,15 @@ final class StringTypeResolver implements TypeResolverInterface
         }
 
         if ($node instanceof ObjectShapeNode) {
-            return Type::object();
+            $shape = [];
+            foreach ($node->items as $item) {
+                $shape[(string) $item->keyName] = [
+                    'type' => $this->getTypeFromNode($item->valueType, $typeContext),
+                    'optional' => $item->optional,
+                ];
+            }
+
+            return $shape ? Type::objectShape($shape) : Type::object();
         }
 
         if ($node instanceof ThisTypeNode) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Introduce the `ObjectShapeType` that holds the exact shape of an anonymous object. Also enables the `StringTypeResolver` to parse `object{foo: int, bar?: string}` and to create the appropriate type.