### PR TITLE
[EventDispatcher] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\EventDispatcher\Tests\Debug;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\Debug\WrappedListener;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
@@ -24,7 +25,7 @@ class WrappedListenerTest extends TestCase
      */
     public function testListenerDescription($listener, $expected)
     {
-        $wrappedListener = new WrappedListener($listener, null, $this->createMock(Stopwatch::class), $this->createMock(EventDispatcherInterface::class));
+        $wrappedListener = new WrappedListener($listener, null, new Stopwatch(), new EventDispatcher());
 
         $this->assertStringMatchesFormat($expected, $wrappedListener->getPretty());
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\EventDispatcher\Tests;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\ImmutableEventDispatcher;
@@ -23,73 +23,81 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class ImmutableEventDispatcherTest extends TestCase
 {
-    private MockObject&EventDispatcherInterface $innerDispatcher;
-    private ImmutableEventDispatcher $dispatcher;
-
-    protected function setUp(): void
-    {
-        $this->innerDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $this->dispatcher = new ImmutableEventDispatcher($this->innerDispatcher);
-    }
-
     public function testDispatchDelegates()
     {
+        $innerDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = new ImmutableEventDispatcher($innerDispatcher);
+
         $event = new Event();
         $resultEvent = new Event();
 
-        $this->innerDispatcher->expects($this->once())
+        $innerDispatcher->expects($this->once())
             ->method('dispatch')
             ->with($event, 'event')
             ->willReturn($resultEvent);
 
-        $this->assertSame($resultEvent, $this->dispatcher->dispatch($event, 'event'));
+        $this->assertSame($resultEvent, $dispatcher->dispatch($event, 'event'));
     }
 
     public function testGetListenersDelegates()
     {
-        $this->innerDispatcher->expects($this->once())
+        $innerDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = new ImmutableEventDispatcher($innerDispatcher);
+
+        $innerDispatcher->expects($this->once())
             ->method('getListeners')
             ->with('event')
             ->willReturn(['result']);
 
-        $this->assertSame(['result'], $this->dispatcher->getListeners('event'));
+        $this->assertSame(['result'], $dispatcher->getListeners('event'));
     }
 
     public function testHasListenersDelegates()
     {
-        $this->innerDispatcher->expects($this->once())
+        $innerDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = new ImmutableEventDispatcher($innerDispatcher);
+
+        $innerDispatcher->expects($this->once())
             ->method('hasListeners')
             ->with('event')
             ->willReturn(true);
 
-        $this->assertTrue($this->dispatcher->hasListeners('event'));
+        $this->assertTrue($dispatcher->hasListeners('event'));
     }
 
     public function testAddListenerDisallowed()
     {
+        $dispatcher = new ImmutableEventDispatcher(new EventDispatcher());
+
         $this->expectException(\BadMethodCallException::class);
-        $this->dispatcher->addListener('event', fn () => 'foo');
+        $dispatcher->addListener('event', fn () => 'foo');
     }
 
     public function testAddSubscriberDisallowed()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $subscriber = $this->createMock(EventSubscriberInterface::class);
+        $dispatcher = new ImmutableEventDispatcher(new EventDispatcher());
 
-        $this->dispatcher->addSubscriber($subscriber);
+        $this->expectException(\BadMethodCallException::class);
+        $subscriber = $this->createStub(EventSubscriberInterface::class);
+
+        $dispatcher->addSubscriber($subscriber);
     }
 
     public function testRemoveListenerDisallowed()
     {
+        $dispatcher = new ImmutableEventDispatcher(new EventDispatcher());
+
         $this->expectException(\BadMethodCallException::class);
-        $this->dispatcher->removeListener('event', fn () => 'foo');
+        $dispatcher->removeListener('event', fn () => 'foo');
     }
 
     public function testRemoveSubscriberDisallowed()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $subscriber = $this->createMock(EventSubscriberInterface::class);
+        $dispatcher = new ImmutableEventDispatcher(new EventDispatcher());
 
-        $this->dispatcher->removeSubscriber($subscriber);
+        $this->expectException(\BadMethodCallException::class);
+        $subscriber = $this->createStub(EventSubscriberInterface::class);
+
+        $dispatcher->removeSubscriber($subscriber);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT