### PR TITLE
[Serializer] Fix `'*'` context group to serialize only properties with at least one group

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -42,7 +42,8 @@ class SerializerExtractor implements PropertyListExtractorInterface
         $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            if (!$serializerAttributeMetadata->isIgnored() && (null === $context['serializer_groups'] || \in_array('*', $context['serializer_groups'], true) || array_intersect($serializerAttributeMetadata->getGroups(), $context['serializer_groups']))) {
+            $attributeGroups = $serializerAttributeMetadata->getGroups();
+            if (!$serializerAttributeMetadata->isIgnored() && (null === $context['serializer_groups'] || (\in_array('*', $context['serializer_groups'], true) && [] !== $attributeGroups) || array_intersect($attributeGroups, $context['serializer_groups']))) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -50,6 +50,21 @@ class SerializerExtractorTest extends TestCase
         $this->assertSame(['analyses', 'feet'], $this->extractor->getProperties(AdderRemoverDummy::class, ['serializer_groups' => null]));
     }
 
+    public function testGetPropertiesWithAsteriskGroup()
+    {
+        $this->assertSame(['collection'], $this->extractor->getProperties(Dummy::class, ['serializer_groups' => ['*']]));
+    }
+
+    public function testGetPropertiesWithAsteriskGroupWhenNoPropertyHasGroup()
+    {
+        $this->assertSame([], $this->extractor->getProperties(AdderRemoverDummy::class, ['serializer_groups' => ['*']]));
+    }
+
+    public function testGetPropertiesWithAsteriskGroupExcludesIgnoredProperties()
+    {
+        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['*']]));
+    }
+
     public function testGetPropertiesWithNonExistentClassReturnsNull()
     {
         $this->assertNull($this->extractor->getProperties('NonExistent'));

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -232,10 +232,12 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                 $ignoreUsed = true;
             }
 
+            $attributeGroups = $attributeMetadata->getGroups();
+
             // If you update this check, update accordingly the one in Symfony\Component\PropertyInfo\Extractor\SerializerExtractor::getProperties()
             if (
                 !$ignore
-                && ([] === $groups || \in_array('*', $groups, true) || array_intersect($attributeMetadata->getGroups(), $groups))
+                && ([] === $groups || (\in_array('*', $groups, true) && [] !== $attributeGroups) || array_intersect($attributeGroups, $groups))
                 && $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -85,7 +85,7 @@ class AbstractNormalizerTest extends TestCase
         $this->assertEquals(['a3', 'a4'], $result);
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], true);
-        $this->assertEquals(['a1', 'a2', 'a3', 'a4'], $result);
+        $this->assertEquals(['a2', 'a3', 'a4'], $result);
     }
 
     public function testGetAllowedAttributesAsObjects()
@@ -120,7 +120,7 @@ class AbstractNormalizerTest extends TestCase
         $this->assertEquals([$a3, $a4], $result);
 
         $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], false);
-        $this->assertEquals([$a1, $a2, $a3, $a4], $result);
+        $this->assertEquals([$a2, $a3, $a4], $result);
     }
 
     public function testObjectWithStaticConstructor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #62912 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
