### PR TITLE
[FrameworkBundle] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -21,11 +21,11 @@ class RouterCacheWarmerTest extends TestCase
 {
     public function testWarmUpWithWarmebleInterface()
     {
-        $containerMock = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['get', 'has'])->getMock();
+        $container = new Container();
 
-        $routerMock = $this->getMockBuilder(testRouterInterfaceWithWarmebleInterface::class)->onlyMethods(['match', 'generate', 'getContext', 'setContext', 'getRouteCollection', 'warmUp'])->getMock();
-        $containerMock->expects($this->any())->method('get')->with('router')->willReturn($routerMock);
-        $routerCacheWarmer = new RouterCacheWarmer($containerMock);
+        $routerMock = $this->createStub(testRouterInterfaceWithWarmableInterface::class);
+        $container->set('router', $routerMock);
+        $routerCacheWarmer = new RouterCacheWarmer($container);
 
         $routerCacheWarmer->warmUp('/tmp');
         $routerMock->expects($this->any())->method('warmUp')->with('/tmp')->willReturn([]);
@@ -34,21 +34,21 @@ class RouterCacheWarmerTest extends TestCase
 
     public function testWarmUpWithoutWarmebleInterface()
     {
-        $containerMock = $this->getMockBuilder(ContainerInterface::class)->onlyMethods(['get', 'has'])->getMock();
+        $container = new Container();
 
-        $routerMock = $this->getMockBuilder(testRouterInterfaceWithoutWarmebleInterface::class)->onlyMethods(['match', 'generate', 'getContext', 'setContext', 'getRouteCollection'])->getMock();
-        $containerMock->expects($this->any())->method('get')->with('router')->willReturn($routerMock);
-        $routerCacheWarmer = new RouterCacheWarmer($containerMock);
+        $routerMock = $this->createStub(testRouterInterfaceWithoutWarmableInterface::class);
+        $container->set('router', $routerMock);
+        $routerCacheWarmer = new RouterCacheWarmer($container);
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('cannot be warmed up because it does not implement "Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface"');
         $routerCacheWarmer->warmUp('/tmp');
     }
 }
 
-interface testRouterInterfaceWithWarmebleInterface extends RouterInterface, WarmableInterface
+interface testRouterInterfaceWithWarmableInterface extends RouterInterface, WarmableInterface
 {
 }
 
-interface testRouterInterfaceWithoutWarmebleInterface extends RouterInterface
+interface testRouterInterfaceWithoutWarmableInterface extends RouterInterface
 {
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
@@ -23,20 +23,13 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class CachePoolClearCommandTest extends TestCase
 {
-    private CacheItemPoolInterface $cachePool;
-
-    protected function setUp(): void
-    {
-        $this->cachePool = $this->createMock(CacheItemPoolInterface::class);
-    }
-
     /**
      * @dataProvider provideCompletionSuggestions
      */
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application($this->getKernel());
-        $application->add(new CachePoolClearCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
+        $application->add(new CachePoolClearCommand(new Psr6CacheClearer(['foo' => new ArrayAdapter()]), ['foo']));
         $tester = new CommandCompletionTester($application->get('cache:pool:clear'));
 
         $suggestions = $tester->complete($input);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
@@ -16,6 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolDeleteCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -24,26 +25,20 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class CachePoolDeleteCommandTest extends TestCase
 {
-    private MockObject&CacheItemPoolInterface $cachePool;
-
-    protected function setUp(): void
-    {
-        $this->cachePool = $this->createMock(CacheItemPoolInterface::class);
-    }
-
     public function testCommandWithValidKey()
     {
-        $this->cachePool->expects($this->once())
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $cachePool->expects($this->once())
             ->method('hasItem')
             ->with('bar')
             ->willReturn(true);
 
-        $this->cachePool->expects($this->once())
+        $cachePool->expects($this->once())
             ->method('deleteItem')
             ->with('bar')
             ->willReturn(true);
 
-        $tester = $this->getCommandTester($this->getKernel());
+        $tester = $this->getCommandTester($this->getKernel(), $cachePool);
         $tester->execute(['pool' => 'foo', 'key' => 'bar']);
 
         $this->assertStringContainsString('[OK] Cache item "bar" was successfully deleted.', $tester->getDisplay());
@@ -51,16 +46,17 @@ class CachePoolDeleteCommandTest extends TestCase
 
     public function testCommandWithInValidKey()
     {
-        $this->cachePool->expects($this->once())
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $cachePool->expects($this->once())
             ->method('hasItem')
             ->with('bar')
             ->willReturn(false);
 
-        $this->cachePool->expects($this->never())
+        $cachePool->expects($this->never())
             ->method('deleteItem')
             ->with('bar');
 
-        $tester = $this->getCommandTester($this->getKernel());
+        $tester = $this->getCommandTester($this->getKernel(), $cachePool);
         $tester->execute(['pool' => 'foo', 'key' => 'bar']);
 
         $this->assertStringContainsString('[NOTE] Cache item "bar" does not exist in cache pool "foo".', $tester->getDisplay());
@@ -68,19 +64,20 @@ class CachePoolDeleteCommandTest extends TestCase
 
     public function testCommandDeleteFailed()
     {
-        $this->cachePool->expects($this->once())
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $cachePool->expects($this->once())
             ->method('hasItem')
             ->with('bar')
             ->willReturn(true);
 
-        $this->cachePool->expects($this->once())
+        $cachePool->expects($this->once())
             ->method('deleteItem')
             ->with('bar')
             ->willReturn(false);
 
         $this->expectExceptionMessage('Cache item "bar" could not be deleted.');
 
-        $tester = $this->getCommandTester($this->getKernel());
+        $tester = $this->getCommandTester($this->getKernel(), $cachePool);
         $tester->execute(['pool' => 'foo', 'key' => 'bar']);
     }
 
@@ -90,7 +87,7 @@ class CachePoolDeleteCommandTest extends TestCase
     public function testComplete(array $input, array $expectedSuggestions)
     {
         $application = new Application($this->getKernel());
-        $application->add(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
+        $application->add(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => new ArrayAdapter()]), ['foo']));
         $tester = new CommandCompletionTester($application->get('cache:pool:delete'));
 
         $suggestions = $tester->complete($input);
@@ -124,10 +121,10 @@ class CachePoolDeleteCommandTest extends TestCase
         return $kernel;
     }
 
-    private function getCommandTester(KernelInterface $kernel): CommandTester
+    private function getCommandTester(KernelInterface $kernel, CacheItemPoolInterface $cachePool): CommandTester
     {
         $application = new Application($kernel);
-        $application->add(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $this->cachePool])));
+        $application->add(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $cachePool])));
 
         return new CommandTester($application->find('cache:pool:delete'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -57,13 +57,11 @@ class RouterMatchCommandTest extends TestCase
         $routeCollection = new RouteCollection();
         $routeCollection->add('foo', new Route('foo'));
         $requestContext = new RequestContext();
-        $router = $this->createMock(RouterInterface::class);
+        $router = $this->createStub(RouterInterface::class);
         $router
-            ->expects($this->any())
             ->method('getRouteCollection')
             ->willReturn($routeCollection);
         $router
-            ->expects($this->any())
             ->method('getContext')
             ->willReturn($requestContext);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsEncryptFromLocalCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsEncryptFromLocalCommandTest.php
@@ -42,7 +42,7 @@ class SecretsEncryptFromLocalCommandTest extends TestCase
 
     public function testFailsWhenLocalVaultIsDisabled()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $command = new SecretsEncryptFromLocalCommand($vault, null);
         $tester = new CommandTester($command);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsGenerateKeysCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsGenerateKeysCommandTest.php
@@ -58,7 +58,7 @@ class SecretsGenerateKeysCommandTest extends TestCase
 
     public function testItFailsGracefullyWhenLocalVaultIsDisabled()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $tester = new CommandTester(new SecretsGenerateKeysCommand($vault));
 
         $this->assertSame(1, $tester->execute(['--local' => true]));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsListCommandTest.php
@@ -24,7 +24,7 @@ class SecretsListCommandTest extends TestCase
      */
     public function testExecute()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['A' => 'a', 'B' => 'b', 'C' => null, 'D' => null, 'E' => null]);
 
         $_ENV = ['A' => '', 'B' => 'A', 'C' => '', 'D' => false, 'E' => null];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRemoveCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRemoveCommandTest.php
@@ -23,10 +23,10 @@ class SecretsRemoveCommandTest extends TestCase
      */
     public function testComplete(bool $withLocalVault, array $input, array $expectedSuggestions)
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['SECRET' => null, 'OTHER_SECRET' => null]);
         if ($withLocalVault) {
-            $localVault = $this->createMock(AbstractVault::class);
+            $localVault = $this->createStub(AbstractVault::class);
             $localVault->method('list')->willReturn(['SECRET' => null]);
         } else {
             $localVault = null;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsSetCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsSetCommandTest.php
@@ -23,9 +23,9 @@ class SecretsSetCommandTest extends TestCase
      */
     public function testComplete(array $input, array $expectedSuggestions)
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['SECRET' => null, 'OTHER_SECRET' => null]);
-        $localVault = $this->createMock(AbstractVault::class);
+        $localVault = $this->createStub(AbstractVault::class);
         $command = new SecretsSetCommand($vault, $localVault);
         $tester = new CommandCompletionTester($command);
         $suggestions = $tester->complete($input);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -167,16 +167,12 @@ class TranslationDebugCommandTest extends TestCase
 
     private function createCommand(array $extractedMessages = [], array $loadedMessages = [], ?KernelInterface $kernel = null, array $transPaths = [], array $codePaths = [], ?ExtractorInterface $extractor = null, array $bundles = [], array $enabledLocales = []): TranslationDebugCommand
     {
-        $translator = $this->createMock(Translator::class);
-        $translator
-            ->expects($this->any())
-            ->method('getFallbackLocales')
-            ->willReturn(['en']);
+        $translator = new Translator('fr');
+        $translator->setFallbackLocales(['en']);
 
         if (!$extractor) {
-            $extractor = $this->createMock(ExtractorInterface::class);
+            $extractor = $this->createStub(ExtractorInterface::class);
             $extractor
-                ->expects($this->any())
                 ->method('extract')
                 ->willReturnCallback(
                     function ($path, $catalogue) use ($extractedMessages) {
@@ -185,9 +181,8 @@ class TranslationDebugCommandTest extends TestCase
                 );
         }
 
-        $loader = $this->createMock(TranslationReader::class);
+        $loader = $this->createStub(TranslationReader::class);
         $loader
-            ->expects($this->any())
             ->method('read')
             ->willReturnCallback(
                 function ($path, $catalogue) use ($loadedMessages) {
@@ -200,21 +195,18 @@ class TranslationDebugCommandTest extends TestCase
                 ['foo', $this->getBundle($this->translationDir)],
                 ['test', $this->getBundle('test')],
             ];
-            $kernel = $this->createMock(KernelInterface::class);
+            $kernel = $this->createStub(KernelInterface::class);
             $kernel
-                ->expects($this->any())
                 ->method('getBundle')
                 ->willReturnMap($returnValues);
         }
 
         $kernel
-            ->expects($this->any())
             ->method('getBundles')
             ->willReturn($bundles);
 
         $container = new Container();
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container);
 
@@ -228,9 +220,8 @@ class TranslationDebugCommandTest extends TestCase
 
     private function getBundle($path)
     {
-        $bundle = $this->createMock(BundleInterface::class);
+        $bundle = $this->createStub(BundleInterface::class);
         $bundle
-            ->expects($this->any())
             ->method('getPath')
             ->willReturn($path)
         ;
@@ -254,9 +245,8 @@ class TranslationDebugCommandTest extends TestCase
                 'foo' => 'foo',
             ],
         ];
-        $extractor = $this->createMock(ExtractorInterface::class);
+        $extractor = $this->createStub(ExtractorInterface::class);
         $extractor
-            ->expects($this->any())
             ->method('extract')
             ->willReturnCallback(
                 function ($path, $catalogue) use ($extractedMessagesWithDomains) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandCompletionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandCompletionTest.php
@@ -69,15 +69,11 @@ class TranslationUpdateCommandCompletionTest extends TestCase
 
     private function createCommandCompletionTester($extractedMessages = [], $loadedMessages = [], ?KernelInterface $kernel = null, array $transPaths = [], array $codePaths = []): CommandCompletionTester
     {
-        $translator = $this->createMock(Translator::class);
-        $translator
-            ->expects($this->any())
-            ->method('getFallbackLocales')
-            ->willReturn(['en']);
+        $translator = new Translator('fr');
+        $translator->setFallbackLocales(['en']);
 
-        $extractor = $this->createMock(ExtractorInterface::class);
+        $extractor = $this->createStub(ExtractorInterface::class);
         $extractor
-            ->expects($this->any())
             ->method('extract')
             ->willReturnCallback(
                 function ($path, $catalogue) use ($extractedMessages) {
@@ -87,9 +83,8 @@ class TranslationUpdateCommandCompletionTest extends TestCase
                 }
             );
 
-        $loader = $this->createMock(TranslationReader::class);
+        $loader = $this->createStub(TranslationReader::class);
         $loader
-            ->expects($this->any())
             ->method('read')
             ->willReturnCallback(
                 function ($path, $catalogue) use ($loadedMessages) {
@@ -97,9 +92,8 @@ class TranslationUpdateCommandCompletionTest extends TestCase
                 }
             );
 
-        $writer = $this->createMock(TranslationWriter::class);
+        $writer = $this->createStub(TranslationWriter::class);
         $writer
-            ->expects($this->any())
             ->method('getFormats')
             ->willReturn(
                 ['php', 'xlf', 'po', 'mo', 'yml', 'yaml', 'ts', 'csv', 'ini', 'json', 'res']
@@ -110,21 +104,18 @@ class TranslationUpdateCommandCompletionTest extends TestCase
                 ['foo', $this->getBundle($this->translationDir)],
                 ['test', $this->getBundle('test')],
             ];
-            $kernel = $this->createMock(KernelInterface::class);
+            $kernel = $this->createStub(KernelInterface::class);
             $kernel
-                ->expects($this->any())
                 ->method('getBundle')
                 ->willReturnMap($returnValues);
         }
 
         $kernel
-            ->expects($this->any())
             ->method('getBundles')
             ->willReturn([new ExtensionPresentBundle()]);
 
         $container = new Container();
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container);
 
@@ -138,9 +129,8 @@ class TranslationUpdateCommandCompletionTest extends TestCase
 
     private function getBundle($path)
     {
-        $bundle = $this->createMock(BundleInterface::class);
+        $bundle = $this->createStub(BundleInterface::class);
         $bundle
-            ->expects($this->any())
             ->method('getPath')
             ->willReturn($path)
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -165,7 +165,7 @@ class TranslationUpdateCommandTest extends TestCase
             }
         }
 
-        $command = $this->createMock(TranslationUpdateCommand::class);
+        $command = $this->createStub(TranslationUpdateCommand::class);
 
         $method = new \ReflectionMethod(TranslationUpdateCommand::class, 'filterDuplicateTransPaths');
 
@@ -194,15 +194,11 @@ class TranslationUpdateCommandTest extends TestCase
 
     private function createCommandTester($extractedMessages = [], $loadedMessages = [], ?KernelInterface $kernel = null, array $transPaths = [], array $codePaths = []): CommandTester
     {
-        $translator = $this->createMock(Translator::class);
-        $translator
-            ->expects($this->any())
-            ->method('getFallbackLocales')
-            ->willReturn(['en']);
+        $translator = new Translator('fr');
+        $translator->setFallbackLocales(['en']);
 
-        $extractor = $this->createMock(ExtractorInterface::class);
+        $extractor = $this->createStub(ExtractorInterface::class);
         $extractor
-            ->expects($this->any())
             ->method('extract')
             ->willReturnCallback(
                 function ($path, $catalogue) use ($extractedMessages) {
@@ -212,9 +208,8 @@ class TranslationUpdateCommandTest extends TestCase
                 }
             );
 
-        $loader = $this->createMock(TranslationReader::class);
+        $loader = $this->createStub(TranslationReader::class);
         $loader
-            ->expects($this->any())
             ->method('read')
             ->willReturnCallback(
                 function ($path, $catalogue) use ($loadedMessages) {
@@ -222,9 +217,8 @@ class TranslationUpdateCommandTest extends TestCase
                 }
             );
 
-        $writer = $this->createMock(TranslationWriter::class);
+        $writer = $this->createStub(TranslationWriter::class);
         $writer
-            ->expects($this->any())
             ->method('getFormats')
             ->willReturn(
                 ['xlf', 'yml', 'yaml']
@@ -235,21 +229,18 @@ class TranslationUpdateCommandTest extends TestCase
                 ['foo', $this->getBundle($this->translationDir)],
                 ['test', $this->getBundle('test')],
             ];
-            $kernel = $this->createMock(KernelInterface::class);
+            $kernel = $this->createStub(KernelInterface::class);
             $kernel
-                ->expects($this->any())
                 ->method('getBundle')
                 ->willReturnMap($returnValues);
         }
 
         $kernel
-            ->expects($this->any())
             ->method('getBundles')
             ->willReturn([]);
 
         $container = new Container();
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container);
 
@@ -263,9 +254,8 @@ class TranslationUpdateCommandTest extends TestCase
 
     private function getBundle($path)
     {
-        $bundle = $this->createMock(BundleInterface::class);
+        $bundle = $this->createStub(BundleInterface::class);
         $bundle
-            ->expects($this->any())
             ->method('getPath')
             ->willReturn($path)
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -35,7 +35,7 @@ class ApplicationTest extends TestCase
 {
     public function testBundleInterfaceImplementation()
     {
-        $bundle = $this->createMock(BundleInterface::class);
+        $bundle = $this->createStub(BundleInterface::class);
 
         $kernel = $this->getKernel([$bundle], true);
 
@@ -131,7 +131,7 @@ class ApplicationTest extends TestCase
         $container->register(ThrowingCommand::class, ThrowingCommand::class);
         $container->setParameter('console.command.ids', [ThrowingCommand::class => ThrowingCommand::class]);
 
-        $kernel = $this->createMock(KernelInterface::class);
+        $kernel = $this->createStub(KernelInterface::class);
         $kernel
             ->method('getBundles')
             ->willReturn([$this->createBundleMock(
@@ -159,7 +159,7 @@ class ApplicationTest extends TestCase
         $container = new ContainerBuilder();
         $container->register('event_dispatcher', EventDispatcher::class);
 
-        $kernel = $this->createMock(KernelInterface::class);
+        $kernel = $this->createStub(KernelInterface::class);
         $kernel
             ->method('getBundles')
             ->willReturn([$this->createBundleMock(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Symfony\Component\WebLink\Link;
 use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class AbstractControllerTest extends TestCase
 {
@@ -258,7 +259,7 @@ class AbstractControllerTest extends TestCase
     public function testFile()
     {
         $container = new Container();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $container->set('http_kernel', $kernel);
 
         $controller = $this->createController();
@@ -401,7 +402,7 @@ class AbstractControllerTest extends TestCase
      */
     public function testdenyAccessUnlessGrantedSetsAttributesAsArray($attribute, $exceptionAttributes)
     {
-        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker = $this->createStub(AuthorizationCheckerInterface::class);
         $authorizationChecker->method('isGranted')->willReturn(false);
 
         $container = new Container();
@@ -557,10 +558,8 @@ class AbstractControllerTest extends TestCase
 
     public function testStreamTwig()
     {
-        $twig = $this->createMock(Environment::class);
-
         $container = new Container();
-        $container->set('twig', $twig);
+        $container->set('twig', new Environment(new ArrayLoader()));
 
         $controller = $this->createController();
         $controller->setContainer($container);
@@ -591,8 +590,7 @@ class AbstractControllerTest extends TestCase
     public function testAddFlash()
     {
         $flashBag = new FlashBag();
-        $session = $this->createMock(Session::class);
-        $session->expects($this->once())->method('getFlashBag')->willReturn($flashBag);
+        $session = new Session(null, null, $flashBag);
 
         $request = new Request();
         $request->setSession($session);
@@ -663,7 +661,7 @@ class AbstractControllerTest extends TestCase
 
     public function testCreateForm()
     {
-        $config = $this->createMock(FormConfigInterface::class);
+        $config = $this->createStub(FormConfigInterface::class);
         $config->method('getInheritData')->willReturn(false);
         $config->method('getName')->willReturn('');
 
@@ -683,7 +681,7 @@ class AbstractControllerTest extends TestCase
 
     public function testCreateFormBuilder()
     {
-        $formBuilder = $this->createMock(FormBuilderInterface::class);
+        $formBuilder = $this->createStub(FormBuilderInterface::class);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createBuilder')->willReturn($formBuilder);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DataCollector/RouterDataCollectorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DataCollector/RouterDataCollectorTest.php
@@ -59,7 +59,7 @@ class RouterDataCollectorTest extends TestCase
 
     protected function createControllerEvent(Request $request): ControllerEvent
     {
-        $kernel = $this->createMock(KernelInterface::class);
+        $kernel = $this->createStub(KernelInterface::class);
 
         return new ControllerEvent($kernel, new RedirectController(), $request, null);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -897,7 +897,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
     public function testMessengerWithoutConsole()
     {
         $extension = $this->createPartialMock(FrameworkExtension::class, ['hasConsole', 'getAlias']);
-        $extension->method('hasConsole')->willReturn(false);
+        $extension->expects($this->atLeastOnce())->method('hasConsole')->willReturn(false);
         $extension->method('getAlias')->willReturn((new FrameworkExtension())->getAlias());
 
         $container = $this->createContainerFromFile('messenger', [], true, false, $extension);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -33,7 +33,7 @@ class RouterTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('You should either pass a "Symfony\Component\DependencyInjection\ContainerInterface" instance or provide the $parameters argument of the "Symfony\Bundle\FrameworkBundle\Routing\Router::__construct" method');
-        new Router($this->createMock(ContainerInterface::class), 'foo');
+        new Router($this->createStub(ContainerInterface::class), 'foo');
     }
 
     public function testGenerateWithServiceParam()
@@ -609,10 +609,9 @@ class RouterTest extends TestCase
 
     private function getServiceContainer(RouteCollection $routes): Container
     {
-        $loader = $this->createMock(LoaderInterface::class);
+        $loader = $this->createStub(LoaderInterface::class);
 
         $loader
-            ->expects($this->any())
             ->method('load')
             ->willReturn($routes)
         ;
@@ -630,10 +629,9 @@ class RouterTest extends TestCase
 
     private function getPsr11ServiceContainer(RouteCollection $routes): ContainerInterface
     {
-        $loader = $this->createMock(LoaderInterface::class);
+        $loader = $this->createStub(LoaderInterface::class);
 
         $loader
-            ->expects($this->any())
             ->method('load')
             ->willReturn($routes)
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -352,8 +352,8 @@ class WebTestCaseTest extends TestCase
 
     private function getResponseTester(Response $response): WebTestCase
     {
-        $client = $this->createMock(KernelBrowser::class);
-        $client->expects($this->any())->method('getResponse')->willReturn($response);
+        $client = $this->createStub(KernelBrowser::class);
+        $client->method('getResponse')->willReturn($response);
 
         $request = new Request([], [], [], [], [], [
             'HTTPS' => 'on',
@@ -361,36 +361,36 @@ class WebTestCaseTest extends TestCase
             'SERVER_NAME' => 'example.com',
         ]);
         $request->setFormat('custom', ['application/vnd.myformat']);
-        $client->expects($this->any())->method('getRequest')->willReturn($request);
+        $client->method('getRequest')->willReturn($request);
 
         return $this->getTester($client);
     }
 
     private function getCrawlerTester(Crawler $crawler): WebTestCase
     {
-        $client = $this->createMock(KernelBrowser::class);
-        $client->expects($this->any())->method('getCrawler')->willReturn($crawler);
+        $client = $this->createStub(KernelBrowser::class);
+        $client->method('getCrawler')->willReturn($crawler);
 
         return $this->getTester($client);
     }
 
     private function getClientTester(): WebTestCase
     {
-        $client = $this->createMock(KernelBrowser::class);
+        $client = $this->createStub(KernelBrowser::class);
         $jar = new CookieJar();
         $jar->set(new Cookie('foo', 'bar', null, '/path', 'example.com'));
-        $client->expects($this->any())->method('getCookieJar')->willReturn($jar);
+        $client->method('getCookieJar')->willReturn($jar);
 
         return $this->getTester($client);
     }
 
     private function getRequestTester(): WebTestCase
     {
-        $client = $this->createMock(KernelBrowser::class);
+        $client = $this->createStub(KernelBrowser::class);
         $request = new Request();
         $request->attributes->set('foo', 'bar');
         $request->attributes->set('_route', 'homepage');
-        $client->expects($this->any())->method('getRequest')->willReturn($request);
+        $client->method('getRequest')->willReturn($request);
 
         return $this->getTester($client);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT