### PR TITLE
[SecurityBundle] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
@@ -37,7 +37,7 @@ class ExpressionCacheWarmerTest extends TestCase
                 $this->assertSame($expectedExpression, $expression);
                 $this->assertSame($expectedNames, $names);
 
-                return $this->createMock(ParsedExpression::class);
+                return $this->createStub(ParsedExpression::class);
             })
         ;
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,7 +32,6 @@ use Symfony\Component\Security\Core\Authorization\Voter\TraceableVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -164,20 +164,14 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertNull($collector->getFirewall());
 
         // Inject an instance that is not context aware
-        $firewallMap = $this
-            ->getMockBuilder(FirewallMapInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $firewallMap = new FirewallMap(new Container(), []);
 
         $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()));
         $collector->collect($request, $response);
         $this->assertNull($collector->getFirewall());
 
         // Null config
-        $firewallMap = $this
-            ->getMockBuilder(FirewallMap::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $firewallMap = new FirewallMap(new Container(), []);
 
         $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()));
         $collector->collect($request, $response);
@@ -190,7 +184,7 @@ class SecurityDataCollectorTest extends TestCase
     public function testGetListeners()
     {
         $request = new Request();
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $event->setResponse($response = new Response());
         $listener = function ($e) use ($event, &$listenerCalled) {
             $listenerCalled += $e === $event;
@@ -235,7 +229,7 @@ class SecurityDataCollectorTest extends TestCase
 
         $strategy = MainConfiguration::STRATEGY_AFFIRMATIVE;
 
-        $accessDecisionManager = $this->createMock(TraceableAccessDecisionManager::class);
+        $accessDecisionManager = $this->createStub(TraceableAccessDecisionManager::class);
 
         $accessDecisionManager
             ->method('getStrategy')
@@ -310,7 +304,7 @@ class SecurityDataCollectorTest extends TestCase
 
         $strategy = MainConfiguration::STRATEGY_UNANIMOUS;
 
-        $accessDecisionManager = $this->createMock(TraceableAccessDecisionManager::class);
+        $accessDecisionManager = $this->createStub(TraceableAccessDecisionManager::class);
 
         $accessDecisionManager
             ->method('getStrategy')
@@ -401,7 +395,7 @@ class SecurityDataCollectorTest extends TestCase
     {
         $strategy = MainConfiguration::STRATEGY_AFFIRMATIVE;
 
-        $accessDecisionManager = $this->createMock(TraceableAccessDecisionManager::class);
+        $accessDecisionManager = $this->createStub(TraceableAccessDecisionManager::class);
 
         $accessDecisionManager
             ->method('getStrategy')

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
@@ -38,8 +38,8 @@ class TraceableFirewallListenerTest extends TestCase
     public function testOnKernelRequestRecordsListeners()
     {
         $request = new Request();
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
-        $event->setResponse($response = new Response());
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event->setResponse(new Response());
         $listener = function ($e) use ($event, &$listenerCalled) {
             $listenerCalled += $e === $event;
         };
@@ -68,7 +68,7 @@ class TraceableFirewallListenerTest extends TestCase
     {
         $request = new Request();
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $event->setResponse($response = new Response());
 
         $supportingAuthenticator = $this->createMock(DummyAuthenticator::class);
@@ -90,17 +90,16 @@ class TraceableFirewallListenerTest extends TestCase
             ->method('createToken')
             ->willReturn($this->createMock(TokenInterface::class));
 
-        $notSupportingAuthenticator = $this->createMock(DummyAuthenticator::class);
+        $notSupportingAuthenticator = $this->createStub(DummyAuthenticator::class);
         $notSupportingAuthenticator
             ->method('supports')
             ->with($request)
             ->willReturn(false);
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $dispatcher = new EventDispatcher();
         $authenticatorManager = new AuthenticatorManager(
             [$notSupportingAuthenticator, $supportingAuthenticator],
-            $tokenStorage,
+            new TokenStorage(),
             $dispatcher,
             'main'
         );

--- a/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
@@ -21,7 +21,7 @@ class VoteListenerTest extends TestCase
 {
     public function testOnVoterVote()
     {
-        $voter = $this->createMock(VoterInterface::class);
+        $voter = $this->createStub(VoterInterface::class);
 
         $traceableAccessDecisionManager = $this
             ->getMockBuilder(TraceableAccessDecisionManager::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/EventAliasTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/EventAliasTest.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -28,9 +28,9 @@ final class EventAliasTest extends AbstractWebTestCase
         $container = $client->getContainer();
         $dispatcher = $container->get('event_dispatcher');
 
-        $dispatcher->dispatch(new AuthenticationSuccessEvent($this->createMock(TokenInterface::class)), AuthenticationEvents::AUTHENTICATION_SUCCESS);
-        $dispatcher->dispatch(new InteractiveLoginEvent($this->createMock(Request::class), $this->createMock(TokenInterface::class)), SecurityEvents::INTERACTIVE_LOGIN);
-        $dispatcher->dispatch(new SwitchUserEvent($this->createMock(Request::class), $this->createMock(UserInterface::class), $this->createMock(TokenInterface::class)), SecurityEvents::SWITCH_USER);
+        $dispatcher->dispatch(new AuthenticationSuccessEvent(new UsernamePasswordToken(new InMemoryUser('John', 'password'), 'main')), AuthenticationEvents::AUTHENTICATION_SUCCESS);
+        $dispatcher->dispatch(new InteractiveLoginEvent(new Request(), new UsernamePasswordToken(new InMemoryUser('John', 'password'), 'main')), SecurityEvents::INTERACTIVE_LOGIN);
+        $dispatcher->dispatch(new SwitchUserEvent(new Request(), new InMemoryUser('John', 'password'), new UsernamePasswordToken(new InMemoryUser('Alice', 'password'), 'main')), SecurityEvents::SWITCH_USER);
 
         $this->assertEquals(
             [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
@@ -12,13 +12,14 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\LoginLink;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Symfony\Bundle\SecurityBundle\LoginLink\FirewallAwareLoginLinkHandler;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkDetails;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 
@@ -26,7 +27,7 @@ class FirewallAwareLoginLinkHandlerTest extends TestCase
 {
     public function testSuccessfulDecoration()
     {
-        $user = $this->createMock(UserInterface::class);
+        $user = new InMemoryUser('John', 'password');
         $linkDetails = new LoginLinkDetails('http://example.com', new \DateTimeImmutable());
         $request = Request::create('http://example.com/verify');
 
@@ -40,9 +41,8 @@ class FirewallAwareLoginLinkHandlerTest extends TestCase
             ->method('consumeLoginLink')
             ->with($request)
             ->willReturn($user);
-        $locator = $this->createLocator([
-            'main_firewall' => $loginLinkHandler,
-        ]);
+        $locator = new Container();
+        $locator->set('main_firewall', $loginLinkHandler);
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
@@ -56,24 +56,11 @@ class FirewallAwareLoginLinkHandlerTest extends TestCase
 
     private function createFirewallMap(string $firewallName)
     {
-        $map = $this->createMock(FirewallMap::class);
-        $map->expects($this->any())
-            ->method('getFirewallConfig')
-            ->willReturn($config = new FirewallConfig($firewallName, 'user_checker'));
+        $context = new FirewallContext([], null, null, new FirewallConfig($firewallName, 'user_checker'));
+        $locator = new Container();
+        $locator->set($firewallName, $context);
+        $map = new FirewallMap($locator, [$firewallName => null]);
 
         return $map;
-    }
-
-    private function createLocator(array $linkers)
-    {
-        $locator = $this->createMock(ContainerInterface::class);
-        $locator->expects($this->any())
-            ->method('has')
-            ->willReturnCallback(fn ($firewallName) => isset($linkers[$firewallName]));
-        $locator->expects($this->any())
-            ->method('get')
-            ->willReturnCallback(fn ($firewallName) => $linkers[$firewallName]);
-
-        return $locator;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
@@ -36,17 +36,11 @@ class FirewallContextTest extends TestCase
 
     private function getExceptionListenerMock()
     {
-        return $this
-            ->getMockBuilder(ExceptionListener::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createStub(ExceptionListener::class);
     }
 
     private function getLogoutListenerMock()
     {
-        return $this
-            ->getMockBuilder(LogoutListener::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createStub(LogoutListener::class);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -60,19 +60,11 @@ class FirewallMapTest extends TestCase
     /** @dataProvider providesStatefulStatelessRequests */
     public function testGetListeners(Request $request, bool $expectedState)
     {
-        $firewallContext = $this->createMock(FirewallContext::class);
-
         $firewallConfig = new FirewallConfig('main', 'user_checker', null, true, true);
-        $firewallContext->expects($this->once())->method('getConfig')->willReturn($firewallConfig);
-
         $listener = function () {};
-        $firewallContext->expects($this->once())->method('getListeners')->willReturn([$listener]);
-
-        $exceptionListener = $this->createMock(ExceptionListener::class);
-        $firewallContext->expects($this->once())->method('getExceptionListener')->willReturn($exceptionListener);
-
-        $logoutListener = $this->createMock(LogoutListener::class);
-        $firewallContext->expects($this->once())->method('getLogoutListener')->willReturn($logoutListener);
+        $exceptionListener = $this->createStub(ExceptionListener::class);
+        $logoutListener = $this->createStub(LogoutListener::class);
+        $firewallContext = new FirewallContext([$listener], $exceptionListener, $logoutListener, $firewallConfig);
 
         $matcher = $this->createMock(RequestMatcherInterface::class);
         $matcher->expects($this->once())
@@ -80,8 +72,8 @@ class FirewallMapTest extends TestCase
             ->with($request)
             ->willReturn(true);
 
-        $container = $this->createMock(Container::class);
-        $container->expects($this->exactly(2))->method('get')->willReturn($firewallContext);
+        $container = new Container();
+        $container->set('security.firewall.map.context.foo', $firewallContext);
 
         $firewallMap = new FirewallMap($container, ['security.firewall.map.context.foo' => $matcher]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT