### PR TITLE
[Yaml] Improve dump of simple hash maps in sequences

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -108,14 +108,15 @@ class Dumper
                 if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($value instanceof \ArrayObject || $value instanceof \stdClass)) {
                     $dumpObjectAsInlineMap = !(array) $value;
                 }
-
+                $isSequenceItem = !$dumpAsMap;
                 $willBeInlined = $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || !$value;
+                $isSimpleSequenceHash = !$willBeInlined && $isSequenceItem && \is_array($value) && Inline::isHash($value) && $this->isSimpleInlineMap($value);
 
                 $output .= \sprintf('%s%s%s%s',
                     $prefix,
                     $dumpAsMap ? Inline::dump($key, $flags).':' : '-',
-                    $willBeInlined || ($compactNestedMapping && \is_array($value) && Inline::isHash($value)) ? ' ' : "\n",
-                    $compactNestedMapping && \is_array($value) && Inline::isHash($value) ? substr($this->doDump($value, $inline - 1, $indent + 2, $flags, $nestingLevel + 1), $indent + 2) : $this->doDump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags, $nestingLevel + 1)
+                    $willBeInlined || $isSimpleSequenceHash || ($compactNestedMapping && \is_array($value) && Inline::isHash($value)) ? ' ' : "\n",
+                    ($compactNestedMapping && \is_array($value) && Inline::isHash($value)) || $isSimpleSequenceHash ? substr($this->doDump($value, $inline - 1, $indent + 2, $flags, $nestingLevel + 1), $indent + 2) : $this->doDump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags, $nestingLevel + 1)
                 ).($willBeInlined ? "\n" : '');
             }
         }
@@ -183,5 +184,16 @@ class Dumper
         }
 
         return '';
+    }
+
+    private function isSimpleInlineMap(array $value): bool
+    {
+        foreach ($value as $v) {
+            if (\is_array($v) || $v instanceof TaggedValue) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -66,8 +66,7 @@ class DumperTest extends TestCase
             bar:
                    - 1
                    - foo
-                   -
-                          a: A
+                   - a: A
             foobar:
                    foo: bar
                    bar:
@@ -110,6 +109,19 @@ class DumperTest extends TestCase
                 $this->assertSame($expected, $this->parser->parse($this->dumper->dump($expected, 10)), $test['test']);
             }
         }
+    }
+
+    public function testDumpSimpleHashesInSequencesCompactly()
+    {
+        $data = ['servers' => [['url' => 'http://example.com']]];
+        $expected = "servers:\n    - url: 'http://example.com'\n";
+        $this->assertSame($expected, $this->dumper->dump($data, 3));
+        $this->assertSameData($data, $this->parser->parse($expected));
+
+        $data = ['servers' => [['url' => 'http://example.com', 'port' => 80]]];
+        $expected = "servers:\n    - url: 'http://example.com'\n      port: 80\n";
+        $this->assertSame($expected, $this->dumper->dump($data, 3));
+        $this->assertSameData($data, $this->parser->parse($expected));
     }
 
     public function testInlineLevel()
@@ -156,8 +168,7 @@ class DumperTest extends TestCase
             bar:
                 - 1
                 - foo
-                -
-                    a: A
+                - a: A
             foobar:
                 foo: bar
                 bar:
@@ -178,8 +189,7 @@ class DumperTest extends TestCase
             bar:
                 - 1
                 - foo
-                -
-                    a: A
+                - a: A
             foobar:
                 foo: bar
                 bar:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

now after generate array to yaml generated like this   
```
servers:
  -
    url: 'http://support_front'
  -
    url: 'http://support_front'
```
    
but most be like this 
```
servers:
  - url: 'http://support_front'
  - url: 'http://support_front'

```
that's work but not canonical and i fixed
 