### PR TITLE
[WebProfiler] fix the security profiler template

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -534,10 +534,14 @@
                                     <tr class="voter_result">
                                         <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
                                         <td class="font-normal">
-                                            {{ decision.result
-                                                ? '<span class="label status-success same-width">GRANTED</span>'
-                                                : '<span class="label status-error same-width">DENIED</span>'
-                                            }}
+                                            {% set result = decision.result|default(null) %}
+                                            {% if result is same as(true) %}
+                                                <span class="label status-success same-width">GRANTED</span>
+                                            {% elseif result is same as(false) %}
+                                                <span class="label status-error same-width">DENIED</span>
+                                            {% else %}
+                                                <span class="label status-warning same-width">ERROR</span>
+                                            {% endif %}
                                         </td>
                                         <td>
                                             {% if decision.attributes|length == 1 %}

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -172,9 +172,7 @@ class AttributeLoader implements LoaderInterface
 
                     $attributeMetadata->setSerializedPath($attribute->getSerializedPath());
                 } elseif ($attribute instanceof Ignore) {
-                    if (!$accessorOrMutator && !$hasProperty) {
-                        $attributeMetadata->setIgnore(true);
-                    }
+                    $attributeMetadata->setIgnore(true);
                 } elseif ($attribute instanceof Context) {
                     if (!$accessorOrMutator && !$hasProperty) {
                         throw new MappingException(\sprintf('Context on "%s::%s()" cannot be added. Context can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62972
| License       | MIT

fixes the security profiler template when access decision manager could not retrieve the result due to an error.