### PR TITLE
[FrameworkBundle] Skip extensions with empty configuration in `reference.php`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\ArrayShapeGenerator;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
 use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -116,9 +118,13 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
             if (!$configuration = $this->getConfiguration($extension, $container)) {
                 continue;
             }
+            $tree = $configuration->getConfigTreeBuilder()->buildTree();
+            if ($tree instanceof ArrayNode && !$tree instanceof PrototypedArrayNode && !$tree->getChildren()) {
+                continue;
+            }
             $anyEnvExtensions[$extensionAlias] = $extension;
             $type = $this->camelCase($extensionAlias).'Config';
-            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()));
+            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($tree));
 
             foreach ($knownEnvs as $env) {
                 if ($envs[$env] ?? $envs['all'] ?? false) {
@@ -132,9 +138,13 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
             if (!$configuration = $this->getConfiguration($extension, $container)) {
                 continue;
             }
+            $tree = $configuration->getConfigTreeBuilder()->buildTree();
+            if ($tree instanceof ArrayNode && !$tree instanceof PrototypedArrayNode && !$tree->getChildren()) {
+                continue;
+            }
             $anyEnvExtensions[$alias] = $extension;
             $type = $this->camelCase($alias).'Config';
-            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($configuration->getConfigTreeBuilder()->buildTree()));
+            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($tree));
         }
         krsort($extensionsPerEnv);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
@@ -97,9 +97,12 @@ class PhpConfigReferenceDumpPassTest extends TestCase
 
         $container->registerExtension(new TestExtension(false));
         $container->registerExtension(new AppExtension());
+        $container->registerExtension(new EmptyConfigExtension());
+        $container->registerExtension(new PrototypedConfigExtension());
 
         $pass = new PhpConfigReferenceDumpPass($this->tempDir.'/reference.php', [
             TestBundle::class => ['all' => true],
+            EmptyConfigBundle::class => ['all' => true],
         ]);
         $pass->process($container);
 
@@ -214,5 +217,66 @@ class AppConfiguration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         return new TreeBuilder('app', 'boolean');
+    }
+}
+
+class EmptyConfigBundle extends Bundle
+{
+    public function getContainerExtension(): ?ExtensionInterface
+    {
+        return new EmptyConfigExtension();
+    }
+}
+
+class EmptyConfigExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
+    {
+        return new EmptyConfiguration();
+    }
+}
+
+class EmptyConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        return new TreeBuilder('empty_config');
+    }
+}
+
+class PrototypedConfigExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
+    {
+        return new PrototypedConfiguration();
+    }
+}
+
+class PrototypedConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('prototyped_config');
+        $rootNode = $treeBuilder->getRootNode();
+
+        if ($rootNode instanceof ArrayNodeDefinition) {
+            $rootNode
+                ->useAttributeAsKey('name')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('value')->end()
+                    ->end()
+                ->end();
+        }
+
+        return $treeBuilder;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -134,12 +134,16 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     fromBundle?: bool|Param, // Default: false
  * }
  * @psalm-type AppConfig = bool|Param
+ * @psalm-type PrototypedConfigConfig = array<string, array{ // Default: []
+ *         value?: scalar|Param|null,
+ *     }>
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
  *     services?: ServicesConfig,
  *     test?: TestConfig,
  *     app?: AppConfig,
+ *     prototyped_config?: PrototypedConfigConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When bundle extensions have a configuration interface but no actual configuration options in their root node, PhpConfigReferenceDumpPass was generating psalm-type annotations like:

    @psalm-type FooConfig = array<mixed>

This caused type errors reported by [mago](https://github.com/carthage-software/mago) (static analyzer) because `array<mixed>` is less specific than `ExtensionType = array<string, mixed>` defined in AppReference.php:

- `array<mixed>` allows keys of any type (int|string)
- `array<string, mixed>` requires string keys only

The fix skips extensions whose root node is an ArrayNode (not a PrototypedArrayNode) with no children, avoiding the generation of these incompatible empty type annotations entirely.
