### PR TITLE
[JsonStreamer] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
@@ -45,7 +45,7 @@ class StreamerDumperTest extends TestCase
     {
         $path = $this->cacheDir.'/streamer.php';
 
-        $dumper = new StreamerDumper($this->createMock(PropertyMetadataLoaderInterface::class), $this->cacheDir, new ConfigCacheFactory(true));
+        $dumper = new StreamerDumper($this->createStub(PropertyMetadataLoaderInterface::class), $this->cacheDir, new ConfigCacheFactory(true));
         $dumper->dump(Type::int(), $path, fn () => 'CONTENT');
 
         $this->assertFileExists($path);
@@ -59,7 +59,7 @@ class StreamerDumperTest extends TestCase
     {
         $path = $this->cacheDir.'/streamer.php';
 
-        $dumper = new StreamerDumper($this->createMock(PropertyMetadataLoaderInterface::class), $this->cacheDir);
+        $dumper = new StreamerDumper($this->createStub(PropertyMetadataLoaderInterface::class), $this->cacheDir);
         $dumper->dump(Type::int(), $path, fn () => 'CONTENT');
 
         $this->assertFileExists($path);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT