### PR TITLE
[ExpressionLanguage] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/NodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/NodeTest.php
@@ -51,7 +51,7 @@ EOF
         }
 
         $node = new Node($nodes);
-        $node->compile($this->createMock(Compiler::class));
+        $node->compile(new Compiler([]));
     }
 
     public function testEvaluateActuallyEvaluatesAllNodes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT