### PR TITLE
[RateLimiter] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
@@ -61,6 +61,6 @@ class LimiterTest extends TestCase
 
     private function createFactory(array $options)
     {
-        return new RateLimiterFactory($options, $this->createMock(StorageInterface::class), $this->createMock(LockFactory::class));
+        return new RateLimiterFactory($options, $this->createStub(StorageInterface::class), $this->createStub(LockFactory::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT