### PR TITLE
[PsrHttpMessageBridge] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
@@ -27,8 +27,8 @@ final class PsrServerRequestResolverTest extends TestCase
 {
     public function testServerRequest()
     {
-        $symfonyRequest = $this->createMock(Request::class);
-        $psrRequest = $this->createMock(ServerRequestInterface::class);
+        $symfonyRequest = new Request();
+        $psrRequest = $this->createStub(ServerRequestInterface::class);
 
         $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
 
@@ -37,8 +37,8 @@ final class PsrServerRequestResolverTest extends TestCase
 
     public function testRequest()
     {
-        $symfonyRequest = $this->createMock(Request::class);
-        $psrRequest = $this->createMock(ServerRequestInterface::class);
+        $symfonyRequest = new Request();
+        $psrRequest = $this->createStub(ServerRequestInterface::class);
 
         $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
 
@@ -47,8 +47,8 @@ final class PsrServerRequestResolverTest extends TestCase
 
     public function testMessage()
     {
-        $symfonyRequest = $this->createMock(Request::class);
-        $psrRequest = $this->createMock(ServerRequestInterface::class);
+        $symfonyRequest = new Request();
+        $psrRequest = $this->createStub(ServerRequestInterface::class);
 
         $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
 

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/EventListener/PsrResponseListenerTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/EventListener/PsrResponseListenerTest.php
@@ -48,6 +48,6 @@ class PsrResponseListenerTest extends TestCase
 
     private function createEventMock(mixed $controllerResult): ViewEvent
     {
-        return new ViewEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST, $controllerResult);
+        return new ViewEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST, $controllerResult);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT