### PR TITLE
[HttpKernel] Improve `Cache` attribute expression vars

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support for `SOURCE_DATE_EPOCH` environment variable
  * Add `ResponseEvent::getControllerAttributes()`
  * Add `Request` attribute `_controller_attributes` to decouple controller attributes from their source code
+ * Pass `request` and `args` variables to `Cache` attribute expressions containing the `Request` object and controller arguments
 
 8.0
 ---

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -221,6 +221,8 @@ class CacheAttributeListenerTest extends TestCase
 
     #[TestWith(['test.getDate()'])]
     #[TestWith(['date'])]
+    #[TestWith(['args["test"].getDate()'])]
+    #[TestWith(['request.attributes.get("date")'])]
     public function testLastModifiedNotModifiedResponse(string $expression)
     {
         $entity = new TestEntity();
@@ -240,6 +242,8 @@ class CacheAttributeListenerTest extends TestCase
 
     #[TestWith(['test.getDate()'])]
     #[TestWith(['date'])]
+    #[TestWith(['args["test"].getDate()'])]
+    #[TestWith(['request.attributes.get("date")'])]
     public function testLastModifiedHeader(string $expression)
     {
         $entity = new TestEntity();
@@ -264,6 +268,8 @@ class CacheAttributeListenerTest extends TestCase
 
     #[TestWith(['test.getId()'])]
     #[TestWith(['id'])]
+    #[TestWith(['args["test"].getId()'])]
+    #[TestWith(['request.attributes.get("id")'])]
     public function testEtagNotModifiedResponse(string $expression)
     {
         $entity = new TestEntity();
@@ -283,6 +289,8 @@ class CacheAttributeListenerTest extends TestCase
 
     #[TestWith(['test.getId()'])]
     #[TestWith(['id'])]
+    #[TestWith(['args["test"].getId()'])]
+    #[TestWith(['request.attributes.get("id")'])]
     public function testEtagHeader(string $expression)
     {
         $entity = new TestEntity();
@@ -455,9 +463,9 @@ class CacheAttributeListenerTest extends TestCase
         return new ResponseEvent($this->getKernel(), $request, HttpKernelInterface::MAIN_REQUEST, $response);
     }
 
-    private function getKernel(): MockObject&HttpKernelInterface
+    private function getKernel(): Stub&HttpKernelInterface
     {
-        return $this->createMock(HttpKernelInterface::class);
+        return $this->createStub(HttpKernelInterface::class);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, the variables passed to a cache expression consist of all request attributes merged with all action arguments. In my opinion, this approach has several drawbacks:

* variable names can clash if an action argument has the same name as a request attribute
* the user does not have access to the full `Request` object when it is needed
* the behavior is inconsistent with the `#[IsGranted]` attribute

This PR proposes aligning the behavior with `#[IsGranted]` by passing two explicit variables to the expression:

* `request`, which holds the `Request` object
* `args`, which holds the action arguments

~To avoid a BC break, this new behavior is disabled by default and can be enabled via the new `framework.use_standard_vars_in_cache_expr` option.~

~In the future, we can deprecate not setting this option to `true` and remove the legacy behavior. For now, I suggest not doing this yet, in order to keep the code compatible with multiple Symfony versions.~