### PR TITLE
[HttpClient] fix assertion for updated syntax error messages in PHP 8.6

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
@@ -86,13 +86,13 @@ class MockResponseTest extends TestCase
         yield [
             'content' => 'not json',
             'responseHeaders' => [],
-            'message' => 'Syntax error for "https://example.com/file.json".',
+            'message' => \PHP_VERSION_ID < 80600 ? 'Syntax error for "https://example.com/file.json".' : 'Syntax error near location 1:1 for "https://example.com/file.json".',
         ];
 
         yield [
             'content' => '[1,2}',
             'responseHeaders' => [],
-            'message' => 'State mismatch (invalid or malformed JSON) for "https://example.com/file.json".',
+            'message' => \PHP_VERSION_ID < 80600 ? 'State mismatch (invalid or malformed JSON) for "https://example.com/file.json".' : 'State mismatch (invalid or malformed JSON) near location 1:5 for "https://example.com/file.json".',
         ];
 
         yield [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

see php/php-src#20629