### PR TITLE
[HttpKernel] Allow the `Cache` attribute to be applied conditionally

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/Cache.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/Cache.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
 final class Cache
 {
     public function __construct(
@@ -121,6 +121,18 @@ final class Cache
          * @see https://datatracker.ietf.org/doc/html/rfc7234#section-5.2.2.3
          */
         public ?bool $noStore = null,
+
+        /**
+         * A value evaluated to determine whether the cache attribute should be applied.
+         *
+         * The value may be either an ExpressionLanguage expression or a Closure and
+         * receives all the request attributes and the resolved controller arguments.
+         *
+         * The result must be a boolean. If true the attribute is applied, if false it is ignored.
+         *
+         * @var string|Expression|\Closure(array<string, mixed>, Request): bool|null
+         */
+        public string|Expression|\Closure|null $if = null,
     ) {
     }
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `Request` attribute `_controller_attributes` to decouple controller attributes from their source code
  * Pass `request` and `args` variables to `Cache` attribute expressions containing the `Request` object and controller arguments
  * Allow using closures with the `Cache` attribute
+ * Allow setting a condition when the `Cache` attribute should be applied
 
 8.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a new `$if` option to the `#[Cache]` attribute. The option accepts either a closure or an expression, which must return a boolean that determines whether the attribute should be applied.

Multiple `#[Cache]` attributes with different conditions can be defined.

This is useful for programmatically deciding whether caching should be enabled, especially in cases where the controller does not return a `Response` object (for example, when using FOSRestBundle).

```php
#[Cache(..., if: static function (array $arguments, Request $request) {
    // some condition
})]
#[Cache(..., if: static function (array $arguments, Request $request) {
    // some other condition
})]
public function index(): Response
{
    // ...
}
```