### PR TITLE
[HttpKernel] Deserialize `UploadedFile` for `#[MapRequestPayload]`

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add support for `UploadedFile` when using `MapRequestPayload`
  * Add support for bundles as compiler pass
  * Add support for `SOURCE_DATE_EPOCH` environment variable
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60440
| License       | MIT

Add support for UploadedFile when deserializing the request using MapRequestPayload

## UseCase

In some case we may have multiple files and we would want to inject everything inside one DTO

```php
class MyRequest {
    public ?string $foo = null;
    public ?UploadedFile $file = null;
}
```

This change merge the data from the request and files before passing it to the denormalizer