### PR TITLE
[PasswordHasher] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\PasswordHasher\Command\UserPasswordHashCommand;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\Hasher\Pbkdf2PasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
 use Symfony\Component\Security\Core\User\InMemoryUser;
@@ -280,7 +279,7 @@ EOTXT
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('There are no configured password hashers for the "security" extension.');
 
-        $tester = new CommandTester(new UserPasswordHashCommand($this->getMockBuilder(PasswordHasherFactoryInterface::class)->getMock(), []));
+        $tester = new CommandTester(new UserPasswordHashCommand(new PasswordHasherFactory([]), []));
         $tester->execute([
             'password' => 'password',
         ], ['interactive' => false]);
@@ -291,7 +290,7 @@ EOTXT
      */
     public function testCompletionSuggestions(array $input, array $expectedSuggestions)
     {
-        $command = new UserPasswordHashCommand($this->createMock(PasswordHasherFactoryInterface::class), ['App\Entity\User']);
+        $command = new UserPasswordHashCommand(new PasswordHasherFactory([]), ['App\Entity\User']);
         $tester = new CommandCompletionTester($command);
 
         $this->assertSame($expectedSuggestions, $tester->complete($input));

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/MigratingPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/MigratingPasswordHasherTest.php
@@ -42,8 +42,8 @@ class MigratingPasswordHasherTest extends TestCase
     {
         $bestHasher = new NativePasswordHasher(4, 12000, 4);
 
-        $extraHasher1 = $this->createMock(PasswordHasherInterface::class);
-        $extraHasher1->expects($this->any())
+        $extraHasher1 = $this->createStub(PasswordHasherInterface::class);
+        $extraHasher1
             ->method('verify')
             ->with('abc', 'foo', 'salt')
             ->willReturn(true);
@@ -52,8 +52,8 @@ class MigratingPasswordHasherTest extends TestCase
 
         $this->assertTrue($hasher->verify('abc', 'foo', 'salt'));
 
-        $extraHasher2 = $this->createMock(PasswordHasherInterface::class);
-        $extraHasher2->expects($this->any())
+        $extraHasher2 = $this->createStub(PasswordHasherInterface::class);
+        $extraHasher2
             ->method('verify')
             ->willReturn(false);
 

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
@@ -31,7 +31,7 @@ class PasswordHasherFactoryTest extends TestCase
             'arguments' => ['sha512', true, 5],
         ]]);
 
-        $hasher = $factory->getPasswordHasher($this->createMock(PasswordAuthenticatedUserInterface::class));
+        $hasher = $factory->getPasswordHasher($this->createStub(PasswordAuthenticatedUserInterface::class));
         $expectedHasher = new MessageDigestPasswordHasher('sha512', true, 5);
 
         $this->assertEquals($expectedHasher->hash('foo', 'moo'), $hasher->hash('foo', 'moo'));
@@ -43,7 +43,7 @@ class PasswordHasherFactoryTest extends TestCase
             PasswordAuthenticatedUserInterface::class => new MessageDigestPasswordHasher('sha1'),
         ]);
 
-        $hasher = $factory->getPasswordHasher($this->createMock(PasswordAuthenticatedUserInterface::class));
+        $hasher = $factory->getPasswordHasher($this->createStub(PasswordAuthenticatedUserInterface::class));
         $expectedHasher = new MessageDigestPasswordHasher('sha1');
         $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
     }
@@ -54,7 +54,7 @@ class PasswordHasherFactoryTest extends TestCase
             PasswordAuthenticatedUserInterface::class => ['instance' => new MessageDigestPasswordHasher('sha1')],
         ]);
 
-        $hasher = $factory->getPasswordHasher($this->createMock(PasswordAuthenticatedUserInterface::class));
+        $hasher = $factory->getPasswordHasher($this->createStub(PasswordAuthenticatedUserInterface::class));
         $expectedHasher = new MessageDigestPasswordHasher('sha1');
         $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
     }

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\PasswordHasher\Tests\Hasher;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
@@ -27,19 +28,17 @@ class UserPasswordHasherTest extends TestCase
     {
         $user = new TestLegacyPasswordAuthenticatedUser('name', null, 'userSalt');
 
-        $mockHasher = $this->createMock(PasswordHasherInterface::class);
-        $mockHasher->expects($this->any())
+        $passwordHasher = $this->createStub(PasswordHasherInterface::class);
+        $passwordHasher
             ->method('hash')
             ->with($this->equalTo('plainPassword'), $this->equalTo('userSalt'))
             ->willReturn('hash');
 
-        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
-        $mockPasswordHasherFactory->expects($this->any())
-            ->method('getPasswordHasher')
-            ->with($user)
-            ->willReturn($mockHasher);
+        $passwordHasherFactory = new PasswordHasherFactory([
+            $user::class => $passwordHasher,
+        ]);
 
-        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+        $passwordHasher = new UserPasswordHasher($passwordHasherFactory);
 
         $encoded = $passwordHasher->hashPassword($user, 'plainPassword');
         $this->assertEquals('hash', $encoded);
@@ -49,19 +48,17 @@ class UserPasswordHasherTest extends TestCase
     {
         $user = new TestPasswordAuthenticatedUser();
 
-        $mockHasher = $this->createMock(PasswordHasherInterface::class);
-        $mockHasher->expects($this->any())
+        $passwordHasher = $this->createStub(PasswordHasherInterface::class);
+        $passwordHasher
             ->method('hash')
             ->with($this->equalTo('plainPassword'), $this->equalTo(null))
             ->willReturn('hash');
 
-        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
-        $mockPasswordHasherFactory->expects($this->any())
-            ->method('getPasswordHasher')
-            ->with($user)
-            ->willReturn($mockHasher);
+        $passwordHasherFactory = new PasswordHasherFactory([
+            $user::class => $passwordHasher,
+        ]);
 
-        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+        $passwordHasher = new UserPasswordHasher($passwordHasherFactory);
 
         $hashedPassword = $passwordHasher->hashPassword($user, 'plainPassword');
 
@@ -72,19 +69,17 @@ class UserPasswordHasherTest extends TestCase
     {
         $user = new TestLegacyPasswordAuthenticatedUser('user', 'hash', 'userSalt');
 
-        $mockHasher = $this->createMock(PasswordHasherInterface::class);
-        $mockHasher->expects($this->any())
+        $passwordHasher = $this->createStub(PasswordHasherInterface::class);
+        $passwordHasher
             ->method('verify')
             ->with($this->equalTo('hash'), $this->equalTo('plainPassword'), $this->equalTo('userSalt'))
             ->willReturn(true);
 
-        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
-        $mockPasswordHasherFactory->expects($this->any())
-            ->method('getPasswordHasher')
-            ->with($user)
-            ->willReturn($mockHasher);
+        $passwordHasherFactory = new PasswordHasherFactory([
+            $user::class => $passwordHasher,
+        ]);
 
-        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+        $passwordHasher = new UserPasswordHasher($passwordHasherFactory);
 
         $isValid = $passwordHasher->isPasswordValid($user, 'plainPassword');
         $this->assertTrue($isValid);
@@ -94,19 +89,17 @@ class UserPasswordHasherTest extends TestCase
     {
         $user = new TestPasswordAuthenticatedUser('hash');
 
-        $mockHasher = $this->createMock(PasswordHasherInterface::class);
-        $mockHasher->expects($this->any())
+        $passwordHasher = $this->createStub(PasswordHasherInterface::class);
+        $passwordHasher
             ->method('verify')
             ->with($this->equalTo('hash'), $this->equalTo('plainPassword'), $this->equalTo(null))
             ->willReturn(true);
 
-        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
-        $mockPasswordHasherFactory->expects($this->any())
-            ->method('getPasswordHasher')
-            ->with($user)
-            ->willReturn($mockHasher);
+        $passwordHasherFactory = new PasswordHasherFactory([
+            $user::class => $passwordHasher,
+        ]);
 
-        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+        $passwordHasher = new UserPasswordHasher($passwordHasherFactory);
 
         $isValid = $passwordHasher->isPasswordValid($user, 'plainPassword');
         $this->assertTrue($isValid);
@@ -117,13 +110,13 @@ class UserPasswordHasherTest extends TestCase
         $user = new InMemoryUser('username', null);
         $hasher = new NativePasswordHasher(4, 20000, 4);
 
-        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
-        $mockPasswordHasherFactory->expects($this->any())
+        $passwordHasherFactory = $this->createStub(PasswordHasherFactoryInterface::class);
+        $passwordHasherFactory
             ->method('getPasswordHasher')
             ->with($user)
             ->willReturn($hasher, $hasher, new NativePasswordHasher(5, 20000, 5), $hasher);
 
-        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+        $passwordHasher = new UserPasswordHasher($passwordHasherFactory);
 
         \Closure::bind(function () use ($passwordHasher) { $this->password = $passwordHasher->hashPassword($this, 'foo', 'salt'); }, $user, class_exists(User::class) ? User::class : InMemoryUser::class)();
         $this->assertFalse($passwordHasher->needsRehash($user));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT