### PR TITLE
 PHP CS Fixer: enable `no_useless_else`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,7 +34,6 @@ return (new PhpCsFixer\Config())
         '@PHPUnit9x1Migration:risky' => true, // take version from src/Symfony/Bridge/PhpUnit/phpunit.xml.dist#L4
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'protected_to_private' => true,
         'header_comment' => [
             'header' => implode('', $fileHeaderParts),
             'validator' => implode('', [
@@ -45,8 +44,10 @@ return (new PhpCsFixer\Config())
                 '/s',
             ]),
         ],
+        'no_useless_else' => true,
         'no_useless_return' => true,
         'php_unit_attributes' => true,
+        'protected_to_private' => true,
         'random_api_migration' => true,
         'static_lambda' => true,
     ])

--- a/src/Symfony/Component/AssetMapper/Compressor/GzipCompressor.php
+++ b/src/Symfony/Component/AssetMapper/Compressor/GzipCompressor.php
@@ -41,15 +41,16 @@ final class GzipCompressor implements SupportedCompressorInterface
 
     public function compress(string $path): void
     {
-        if (null === $reason = $this->zopfliCompressor->getUnsupportedReason()) {
-            $this->zopfliCompressor->compress($path);
+        $unsupportedReason = $this->zopfliCompressor->getUnsupportedReason();
+
+        if (null !== $unsupportedReason) {
+            $this->logger?->warning($unsupportedReason);
+            $this->baseCompress($path);
 
             return;
-        } else {
-            $this->logger?->warning($reason);
         }
 
-        $this->baseCompress($path);
+        $this->zopfliCompressor->compress($path);
     }
 
     public function getUnsupportedReason(): ?string

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -211,9 +211,9 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
             }
 
             return $this->pool->clear($prefix);
-        } else {
-            $this->deferred = [];
         }
+
+        $this->deferred = [];
 
         return $this->pool->clear();
     }

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -569,12 +569,12 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         // wait for the lock to be released
         if ($this->waitForLock($request)) {
             throw new CacheWasLockedException(); // unwind back to handle(), try again
-        } else {
-            // backend is slow as hell, send a 503 response (to avoid the dog pile effect)
-            $entry->setStatusCode(503);
-            $entry->setContent('503 Service Unavailable');
-            $entry->headers->set('Retry-After', 10);
         }
+
+        // backend is slow as hell, send a 503 response (to avoid the dog pile effect)
+        $entry->setStatusCode(503);
+        $entry->setContent('503 Service Unavailable');
+        $entry->headers->set('Retry-After', 10);
 
         return true;
     }

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -169,26 +169,16 @@ final class PhpDocTypeHelper
 
         [$phpType, $class] = $this->getPhpTypeAndClass($docTypeString);
 
-        if ('array' === $docTypeString) {
-            return Type::array();
-        }
-
-        if (null === $class) {
-            return Type::builtin($phpType);
-        }
-
-        if ($docType instanceof PseudoType) {
-            if ($docType->underlyingType() instanceof Integer) {
-                return Type::int();
-            } elseif ($docType->underlyingType() instanceof String_) {
-                return Type::string();
-            } else {
-                // It's safer to fall back to other extractors here, as resolving pseudo types correctly is not easy at the moment
-                return null;
-            }
-        }
-
-        return Type::object($class);
+        return match (true) {
+            'array' === $docTypeString => Type::array(),
+            null === $class => Type::builtin($phpType),
+            $docType instanceof PseudoType => match (true) {
+                $docType->underlyingType() instanceof Integer => Type::int(),
+                $docType->underlyingType() instanceof String_ => Type::string(),
+                default => null, // It's safer to fall back to other extractors here, as resolving pseudo types correctly is not easy at the moment
+            },
+            default => Type::object($class),
+        };
     }
 
     private function getPhpTypeAndClass(string $docType): array

--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
@@ -42,3 +42,5 @@ if (!class_exists(BaseExpressionLanguage::class)) {
         }
     }
 }
+
+// @php-cs-fixer-ignore no_useless_else Keep class-declaration inside if-else condition to help OPCache, especially to prevent class declaration if conditional early-exit on runtime is executed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS
| License       | MIT

almost already following the rule, only few cases to fix