### PR TITLE
[HttpClient] Fix existing headers must be replaced in CachingHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -80,7 +80,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
         foreach ($options['normalized_headers'] as $name => $values) {
             if ('cookie' !== $name) {
                 foreach ($values as $value) {
-                    $request->headers->set($name, substr($value, 2 + \strlen($name)), false);
+                    $request->headers->set($name, substr($value, 2 + \strlen($name)));
                 }
 
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The `CachingHttpClient` works with the HttpFoundation `Request` object by using `Request::create()` which means that it gets initialized with defaults such as

- `user-agent`
- `accept`
- `accept-language`
- `accept-charset`

So when you use this code:

```php
<?php

use Symfony\Component\HttpClient\CachingHttpClient;
use Symfony\Component\HttpClient\CurlHttpClient;
use Symfony\Component\HttpClient\TraceableHttpClient;
use Symfony\Component\HttpKernel\HttpCache\Store;

require __DIR__ . '/vendor/autoload.php';

$traceableClient = new TraceableHttpClient(new CurlHttpClient());
$cachingClient = new CachingHttpClient(
    $traceableClient,
    new Store(__DIR__ . '/cache')
);

$response = $cachingClient->request('GET', 'https://mock.httpstatus.io/200', [
    'headers' => ['Accept-Language' => 'de']
]);
$response->getStatusCode();
dd($traceableClient->getTracedRequests()[0]['info']['debug']);
```

You can see that the headers sent are
```
> GET /200 HTTP/2\r\n
Host: mock.httpstatus.io\r\n
user-agent: Symfony\r\n
accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n
accept: */*\r\n
accept-language: en-us,en;q=0.5\r\n
accept-language: de\r\n
...
```

This can cause issues e.g. with APIs that react to the `Accept-Language` header. The issue here is that I said I want `Accept-Language: de` in my http client instance and what's sent when routing via `CachingHttpClient` is in fact `en-us,en;q=0.5` as well as `de`  💥 

This happens because the `CachingHttpClient` does not replace existing headers (which, as stated before, are added by default).

I tried coming up with a test case for this but it's kinda hard because of how the `CachingHttpClient` is built (it initializes `HttpCache` itself, so it cannot be mocked). The best idea is to get rid of the use of the HttpFoundation's `Request` object in the `CachingHttpClient` completely which happened in the latest Symfony versions anyway 🥳 
