### PR TITLE
[WebLink] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/WebLink/Tests/EventListener/AddLinkHeaderListenerTest.php
+++ b/src/Symfony/Component/WebLink/Tests/EventListener/AddLinkHeaderListenerTest.php
@@ -34,7 +34,7 @@ class AddLinkHeaderListenerTest extends TestCase
 
         $subscriber = new AddLinkHeaderListener();
 
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
         $subscriber->onKernelResponse($event);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT