### PR TITLE
[ObjectMapper] auto map missmatching types

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * The component will map properties recursively if the source and target class do not match
+
 7.4
 ---
 

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -161,9 +161,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 }
 
                 $value = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap);
-                $expectedType = $targetRefl->getProperty($propertyName)->getType()->getName();
-                // If the target type does not match the source type,
-                if (\is_object($value) && $expectedType && class_exists($expectedType) && !($value instanceof $expectedType)) {
+                $expectedType = $targetRefl->getProperty($propertyName)->getType();
+                // If the target type does not match the source type, and the target type a concrete class
+                if (\is_object($value) && $expectedType instanceof \ReflectionNamedType && class_exists($expectedType->getName()) && !($value instanceof $expectedType)) {
                     $value = $this->doMap($value, $expectedType, $objectMap, false);
                 }
                 $this->storeValue($propertyName, $mapToProperties, $ctorArguments, $value);

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -161,6 +161,11 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 }
 
                 $value = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap);
+                $expectedType = $targetRefl->getProperty($propertyName)->getType()->getName();
+                // If the target type does not match the source type,
+                if (\is_object($value) && $expectedType && class_exists($expectedType) && !($value instanceof $expectedType)) {
+                    $value = $this->doMap($value, $expectedType, $objectMap, false);
+                }
                 $this->storeValue($propertyName, $mapToProperties, $ctorArguments, $value);
             }
         }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Baz.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Baz.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
+
+class Baz
+{
+
+    public function __construct(
+        public string $baz
+    ){
+    }
+
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Baz.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Baz.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
 
-class Baz
+class Baz implements BazInterface
 {
 
     public function __construct(

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/BazInterface.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/BazInterface.php
@@ -2,12 +2,6 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
 
-class Out
+interface BazInterface
 {
-
-    public function __construct(
-        public Baz $item
-    ){
-    }
-
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Foo.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Foo.php
@@ -2,11 +2,11 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
 
-class Out
+class Foo
 {
 
     public function __construct(
-        public Baz $item
+        public string $foo
     ){
     }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/FooBaz.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/FooBaz.php
@@ -9,7 +9,6 @@ class FooBaz
         public string $foo,
         public string $baz,
     ){
-
     }
 
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/FooBaz.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/FooBaz.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
+
+class FooBaz
+{
+
+    public function __construct(
+        public string $foo,
+        public string $baz,
+    ){
+
+    }
+
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Out.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Out.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
+
+class Out
+{
+
+    public function __construct(
+        public Baz $item
+    ){
+
+    }
+
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/OutInterface.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/OutInterface.php
@@ -2,11 +2,11 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
 
-class Out
+class OutInterface
 {
 
     public function __construct(
-        public Baz $item
+        public BazInterface $item
     ){
     }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/OutUnion.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/OutUnion.php
@@ -2,11 +2,11 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
 
-class Out
+class OutUnion
 {
 
     public function __construct(
-        public Baz $item
+        public Foo|Baz $item
     ){
     }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Source.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType;
+
+class Source
+{
+
+    public function __construct(
+        public FooBaz $item
+    ){
+
+    }
+
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MissmatchType/Source.php
@@ -8,7 +8,6 @@ class Source
     public function __construct(
         public FooBaz $item
     ){
-
     }
 
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -648,4 +648,21 @@ final class ObjectMapperTest extends TestCase
         $this->assertSame('foo', $out->var1);
         $this->assertSame('bar', $out->b->var2);
     }
+
+    public function testCorrectTypes()
+    {
+        $source = new Fixtures\MissmatchType\Source(
+            item: new Fixtures\MissmatchType\FooBaz(
+                foo: 'a',
+                baz: 'b',
+            )
+        );
+
+        $mapper = new ObjectMapper();
+        $out = $mapper->map($source, Fixtures\MissmatchType\Out::class);
+
+        $this->assertInstanceOf(Fixtures\MissmatchType\Out::class, $out);
+        $this->assertInstanceOf(Fixtures\MissmatchType\Baz::class, $out->item);
+        $this->assertEquals('b', $out->item->baz);
+    }
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -58,6 +58,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Target;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\A as MapTargetToSourceA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\B as MapTargetToSourceB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType\OutInterface;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MissmatchType\OutUnion;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\A as MultipleTargetPropertyA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as MultipleTargetPropertyB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
@@ -663,6 +665,27 @@ final class ObjectMapperTest extends TestCase
 
         $this->assertInstanceOf(Fixtures\MissmatchType\Out::class, $out);
         $this->assertInstanceOf(Fixtures\MissmatchType\Baz::class, $out->item);
-        $this->assertEquals('b', $out->item->baz);
+        $this->assertSame('b', $out->item->baz);
+    }
+
+    #[DataProvider('unhandledTypesProvider')]
+    public function testUnmappableTypes(string $target)
+    {
+        $this->expectException(\TypeError::class);
+        $source = new Fixtures\MissmatchType\Source(
+            item: new Fixtures\MissmatchType\FooBaz(
+                foo: 'a',
+                baz: 'b',
+            )
+        );
+
+        $mapper = new ObjectMapper();
+        $mapper->map($source, $target);
+    }
+
+    public static function unhandledTypesProvider(): iterable
+    {
+        yield [OutUnion::class];
+        yield [OutInterface::class];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

Allow auto mapping when the source type does not match the target type

## Use case

If we want to convert an entity (for instance a Post attached to a Category).

```php
class PostDto {
     
    public CategoryDTO $category

}
```

With the current version, it triggers an error when the object mapper try to fill `Category` inside `CategoryDTO`. With my change, the mapper will automatically map `Category` into `CategoryDTO`.
