### PR TITLE
[MonologBridge] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ChromePhpHandlerTest.php
@@ -28,7 +28,7 @@ class ChromePhpHandlerTest extends TestCase
         $request->headers->remove('User-Agent');
 
         $response = new Response('foo');
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
         $listener = new ChromePhpHandler();
         $listener->onKernelResponse($event);

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
-use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -179,12 +179,12 @@ class ConsoleHandlerTest extends TestCase
             $logger->info('After terminate message.');
         });
 
-        $event = new ConsoleCommandEvent(new Command('foo'), $this->createMock(InputInterface::class), $output);
+        $event = new ConsoleCommandEvent(new Command('foo'), new ArrayInput([]), $output);
         $dispatcher->dispatch($event, ConsoleEvents::COMMAND);
         $this->assertStringContainsString('Before command message.', $out = $output->fetch());
         $this->assertStringContainsString('After command message.', $out);
 
-        $event = new ConsoleTerminateEvent(new Command('foo'), $this->createMock(InputInterface::class), $output, 0);
+        $event = new ConsoleTerminateEvent(new Command('foo'), new ArrayInput([]), $output, 0);
         $dispatcher->dispatch($event, ConsoleEvents::TERMINATE);
         $this->assertStringContainsString('Before terminate message.', $out = $output->fetch());
         $this->assertStringContainsString('After terminate message.', $out);

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/FirePHPHandlerTest.php
@@ -103,9 +103,16 @@ class FirePHPHandlerTest extends TestCase
             return new FirePHPHandler();
         }
 
-        $handler = $this->getMockBuilder(FirePHPHandler::class)
-            ->onlyMethods(['isWebRequest'])
-            ->getMock();
+        if (method_exists($this, 'getStubBuilder')) {
+            $handler = self::getStubBuilder(FirePHPHandler::class)
+                ->onlyMethods(['isWebRequest'])
+                ->getStub();
+        } else {
+            $handler = $this->getMockBuilder(FirePHPHandler::class)
+                ->onlyMethods(['isWebRequest'])
+                ->getMock();
+        }
+
         // Disable web request detection
         $handler->method('isWebRequest')->willReturn(true);
 

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
@@ -17,7 +17,7 @@ use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\NullOutput;
 
 class ConsoleCommandProcessorTest extends TestCase
 {
@@ -63,12 +63,11 @@ class ConsoleCommandProcessorTest extends TestCase
 
     private function getConsoleEvent(): ConsoleEvent
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
         $input->method('getArguments')->willReturn(self::TEST_ARGUMENTS);
         $input->method('getOptions')->willReturn(self::TEST_OPTIONS);
-        $command = $this->createMock(Command::class);
-        $command->method('getName')->willReturn(self::TEST_NAME);
+        $command = new Command(self::TEST_NAME);
 
-        return new ConsoleEvent($command, $input, $this->createMock(OutputInterface::class));
+        return new ConsoleEvent($command, $input, new NullOutput());
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/RouteProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/RouteProcessorTest.php
@@ -125,12 +125,12 @@ class RouteProcessorTest extends TestCase
 
     private function getRequestEvent(Request $request, int $requestType = HttpKernelInterface::MAIN_REQUEST): RequestEvent
     {
-        return new RequestEvent($this->createMock(HttpKernelInterface::class), $request, $requestType);
+        return new RequestEvent($this->createStub(HttpKernelInterface::class), $request, $requestType);
     }
 
     private function getFinishRequestEvent(Request $request): FinishRequestEvent
     {
-        return new FinishRequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        return new FinishRequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
     }
 
     private function mockEmptyRequest(): Request
@@ -149,7 +149,7 @@ class RouteProcessorTest extends TestCase
 
     private function mockRequest(array $attributes): Request
     {
-        $request = $this->createMock(Request::class);
+        $request = new Request();
         $request->attributes = new ParameterBag($attributes);
 
         return $request;

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/SwitchUserTokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/SwitchUserTokenProcessorTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\Monolog\Tests\Processor;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\SwitchUserTokenProcessor;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
@@ -30,8 +30,8 @@ class SwitchUserTokenProcessorTest extends TestCase
     {
         $originalToken = new UsernamePasswordToken(new InMemoryUser('original_user', 'password', ['ROLE_SUPER_ADMIN']), 'provider', ['ROLE_SUPER_ADMIN']);
         $switchUserToken = new SwitchUserToken(new InMemoryUser('user', 'passsword', ['ROLE_USER']), 'provider', ['ROLE_USER'], $originalToken);
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage->method('getToken')->willReturn($switchUserToken);
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($switchUserToken);
 
         $processor = new SwitchUserTokenProcessor($tokenStorage);
         $record = RecordFactory::create();

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\Monolog\Tests\Processor;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 
@@ -28,8 +28,8 @@ class TokenProcessorTest extends TestCase
     public function testProcessor()
     {
         $token = new UsernamePasswordToken(new InMemoryUser('user', 'password', ['ROLE_USER']), 'provider', ['ROLE_USER']);
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage->method('getToken')->willReturn($token);
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($token);
 
         $processor = new TokenProcessor($tokenStorage);
         $record = RecordFactory::create();

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -91,7 +91,7 @@ class WebProcessorTest extends TestCase
         $request->server->replace($server);
         $request->headers->replace($server);
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         return [$event, $server];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT