### PR TITLE
[ObjectMapper] Throw exception for invalid transform callable

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Exception/NoSuchCallableException.php
+++ b/src/Symfony/Component/ObjectMapper/Exception/NoSuchCallableException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Exception;
+
+/**
+ * Thrown when an invalid transform callable is defined.
+ *
+ * @author Michaël Marinetti <github@marinetti.fr>
+ */
+class NoSuchCallableException extends MappingException
+{
+}

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -146,7 +146,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 }
 
                 $value = $this->getRawValue($source, $sourcePropertyName);
-                if ($if && ($fn = $this->getCallable($if, $this->conditionCallableLocator)) && !$this->call($fn, $value, $source, $mappedTarget)) {
+                if ($if && ($fn = $this->getCallable($if, $this->conditionCallableLocator, ConditionCallableInterface::class)) && !$this->call($fn, $value, $source, $mappedTarget)) {
                     continue;
                 }
 
@@ -312,7 +312,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     {
         $mapTo = null;
         foreach ($metadata as $mapAttribute) {
-            if (($if = $mapAttribute->if) && ($fn = $this->getCallable($if, $this->conditionCallableLocator)) && !$this->call($fn, $value, $source, $target)) {
+            if (($if = $mapAttribute->if) && ($fn = $this->getCallable($if, $this->conditionCallableLocator, ConditionCallableInterface::class)) && !$this->call($fn, $value, $source, $target)) {
                 continue;
             }
 
@@ -335,9 +335,8 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         foreach ($transforms as $transform) {
-            if ($fn = $this->getCallable($transform, $this->transformCallableLocator)) {
-                $value = $this->call($fn, $value, $source, $target);
-            }
+            $fn = $this->getCallable($transform, $this->transformCallableLocator, TransformCallableInterface::class);
+            $value = $this->call($fn, $value, $source, $target);
         }
 
         return $value;
@@ -345,15 +344,26 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
     /**
      * @param (string|callable(mixed $value, object $object): mixed) $fn
+     * @param class-string|null                                      $expectedInterface
      */
-    private function getCallable(string|callable $fn, ?ContainerInterface $locator = null): callable
+    private function getCallable(string|callable $fn, ?ContainerInterface $locator = null, ?string $expectedInterface = null): callable
     {
         if (\is_callable($fn)) {
+            if ($expectedInterface && \is_object($fn) && !$fn instanceof $expectedInterface) {
+                throw new NoSuchCallableException(\sprintf('"%s" is not a valid callable. Make sure it implements "%s".', get_debug_type($fn), $expectedInterface));
+            }
+
             return $fn;
         }
 
         if ($locator?->has($fn)) {
-            return $locator->get($fn);
+            $callable = $locator->get($fn);
+
+            if ($expectedInterface && !$callable instanceof $expectedInterface) {
+                throw new NoSuchCallableException(\sprintf('"%s" is not a valid callable. Make sure it implements "%s".', $fn, $expectedInterface));
+            }
+
+            return $callable;
         }
 
         throw new NoSuchCallableException(\sprintf('"%s" is not a valid callable.', $fn));

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\ObjectMapper;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Exception\NoSuchCallableException;
 use Symfony\Component\ObjectMapper\Exception\NoSuchPropertyException;
 use Symfony\Component\ObjectMapper\Metadata\Mapping;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
@@ -345,7 +346,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     /**
      * @param (string|callable(mixed $value, object $object): mixed) $fn
      */
-    private function getCallable(string|callable $fn, ?ContainerInterface $locator = null): ?callable
+    private function getCallable(string|callable $fn, ?ContainerInterface $locator = null): callable
     {
         if (\is_callable($fn)) {
             return $fn;
@@ -355,7 +356,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             return $locator->get($fn);
         }
 
-        return null;
+        throw new NoSuchCallableException(\sprintf('"%s" is not a valid callable.', $fn));
     }
 
     /**

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InvalidConfiguration.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InvalidConfiguration.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(D::class)]
+class InvalidConfiguration
+{
+    public function __construct(#[Map('baz')] public readonly string $foo, #[Map(transform: 'wrongMethod')] public readonly string $bar)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Exception\NoSuchCallableException;
 use Symfony\Component\ObjectMapper\Exception\NoSuchPropertyException;
 use Symfony\Component\ObjectMapper\Metadata\Mapping;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
@@ -57,6 +58,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\A as Instance
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B as InstanceCallbackB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\A as InstanceCallbackWithArgumentsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\B as InstanceCallbackWithArgumentsB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InvalidConfiguration;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\LazyFoo;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
@@ -709,5 +711,13 @@ final class ObjectMapperTest extends TestCase
             (new \ReflectionProperty($target, 'withoutDefault'))->isInitialized($target),
             'Property without default value should remain uninitialized'
         );
+    }
+
+    public function testHasInvalidTransformValue()
+    {
+        $this->expectExceptionObject(new NoSuchCallableException(
+            '"wrongMethod" is not a valid callable.'
+        ));
+        (new ObjectMapper())->map(new InvalidConfiguration('foo', 'bar'));
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -363,6 +363,14 @@ final class ObjectMapperTest extends TestCase
         $mapper->map($u);
     }
 
+    public function testHasInvalidTransformValue()
+    {
+        $this->expectException(NoSuchCallableException::class);
+        $this->expectExceptionMessage('"wrongMethod" is not a valid callable. If you use a class, make sure it implements "Symfony\Component\ObjectMapper\TransformCallableInterface".');
+
+        (new ObjectMapper())->map(new InvalidConfiguration('foo', 'bar'));
+    }
+
     public function testTransformToWrongObject()
     {
         $this->expectException(MappingException::class);
@@ -711,13 +719,5 @@ final class ObjectMapperTest extends TestCase
             (new \ReflectionProperty($target, 'withoutDefault'))->isInitialized($target),
             'Property without default value should remain uninitialized'
         );
-    }
-
-    public function testHasInvalidTransformValue()
-    {
-        $this->expectExceptionObject(new NoSuchCallableException(
-            '"wrongMethod" is not a valid callable.'
-        ));
-        (new ObjectMapper())->map(new InvalidConfiguration('foo', 'bar'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62938
| License       | MIT

This PR improves DX by throwing a `MappingTransformException` when a `transform` value in the `#[Map]` attribute is not a valid callable.

Previously, invalid transforms (e.g., a class that doesn't implement `TransformCallableInterface`) were silently ignored, making debugging difficult.

**Before:**
```php
#[Map(target: 'bar', transform: ClassNotImplementingTransformCallableInterface::class)]
public ?Bar $bar;

// No error raised, property silently not transformed
```

After:
```php
#[Map(target: 'bar', transform: ClassNotImplementingTransformCallableInterface::class)]
public ?Bar $bar;

// Throws: MappingTransformException: Transform "ClassNotImplementingTransformCallableInterface" is not a valid callable.
```

This applies to both class-level and property-level transforms.

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234