### PR TITLE
[WebProfilerBundle] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -137,10 +137,9 @@ class ProfilerControllerTest extends WebTestCase
 
     public function testToolbarStylesheetActionWithProfilerDisabled()
     {
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $twig = $this->createMock(Environment::class);
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
 
-        $controller = new ProfilerController($urlGenerator, null, $twig, []);
+        $controller = new ProfilerController($urlGenerator, null, new Environment(new ArrayLoader()), []);
 
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('The profiler must be enabled.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT