### PR TITLE
[BrowserKit] Allow wrapping response content to give proper context when fetching fragments

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -12,6 +12,7 @@ BrowserKit
 ----------
 
  * Deprecate `AbstractBrowser::useHtml5Parser()`; Symfony 8 will unconditionally use the native HTML5 parser
+ * Add `AbstractBrowser::wrapContent()` method to wrap response content and give proper context when fetching fragments
 
 Cache
 -----

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `isFirstPage()` and `isLastPage()` methods to the History class for checking navigation boundaries
  * Add PHPUnit constraints: `BrowserHistoryIsOnFirstPage` and `BrowserHistoryIsOnLastPage`
  * Deprecate `AbstractBrowser::useHtml5Parser()`; Symfony 8 will unconditionally use the native HTML5 parser
+ * Add `AbstractBrowser::wrapContent()` method to wrap response content and give proper context when fetching fragments
 
 6.4
 ---

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -108,6 +108,16 @@ class AbstractBrowserTest extends TestCase
         $client->getResponse();
     }
 
+    public function testGetResponseWithWrappedContent()
+    {
+        $client = $this->getBrowser();
+        $client->setNextResponse(new Response('<tr><td>Cell content</td></tr>'));
+        $client->wrapContent('<table>%s</table>');
+        $crawler = $client->request('GET', 'http://example.com/');
+
+        $this->assertStringContainsString('<tr><td>Cell content</td></tr>', $crawler->html());
+    }
+
     public function testGetInternalResponseNull()
     {
         $client = $this->getBrowser();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62834
| License       | MIT

This PR adds a new `wrapContent` method to `AbstractBrowser` to wrap response content. The PR target 7.4 to allow tests migration before definitive native HTML parser adoption.

Example with a controller which returns `<tr><td>Cell content</td></tr>`:
```php
// Will display "<head></head><body>Cell content</body>" due to native HTML5 parser
// Note that tr and td tags are removed since they are not inside a table tag
echo $client->xmlHttpRequest('GET', 'http://example.com/segment')->html();

// Will display "<table><tbody><tr><td>Cell content</td></tr></tbody></table>" since this HTML is valid
// Note that tr and td tags are preserved
echo $client->wrapContent('<table>%s</table>')->xmlHttpRequest('GET', 'http://example.com/segment')->html();
```
