### PR TITLE
[HttpFoundation] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -1040,7 +1040,7 @@ class ResponseTest extends ResponseTestCase
     public function testNoDeprecationsAreTriggered()
     {
         new DefaultResponse();
-        $this->createMock(Response::class);
+        new Response();
 
         // we just need to ensure that subclasses of Response can be created without any deprecations
         // being triggered if the subclass does not override any final methods

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
@@ -23,17 +23,15 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MarshallingSessionH
 class MarshallingSessionHandlerTest extends TestCase
 {
     protected MockObject&\SessionHandlerInterface $handler;
-    protected MockObject&MarshallerInterface $marshaller;
 
     protected function setUp(): void
     {
-        $this->marshaller = $this->createMock(MarshallerInterface::class);
         $this->handler = $this->createMock(AbstractSessionHandler::class);
     }
 
     public function testOpen()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->createStub(MarshallerInterface::class));
 
         $this->handler->expects($this->once())->method('open')
             ->with('path', 'name')->willReturn(true);
@@ -43,7 +41,7 @@ class MarshallingSessionHandlerTest extends TestCase
 
     public function testClose()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->createStub(MarshallerInterface::class));
 
         $this->handler->expects($this->once())->method('close')->willReturn(true);
 
@@ -52,7 +50,7 @@ class MarshallingSessionHandlerTest extends TestCase
 
     public function testDestroy()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->createStub(MarshallerInterface::class));
 
         $this->handler->expects($this->once())->method('destroy')
             ->with('session_id')->willReturn(true);
@@ -62,7 +60,7 @@ class MarshallingSessionHandlerTest extends TestCase
 
     public function testGc()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->createStub(MarshallerInterface::class));
 
         $this->handler->expects($this->once())->method('gc')
             ->with(4711)->willReturn(1);
@@ -72,11 +70,12 @@ class MarshallingSessionHandlerTest extends TestCase
 
     public function testRead()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshaller = $this->createMock(MarshallerInterface::class);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $marshaller);
 
         $this->handler->expects($this->once())->method('read')->with('session_id')
             ->willReturn('data');
-        $this->marshaller->expects($this->once())->method('unmarshall')->with('data')
+        $marshaller->expects($this->once())->method('unmarshall')->with('data')
             ->willReturn('unmarshalled_data')
         ;
 
@@ -86,9 +85,10 @@ class MarshallingSessionHandlerTest extends TestCase
 
     public function testWrite()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshaller = $this->createMock(MarshallerInterface::class);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $marshaller);
 
-        $this->marshaller->expects($this->once())->method('marshall')
+        $marshaller->expects($this->once())->method('marshall')
             ->with(['data' => 'data'], [])
             ->willReturn(['data' => 'marshalled_data']);
 
@@ -101,7 +101,7 @@ class MarshallingSessionHandlerTest extends TestCase
 
     public function testValidateId()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->createStub(MarshallerInterface::class));
 
         $this->handler->expects($this->once())->method('validateId')
             ->with('session_id')->willReturn(true);
@@ -111,7 +111,7 @@ class MarshallingSessionHandlerTest extends TestCase
 
     public function testUpdateTimestamp()
     {
-        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->createStub(MarshallerInterface::class));
 
         $this->handler->expects($this->once())->method('updateTimestamp')
             ->with('session_id', 'data')->willReturn(true);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -25,9 +25,6 @@ class MemcachedSessionHandlerTest extends TestCase
     private const PREFIX = 'prefix_';
     private const TTL = 1000;
 
-    protected MemcachedSessionHandler $storage;
-    protected MockObject&\Memcached $memcached;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -35,94 +32,86 @@ class MemcachedSessionHandlerTest extends TestCase
         if (version_compare(phpversion('memcached'), '2.2.0', '>=') && version_compare(phpversion('memcached'), '3.0.0b1', '<')) {
             $this->markTestSkipped('Tests can only be run with memcached extension 2.1.0 or lower, or 3.0.0b1 or higher');
         }
-
-        $r = new \ReflectionClass(\Memcached::class);
-        $methodsToMock = array_map(fn ($m) => $m->name, $r->getMethods(\ReflectionMethod::IS_PUBLIC));
-        $methodsToMock = array_diff($methodsToMock, ['getDelayed', 'getDelayedByKey']);
-
-        $this->memcached = $this->getMockBuilder(\Memcached::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods($methodsToMock)
-            ->getMock();
-
-        $this->storage = new MemcachedSessionHandler(
-            $this->memcached,
-            ['prefix' => self::PREFIX, 'expiretime' => self::TTL]
-        );
     }
 
     public function testOpenSession()
     {
-        $this->assertTrue($this->storage->open('', ''));
+        $this->assertTrue($this->getSessionHandler()->open('', ''));
     }
 
     public function testCloseSession()
     {
-        $this->memcached
+        $memcached = $this->getMemcachedMock();
+        $memcached
             ->expects($this->once())
             ->method('quit')
             ->willReturn(true)
         ;
 
-        $this->assertTrue($this->storage->close());
+        $this->assertTrue($this->getSessionHandler($memcached)->close());
     }
 
     public function testReadSession()
     {
-        $this->memcached
+        $memcached = $this->getMemcachedMock();
+        $memcached
             ->expects($this->once())
             ->method('get')
             ->with(self::PREFIX.'id')
         ;
 
-        $this->assertEquals('', $this->storage->read('id'));
+        $this->assertEquals('', $this->getSessionHandler($memcached)->read('id'));
     }
 
     public function testWriteSession()
     {
-        $this->memcached
+        $memcached = $this->getMemcachedMock();
+        $memcached
             ->expects($this->once())
             ->method('set')
             ->with(self::PREFIX.'id', 'data', $this->equalTo(self::TTL, 2))
             ->willReturn(true)
         ;
 
-        $this->assertTrue($this->storage->write('id', 'data'));
+        $this->assertTrue($this->getSessionHandler($memcached)->write('id', 'data'));
     }
 
     public function testWriteSessionWithLargeTTL()
     {
-        $this->memcached
+        $memcached = $this->getMemcachedMock();
+        $memcached
             ->expects($this->once())
             ->method('set')
             ->with(self::PREFIX.'id', 'data', $this->equalTo(time() + self::TTL + 60 * 60 * 24 * 30, 2))
             ->willReturn(true)
         ;
 
-        $storage = new MemcachedSessionHandler(
-            $this->memcached,
+        $sessionHandler = new MemcachedSessionHandler(
+            $memcached,
             ['prefix' => self::PREFIX, 'expiretime' => self::TTL + 60 * 60 * 24 * 30]
         );
 
-        $this->assertTrue($storage->write('id', 'data'));
+        $this->assertTrue($sessionHandler->write('id', 'data'));
     }
 
     public function testDestroySession()
     {
-        $this->storage->open('', 'sid');
-        $this->memcached
+        $memcached = $this->getMemcachedMock();
+        $sessionHandler = $this->getSessionHandler($memcached);
+        $sessionHandler->open('', 'sid');
+        $memcached
             ->expects($this->once())
             ->method('delete')
             ->with(self::PREFIX.'id')
             ->willReturn(true)
         ;
 
-        $this->assertTrue($this->storage->destroy('id'));
+        $this->assertTrue($sessionHandler->destroy('id'));
     }
 
     public function testGcSession()
     {
-        $this->assertIsInt($this->storage->gc(123));
+        $this->assertIsInt($this->getSessionHandler()->gc(123));
     }
 
     /**
@@ -130,8 +119,9 @@ class MemcachedSessionHandlerTest extends TestCase
      */
     public function testSupportedOptions($options, $supported)
     {
+        $memcached = $this->createStub(\Memcached::class);
         try {
-            new MemcachedSessionHandler($this->memcached, $options);
+            new MemcachedSessionHandler($memcached, $options);
             $this->assertTrue($supported);
         } catch (\InvalidArgumentException $e) {
             $this->assertFalse($supported);
@@ -150,8 +140,27 @@ class MemcachedSessionHandlerTest extends TestCase
 
     public function testGetConnection()
     {
-        $method = new \ReflectionMethod($this->storage, 'getMemcached');
+        $memcached = $this->createStub(\Memcached::class);
+        $sessionHandler = $this->getSessionHandler($memcached);
+        $method = new \ReflectionMethod($sessionHandler, 'getMemcached');
 
-        $this->assertInstanceOf(\Memcached::class, $method->invoke($this->storage));
+        $this->assertSame($memcached, $method->invoke($sessionHandler));
+    }
+
+    private function getMemcachedMock(): MockObject&\Memcached
+    {
+        $r = new \ReflectionClass(\Memcached::class);
+        $methodsToMock = array_map(fn ($m) => $m->name, $r->getMethods(\ReflectionMethod::IS_PUBLIC));
+        $methodsToMock = array_diff($methodsToMock, ['getDelayed', 'getDelayedByKey']);
+
+        return $this->getMockBuilder(\Memcached::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods($methodsToMock)
+            ->getMock();
+    }
+
+    private function getSessionHandler(?\Memcached $memcached = null, ?array $options = null): MemcachedSessionHandler
+    {
+        return new MemcachedSessionHandler($memcached ?? $this->createStub(\Memcached::class), $options ?? ['prefix' => self::PREFIX, 'expiretime' => self::TTL]);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -395,8 +395,8 @@ class PdoSessionHandlerTest extends TestCase
         $pdo = new MockPdo('sqlsrv', null, '10');
         $boundData = [];
 
-        $mergeStmt = $this->createMock(\PDOStatement::class);
-        $selectStmt = $this->createMock(\PDOStatement::class);
+        $mergeStmt = $this->createStub(\PDOStatement::class);
+        $selectStmt = $this->createStub(\PDOStatement::class);
         $selectStmt->method('fetchAll')->willReturn([]);
 
         $mergeStmt->method('bindParam')

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
@@ -53,7 +53,7 @@ class SessionHandlerFactoryTest extends TestCase
      */
     public function testCreateRedisHandlerFromConnectionObject()
     {
-        $handler = SessionHandlerFactory::createHandler($this->createMock(\Redis::class));
+        $handler = SessionHandlerFactory::createHandler($this->createStub(\Redis::class));
         $this->assertInstanceOf(RedisSessionHandler::class, $handler);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
