### PR TITLE
[Mailer][MicrosoftGraph] Also bypass `Return-Path` header within `MicrosoftGraphApiTransport`

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
@@ -171,7 +171,7 @@ class MicrosoftGraphApiTransport extends AbstractApiTransport
     {
         $headers = [];
 
-        $headersToBypass = ['x-ms-client-request-id', 'operation-id', 'authorization', 'x-ms-content-sha256', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to'];
+        $headersToBypass = ['x-ms-client-request-id', 'operation-id', 'authorization', 'x-ms-content-sha256', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to', 'return-path'];
 
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We use the MicrosoftGraph-Bridge for one of our clients and were trying to send an email with a return path set, that one however fails due to the following warning:

```
"InvalidInternetMessageHeader","message":"The internet message header name 'Return-Path' should start with 'x-' or 'X-'
```

Return path being a standard email header, this should also be included within `$headersToBypass`.
It would be good if we could configure those headers as well but that would be a feature.
