### PR TITLE
[FrameworkBundle] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
@@ -64,7 +64,7 @@ class RouterCacheWarmerTest extends TestCase
     {
         $container = new Container();
 
-        $routerMock = $this->getMockBuilder(testRouterInterfaceWithoutWarmableInterface::class)->onlyMethods(['match', 'generate', 'getContext', 'setContext', 'getRouteCollection'])->getMock();
+        $routerMock = $this->createStub(testRouterInterfaceWithoutWarmableInterface::class);
         $container->set('router', $routerMock);
         $routerCacheWarmer = new RouterCacheWarmer($container);
         $preload = $routerCacheWarmer->warmUp('/tmp');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRevealCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRevealCommandTest.php
@@ -22,7 +22,7 @@ class SecretsRevealCommandTest extends TestCase
 {
     public function testExecute()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['secretKey' => 'secretValue']);
 
         $command = new SecretsRevealCommand($vault);
@@ -35,7 +35,7 @@ class SecretsRevealCommandTest extends TestCase
 
     public function testInvalidName()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['secretKey' => 'secretValue']);
 
         $command = new SecretsRevealCommand($vault);
@@ -48,7 +48,7 @@ class SecretsRevealCommandTest extends TestCase
 
     public function testFailedDecrypt()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['secretKey' => null]);
 
         $command = new SecretsRevealCommand($vault);
@@ -64,7 +64,7 @@ class SecretsRevealCommandTest extends TestCase
      */
     public function testLocalVaultOverride()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['secretKey' => 'secretValue']);
 
         $_ENV = ['secretKey' => 'newSecretValue'];
@@ -83,7 +83,7 @@ class SecretsRevealCommandTest extends TestCase
      */
     public function testOnlyLocalVaultContainsName()
     {
-        $vault = $this->createMock(AbstractVault::class);
+        $vault = $this->createStub(AbstractVault::class);
         $vault->method('list')->willReturn(['otherKey' => 'secretValue']);
 
         $_ENV = ['secretKey' => 'secretValue'];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandTest.php
@@ -193,7 +193,7 @@ class TranslationExtractCommandTest extends TestCase
             ->method('set');
 
         // Calling private method
-        $translationUpdate = $this->createMock(TranslationExtractCommand::class);
+        $translationUpdate = $this->createStub(TranslationExtractCommand::class);
         $reflection = new \ReflectionObject($translationUpdate);
         $method = $reflection->getMethod('removeNoFillTranslations');
         $method->invokeArgs($translationUpdate, [$operation]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -64,7 +64,7 @@ class KernelBrowserTest extends AbstractWebTestCase
 
     public function testGetProfileWithoutRequest()
     {
-        $browser = new KernelBrowser($this->createMock(KernelInterface::class));
+        $browser = new KernelBrowser($this->createStub(KernelInterface::class));
 
         $this->assertFalse($browser->getProfile());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT