### PR TITLE
 Improve message wording in InsufficientAuthenticationException

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
@@ -23,6 +23,6 @@ class InsufficientAuthenticationException extends AuthenticationException
 {
     public function getMessageKey(): string
     {
-        return 'Not privileged to request the resource.';
+        return 'Insufficient permissions to access this resource.';
     }
 }


### PR DESCRIPTION
| Q | A |
|---|---|
| Branch? | 6.4 |
| Bug fix? | no |
| New feature? | no |
| Deprecations? | no |
| Issues | — |
| License | MIT |

**Title:** Improve message wording in InsufficientAuthenticationException

**File:** src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php

**Changes:**
- Exception message changed from:
  'Not privileged to request the resource.'
  to:
  'Insufficient permissions to access this resource.'

**Description:**
- Previous message was unclear and grammatically incorrect.
- New message is clear, standard, and developer-friendly.
- No code behavior is changed; only the message is improved.

**Tests:**
- No direct tests exist for this message.
- Existing tests will not break.

