### PR TITLE
[DoctrineBridge] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -173,7 +173,7 @@ class EntityValueResolverTest extends TestCase
 
     public function testResolveWithNullId()
     {
-        $manager = $this->createMock(ObjectManager::class);
+        $manager = $this->createStub(ObjectManager::class);
         $registry = $this->createRegistry($manager);
         $resolver = new EntityValueResolver($registry);
 
@@ -332,8 +332,8 @@ class EntityValueResolverTest extends TestCase
         $conference = new \stdClass();
         $article = new \stdClass();
 
-        $repository = $this->createMock(ObjectRepository::class);
-        $repository->expects($this->any())
+        $repository = $this->createStub(ObjectRepository::class);
+        $repository
             ->method('findOneBy')
             ->willReturnCallback(static fn ($v) => match ($v) {
                 ['slug' => 'vienna-2024'] => $conference,

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/IdleConnection/DriverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/IdleConnection/DriverTest.php
@@ -24,7 +24,7 @@ class DriverTest extends TestCase
     public function testConnect()
     {
         $driverMock = $this->createMock(DriverInterface::class);
-        $connectionMock = $this->createMock(ConnectionInterface::class);
+        $connectionMock = $this->createStub(ConnectionInterface::class);
 
         $driverMock->expects($this->once())
             ->method('connect')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT