### PR TITLE
[TwigBridge] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
@@ -166,12 +166,10 @@ class SecurityExtensionTest extends TestCase
     {
         ClassExistsMock::withMockedClasses([AccessDecision::class => false]);
 
-        $securityChecker = $this->createMock(AuthorizationCheckerInterface::class);
-
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Using the "access_decision()" function requires symfony/security-core >= 7.3. Try running "composer update symfony/security-core".');
 
-        $securityExtension = new SecurityExtension($securityChecker);
+        $securityExtension = new SecurityExtension($this->createStub(AuthorizationCheckerInterface::class));
         $securityExtension->getAccessDecision('ROLE', 'object');
     }
 
@@ -181,7 +179,7 @@ class SecurityExtensionTest extends TestCase
             $this->markTestSkipped('This test requires symfony/security-core 7.3 or superior.');
         }
 
-        $user = $this->createMock(UserInterface::class);
+        $user = new InMemoryUser('john', 'password');
         $securityChecker = $this->createMockAuthorizationChecker();
 
         $securityExtension = new SecurityExtension($securityChecker);
@@ -200,7 +198,7 @@ class SecurityExtensionTest extends TestCase
             $this->markTestSkipped('This test requires symfony/security-core 7.3 or superior.');
         }
 
-        $user = $this->createMock(UserInterface::class);
+        $user = new InMemoryUser('john', 'password');
         $securityChecker = $this->createMockAuthorizationChecker();
 
         $securityExtension = new SecurityExtension($securityChecker);
@@ -227,7 +225,7 @@ class SecurityExtensionTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Using the "access_decision_for_user()" function requires symfony/security-core >= 7.3. Try running "composer update symfony/security-core".');
 
-        $securityExtension->getAccessDecisionForUser($this->createMock(UserInterface::class), 'ROLE', 'object');
+        $securityExtension->getAccessDecisionForUser(new InMemoryUser('john', 'password'), 'ROLE', 'object');
     }
 
     private function createMockAuthorizationChecker(): AuthorizationCheckerInterface&UserAuthorizationCheckerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT