### PR TITLE
[DependencyInjection] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -46,7 +46,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
                 $tmpProviders = $container->getExpressionLanguageProviders();
             });
 
-        $provider = $this->createMock(ExpressionFunctionProviderInterface::class);
+        $provider = $this->createStub(ExpressionFunctionProviderInterface::class);
         $container = new ContainerBuilder(new ParameterBag());
         $container->registerExtension($extension);
         $container->prependExtensionConfig('foo', ['bar' => true]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
@@ -25,10 +25,10 @@ class PassConfigTest extends TestCase
         $config = new PassConfig();
         $config->setBeforeOptimizationPasses([]);
 
-        $pass1 = $this->createMock(CompilerPassInterface::class);
+        $pass1 = $this->createStub(CompilerPassInterface::class);
         $config->addPass($pass1, PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
 
-        $pass2 = $this->createMock(CompilerPassInterface::class);
+        $pass2 = $this->createStub(CompilerPassInterface::class);
         $config->addPass($pass2, PassConfig::TYPE_BEFORE_OPTIMIZATION, 30);
 
         $passes = $config->getBeforeOptimizationPasses();

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -462,8 +462,8 @@ class ContainerBuilderTest extends TestCase
         $builder = new ContainerBuilder();
         $builder->setResourceTracking(false);
         $defaultPasses = $builder->getCompiler()->getPassConfig()->getPasses();
-        $builder->addCompilerPass($pass1 = $this->createMock(CompilerPassInterface::class), PassConfig::TYPE_BEFORE_OPTIMIZATION, -5);
-        $builder->addCompilerPass($pass2 = $this->createMock(CompilerPassInterface::class), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
+        $builder->addCompilerPass($pass1 = $this->createStub(CompilerPassInterface::class), PassConfig::TYPE_BEFORE_OPTIMIZATION, -5);
+        $builder->addCompilerPass($pass2 = $this->createStub(CompilerPassInterface::class), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
 
         $passes = $builder->getCompiler()->getPassConfig()->getPasses();
         $this->assertCount(\count($passes) - 2, $defaultPasses);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT