### PR TITLE
[Messenger] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
@@ -29,7 +29,7 @@ class AmazonSqsReceiverTest extends TestCase
         $serializer = $this->createSerializer();
 
         $sqsEnvelop = $this->createSqsEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('get')->willReturn($sqsEnvelop);
 
         $receiver = new AmazonSqsReceiver($connection, $serializer);
@@ -42,7 +42,7 @@ class AmazonSqsReceiverTest extends TestCase
     {
         $this->expectException(MessageDecodingFailedException::class);
 
-        $serializer = $this->createMock(PhpSerializer::class);
+        $serializer = $this->createStub(PhpSerializer::class);
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
         $sqsEnvelop = $this->createSqsEnvelope();

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
@@ -30,7 +30,7 @@ class AmazonSqsSenderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers']);
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);
@@ -48,7 +48,7 @@ class AmazonSqsSenderTest extends TestCase
         $connection->expects($this->once())->method('send')
             ->with($encoded['body'], $encoded['headers'], 0, $stamp->getMessageGroupId(), $stamp->getMessageDeduplicationId());
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);
@@ -66,7 +66,7 @@ class AmazonSqsSenderTest extends TestCase
         $connection->expects($this->once())->method('send')
             ->with($encoded['body'], $encoded['headers'], 0, null, null, $stamp->getTraceId());
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);
@@ -81,7 +81,7 @@ class AmazonSqsSenderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with(base64_encode($encoded['body']), $encoded['headers']);
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\Http\ServerException;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceiver;
@@ -30,21 +29,6 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class AmazonSqsTransportTest extends TestCase
 {
-    private MockObject&Connection $connection;
-    private MockObject&ReceiverInterface $receiver;
-    private MockObject&SenderInterface $sender;
-    private AmazonSqsTransport $transport;
-
-    protected function setUp(): void
-    {
-        $this->connection = $this->createMock(Connection::class);
-        // Mocking the concrete receiver class because mocking multiple interfaces is deprecated
-        $this->receiver = $this->createMock(AmazonSqsReceiver::class);
-        $this->sender = $this->createMock(SenderInterface::class);
-
-        $this->transport = new AmazonSqsTransport($this->connection, null, $this->receiver, $this->sender);
-    }
-
     public function testItIsATransport()
     {
         $transport = $this->getTransport();
@@ -55,8 +39,8 @@ class AmazonSqsTransportTest extends TestCase
     public function testReceivesMessages()
     {
         $transport = $this->getTransport(
-            $serializer = $this->createMock(SerializerInterface::class),
-            $connection = $this->createMock(Connection::class)
+            $serializer = $this->createStub(SerializerInterface::class),
+            $connection = $this->createStub(Connection::class)
         );
 
         $decodedMessage = new DummyMessage('Decoded.');
@@ -83,86 +67,104 @@ class AmazonSqsTransportTest extends TestCase
 
     public function testItCanGetMessagesViaTheReceiver()
     {
+        $receiver = $this->createMock(AmazonSqsReceiver::class);
+        $transport = $this->getTransport(null, null, $receiver);
         $envelopes = [new Envelope(new \stdClass()), new Envelope(new \stdClass())];
-        $this->receiver->expects($this->once())->method('get')->willReturn($envelopes);
-        $this->assertSame($envelopes, $this->transport->get());
+        $receiver->expects($this->once())->method('get')->willReturn($envelopes);
+        $this->assertSame($envelopes, $transport->get());
     }
 
     public function testItCanAcknowledgeAMessageViaTheReceiver()
     {
+        $receiver = $this->createMock(AmazonSqsReceiver::class);
+        $transport = $this->getTransport(null, null, $receiver);
         $envelope = new Envelope(new \stdClass());
-        $this->receiver->expects($this->once())->method('ack')->with($envelope);
-        $this->transport->ack($envelope);
+        $receiver->expects($this->once())->method('ack')->with($envelope);
+        $transport->ack($envelope);
     }
 
     public function testItCanRejectAMessageViaTheReceiver()
     {
+        $receiver = $this->createMock(AmazonSqsReceiver::class);
+        $transport = $this->getTransport(null, null, $receiver);
         $envelope = new Envelope(new \stdClass());
-        $this->receiver->expects($this->once())->method('reject')->with($envelope);
-        $this->transport->reject($envelope);
+        $receiver->expects($this->once())->method('reject')->with($envelope);
+        $transport->reject($envelope);
     }
 
     public function testItCanGetMessageCountViaTheReceiver()
     {
+        $receiver = $this->createMock(AmazonSqsReceiver::class);
+        $transport = $this->getTransport(null, null, $receiver);
         $messageCount = 15;
-        $this->receiver->expects($this->once())->method('getMessageCount')->willReturn($messageCount);
-        $this->assertSame($messageCount, $this->transport->getMessageCount());
+        $receiver->expects($this->once())->method('getMessageCount')->willReturn($messageCount);
+        $this->assertSame($messageCount, $transport->getMessageCount());
     }
 
     public function testItCanSendAMessageViaTheSender()
     {
+        $sender = $this->createMock(SenderInterface::class);
+        $transport = $this->getTransport(null, null, null, $sender);
         $envelope = new Envelope(new \stdClass());
-        $this->sender->expects($this->once())->method('send')->with($envelope)->willReturn($envelope);
-        $this->assertSame($envelope, $this->transport->send($envelope));
+        $sender->expects($this->once())->method('send')->with($envelope)->willReturn($envelope);
+        $this->assertSame($envelope, $transport->send($envelope));
     }
 
     public function testItCanSetUpTheConnection()
     {
-        $this->connection->expects($this->once())->method('setup');
-        $this->transport->setup();
+        $connection = $this->createMock(Connection::class);
+        $transport = $this->getTransport(null, $connection);
+        $connection->expects($this->once())->method('setup');
+        $transport->setup();
     }
 
     public function testItConvertsHttpExceptionDuringSetupIntoTransportException()
     {
-        $this->connection
+        $connection = $this->createMock(Connection::class);
+        $transport = $this->getTransport(null, $connection);
+        $connection
             ->expects($this->once())
             ->method('setup')
             ->willThrowException($this->createHttpException());
 
         $this->expectException(TransportException::class);
 
-        $this->transport->setup();
+        $transport->setup();
     }
 
     public function testItCanResetTheConnection()
     {
-        $this->connection->expects($this->once())->method('reset');
-        $this->transport->reset();
+        $connection = $this->createMock(Connection::class);
+        $transport = $this->getTransport(null, $connection);
+        $connection->expects($this->once())->method('reset');
+        $transport->reset();
     }
 
     public function testItConvertsHttpExceptionDuringResetIntoTransportException()
     {
-        $this->connection
+        $connection = $this->createMock(Connection::class);
+        $transport = $this->getTransport(null, $connection);
+        $connection
             ->expects($this->once())
             ->method('reset')
             ->willThrowException($this->createHttpException());
 
         $this->expectException(TransportException::class);
 
-        $this->transport->reset();
+        $transport->reset();
     }
 
-    private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null)
+    private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null, ?ReceiverInterface $receiver = null, ?SenderInterface $sender = null)
     {
-        $serializer ??= $this->createMock(SerializerInterface::class);
-        $connection ??= $this->createMock(Connection::class);
+        $serializer ??= $this->createStub(SerializerInterface::class);
+        $connection ??= $this->createStub(Connection::class);
 
-        return new AmazonSqsTransport($connection, $serializer);
+        return new AmazonSqsTransport($connection, $serializer, $receiver, $sender);
     }
 
     private function createHttpException(): HttpException
     {
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('getInfo')->willReturnCallback(static function (?string $type = null) {
             $info = [
                 'http_code' => 500,

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -23,7 +23,6 @@ use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ConnectionTest extends TestCase
 {
@@ -46,7 +45,7 @@ class ConnectionTest extends TestCase
         $awsKey = 'some_aws_access_key_value';
         $awsSecret = 'some_aws_secret_value';
         $region = 'eu-west-1';
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => $region, 'accessKeyId' => $awsKey, 'accessKeySecret' => $awsSecret], null, $httpClient)),
             Connection::fromDsn('sqs://default/queue', [
@@ -63,7 +62,7 @@ class ConnectionTest extends TestCase
         $awsSecret = 'some_aws_secret_value';
         $sessionToken = 'some_aws_sessionToken';
         $region = 'eu-west-1';
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => $region, 'accessKeyId' => $awsKey, 'accessKeySecret' => $awsSecret, 'sessionToken' => $sessionToken], null, $httpClient)),
             Connection::fromDsn('sqs://default/queue', [
@@ -85,7 +84,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsn()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://default/queue', [], $httpClient)
@@ -94,7 +93,7 @@ class ConnectionTest extends TestCase
 
     public function testDsnPrecedence()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue_dsn'], new SqsClient(['region' => 'us-east-2', 'accessKeyId' => 'key_dsn', 'accessKeySecret' => 'secret_dsn'], null, $httpClient)),
             Connection::fromDsn('sqs://key_dsn:secret_dsn@default/queue_dsn?region=us-east-2', ['region' => 'eu-west-3', 'queue_name' => 'queue_options', 'access_key' => 'key_option', 'secret_key' => 'secret_option'], $httpClient)
@@ -103,7 +102,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithRegion()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'us-west-2', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://default/queue?region=us-west-2', [], $httpClient)
@@ -112,7 +111,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnAsQueueUrl()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'ab1-MyQueue-A2BCDEF3GHI4', 'account' => '123456789012'], new SqsClient(['region' => 'us-east-2', 'endpoint' => 'https://sqs.us-east-2.amazonaws.com', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient), 'https://sqs.us-east-2.amazonaws.com/123456789012/ab1-MyQueue-A2BCDEF3GHI4'),
             Connection::fromDsn('https://sqs.us-east-2.amazonaws.com/123456789012/ab1-MyQueue-A2BCDEF3GHI4', [], $httpClient)
@@ -121,7 +120,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithCustomEndpoint()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://localhost/queue', [], $httpClient)
@@ -130,7 +129,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithSslMode()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://localhost/queue?sslmode=disable', [], $httpClient)
@@ -139,7 +138,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithSslModeOnDefault()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://default/queue?sslmode=disable', [], $httpClient)
@@ -148,7 +147,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithCustomEndpointAndPort()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'https://localhost:1234', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://localhost:1234/queue', [], $httpClient)
@@ -157,7 +156,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithOptions()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['account' => '213', 'queue_name' => 'queue', 'buffer_size' => 1, 'wait_time' => 5, 'auto_setup' => false], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://default/213/queue', ['buffer_size' => 1, 'wait_time' => 5, 'auto_setup' => false], $httpClient)
@@ -166,7 +165,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithQueryOptions()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
         $this->assertEquals(
             new Connection(['account' => '213', 'queue_name' => 'queue', 'buffer_size' => 1, 'wait_time' => 5, 'auto_setup' => false], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://default/213/queue?buffer_size=1&wait_time=5&auto_setup=0', [], $httpClient)
@@ -175,7 +174,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithQueueNameOption()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
 
         $this->assertEquals(
             new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
@@ -190,7 +189,7 @@ class ConnectionTest extends TestCase
 
     public function testFromDsnWithAccountAndEndpointOption()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
 
         $this->assertEquals(
             new Connection(['account' => 12345], new SqsClient(['endpoint' => 'https://custom-endpoint.tld', 'region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
@@ -272,8 +271,8 @@ class ConnectionTest extends TestCase
         $this->expectException(HttpException::class);
         $this->expectExceptionMessage('SQS error happens');
 
-        $client = $this->createMock(SqsClient::class);
-        $client->expects($this->any())
+        $client = $this->createStub(SqsClient::class);
+        $client
             ->method('getQueueUrl')
             ->with(['QueueName' => 'queue', 'QueueOwnerAWSAccountId' => 123])
             ->willReturn(ResultMockFactory::createFailing(GetQueueUrlResult::class, 400, 'SQS error happens'));

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceivedStampTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceivedStampTest.php
@@ -21,7 +21,7 @@ class AmqpReceivedStampTest extends TestCase
 {
     public function testStamp()
     {
-        $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
+        $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
 
         $stamp = new AmqpReceivedStamp($amqpEnvelope, 'queueName');
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -36,7 +36,7 @@ class AmqpReceiverTest extends TestCase
         );
 
         $amqpEnvelope = $this->createAMQPEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
 
@@ -49,9 +49,9 @@ class AmqpReceiverTest extends TestCase
     public function testItThrowsATransportExceptionIfItCannotAcknowledgeMessage()
     {
         $this->expectException(TransportException::class);
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $amqpEnvelope = $this->createAMQPEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
         $connection->method('ack')->with($amqpEnvelope, 'queueName')->willThrowException(new \AMQPException());
@@ -63,9 +63,9 @@ class AmqpReceiverTest extends TestCase
     public function testItThrowsATransportExceptionIfItCannotRejectMessage()
     {
         $this->expectException(TransportException::class);
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $amqpEnvelope = $this->createAMQPEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
         $connection->method('nack')->with($amqpEnvelope, 'queueName', \AMQP_NOPARAM)->willThrowException(new \AMQPException());
@@ -76,7 +76,7 @@ class AmqpReceiverTest extends TestCase
 
     private function createAMQPEnvelope(): \AMQPEnvelope
     {
-        $envelope = $this->createMock(\AMQPEnvelope::class);
+        $envelope = $this->createStub(\AMQPEnvelope::class);
         $envelope->method('getBody')->willReturn('{"message": "Hi"}');
         $envelope->method('getHeaders')->willReturn([
             'type' => DummyMessage::class,

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
@@ -30,7 +30,7 @@ class AmqpSenderTest extends TestCase
         $envelope = new Envelope(new DummyMessage('Oy'));
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
@@ -45,7 +45,7 @@ class AmqpSenderTest extends TestCase
         $envelope = (new Envelope(new DummyMessage('Oy')))->with($stamp = new AmqpStamp('rk'));
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
@@ -60,7 +60,7 @@ class AmqpSenderTest extends TestCase
         $envelope = new Envelope(new DummyMessage('Oy'));
         $encoded = ['body' => '...'];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
@@ -75,7 +75,7 @@ class AmqpSenderTest extends TestCase
         $envelope = new Envelope(new DummyMessage('Oy'));
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class, 'Content-Type' => 'application/json']];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
@@ -92,7 +92,7 @@ class AmqpSenderTest extends TestCase
         $envelope = (new Envelope(new DummyMessage('Oy')))->with($stamp = new AmqpStamp('rk', \AMQP_NOPARAM, ['content_type' => 'custom']));
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class, 'Content-Type' => 'application/json']];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
@@ -109,10 +109,10 @@ class AmqpSenderTest extends TestCase
         $envelope = new Envelope(new DummyMessage('Oy'));
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('publish')->with($encoded['body'], $encoded['headers'])->willThrowException(new \AMQPException());
 
         $sender = new AmqpSender($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpStampTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpStampTest.php
@@ -37,7 +37,7 @@ class AmqpStampTest extends TestCase
 
     public function testCreateFromAmqpEnvelope()
     {
-        $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
+        $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
         $amqpEnvelope->method('getRoutingKey')->willReturn('routingkey');
         $amqpEnvelope->method('getDeliveryMode')->willReturn(2);
         $amqpEnvelope->method('getPriority')->willReturn(5);
@@ -56,7 +56,7 @@ class AmqpStampTest extends TestCase
 
     public function testCreateFromAmqpEnvelopeWithPreviousStamp()
     {
-        $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
+        $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
         $amqpEnvelope->method('getRoutingKey')->willReturn('routingkey');
         $amqpEnvelope->method('getDeliveryMode')->willReturn(2);
         $amqpEnvelope->method('getPriority')->willReturn(5);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportFactoryTest.php
@@ -34,7 +34,7 @@ class AmqpTransportFactoryTest extends TestCase
     public function testItCreatesTheTransport()
     {
         $factory = new AmqpTransportFactory();
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
 
         $expectedTransport = new AmqpTransport(Connection::fromDsn('amqp://localhost', ['host' => 'localhost']), $serializer);
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
@@ -34,13 +34,13 @@ class AmqpTransportTest extends TestCase
     public function testReceivesMessages()
     {
         $transport = $this->getTransport(
-            $serializer = $this->createMock(SerializerInterface::class),
-            $connection = $this->createMock(Connection::class)
+            $serializer = $this->createStub(SerializerInterface::class),
+            $connection = $this->createStub(Connection::class)
         );
 
         $decodedMessage = new DummyMessage('Decoded.');
 
-        $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
+        $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
         $amqpEnvelope->method('getBody')->willReturn('body');
         $amqpEnvelope->method('getHeaders')->willReturn(['my' => 'header']);
 
@@ -54,8 +54,8 @@ class AmqpTransportTest extends TestCase
 
     private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null): AmqpTransport
     {
-        $serializer ??= $this->createMock(SerializerInterface::class);
-        $connection ??= $this->createMock(Connection::class);
+        $serializer ??= $this->createStub(SerializerInterface::class);
+        $connection ??= $this->createStub(Connection::class);
 
         return new AmqpTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -149,8 +149,8 @@ class ConnectionTest extends TestCase
     public function testSetsParametersOnTheQueueAndExchange()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
             $amqpQueue = $this->createMock(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
@@ -232,8 +232,8 @@ class ConnectionTest extends TestCase
         $factory = new TestAmqpFactory(
             $amqpConnection = $this->createMock(\AMQPConnection::class),
             $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $amqpExchange = $this->createMock(\AMQPExchange::class)
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
+            $amqpExchange = $this->createStub(\AMQPExchange::class)
         );
 
         // makes sure the channel looks connected, so it's not re-created
@@ -249,8 +249,8 @@ class ConnectionTest extends TestCase
         $factory = new TestAmqpFactory(
             $amqpConnection = $this->createMock(\AMQPConnection::class),
             $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $amqpExchange = $this->createMock(\AMQPExchange::class)
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
+            $amqpExchange = $this->createStub(\AMQPExchange::class)
         );
 
         // makes sure the channel looks connected, so it's not re-created
@@ -264,8 +264,8 @@ class ConnectionTest extends TestCase
     public function testItSetupsTheConnectionWithDefaults()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
             $amqpQueue = $this->createMock(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
@@ -281,13 +281,13 @@ class ConnectionTest extends TestCase
 
     public function testItSetupsTheConnection()
     {
-        $amqpConnection = $this->createMock(\AMQPConnection::class);
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpConnection = $this->createStub(\AMQPConnection::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
         $amqpExchange = $this->createMock(\AMQPExchange::class);
         $amqpQueue0 = $this->createMock(\AMQPQueue::class);
         $amqpQueue1 = $this->createMock(\AMQPQueue::class);
 
-        $factory = $this->createMock(AmqpFactory::class);
+        $factory = $this->createStub(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
         $factory->method('createExchange')->willReturn($amqpExchange);
@@ -336,13 +336,13 @@ class ConnectionTest extends TestCase
 
     public function testItSetupsTheTTLConnection()
     {
-        $amqpConnection = $this->createMock(\AMQPConnection::class);
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpConnection = $this->createStub(\AMQPConnection::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
         $amqpExchange = $this->createMock(\AMQPExchange::class);
         $amqpQueue0 = $this->createMock(\AMQPQueue::class);
         $amqpQueue1 = $this->createMock(\AMQPQueue::class);
 
-        $factory = $this->createMock(AmqpFactory::class);
+        $factory = $this->createStub(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
         $factory->method('createExchange')->willReturn($amqpExchange);
@@ -391,12 +391,12 @@ class ConnectionTest extends TestCase
 
     public function testBindingArguments()
     {
-        $amqpConnection = $this->createMock(\AMQPConnection::class);
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpConnection = $this->createStub(\AMQPConnection::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
         $amqpExchange = $this->createMock(\AMQPExchange::class);
         $amqpQueue = $this->createMock(\AMQPQueue::class);
 
-        $factory = $this->createMock(AmqpFactory::class);
+        $factory = $this->createStub(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
         $factory->method('createExchange')->willReturn($amqpExchange);
@@ -417,8 +417,8 @@ class ConnectionTest extends TestCase
     public function testItCanDisableTheSetup()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
             $amqpQueue = $this->createMock(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
@@ -440,8 +440,8 @@ class ConnectionTest extends TestCase
     public function testItSetupQueuesOnce()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
             $amqpQueue = $this->createMock(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
@@ -457,17 +457,17 @@ class ConnectionTest extends TestCase
 
     public function testAutoSetupWithDelayDeclaresExchangeQueuesAndDelay()
     {
-        $amqpConnection = $this->createMock(\AMQPConnection::class);
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpConnection = $this->createStub(\AMQPConnection::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
 
-        $factory = $this->createMock(AmqpFactory::class);
+        $factory = $this->createStub(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
 
         $amqpQueue = $this->createMock(\AMQPQueue::class);
         $factory
             ->method('createQueue')
-            ->willReturn($amqpQueue, $this->createMock(\AMQPQueue::class));
+            ->willReturn($amqpQueue, $this->createStub(\AMQPQueue::class));
 
         $amqpExchange = $this->createMock(\AMQPExchange::class);
         $delayExchange = $this->createMock(\AMQPExchange::class);
@@ -504,8 +504,8 @@ class ConnectionTest extends TestCase
     public function testItPublishesImmediatelyWithNegativeDelay()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
             $amqpQueue = $this->createMock(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
@@ -539,25 +539,25 @@ class ConnectionTest extends TestCase
             ->with('{}', 'delay_messages__5000_retry', \AMQP_NOPARAM);
         $connection = $this->createDelayOrRetryConnection($delayExchange, '', 'delay_messages__5000_retry');
 
-        $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
+        $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
         $amqpStamp = AmqpStamp::createFromAmqpEnvelope($amqpEnvelope, null, '');
         $connection->publish('{}', [], 5000, $amqpStamp);
     }
 
     public function testItDelaysTheMessageWithADifferentRoutingKeyAndTTLs()
     {
-        $amqpConnection = $this->createMock(\AMQPConnection::class);
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpConnection = $this->createStub(\AMQPConnection::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
 
-        $factory = $this->createMock(AmqpFactory::class);
+        $factory = $this->createStub(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
 
         $delayQueue = $this->createMock(\AMQPQueue::class);
-        $factory->method('createQueue')->willReturn($this->createMock(\AMQPQueue::class), $delayQueue);
+        $factory->method('createQueue')->willReturn($this->createStub(\AMQPQueue::class), $delayQueue);
 
         $delayExchange = $this->createMock(\AMQPExchange::class);
-        $factory->method('createExchange')->willReturn($this->createMock(\AMQPExchange::class), $delayExchange);
+        $factory->method('createExchange')->willReturn($this->createStub(\AMQPExchange::class), $delayExchange);
 
         $connectionOptions = [
             'retry' => [
@@ -587,10 +587,10 @@ class ConnectionTest extends TestCase
         $this->expectException(\AMQPException::class);
         $this->expectExceptionMessage('Could not connect to the AMQP server. Please verify the provided DSN.');
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $amqpExchange = $this->createMock(\AMQPExchange::class)
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
+            $amqpExchange = $this->createStub(\AMQPExchange::class)
         );
 
         $amqpConnection->method('connect')->willThrowException(
@@ -607,10 +607,10 @@ class ConnectionTest extends TestCase
         $this->expectExceptionMessage('No CA certificate has been provided. Set "amqp.cacert" in your php.ini or pass the "cacert" parameter in the DSN to use SSL. Alternatively, you can use amqp:// to use without SSL.');
 
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $amqpExchange = $this->createMock(\AMQPExchange::class)
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
+            $amqpExchange = $this->createStub(\AMQPExchange::class)
         );
 
         $oldCaCertValue = ini_set('amqp.cacert', '');
@@ -625,9 +625,9 @@ class ConnectionTest extends TestCase
     public function testAmqpStampHeadersAreUsed()
     {
         $factory = new TestAmqpFactory(
-            $this->createMock(\AMQPConnection::class),
-            $this->createMock(\AMQPChannel::class),
-            $this->createMock(\AMQPQueue::class),
+            $this->createStub(\AMQPConnection::class),
+            $this->createStub(\AMQPChannel::class),
+            $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -640,9 +640,9 @@ class ConnectionTest extends TestCase
     public function testAmqpStampDeliveryModeIsUsed()
     {
         $factory = new TestAmqpFactory(
-            $this->createMock(\AMQPConnection::class),
-            $this->createMock(\AMQPChannel::class),
-            $this->createMock(\AMQPQueue::class),
+            $this->createStub(\AMQPConnection::class),
+            $this->createStub(\AMQPChannel::class),
+            $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -655,9 +655,9 @@ class ConnectionTest extends TestCase
     public function testItCanPublishWithTheDefaultRoutingKey()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -670,9 +670,9 @@ class ConnectionTest extends TestCase
     public function testItCanPublishWithASuppliedRoutingKey()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -684,18 +684,18 @@ class ConnectionTest extends TestCase
 
     public function testItDelaysTheMessageWithTheInitialSuppliedRoutingKeyAsArgument()
     {
-        $amqpConnection = $this->createMock(\AMQPConnection::class);
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpConnection = $this->createStub(\AMQPConnection::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
 
-        $factory = $this->createMock(AmqpFactory::class);
+        $factory = $this->createStub(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
 
         $delayQueue = $this->createMock(\AMQPQueue::class);
-        $factory->method('createQueue')->willReturn($this->createMock(\AMQPQueue::class), $delayQueue);
+        $factory->method('createQueue')->willReturn($this->createStub(\AMQPQueue::class), $delayQueue);
 
         $delayExchange = $this->createMock(\AMQPExchange::class);
-        $factory->method('createExchange')->willReturn($this->createMock(\AMQPExchange::class), $delayExchange);
+        $factory->method('createExchange')->willReturn($this->createStub(\AMQPExchange::class), $delayExchange);
 
         $connectionOptions = [
             'retry' => [
@@ -723,9 +723,9 @@ class ConnectionTest extends TestCase
     public function testItCanPublishWithCustomFlagsAndAttributes()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -743,10 +743,10 @@ class ConnectionTest extends TestCase
     public function testItPublishMessagesWithoutWaitingForConfirmation()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
             $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $amqpExchange = $this->createMock(\AMQPExchange::class)
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
+            $amqpExchange = $this->createStub(\AMQPExchange::class)
         );
 
         $amqpChannel->expects($this->never())->method('waitForConfirm')->with(0.5);
@@ -758,10 +758,10 @@ class ConnectionTest extends TestCase
     public function testSetChannelToConfirmMessage()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
             $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $amqpExchange = $this->createMock(\AMQPExchange::class)
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
+            $amqpExchange = $this->createStub(\AMQPExchange::class)
         );
 
         $amqpChannel->expects($this->once())->method('confirmSelect');
@@ -773,10 +773,10 @@ class ConnectionTest extends TestCase
     public function testItCanPublishAndWaitForConfirmation()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
             $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
-            $amqpExchange = $this->createMock(\AMQPExchange::class)
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
+            $amqpExchange = $this->createStub(\AMQPExchange::class)
         );
 
         $amqpChannel->expects($this->once())->method('waitForConfirm')->with(0.5);
@@ -809,9 +809,9 @@ class ConnectionTest extends TestCase
     public function testItCanRetryPublishWhenAMQPConnectionExceptionIsThrown()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -829,9 +829,9 @@ class ConnectionTest extends TestCase
     public function testItCanRetryPublishWithDelayWhenAMQPConnectionExceptionIsThrown()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -849,9 +849,9 @@ class ConnectionTest extends TestCase
     public function testItWillRetryMaxThreeTimesWhenAMQPConnectionExceptionIsThrown()
     {
         $factory = new TestAmqpFactory(
-            $amqpConnection = $this->createMock(\AMQPConnection::class),
-            $amqpChannel = $this->createMock(\AMQPChannel::class),
-            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpConnection = $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createStub(\AMQPChannel::class),
+            $amqpQueue = $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -875,16 +875,16 @@ class ConnectionTest extends TestCase
 
     private function createDelayOrRetryConnection(\AMQPExchange $delayExchange, string $deadLetterExchangeName, string $delayQueueName): Connection
     {
-        $amqpConnection = $this->createMock(\AMQPConnection::class);
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpConnection = $this->createStub(\AMQPConnection::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
 
-        $factory = $this->createMock(AmqpFactory::class);
+        $factory = $this->createStub(AmqpFactory::class);
         $factory->method('createConnection')->willReturn($amqpConnection);
         $factory->method('createChannel')->willReturn($amqpChannel);
 
         $delayQueue = $this->createMock(\AMQPQueue::class);
-        $factory->method('createQueue')->willReturn($this->createMock(\AMQPQueue::class), $delayQueue);
-        $factory->method('createExchange')->willReturn($this->createMock(\AMQPExchange::class), $delayExchange);
+        $factory->method('createQueue')->willReturn($this->createStub(\AMQPQueue::class), $delayQueue);
+        $factory->method('createExchange')->willReturn($this->createStub(\AMQPExchange::class), $delayExchange);
 
         $delayQueue->expects($this->once())->method('setName')->with($delayQueueName);
         $delayQueue->expects($this->once())->method('setArguments')->with([

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdSenderTest.php
@@ -33,7 +33,7 @@ final class BeanstalkdSenderTest extends TestCase
             ->willReturn('1')
         ;
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new BeanstalkdSender($connection, $serializer);
@@ -53,7 +53,7 @@ final class BeanstalkdSenderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'], 500);
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new BeanstalkdSender($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdTransportFactoryTest.php
@@ -30,7 +30,7 @@ final class BeanstalkdTransportFactoryTest extends TestCase
     public function testCreateTransport()
     {
         $factory = new BeanstalkdTransportFactory();
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
 
         $this->assertEquals(
             new BeanstalkdTransport(Connection::fromDsn('beanstalkd://127.0.0.1'), $serializer),

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdTransportTest.php
@@ -31,8 +31,8 @@ final class BeanstalkdTransportTest extends TestCase
     public function testReceivesMessages()
     {
         $transport = $this->getTransport(
-            $serializer = $this->createMock(SerializerInterface::class),
-            $connection = $this->createMock(Connection::class)
+            $serializer = $this->createStub(SerializerInterface::class),
+            $connection = $this->createStub(Connection::class)
         );
 
         $decodedMessage = new DummyMessage('Decoded.');
@@ -52,8 +52,8 @@ final class BeanstalkdTransportTest extends TestCase
 
     private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null): BeanstalkdTransport
     {
-        $serializer ??= $this->createMock(SerializerInterface::class);
-        $connection ??= $this->createMock(Connection::class);
+        $serializer ??= $this->createStub(SerializerInterface::class);
+        $connection ??= $this->createStub(Connection::class);
 
         return new BeanstalkdTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
@@ -39,7 +39,7 @@ class DoctrineReceiverTest extends TestCase
         $serializer = $this->createSerializer();
 
         $doctrineEnvelope = $this->createDoctrineEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('get')->willReturn($doctrineEnvelope);
 
         $receiver = new DoctrineReceiver($connection, $serializer);
@@ -63,7 +63,7 @@ class DoctrineReceiverTest extends TestCase
     public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException()
     {
         $this->expectException(MessageDecodingFailedException::class);
-        $serializer = $this->createMock(PhpSerializer::class);
+        $serializer = $this->createStub(PhpSerializer::class);
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
         $doctrineEnvelop = $this->createDoctrineEnvelope();
@@ -78,7 +78,7 @@ class DoctrineReceiverTest extends TestCase
     public function testOccursRetryableExceptionFromConnection()
     {
         $serializer = $this->createSerializer();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $driverException = class_exists(Exception::class) ? Exception::new(new \PDOException('Deadlock', 40001)) : new PDOException(new \PDOException('Deadlock', 40001));
         if (!class_exists(Version::class)) {
             // This is doctrine/dbal 3.x
@@ -107,7 +107,7 @@ class DoctrineReceiverTest extends TestCase
         $serializer = $this->createSerializer();
 
         $doctrineEnvelope = $this->createRetriedDoctrineEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('get')->willReturn($doctrineEnvelope);
 
         $receiver = new DoctrineReceiver($connection, $serializer);
@@ -125,7 +125,7 @@ class DoctrineReceiverTest extends TestCase
 
         $doctrineEnvelope1 = $this->createDoctrineEnvelope();
         $doctrineEnvelope2 = $this->createDoctrineEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('findAll')->with(50)->willReturn([$doctrineEnvelope1, $doctrineEnvelope2]);
 
         $receiver = new DoctrineReceiver($connection, $serializer);
@@ -140,7 +140,7 @@ class DoctrineReceiverTest extends TestCase
 
         $doctrineEnvelope1 = $this->createRetriedDoctrineEnvelope();
         $doctrineEnvelope2 = $this->createRetriedDoctrineEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('findAll')->willReturn([$doctrineEnvelope1, $doctrineEnvelope2]);
 
         $receiver = new DoctrineReceiver($connection, $serializer);
@@ -157,7 +157,7 @@ class DoctrineReceiverTest extends TestCase
         $serializer = $this->createSerializer();
 
         $doctrineEnvelope = $this->createDoctrineEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('find')->with(10)->willReturn($doctrineEnvelope);
 
         $receiver = new DoctrineReceiver($connection, $serializer);
@@ -170,7 +170,7 @@ class DoctrineReceiverTest extends TestCase
         $serializer = $this->createSerializer();
 
         $doctrineEnvelope = $this->createRetriedDoctrineEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('find')->with(3)->willReturn($doctrineEnvelope);
 
         $receiver = new DoctrineReceiver($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineSenderTest.php
@@ -30,7 +30,7 @@ class DoctrineSenderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'])->willReturn('15');
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new DoctrineSender($connection, $serializer);
@@ -50,7 +50,7 @@ class DoctrineSenderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'], 500);
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new DoctrineSender($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportFactoryTest.php
@@ -32,7 +32,7 @@ class DoctrineTransportFactoryTest extends TestCase
     public function testSupports()
     {
         $factory = new DoctrineTransportFactory(
-            $this->createMock(ConnectionRegistry::class)
+            $this->createStub(ConnectionRegistry::class)
         );
 
         $this->assertTrue($factory->supports('doctrine://default', []));
@@ -41,10 +41,10 @@ class DoctrineTransportFactoryTest extends TestCase
 
     public function testCreateTransport()
     {
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
-        $schemaManager = $this->createMock(AbstractSchemaManager::class);
-        $schemaConfig = $this->createMock(SchemaConfig::class);
-        $platform = $this->createMock(AbstractPlatform::class);
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
+        $schemaManager = $this->createStub(AbstractSchemaManager::class);
+        $schemaConfig = $this->createStub(SchemaConfig::class);
+        $platform = $this->createStub(AbstractPlatform::class);
         $schemaManager->method('createSchemaConfig')->willReturn($schemaConfig);
         $driverConnection->method(
             method_exists(\Doctrine\DBAL\Connection::class, 'createSchemaManager')
@@ -59,7 +59,7 @@ class DoctrineTransportFactoryTest extends TestCase
             ->willReturn($driverConnection);
 
         $factory = new DoctrineTransportFactory($registry);
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
 
         $this->assertEquals(
             new DoctrineTransport(new Connection(PostgreSqlConnection::buildConfiguration('doctrine://default'), $driverConnection), $serializer),
@@ -69,10 +69,10 @@ class DoctrineTransportFactoryTest extends TestCase
 
     public function testCreateTransportNotifyWithPostgreSQLPlatform()
     {
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
-        $schemaManager = $this->createMock(AbstractSchemaManager::class);
-        $schemaConfig = $this->createMock(SchemaConfig::class);
-        $platform = $this->createMock(PostgreSQLPlatform::class);
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
+        $schemaManager = $this->createStub(AbstractSchemaManager::class);
+        $schemaConfig = $this->createStub(SchemaConfig::class);
+        $platform = $this->createStub(PostgreSQLPlatform::class);
         $schemaManager->method('createSchemaConfig')->willReturn($schemaConfig);
         $driverConnection->method(
             method_exists(\Doctrine\DBAL\Connection::class, 'createSchemaManager')
@@ -88,7 +88,7 @@ class DoctrineTransportFactoryTest extends TestCase
             ->willReturn($driverConnection);
 
         $factory = new DoctrineTransportFactory($registry);
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
 
         $this->assertEquals(
             new DoctrineTransport(new PostgreSqlConnection(PostgreSqlConnection::buildConfiguration('doctrine://default'), $driverConnection), $serializer),
@@ -108,6 +108,6 @@ class DoctrineTransportFactoryTest extends TestCase
             });
 
         $factory = new DoctrineTransportFactory($registry);
-        $factory->createTransport('doctrine://default', [], $this->createMock(SerializerInterface::class));
+        $factory->createTransport('doctrine://default', [], $this->createStub(SerializerInterface::class));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
@@ -33,8 +33,8 @@ class DoctrineTransportTest extends TestCase
     public function testReceivesMessages()
     {
         $transport = $this->getTransport(
-            $serializer = $this->createMock(SerializerInterface::class),
-            $connection = $this->createMock(Connection::class)
+            $serializer = $this->createStub(SerializerInterface::class),
+            $connection = $this->createStub(Connection::class)
         );
 
         $decodedMessage = new DummyMessage('Decoded.');
@@ -60,7 +60,7 @@ class DoctrineTransportTest extends TestCase
         );
 
         $schema = new Schema();
-        $dbalConnection = $this->createMock(DbalConnection::class);
+        $dbalConnection = $this->createStub(DbalConnection::class);
 
         $connection->expects($this->once())
             ->method('configureSchema')
@@ -71,8 +71,8 @@ class DoctrineTransportTest extends TestCase
 
     private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null): DoctrineTransport
     {
-        $serializer ??= $this->createMock(SerializerInterface::class);
-        $connection ??= $this->createMock(Connection::class);
+        $serializer ??= $this->createStub(SerializerInterface::class);
+        $connection ??= $this->createStub(Connection::class);
 
         return new DoctrineTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -30,7 +30,7 @@ class PostgreSqlConnectionTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot serialize '.PostgreSqlConnection::class);
 
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
         $driverConnection->method('executeStatement')->willReturn(1);
 
         $connection = new PostgreSqlConnection([], $driverConnection);
@@ -42,7 +42,7 @@ class PostgreSqlConnectionTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot unserialize '.PostgreSqlConnection::class);
 
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
         $driverConnection->method('executeStatement')->willReturn(1);
 
         $connection = new PostgreSqlConnection([], $driverConnection);
@@ -124,7 +124,7 @@ class PostgreSqlConnectionTest extends TestCase
 
     public function testGetExtraSetupSql()
     {
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
         $driverConnection->method('executeStatement')->willReturn(1);
         $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 
@@ -141,7 +141,7 @@ class PostgreSqlConnectionTest extends TestCase
 
     public function testTransformTableNameWithSchemaToValidProcedureName()
     {
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
         $driverConnection->method('executeStatement')->willReturn(1);
         $connection = new PostgreSqlConnection(['table_name' => 'schema.queue_table'], $driverConnection);
 
@@ -155,7 +155,7 @@ class PostgreSqlConnectionTest extends TestCase
 
     public function testGetExtraSetupSqlWrongTable()
     {
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
         $driverConnection->method('executeStatement')->willReturn(1);
         $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -495,10 +495,11 @@ class ConnectionTest extends TestCase
     private function createRedisMock(): \Redis
     {
         $redis = $this->createMock(\Redis::class);
-        $redis->expects($this->any())
+        $redis
+            ->expects($this->atLeastOnce())
             ->method('connect')
             ->willReturn(true);
-        $redis->expects($this->any())
+        $redis
             ->method('isConnected')
             ->willReturnOnConsecutiveCalls(false, true, true);
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
@@ -34,7 +34,7 @@ class RedisReceiverTest extends TestCase
      */
     public function testItReturnsTheDecodedMessageToTheHandler(array $redisEnvelope, $expectedMessage, SerializerInterface $serializer)
     {
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('get')->willReturn($redisEnvelope);
 
         $receiver = new RedisReceiver($connection, $serializer);
@@ -57,7 +57,7 @@ class RedisReceiverTest extends TestCase
     {
         $this->expectException(MessageDecodingFailedException::class);
 
-        $serializer = $this->createMock(PhpSerializer::class);
+        $serializer = $this->createStub(PhpSerializer::class);
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
         $connection = $this->createMock(Connection::class);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisSenderTest.php
@@ -29,7 +29,7 @@ class RedisSenderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('add')->with($encoded['body'], $encoded['headers'])->willReturn('THE_MESSAGE_ID');
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new RedisSender($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
@@ -31,8 +31,8 @@ class RedisTransportTest extends TestCase
     public function testReceivesMessages()
     {
         $transport = $this->getTransport(
-            $serializer = $this->createMock(SerializerInterface::class),
-            $connection = $this->createMock(Connection::class)
+            $serializer = $this->createStub(SerializerInterface::class),
+            $connection = $this->createStub(Connection::class)
         );
 
         $decodedMessage = new DummyMessage('Decoded.');
@@ -56,8 +56,8 @@ class RedisTransportTest extends TestCase
 
     private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null): RedisTransport
     {
-        $serializer ??= $this->createMock(SerializerInterface::class);
-        $connection ??= $this->createMock(Connection::class);
+        $serializer ??= $this->createStub(SerializerInterface::class);
+        $connection ??= $this->createStub(Connection::class);
 
         return new RedisTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -30,13 +30,10 @@ class FailedMessagesRemoveCommandTest extends TestCase
         $globalFailureReceiverName = 'failure_receiver';
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->expects($this->once())->method('find')->with(20)->willReturn(new Envelope(new \stdClass()));
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
 
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$globalFailureReceiverName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -51,13 +48,10 @@ class FailedMessagesRemoveCommandTest extends TestCase
         $globalFailureReceiverName = 'failure_receiver';
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->expects($this->once())->method('find')->with(20)->willReturn(new Envelope(new \stdClass()));
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
 
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$globalFailureReceiverName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -72,13 +66,10 @@ class FailedMessagesRemoveCommandTest extends TestCase
         $failureReveiverName = 'specific_failure_receiver';
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->expects($this->once())->method('find')->with(20)->willReturn(new Envelope(new \stdClass()));
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($failureReveiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($failureReveiverName)->willReturn($receiver);
 
         $command = new FailedMessagesRemoveCommand(
             $failureReveiverName,
-            $serviceLocator
+            new ServiceLocator([$failureReveiverName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -92,13 +83,10 @@ class FailedMessagesRemoveCommandTest extends TestCase
     {
         $failureReceiverName = 'failure_receiver';
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($failureReceiverName)->willReturn(false);
-
         $this->expectException(InvalidArgumentException::class);
         $command = new FailedMessagesRemoveCommand(
             $failureReceiverName,
-            $serviceLocator
+            new ServiceLocator([])
         );
 
         $tester = new CommandTester($command);
@@ -128,13 +116,9 @@ class FailedMessagesRemoveCommandTest extends TestCase
             })
         ;
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
-
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$globalFailureReceiverName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -165,13 +149,9 @@ class FailedMessagesRemoveCommandTest extends TestCase
             })
         ;
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
-
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$globalFailureReceiverName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -186,17 +166,14 @@ class FailedMessagesRemoveCommandTest extends TestCase
     {
         $globalFailureReceiverName = 'failure_receiver';
 
-        $receiver = $this->createMock(ListableReceiverInterface::class);
-
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('getProvidedServices')->willReturn([
-            'global_receiver' => $receiver,
-            $globalFailureReceiverName => $receiver,
-        ]);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
 
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([
+                'global_receiver' => fn () => $receiver,
+                $globalFailureReceiverName => fn () => $receiver,
+            ])
         );
         $tester = new CommandCompletionTester($command);
 
@@ -214,13 +191,9 @@ class FailedMessagesRemoveCommandTest extends TestCase
             Envelope::wrap(new \stdClass(), [new TransportMessageIdStamp('78c2da843723')]),
         ]);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
-
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$globalFailureReceiverName => fn () => $receiver])
         );
         $tester = new CommandCompletionTester($command);
 
@@ -240,13 +213,9 @@ class FailedMessagesRemoveCommandTest extends TestCase
             Envelope::wrap(new \stdClass(), [new TransportMessageIdStamp('78c2da843723')]),
         ]);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($anotherFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($anotherFailureReceiverName)->willReturn($receiver);
-
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$anotherFailureReceiverName => fn () => $receiver])
         );
 
         $tester = new CommandCompletionTester($command);
@@ -260,11 +229,7 @@ class FailedMessagesRemoveCommandTest extends TestCase
     {
         $globalFailureReceiverName = 'failure_receiver';
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($this->createMock(ListableReceiverInterface::class));
-
-        $command = new FailedMessagesRemoveCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesRemoveCommand('failure_receiver', new ServiceLocator([$globalFailureReceiverName => fn () => $this->createStub(ListableReceiverInterface::class)]));
         $tester = new CommandTester($command);
 
         $this->expectException(RuntimeException::class);
@@ -276,12 +241,9 @@ class FailedMessagesRemoveCommandTest extends TestCase
     {
         $globalFailureReceiverName = 'failure_receiver';
 
-        $receiver = $this->createMock(ListableReceiverInterface::class);
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
 
-        $command = new FailedMessagesRemoveCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesRemoveCommand('failure_receiver', new ServiceLocator([$globalFailureReceiverName => fn () => $receiver]));
         $tester = new CommandTester($command);
 
         $tester->execute(['--all' => true]);
@@ -297,11 +259,7 @@ class FailedMessagesRemoveCommandTest extends TestCase
         $receiver = $this->createMock(DoctrineReceiver::class);
         $receiver->expects($this->once())->method('getMessageCount')->willReturn(2);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
-
-        $command = new FailedMessagesRemoveCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesRemoveCommand('failure_receiver', new ServiceLocator([$globalFailureReceiverName => fn () => $receiver]));
         $tester = new CommandTester($command);
 
         $tester->execute(['--all' => true]);
@@ -314,11 +272,7 @@ class FailedMessagesRemoveCommandTest extends TestCase
     {
         $globalFailureReceiverName = 'failure_receiver';
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($this->createMock(ListableReceiverInterface::class));
-
-        $command = new FailedMessagesRemoveCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesRemoveCommand('failure_receiver', new ServiceLocator([$globalFailureReceiverName => fn () => $this->createStub(ListableReceiverInterface::class)]));
         $tester = new CommandTester($command);
 
         $this->expectException(RuntimeException::class);
@@ -340,11 +294,7 @@ class FailedMessagesRemoveCommandTest extends TestCase
 
         $receiver->expects($this->once())->method('all')->willReturn($series);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
-
-        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, $serviceLocator);
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, new ServiceLocator([$globalFailureReceiverName => fn () => $receiver]));
         $tester = new CommandTester($command);
         $tester->execute(['--all' => true, '--force' => true, '--show-messages' => true]);
 
@@ -355,16 +305,12 @@ class FailedMessagesRemoveCommandTest extends TestCase
     public function testSuccessMessageGoesToStdout()
     {
         $globalFailureReceiverName = 'failure_receiver';
-        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
 
         $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp('some_id')]);
         $receiver->method('find')->with('some_id')->willReturn($envelope);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->willReturn(true);
-        $serviceLocator->method('get')->willReturn($receiver);
-
-        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, $serviceLocator);
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, new ServiceLocator([$globalFailureReceiverName => fn () => $receiver]));
         $tester = new CommandTester($command);
         $tester->execute(['id' => ['some_id'], '--force' => true], ['capture_stderr_separately' => true]);
 
@@ -378,15 +324,11 @@ class FailedMessagesRemoveCommandTest extends TestCase
     public function testErrorMessageGoesToStderr()
     {
         $globalFailureReceiverName = 'failure_receiver';
-        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
 
         $receiver->method('find')->with('not_found')->willReturn(null);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->willReturn(true);
-        $serviceLocator->method('get')->willReturn($receiver);
-
-        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, $serviceLocator);
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, new ServiceLocator([$globalFailureReceiverName => fn () => $receiver]));
         $tester = new CommandTester($command);
         $tester->execute(['id' => ['not_found']], ['capture_stderr_separately' => true]);
 
@@ -400,16 +342,12 @@ class FailedMessagesRemoveCommandTest extends TestCase
     public function testNoteMessageGoesToStderr()
     {
         $globalFailureReceiverName = 'failure_receiver';
-        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
 
         $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp('some_id')]);
         $receiver->method('find')->with('some_id')->willReturn($envelope);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->willReturn(true);
-        $serviceLocator->method('get')->willReturn($receiver);
-
-        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, $serviceLocator);
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, new ServiceLocator([$globalFailureReceiverName => fn () => $receiver]));
         $tester = new CommandTester($command);
         $tester->setInputs(['no']);
         $tester->execute(['id' => ['some_id']], ['capture_stderr_separately' => true]);

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -59,13 +59,10 @@ class FailedMessagesShowCommandTest extends TestCase
         $receiver->expects($this->once())->method('find')->with(15)->willReturn($envelope);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $command = new FailedMessagesShowCommand(
             $failureTransportName,
-            $serviceLocator
+            new ServiceLocator([$failureTransportName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -103,13 +100,10 @@ EOF
         $receiver->expects($this->once())->method('find')->with(15)->willReturn($envelope);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $command = new FailedMessagesShowCommand(
             $failureTransportName,
-            $serviceLocator
+            new ServiceLocator([$failureTransportName => fn () => $receiver])
         );
         $tester = new CommandTester($command);
         $tester->execute(['id' => 15]);
@@ -130,15 +124,12 @@ EOF
 
     public function testReceiverShouldBeListableWithServiceLocator()
     {
-        $receiver = $this->createMock(ReceiverInterface::class);
+        $receiver = $this->createStub(ReceiverInterface::class);
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $command = new FailedMessagesShowCommand(
             $failureTransportName,
-            $serviceLocator
+            new ServiceLocator([$failureTransportName => fn () => $receiver])
         );
 
         $this->expectExceptionMessage('The "failure_receiver" receiver does not support listing or showing specific messages.');
@@ -162,17 +153,13 @@ EOF
         $receiver->expects($this->once())->method('all')->with()->willReturn([$envelope]);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
-        $serviceLocator->method('getProvidedServices')->willReturn([
-            $failureTransportName => [],
-            'failure_receiver_2' => [],
-            'failure_receiver_3' => [],
-        ]);
         $command = new FailedMessagesShowCommand(
             $failureTransportName,
-            $serviceLocator
+            new ServiceLocator([
+                $failureTransportName => fn () => $receiver,
+                'failure_receiver_2' => fn () => $receiver,
+                'failure_receiver_3' => fn () => $receiver,
+            ])
         );
         $tester = new CommandTester($command);
         $tester->setInputs([0]);
@@ -198,13 +185,10 @@ EOF;
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->expects($this->once())->method('all')->with()->willReturn([]);
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $command = new FailedMessagesShowCommand(
             $failureTransportName,
-            $serviceLocator
+            new ServiceLocator([$failureTransportName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -225,13 +209,10 @@ EOF;
         $receiver->expects($this->once())->method('all')->with()->willReturn([$envelope]);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $command = new FailedMessagesShowCommand(
             $failureTransportName,
-            $serviceLocator
+            new ServiceLocator([$failureTransportName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -248,15 +229,12 @@ EOF;
             new RedeliveryStamp(0),
             ErrorDetailsStamp::create(new \RuntimeException('Things are bad!')),
         ]);
-        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
         $receiver->method('all')->with()->willReturn([$envelope]);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
-        $command = new FailedMessagesShowCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator([$failureTransportName => fn () => $receiver]));
 
         $tester = new CommandTester($command);
         $tester->execute([]);
@@ -280,15 +258,12 @@ EOF;
             new RedeliveryStamp(0),
             ErrorDetailsStamp::create(new \RuntimeException('Things are bad!')),
         ]);
-        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
         $receiver->method('all')->with()->willReturn([$envelope, $envelope]);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
-        $command = new FailedMessagesShowCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator([$failureTransportName => fn () => $receiver]));
 
         $tester = new CommandTester($command);
         $tester->execute(['--stats' => 1]);
@@ -297,16 +272,13 @@ EOF;
 
     public function testInvalidMessagesThrowsExceptionWithServiceLocator()
     {
-        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $command = new FailedMessagesShowCommand(
             $failureTransportName,
-            $serviceLocator
+            new ServiceLocator([$failureTransportName => fn () => $receiver])
         );
 
         $this->expectExceptionMessage('The message "15" was not found.');
@@ -329,11 +301,8 @@ EOF;
         $receiver->expects($this->once())->method('find')->with(42)->willReturn($envelope);
 
         $failureTransportName = 'failure_receiver';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
-        $command = new FailedMessagesShowCommand($failureTransportName, $serviceLocator);
+        $command = new FailedMessagesShowCommand($failureTransportName, new ServiceLocator([$failureTransportName => fn () => $receiver]));
         $tester = new CommandTester($command);
         $tester->execute(['id' => 42], ['verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE]);
         $this->assertStringMatchesFormat(sprintf(<<<'EOF'
@@ -375,13 +344,10 @@ EOF
         $receiver->expects($this->once())->method('all')->with()->willReturn([$envelope]);
 
         $failureTransportName = 'failure_receiver_another';
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $command = new FailedMessagesShowCommand(
             'global_but_not_used',
-            $serviceLocator
+            new ServiceLocator([$failureTransportName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);
@@ -399,17 +365,14 @@ EOF
     {
         $globalFailureReceiverName = 'failure_receiver';
 
-        $receiver = $this->createMock(ListableReceiverInterface::class);
-
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('getProvidedServices')->willReturn([
-            'global_receiver' => $receiver,
-            $globalFailureReceiverName => $receiver,
-        ]);
+        $receiver = $this->createStub(ListableReceiverInterface::class);
 
         $command = new FailedMessagesShowCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([
+                'global_receiver' => $receiver,
+                $globalFailureReceiverName => fn () => $receiver,
+            ])
         );
         $tester = new CommandCompletionTester($command);
 
@@ -427,13 +390,9 @@ EOF
             Envelope::wrap(new \stdClass(), [new TransportMessageIdStamp('78c2da843723')]),
         ]);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
-
         $command = new FailedMessagesShowCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$globalFailureReceiverName => fn () => $receiver])
         );
         $tester = new CommandCompletionTester($command);
 
@@ -453,13 +412,9 @@ EOF
             Envelope::wrap(new \stdClass(), [new TransportMessageIdStamp('78c2da843723')]),
         ]);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($anotherFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($anotherFailureReceiverName)->willReturn($receiver);
-
         $command = new FailedMessagesShowCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$anotherFailureReceiverName => fn () => $receiver])
         );
         $tester = new CommandCompletionTester($command);
 
@@ -479,11 +434,7 @@ EOF
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->expects($this->once())->method('all')->with(50)->willReturn([$envelope]);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->willReturn(true);
-        $serviceLocator->method('get')->willReturn($receiver);
-
-        $command = new FailedMessagesShowCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => fn () => $receiver]));
         $tester = new CommandTester($command);
         $tester->execute([], ['capture_stderr_separately' => true]);
 
@@ -527,11 +478,7 @@ EOF
             }
         };
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->willReturn(true);
-        $serviceLocator->method('get')->willReturn($receiver);
-
-        $command = new FailedMessagesShowCommand('failure_receiver', $serviceLocator);
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => fn () => $receiver]));
         $tester = new CommandTester($command);
         $tester->execute(['--max' => 5], ['capture_stderr_separately' => true]);
 

--- a/src/Symfony/Component/Messenger/Tests/Command/StatsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StatsCommandTest.php
@@ -27,14 +27,13 @@ class StatsCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $messageCountableTransport = $this->createMock(MessageCountAwareInterface::class);
+        $messageCountableTransport = $this->createStub(MessageCountAwareInterface::class);
         $messageCountableTransport->method('getMessageCount')->willReturn(6);
 
-        $simpleTransport = $this->createMock(TransportInterface::class);
+        $simpleTransport = $this->createStub(TransportInterface::class);
 
         // mock a service locator
-        /** @var MockObject&ServiceLocator $serviceLocator */
-        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator = $this->createStub(ServiceLocator::class);
         $serviceLocator
             ->method('get')
             ->willReturnCallback(function (string $transportName) use ($messageCountableTransport, $simpleTransport) {

--- a/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/StopWorkersCommandTest.php
@@ -35,8 +35,8 @@ class StopWorkersCommandTest extends TestCase
 
     public function testSuccessMessageGoesToStdout()
     {
-        $cachePool = $this->createMock(CacheItemPoolInterface::class);
-        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cachePool = $this->createStub(CacheItemPoolInterface::class);
+        $cacheItem = $this->createStub(CacheItemInterface::class);
         $cacheItem->method('set');
         $cachePool->method('getItem')->willReturn($cacheItem);
         $cachePool->method('save');

--- a/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
@@ -38,7 +38,7 @@ class MessengerDataCollectorTest extends TestCase
         $message = new DummyMessage('dummy message');
         $envelope = new Envelope($message);
 
-        $bus = $this->createMock(MessageBusInterface::class);
+        $bus = $this->createStub(MessageBusInterface::class);
         $bus->method('dispatch')->with($message)->willReturn($envelope);
         $bus = new TraceableMessageBus($bus);
 
@@ -79,7 +79,7 @@ DUMP;
     {
         $message = new DummyMessage('dummy message');
 
-        $bus = $this->createMock(MessageBusInterface::class);
+        $bus = $this->createStub(MessageBusInterface::class);
         $bus->method('dispatch')->with($message)->willThrowException(new \RuntimeException('foo'));
         $bus = new TraceableMessageBus($bus);
 
@@ -126,11 +126,11 @@ DUMP
 
     public function testKeepsOrderedDispatchCalls()
     {
-        $firstBus = $this->createMock(MessageBusInterface::class);
+        $firstBus = $this->createStub(MessageBusInterface::class);
         $firstBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
         $firstBus = new TraceableMessageBus($firstBus);
 
-        $secondBus = $this->createMock(MessageBusInterface::class);
+        $secondBus = $this->createStub(MessageBusInterface::class);
         $secondBus->method('dispatch')->willReturn(new Envelope(new \stdClass()));
         $secondBus = new TraceableMessageBus($secondBus);
 

--- a/src/Symfony/Component/Messenger/Tests/EventListener/ResetServicesListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/ResetServicesListenerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
+use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Worker;
 
 class ResetServicesListenerTest extends TestCase
@@ -34,7 +35,7 @@ class ResetServicesListenerTest extends TestCase
         $servicesResetter = $this->createMock(ServicesResetter::class);
         $servicesResetter->expects($shouldReset ? $this->once() : $this->never())->method('reset');
 
-        $event = new WorkerRunningEvent($this->createMock(Worker::class), !$shouldReset);
+        $event = new WorkerRunningEvent(new Worker([], new MessageBus()), !$shouldReset);
 
         $resetListener = new ResetServicesListener($servicesResetter);
         $resetListener->resetServices($event);
@@ -45,7 +46,7 @@ class ResetServicesListenerTest extends TestCase
         $servicesResetter = $this->createMock(ServicesResetter::class);
         $servicesResetter->expects($this->once())->method('reset');
 
-        $event = new WorkerStoppedEvent($this->createMock(Worker::class));
+        $event = new WorkerStoppedEvent(new Worker([], new MessageBus()));
 
         $resetListener = new ResetServicesListener($servicesResetter);
         $resetListener->resetServicesAtStop($event);

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
@@ -34,9 +34,9 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
             return true;
         }))->willReturnArgument(0);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->willReturn(true);
-        $serviceLocator->expects($this->once())->method('get')->with($receiverName)->willReturn($sender);
+        $serviceLocator = new ServiceLocator([
+            $receiverName => fn () => $sender,
+        ]);
         $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
 
         $exception = new \Exception('no!');
@@ -51,8 +51,7 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $sender = $this->createMock(SenderInterface::class);
         $sender->expects($this->never())->method('send');
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
+        $listener = new SendFailedMessageToFailureTransportListener(new ServiceLocator([]));
 
         $envelope = new Envelope(new \stdClass());
         $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \Exception());
@@ -67,9 +66,8 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
 
         $sender = $this->createMock(SenderInterface::class);
         $sender->expects($this->never())->method('send');
-        $serviceLocator = $this->createMock(ServiceLocator::class);
 
-        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
+        $listener = new SendFailedMessageToFailureTransportListener(new ServiceLocator([]));
         $envelope = new Envelope(new \stdClass(), [
             new SentToFailureTransportStamp($receiverName),
         ]);
@@ -83,8 +81,7 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $sender = $this->createMock(SenderInterface::class);
         $sender->expects($this->never())->method('send');
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator, null);
+        $listener = new SendFailedMessageToFailureTransportListener(new ServiceLocator([]), null);
 
         $exception = new \Exception('no!');
         $envelope = new Envelope(new \stdClass());
@@ -106,9 +103,9 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
             return true;
         }))->willReturnArgument(0);
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->method('has')->with($receiverName)->willReturn(true);
-        $serviceLocator->method('get')->with($receiverName)->willReturn($sender);
+        $serviceLocator = new ServiceLocator([
+            $receiverName => fn () => $sender,
+        ]);
 
         $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
 

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnFailureLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnFailureLimitListenerTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnFailureLimitListener;
+use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Worker;
 
@@ -61,8 +62,7 @@ class StopWorkerOnFailureLimitListenerTest extends TestCase
                 $this->equalTo(['count' => 1])
             );
 
-        $worker = $this->createMock(Worker::class);
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerRunningEvent(new Worker([], new MessageBus()), false);
 
         $failureLimitListener = new StopWorkerOnFailureLimitListener(1, $logger);
         $failureLimitListener->onMessageFailed($this->createFailedEvent());
@@ -73,6 +73,6 @@ class StopWorkerOnFailureLimitListenerTest extends TestCase
     {
         $envelope = new Envelope(new DummyMessage('hello'));
 
-        return new WorkerMessageFailedEvent($envelope, 'default', $this->createMock(\Throwable::class));
+        return new WorkerMessageFailedEvent($envelope, 'default', new \Exception());
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMemoryLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMemoryLimitListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMemoryLimitListener;
+use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Worker;
 
 class StopWorkerOnMemoryLimitListenerTest extends TestCase
@@ -49,8 +50,7 @@ class StopWorkerOnMemoryLimitListenerTest extends TestCase
 
         $memoryResolver = fn () => 70;
 
-        $worker = $this->createMock(Worker::class);
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerRunningEvent(new Worker([], new MessageBus()), false);
 
         $memoryLimitListener = new StopWorkerOnMemoryLimitListener(64, $logger, $memoryResolver);
         $memoryLimitListener->onWorkerRunning($event);

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMessageLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnMessageLimitListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Worker;
 
 class StopWorkerOnMessageLimitListenerTest extends TestCase
@@ -52,8 +53,7 @@ class StopWorkerOnMessageLimitListenerTest extends TestCase
                 $this->equalTo(['count' => 1])
             );
 
-        $worker = $this->createMock(Worker::class);
-        $event = new WorkerRunningEvent($worker, false);
+        $event = new WorkerRunningEvent(new Worker([], new MessageBus()), false);
 
         $maximumCountListener = new StopWorkerOnMessageLimitListener(1, $logger);
         $maximumCountListener->onWorkerRunning($event);

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -22,7 +22,7 @@ class HandlersLocatorTest extends TestCase
 {
     public function testItYieldsHandlerDescriptors()
     {
-        $handler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $handler = new HandlersLocatorTestCallable();
         $locator = new HandlersLocator([
             DummyMessage::class => [$handler],
         ]);
@@ -35,13 +35,13 @@ class HandlersLocatorTest extends TestCase
 
     public function testItReturnsOnlyHandlersMatchingTransport()
     {
-        $firstHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
-        $secondHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $firstHandler = new HandlersLocatorTestCallable();
+        $secondHandler = new HandlersLocatorTestCallable();
 
         $locator = new HandlersLocator([
             DummyMessage::class => [
                 $first = new HandlerDescriptor($firstHandler, ['alias' => 'one']),
-                new HandlerDescriptor($this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']), ['from_transport' => 'ignored', 'alias' => 'two']),
+                new HandlerDescriptor(new HandlersLocatorTestCallable(), ['from_transport' => 'ignored', 'alias' => 'two']),
                 $second = new HandlerDescriptor($secondHandler, ['from_transport' => 'transportName', 'alias' => 'three']),
             ],
         ]);
@@ -59,8 +59,8 @@ class HandlersLocatorTest extends TestCase
 
     public function testItReturnsOnlyHandlersMatchingMessageNamespace()
     {
-        $firstHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
-        $secondHandler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $firstHandler = new HandlersLocatorTestCallable();
+        $secondHandler = new HandlersLocatorTestCallable();
 
         $locator = new HandlersLocator([
             str_replace('DummyMessage', '*', DummyMessage::class) => [

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
@@ -230,8 +230,8 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             $eventHandlingMiddleware,
         ]);
 
-        $fakePutMessageOnQueue = $this->createMock(MiddlewareInterface::class);
-        $fakePutMessageOnQueue->expects($this->any())
+        $fakePutMessageOnQueue = $this->createStub(MiddlewareInterface::class);
+        $fakePutMessageOnQueue
             ->method('handle')
             ->with($this->callback(function ($envelope) use ($messageBusAfterQueue) {
                 // Fake putting the message on the queue
@@ -272,7 +272,7 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
         $event = new DummyEvent('First event');
 
         $middleware = new DispatchAfterCurrentBusMiddleware();
-        $handlingMiddleware = $this->createMock(MiddlewareInterface::class);
+        $handlingMiddleware = $this->createStub(MiddlewareInterface::class);
 
         $handlingMiddleware
             ->method('handle')
@@ -284,9 +284,9 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
             $handlingMiddleware,
         ]);
 
-        $enveloppe = $eventBus->dispatch($event, [new DispatchAfterCurrentBusStamp()]);
+        $envelope = $eventBus->dispatch($event, [new DispatchAfterCurrentBusStamp()]);
 
-        self::assertNull($enveloppe->last(DispatchAfterCurrentBusStamp::class));
+        self::assertNull($envelope->last(DispatchAfterCurrentBusStamp::class));
     }
 
     private function expectHandledMessage($message): Callback

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -174,10 +174,8 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
 
     public function testMessageAlreadyHandled()
     {
-        $handler = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
-
         $middleware = new HandleMessageMiddleware(new HandlersLocator([
-            DummyMessage::class => [$handler],
+            DummyMessage::class => [new HandleMessageMiddlewareTestCallable()],
         ]));
 
         $envelope = new Envelope(new DummyMessage('Hey'));

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Exception\NoSenderForMessageException;
@@ -198,14 +199,12 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
     {
         $envelope = new Envelope(new DummyMessage('original envelope'));
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
-
         $sendersLocator = $this->createSendersLocator([DummyMessage::class => []], []);
 
         $this->expectException(NoSenderForMessageException::class);
         $this->expectExceptionMessage('No sender for message "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage"');
 
-        $middleware = new SendMessageMiddleware($sendersLocator, $dispatcher, false);
+        $middleware = new SendMessageMiddleware($sendersLocator, new EventDispatcher(), false);
         $middleware->handle($envelope, $this->getStackMock(false));
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
@@ -59,7 +59,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
                 $constraint->evaluate($name);
                 $this->assertSame($expectedCategory, $category);
 
-                return $this->createMock(StopwatchEvent::class);
+                return new StopwatchEvent(1.0);
             })
         ;
         $stopwatch->expects($this->exactly(2))
@@ -72,7 +72,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
 
                 $this->assertSame(array_shift($stopSeries), $name);
 
-                return $this->createMock(StopwatchEvent::class);
+                return new StopwatchEvent(1.0);
             })
         ;
 
@@ -149,13 +149,11 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
 
         $stackMiddleware = new StackMiddleware([
             null,
-            $this->createMock(MiddlewareInterface::class),
-            $this->createMock(MiddlewareInterface::class),
+            $this->createStub(MiddlewareInterface::class),
+            $this->createStub(MiddlewareInterface::class),
         ]);
 
-        $stopwatch = $this->createMock(Stopwatch::class);
-
-        $traceableStack = new TraceableStack($stackMiddleware, $stopwatch, 'command_bus', 'messenger.middleware');
+        $traceableStack = new TraceableStack($stackMiddleware, new Stopwatch(), 'command_bus', 'messenger.middleware');
         $clonedStack = clone $traceableStack;
 
         $traceableStackMiddleware1 = $traceableStack->next();
@@ -180,7 +178,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
         // import TraceableStack
         class_exists(TraceableMiddleware::class);
 
-        $middlewareIterable = [null, $this->createMock(MiddlewareInterface::class)];
+        $middlewareIterable = [null, $this->createStub(MiddlewareInterface::class)];
 
         $stackMiddleware = new StackMiddleware($middlewareIterable);
 
@@ -201,7 +199,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
                 $constraint->evaluate($name);
                 $this->assertSame($expectedCategory, $category);
 
-                return $this->createMock(StopwatchEvent::class);
+                return new StopwatchEvent(1.0);
             })
         ;
 
@@ -215,7 +213,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
                 $constraint = array_shift($stopSeries);
                 $constraint->evaluate($name);
 
-                return $this->createMock(StopwatchEvent::class);
+                return new StopwatchEvent(1.0);
             })
         ;
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/ValidationMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/ValidationMiddlewareTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Middleware\ValidationMiddleware;
 use Symfony\Component\Messenger\Stamp\ValidationStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -32,7 +33,7 @@ class ValidationMiddlewareTest extends MiddlewareTestCase
             ->expects($this->once())
             ->method('validate')
             ->with($message)
-            ->willReturn($this->createMock(ConstraintViolationListInterface::class))
+            ->willReturn(new ConstraintViolationList())
         ;
 
         (new ValidationMiddleware($validator))->handle($envelope, $this->getStackMock());
@@ -47,7 +48,7 @@ class ValidationMiddlewareTest extends MiddlewareTestCase
             ->expects($this->once())
             ->method('validate')
             ->with($message, null, $groups)
-            ->willReturn($this->createMock(ConstraintViolationListInterface::class))
+            ->willReturn(new ConstraintViolationList())
         ;
 
         (new ValidationMiddleware($validator))->handle($envelope, $this->getStackMock());

--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportFactoryTest.php
@@ -42,7 +42,7 @@ class InMemoryTransportFactoryTest extends TestCase
     public function testCreateTransport()
     {
         /** @var SerializerInterface $serializer */
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
 
         $this->assertInstanceOf(InMemoryTransport::class, $this->factory->createTransport('in-memory://', [], $serializer));
     }
@@ -78,7 +78,7 @@ class InMemoryTransportFactoryTest extends TestCase
 
     public function testResetCreatedTransports()
     {
-        $transport = $this->factory->createTransport('in-memory://', [], $this->createMock(SerializerInterface::class));
+        $transport = $this->factory->createTransport('in-memory://', [], $this->createStub(SerializerInterface::class));
         $transport->send(Envelope::wrap(new DummyMessage('Hello.')));
 
         $this->assertCount(1, $transport->get());

--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
@@ -33,7 +33,7 @@ class InMemoryTransportTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->serializer = $this->createStub(SerializerInterface::class);
         $this->transport = new InMemoryTransport();
         $this->serializeTransport = new InMemoryTransport($this->serializer);
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Receiver/SingleMessageReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Receiver/SingleMessageReceiverTest.php
@@ -20,7 +20,7 @@ class SingleMessageReceiverTest extends TestCase
 {
     public function testItReceivesOnlyOneMessage()
     {
-        $innerReceiver = $this->createMock(ReceiverInterface::class);
+        $innerReceiver = $this->createStub(ReceiverInterface::class);
         $envelope = new Envelope(new \stdClass());
 
         $receiver = new SingleMessageReceiver($innerReceiver, $envelope);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -24,7 +24,7 @@ class SendersLocatorTest extends TestCase
 {
     public function testItReturnsTheSenderBasedOnTheMessageClass()
     {
-        $sender = $this->createMock(SenderInterface::class);
+        $sender = $this->createStub(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'my_sender' => $sender,
         ]);
@@ -38,8 +38,8 @@ class SendersLocatorTest extends TestCase
 
     public function testItReturnsTheSenderBasedOnTransportNamesStamp()
     {
-        $mySender = $this->createMock(SenderInterface::class);
-        $otherSender = $this->createMock(SenderInterface::class);
+        $mySender = $this->createStub(SenderInterface::class);
+        $otherSender = $this->createStub(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'my_sender' => $mySender,
             'other_sender' => $otherSender,
@@ -54,9 +54,9 @@ class SendersLocatorTest extends TestCase
 
     public function testSendersMapWithFallback()
     {
-        $firstSender = $this->createMock(SenderInterface::class);
-        $secondSender = $this->createMock(SenderInterface::class);
-        $thirdSender = $this->createMock(SenderInterface::class);
+        $firstSender = $this->createStub(SenderInterface::class);
+        $secondSender = $this->createStub(SenderInterface::class);
+        $thirdSender = $this->createStub(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'first' => $firstSender,
             'second' => $secondSender,

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sync/SyncTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger\Tests\Transport\Sync;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransport;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
@@ -21,9 +21,8 @@ class SyncTransportFactoryTest extends TestCase
 {
     public function testCreateTransport()
     {
-        $serializer = $this->createMock(SerializerInterface::class);
-        $bus = $this->createMock(MessageBusInterface::class);
-        $factory = new SyncTransportFactory($bus);
+        $serializer = $this->createStub(SerializerInterface::class);
+        $factory = new SyncTransportFactory(new MessageBus());
         $transport = $factory->createTransport('sync://', [], $serializer);
         $this->assertInstanceOf(SyncTransport::class, $transport);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License | MIT
