### PR TITLE
[Messenger] fix lowest required Serializer component version

### DIFF
--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -32,7 +32,7 @@
         "symfony/lock": "^7.4|^8.0",
         "symfony/rate-limiter": "^6.4|^7.0|^8.0",
         "symfony/routing": "^6.4|^7.0|^8.0",
-        "symfony/serializer": "^6.4|^7.0|^8.0",
+        "symfony/serializer": "^6.4.32|~7.3.10|^7.4.4|^8.0.4",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/stopwatch": "^6.4|^7.0|^8.0",
         "symfony/validator": "^6.4|^7.0|^8.0",
@@ -45,7 +45,7 @@
         "symfony/framework-bundle": "<6.4",
         "symfony/http-kernel": "<7.3",
         "symfony/lock": "<7.4",
-        "symfony/serializer": "<6.4.32"
+        "symfony/serializer": "<6.4.32|>=7.3,<7.3.10|>=7.4,<7.4.4|>=8.0,<8.0.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Messenger\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

following #62779