### PR TITLE
[Messenger] Fix DBALv4 support by replacing trigger by explicit pg_notify()

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -122,37 +122,6 @@ class PostgreSqlConnectionTest extends TestCase
         $this->assertSame(2, $wrappedConnection->countNotifyCalls());
     }
 
-    public function testGetExtraSetupSql()
-    {
-        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
-        $driverConnection->method('executeStatement')->willReturn(1);
-        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
-
-        $table = new Table('queue_table');
-        $table->addOption('_symfony_messenger_table_name', 'queue_table');
-        $sql = implode("\n", $connection->getExtraSetupSqlForTable($table));
-
-        $this->assertStringContainsString('CREATE TRIGGER', $sql);
-
-        // We MUST NOT use transaction, that will mess with the PDO in PHP 8
-        $this->assertStringNotContainsString('BEGIN;', $sql);
-        $this->assertStringNotContainsString('COMMIT;', $sql);
-    }
-
-    public function testTransformTableNameWithSchemaToValidProcedureName()
-    {
-        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
-        $driverConnection->method('executeStatement')->willReturn(1);
-        $connection = new PostgreSqlConnection(['table_name' => 'schema.queue_table'], $driverConnection);
-
-        $table = new Table('schema.queue_table');
-        $table->addOption('_symfony_messenger_table_name', 'schema.queue_table');
-        $sql = implode("\n", $connection->getExtraSetupSqlForTable($table));
-
-        $this->assertStringContainsString('CREATE OR REPLACE FUNCTION schema.notify_queue_table', $sql);
-        $this->assertStringContainsString('FOR EACH ROW EXECUTE PROCEDURE schema.notify_queue_table()', $sql);
-    }
-
     public function testGetExtraSetupSqlWrongTable()
     {
         $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -447,23 +447,17 @@ class Connection implements ResetInterface
 
         try {
             if ($this->driverConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-                $first = $this->driverConnection->fetchFirstColumn($sql, $parameters, $types);
-
-                $id = $first[0] ?? null;
-
-                if (!$id) {
+                if (!$id = $this->driverConnection->fetchFirstColumn($sql, $parameters, $types)[0] ?? null) {
                     throw new TransportException('no id was returned by PostgreSQL from RETURNING clause.');
                 }
+
+                $this->driverConnection->executeStatement('SELECT pg_notify(?, ?)', [$this->configuration['table_name'], $this->configuration['queue_name']]);
             } elseif ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
                 $sequenceName = $this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX;
 
                 $this->driverConnection->executeStatement($sql, $parameters, $types);
 
-                $result = $this->driverConnection->fetchOne('SELECT '.$sequenceName.'.CURRVAL FROM DUAL');
-
-                $id = (int) $result;
-
-                if (!$id) {
+                if (!$id = (int) $this->driverConnection->fetchOne('SELECT '.$sequenceName.'.CURRVAL FROM DUAL')) {
                     throw new TransportException('no id was returned by Oracle from sequence: '.$sequenceName);
                 }
             } else {

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
-use Doctrine\DBAL\Schema\Table;
-
 /**
  * Uses PostgreSQL LISTEN/NOTIFY to push messages to workers.
  *
@@ -89,61 +87,6 @@ final class PostgreSqlConnection extends Connection
         }
 
         return parent::get();
-    }
-
-    public function setup(): void
-    {
-        parent::setup();
-
-        $this->executeStatement(implode("\n", $this->getTriggerSql()));
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getExtraSetupSqlForTable(Table $createdTable): array
-    {
-        if (!$createdTable->hasOption(self::TABLE_OPTION_NAME)) {
-            return [];
-        }
-
-        if ($createdTable->getOption(self::TABLE_OPTION_NAME) !== $this->configuration['table_name']) {
-            return [];
-        }
-
-        return $this->getTriggerSql();
-    }
-
-    private function getTriggerSql(): array
-    {
-        $functionName = $this->createTriggerFunctionName();
-
-        return [
-            // create trigger function
-            \sprintf(<<<'SQL'
-CREATE OR REPLACE FUNCTION %1$s() RETURNS TRIGGER AS $$
-    BEGIN
-        PERFORM pg_notify('%2$s', NEW.queue_name::text);
-        RETURN NEW;
-    END;
-$$ LANGUAGE plpgsql;
-SQL
-                , $functionName, $this->configuration['table_name']),
-            // register trigger
-            \sprintf('DROP TRIGGER IF EXISTS notify_trigger ON %s;', $this->configuration['table_name']),
-            \sprintf('CREATE TRIGGER notify_trigger AFTER INSERT OR UPDATE ON %1$s FOR EACH ROW EXECUTE PROCEDURE %2$s();', $this->configuration['table_name'], $functionName),
-        ];
-    }
-
-    private function createTriggerFunctionName(): string
-    {
-        $tableConfig = explode('.', $this->configuration['table_name']);
-
-        if (1 === \count($tableConfig)) {
-            return \sprintf('notify_%1$s', $tableConfig[0]);
-        }
-
-        return \sprintf('%1$s.notify_%2$s', $tableConfig[0], $tableConfig[1]);
     }
 
     private function unlisten(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54039
| License       | MIT

There's no need for any trigger after all!