### PR TITLE
[PropertyAccess][PropertyInfo][Serializer] Skip methods that look like getters but return void or never

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestIgnoreVoidAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestIgnoreVoidAccessor.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class TestIgnoreVoidAccessor
+{
+    public bool $setValue = false;
+    public bool $setterValue = false;
+    public bool $neverValue = false;
+    public bool $normalValue = false;
+
+    public function setValue(): void
+    {
+        $this->setValue = true;
+    }
+
+    public function setSetterValue(): void
+    {
+        $this->setterValue = true;
+    }
+
+    public function setNeverValue(): never
+    {
+        // Simulate a setter that does not return anything and exits
+        $this->neverValue = true;
+        exit;
+    }
+
+    public function setUndefinedValue(): void
+    {
+        // This method is intentionally left empty to simulate a missing setter
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassSetValue;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassTypedProperty;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassTypeErrorInsideCall;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestIgnoreVoidAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestPublicPropertyDynamicallyCreated;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestPublicPropertyGetterOnObject;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestPublicPropertyGetterOnObjectMagicGet;
@@ -993,6 +994,33 @@ class PropertyAccessorTest extends TestCase
         $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty::$privateUninitialized" is not readable because it is typed "DateTimeInterface". You should initialize it or declare a default value instead.');
 
         $this->propertyAccessor->getValue(new UninitializedObjectProperty(), 'privateUninitialized');
+    }
+
+    /**
+     * @dataProvider voidAccessorProvider
+     */
+    public function testIgnoreVoidAccessor(string $property, mixed $value)
+    {
+        $object = new TestIgnoreVoidAccessor();
+        if (null === $value) {
+            $this->expectException(NoSuchPropertyException::class);
+        }
+
+        $this->assertSame(
+            $value,
+            $this->propertyAccessor->getValue($object, $property),
+        );
+    }
+
+    public static function voidAccessorProvider()
+    {
+        return [
+            ['setValue', false],
+            ['setterValue', false],
+            ['neverValue', false],
+            ['normalValue', false],
+            ['undefinedValue', null],
+        ];
     }
 
     public function testGetValuePropertyThrowsExceptionIfUninitializedWithLazyGhost()

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -278,19 +278,24 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
     {
         $prefixes = self::ACCESSOR === $type ? $this->accessorPrefixes : $this->mutatorPrefixes;
         $prefix = null;
+        $method = null;
 
         foreach ($prefixes as $prefix) {
             $methodName = $prefix.$ucFirstProperty;
 
             try {
-                $reflectionMethod = new \ReflectionMethod($class, $methodName);
-                if ($reflectionMethod->isStatic()) {
+                $method = new \ReflectionMethod($class, $methodName);
+                if ($method->isStatic()) {
+                    continue;
+                }
+
+                if (self::ACCESSOR === $type && \in_array((string) $method->getReturnType(), ['void', 'never'], true)) {
                     continue;
                 }
 
                 if (
-                    (self::ACCESSOR === $type && 0 === $reflectionMethod->getNumberOfRequiredParameters())
-                    || (self::MUTATOR === $type && $reflectionMethod->getNumberOfParameters() >= 1)
+                    (self::ACCESSOR === $type && !$method->getNumberOfRequiredParameters())
+                    || (self::MUTATOR === $type && $method->getNumberOfParameters() >= 1)
                 ) {
                     break;
                 }
@@ -299,17 +304,17 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             }
         }
 
-        if (!isset($reflectionMethod)) {
+        if (!$method) {
             return null;
         }
 
-        if (null === $rawDocNode = $reflectionMethod->getDocComment() ?: null) {
+        if (null === $rawDocNode = $method->getDocComment() ?: null) {
             return null;
         }
 
         $phpDocNode = $this->getPhpDocNode($rawDocNode);
 
-        return [$phpDocNode, $prefix, $reflectionMethod->class];
+        return [$phpDocNode, $prefix, $method->class];
     }
 
     private function getPhpDocNode(string $rawDocNode): PhpDocNode

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\PseudoTypeDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\VoidNeverReturnTypeDummy;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -475,6 +476,18 @@ class PhpDocExtractorTest extends TestCase
             ['promoted', null],
             ['promotedAndMutated', [new Type(Type::BUILTIN_TYPE_STRING)]],
         ];
+    }
+
+    public function testSkipVoidNeverReturnTypeAccessors()
+    {
+        // Methods that return void or never should be skipped, so no types should be extracted
+        $this->assertNull($this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'voidProperty'));
+        $this->assertNull($this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'neverProperty'));
+        // Normal getter should still work
+        $types = $this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'normalProperty');
+        $this->assertNotNull($types);
+        $this->assertCount(1, $types);
+        $this->assertEquals(Type::BUILTIN_TYPE_STRING, $types[0]->getBuiltinType());
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\RootDummy\RootDummyItem;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\AnotherNamespace\DummyInAnotherNamespace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\VoidNeverReturnTypeDummy;
 use Symfony\Component\PropertyInfo\Type;
 
 require_once __DIR__.'/../Fixtures/Extractor/DummyNamespace.php';
@@ -585,6 +586,13 @@ class PhpStanExtractorTest extends TestCase
                 ),
             ],
         ];
+    }
+
+    public function testSkipVoidNeverReturnTypeAccessors()
+    {
+        $this->assertNull($this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'voidProperty'));
+        $this->assertNull($this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'neverProperty'));
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_STRING)], $this->extractor->getTypes(VoidNeverReturnTypeDummy::class, 'normalProperty'));
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\SnakeCaseDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\UnderscoreDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\VirtualProperties;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\VoidNeverReturnTypeDummy;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -560,7 +561,7 @@ class ReflectionExtractorTest extends TestCase
             [Dummy::class, 'static', true, PropertyReadInfo::TYPE_METHOD, 'getStatic', PropertyReadInfo::VISIBILITY_PUBLIC, true],
             [Dummy::class, 'foo', true, PropertyReadInfo::TYPE_PROPERTY, 'foo', PropertyReadInfo::VISIBILITY_PUBLIC, false],
             [Php71Dummy::class, 'foo', true, PropertyReadInfo::TYPE_METHOD, 'getFoo', PropertyReadInfo::VISIBILITY_PUBLIC, false],
-            [Php71Dummy::class, 'buz', true, PropertyReadInfo::TYPE_METHOD, 'getBuz', PropertyReadInfo::VISIBILITY_PUBLIC, false],
+            [Php71Dummy::class, 'buz', false, null, null, null, null],
             [UnderscoreDummy::class, '_', true, PropertyReadInfo::TYPE_METHOD, 'get_', PropertyReadInfo::VISIBILITY_PUBLIC, false],
             [UnderscoreDummy::class, '__', true, PropertyReadInfo::TYPE_METHOD, 'get__', PropertyReadInfo::VISIBILITY_PUBLIC, false],
             [UnderscoreDummy::class, 'foo_bar', false, null, null, null, null],
@@ -826,5 +827,14 @@ class ReflectionExtractorTest extends TestCase
         yield 'empty string' => ['', ''];
         yield 'no underscore' => ['fooBar', 'FooBar'];
         yield 'pascal case' => ['FooBar', 'FooBar'];
+    }
+
+    public function testSkipVoidNeverReturnTypeAccessors()
+    {
+        $this->assertFalse($this->extractor->isReadable(VoidNeverReturnTypeDummy::class, 'voidProperty'));
+        $this->assertFalse($this->extractor->isReadable(VoidNeverReturnTypeDummy::class, 'neverProperty'));
+        $this->assertTrue($this->extractor->isReadable(VoidNeverReturnTypeDummy::class, 'normalProperty'));
+        $this->assertNull($this->extractor->getReadInfo(VoidNeverReturnTypeDummy::class, 'voidProperty'));
+        $this->assertNull($this->extractor->getReadInfo(VoidNeverReturnTypeDummy::class, 'neverProperty'));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/VoidNeverReturnTypeDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/VoidNeverReturnTypeDummy.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class VoidNeverReturnTypeDummy
+{
+    public string $normalProperty = 'value';
+
+    /**
+     * @return string
+     */
+    public function getNormalProperty(): string
+    {
+        return $this->normalProperty;
+    }
+
+    public function getVoidProperty(): void
+    {
+        // This looks like a getter but returns void, should be ignored
+    }
+
+    public function getNeverProperty(): never
+    {
+        // This looks like a getter but returns never, should be ignored
+        throw new \Exception('Never returns');
+    }
+
+    public function setValue(): void
+    {
+        // This looks like a setter but has no parameters, should be ignored as accessor
+    }
+
+    public function setNeverValue(): never
+    {
+        // This looks like a setter but has no parameters and returns never, should be ignored as accessor
+        throw new \Exception('Never returns');
+    }
+}
+

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -130,13 +130,14 @@ class AttributeLoader implements LoaderInterface
             }
 
             $accessorOrMutator = match ($name[0]) {
-                's' => str_starts_with($name, 'set') && isset($name[$i = 3]),
+                's' => str_starts_with($name, 'set') && isset($name[$i = 3]) && $method->getNumberOfParameters(),
                 'g' => str_starts_with($name, 'get') && isset($name[$i = 3]),
                 'h' => str_starts_with($name, 'has') && isset($name[$i = 3]),
                 'c' => str_starts_with($name, 'can') && isset($name[$i = 3]),
                 'i' => str_starts_with($name, 'is') && isset($name[$i = 2]),
                 default => false,
-            };
+            } && ('s' === $name[0] || !$method->getNumberOfRequiredParameters() && !\in_array((string) $method->getReturnType(), ['void', 'never'], true));
+
             if ($accessorOrMutator && !ctype_lower($name[$i])) {
                 if ($this->hasProperty($method->getDeclaringClass(), $name)) {
                     $attributeName = $name;

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -105,8 +105,9 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         return !$method->isStatic()
             && !($method->getAttributes(Ignore::class) || $method->getAttributes(LegacyIgnore::class))
             && !$method->getNumberOfRequiredParameters()
+            && !\in_array((string) $method->getReturnType(), ['void', 'never'], true)
             && ((2 < ($methodLength = \strlen($method->name)) && str_starts_with($method->name, 'is') && !ctype_lower($method->name[2]))
-                || (3 < $methodLength && (str_starts_with($method->name, 'has') || str_starts_with($method->name, 'get')) && !ctype_lower($method->name[3]))
+                || (3 < $methodLength && (str_starts_with($method->name, 'has') || str_starts_with($method->name, 'get') || str_starts_with($method->name, 'can')) && !ctype_lower($method->name[3]))
             );
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -88,10 +88,11 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
         foreach ($reflClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflMethod) {
             if (
-                0 !== $reflMethod->getNumberOfRequiredParameters()
+                $reflMethod->getNumberOfRequiredParameters()
                 || $reflMethod->isStatic()
                 || $reflMethod->isConstructor()
                 || $reflMethod->isDestructor()
+                || \in_array((string) $reflMethod->getReturnType(), ['void', 'never'], true)
             ) {
                 continue;
             }
@@ -198,11 +199,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
     private function hasAttributeAccessorMethod(string $class, string $attribute): bool
     {
-        if (!isset(self::$reflectionCache[$class])) {
-            self::$reflectionCache[$class] = new \ReflectionClass($class);
-        }
-
-        $reflection = self::$reflectionCache[$class];
+        $reflection = self::$reflectionCache[$class] ??= new \ReflectionClass($class);
 
         if (!$reflection->hasMethod($attribute)) {
             return false;
@@ -212,6 +209,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
         return !$method->isStatic()
             && !$method->getAttributes(Ignore::class)
-            && !$method->getNumberOfRequiredParameters();
+            && !$method->getNumberOfRequiredParameters()
+            && !\in_array((string) $method->getReturnType(), ['void', 'never'], true);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/AccessorishGetters.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/AccessorishGetters.php
@@ -33,7 +33,7 @@ class AccessorishGetters
     {
     }
 
-    public function setField4()
+    public function setField4($value)
     {
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/VoidNeverReturnTypeDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/VoidNeverReturnTypeDummy.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class VoidNeverReturnTypeDummy
+{
+    public string $normalProperty = 'value';
+
+    public function getNormalProperty(): string
+    {
+        return $this->normalProperty;
+    }
+
+    public function getVoidProperty(): void
+    {
+        // This looks like a getter but returns void, should be ignored
+    }
+
+    public function getNeverProperty(): never
+    {
+        // This looks like a getter but returns never, should be ignored
+        throw new \Exception('Never returns');
+    }
+
+    public function setValue(): void
+    {
+        // This looks like a setter but has no parameters, should be ignored as accessor
+    }
+
+    public function setNeverValue(): never
+    {
+        // This looks like a setter but has no parameters and returns never, should be ignored as accessor
+        throw new \Exception('Never returns');
+    }
+}
+

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderWithAttributesTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderWithAttributesTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\Tests\Mapping\Loader;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Tests\Fixtures\VoidNeverReturnTypeDummy;
 
 class AttributeLoaderWithAttributesTest extends AttributeLoaderTestCase
 {
@@ -35,5 +36,16 @@ class AttributeLoaderWithAttributesTest extends AttributeLoaderTestCase
         $classMetadata = new ClassMetadata($this->getNamespace().'\BadAttributeDummy');
 
         $this->loader->loadClassMetadata($classMetadata);
+    }
+
+    public function testSkipVoidNeverReturnTypeAccessors()
+    {
+        $classMetadata = new ClassMetadata(VoidNeverReturnTypeDummy::class);
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertArrayHasKey('normalProperty', $attributesMetadata);
+        $this->assertArrayNotHasKey('voidProperty', $attributesMetadata);
+        $this->assertArrayNotHasKey('neverProperty', $attributesMetadata);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\ScalarNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Fixtures\StdClassNormalizer;
+use Symfony\Component\Serializer\Tests\Fixtures\VoidNeverReturnTypeDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CircularReferenceTestTrait;
@@ -619,6 +620,16 @@ class GetSetMethodNormalizerTest extends TestCase
         );
 
         $this->assertInstanceOf(GetSetMethodDiscriminatedDummyOne::class, $obj);
+    }
+
+    public function testSkipVoidNeverReturnTypeAccessors()
+    {
+        $obj = new VoidNeverReturnTypeDummy();
+        $normalized = $this->normalizer->normalize($obj);
+        $this->assertArrayHasKey('normalProperty', $normalized);
+        $this->assertArrayNotHasKey('voidProperty', $normalized);
+        $this->assertArrayNotHasKey('neverProperty', $normalized);
+        $this->assertEquals('value', $normalized['normalProperty']);
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -50,6 +50,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\Php74DummyPrivate;
 use Symfony\Component\Serializer\Tests\Fixtures\Php80Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Fixtures\StdClassNormalizer;
+use Symfony\Component\Serializer\Tests\Fixtures\VoidNeverReturnTypeDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\AttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
@@ -1181,6 +1182,16 @@ class ObjectNormalizerTest extends TestCase
 
         $normalizedWithGroups = $normalizer->normalize($object, null, [AbstractNormalizer::GROUPS => ['test']]);
         $this->assertArrayHasKey('isSomething', $normalizedWithGroups);
+    }
+
+    public function testSkipVoidNeverReturnTypeAccessors()
+    {
+        $obj = new VoidNeverReturnTypeDummy();
+        $normalized = $this->normalizer->normalize($obj);
+        $this->assertArrayHasKey('normalProperty', $normalized);
+        $this->assertArrayNotHasKey('voidProperty', $normalized);
+        $this->assertArrayNotHasKey('neverProperty', $normalized);
+        $this->assertEquals('value', $normalized['normalProperty']);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62871
| License       | MIT

Fall back to property when potential getter is not readable. For example when it acts as a setter with the same name.
 - Exclude methods that have a return type of void or never
 - Added tests to cover the implementation 

Please beware that fluent methods (those who return $this) and methods that do not have any return type are not excluded from this check.

