### PR TITLE
[Messenger] Route decode failures through failure handling

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -59,6 +59,14 @@ HttpKernel
    ```
  * Deprecate passing a `ControllerArgumentsEvent` to the `ViewEvent` constructor; pass a `ControllerArgumentsMetadata` instead
 
+Messenger
+---------
+
+ * Serializers now return `Envelope<MessageDecodingFailedException>` on decode failure instead of throwing;
+   custom serializers that still throw are supported via a BC fallback in receivers
+ * Receivers no longer delete messages from the queue on decode failure;
+   they are routed through the normal retry/failure transport path instead
+
 Security
 --------
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -130,6 +130,7 @@ use Symfony\Component\Messenger\Bridge as MessengerBridge;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface as MessengerTransportFactoryInterface;
@@ -2444,6 +2445,7 @@ class FrameworkExtension extends Extension
                 ['id' => 'add_bus_name_stamp_middleware'],
                 ['id' => 'reject_redelivered_message_middleware'],
                 ['id' => 'dispatch_after_current_bus'],
+                ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
                 ['id' => 'failed_message_processing_middleware'],
             ],
             'after' => [
@@ -2531,6 +2533,7 @@ class FrameworkExtension extends Extension
         $senderAliases = [];
         $transportRetryReferences = [];
         $transportRateLimiterReferences = [];
+        $serializerReferencesByTransport = [];
         $serializerIds = [];
         foreach ($config['transports'] as $name => $transport) {
             $serializerId = $transport['serializer'] ?? 'messenger.default_serializer';
@@ -2538,6 +2541,7 @@ class FrameworkExtension extends Extension
                 'alias' => $name,
                 'is_failure_transport' => \in_array($name, $failureTransports, true),
             ];
+            $serializerReferencesByTransport[$name] = new Reference($serializerId);
             if (str_starts_with($transport['dsn'], 'sync://')) {
                 $tags['is_consumable'] = false;
             }
@@ -2573,6 +2577,12 @@ class FrameworkExtension extends Extension
 
                 $transportRateLimiterReferences[$name] = new Reference('limiter.'.$transport['rate_limiter']);
             }
+        }
+
+        if (class_exists(DecodeFailedMessageMiddleware::class)) {
+            $container->getDefinition('messenger.transport.serializer_locator')->replaceArgument(0, $serializerReferencesByTransport);
+        } else {
+            $container->removeDefinition('messenger.middleware.decode_failed_message_middleware');
         }
 
         $senderReferences = [];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -28,6 +28,7 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
@@ -130,6 +131,15 @@ return static function (ContainerConfigurator $container) {
         ->set('messenger.middleware.reject_redelivered_message_middleware', RejectRedeliveredMessageMiddleware::class)
 
         ->set('messenger.middleware.failed_message_processing_middleware', FailedMessageProcessingMiddleware::class)
+
+        ->set('messenger.transport.serializer_locator', ServiceLocator::class)
+            ->args([[]])
+            ->tag('container.service_locator')
+
+        ->set('messenger.middleware.decode_failed_message_middleware', DecodeFailedMessageMiddleware::class)
+            ->args([
+                service('messenger.transport.serializer_locator'),
+            ])
 
         ->set('messenger.middleware.traceable', TraceableMiddleware::class)
             ->abstract()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -72,6 +72,7 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFac
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
+use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\Notifier\ChatterInterface;
@@ -1252,6 +1253,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.commands']],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
+            ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
             ['id' => 'handle_message', 'arguments' => [false]],
@@ -1263,6 +1265,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.events']],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
+            ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message', 'arguments' => [true]],
@@ -1296,6 +1299,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.events']],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
+            ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
             ['id' => 'handle_message', 'arguments' => [false]],
@@ -1317,6 +1321,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.commands']],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
+            ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
@@ -1329,6 +1334,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.events']],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
+            ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
@@ -40,20 +40,20 @@ class AmazonSqsReceiverTest extends TestCase
         $this->assertEquals(new DummyMessage('Hi'), $actualEnvelopes[0]->getMessage());
     }
 
-    public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException()
+    public function testItReturnsSerializedEnvelopeWhenDecodingFails()
     {
-        $this->expectException(MessageDecodingFailedException::class);
-
         $serializer = $this->createStub(PhpSerializer::class);
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
         $sqsEnvelop = $this->createSqsEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('get')->willReturn($sqsEnvelop);
-        $connection->expects($this->once())->method('reject');
 
         $receiver = new AmazonSqsReceiver($connection, $serializer);
-        iterator_to_array($receiver->get());
+        $envelopes = iterator_to_array($receiver->get());
+
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
     public function testKeepalive()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
@@ -38,32 +39,32 @@ class AmazonSqsReceiver implements KeepaliveReceiverInterface, MessageCountAware
     public function get(): iterable
     {
         try {
-            $sqsEnvelope = $this->connection->get();
+            if (!$sqsEnvelope = $this->connection->get()) {
+                return;
+            }
         } catch (HttpException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
-        if (null === $sqsEnvelope) {
-            return;
-        }
+
+        $stamps = [
+            new AmazonSqsReceivedStamp($sqsEnvelope['id']),
+            new TransportMessageIdStamp($sqsEnvelope['id']),
+        ];
 
         try {
-            $envelope = $this->serializer->decode([
+            yield $this->serializer->decode($sqsEnvelope = [
                 'body' => $sqsEnvelope['body'],
                 'headers' => $sqsEnvelope['headers'],
-            ]);
-        } catch (MessageDecodingFailedException $exception) {
-            $this->connection->reject($sqsEnvelope['id']);
-
-            throw $exception;
+            ])->with(...$stamps);
+        } catch (MessageDecodingFailedException $e) {
+            yield MessageDecodingFailedException::wrap($sqsEnvelope, $e->getMessage(), $e->getCode(), $e)->with(...$stamps);
         }
-
-        yield $envelope->with(new AmazonSqsReceivedStamp($sqsEnvelope['id']));
     }
 
     public function ack(Envelope $envelope): void
     {
         try {
-            $this->connection->delete($this->findSqsReceivedStamp($envelope)->getId());
+            $this->connection->delete($this->findSqsReceivedStampId($envelope));
         } catch (HttpException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
@@ -72,7 +73,7 @@ class AmazonSqsReceiver implements KeepaliveReceiverInterface, MessageCountAware
     public function reject(Envelope $envelope): void
     {
         try {
-            $this->connection->reject($this->findSqsReceivedStamp($envelope)->getId());
+            $this->connection->reject($this->findSqsReceivedStampId($envelope));
         } catch (HttpException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
@@ -81,7 +82,7 @@ class AmazonSqsReceiver implements KeepaliveReceiverInterface, MessageCountAware
     public function keepalive(Envelope $envelope, ?int $seconds = null): void
     {
         try {
-            $this->connection->keepalive($this->findSqsReceivedStamp($envelope)->getId(), $seconds);
+            $this->connection->keepalive($this->findSqsReceivedStampId($envelope), $seconds);
         } catch (HttpException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
@@ -96,15 +97,8 @@ class AmazonSqsReceiver implements KeepaliveReceiverInterface, MessageCountAware
         }
     }
 
-    private function findSqsReceivedStamp(Envelope $envelope): AmazonSqsReceivedStamp
+    private function findSqsReceivedStampId(Envelope $envelope): string
     {
-        /** @var AmazonSqsReceivedStamp|null $sqsReceivedStamp */
-        $sqsReceivedStamp = $envelope->last(AmazonSqsReceivedStamp::class);
-
-        if (null === $sqsReceivedStamp) {
-            throw new LogicException('No AmazonSqsReceivedStamp found on the Envelope.');
-        }
-
-        return $sqsReceivedStamp;
+        return $envelope->last(AmazonSqsReceivedStamp::class)?->getId() ?? throw new LogicException('No AmazonSqsReceivedStamp found on the Envelope.');
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
@@ -20,7 +20,7 @@
         "async-aws/core": "^1.7",
         "async-aws/sqs": "^1.0|^2.0",
         "psr/log": "^1|^2|^3",
-        "symfony/messenger": "^7.4|^8.0",
+        "symfony/messenger": "^8.1",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceivedStamp;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
@@ -138,6 +139,23 @@ class AmqpReceiverTest extends TestCase
         /** @var TransportMessageIdStamp $transportMessageIdStamp */
         $transportMessageIdStamp = $actualEnvelope->last(TransportMessageIdStamp::class);
         $this->assertNull($transportMessageIdStamp);
+    }
+
+    public function testItReturnsSerializedEnvelopeWhenDecodingFails()
+    {
+        $serializer = $this->createStub(SerializerInterface::class);
+        $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
+
+        $amqpEnvelope = $this->createAMQPEnvelope();
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+        $envelopes = iterator_to_array($receiver->get());
+
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
     private function createAMQPEnvelope(?string $messageId = null): \AMQPEnvelope

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -60,11 +60,11 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
             try {
                 $this->connection->queue($queueName)->getConnection()->reconnect();
                 $amqpEnvelope = $this->connection->get($queueName);
-            } catch (\AMQPException $exception) {
-                throw new TransportException($exception->getMessage(), 0, $exception);
+            } catch (\AMQPException $e) {
+                throw new TransportException($e->getMessage(), 0, $e);
             }
-        } catch (\AMQPException $exception) {
-            throw new TransportException($exception->getMessage(), 0, $exception);
+        } catch (\AMQPException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
 
         if (null === $amqpEnvelope) {
@@ -72,26 +72,20 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
         }
 
         $body = $amqpEnvelope->getBody();
+        $id = $amqpEnvelope->getMessageId();
+        $stamps = [
+            new AmqpReceivedStamp($amqpEnvelope, $queueName),
+            ...($id ? [new TransportMessageIdStamp($id)] : []),
+        ];
 
         try {
-            $envelope = $this->serializer->decode([
+            yield $this->serializer->decode($data = [
                 'body' => false === $body ? '' : $body, // workaround https://github.com/pdezwart/php-amqp/issues/351
                 'headers' => $amqpEnvelope->getHeaders(),
-            ]);
-        } catch (MessageDecodingFailedException $exception) {
-            // invalid message of some type
-            $this->rejectAmqpEnvelope($amqpEnvelope, $queueName);
-
-            throw $exception;
+            ])->withoutAll(TransportMessageIdStamp::class)->with(...$stamps);
+        } catch (MessageDecodingFailedException $e) {
+            yield MessageDecodingFailedException::wrap($data, $e->getMessage(), $e->getCode(), $e)->with(...$stamps);
         }
-
-        if (null !== $amqpEnvelope->getMessageId()) {
-            $envelope = $envelope
-                ->withoutAll(TransportMessageIdStamp::class)
-                ->with(new TransportMessageIdStamp($amqpEnvelope->getMessageId()));
-        }
-
-        yield $envelope->with(new AmqpReceivedStamp($amqpEnvelope, $queueName));
     }
 
     public function ack(Envelope $envelope): void
@@ -106,11 +100,11 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
 
                 $this->connection->queue($stamp->getQueueName())->getConnection()->reconnect();
                 $this->connection->ack($stamp->getAmqpEnvelope(), $stamp->getQueueName());
-            } catch (\AMQPException $exception) {
-                throw new TransportException($exception->getMessage(), 0, $exception);
+            } catch (\AMQPException $e) {
+                throw new TransportException($e->getMessage(), 0, $e);
             }
-        } catch (\AMQPException $exception) {
-            throw new TransportException($exception->getMessage(), 0, $exception);
+        } catch (\AMQPException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
     }
 
@@ -128,8 +122,8 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
     {
         try {
             return $this->connection->countMessagesInQueues();
-        } catch (\AMQPException $exception) {
-            throw new TransportException($exception->getMessage(), 0, $exception);
+        } catch (\AMQPException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
     }
 
@@ -141,21 +135,16 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
             try {
                 $this->connection->queue($queueName)->getConnection()->reconnect();
                 $this->connection->nack($amqpEnvelope, $queueName, \AMQP_NOPARAM);
-            } catch (\AMQPException $exception) {
-                throw new TransportException($exception->getMessage(), 0, $exception);
+            } catch (\AMQPException $e) {
+                throw new TransportException($e->getMessage(), 0, $e);
             }
-        } catch (\AMQPException $exception) {
-            throw new TransportException($exception->getMessage(), 0, $exception);
+        } catch (\AMQPException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
     }
 
     private function findAmqpStamp(Envelope $envelope): AmqpReceivedStamp
     {
-        $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
-        if (null === $amqpReceivedStamp) {
-            throw new LogicException('No "AmqpReceivedStamp" stamp found on the Envelope.');
-        }
-
-        return $amqpReceivedStamp;
+        return $envelope->last(AmqpReceivedStamp::class) ?? throw new LogicException('No "AmqpReceivedStamp" stamp found on the Envelope.');
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4",
         "ext-amqp": "*",
-        "symfony/messenger": "^7.4|^8.0"
+        "symfony/messenger": "^8.1"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0",

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdReceiverTest.php
@@ -42,7 +42,7 @@ final class BeanstalkdReceiverTest extends TestCase
         $connection->expects($this->once())->method('getTube')->willReturn($tube);
 
         $receiver = new BeanstalkdReceiver($connection, $serializer);
-        $actualEnvelopes = $receiver->get();
+        $actualEnvelopes = iterator_to_array($receiver->get());
         $this->assertCount(1, $actualEnvelopes);
         /** @var Envelope $actualEnvelope */
         $actualEnvelope = $actualEnvelopes[0];
@@ -69,15 +69,12 @@ final class BeanstalkdReceiverTest extends TestCase
         $connection->expects($this->once())->method('get')->willReturn(null);
 
         $receiver = new BeanstalkdReceiver($connection, $serializer);
-        $actualEnvelopes = $receiver->get();
-        $this->assertIsArray($actualEnvelopes);
+        $actualEnvelopes = iterator_to_array($receiver->get());
         $this->assertCount(0, $actualEnvelopes);
     }
 
-    public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException()
+    public function testItReturnsSerializedEnvelopeWhenDecodingFails()
     {
-        $this->expectException(MessageDecodingFailedException::class);
-
         $serializer = $this->createMock(PhpSerializer::class);
         $serializer->expects($this->once())->method('decode')->willThrowException(new MessageDecodingFailedException());
 
@@ -85,10 +82,13 @@ final class BeanstalkdReceiverTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('get')->willReturn($beanstalkdEnvelope);
         $connection->expects($this->once())->method('getMessagePriority')->with($beanstalkdEnvelope['id'])->willReturn(2);
-        $connection->expects($this->once())->method('reject')->with($beanstalkdEnvelope['id'], 2);
+        $connection->expects($this->once())->method('getTube')->willReturn('tube');
 
         $receiver = new BeanstalkdReceiver($connection, $serializer);
-        $receiver->get();
+        $envelopes = iterator_to_array($receiver->get());
+
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
     #[DataProvider('provideRejectCases')]

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdTransportTest.php
@@ -47,7 +47,7 @@ final class BeanstalkdTransportTest extends TestCase
         $serializer->expects($this->once())->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
         $connection->method('get')->willReturn($beanstalkdEnvelope);
 
-        $envelopes = $transport->get();
+        $envelopes = iterator_to_array($transport->get());
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/BeanstalkdReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/BeanstalkdReceiver.php
@@ -37,43 +37,35 @@ class BeanstalkdReceiver implements KeepaliveReceiverInterface, MessageCountAwar
 
     public function get(): iterable
     {
-        $beanstalkdEnvelope = $this->connection->get();
-
-        if (null === $beanstalkdEnvelope) {
-            return [];
+        if (!$beanstalkdEnvelope = $this->connection->get()) {
+            return;
         }
+
+        $stamps = [
+            new BeanstalkdReceivedStamp($beanstalkdEnvelope['id'], $this->connection->getTube()),
+            new TransportMessageIdStamp($beanstalkdEnvelope['id']),
+            new BeanstalkdPriorityStamp($this->connection->getMessagePriority($beanstalkdEnvelope['id'])),
+        ];
 
         try {
-            $envelope = $this->serializer->decode([
+            yield $this->serializer->decode($beanstalkdEnvelope = [
                 'body' => $beanstalkdEnvelope['body'],
                 'headers' => $beanstalkdEnvelope['headers'],
-            ]);
-        } catch (MessageDecodingFailedException $exception) {
-            $this->connection->reject(
-                $beanstalkdEnvelope['id'],
-                $this->connection->getMessagePriority($beanstalkdEnvelope['id']),
-            );
-
-            throw $exception;
+            ])->withoutAll(TransportMessageIdStamp::class)->with(...$stamps);
+        } catch (MessageDecodingFailedException $e) {
+            yield MessageDecodingFailedException::wrap($beanstalkdEnvelope, $e->getMessage(), $e->getCode(), $e)->with(...$stamps);
         }
-
-        return [$envelope
-            ->withoutAll(TransportMessageIdStamp::class)
-            ->with(
-                new BeanstalkdReceivedStamp($beanstalkdEnvelope['id'], $this->connection->getTube()),
-                new TransportMessageIdStamp($beanstalkdEnvelope['id']),
-            )];
     }
 
     public function ack(Envelope $envelope): void
     {
-        $this->connection->ack($this->findBeanstalkdReceivedStamp($envelope)->getId());
+        $this->connection->ack($this->findBeanstalkdReceivedStampId($envelope));
     }
 
     public function reject(Envelope $envelope): void
     {
         $this->connection->reject(
-            $this->findBeanstalkdReceivedStamp($envelope)->getId(),
+            $this->findBeanstalkdReceivedStampId($envelope),
             $envelope->last(BeanstalkdPriorityStamp::class)?->priority,
             $envelope->last(SentForRetryStamp::class)?->isSent ?? false,
         );
@@ -81,7 +73,7 @@ class BeanstalkdReceiver implements KeepaliveReceiverInterface, MessageCountAwar
 
     public function keepalive(Envelope $envelope, ?int $seconds = null): void
     {
-        $this->connection->keepalive($this->findBeanstalkdReceivedStamp($envelope)->getId());
+        $this->connection->keepalive($this->findBeanstalkdReceivedStampId($envelope), $seconds);
     }
 
     public function getMessageCount(): int
@@ -89,15 +81,8 @@ class BeanstalkdReceiver implements KeepaliveReceiverInterface, MessageCountAwar
         return $this->connection->getMessageCount();
     }
 
-    private function findBeanstalkdReceivedStamp(Envelope $envelope): BeanstalkdReceivedStamp
+    private function findBeanstalkdReceivedStampId(Envelope $envelope): string
     {
-        /** @var BeanstalkdReceivedStamp|null $beanstalkdReceivedStamp */
-        $beanstalkdReceivedStamp = $envelope->last(BeanstalkdReceivedStamp::class);
-
-        if (null === $beanstalkdReceivedStamp) {
-            throw new LogicException('No BeanstalkdReceivedStamp found on the Envelope.');
-        }
-
-        return $beanstalkdReceivedStamp;
+        return $envelope->last(BeanstalkdReceivedStamp::class)?->getId() ?? throw new LogicException('No BeanstalkdReceivedStamp found on the Envelope.');
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=8.4",
         "pda/pheanstalk": "^5.1|^7.0|^8.0",
-        "symfony/messenger": "^7.4|^8.0"
+        "symfony/messenger": "^8.1"
     },
     "require-dev": {
         "symfony/property-access": "^7.4|^8.0",

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
@@ -58,19 +58,20 @@ class DoctrineReceiverTest extends TestCase
         $this->assertSame(1, $transportMessageIdStamp->getId());
     }
 
-    public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException()
+    public function testItReturnsSerializedEnvelopeWhenDecodingFails()
     {
-        $this->expectException(MessageDecodingFailedException::class);
         $serializer = $this->createStub(PhpSerializer::class);
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
         $doctrineEnvelop = $this->createDoctrineEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('get')->willReturn($doctrineEnvelop);
-        $connection->expects($this->once())->method('reject');
 
         $receiver = new DoctrineReceiver($connection, $serializer);
-        $receiver->get();
+        $envelopes = $receiver->get();
+
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
     public function testOccursRetryableExceptionFromConnection()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
@@ -69,19 +69,19 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
     public function ack(Envelope $envelope): void
     {
         $this->withRetryableExceptionRetry(function () use ($envelope) {
-            $this->connection->ack($this->findDoctrineReceivedStamp($envelope)->getId());
+            $this->connection->ack($this->findDoctrineReceivedStampId($envelope));
         });
     }
 
     public function keepalive(Envelope $envelope, ?int $seconds = null): void
     {
-        $this->connection->keepalive($this->findDoctrineReceivedStamp($envelope)->getId(), $seconds);
+        $this->connection->keepalive($this->findDoctrineReceivedStampId($envelope), $seconds);
     }
 
     public function reject(Envelope $envelope): void
     {
         $this->withRetryableExceptionRetry(function () use ($envelope) {
-            $this->connection->reject($this->findDoctrineReceivedStamp($envelope)->getId());
+            $this->connection->reject($this->findDoctrineReceivedStampId($envelope));
         });
     }
 
@@ -122,37 +122,26 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
         return $this->createEnvelopeFromData($doctrineEnvelope);
     }
 
-    private function findDoctrineReceivedStamp(Envelope $envelope): DoctrineReceivedStamp
+    private function findDoctrineReceivedStampId(Envelope $envelope): string
     {
-        /** @var DoctrineReceivedStamp|null $doctrineReceivedStamp */
-        $doctrineReceivedStamp = $envelope->last(DoctrineReceivedStamp::class);
-
-        if (null === $doctrineReceivedStamp) {
-            throw new LogicException('No DoctrineReceivedStamp found on the Envelope.');
-        }
-
-        return $doctrineReceivedStamp;
+        return $envelope->last(DoctrineReceivedStamp::class)?->getId() ?? throw new LogicException('No DoctrineReceivedStamp found on the Envelope.');
     }
 
     private function createEnvelopeFromData(array $data): Envelope
     {
+        $stamps = [
+            new DoctrineReceivedStamp($data['id']),
+            new TransportMessageIdStamp($data['id']),
+        ];
+
         try {
-            $envelope = $this->serializer->decode([
+            return $this->serializer->decode($data = [
                 'body' => $data['body'],
                 'headers' => $data['headers'],
-            ]);
-        } catch (MessageDecodingFailedException $exception) {
-            $this->connection->reject($data['id']);
-
-            throw $exception;
+            ])->withoutAll(TransportMessageIdStamp::class)->with(...$stamps);
+        } catch (MessageDecodingFailedException $e) {
+            return MessageDecodingFailedException::wrap($data, $e->getMessage(), $e->getCode(), $e)->with(...$stamps);
         }
-
-        return $envelope
-            ->withoutAll(TransportMessageIdStamp::class)
-            ->with(
-                new DoctrineReceivedStamp($data['id']),
-                new TransportMessageIdStamp($data['id'])
-            );
     }
 
     private function withRetryableExceptionRetry(callable $callable): void

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
@@ -53,17 +53,17 @@ class RedisReceiverTest extends TestCase
     #[DataProvider('rejectedRedisEnvelopeProvider')]
     public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException(array $redisEnvelope)
     {
-        $this->expectException(MessageDecodingFailedException::class);
-
         $serializer = $this->createStub(PhpSerializer::class);
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('get')->willReturn($redisEnvelope);
-        $connection->expects($this->once())->method('reject');
 
         $receiver = new RedisReceiver($connection, $serializer);
-        $receiver->get();
+        $envelopes = $receiver->get();
+
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
     public static function redisEnvelopeProvider(): \Generator

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -59,27 +59,29 @@ class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInte
             return [];
         }
 
+        $stamps = [
+            new RedisReceivedStamp($message['id']),
+            new TransportMessageIdStamp($message['id']),
+        ];
+
         try {
             if (\array_key_exists('body', $redisEnvelope) && \array_key_exists('headers', $redisEnvelope)) {
-                $envelope = $this->serializer->decode([
+                $envelope = $this->serializer->decode($redisEnvelope = [
                     'body' => $redisEnvelope['body'],
                     'headers' => $redisEnvelope['headers'],
                 ]);
             } else {
                 $envelope = $this->serializer->decode($redisEnvelope);
             }
-        } catch (MessageDecodingFailedException $exception) {
-            $this->connection->reject($message['id']);
-
-            throw $exception;
+        } catch (MessageDecodingFailedException $e) {
+            return [
+                MessageDecodingFailedException::wrap($redisEnvelope, $e->getMessage(), $e->getCode(), $e)->with(...$stamps),
+            ];
         }
 
-        return [$envelope
-            ->withoutAll(TransportMessageIdStamp::class)
-            ->with(
-                new RedisReceivedStamp($message['id']),
-                new TransportMessageIdStamp($message['id'])
-            )];
+        return [
+            $envelope->withoutAll(TransportMessageIdStamp::class)->with(...$stamps),
+        ];
     }
 
     public function ack(Envelope $envelope): void

--- a/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4",
         "ext-redis": "*",
-        "symfony/messenger": "^7.4|^8.0"
+        "symfony/messenger": "^8.1"
     },
     "require-dev": {
         "symfony/property-access": "^7.4|^8.0",

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.1
 ---
 
+ * Add `DecodeFailedMessageMiddleware` to re-decode failed messages using the transport's serializer
+ * Receivers no longer delete messages on decode failure; they are routed through the normal retry/failure transport path
  * Add regex support for transport name patterns in the `messenger:consume` command
  * Add an idle timeout option to the `BatchHandlerTrait`
 

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
@@ -74,42 +75,26 @@ abstract class AbstractFailedMessagesCommand extends Command
 
         $io->title('Failed Message Details');
 
-        $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
-        $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
+        $messageClass = $envelope->getMessage()::class;
         $lastErrorDetailsStamp = $envelope->last(ErrorDetailsStamp::class);
-        $lastMessageDecodingFailedStamp = $envelope->last(MessageDecodingFailedStamp::class);
+        $lastMessageDecodingFailed = MessageDecodingFailedException::class === $messageClass || $envelope->last(MessageDecodingFailedStamp::class);
 
         $rows = [
-            ['Class', $envelope->getMessage()::class],
+            ['Class', $messageClass],
         ];
 
         if (null !== $id = $this->getMessageId($envelope)) {
             $rows[] = ['Message Id', $id];
         }
 
-        if (null === $sentToFailureTransportStamp) {
+        if (!$sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class)) {
             $errorIo->warning('Message does not appear to have been sent to this transport after failing');
         } else {
-            $failedAt = '';
-            $errorMessage = '';
-            $errorCode = '';
-            $errorClass = '(unknown)';
-
-            if (null !== $lastRedeliveryStamp) {
-                $failedAt = $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s');
-            }
-
-            if (null !== $lastErrorDetailsStamp) {
-                $errorMessage = $lastErrorDetailsStamp->getExceptionMessage();
-                $errorCode = $lastErrorDetailsStamp->getExceptionCode();
-                $errorClass = $lastErrorDetailsStamp->getExceptionClass();
-            }
-
             $rows = array_merge($rows, [
-                ['Failed at', $failedAt],
-                ['Error', $errorMessage],
-                ['Error Code', $errorCode],
-                ['Error Class', $errorClass],
+                ['Failed at', $envelope->last(RedeliveryStamp::class)?->getRedeliveredAt()->format('Y-m-d H:i:s') ?? ''],
+                ['Error', $lastErrorDetailsStamp?->getExceptionMessage() ?? ''],
+                ['Error Code', $lastErrorDetailsStamp?->getExceptionCode() ?? ''],
+                ['Error Class', $lastErrorDetailsStamp?->getExceptionClass() ?? '(unknown)'],
                 ['Transport', $sentToFailureTransportStamp->getOriginalReceiverName()],
             ]);
         }
@@ -125,7 +110,7 @@ abstract class AbstractFailedMessagesCommand extends Command
 
         if ($io->isVeryVerbose()) {
             $io->title('Message:');
-            if (null !== $lastMessageDecodingFailedStamp) {
+            if ($lastMessageDecodingFailed) {
                 $errorIo->error('The message could not be decoded. See below an APPROXIMATIVE representation of the class.');
             }
             $dump = new Dumper($io, null, $this->createCloner());
@@ -134,7 +119,7 @@ abstract class AbstractFailedMessagesCommand extends Command
             $flattenException = $lastErrorDetailsStamp?->getFlattenException();
             $io->writeln(null === $flattenException ? '(no data)' : $dump($flattenException));
         } else {
-            if (null !== $lastMessageDecodingFailedStamp) {
+            if ($lastMessageDecodingFailed) {
                 $errorIo->error('The message could not be decoded.');
             }
             $io->writeln(' Re-run command with <info>-vv</info> to see more message & error details.');

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -25,7 +25,6 @@ use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageSkipEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
@@ -217,10 +216,6 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             $envelope = $messageReceivedEvent->getEnvelope();
 
             $this->displaySingleMessage($envelope, $io, $errorIo);
-
-            if ($envelope->last(MessageDecodingFailedStamp::class)) {
-                throw new \RuntimeException(\sprintf('The message with id "%s" could not decoded, it can only be shown or removed.', $this->getMessageId($envelope) ?? '?'));
-            }
 
             $this->forceExit = true;
             try {

--- a/src/Symfony/Component/Messenger/Exception/MessageDecodingFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/MessageDecodingFailedException.php
@@ -11,9 +11,24 @@
 
 namespace Symfony\Component\Messenger\Exception;
 
+use Symfony\Component\Messenger\Envelope;
+
 /**
  * Thrown when a message cannot be decoded in a serializer.
  */
 class MessageDecodingFailedException extends InvalidArgumentException
 {
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+        public readonly array $encodedEnvelope = [],
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function wrap(array $encodedEnvelope, string $message, int $code = 0, ?\Throwable $previous = null): Envelope
+    {
+        return new Envelope(new self($message, $code, $previous, $encodedEnvelope));
+    }
 }

--- a/src/Symfony/Component/Messenger/Middleware/DecodeFailedMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DecodeFailedMessageMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+/**
+ * Replays the transport serializer when a message could not be decoded initially.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class DecodeFailedMessageMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ContainerInterface $serializerLocator,
+    ) {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $message = $envelope->getMessage();
+
+        if (!$message instanceof MessageDecodingFailedException) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        // When retrying from the failure transport, use the original transport name
+        // so we can look up the correct serializer; fall back to the current ReceivedStamp.
+        $transportName = $envelope->last(SentToFailureTransportStamp::class)?->getOriginalReceiverName()
+            ?? $envelope->last(ReceivedStamp::class)?->getTransportName()
+            ?? throw new LogicException('A ReceivedStamp is required to decode a serialized envelope message.');
+
+        if (!$this->serializerLocator->has($transportName)) {
+            throw new LogicException(\sprintf('No serializer is configured for the "%s" transport.', $transportName));
+        }
+
+        $serializer = $this->serializerLocator->get($transportName);
+        if (!$serializer instanceof SerializerInterface) {
+            throw new LogicException(\sprintf('The serializer configured for the "%s" transport must implement "%s".', $transportName, SerializerInterface::class));
+        }
+
+        $decodedEnvelope = $serializer->decode($message->encodedEnvelope);
+
+        if ($decodedEnvelope->getMessage() instanceof MessageDecodingFailedException) {
+            throw $decodedEnvelope->getMessage();
+        }
+
+        $envelope = $decodedEnvelope->with(...array_merge(...array_values($envelope->all())));
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/FailedMessageProcessingMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/FailedMessageProcessingMiddleware.php
@@ -23,9 +23,7 @@ class FailedMessageProcessingMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         // look for "received" messages decorated with the SentToFailureTransportStamp
-        /** @var SentToFailureTransportStamp|null $sentToFailureStamp */
-        $sentToFailureStamp = $envelope->last(SentToFailureTransportStamp::class);
-        if (null !== $sentToFailureStamp && null !== $envelope->last(ReceivedStamp::class)) {
+        if ($envelope->last(ReceivedStamp::class) && $sentToFailureStamp = $envelope->last(SentToFailureTransportStamp::class)) {
             // mark the message as "received" from the original transport
             // this guarantees the same behavior as when originally received
             $envelope = $envelope->with(new ReceivedStamp($sentToFailureStamp->getOriginalReceiverName()));

--- a/src/Symfony/Component/Messenger/Middleware/RejectRedeliveredMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/RejectRedeliveredMessageMiddleware.php
@@ -33,8 +33,7 @@ class RejectRedeliveredMessageMiddleware implements MiddlewareInterface
 {
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
-        if ($amqpReceivedStamp instanceof AmqpReceivedStamp && $amqpReceivedStamp->getAmqpEnvelope()->isRedelivery()) {
+        if ($envelope->last(AmqpReceivedStamp::class)?->getAmqpEnvelope()->isRedelivery()) {
             throw new RejectRedeliveredMessageException('Redelivered message from AMQP detected that will be rejected and trigger the retry logic.');
         }
 

--- a/src/Symfony/Component/Messenger/Middleware/ValidationMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ValidationMiddleware.php
@@ -29,11 +29,7 @@ class ValidationMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $message = $envelope->getMessage();
-        $groups = null;
-        /** @var ValidationStamp|null $validationStamp */
-        if ($validationStamp = $envelope->last(ValidationStamp::class)) {
-            $groups = $validationStamp->getGroups();
-        }
+        $groups = $envelope->last(ValidationStamp::class)?->getGroups();
 
         $violations = $this->validator->validate($message, null, $groups);
         if (\count($violations)) {

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DecodeFailedMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DecodeFailedMessageMiddlewareTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\AckStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+class DecodeFailedMessageMiddlewareTest extends TestCase
+{
+    public function testItDecodesSerializedEnvelope()
+    {
+        $decodedEnvelope = new Envelope(new DummyMessage('decoded'));
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with(['body' => 'body', 'headers' => ['type' => DummyMessage::class]])
+            ->willReturn($decodedEnvelope);
+
+        $locator = new InMemoryLocator(['async' => $serializer]);
+        $middleware = new DecodeFailedMessageMiddleware($locator);
+
+        $nextMiddleware = new class implements MiddlewareInterface {
+            public ?Envelope $envelope = null;
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                return $this->envelope = $envelope;
+            }
+        };
+
+        $ack = static fn (): bool => true;
+        $envelope = MessageDecodingFailedException::wrap([
+            'body' => 'body',
+            'headers' => ['type' => DummyMessage::class],
+        ], 'Could not decode.')
+            ->with(new ReceivedStamp('async'), new AckStamp($ack));
+
+        $middleware->handle($envelope, new StackMiddleware($nextMiddleware));
+
+        $this->assertInstanceOf(DummyMessage::class, $nextMiddleware->envelope?->getMessage());
+        $this->assertNotNull($nextMiddleware->envelope?->last(AckStamp::class));
+    }
+
+    public function testItUsesOriginalTransportNameWhenRetryingFromFailureTransport()
+    {
+        $decodedEnvelope = new Envelope(new DummyMessage('decoded'));
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with(['body' => 'body', 'headers' => []])
+            ->willReturn($decodedEnvelope);
+
+        // 'async' is the original transport, 'failed' is the failure transport
+        $locator = new InMemoryLocator(['async' => $serializer]);
+        $middleware = new DecodeFailedMessageMiddleware($locator);
+
+        $nextMiddleware = new class implements MiddlewareInterface {
+            public ?Envelope $envelope = null;
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                return $this->envelope = $envelope;
+            }
+        };
+
+        $envelope = MessageDecodingFailedException::wrap(['body' => 'body', 'headers' => []], 'Could not decode.')
+            ->with(
+                new ReceivedStamp('failed'),
+                new SentToFailureTransportStamp('async'),
+            );
+
+        $middleware->handle($envelope, new StackMiddleware($nextMiddleware));
+
+        $this->assertInstanceOf(DummyMessage::class, $nextMiddleware->envelope?->getMessage());
+    }
+
+    public function testItThrowsWhenNoReceivedStampAndNoSentToFailureStamp()
+    {
+        $middleware = new DecodeFailedMessageMiddleware(new InMemoryLocator([]));
+
+        $envelope = MessageDecodingFailedException::wrap(['body' => 'body', 'headers' => []], 'Could not decode.');
+
+        $this->expectException(\Symfony\Component\Messenger\Exception\LogicException::class);
+        $this->expectExceptionMessage('ReceivedStamp');
+        $middleware->handle($envelope, new StackMiddleware());
+    }
+
+    public function testItThrowsWhenDecodingStillFails()
+    {
+        $serializer = $this->createStub(SerializerInterface::class);
+        $serializer->method('decode')->willThrowException(new MessageDecodingFailedException('boom'));
+
+        $middleware = new DecodeFailedMessageMiddleware(new InMemoryLocator(['transport' => $serializer]));
+
+        $envelope = MessageDecodingFailedException::wrap(['body' => 'body', 'headers' => []], 'Could not decode.')
+            ->with(new ReceivedStamp('transport'));
+
+        $this->expectException(MessageDecodingFailedException::class);
+        $middleware->handle($envelope, new StackMiddleware());
+    }
+
+    public function testItIgnoresRegularMessages()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('decode');
+
+        $middleware = new DecodeFailedMessageMiddleware(new InMemoryLocator(['async' => $serializer]));
+
+        $envelope = new Envelope(new DummyMessage('ok'));
+
+        $middleware->handle($envelope, new StackMiddleware());
+    }
+}
+
+class InMemoryLocator implements ContainerInterface
+{
+    /**
+     * @param array<string, object> $services
+     */
+    public function __construct(
+        private array $services,
+    ) {
+    }
+
+    public function get(string $id): mixed
+    {
+        if (!$this->has($id)) {
+            throw new class(\sprintf('Service "%s" not found.', $id)) extends \RuntimeException implements NotFoundExceptionInterface {
+            };
+        }
+
+        return $this->services[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return \array_key_exists($id, $this->services);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -35,46 +35,42 @@ class PhpSerializerTest extends TestCase
     {
         $serializer = $this->createPhpSerializer();
 
-        $this->expectException(MessageDecodingFailedException::class);
-        $this->expectExceptionMessage('Encoded envelope should have at least a "body", or maybe you should implement your own serializer');
+        $envelope = $serializer->decode([]);
 
-        $serializer->decode([]);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testDecodingFailsWithBadFormat()
     {
         $serializer = $this->createPhpSerializer();
 
-        $this->expectException(MessageDecodingFailedException::class);
-        $this->expectExceptionMessageMatches('/Could not decode/');
-
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => '{"message": "bar"}',
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testDecodingFailsWithBadBase64Body()
     {
         $serializer = $this->createPhpSerializer();
 
-        $this->expectException(MessageDecodingFailedException::class);
-        $this->expectExceptionMessageMatches('/Could not decode/');
-
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => 'x',
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testDecodingFailsWithBadClass()
     {
         $serializer = $this->createPhpSerializer();
 
-        $this->expectException(MessageDecodingFailedException::class);
-        $this->expectExceptionMessageMatches('/class "ReceivedSt0mp" not found/');
-
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => 'O:13:"ReceivedSt0mp":0:{}',
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testDecodingFailsForPropertyTypeMismatch()
@@ -84,10 +80,9 @@ class PhpSerializerTest extends TestCase
         // Simulate a change of property type in the code base
         $encodedEnvelope['body'] = str_replace('s:4:\"true\"', 'b:1', $encodedEnvelope['body']);
 
-        $this->expectException(MessageDecodingFailedException::class);
-        $this->expectExceptionMessageMatches('/Could not decode/');
+        $envelope = $serializer->decode($encodedEnvelope);
 
-        $serializer->decode($encodedEnvelope);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testEncodedSkipsNonEncodeableStamps()

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerWithClassNotFoundSupportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerWithClassNotFoundSupportTest.php
@@ -21,13 +21,13 @@ class PhpSerializerWithClassNotFoundSupportTest extends PhpSerializerTest
 {
     public function testDecodingFailsWithBadClass()
     {
-        $this->expectException(MessageDecodingFailedException::class);
-
         $serializer = $this->createPhpSerializer();
 
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => 'O:13:"ReceivedSt0mp":0:{}',
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testDecodingFailsButCreateClassNotFound()
@@ -40,26 +40,8 @@ class PhpSerializerWithClassNotFoundSupportTest extends PhpSerializerTest
 
         $envelope = $serializer->decode($encodedEnvelope);
 
-        $lastMessageDecodingFailedStamp = $envelope->last(MessageDecodingFailedStamp::class);
-        $this->assertInstanceOf(MessageDecodingFailedStamp::class, $lastMessageDecodingFailedStamp);
-        $message = $envelope->getMessage();
-        // The class does not exist, so we cannot use anything else. The only
-        // purpose of this feature is to aim debugging (so dumping value)
-        ob_start();
-        var_dump($message);
-        $content = ob_get_clean();
-        // remove object ID
-        $content = preg_replace('/#\d+/', '', $content);
-        $expected = <<<EOT
-            object(__PHP_Incomplete_Class) (2) {
-              ["__PHP_Incomplete_Class_Name"]=>
-              string(55) "Symfony\Component\Messenger\Tests\Fixtures\OupsyMessage"
-              ["message":"Symfony\Component\Messenger\Tests\Fixtures\OupsyMessage":private]=>
-              string(5) "Hello"
-            }
-
-            EOT;
-        $this->assertEquals($expected, $content);
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $envelope->getMessage());
+        $this->assertNotNull($envelope->last(MessageDecodingFailedStamp::class));
     }
 
     protected function createPhpSerializer(): PhpSerializer

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -178,55 +178,43 @@ class SerializerTest extends TestCase
 
     public function testDecodingFailsWithBadFormat()
     {
-        $this->expectException(MessageDecodingFailedException::class);
-
         $serializer = new Serializer();
 
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => '{foo',
             'headers' => ['type' => 'stdClass'],
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     #[DataProvider('getMissingKeyTests')]
-    public function testDecodingFailsWithMissingKeys(array $data, string $expectedMessage)
+    public function testDecodingFailsWithMissingKeys(array $data)
     {
-        $this->expectException(MessageDecodingFailedException::class);
-        $this->expectExceptionMessage($expectedMessage);
-
         $serializer = new Serializer();
 
-        $serializer->decode($data);
+        $envelope = $serializer->decode($data);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public static function getMissingKeyTests(): iterable
     {
-        yield 'no_body' => [
-            ['headers' => ['type' => 'bar']],
-            'Encoded envelope should have at least a "body" and some "headers", or maybe you should implement your own serializer.',
-        ];
-
-        yield 'no_headers' => [
-            ['body' => '{}'],
-            'Encoded envelope should have at least a "body" and some "headers", or maybe you should implement your own serializer.',
-        ];
-
-        yield 'no_headers_type' => [
-            ['body' => '{}', 'headers' => ['foo' => 'bar']],
-            'Encoded envelope does not have a "type" header.',
-        ];
+        yield 'no_body' => [['headers' => ['type' => 'bar']]];
+        yield 'no_headers' => [['body' => '{}']];
+        yield 'no_headers_type' => [['body' => '{}', 'headers' => ['foo' => 'bar']]];
     }
 
     public function testDecodingFailsWithBadClass()
     {
-        $this->expectException(MessageDecodingFailedException::class);
-
         $serializer = new Serializer();
 
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => '{}',
             'headers' => ['type' => 'NonExistentClass'],
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testEncodedSkipsNonEncodeableStamps()
@@ -245,27 +233,27 @@ class SerializerTest extends TestCase
     {
         $serializer = new Serializer();
 
-        $this->expectException(MessageDecodingFailedException::class);
-
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => '{}',
             'headers' => ['type' => DummySymfonySerializerInvalidConstructor::class],
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testDecodingStampFailedDeserialization()
     {
         $serializer = new Serializer();
 
-        $this->expectException(MessageDecodingFailedException::class);
-
-        $serializer->decode([
+        $envelope = $serializer->decode([
             'body' => '{"message":"hello"}',
             'headers' => [
                 'type' => DummyMessage::class,
                 'X-Message-Stamp-'.SerializerStamp::class => '[{}]',
             ],
         ]);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
     }
 
     public function testEncodeUsesTypeToClassMapForType()

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidMessageSignatureException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
@@ -65,8 +66,9 @@ class SigningSerializerTest extends TestCase
         $envelope = new Envelope(new DummyMessage('hello'));
         $encoded = $inner->encode($envelope);
 
-        $this->expectException(InvalidMessageSignatureException::class);
-        $serializer->decode($encoded);
+        $envelope = $serializer->decode($encoded);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
+        $this->assertInstanceOf(InvalidMessageSignatureException::class, $envelope->getMessage()->getPrevious());
     }
 
     public function testDecodeRejectsInvalidSignature()
@@ -76,8 +78,9 @@ class SigningSerializerTest extends TestCase
         $encoded = $serializer->encode($envelope);
         $encoded['headers']['Body-Sign'] = 'tampered';
 
-        $this->expectException(InvalidMessageSignatureException::class);
-        $serializer->decode($encoded);
+        $envelope = $serializer->decode($encoded);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
+        $this->assertInstanceOf(InvalidMessageSignatureException::class, $envelope->getMessage()->getPrevious());
     }
 
     public function testEncodeSignsWhenSignedTypeIsInterfaceImplementedByMessage()
@@ -95,7 +98,6 @@ class SigningSerializerTest extends TestCase
     public function testDecodeVerifiesWhenSignedTypeIsParentClassOfMessage()
     {
         $serializer = $this->createSerializer([DummyMessage::class]);
-        $inner = new PhpSerializer();
 
         // Encode with signature by using the SigningSerializer against a child instance
         $encoded = $serializer->encode(new Envelope(new ChildDummyMessage('child')));
@@ -103,8 +105,9 @@ class SigningSerializerTest extends TestCase
         // Tamper by removing signature to ensure verification occurs for child type
         unset($encoded['headers']['Body-Sign']);
 
-        $this->expectException(InvalidMessageSignatureException::class);
-        $serializer->decode($encoded);
+        $envelope = $serializer->decode($encoded);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
+        $this->assertInstanceOf(InvalidMessageSignatureException::class, $envelope->getMessage()->getPrevious());
     }
 
     private function createSerializer(array $signedTypes): SerializerInterface

--- a/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
@@ -35,9 +35,9 @@ interface ReceiverInterface
      *
      * If applicable, the Envelope should contain a TransportMessageIdStamp.
      *
-     * If a received message cannot be decoded, the message should not
-     * be retried again (e.g. if there's a queue, it should be removed)
-     * and a MessageDecodingFailedException should be thrown.
+     * If a received message cannot be decoded, the transport should return
+     * an Envelope containing a MessageDecodingFailedException so the worker
+     * can route it through the usual failure handling path.
      *
      * @return iterable<Envelope>
      *

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\Serialization;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
@@ -42,16 +43,32 @@ class PhpSerializer implements SerializerInterface
     public function decode(array $encodedEnvelope): Envelope
     {
         if (empty($encodedEnvelope['body'])) {
-            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body", or maybe you should implement your own serializer.');
+            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Encoded envelope should have at least a "body", or maybe you should implement your own serializer.');
         }
 
         if (!str_ends_with($encodedEnvelope['body'], '}')) {
             $encodedEnvelope['body'] = base64_decode($encodedEnvelope['body']);
         }
 
-        $serializeEnvelope = stripslashes($encodedEnvelope['body']);
+        if ('' === $serializeEnvelope = stripslashes($encodedEnvelope['body'])) {
+            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Encoded envelope should have at least a "body", or maybe you should implement your own serializer.');
+        }
 
-        return $this->safelyUnserialize($serializeEnvelope);
+        try {
+            $envelope = $this->safelyUnserialize($serializeEnvelope);
+
+            if (!$envelope instanceof Envelope) {
+                return MessageDecodingFailedException::wrap($encodedEnvelope, 'Could not decode message into an Envelope.');
+            }
+
+            if ($envelope->getMessage() instanceof \__PHP_Incomplete_Class) {
+                $envelope = $envelope->with(new MessageDecodingFailedStamp());
+            }
+        } catch (\Throwable $e) {
+            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Could not decode Envelope: '.$e->getMessage(), $e->getCode(), $e);
+        }
+
+        return $envelope;
     }
 
     public function encode(Envelope $envelope): array
@@ -69,12 +86,8 @@ class PhpSerializer implements SerializerInterface
         ];
     }
 
-    private function safelyUnserialize(string $contents): Envelope
+    private function safelyUnserialize(string $contents): mixed
     {
-        if ('' === $contents) {
-            throw new MessageDecodingFailedException('Could not decode an empty message using PHP serialization.');
-        }
-
         if ($this->acceptPhpIncompleteClass) {
             $prevUnserializeHandler = ini_set('unserialize_callback_func', null);
         } else {
@@ -89,28 +102,11 @@ class PhpSerializer implements SerializerInterface
         });
 
         try {
-            /** @var Envelope */
-            $envelope = unserialize($contents);
-        } catch (\Throwable $e) {
-            if ($e instanceof MessageDecodingFailedException) {
-                throw $e;
-            }
-
-            throw new MessageDecodingFailedException('Could not decode Envelope: '.$e->getMessage(), 0, $e);
+            return unserialize($contents);
         } finally {
             restore_error_handler();
             ini_set('unserialize_callback_func', $prevUnserializeHandler);
         }
-
-        if (!$envelope instanceof Envelope) {
-            throw new MessageDecodingFailedException('Could not decode message into an Envelope.');
-        }
-
-        if ($envelope->getMessage() instanceof \__PHP_Incomplete_Class) {
-            $envelope = $envelope->with(new MessageDecodingFailedStamp());
-        }
-
-        return $envelope;
     }
 
     /**
@@ -118,6 +114,6 @@ class PhpSerializer implements SerializerInterface
      */
     public static function handleUnserializeCallback(string $class): never
     {
-        throw new MessageDecodingFailedException(\sprintf('Message class "%s" not found during decoding.', $class));
+        throw new InvalidArgumentException(\sprintf('Message class "%s" not found during decoding.', $class));
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -23,7 +23,6 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -83,14 +82,18 @@ class Serializer implements SerializerInterface
     public function decode(array $encodedEnvelope): Envelope
     {
         if (empty($encodedEnvelope['body']) || empty($encodedEnvelope['headers'])) {
-            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body" and some "headers", or maybe you should implement your own serializer.');
+            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Encoded envelope should have at least a "body" and some "headers", or maybe you should implement your own serializer.');
         }
 
         if (empty($encodedEnvelope['headers']['type'])) {
-            throw new MessageDecodingFailedException('Encoded envelope does not have a "type" header.');
+            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Encoded envelope does not have a "type" header.');
         }
 
-        $stamps = $this->decodeStamps($encodedEnvelope);
+        try {
+            $stamps = $this->decodeStamps($encodedEnvelope);
+        } catch (\Throwable $e) {
+            return MessageDecodingFailedException::wrap($encodedEnvelope, $e->getMessage(), (int) $e->getCode(), $e);
+        }
         $stamps[] = new SerializedMessageStamp($encodedEnvelope['body']);
 
         $serializerStamp = $this->findFirstSerializerStamp($stamps);
@@ -105,8 +108,8 @@ class Serializer implements SerializerInterface
 
         try {
             $message = $this->serializer->deserialize($encodedEnvelope['body'], $type, $this->format, $context);
-        } catch (ExceptionInterface $e) {
-            throw new MessageDecodingFailedException('Could not decode message: '.$e->getMessage(), $e->getCode(), $e);
+        } catch (\Throwable $e) {
+            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Could not decode message: '.$e->getMessage(), (int) $e->getCode(), $e);
         }
 
         return new Envelope($message, $stamps);
@@ -115,12 +118,10 @@ class Serializer implements SerializerInterface
     public function encode(Envelope $envelope): array
     {
         $context = $this->context;
-        /** @var SerializerStamp|null $serializerStamp */
         if ($serializerStamp = $envelope->last(SerializerStamp::class)) {
             $context = $serializerStamp->getContext() + $context;
         }
 
-        /** @var SerializedMessageStamp|null $serializedMessageStamp */
         $serializedMessageStamp = $envelope->last(SerializedMessageStamp::class);
 
         $envelope = $envelope->withoutStampsOfType(NonSendableStampInterface::class);
@@ -147,17 +148,10 @@ class Serializer implements SerializerInterface
                 continue;
             }
 
-            try {
-                $stamps[] = $this->serializer->deserialize($value, substr($name, \strlen(self::STAMP_HEADER_PREFIX)).'[]', $this->format, $this->context);
-            } catch (ExceptionInterface $e) {
-                throw new MessageDecodingFailedException('Could not decode stamp: '.$e->getMessage(), $e->getCode(), $e);
-            }
-        }
-        if ($stamps) {
-            $stamps = array_merge(...$stamps);
+            $stamps[] = $this->serializer->deserialize($value, substr($name, \strlen(self::STAMP_HEADER_PREFIX)).'[]', $this->format, $this->context);
         }
 
-        return $stamps;
+        return array_merge(...$stamps);
     }
 
     private function encodeStamps(Envelope $envelope): array

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerInterface.php
@@ -29,6 +29,12 @@ interface SerializerInterface
      * - `body` (string) - the message body
      * - `headers` (string<string>) - a key/value pair of headers
      *
+     * On failure, implementations SHOULD return an Envelope wrapping a
+     * MessageDecodingFailedException instead of throwing, so that the worker
+     * can route the failure through the normal retry/DLQ path. Throwing a
+     * MessageDecodingFailedException is still supported for BC with custom
+     * serializers; transports will wrap the exception as a fallback.
+     *
      * @param array{body: string, headers?: array<string, string>} $encodedEnvelope
      *
      * @throws MessageDecodingFailedException

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Transport\Serialization;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidMessageSignatureException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -54,17 +55,21 @@ final class SigningSerializer implements SerializerInterface
 
         $headers = $encodedEnvelope['headers'] ?? [];
 
-        if (!$sign = $headers['Body-Sign'] ?? null) {
-            throw new InvalidMessageSignatureException(\sprintf('Message "%s" requires a signature but none was found.', $type));
-        }
+        try {
+            if (!$sign = $headers['Body-Sign'] ?? null) {
+                throw new InvalidMessageSignatureException(\sprintf('Message "%s" requires a signature but none was found.', $type));
+            }
 
-        if ($this->algorithm !== $algo = $headers['Sign-Algo'] ?? $this->algorithm) {
-            throw new InvalidMessageSignatureException(\sprintf('Expected "%s" signature algorithm for message "%s", "%s" given.', $this->algorithm, $type, $algo));
-        }
+            if ($this->algorithm !== $algo = $headers['Sign-Algo'] ?? $this->algorithm) {
+                throw new InvalidMessageSignatureException(\sprintf('Expected "%s" signature algorithm for message "%s", "%s" given.', $this->algorithm, $type, $algo));
+            }
 
-        $expected = hash_hmac($algo, $encodedEnvelope['body'] ?? '', $this->signingKey);
-        if (!hash_equals($sign, $expected)) {
-            throw new InvalidMessageSignatureException(\sprintf('Invalid signature for message "%s".', $type));
+            $expected = hash_hmac($algo, $encodedEnvelope['body'] ?? '', $this->signingKey);
+            if (!hash_equals($sign, $expected)) {
+                throw new InvalidMessageSignatureException(\sprintf('Invalid signature for message "%s".', $type));
+            }
+        } catch (\Throwable $e) {
+            return MessageDecodingFailedException::wrap($encodedEnvelope, $e->getMessage(), (int) $e->getCode(), $e);
         }
 
         unset($headers['Body-Sign'], $headers['Sign-Algo']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #44117, also related to #39622
| License       | MIT

Previously, when a transport could not decode a message, `MessageDecodingFailedException` was thrown inside receivers' `get()`, causing the message to be deleted from the queue with no retry or DLQ routing.

This PR routes decode failures through the normal failure-handling path instead of silently losing messages.

This changes a bit the contracts of serializers: they should now return `Envelope<MessageDecodingFailedException>` on decode failure, wrapping the raw encoded envelope. Throwing is still supported for BC with custom serializers - receivers catch and wrap it as a fallback.

A new `DecodeFailedMessageMiddleware` sits early in the default middleware stack (before `failed_message_processing_middleware`). When it encounters an envelope whose message is a `MessageDecodingFailedException`, it:

1. Determines the original transport name to look up the correct serializer.
2. Re-decodes the raw payload; if decoding still fails, the `MessageDecodingFailedException` is thrown so that standard retry/DLQ handling kicks in.
3. If decoding succeeds (e.g. after a deployment that adds the missing class), merges all stamps from the wrapping envelope onto the freshly decoded one and continues through the stack normally.

Receivers no longer delete-then-throw. Instead they yield the wrapped envelope with the same stamps as a successful decode, so `ack()`/`reject()` work correctly downstream. The old catch-and-throw path is kept only as a BC fallback for custom serializers that still throw.

A message that cannot be decoded is therefore no longer lost. It travels through the bus as a `MessageDecodingFailedException`, hits the failure/retry infrastructure like any other failed message, and is automatically retried (triggering `DecodeFailedMessageMiddleware` again) once the serializer or class definition is fixed.