### PR TITLE
[ObjectMapper] throw exception when invalid transform

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Exception/NoSuchCallableException.php
+++ b/src/Symfony/Component/ObjectMapper/Exception/NoSuchCallableException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Exception;
+
+/**
+ * Thrown when an invalid transform callable is defined.
+ *
+ * @author Michaël Marinetti <github@marinetti.fr>
+ */
+class NoSuchCallableException extends MappingException
+{
+}

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\ObjectMapper;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Exception\NoSuchCallableException;
 use Symfony\Component\ObjectMapper\Exception\NoSuchPropertyException;
 use Symfony\Component\ObjectMapper\Metadata\Mapping;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
@@ -345,7 +346,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     /**
      * @param (string|callable(mixed $value, object $object): mixed) $fn
      */
-    private function getCallable(string|callable $fn, ?ContainerInterface $locator = null): ?callable
+    private function getCallable(string|callable $fn, ?ContainerInterface $locator = null): callable
     {
         if (\is_callable($fn)) {
             return $fn;
@@ -355,7 +356,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             return $locator->get($fn);
         }
 
-        return null;
+        throw new NoSuchCallableException(\sprintf('"%s" is not a valid callable.', $fn));
     }
 
     /**

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InvalidConfiguration.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InvalidConfiguration.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(D::class)]
+class InvalidConfiguration
+{
+    public function __construct(#[Map('baz')] public readonly string $foo, #[Map(transform: 'wrongMethod')] public readonly string $bar)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
+use Symfony\Component\ObjectMapper\Exception\NoSuchCallableException;
 use Symfony\Component\ObjectMapper\Exception\NoSuchPropertyException;
 use Symfony\Component\ObjectMapper\Metadata\Mapping;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
@@ -57,6 +58,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\A as Instance
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B as InstanceCallbackB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\A as InstanceCallbackWithArgumentsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\B as InstanceCallbackWithArgumentsB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InvalidConfiguration;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\LazyFoo;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
@@ -709,5 +711,13 @@ final class ObjectMapperTest extends TestCase
             (new \ReflectionProperty($target, 'withoutDefault'))->isInitialized($target),
             'Property without default value should remain uninitialized'
         );
+    }
+
+    public function testHasInvalidTransformValue()
+    {
+        $this->expectExceptionObject(new NoSuchCallableException(
+            '"wrongMethod" is not a valid callable.'
+        ));
+        (new ObjectMapper())->map(new InvalidConfiguration('foo', 'bar'));
     }
 }


### PR DESCRIPTION
…cannot be called

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62938
| License       | MIT

This change add a thrown exception when a transform value is defined but cannot be used.

This is related to the issue #62957
