### PR TITLE
[Config] Allow `ParamConfigurator` in `ParametersConfig`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\Definition\ArrayShapeGenerator;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -171,6 +172,8 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
             $routesTypes = strtr(self::ROUTES_TYPES_TEMPLATE, ['{SHAPE}' => $routesTypes]);
             $routesTypes = substr_replace($phpdoc, $routesTypes, $i);
         }
+
+        $appTypes = str_replace('\\'.ParamConfigurator::class, 'Param', $appTypes);
 
         $configReference = strtr(self::REFERENCE_TEMPLATE, [
             '{APP_TYPES}' => $appTypes,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -33,7 +33,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     type?: string|null,
  *     ignore_errors?: bool,
  * }>
- * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|null>|null>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
  * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
  * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,7 +21,7 @@
         "ext-xml": "*",
         "symfony/cache": "^6.4.12|^7.0|^8.0",
         "symfony/config": "^7.4.3|^8.0.3",
-        "symfony/dependency-injection": "^7.4|^8.0",
+        "symfony/dependency-injection": "^7.4.4|^8.0.4",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^7.3|^8.0",
         "symfony/event-dispatcher": "^6.4|^7.0|^8.0",

--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Config\Definition;
 
+use Symfony\Component\Config\Loader\ParamConfigurator;
+
 /**
  * @author Alexandre Daubois <alex.daubois@gmail.com>
  */
@@ -32,11 +34,16 @@ final class ArrayShapeGenerator
                 $node instanceof ScalarNode => 'scalar|null',
                 default => 'mixed',
             };
-            if ('mixed' !== $typeString) {
-                $typeString .= '|Param';
+
+            if ('mixed' === $typeString) {
+                return $typeString;
             }
 
-            return $typeString;
+            if (str_ends_with($typeString, '|null')) {
+                return substr_replace($typeString, '|\\'.ParamConfigurator::class, -5, 0);
+            }
+
+            return $typeString.'|\\'.ParamConfigurator::class;
         }
 
         if ($node instanceof PrototypedArrayNode) {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -52,11 +52,11 @@ class ArrayShapeGeneratorTest extends TestCase
         $nullableBooleanNode = new BooleanNode('node');
         $nullableBooleanNode->setDefaultValue(null);
 
-        yield [$nullableBooleanNode, 'bool|null'];
+        yield [$nullableBooleanNode, 'bool|\Symfony\Component\Config\Loader\ParamConfigurator|null'];
         yield [new EnumNode('node', values: ['a', 'b']), '"a"|"b"'];
         yield [new EnumNode('node', enumFqcn: StringBackedTestEnum::class), 'value-of<\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum>|\Symfony\Component\Config\Tests\Fixtures\StringBackedTestEnum'];
         yield [new EnumNode('node', enumFqcn: IntegerBackedTestEnum::class), 'value-of<\Symfony\Component\Config\Tests\Fixtures\IntegerBackedTestEnum>|\Symfony\Component\Config\Tests\Fixtures\IntegerBackedTestEnum'];
-        yield [new ScalarNode('node'), 'scalar|null'];
+        yield [new ScalarNode('node'), 'scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null'];
         yield [new VariableNode('node'), 'mixed'];
 
         yield [new IntegerNode('node'), 'int'];
@@ -78,7 +78,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($prototype);
 
-        $expected = "array{\n *     proto?: list<string|Param>,\n * }";
+        $expected = "array{\n *     proto?: list<string|\Symfony\Component\Config\Loader\ParamConfigurator>,\n * }";
 
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
     }
@@ -92,7 +92,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($prototype);
 
-        $expected = "array{\n *     proto?: array<string, string|Param>,\n * }";
+        $expected = "array{\n *     proto?: array<string, string|\Symfony\Component\Config\Loader\ParamConfigurator>,\n * }";
 
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
     }
@@ -120,7 +120,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($child);
 
-        $this->assertStringContainsString('node?: bool|Param, // Deprecated: The "node" option is deprecated. // This is a boolean node. // Default: true', ArrayShapeGenerator::generate($root));
+        $this->assertStringContainsString('node?: bool|\Symfony\Component\Config\Loader\ParamConfigurator, // Deprecated: The "node" option is deprecated. // This is a boolean node. // Default: true', ArrayShapeGenerator::generate($root));
     }
 
     public function testPhpDocHandleMultilineDoc()
@@ -133,7 +133,7 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($child);
 
-        $this->assertStringContainsString('node?: bool|Param, // Deprecated: The "node" option is deprecated. // This is a boolean node. Set to true to enable it. Set to false to disable it. // Default: true', ArrayShapeGenerator::generate($root));
+        $this->assertStringContainsString('node?: bool|\Symfony\Component\Config\Loader\ParamConfigurator, // Deprecated: The "node" option is deprecated. // This is a boolean node. Set to true to enable it. Set to false to disable it. // Default: true', ArrayShapeGenerator::generate($root));
     }
 
     public function testPhpDocShapeSingleLevel()
@@ -159,7 +159,7 @@ class ArrayShapeGeneratorTest extends TestCase
 
         $this->assertSame(<<<'CODE'
             bool|array{
-             *     enabled?: bool|Param, // Default: false
+             *     enabled?: bool|\Symfony\Component\Config\Loader\ParamConfigurator, // Default: false
              * }
             CODE, ArrayShapeGenerator::generate($root->getNode()));
     }
@@ -171,7 +171,7 @@ class ArrayShapeGeneratorTest extends TestCase
 
         $this->assertSame(<<<'CODE'
             bool|array{
-             *     enabled?: bool|Param, // Default: true
+             *     enabled?: bool|\Symfony\Component\Config\Loader\ParamConfigurator, // Default: true
              * }
             CODE, ArrayShapeGenerator::generate($root->getNode()));
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
@@ -42,7 +42,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     type?: string|null,
  *     ignore_errors?: bool,
  * }>
- * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|null>|null>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|\Symfony\Component\Config\Loader\ParamConfigurator|null>|\Symfony\Component\Config\Loader\ParamConfigurator|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
  * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
  * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Fixes typing to allow using parameters for other parameters.

I ran into this when using code like the following:
```php
return App::config([
    'parameters' => [
        'my_param' => env('MY_ENV'),
    ],
]);
```