### PR TITLE
[Notifier] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bandwidth/Tests/BandwidthTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bandwidth/Tests/BandwidthTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Bandwidth\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Bandwidth\BandwidthOptions;
 use Symfony\Component\Notifier\Bridge\Bandwidth\BandwidthTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
@@ -60,14 +61,11 @@ final class BandwidthTransportTest extends TransportTestCase
     public function testNoInvalidArgumentExceptionIsThrownIfFromIsValid(string $from)
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(202);
-        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['id' => 'foo']));
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://messaging.bandwidth.com/api/v2/users/account_id/messages', $url);
 
-            return $response;
+            return new MockResponse(json_encode(['id' => 'foo']), ['http_code' => 202]);
         });
         $transport = $this->createTransport($client, $from);
         $sentMessage = $transport->send($message);

--- a/src/Symfony/Component/Notifier/Bridge/Brevo/Tests/BrevoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Brevo/Tests/BrevoTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Brevo\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Brevo\BrevoTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -46,15 +47,7 @@ final class BrevoTransportTest extends TransportTestCase
 
     public function testSendWithErrorResponseThrowsTransportException()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['code' => 400, 'message' => 'bad request']));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(static fn (): ResponseInterface => new MockResponse(json_encode(['code' => 400, 'message' => 'bad request']), ['http_code' => 400]));
 
         $transport = self::createTransport($client);
 

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/Tests/ChatworkTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/Tests/ChatworkTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Chatwork\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Chatwork\ChatworkTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -20,7 +21,6 @@ use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ChatworkTransportTest extends TransportTestCase
 {
@@ -47,15 +47,7 @@ class ChatworkTransportTest extends TransportTestCase
 
     public function testWithErrorResponseThrows()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['errors' => ['first error', 'second error']]));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['errors' => ['first error', 'second error']]), ['http_code' => 400]));
 
         $transport = $this->createTransport($client);
 

--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/Tests/ClickSendTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/Tests/ClickSendTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\ClickSend\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\ClickSend\ClickSendOptions;
 use Symfony\Component\Notifier\Bridge\ClickSend\ClickSendTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
@@ -60,10 +61,7 @@ final class ClickSendTransportTest extends TransportTestCase
     public function testNoInvalidArgumentExceptionIsThrownIfFromIsValid(string $from)
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(200);
-        $response->expects(self::once())->method('getContent')->willReturn('');
-        $client = new MockHttpClient(function (string $method, string $url, array $options) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://rest.clicksend.com/v3/sms/send', $url);
 
@@ -75,7 +73,7 @@ final class ClickSendTransportTest extends TransportTestCase
             self::assertArrayHasKey('list_id', $message);
             self::assertArrayNotHasKey('to', $message);
 
-            return $response;
+            return new MockResponse('');
         });
         $transport = $this->createTransport($client, $from);
         $transport->send($message);
@@ -84,10 +82,7 @@ final class ClickSendTransportTest extends TransportTestCase
     public function testNoInvalidArgumentExceptionIsThrownIfFromIsValidWithoutOptionalParameters()
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(200);
-        $response->expects(self::once())->method('getContent')->willReturn('');
-        $client = new MockHttpClient(function (string $method, string $url, array $options) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://rest.clicksend.com/v3/sms/send', $url);
 
@@ -98,7 +93,7 @@ final class ClickSendTransportTest extends TransportTestCase
             self::assertArrayNotHasKey('list_id', $message);
             self::assertArrayHasKey('to', $message);
 
-            return $response;
+            return new MockResponse('');
         });
         $transport = $this->createTransport($client, null, null, null, null);
         $transport->send($message);

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/Tests/ContactEveryoneTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\ContactEveryone\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\ContactEveryone\ContactEveryoneOptions;
 use Symfony\Component\Notifier\Bridge\ContactEveryone\ContactEveryoneTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
@@ -49,9 +50,7 @@ final class ContactEveryoneTransportTest extends TransportTestCase
     public function testSendSuccessfully()
     {
         $messageId = bin2hex(random_bytes(7));
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('getStatusCode')->willReturn(200);
-        $response->method('getContent')->willReturn($messageId);
+        $response = new MockResponse($messageId);
         $client = new MockHttpClient(static fn (): ResponseInterface => $response);
 
         $transport = $this->createTransport($client);

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Discord\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransport;
 use Symfony\Component\Notifier\Exception\LengthException;
 use Symfony\Component\Notifier\Exception\TransportException;
@@ -20,7 +21,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class DiscordTransportTest extends TransportTestCase
 {
@@ -57,15 +57,7 @@ final class DiscordTransportTest extends TransportTestCase
 
     public function testSendWithErrorResponseThrows()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['message' => 'testDescription', 'code' => 'testErrorCode']));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['message' => 'testDescription', 'code' => 'testErrorCode']), ['http_code' => 400]));
 
         $transport = self::createTransport($client);
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeChat/Tests/FakeChatTransportFactoryTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Notifier\Bridge\FakeChat\Tests;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatTransportFactory;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
@@ -56,7 +59,7 @@ final class FakeChatTransportFactoryTest extends TransportFactoryTestCase
 
     public function createFactory(): FakeChatTransportFactory
     {
-        return new FakeChatTransportFactory($this->createMock(MailerInterface::class), $this->createMock(LoggerInterface::class));
+        return new FakeChatTransportFactory(new Mailer(new NullTransport()), new NullLogger());
     }
 
     public static function createProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsTransportFactoryTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsTransportFactory;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
@@ -56,7 +59,7 @@ final class FakeSmsTransportFactoryTest extends TransportFactoryTestCase
 
     public function createFactory(): FakeSmsTransportFactory
     {
-        return new FakeSmsTransportFactory($this->createMock(MailerInterface::class), $this->createMock(LoggerInterface::class));
+        return new FakeSmsTransportFactory(new Mailer(new NullTransport()), new NullLogger());
     }
 
     public static function createProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/Tests/FortySixElksTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/Tests/FortySixElksTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\FortySixElks\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\FortySixElks\FortySixElksTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -20,7 +21,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class FortySixElksTransportTest extends TransportTestCase
 {
@@ -47,10 +47,7 @@ class FortySixElksTransportTest extends TransportTestCase
 
     public function testSendSuccessfully()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('getStatusCode')->willReturn(200);
-        $response->method('getContent')->willReturn(file_get_contents(__DIR__.'/Fixtures/success-response.json'));
-        $client = new MockHttpClient($response);
+        $client = new MockHttpClient(new MockResponse(file_get_contents(__DIR__.'/Fixtures/success-response.json')));
         $transport = $this->createTransport($client);
         $sentMessage = $transport->send(new SmsMessage('+46701111111', 'Hello!'));
 
@@ -63,10 +60,7 @@ class FortySixElksTransportTest extends TransportTestCase
      */
     public function testExceptionIsThrownWhenSendFailed(int $statusCode, string $content, string $expectedExceptionMessage)
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('getStatusCode')->willReturn($statusCode);
-        $response->method('getContent')->willReturn($content);
-        $client = new MockHttpClient($response);
+        $client = new MockHttpClient(new MockResponse($content, ['http_code' => $statusCode]));
         $transport = $this->createTransport($client);
 
         $this->expectException(TransportException::class);

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\GatewayApi\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiOptions;
 use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -20,7 +21,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Piergiuseppe Longo <piergiuseppe.longo@gmail.com>
@@ -52,15 +52,7 @@ final class GatewayApiTransportTest extends TransportTestCase
 
     public function testSend()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['ids' => [42]]));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['ids' => [42]])));
 
         $message = new SmsMessage('3333333333', 'Hello!');
 

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/Tests/LineNotifyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/Tests/LineNotifyTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\LineNotify\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\LineNotify\LineNotifyTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -19,7 +20,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Akira Kurozumi <info@a-zumi.net>
@@ -49,15 +49,7 @@ final class LineNotifyTransportTest extends TransportTestCase
 
     public function testSendWithErrorResponseThrows()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['message' => 'testDescription', 'code' => 'testErrorCode', 'status' => 'testStatus']));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['message' => 'testDescription', 'code' => 'testErrorCode', 'status' => 'testStatus']), ['http_code' => 400]));
 
         $transport = $this->createTransport($client);
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\LinkedIn\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
@@ -49,15 +50,7 @@ final class LinkedInTransportTest extends TransportTestCase
 
     public function testSendWithEmptyArrayResponseThrowsTransportException()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(500);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn('[]');
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse('[]', ['http_code' => 500]));
 
         $transport = self::createTransport($client);
 
@@ -71,16 +64,7 @@ final class LinkedInTransportTest extends TransportTestCase
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('testErrorCode');
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn('testErrorCode');
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse('testErrorCode', ['http_code' => 400]));
 
         $transport = self::createTransport($client);
 
@@ -90,16 +74,6 @@ final class LinkedInTransportTest extends TransportTestCase
     public function testSendWithOptions()
     {
         $message = 'testMessage';
-
-        $response = $this->createMock(ResponseInterface::class);
-
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(201);
-
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['id' => '42']));
 
         $expectedBody = json_encode([
             'specificContent' => [
@@ -119,12 +93,11 @@ final class LinkedInTransportTest extends TransportTestCase
         ]);
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use (
-            $response,
             $expectedBody
         ): ResponseInterface {
             $this->assertSame($expectedBody, $options['body']);
 
-            return $response;
+            return new MockResponse(json_encode(['id' => '42']), ['http_code' => 201]);
         });
         $transport = self::createTransport($client);
 
@@ -134,16 +107,6 @@ final class LinkedInTransportTest extends TransportTestCase
     public function testSendWithNotification()
     {
         $message = 'testMessage';
-
-        $response = $this->createMock(ResponseInterface::class);
-
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(201);
-
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['id' => '42']));
 
         $notification = new Notification($message);
         $chatMessage = ChatMessage::fromNotification($notification);
@@ -166,12 +129,11 @@ final class LinkedInTransportTest extends TransportTestCase
         ]);
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use (
-            $response,
             $expectedBody
         ): ResponseInterface {
             $this->assertSame($expectedBody, $options['body']);
 
-            return $response;
+            return new MockResponse(json_encode(['id' => '42']), ['http_code' => 201]);
         });
 
         $transport = self::createTransport($client);
@@ -183,10 +145,10 @@ final class LinkedInTransportTest extends TransportTestCase
     {
         $this->expectException(LogicException::class);
 
-        $client = new MockHttpClient(fn (string $method, string $url, array $options = []): ResponseInterface => $this->createMock(ResponseInterface::class));
+        $client = new MockHttpClient(new MockResponse());
 
         $transport = self::createTransport($client);
 
-        $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
+        $transport->send(new ChatMessage('testMessage', $this->createStub(MessageOptionsInterface::class)));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportFactoryTest.php
@@ -25,7 +25,7 @@ final class MercureTransportFactoryTest extends TransportFactoryTestCase
 {
     public function createFactory(): MercureTransportFactory
     {
-        $hub = $this->createMock(HubInterface::class);
+        $hub = $this->createStub(HubInterface::class);
         $hubRegistry = new HubRegistry($hub, ['hubId' => $hub]);
 
         return new MercureTransportFactory($hubRegistry);
@@ -62,7 +62,7 @@ final class MercureTransportFactoryTest extends TransportFactoryTestCase
 
     public function testNotFoundHubThrows()
     {
-        $hub = $this->createMock(HubInterface::class);
+        $hub = $this->createStub(HubInterface::class);
         $hubRegistry = new HubRegistry($hub, ['hubId' => $hub, 'anotherHubId' => $hub]);
         $factory = new MercureTransportFactory($hubRegistry);
 

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
@@ -83,7 +83,7 @@ final class MercureTransportTest extends TransportTestCase
     public function testSendWithNonMercureOptionsThrows()
     {
         $this->expectException(LogicException::class);
-        self::createTransport()->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
+        self::createTransport()->send(new ChatMessage('testMessage', $this->createStub(MessageOptionsInterface::class)));
     }
 
     public function testSendWithTransportFailureThrows()

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/Tests/MessageMediaTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/Tests/MessageMediaTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\MessageMedia\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\MessageMedia\MessageMediaOptions;
 use Symfony\Component\Notifier\Bridge\MessageMedia\MessageMediaTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
@@ -21,7 +22,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class MessageMediaTransportTest extends TransportTestCase
 {
@@ -55,13 +55,7 @@ final class MessageMediaTransportTest extends TransportTestCase
      */
     public function testExceptionIsThrownWhenHttpSendFailed(int $statusCode, string $content, string $expectedExceptionMessage)
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('getStatusCode')
-            ->willReturn($statusCode);
-        $response->method('getContent')
-            ->willReturn($content);
-
-        $client = new MockHttpClient($response);
+        $client = new MockHttpClient(new MockResponse($content, ['http_code' => $statusCode]));
 
         $transport = new MessageMediaTransport('apiKey', 'apiSecret', null, $client);
         $this->expectException(TransportException::class);

--- a/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Novu\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Novu\NovuOptions;
 use Symfony\Component\Notifier\Bridge\Novu\NovuTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
@@ -21,7 +22,6 @@ use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class NovuTransportTest extends TransportTestCase
 {
@@ -48,15 +48,7 @@ class NovuTransportTest extends TransportTestCase
 
     public function testWithErrorResponseThrows()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['error' => 'Bad request', 'message' => 'subscriberId under property to is not configured']));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['error' => 'Bad request', 'message' => 'subscriberId under property to is not configured']), ['http_code' => 400]));
 
         $transport = $this->createTransport($client);
 

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Ntfy\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Ntfy\NtfyTransport;
 use Symfony\Component\Notifier\Message\PushMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -63,19 +64,11 @@ final class NtfyTransportTest extends TransportTestCase
 
     public function testSend()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
-
-        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
             $expectedBody = json_encode(['topic' => 'test', 'title' => 'Hello', 'message' => 'World']);
             $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
 
-            return $response;
+            return new MockResponse(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
         });
 
         $transport = $this->createTransport($client);
@@ -87,21 +80,13 @@ final class NtfyTransportTest extends TransportTestCase
 
     public function testSendWithPassword()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
-
-        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
             $expectedBody = json_encode(['topic' => 'test', 'title' => 'Hello', 'message' => 'World']);
             $expectedAuthorization = 'Authorization: Bearer testtokentesttoken';
             $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
             $this->assertTrue(\in_array($expectedAuthorization, $options['headers'], true));
 
-            return $response;
+            return new MockResponse(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
         });
 
         $transport = $this->createTransport($client)->setPassword('testtokentesttoken');
@@ -113,21 +98,13 @@ final class NtfyTransportTest extends TransportTestCase
 
     public function testSendWithUserAndPassword()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
-
-        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
             $expectedBody = json_encode(['topic' => 'test', 'title' => 'Hello', 'message' => 'World']);
             $expectedAuthorization = 'Authorization: Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ';
             $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
             $this->assertTrue(\in_array($expectedAuthorization, $options['headers']));
 
-            return $response;
+            return new MockResponse(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
         });
 
         $transport = $this->createTransport($client)->setUser('test_user')->setPassword('test_password');

--- a/src/Symfony/Component/Notifier/Bridge/Plivo/Tests/PlivoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Plivo/Tests/PlivoTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Plivo\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Plivo\PlivoOptions;
 use Symfony\Component\Notifier\Bridge\Plivo\PlivoTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
@@ -62,14 +63,11 @@ final class PlivoTransportTest extends TransportTestCase
     public function testNoInvalidArgumentExceptionIsThrownIfFromIsValid(string $from)
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(202);
-        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['message' => 'message(s) queued', 'message_uuid' => ['foo'], 'api_id' => 'bar']));
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://api.plivo.com/v1/Account/authId/Message/', $url);
 
-            return $response;
+            return new MockResponse(json_encode(['message' => 'message(s) queued', 'message_uuid' => ['foo'], 'api_id' => 'bar']), ['http_code' => 202]);
         }
         );
         $transport = $this->createTransport($client, $from);

--- a/src/Symfony/Component/Notifier/Bridge/Pushover/Tests/PushoverTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/Tests/PushoverTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Pushover\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Pushover\PushoverTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\PushMessage;
@@ -49,16 +50,6 @@ final class PushoverTransportTest extends TransportTestCase
         $messageSubject = 'testMessageSubject';
         $messageContent = 'testMessageContent';
 
-        $response = $this->createMock(ResponseInterface::class);
-
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['status' => 1, 'request' => 'uuid']));
-
         $expectedBody = http_build_query([
             'message' => 'testMessageContent',
             'title' => 'testMessageSubject',
@@ -67,12 +58,11 @@ final class PushoverTransportTest extends TransportTestCase
         ], '', '&');
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use (
-            $response,
             $expectedBody
         ): ResponseInterface {
             $this->assertSame($expectedBody, $options['body']);
 
-            return $response;
+            return new MockResponse(json_encode(['status' => 1, 'request' => 'uuid']));
         });
         $transport = self::createTransport($client);
 
@@ -86,16 +76,6 @@ final class PushoverTransportTest extends TransportTestCase
         $messageSubject = 'testMessageSubject';
         $messageContent = 'testMessageContent';
 
-        $response = $this->createMock(ResponseInterface::class);
-
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
-
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['status' => 1, 'request' => 'uuid']));
-
         $notification = (new Notification($messageSubject))->content($messageContent);
         $pushMessage = PushMessage::fromNotification($notification);
 
@@ -107,12 +87,11 @@ final class PushoverTransportTest extends TransportTestCase
         ]);
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use (
-            $response,
             $expectedBody
         ): ResponseInterface {
             $this->assertSame($expectedBody, $options['body']);
 
-            return $response;
+            return new MockResponse(json_encode(['status' => 1, 'request' => 'uuid']));
         });
         $transport = self::createTransport($client);
 

--- a/src/Symfony/Component/Notifier/Bridge/RingCentral/Tests/RingCentralTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RingCentral/Tests/RingCentralTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\RingCentral\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\RingCentral\RingCentralOptions;
 use Symfony\Component\Notifier\Bridge\RingCentral\RingCentralTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
@@ -60,14 +61,11 @@ final class RingCentralTransportTest extends TransportTestCase
     public function testNoInvalidArgumentExceptionIsThrownIfFromIsValid(string $from)
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(200);
-        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['id' => 'foo']));
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://platform.ringcentral.com/restapi/v1.0/account/~/extension/~/sms', $url);
 
-            return $response;
+            return new MockResponse(json_encode(['id' => 'foo']));
         }
         );
         $transport = $this->createTransport($client, $from);

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Sendinblue\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -19,7 +20,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @group legacy
@@ -49,15 +49,7 @@ final class SendinblueTransportTest extends TransportTestCase
 
     public function testSendWithErrorResponseThrowsTransportException()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['code' => 400, 'message' => 'bad request']));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['code' => 400, 'message' => 'bad request']), ['http_code' => 400]));
 
         $transport = self::createTransport($client);
 

--- a/src/Symfony/Component/Notifier/Bridge/SimpleTextin/Tests/SimpleTextinTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SimpleTextin/Tests/SimpleTextinTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\SimpleTextin\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\SimpleTextin\SimpleTextinTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -59,15 +60,11 @@ final class SimpleTextinTransportTest extends TransportTestCase
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(201);
-        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['id' => 'foo']));
-
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://api-app2.simpletexting.com/v2/api/messages', $url);
 
-            return $response;
+            return new MockResponse(json_encode(['id' => 'foo']), ['http_code' => 201]);
         });
 
         $transport = $this->createTransport($client, $from);

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/Tests/SmsBiurasTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\SmsBiuras\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -50,15 +51,7 @@ final class SmsBiurasTransportTest extends TransportTestCase
     {
         $message = new SmsMessage('0037012345678', 'Hello World');
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->atLeast(1))
-            ->method('getStatusCode')
-            ->willReturn(200);
-        $response->expects($this->atLeast(1))
-            ->method('getContent')
-            ->willReturn('OK: 519545');
-
-        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $message, $expected): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($message, $expected): ResponseInterface {
             $this->assertSame('GET', $method);
             $this->assertSame(\sprintf(
                 'https://savitarna.smsbiuras.lt/api?uid=uid&apikey=api_key&message=%s&from=from&test=%s&to=%s',
@@ -68,10 +61,7 @@ final class SmsBiurasTransportTest extends TransportTestCase
             ), $url);
             $this->assertSame($expected, $options['query']['test']);
 
-            $this->assertSame(200, $response->getStatusCode());
-            $this->assertSame('OK: 519545', $response->getContent());
-
-            return $response;
+            return new MockResponse('OK: 519545');
         });
 
         $transport = new SmsBiurasTransport('uid', 'api_key', 'from', $testMode, $client);

--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/Tests/SmsmodeTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/Tests/SmsmodeTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Smsmode\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Smsmode\SmsmodeOptions;
 use Symfony\Component\Notifier\Bridge\Smsmode\SmsmodeTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
@@ -60,17 +61,11 @@ final class SmsmodeTransportTest extends TransportTestCase
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
 
-        $response = $this->createMock(ResponseInterface::class);
-
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(201);
-
-        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['messageId' => 'foo']));
-
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://rest.smsmode.com/sms/v1/messages', $url);
 
-            return $response;
+            return new MockResponse(json_encode(['messageId' => 'foo']), ['http_code' => 201]);
         });
 
         $transport = $this->createTransport($client, $from);
@@ -84,16 +79,12 @@ final class SmsmodeTransportTest extends TransportTestCase
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(201);
-        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['messageId' => 'foo']));
-
-        $transport = $this->createTransport(new MockHttpClient(function (string $method, string $url, array $options) use ($response): ResponseInterface {
+        $transport = $this->createTransport(new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame('https://rest.smsmode.com/sms/v1/messages', $url);
             $this->assertSame('Accept: application/json', $options['normalized_headers']['accept'][0]);
 
-            return $response;
+            return new MockResponse(json_encode(['messageId' => 'foo']), ['http_code' => 201]);
         }), 'foo');
 
         $result = $transport->send($message);

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Telegram\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransport;
 use Symfony\Component\Notifier\Exception\MultipleExclusiveOptionsUsedException;
@@ -55,15 +56,7 @@ final class TelegramTransportTest extends TransportTestCase
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/post.+testDescription.+400/');
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['description' => 'testDescription', 'error_code' => 400]));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['description' => 'testDescription', 'error_code' => 400]), ['http_code' => 400]));
 
         $transport = self::createTransport($client, 'testChannel');
 
@@ -75,15 +68,7 @@ final class TelegramTransportTest extends TransportTestCase
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/edit.+testDescription.+404/');
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(400);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode(['description' => 'testDescription', 'error_code' => 404]));
-
-        $client = new MockHttpClient(static fn (): ResponseInterface => $response);
+        $client = new MockHttpClient(new MockResponse(json_encode(['description' => 'testDescription', 'error_code' => 404]), ['http_code' => 400]));
 
         $transport = $this->createTransport($client, 'testChannel');
         $transport->send(new ChatMessage(

--- a/src/Symfony/Component/Notifier/Bridge/Termii/Tests/TermiiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Termii/Tests/TermiiTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Termii\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Termii\TermiiOptions;
 use Symfony\Component\Notifier\Bridge\Termii\TermiiTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
@@ -62,14 +63,11 @@ final class TermiiTransportTest extends TransportTestCase
     public function testNoInvalidArgumentExceptionIsThrownIfFromIsValid(string $from)
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects(self::exactly(2))->method('getStatusCode')->willReturn(200);
-        $response->expects(self::once())->method('getContent')->willReturn(json_encode(['message' => 'Successfully sent', 'message_id' => 'foo', 'balance' => 9, 'user' => 'Foo Bar']));
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url): ResponseInterface {
             self::assertSame('POST', $method);
             self::assertSame('https://api.ng.termii.com/api/sms/send', $url);
 
-            return $response;
+            return new MockResponse(json_encode(['message' => 'Successfully sent', 'message_id' => 'foo', 'balance' => 9, 'user' => 'Foo Bar']));
         }
         );
         $transport = $this->createTransport($client, $from);

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/Tests/TurboSmsTransportTest.php
@@ -166,7 +166,7 @@ final class TurboSmsTransportTest extends TransportTestCase
         $this->expectExceptionMessage('The sender length of a TurboSMS message must not exceed 20 characters.');
 
         $message = new SmsMessage('380931234567', 'Hello!');
-        $transport = new TurboSmsTransport('authToken', 'abcdefghijklmnopqrstu', $this->createMock(HttpClientInterface::class));
+        $transport = new TurboSmsTransport('authToken', 'abcdefghijklmnopqrstu', new MockHttpClient());
 
         $transport->send($message);
     }
@@ -174,7 +174,7 @@ final class TurboSmsTransportTest extends TransportTestCase
     public function testInvalidSubjectWithLatinSymbols()
     {
         $message = new SmsMessage('380931234567', str_repeat('z', 1522));
-        $transport = new TurboSmsTransport('authToken', 'sender', $this->createMock(HttpClientInterface::class));
+        $transport = new TurboSmsTransport('authToken', 'sender', new MockHttpClient());
 
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('The subject length for "latin" symbols of a TurboSMS message must not exceed 1521 characters.');
@@ -185,7 +185,7 @@ final class TurboSmsTransportTest extends TransportTestCase
     public function testInvalidSubjectWithCyrillicSymbols()
     {
         $message = new SmsMessage('380931234567', str_repeat('z', 661).'Й');
-        $transport = new TurboSmsTransport('authToken', 'sender', $this->createMock(HttpClientInterface::class));
+        $transport = new TurboSmsTransport('authToken', 'sender', new MockHttpClient());
 
         $this->expectException(LengthException::class);
         $this->expectExceptionMessage('The subject length for "cyrillic" symbols of a TurboSMS message must not exceed 661 characters.');

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Twilio\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -88,23 +89,15 @@ final class TwilioTransportTest extends TransportTestCase
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(201);
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn(json_encode([
-                'sid' => '123',
-                'message' => 'foo',
-                'more_info' => 'bar',
-            ]));
-
-        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame('https://api.twilio.com/2010-04-01/Accounts/accountSid/Messages.json', $url);
 
-            return $response;
+            return new MockResponse(json_encode([
+                'sid' => '123',
+                'message' => 'foo',
+                'more_info' => 'bar',
+            ]), ['http_code' => 201]);
         });
 
         $transport = self::createTransport($client, $from);

--- a/src/Symfony/Component/Notifier/Tests/Channel/BrowserChannelTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Channel/BrowserChannelTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Notifier\Channel\BrowserChannel;
 use Symfony\Component\Notifier\Exception\FlashMessageImportanceMapperException;
 use Symfony\Component\Notifier\FlashMessage\BootstrapFlashMessageImportanceMapper;
@@ -37,8 +38,7 @@ class BrowserChannelTest extends TestCase
         string $importance,
         string $expectedFlashMessageType,
     ) {
-        $session = $this->createMock(Session::class);
-        $session->method('getFlashBag')->willReturn(new FlashBag());
+        $session = new Session(new MockArraySessionStorage(), null, new FlashBag());
         $browserChannel = $this->buildBrowserChannel($session, $mapper);
         $notification = new Notification();
         $notification->importance($importance);
@@ -51,8 +51,7 @@ class BrowserChannelTest extends TestCase
 
     public function testUnknownImportanceMappingIsReported()
     {
-        $session = $this->createMock(Session::class);
-        $session->method('getFlashBag')->willReturn(new FlashBag());
+        $session = new Session(new MockArraySessionStorage(), null, new FlashBag());
         $browserChannel = $this->buildBrowserChannel($session, new DefaultFlashMessageImportanceMapper());
         $notification = new Notification();
         $notification->importance('unknown-importance-string');

--- a/src/Symfony/Component/Notifier/Tests/ChatterTest.php
+++ b/src/Symfony/Component/Notifier/Tests/ChatterTest.php
@@ -42,6 +42,9 @@ class ChatterTest extends TestCase
             ->method('send')
             ->with($message)
             ->willReturn($sentMessage);
+        $this->bus
+            ->expects($this->never())
+            ->method('dispatch');
 
         $chatter = new Chatter($this->transport);
         $this->assertSame($sentMessage, $chatter->send($message));

--- a/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Tests\Event;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Event\FailedMessageEvent;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -20,9 +21,7 @@ use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
-use Symfony\Component\Notifier\Transport\NullTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class FailedMessageEventTest extends TestCase
 {
@@ -53,7 +52,7 @@ class FailedMessageEventTest extends TestCase
     public function testFailedMessageEventIsDisptachIfError()
     {
         $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
-        $clientMock = $this->createMock(HttpClientInterface::class);
+        $clientMock = new MockHttpClient();
 
         $transport = new class($clientMock, $eventDispatcherMock) extends AbstractTransport {
             public NullTransportException $exception;

--- a/src/Symfony/Component/Notifier/Tests/TexterTest.php
+++ b/src/Symfony/Component/Notifier/Tests/TexterTest.php
@@ -23,12 +23,10 @@ use Symfony\Component\Notifier\Transport\TransportInterface;
 class TexterTest extends TestCase
 {
     private MockObject&TransportInterface $transport;
-    private MockObject&MessageBusInterface $bus;
 
     protected function setUp(): void
     {
         $this->transport = $this->createMock(TransportInterface::class);
-        $this->bus = $this->createMock(MessageBusInterface::class);
     }
 
     public function testSendWithoutBus()
@@ -56,13 +54,14 @@ class TexterTest extends TestCase
             ->method('send')
             ->with($message);
 
-        $this->bus
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
             ->expects($this->once())
             ->method('dispatch')
             ->with($message)
             ->willReturn(new Envelope(new \stdClass()));
 
-        $texter = new Texter($this->transport, $this->bus);
+        $texter = new Texter($this->transport, $bus);
         $this->assertNull($texter->send($message));
     }
 }

--- a/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
@@ -46,8 +46,8 @@ class FailoverTransportTest extends TestCase
 
     public function testSendMessageNotSupportedByAnyTransport()
     {
-        $t1 = $this->createMock(TransportInterface::class);
-        $t2 = $this->createMock(TransportInterface::class);
+        $t1 = $this->createStub(TransportInterface::class);
+        $t2 = $this->createStub(TransportInterface::class);
 
         $t = new FailoverTransport([$t1, $t2]);
 
@@ -80,11 +80,11 @@ class FailoverTransportTest extends TestCase
 
         $t1 = $this->createMock(TransportInterface::class);
         $t1->method('supports')->with($message)->willReturn(true);
-        $t1->expects($this->once())->method('send')->with($message)->willThrowException($this->createMock(TransportExceptionInterface::class));
+        $t1->expects($this->once())->method('send')->with($message)->willThrowException($this->createStub(TransportExceptionInterface::class));
 
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);
-        $t2->expects($this->once())->method('send')->with($message)->willThrowException($this->createMock(TransportExceptionInterface::class));
+        $t2->expects($this->once())->method('send')->with($message)->willThrowException($this->createStub(TransportExceptionInterface::class));
 
         $t = new FailoverTransport([$t1, $t2]);
 
@@ -100,7 +100,7 @@ class FailoverTransportTest extends TestCase
 
         $t1 = $this->createMock(TransportInterface::class);
         $t1->method('supports')->with($message)->willReturn(true);
-        $t1->expects($this->once())->method('send')->willThrowException($this->createMock(TransportExceptionInterface::class));
+        $t1->expects($this->once())->method('send')->willThrowException($this->createStub(TransportExceptionInterface::class));
 
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);
@@ -117,7 +117,7 @@ class FailoverTransportTest extends TestCase
 
         $t1 = $this->createMock(TransportInterface::class);
         $t1->method('supports')->with($message)->willReturn(true);
-        $t1->method('send')->willThrowException($this->createMock(TransportExceptionInterface::class));
+        $t1->method('send')->willThrowException($this->createStub(TransportExceptionInterface::class));
         $t1->expects($this->once())->method('send');
         $t2 = $this->createMock(TransportInterface::class);
         $t2->method('supports')->with($message)->willReturn(true);
@@ -127,7 +127,7 @@ class FailoverTransportTest extends TestCase
             ->method('send')
             ->willReturnCallback(function () use ($matcher, $message) {
                 if (3 === $matcher->getInvocationCount()) {
-                    throw $this->createMock(TransportExceptionInterface::class);
+                    throw $this->createStub(TransportExceptionInterface::class);
                 }
 
                 return new SentMessage($message, 't2');
@@ -155,7 +155,7 @@ class FailoverTransportTest extends TestCase
         $t1->expects($t1Matcher)->method('send')
             ->willReturnCallback(function () use ($t1Matcher, $message) {
                 if (1 === $t1Matcher->getInvocationCount()) {
-                    throw $this->createMock(TransportExceptionInterface::class);
+                    throw $this->createStub(TransportExceptionInterface::class);
                 }
 
                 return new SentMessage($message, 't1');
@@ -169,7 +169,7 @@ class FailoverTransportTest extends TestCase
                 return new SentMessage($message, 't1');
             }
 
-            throw $this->createMock(TransportExceptionInterface::class);
+            throw $this->createStub(TransportExceptionInterface::class);
         });
 
         $t = new FailoverTransport([$t1, $t2], 1);

--- a/src/Symfony/Component/Notifier/Tests/Transport/NullTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/NullTransportFactoryTest.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\Notifier\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 use Symfony\Component\Notifier\Transport\NullTransport;
 use Symfony\Component\Notifier\Transport\NullTransportFactory;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
@@ -29,8 +29,8 @@ class NullTransportFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->nullTransportFactory = new NullTransportFactory(
-            $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(HttpClientInterface::class)
+            new EventDispatcher(),
+            new MockHttpClient()
         );
     }
 

--- a/src/Symfony/Component/Notifier/Tests/Transport/TransportsTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/TransportsTest.php
@@ -66,7 +66,7 @@ class TransportsTest extends TestCase
     public function testThrowExceptionIfNoSupportedTransportWasFound()
     {
         $transports = new Transports([
-            'one' => $one = $this->createMock(TransportInterface::class),
+            'one' => $one = $this->createStub(TransportInterface::class),
         ]);
 
         $message = new ChatMessage('subject');
@@ -82,8 +82,8 @@ class TransportsTest extends TestCase
     public function testThrowExceptionIfTransportDefinedByMessageIsNotSupported()
     {
         $transports = new Transports([
-            'one' => $one = $this->createMock(TransportInterface::class),
-            'two' => $two = $this->createMock(TransportInterface::class),
+            'one' => $one = $this->createStub(TransportInterface::class),
+            'two' => $two = $this->createStub(TransportInterface::class),
         ]);
 
         $message = new ChatMessage('subject');
@@ -101,7 +101,7 @@ class TransportsTest extends TestCase
     public function testThrowExceptionIfTransportDefinedByMessageDoesNotExist()
     {
         $transports = new Transports([
-            'one' => $one = $this->createMock(TransportInterface::class),
+            'one' => $one = $this->createStub(TransportInterface::class),
         ]);
 
         $message = new ChatMessage('subject');

--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -21,7 +21,9 @@
     },
     "require-dev": {
         "symfony/event-dispatcher-contracts": "^2.5|^3",
+        "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/http-client-contracts": "^2.5|^3",
+        "symfony/http-client": "^6.4|^7.0",
         "symfony/http-foundation": "^5.4|^6.0|^7.0",
         "symfony/messenger": "^5.4|^6.0|^7.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT