### PR TITLE
[VarDumper] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/DoctrineCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DoctrineCasterTest.php
@@ -29,7 +29,7 @@ class DoctrineCasterTest extends TestCase
     {
         $classMetadata = new ClassMetadata(__CLASS__);
 
-        $collection = new PersistentCollection($this->createMock(EntityManagerInterface::class), $classMetadata, new ArrayCollection(['test']));
+        $collection = new PersistentCollection($this->createStub(EntityManagerInterface::class), $classMetadata, new ArrayCollection(['test']));
 
         if (property_exists(PersistentCollection::class, 'isDirty')) {
             // Collections >= 2

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
@@ -35,7 +35,7 @@ class HtmlDescriptorTest extends TestCase
     public function testItOutputsStylesAndScriptsOnFirstDescribeCall()
     {
         $output = new BufferedOutput();
-        $dumper = $this->createMock(HtmlDumper::class);
+        $dumper = $this->createStub(HtmlDumper::class);
         $dumper->method('dump')->willReturn('[DUMPED]');
         $descriptor = new HtmlDescriptor($dumper);
 
@@ -54,7 +54,7 @@ class HtmlDescriptorTest extends TestCase
     public function testDescribe(array $context, string $expectedOutput)
     {
         $output = new BufferedOutput();
-        $dumper = $this->createMock(HtmlDumper::class);
+        $dumper = $this->createStub(HtmlDumper::class);
         $dumper->method('dump')->willReturn('[DUMPED]');
         $descriptor = new HtmlDescriptor($dumper);
 

--- a/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
@@ -38,6 +38,6 @@ class ServerDumpCommandTest extends TestCase
 
     private function createCommand(): ServerDumpCommand
     {
-        return new ServerDumpCommand($this->createMock(DumpServer::class));
+        return new ServerDumpCommand($this->createStub(DumpServer::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT