### PR TITLE
[DomCrawler] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -886,7 +886,7 @@ class FormTest extends TestCase
         ;
 
         $field
-            ->expects($this->any())
+            ->expects($this->atLeastOnce())
             ->method('getName')
             ->willReturn($name)
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT