### PR TITLE
[JsonPath] Fix tests for PHP 8.6

### DIFF
--- a/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
@@ -31,7 +31,7 @@ class JsonCrawlerTest extends TestCase
     public function testInvalidInputJson()
     {
         $this->expectException(InvalidJsonStringInputException::class);
-        $this->expectExceptionMessage('Invalid JSON input: Syntax error.');
+        $this->expectExceptionMessage('Invalid JSON input: Syntax error');
 
         (new JsonCrawler('invalid'))->find('$..*');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Same reason as https://github.com/symfony/symfony/pull/62943, in 8.6 it outputs `Syntax error near location...`.