### PR TITLE
[PropertyInfo] do not parse `scalar` as an object

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -400,7 +400,19 @@ class PhpDocExtractorTest extends TestCase
 
     public function testUnknownPseudoType()
     {
-        $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, false, 'scalar')], $this->extractor->getTypes(PseudoTypeDummy::class, 'unknownPseudoType'));
+        $this->assertEquals([
+            new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\\Component\\PropertyInfo\\Tests\\Fixtures\\unknownpseudo')
+        ], $this->extractor->getTypes(PseudoTypeDummy::class, 'unknownPseudoType'));
+    }
+
+    public function testScalarPseudoType()
+    {
+        $this->assertEquals([
+            new Type(Type::BUILTIN_TYPE_BOOL),
+            new Type(Type::BUILTIN_TYPE_FLOAT),
+            new Type(Type::BUILTIN_TYPE_INT),
+            new Type(Type::BUILTIN_TYPE_STRING),
+        ], $this->extractor->getTypes(PseudoTypeDummy::class, 'scalarPseudoType'));
     }
 
     public function testGenericInterface()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypeDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypeDummy.php
@@ -16,5 +16,10 @@ class PseudoTypeDummy
     /**
      * @var scalar
      */
+    public $scalarPseudoType;
+
+    /**
+     * @var unknownpseudo
+     */
     public $unknownPseudoType;
 }

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -21,6 +21,7 @@ use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\Null_;
 use phpDocumentor\Reflection\Types\Nullable;
+use phpDocumentor\Reflection\Types\Scalar;
 use phpDocumentor\Reflection\Types\String_;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -54,6 +55,15 @@ final class PhpDocTypeHelper
         if ($varType instanceof Nullable) {
             $nullable = true;
             $varType = $varType->getActualType();
+        }
+
+        if ($varType instanceof Scalar) {
+            return [
+                new Type(Type::BUILTIN_TYPE_BOOL),
+                new Type(Type::BUILTIN_TYPE_FLOAT),
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_STRING),
+            ];
         }
 
         if (!$varType instanceof Compound) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | see https://github.com/symfony/symfony/pull/62887#discussion_r2661672924, related to #45720
| License       | MIT