### PR TITLE
[Console] Add `#[AskChoice]` attribute for interactive choice questions

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -96,7 +96,7 @@ class Argument
             $self->suggestedValues = array_column($self->typeName::cases(), 'value');
         }
 
-        $self->interactiveAttribute = Ask::tryFrom($member, $self->name);
+        $self->interactiveAttribute = Ask::tryFrom($member, $self->name) ?? AskChoice::tryFrom($member, $self->name);
 
         if ($self->interactiveAttribute && $isOptional) {
             throw new LogicException(\sprintf('The %s "$%s" argument of "%s" cannot be both interactive and optional.', $reflection->getMemberName(), $self->name, $reflection->getSourceName()));

--- a/src/Symfony/Component/Console/Attribute/AskChoice.php
+++ b/src/Symfony/Component/Console/Attribute/AskChoice.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute;
+
+use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
+use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
+class AskChoice implements InteractiveAttributeInterface
+{
+    public ?\Closure $validator;
+    public array|\Closure $choices;
+    private \Closure $closure;
+
+    /**
+     * @param string                                                     $question     The question to ask the user
+     * @param array<string|int|float>|callable():array<string|int|float> $choices      The list of available choices (leave empty to use enum cases)
+     * @param string|int|float|null                                      $default      The default answer to return if the user enters nothing
+     * @param string                                                     $errorMessage The error message when the answer is invalid
+     * @param string                                                     $prompt       The prompt displayed before the user input
+     * @param callable|null                                              $validator    The validator for the answer
+     * @param int|null                                                   $maxAttempts  The maximum number of attempts allowed to answer the question.
+     *                                                                                 Null means an unlimited number of attempts
+     */
+    public function __construct(
+        public string $question,
+        array|callable $choices = [],
+        public string|int|float|null $default = null,
+        public string $errorMessage = 'Value "%s" is invalid',
+        public string $prompt = ' > ',
+        ?callable $validator = null,
+        public ?int $maxAttempts = null,
+    ) {
+        $this->validator = $validator ? $validator(...) : null;
+        $this->choices = \is_callable($choices) ? $choices(...) : $choices;
+    }
+
+    /**
+     * @internal
+     */
+    public static function tryFrom(\ReflectionParameter|\ReflectionProperty $member, string $name): ?self
+    {
+        $reflection = new ReflectionMember($member);
+
+        if (!$self = $reflection->getAttribute(self::class)) {
+            return null;
+        }
+
+        $type = $reflection->getType();
+
+        if (!$type instanceof \ReflectionNamedType) {
+            throw new LogicException(\sprintf('The %s "$%s" of "%s" must have a named type. Untyped, Union or Intersection types are not supported for choice questions.', $reflection->getMemberName(), $name, $reflection->getSourceName()));
+        }
+
+        $isBackedEnum = is_subclass_of($type->getName(), \BackedEnum::class);
+
+        // Validate that choices are provided or can be derived from enum
+        if (!$self->choices && !$isBackedEnum) {
+            throw new LogicException(\sprintf('The #[AskChoice] attribute for the %s "$%s" of "%s" requires either explicit choices or a BackedEnum type.', $reflection->getMemberName(), $name, $reflection->getSourceName()));
+        }
+
+        $self->closure = function (SymfonyStyle $io, InputInterface $input) use ($self, $reflection, $name, $type, $isBackedEnum) {
+            if ($reflection->isProperty() && isset($this->{$reflection->getName()})) {
+                return;
+            }
+
+            if ($reflection->isParameter() && !\in_array($input->getArgument($name), [null, []], true)) {
+                return;
+            }
+
+            $choices = $self->choices instanceof \Closure ? ($self->choices)() : $self->choices;
+
+            // Derive choices from enum cases if not provided
+            if (!$choices && $isBackedEnum) {
+                /** @var class-string<\BackedEnum> $enumClass */
+                $enumClass = $type->getName();
+                $choices = array_column($enumClass::cases(), 'value');
+            }
+
+            $question = new ChoiceQuestion($self->question, $choices, $self->default);
+            $question->setMultiselect('array' === $type->getName());
+            $question->setErrorMessage($self->errorMessage);
+            $question->setPrompt($self->prompt);
+            $question->setMaxAttempts($self->maxAttempts);
+
+            if (!$self->validator && $reflection->isProperty() && !$isBackedEnum && 'array' !== $type->getName()) {
+                $self->validator = function (mixed $value) use ($reflection): mixed {
+                    return $this->{$reflection->getName()} = $value;
+                };
+            }
+
+            if ($self->validator) {
+                $question->setValidator($self->validator);
+            }
+
+            $value = $io->askQuestion($question);
+
+            if (null === $value && !$reflection->isNullable()) {
+                return;
+            }
+
+            // Convert back to enum if needed
+            if ($isBackedEnum) {
+                /** @var class-string<\BackedEnum> $enumClass */
+                $enumClass = $type->getName();
+                if ($question->isMultiselect() && \is_array($value)) {
+                    $value = array_map(static fn ($v) => $enumClass::from($v), $value);
+                } else {
+                    $value = $enumClass::from($value);
+                }
+            }
+
+            if ($reflection->isProperty()) {
+                $this->{$reflection->getName()} = $value;
+            } else {
+                $input->setArgument($name, $value);
+            }
+        };
+
+        return $self;
+    }
+
+    /**
+     * @internal
+     */
+    public function getFunction(object $instance): \ReflectionFunction
+    {
+        return new \ReflectionFunction($this->closure->bindTo($instance, $instance::class));
+    }
+}

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `#[AskChoice]` attribute for interactive choice questions in invokable commands
  * Add support for method-based commands with `#[AsCommand]` attribute
 
 8.0

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInteractiveChoiceAttributeTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInteractiveChoiceAttributeTestCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\AskChoice;
+use Symfony\Component\Console\Attribute\MapInput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('invokable:interactive:choice')]
+class InvokableWithInteractiveChoiceAttributeTestCommand
+{
+    public function __invoke(
+        SymfonyStyle $io,
+
+        #[Argument, AskChoice('Select a color', ['red', 'green', 'blue'])]
+        string $color,
+
+        #[MapInput]
+        ChoiceDto $dto,
+    ): int {
+        $io->writeln('Color: '.$color);
+        $io->writeln('Size: '.$dto->size);
+        $io->writeln('Status: '.$dto->status->value);
+        $io->writeln('Features: '.implode(',', $dto->features));
+
+        return Command::SUCCESS;
+    }
+}
+
+class ChoiceDto
+{
+    #[Argument]
+    #[AskChoice('Select a size', ['small', 'medium', 'large'], default: 'medium')]
+    public string $size;
+
+    #[Argument]
+    #[AskChoice('Select a status')]
+    public ChoiceStatus $status;
+
+    #[Argument]
+    #[AskChoice('Select features', ['auth', 'api', 'cache'])]
+    public array $features;
+}
+
+enum ChoiceStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Pending = 'pending';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR introduces the `#[AskChoice]` attribute for interactive invokable commands, complementing the existing `#[Ask]` attribute. It provides a declarative way to prompt users with choice questions.

### Usage

The attribute can be applied to **parameters** or **properties** (via `#[MapInput]`).

#### Basic usage with explicit choices (parameter)

```php
#[AsCommand('app:create-user')]
class CreateUserCommand
{
    public function __invoke(
        #[Argument]
        #[AskChoice('Select a role', ['admin', 'editor', 'viewer'])]
        string $role,
    ): int {
        // $role will be one of: 'admin', 'editor', 'viewer'
    }
}
```
Rendering:
```bash
Select a role:
 [0] admin
 [1] editor
 [2] viewer
>
```

#### With default value (property)

```php
class UserInput
{
    #[Argument]
    #[AskChoice('Select environment', ['dev', 'staging', 'prod'], default: 'dev')]
    public string $env;
}
```

#### Auto-derived choices from BackedEnum

When the type is a `BackedEnum`, choices are automatically derived from enum cases:

```php
enum Status: string
{
    case Active = 'active';
    case Inactive = 'inactive';
}

class UserInput
{
    #[Argument]
    #[AskChoice('Select a status')]
    public Status $status;  // Choices: ['active', 'inactive']
}
```

#### Multi-select (array type)

When the property/parameter type is `array`, multi-select is automatically enabled:

```php
class UserInput
{
    #[Argument]
    #[AskChoice('Select features', ['auth', 'api', 'cache'])]
    public array $features;  // User can select multiple values
}
```

### Attribute options

| Option         | Type                       | Default                   | Description                                |
|----------------|----------------------------|---------------------------|--------------------------------------------|
| `question`     | `string`                   | *(required)*              | The question to display                    |
| `choices`      | `array\|callable`       | `[]`                      | Available choices (auto-derived for enums)  |
| `default`      | `string\|int\|float\|null` | `null`                    | Default value if user presses enter        |
| `errorMessage` | `string`                   | `'Value "%s" is invalid'` | Error message for invalid input            |
| `prompt`       | `string`                   | `' > '`                   | Input prompt                               |
| `validator`    | `callable\|null`           | `null`                    | Custom validator                           |
| `maxAttempts`  | `int\|null`                | `null`                    | Max retry attempts (null = unlimited)      |

Cheers!