### PR TITLE
[PropertyAccess] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
@@ -100,7 +100,7 @@ class PropertyAccessorBuilderTest extends TestCase
 
     public function testUseReadInfoExtractor()
     {
-        $readInfoExtractor = $this->createMock(PropertyReadInfoExtractorInterface::class);
+        $readInfoExtractor = $this->createStub(PropertyReadInfoExtractorInterface::class);
 
         $this->builder->setReadInfoExtractor($readInfoExtractor);
 
@@ -110,7 +110,7 @@ class PropertyAccessorBuilderTest extends TestCase
 
     public function testUseWriteInfoExtractor()
     {
-        $writeInfoExtractor = $this->createMock(PropertyWriteInfoExtractorInterface::class);
+        $writeInfoExtractor = $this->createStub(PropertyWriteInfoExtractorInterface::class);
 
         $this->builder->setWriteInfoExtractor($writeInfoExtractor);
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
@@ -123,12 +123,12 @@ abstract class PropertyAccessorCollectionTestCase extends PropertyAccessorArrayA
 
     public function testSetValueCallsAdderAndRemoverForNestedCollections()
     {
-        $car = $this->createMock(__CLASS__.'_CompositeCar');
+        $car = $this->createStub(__CLASS__.'_CompositeCar');
         $structure = $this->createMock(__CLASS__.'_CarStructure');
         $axesBefore = $this->getContainer([1 => 'second', 3 => 'fourth']);
         $axesAfter = $this->getContainer([0 => 'first', 1 => 'second', 2 => 'third']);
 
-        $car->expects($this->any())
+        $car
             ->method('getStructure')
             ->willReturn($structure);
 
@@ -158,11 +158,11 @@ abstract class PropertyAccessorCollectionTestCase extends PropertyAccessorArrayA
     {
         $this->expectException(NoSuchPropertyException::class);
         $this->expectExceptionMessageMatches('/Could not determine access type for property "axes" in class "Mock_PropertyAccessorCollectionTestCase_CarNoAdderAndRemover_[^"]*"./');
-        $car = $this->createMock(__CLASS__.'_CarNoAdderAndRemover');
+        $car = $this->createStub(__CLASS__.'_CarNoAdderAndRemover');
         $axesBefore = $this->getContainer([1 => 'second', 3 => 'fourth']);
         $axesAfter = $this->getContainer([0 => 'first', 1 => 'second', 2 => 'third']);
 
-        $car->expects($this->any())
+        $car
             ->method('getAxes')
             ->willReturn($axesBefore);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT