### PR TITLE
 Add `mtarld` as `TypeInfo` and `JsonStreamer` CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,8 @@
 /src/Symfony/Component/HttpKernel/Log/Logger.php @dunglas
 # JsonPath
 /src/Symfony/Component/JsonPath/ @alexandre-daubois
+# JsonStreamer
+/src/Symfony/Component/JsonStreamer/ @mtarld
 # Lock
 /src/Symfony/Component/Lock/ @jderusse
 # Notifer
@@ -50,6 +52,8 @@
 /src/Symfony/Component/Translation/ @welcomattic
 # TwigBundle
 /src/Symfony/Bundle/TwigBundle/ @yceruto
+# TypeInfo
+/src/Symfony/Component/TypeInfo/ @mtarld
 # WebLink
 /src/Symfony/Component/WebLink/ @dunglas
 # Workflow


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In order to follow-up changes in `TypeInfo` and `JsonStreamer` component, add myself in `CODEOWNERS` file.

/cc @OskarStark 