### PR TITLE
[HttpKernel] Allow using closures with the `Cache` attribute

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/Cache.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/Cache.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\HttpFoundation\Request;
+
 /**
  * Describes the default HTTP cache headers on controllers.
  * Headers defined in the Cache attribute are ignored if they are already set
@@ -66,24 +69,28 @@ final class Cache
         public array $vary = [],
 
         /**
-         * An expression to compute the Last-Modified HTTP header.
+         * A value evaluated to compute the Last-Modified HTTP header.
          *
-         * The expression is evaluated by the ExpressionLanguage component, it
+         * The value may be either an ExpressionLanguage expression or a Closure and
          * receives all the request attributes and the resolved controller arguments.
          *
-         * The result of the expression must be a DateTimeInterface.
+         * The result must be an instance of \DateTimeInterface.
+         *
+         * @var string|Expression|\Closure(array<string, mixed>, Request): \DateTimeInterface|null
          */
-        public ?string $lastModified = null,
+        public string|Expression|\Closure|null $lastModified = null,
 
         /**
-         * An expression to compute the ETag HTTP header.
+         * A value evaluated to compute the ETag HTTP header.
          *
-         * The expression is evaluated by the ExpressionLanguage component, it
+         * The value may be either an ExpressionLanguage expression or a Closure and
          * receives all the request attributes and the resolved controller arguments.
          *
          * The result must be a string that will be hashed.
+         *
+         * @var string|Expression|\Closure(array<string, mixed>, Request): string|null
          */
-        public ?string $etag = null,
+        public string|Expression|\Closure|null $etag = null,
 
         /**
          * max-stale Cache-Control header

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `ResponseEvent::getControllerAttributes()`
  * Add `Request` attribute `_controller_attributes` to decouple controller attributes from their source code
  * Pass `request` and `args` variables to `Cache` attribute expressions containing the `Request` object and controller arguments
+ * Allow using closures with the `Cache` attribute
 
 8.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR allows closures to be used with the `#[Cache]` attribute as an alternative to expressions.

```php
#[Cache(lastModified: static function (array $arguments, Request $request) {
    return $request->attributes->get('date');
})]
public function index(): Response
{
    // ...
}
```