### PR TITLE
[Serializer] Fix #[Ignore] on same-name properties <-> methods

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -186,9 +186,7 @@ class AttributeLoader implements LoaderInterface
 
                     $attributeMetadata->setSerializedPath($annotation->getSerializedPath());
                 } elseif ($annotation instanceof Ignore) {
-                    if ($accessorOrMutator && !$hasProperty) {
-                        $attributeMetadata->setIgnore(true);
-                    }
+                    $attributeMetadata->setIgnore(true);
                 } elseif ($annotation instanceof Context) {
                     if (!$accessorOrMutator && !$hasProperty) {
                         throw new MappingException(\sprintf('Context on "%s::%s()" cannot be added. Context can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1126,6 +1126,28 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame([], $normalizer->normalize($object, null, ['groups' => 'bar']));
     }
 
+    public function testIgnoreAttributeOnMethodWithSameNameAsProperty()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $object = new ObjectWithIgnoredMethodSameNameAsProperty('should_be_ignored', 'should_be_serialized');
+
+        $this->assertSame(['visible' => 'should_be_serialized'], $normalizer->normalize($object));
+    }
+
+    public function testIgnoreAttributeOnMethodWithSameNameAsPropertyWithGroups()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $object = new ObjectWithIgnoredMethodSameNameAsPropertyWithGroups('ignored', 'visible_default', 'visible_group');
+
+        // without groups - should include both visible properties
+        $this->assertSame(['visibleDefault' => 'visible_default', 'visibleGroup' => 'visible_group'], $normalizer->normalize($object));
+
+        // with groups - should only include group-specific property, ignored method should never appear
+        $this->assertSame(['visibleGroup' => 'visible_group'], $normalizer->normalize($object, null, ['groups' => ['group1']]));
+    }
+
     /**
      * Priority of accessor methods is defined by the PropertyReadInfoExtractorInterface passed to the PropertyAccessor
      * component. By default ReflectionExtractor::$defaultAccessorPrefixes are used.
@@ -1686,5 +1708,51 @@ class ObjectWithMethodSameNameThanProperty
     public function shouldDoThing()
     {
         return $this->shouldDoThing;
+    }
+}
+
+class ObjectWithIgnoredMethodSameNameAsProperty
+{
+    public string $visible;
+
+    private $ignored;
+
+    public function __construct(string $ignored, string $visible)
+    {
+        $this->ignored = $ignored;
+        $this->visible = $visible;
+    }
+
+    #[Ignore]
+    public function ignored()
+    {
+        return $this->ignored;
+    }
+}
+
+class ObjectWithIgnoredMethodSameNameAsPropertyWithGroups
+{
+    public string $visibleDefault;
+    public string $visibleGroup;
+
+    private $ignored;
+
+    public function __construct(string $ignored, string $visibleDefault, string $visibleGroup)
+    {
+        $this->ignored = $ignored;
+        $this->visibleDefault = $visibleDefault;
+        $this->visibleGroup = $visibleGroup;
+    }
+
+    #[Ignore]
+    public function ignored()
+    {
+        return $this->ignored;
+    }
+
+    #[Groups(['group1'])]
+    public function visibleGroup()
+    {
+        return $this->visibleGroup;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follows #62838

We should always set the ignore flag when the `#[Ignore]` attribute is present, regardless of the `$accessorOrMutator` or `$hasProperty` flags.