### PR TITLE
[Process] Fix escaping of arguments with equal signs on Windows

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -180,7 +180,7 @@ class HttpClientDataCollectorTest extends TestCase
         $curlCommand = $collectedData['http_client']['traces'][0]['curlCommand'];
 
         $isWindows = '\\' === \DIRECTORY_SEPARATOR;
-        self::assertEquals(\sprintf($expectedCurlCommand, $isWindows ? '"' : "'", $isWindows ? '' : "'"), $curlCommand);
+        self::assertEquals(\sprintf($expectedCurlCommand, $isWindows ? '"' : "'", $isWindows ? '"' : "'"), $curlCommand);
     }
 
     public static function provideCurlRequests(): iterable

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1574,7 +1574,7 @@ class Process implements \IteratorAggregate
         if (str_contains($argument, "\0")) {
             $argument = str_replace("\0", '?', $argument);
         }
-        if (!preg_match('/[()%!^"<>&|\s]/', $argument)) {
+        if (!preg_match('{[^A-Za-z0-9._-]}', $argument)) {
             return $argument;
         }
         $argument = preg_replace('/(\\\\+)$/', '$1$1', $argument);

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1471,12 +1471,12 @@ class ProcessTest extends TestCase
     {
         $p = new Process(['/usr/bin/php']);
 
-        $expected = '\\' === \DIRECTORY_SEPARATOR ? '/usr/bin/php' : "'/usr/bin/php'";
+        $expected = '\\' === \DIRECTORY_SEPARATOR ? '"/usr/bin/php"' : "'/usr/bin/php'";
         $this->assertSame($expected, $p->getCommandLine());
 
         $p = new Process(['cd', '/d']);
 
-        $expected = '\\' === \DIRECTORY_SEPARATOR ? 'cd /d' : "'cd' '/d'";
+        $expected = '\\' === \DIRECTORY_SEPARATOR ? 'cd "/d"' : "'cd' '/d'";
         $this->assertSame($expected, $p->getCommandLine());
     }
 
@@ -1536,6 +1536,18 @@ class ProcessTest extends TestCase
         $p->run(null, ['code' => 'echo $argv[1];', 'def' => '"DEF"']);
 
         $this->assertSame('"DEF"', rtrim($p->getOutput()));
+    }
+
+    public function testArgumentsWithEqualsAreQuoted()
+    {
+        $process = new Process(['command', 'foo=bar']);
+        $commandLine = $process->getCommandLine();
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->assertStringContainsString('"foo=bar"', $commandLine, 'Argument with equals sign should be double-quoted on Windows');
+        } else {
+            $this->assertStringContainsString("'foo=bar'", $commandLine, 'Argument with equals sign should be single-quoted on POSIX');
+        }
     }
 
     public function testPreparedCommandWithMissingValue()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62921
| License       | MIT

Arguments containing an equals sign (`=`) are currently not quoted on Windows. This causes MSYS2/Git Bash to misinterpret paths, potentially leading to critical issues like unintended directory deletion.
This PR adds `=` to the list of characters triggering argument quoting in [Process.php](https://github.com/symfony/symfony/blob/3613fbc5a6336392bccadd90a69b8028bfd93c88/src/Symfony/Component/Process/Process.php#L1662).

Not sure if we should target 6.4 or 5.4, since this has some security implications
