### PR TITLE
[DoctrineBridge] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -16,7 +16,6 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
@@ -30,7 +29,7 @@ class EntityValueResolverTest extends TestCase
 {
     public function testResolveWithoutClass()
     {
-        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -42,7 +41,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testResolveWithoutAttribute()
     {
-        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry, null, new MapEntity(disabled: true));
 
@@ -65,7 +64,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testResolveWithNoIdAndDataOptional()
     {
-        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -132,7 +131,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testResolveWithNullId()
     {
-        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -146,7 +145,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testResolveWithArrayIdNullValue()
     {
-        $manager = $this->createMock(ObjectManager::class);
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -187,7 +186,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testUsedProperIdentifier()
     {
-        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -219,7 +218,7 @@ class EntityValueResolverTest extends TestCase
 
         $argument = $this->createArgument('stdClass', new MapEntity(), 'arg', true);
 
-        $metadata = $this->getMockBuilder(ClassMetadata::class)->getMock();
+        $metadata = $this->createStub(ClassMetadata::class);
         $manager->expects($this->once())
             ->method('getClassMetadata')
             ->with('stdClass')
@@ -272,7 +271,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testExceptionWithExpressionIfNoLanguageAvailable()
     {
-        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -390,7 +389,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testAlreadyResolved()
     {
-        $manager = $this->getMockBuilder(ObjectManager::class)->getMock();
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -407,11 +406,11 @@ class EntityValueResolverTest extends TestCase
         return new ArgumentMetadata($name, $class ?? \stdClass::class, false, false, null, $isNullable, $entity ? [$entity] : []);
     }
 
-    private function createRegistry(?ObjectManager $manager = null): ManagerRegistry&MockObject
+    private function createRegistry(?ObjectManager $manager = null): ManagerRegistry
     {
-        $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
+        $registry = $this->createStub(ManagerRegistry::class);
 
-        $registry->expects($this->any())
+        $registry
             ->method('getManagerForClass')
             ->willReturn($manager);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -146,23 +146,19 @@ class DoctrineDataCollectorTest extends TestCase
 
     private function createCollector(array $queries): DoctrineDataCollector
     {
-        $connection = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->expects($this->any())
+        $connection = $this->createStub(Connection::class);
+        $connection
             ->method('getDatabasePlatform')
             ->willReturn(new MySqlPlatform());
 
-        $registry = $this->createMock(ManagerRegistry::class);
+        $registry = $this->createStub(ManagerRegistry::class);
         $registry
-            ->expects($this->any())
             ->method('getConnectionNames')
             ->willReturn(['default' => 'doctrine.dbal.default_connection']);
         $registry
-            ->expects($this->any())
             ->method('getManagerNames')
             ->willReturn(['default' => 'doctrine.orm.default_entity_manager']);
-        $registry->expects($this->any())
+        $registry
             ->method('getConnection')
             ->willReturn($connection);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -24,26 +23,40 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  */
 class DoctrineExtensionTest extends TestCase
 {
-    private MockObject&AbstractDoctrineExtension $extension;
+    private AbstractDoctrineExtension $extension;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->extension = $this
-            ->getMockBuilder(AbstractDoctrineExtension::class)
-            ->onlyMethods([
-                'getMappingResourceConfigDirectory',
-                'getObjectManagerElementName',
-                'getMappingObjectDefaultName',
-                'getMappingResourceExtension',
-                'getMetadataDriverClass',
-                'load',
-            ])
-            ->getMock()
-        ;
+        if (method_exists($this, 'getStubBuilder')) {
+            $this->extension = self::getStubBuilder(AbstractDoctrineExtension::class)
+                ->onlyMethods([
+                    'getMappingResourceConfigDirectory',
+                    'getObjectManagerElementName',
+                    'getMappingObjectDefaultName',
+                    'getMappingResourceExtension',
+                    'getMetadataDriverClass',
+                    'load',
+                ])
+                ->getStub()
+            ;
+        } else {
+            $this->extension = $this
+                ->getMockBuilder(AbstractDoctrineExtension::class)
+                ->onlyMethods([
+                    'getMappingResourceConfigDirectory',
+                    'getObjectManagerElementName',
+                    'getMappingObjectDefaultName',
+                    'getMappingResourceExtension',
+                    'getMetadataDriverClass',
+                    'load',
+                ])
+                ->getMock()
+            ;
+        }
 
-        $this->extension->expects($this->any())
+        $this->extension
             ->method('getObjectManagerElementName')
             ->willReturnCallback(fn ($name) => 'doctrine.orm.'.$name);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bridge\Doctrine\Tests\Form\ChoiceList;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
@@ -27,41 +26,41 @@ use Symfony\Component\Form\Exception\LogicException;
  */
 class DoctrineChoiceLoaderTest extends TestCase
 {
-    private MockObject&ObjectManager $om;
-    private MockObject&ObjectRepository $repository;
+    private ObjectManager $om;
+    private ObjectRepository $repository;
     private string $class;
-    private MockObject&IdReader $idReader;
-    private MockObject&EntityLoaderInterface $objectLoader;
+    private IdReader $idReader;
+    private EntityLoaderInterface $objectLoader;
     private \stdClass $obj1;
     private \stdClass $obj2;
     private \stdClass $obj3;
 
     protected function setUp(): void
     {
-        $this->om = $this->createMock(ObjectManager::class);
+        $this->om = $this->createStub(ObjectManager::class);
         $this->repository = $this->createMock(ObjectRepository::class);
         $this->class = 'stdClass';
-        $this->idReader = $this->createMock(IdReader::class);
-        $this->idReader->expects($this->any())
+        $this->idReader = $this->createStub(IdReader::class);
+        $this->idReader
             ->method('isSingleId')
             ->willReturn(true)
         ;
 
-        $this->objectLoader = $this->createMock(EntityLoaderInterface::class);
+        $this->objectLoader = $this->createStub(EntityLoaderInterface::class);
         $this->obj1 = (object) ['name' => 'A'];
         $this->obj2 = (object) ['name' => 'B'];
         $this->obj3 = (object) ['name' => 'C'];
 
-        $this->om->expects($this->any())
+        $this->om
             ->method('getRepository')
             ->with($this->class)
             ->willReturn($this->repository);
 
-        $this->om->expects($this->any())
+        $this->om
             ->method('getClassMetadata')
             ->with($this->class)
             ->willReturn(new ClassMetadata($this->class));
-        $this->repository->expects($this->any())
+        $this->repository
             ->method('findAll')
             ->willReturn([$this->obj1, $this->obj2, $this->obj3])
         ;
@@ -92,6 +91,7 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     public function testLoadChoiceListUsesObjectLoaderIfAvailable()
     {
+        $this->objectLoader = $this->createMock(EntityLoaderInterface::class);
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,
@@ -161,7 +161,7 @@ class DoctrineChoiceLoaderTest extends TestCase
         $this->repository->expects($this->never())
             ->method('findAll');
 
-        $this->idReader->expects($this->any())
+        $this->idReader
             ->method('getIdValue')
             ->with($this->obj2)
             ->willReturn('2');
@@ -206,7 +206,7 @@ class DoctrineChoiceLoaderTest extends TestCase
         $this->repository->expects($this->never())
             ->method('findAll');
 
-        $this->idReader->expects($this->any())
+        $this->idReader
             ->method('getIdValue')
             ->with($this->obj2)
             ->willReturn('2');
@@ -253,6 +253,7 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     public function testLegacyLoadChoicesForValuesLoadsOnlyChoicesIfValueUseIdReader()
     {
+        $this->objectLoader = $this->createMock(EntityLoaderInterface::class);
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,
@@ -260,7 +261,7 @@ class DoctrineChoiceLoaderTest extends TestCase
             $this->objectLoader
         );
 
-        $this->idReader->expects($this->any())
+        $this->idReader
             ->method('getIdField')
             ->willReturn('idField');
 
@@ -278,6 +279,7 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     public function testLoadChoicesForValuesLoadsOnlyChoicesIfValueUseIdReader()
     {
+        $this->objectLoader = $this->createMock(EntityLoaderInterface::class);
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,
@@ -287,7 +289,7 @@ class DoctrineChoiceLoaderTest extends TestCase
 
         $choices = [$this->obj2, $this->obj3];
 
-        $this->idReader->expects($this->any())
+        $this->idReader
             ->method('getIdField')
             ->willReturn('idField');
 
@@ -299,7 +301,7 @@ class DoctrineChoiceLoaderTest extends TestCase
             ->with('idField', [4 => '3', 7 => '2'])
             ->willReturn($choices);
 
-        $this->idReader->expects($this->any())
+        $this->idReader
             ->method('getIdValue')
             ->willReturnMap([
                 [$this->obj2, '2'],
@@ -335,6 +337,7 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     public function testLoadChoicesForValuesLoadsOnlyChoicesIfValueIsIdReader()
     {
+        $this->objectLoader = $this->createMock(EntityLoaderInterface::class);
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,
@@ -345,7 +348,7 @@ class DoctrineChoiceLoaderTest extends TestCase
         $choices = [$this->obj2, $this->obj3];
         $value = [$this->idReader, 'getIdValue'];
 
-        $this->idReader->expects($this->any())
+        $this->idReader
             ->method('getIdField')
             ->willReturn('idField');
 
@@ -357,7 +360,7 @@ class DoctrineChoiceLoaderTest extends TestCase
             ->with('idField', ['2'])
             ->willReturn($choices);
 
-        $this->idReader->expects($this->any())
+        $this->idReader
             ->method('getIdValue')
             ->willReturnMap([
                 [$this->obj2, '2'],
@@ -374,6 +377,8 @@ class DoctrineChoiceLoaderTest extends TestCase
             ->method('isSingleId')
             ->willReturn(false)
         ;
+        $this->repository->expects($this->never())
+            ->method('findAll');
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "$idReader" argument of "Symfony\\Bridge\\Doctrine\\Form\\ChoiceList\\DoctrineChoiceLoader::__construct" must be null when the query cannot be optimized because of composite id fields.');

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/EventListener/MergeDoctrineCollectionListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/EventListener/MergeDoctrineCollectionListenerTest.php
@@ -25,13 +25,13 @@ class MergeDoctrineCollectionListenerTest extends TestCase
 {
     private ArrayCollection $collection;
     private EventDispatcher $dispatcher;
-    private MockObject&FormFactoryInterface $factory;
+    private FormFactoryInterface $factory;
 
     protected function setUp(): void
     {
         $this->collection = new ArrayCollection(['test']);
         $this->dispatcher = new EventDispatcher();
-        $this->factory = $this->createMock(FormFactoryInterface::class);
+        $this->factory = $this->createStub(FormFactoryInterface::class);
     }
 
     protected function getBuilder()

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -31,13 +31,13 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
 
     protected function getExtensions()
     {
-        $manager = $this->createMock(ManagerRegistry::class);
+        $manager = $this->createStub(ManagerRegistry::class);
 
-        $manager->expects($this->any())
+        $manager
             ->method('getManager')
             ->willReturn($this->em);
 
-        $manager->expects($this->any())
+        $manager
             ->method('getManagerForClass')
             ->willReturn($this->em);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -16,7 +16,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\ManagerRegistry;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -54,12 +53,12 @@ class EntityTypeTest extends BaseTypeTestCase
     private const COMPOSITE_STRING_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeStringIdEntity';
 
     private EntityManager $em;
-    private MockObject&ManagerRegistry $emRegistry;
+    private ManagerRegistry $emRegistry;
 
     protected function setUp(): void
     {
         $this->em = DoctrineTestHelper::createTestEntityManager();
-        $this->emRegistry = $this->createRegistryMock('default', $this->em);
+        $this->emRegistry = $this->createRegistryMock($this->em);
 
         parent::setUp();
 
@@ -1137,6 +1136,7 @@ class EntityTypeTest extends BaseTypeTestCase
 
     public function testGetManagerForClassIfNoEm()
     {
+        $this->emRegistry = $this->createMock(ManagerRegistry::class);
         $this->emRegistry->expects($this->never())
             ->method('getManager');
 
@@ -1145,7 +1145,10 @@ class EntityTypeTest extends BaseTypeTestCase
             ->with(self::SINGLE_IDENT_CLASS)
             ->willReturn($this->em);
 
-        $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+        $factory = Forms::createFormFactoryBuilder()
+            ->addExtensions($this->getExtensions())
+            ->getFormFactory();
+        $factory->createNamed('name', static::TESTED_TYPE, null, [
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
@@ -1154,13 +1157,17 @@ class EntityTypeTest extends BaseTypeTestCase
 
     public function testExplicitEm()
     {
+        $this->emRegistry = $this->createMock(ManagerRegistry::class);
         $this->emRegistry->expects($this->never())
             ->method('getManager');
 
         $this->emRegistry->expects($this->never())
             ->method('getManagerForClass');
 
-        $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+        $factory = Forms::createFormFactoryBuilder()
+            ->addExtensions($this->getExtensions())
+            ->getFormFactory();
+        $factory->createNamed('name', static::TESTED_TYPE, null, [
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'choice_label' => 'name',
@@ -1279,12 +1286,12 @@ class EntityTypeTest extends BaseTypeTestCase
         $this->assertSame($choiceList1, $choiceList3);
     }
 
-    protected function createRegistryMock($name, $em): MockObject&ManagerRegistry
+    private function createRegistryMock($em): ManagerRegistry
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry
             ->method('getManager')
-            ->with($this->equalTo($name))
+            ->with($this->equalTo('default'))
             ->willReturn($em);
 
         return $registry;

--- a/src/Symfony/Bridge/Doctrine/Tests/IdGenerator/UlidGeneratorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/IdGenerator/UlidGeneratorTest.php
@@ -34,8 +34,8 @@ class UlidGeneratorTest extends TestCase
     {
         $ulid = new Ulid('00000000000000000000000000');
         $em = (new \ReflectionClass(EntityManager::class))->newInstanceWithoutConstructor();
-        $factory = $this->createMock(UlidFactory::class);
-        $factory->expects($this->any())
+        $factory = $this->createStub(UlidFactory::class);
+        $factory
             ->method('create')
             ->willReturn($ulid);
         $generator = new UlidGenerator($factory);

--- a/src/Symfony/Bridge/Doctrine/Tests/IdGenerator/UuidGeneratorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/IdGenerator/UuidGeneratorTest.php
@@ -35,8 +35,8 @@ class UuidGeneratorTest extends TestCase
     {
         $uuid = new UuidV4();
         $em = (new \ReflectionClass(EntityManager::class))->newInstanceWithoutConstructor();
-        $factory = $this->createMock(UuidFactory::class);
-        $factory->expects($this->any())
+        $factory = $this->createStub(UuidFactory::class);
+        $factory
             ->method('create')
             ->willReturn($uuid);
         $generator = new UuidGenerator($factory);

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineClearEntityManagerWorkerSubscriberTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineClearEntityManagerWorkerSubscriberTest.php
@@ -28,7 +28,7 @@ class DoctrineClearEntityManagerWorkerSubscriberTest extends MiddlewareTestCase
         $entityManager2->expects($this->once())
             ->method('clear');
 
-        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
         $managerRegistry
             ->method('getManagers')
             ->with()

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
@@ -24,8 +24,8 @@ use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
 {
     private MockObject&Connection $connection;
-    private MockObject&EntityManagerInterface $entityManager;
-    private MockObject&ManagerRegistry $managerRegistry;
+    private EntityManagerInterface $entityManager;
+    private ManagerRegistry $managerRegistry;
     private DoctrineCloseConnectionMiddleware $middleware;
     private string $entityManagerName = 'default';
 
@@ -33,10 +33,10 @@ class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
     {
         $this->connection = $this->createMock(Connection::class);
 
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->entityManager->method('getConnection')->willReturn($this->connection);
 
-        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->managerRegistry = $this->createStub(ManagerRegistry::class);
         $this->managerRegistry->method('getManager')->willReturn($this->entityManager);
 
         $this->middleware = new DoctrineCloseConnectionMiddleware(
@@ -59,7 +59,8 @@ class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
 
     public function testInvalidEntityManagerThrowsException()
     {
-        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->connection->expects($this->never())->method('getDatabasePlatform');
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
         $managerRegistry
             ->method('getManager')
             ->with('unknown_manager')

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -24,7 +24,7 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
 {
     private AbstractLogger $logger;
     private MockObject&Connection $connection;
-    private MockObject&EntityManagerInterface $entityManager;
+    private EntityManagerInterface $entityManager;
     private DoctrineOpenTransactionLoggerMiddleware $middleware;
 
     protected function setUp(): void
@@ -40,10 +40,10 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
 
         $this->connection = $this->createMock(Connection::class);
 
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->entityManager->method('getConnection')->willReturn($this->connection);
 
-        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
         $managerRegistry->method('getManager')->willReturn($this->entityManager);
 
         $this->middleware = new DoctrineOpenTransactionLoggerMiddleware($managerRegistry, null, $this->logger);

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -27,8 +27,8 @@ use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
 {
     private Connection&MockObject $connection;
-    private EntityManagerInterface&MockObject $entityManager;
-    private ManagerRegistry&MockObject $managerRegistry;
+    private EntityManagerInterface $entityManager;
+    private ManagerRegistry $managerRegistry;
     private DoctrinePingConnectionMiddleware $middleware;
     private string $entityManagerName = 'default';
 
@@ -36,10 +36,10 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
     {
         $this->connection = $this->createMock(Connection::class);
 
-        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager = $this->createStub(EntityManagerInterface::class);
         $this->entityManager->method('getConnection')->willReturn($this->connection);
 
-        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->managerRegistry = $this->createStub(ManagerRegistry::class);
         $this->managerRegistry->method('getManager')->willReturn($this->entityManager);
 
         $this->middleware = new DoctrinePingConnectionMiddleware(
@@ -59,10 +59,10 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
                 static $counter = 0;
 
                 if (1 === ++$counter) {
-                    throw $this->createMock(DBALException::class);
+                    throw $this->createStub(DBALException::class);
                 }
 
-                return $this->createMock(Result::class);
+                return $this->createStub(Result::class);
             });
 
         $this->connection->expects($this->once())
@@ -77,27 +77,36 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
 
     public function testMiddlewarePingResetEntityManager()
     {
-        $this->connection->method('getDatabasePlatform')
+        $this->connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
             ->willReturn($this->mockPlatform());
 
-        $this->entityManager->expects($this->once())
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($this->connection);
+        $entityManager->expects($this->once())
             ->method('isOpen')
             ->willReturn(false)
         ;
-        $this->managerRegistry->expects($this->once())
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->method('getManager')->willReturn($entityManager);
+        $managerRegistry->expects($this->once())
             ->method('resetManager')
             ->with($this->entityManagerName)
         ;
+        $middleware = new DoctrinePingConnectionMiddleware($managerRegistry, $this->entityManagerName);
 
         $envelope = new Envelope(new \stdClass(), [
             new ConsumedByWorkerStamp(),
         ]);
-        $this->middleware->handle($envelope, $this->getStackMock());
+        $middleware->handle($envelope, $this->getStackMock());
     }
 
     public function testInvalidEntityManagerThrowsException()
     {
-        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->connection->expects($this->never())->method('getDatabasePlatform');
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
         $managerRegistry
             ->method('getManager')
             ->with('unknown_manager')
@@ -127,9 +136,9 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
         $this->middleware->handle($envelope, $this->getStackMock());
     }
 
-    private function mockPlatform(): AbstractPlatform&MockObject
+    private function mockPlatform(): AbstractPlatform
     {
-        $platform = $this->createMock(AbstractPlatform::class);
+        $platform = $this->createStub(AbstractPlatform::class);
         $platform->method('getDummySelectSQL')->willReturn('SELECT 1');
 
         return $platform;

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
@@ -24,7 +24,7 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
     public function testPostGenerateSchema()
     {
         $schema = new Schema();
-        $dbalConnection = $this->createMock(Connection::class);
+        $dbalConnection = $this->createStub(Connection::class);
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
@@ -24,7 +24,7 @@ class LockStoreSchemaListenerTest extends TestCase
     public function testPostGenerateSchemaLockPdo()
     {
         $schema = new Schema();
-        $dbalConnection = $this->createMock(Connection::class);
+        $dbalConnection = $this->createStub(Connection::class);
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
@@ -28,7 +28,7 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
     public function testPostGenerateSchema()
     {
         $schema = new Schema();
-        $dbalConnection = $this->createMock(Connection::class);
+        $dbalConnection = $this->createStub(Connection::class);
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
@@ -24,7 +24,7 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
     public function testPostGenerateSchemaPdo()
     {
         $schema = new Schema();
-        $dbalConnection = $this->createMock(Connection::class);
+        $dbalConnection = $this->createStub(Connection::class);
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -25,6 +25,7 @@ use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
 use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\User;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -161,7 +162,7 @@ class EntityUserProviderTest extends TestCase
             ->method('loadUserByIdentifier')
             ->with('name')
             ->willReturn(
-                $this->createMock(UserInterface::class)
+                new InMemoryUser('John', 'password')
             );
 
         $provider = new EntityUserProvider(
@@ -179,7 +180,7 @@ class EntityUserProviderTest extends TestCase
             ->method('loadUserByIdentifier')
             ->with('name', ['foo' => 'bar'])
             ->willReturn(
-                $this->createMock(UserInterface::class)
+                new InMemoryUser('John', 'password')
             );
 
         $provider = new EntityUserProvider(
@@ -192,7 +193,7 @@ class EntityUserProviderTest extends TestCase
 
     public function testLoadUserByIdentifierShouldDeclineInvalidInterface()
     {
-        $repository = $this->createMock(ObjectRepository::class);
+        $repository = $this->createStub(ObjectRepository::class);
 
         $provider = new EntityUserProvider(
             $this->getManager($this->getObjectManager($repository)),
@@ -249,8 +250,8 @@ class EntityUserProviderTest extends TestCase
 
     private function getManager($em, $name = null)
     {
-        $manager = $this->createMock(ManagerRegistry::class);
-        $manager->expects($this->any())
+        $manager = $this->createStub(ManagerRegistry::class);
+        $manager
             ->method('getManager')
             ->with($this->equalTo($name))
             ->willReturn($em);
@@ -260,7 +261,7 @@ class EntityUserProviderTest extends TestCase
 
     private function getObjectManager($repository)
     {
-        $objectManager = $this->createMock(ObjectManager::class);
+        $objectManager = $this->createStub(ObjectManager::class);
         $objectManager->method('getRepository')
             ->willReturn($repository);
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
@@ -99,7 +99,7 @@ final class UlidTypeTest extends TestCase
 
     public function testUlidInterfaceConvertsToPHPValue()
     {
-        $ulid = $this->createMock(AbstractUid::class);
+        $ulid = $this->createStub(AbstractUid::class);
         $actual = $this->type->convertToPHPValue($ulid, new SQLitePlatform());
 
         $this->assertSame($ulid, $actual);

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
@@ -106,7 +106,7 @@ final class UuidTypeTest extends TestCase
 
     public function testUuidInterfaceConvertsToPHPValue()
     {
-        $uuid = $this->createMock(AbstractUid::class);
+        $uuid = $this->createStub(AbstractUid::class);
         $actual = $this->type->convertToPHPValue($uuid, new SqlitePlatform());
 
         $this->assertSame($uuid, $actual);

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -72,7 +72,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
     protected function createRegistryMock($em = null)
     {
-        $registry = $this->createMock(ManagerRegistry::class);
+        $registry = $this->createStub(ManagerRegistry::class);
 
         if (null === $em) {
             $registry->method('getManager')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT