### PR TITLE
[Mime] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Mime/Tests/Crypto/DkimSignerTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/DkimSignerTest.php
@@ -94,7 +94,7 @@ EOF;
 
     public function testSignWithUnsupportedAlgorithm()
     {
-        $message = $this->createMock(Message::class);
+        $message = $this->createStub(Message::class);
 
         $signer = new DkimSigner(self::$pk, 'testdkim.symfony.net', 'sf', [
             'algorithm' => 'unsupported-value',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT