### PR TITLE
[Serializer] Fix removing nested values

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -859,7 +859,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     private function removeNestedValue(array $path, array $data): array
     {
         $element = array_shift($path);
-        if (!$path || !$data[$element] = $this->removeNestedValue($path, $data[$element])) {
+        if (!$path || !$data[$element] || !$data[$element] = $this->removeNestedValue($path, $data[$element])) {
             unset($data[$element]);
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
@@ -871,6 +872,42 @@ class AbstractObjectNormalizerTest extends TestCase
         $test = $normalizer->denormalize($data, $obj::class);
         $this->assertNull($test->foo);
         $this->assertFalse((new \ReflectionProperty($obj, 'bar'))->isInitialized($obj));
+    }
+
+    public function testDenormalizeNullCoalescingValues()
+    {
+        if (!method_exists(PropertyPath::class, 'isNullSafe')) {
+            $this->markTestSkipped('null coalescing property path is not supported before symfony/property-access 6.2');
+        }
+
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+
+        $data = [
+            'data' => [
+                'foo' => 'test',
+            ],
+            'empty_data' => null,
+        ];
+
+        $obj = new class {
+            #[SerializedPath('[data][foo?]')]
+            public ?string $foo;
+
+            #[SerializedPath('[data][bar?]')]
+            public ?string $bar;
+
+            #[SerializedPath('[empty_data?][nothing]')]
+            public ?string $nothing;
+
+            #[SerializedPath('[not_set?][nothing]')]
+            public ?string $notSet;
+        };
+
+        $test = $normalizer->denormalize($data, $obj::class);
+        $this->assertSame('test', $test->foo);
+        $this->assertFalse((new \ReflectionProperty($obj, 'bar'))->isInitialized($obj));
+        $this->assertNull($test->nothing);
+        $this->assertFalse((new \ReflectionProperty($obj, 'notSet'))->isInitialized($obj));
     }
 
     public function testNormalizeBasedOnAllowedAttributes()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62937
| License       | MIT

Fixes #62937 by checking if the element is valid before going deeper.