### PR TITLE
[Semaphore] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Semaphore/Tests/SemaphoreFactoryTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/SemaphoreFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Semaphore\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Semaphore\Key;
 use Symfony\Component\Semaphore\PersistingStoreInterface;
 use Symfony\Component\Semaphore\SemaphoreFactory;
@@ -37,9 +37,8 @@ class SemaphoreFactoryTest extends TestCase
                 return true;
             }));
 
-        $logger = $this->createMock(LoggerInterface::class);
         $factory = new SemaphoreFactory($store);
-        $factory->setLogger($logger);
+        $factory->setLogger(new NullLogger());
 
         $semaphore1 = $factory->createSemaphore('foo', 4);
         $semaphore2 = $factory->createSemaphore('foo', 4);
@@ -65,9 +64,8 @@ class SemaphoreFactoryTest extends TestCase
                 return true;
             }));
 
-        $logger = $this->createMock(LoggerInterface::class);
         $factory = new SemaphoreFactory($store);
-        $factory->setLogger($logger);
+        $factory->setLogger(new NullLogger());
 
         $key = new Key('foo', 4);
         $semaphore1 = $factory->createSemaphoreFromKey($key);

--- a/src/Symfony/Component/Semaphore/Tests/SemaphoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/SemaphoreTest.php
@@ -240,7 +240,7 @@ class SemaphoreTest extends TestCase
 
     public function testExpiration()
     {
-        $store = $this->createMock(PersistingStoreInterface::class);
+        $store = $this->createStub(PersistingStoreInterface::class);
 
         $key = new Key('key', 1);
         $semaphore = new Semaphore($key, $store);
@@ -257,7 +257,7 @@ class SemaphoreTest extends TestCase
      */
     public function testExpirationResetAfter()
     {
-        $store = $this->createMock(PersistingStoreInterface::class);
+        $store = $this->createStub(PersistingStoreInterface::class);
 
         $key = new Key('key', 1);
         $semaphore = new Semaphore($key, $store, 1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT