### PR TITLE
[TwigBundle] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -56,12 +56,12 @@ class TemplateIteratorTest extends TestCase
 
     private function createKernelMock(): Kernel
     {
-        $bundle = $this->createMock(BundleInterface::class);
-        $bundle->expects($this->any())->method('getName')->willReturn('BarBundle');
-        $bundle->expects($this->any())->method('getPath')->willReturn(__DIR__.'/Fixtures/templates/BarBundle');
+        $bundle = $this->createStub(BundleInterface::class);
+        $bundle->method('getName')->willReturn('BarBundle');
+        $bundle->method('getPath')->willReturn(__DIR__.'/Fixtures/templates/BarBundle');
 
-        $kernel = $this->createMock(Kernel::class);
-        $kernel->expects($this->any())->method('getBundles')->willReturn([
+        $kernel = $this->createStub(Kernel::class);
+        $kernel->method('getBundles')->willReturn([
             $bundle,
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT