### PR TITLE
[FrameworkBundle] Enable mocking non-shared services in tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
  * Add support for `framework.secrets.decryption_env_var` to contain dots
+ * Enable mocking non-shared services in tests
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
@@ -63,5 +63,17 @@ class TestServiceContainerRealRefPass implements CompilerPassInterface
         if ($container->hasDefinition('test.service_container') && $renamedIds) {
             $container->getDefinition('test.service_container')->setArgument(2, $renamedIds);
         }
+
+        $nonSharedServices = [];
+
+        foreach ($definitions as $id => $definition) {
+            if (($id && '.' !== $id[0] || isset($privateServices[$id])) && !$definition->isShared() && !$definition->hasErrors() && !$definition->isAbstract()) {
+                $nonSharedServices[$id] = true;
+            }
+        }
+
+        if ($container->hasDefinition('test.service_container') && $nonSharedServices) {
+            $container->getDefinition('test.service_container')->setArgument(3, $nonSharedServices);
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -33,6 +33,7 @@ class TestContainer extends Container
         private KernelInterface $kernel,
         private string $privateServicesLocatorId,
         private array $renamedIds = [],
+        private array $nonSharedServices = [],
     ) {
     }
 
@@ -70,6 +71,15 @@ class TestContainer extends Container
     {
         $container = $this->getPublicContainer();
         $renamedId = $this->renamedIds[$id] ?? $id;
+
+        if (isset($this->nonSharedServices[$renamedId])) {
+            if (!$service instanceof \Closure) {
+                throw new InvalidArgumentException(\sprintf('The "%s" service is non-shared and must be replaced by a closure that should act as a factory.', $id));
+            }
+            $container->factories[$renamedId] = $container->factories['service_container'][$renamedId] = $service;
+
+            return;
+        }
 
         if (!$this->getPrivateContainer()->has($renamedId)) {
             $container->set($renamedId, $service);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/PublicService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/PublicService.php
@@ -15,10 +15,21 @@ class PublicService
 {
     private NonPublicService $nonPublicService;
     private PrivateService $privateService;
+    private PrivateService $decorated;
+    public object $nonSharedService;
+    public object $nonSharedAlias;
 
-    public function __construct(NonPublicService $nonPublicService, PrivateService $privateService)
-    {
+    public function __construct(
+        NonPublicService $nonPublicService,
+        PrivateService $privateService,
+        PrivateService $decorated,
+        object $nonSharedService,
+        object $nonSharedAlias,
+    ) {
         $this->nonPublicService = $nonPublicService;
         $this->privateService = $privateService;
+        $this->decorated = $decorated;
+        $this->nonSharedService = $nonSharedService;
+        $this->nonSharedAlias = $nonSharedAlias;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\TestWith;
 use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\NonPublicService;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService;
@@ -66,6 +67,35 @@ class TestServiceContainerTest extends AbstractWebTestCase
         $service = new PrivateService();
         $container->set('decorated', $service);
         $this->assertSame($service, $container->get('decorated')->inner);
+    }
+
+    #[TestWith(['non_shared_service'])]
+    #[TestWith(['non_shared_alias'])]
+    public function testSetNonSharedService(string $serviceId)
+    {
+        static::bootKernel(['test_case' => 'TestServiceContainer']);
+
+        $container = static::getContainer();
+
+        $services = [$service1 = new \stdClass(), $service2 = new \stdClass()];
+        $container->set($serviceId, static function () use (&$services) {
+            return array_pop($services);
+        });
+
+        $this->assertSame($service2, $container->get(PublicService::class)->nonSharedService);
+        $this->assertSame($service1, $container->get(PublicService::class)->nonSharedAlias);
+    }
+
+    public function testThrowsExceptionWhenNonSharedServiceIsReplacedByNonCallable()
+    {
+        static::bootKernel(['test_case' => 'TestServiceContainer']);
+
+        $container = static::getContainer();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "non_shared_service" service is non-shared and must be replaced by a closure that should act as a factory.');
+
+        $container->set('non_shared_service', new \stdClass());
     }
 
     #[DoesNotPerformAssertions]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/services.yml
@@ -17,12 +17,22 @@ services:
             - '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\NonPublicService'
             - '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService'
             - '@decorated'
+            - '@non_shared_service'
+            - '@non_shared_alias'
 
     decorator:
         class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService
         decorates: decorated
         properties:
             inner: '@.inner'
+
+    non_shared_service:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService
+        shared: false
+        properties:
+            inner: '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService'
+
+    non_shared_alias: '@non_shared_service'
 
     Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\ResettableService:
         public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, it's not possible to replace non-shared services in the `TestContainer`. I'm not sure if this is the best approach, I'm open to suggestions.

```php
$container = static::getContainer();
$container->set('service.id', static function () {
    return new stdClass();
});
```