### PR TITLE
[TwigBridge] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/EventListener/TemplateAttributeListenerTest.php
@@ -74,7 +74,7 @@ class TemplateAttributeListenerTest extends TestCase
         ]));
 
         $request = new Request();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, [new TemplateAttributeController(), 'foo'], ['Bar'], $request, null);
         $listener = new TemplateAttributeListener($twig);
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\UserAuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class SecurityExtensionTest extends TestCase
@@ -54,14 +55,12 @@ class SecurityExtensionTest extends TestCase
             $this->markTestSkipped('This test requires symfony/security-core 7.3 or superior.');
         }
 
-        $securityChecker = $this->createMock(AuthorizationCheckerInterface::class);
-
         ClassExistsMock::withMockedClasses([FieldVote::class => false]);
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Passing a $field to the "is_granted()" function requires symfony/acl.');
 
-        $securityExtension = new SecurityExtension($securityChecker);
+        $securityExtension = new SecurityExtension($this->createStub(AuthorizationCheckerInterface::class));
         $securityExtension->isGranted('ROLE', 'object', 'bar');
     }
 
@@ -74,7 +73,7 @@ class SecurityExtensionTest extends TestCase
             $this->markTestSkipped('This test requires symfony/security-core 7.3 or superior.');
         }
 
-        $user = $this->createMock(UserInterface::class);
+        $user = new InMemoryUser('john', 'password');
         $securityChecker = $this->createMockAuthorizationChecker();
 
         $securityExtension = new SecurityExtension($securityChecker);
@@ -115,7 +114,7 @@ class SecurityExtensionTest extends TestCase
         $this->expectExceptionMessage('Passing a $field to the "is_granted_for_user()" function requires symfony/acl.');
 
         $securityExtension = new SecurityExtension($securityChecker);
-        $securityExtension->isGrantedForUser($this->createMock(UserInterface::class), 'ROLE', 'object', 'bar');
+        $securityExtension->isGrantedForUser(new InMemoryUser('john', 'password'), 'ROLE', 'object', 'bar');
     }
 
     private function createMockAuthorizationChecker(): AuthorizationCheckerInterface&UserAuthorizationCheckerInterface

--- a/src/Symfony/Bridge/Twig/Tests/Mime/WrappedTemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/WrappedTemplatedEmailTest.php
@@ -16,6 +16,7 @@ use Symfony\Bridge\Twig\Mime\BodyRenderer;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bridge\Twig\Mime\WrappedTemplatedEmail;
 use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 use Twig\Loader\FilesystemLoader;
 
 /**
@@ -103,18 +104,16 @@ class WrappedTemplatedEmailTest extends TestCase
 
     public function testGetReturnPathWhenNull()
     {
-        $twig = $this->createMock(Environment::class);
         $message = new TemplatedEmail();
-        $email = new WrappedTemplatedEmail($twig, $message);
+        $email = new WrappedTemplatedEmail(new Environment(new ArrayLoader()), $message);
 
         $this->assertSame('', $email->getReturnPath());
     }
 
     public function testGetReturnPathWhenSet()
     {
-        $twig = $this->createMock(Environment::class);
         $message = (new TemplatedEmail())->returnPath('test@example.com');
-        $email = new WrappedTemplatedEmail($twig, $message);
+        $email = new WrappedTemplatedEmail(new Environment(new ArrayLoader()), $message);
 
         $this->assertSame('test@example.com', $email->getReturnPath());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT