### PR TITLE
[FrameworkBundle] Better deprecation message when running `bin/console debug:container --show-arguments`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -152,7 +152,7 @@ EOF
             $options = ['tag' => $tag];
         } elseif ($name = $input->getArgument('name')) {
             if ($input->getOption('show-arguments')) {
-                $errorIo->warning('The "--show-arguments" option is deprecated.');
+                $errorIo->warning('The "--show-arguments" option is deprecated, as arguments are now always shown.');
             }
 
             $name = $this->findProperServiceName($input, $errorIo, $object, $name, $input->getOption('show-hidden'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -361,6 +361,6 @@ TXT
         $tester->run(['command' => 'debug:container', 'name' => 'router', '--show-arguments' => true]);
 
         $tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('[WARNING] The "--show-arguments" option is deprecated.', $tester->getDisplay());
+        $this->assertStringContainsString('[WARNING] The "--show-arguments" option is deprecated, as arguments are now always shown.', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

I had to search why is has been deprecated. Let's save some time!
