### PR TITLE
[JsonStreamer] Leverage `ContainerBuilder::findTaggedResourceIds` and `Definition::addResourceTag`

### DIFF
--- a/src/Symfony/Component/JsonStreamer/DependencyInjection/StreamablePass.php
+++ b/src/Symfony/Component/JsonStreamer/DependencyInjection/StreamablePass.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\JsonStreamer\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * Sets the streamable metadata to the services that need them.
@@ -30,21 +29,11 @@ class StreamablePass implements CompilerPassInterface
 
         $streamable = [];
 
-        // retrieve concrete services tagged with "json_streamer.streamable" tag
-        foreach ($container->getDefinitions() as $id => $definition) {
-            if (!$tag = $definition->getTag('json_streamer.streamable')[0] ?? null) {
-                continue;
-            }
-            if (!$definition->hasTag('container.excluded')) {
-                throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "json_streamer.streamable" is missing the "container.excluded" tag.', $id));
-            }
-            $class = $container->getParameterBag()->resolveValue($definition->getClass());
-            if (!$class || $definition->isAbstract()) {
-                throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "json_streamer.streamable" must have a class and not be abstract.', $id));
-            }
+        foreach ($container->findTaggedResourceIds('json_streamer.streamable') as $id => $tag) {
+            $class = $container->getDefinition($id)->getClass();
             $streamable[$class] = [
-                'object' => $tag['object'],
-                'list' => $tag['list'],
+                'object' => $tag[0]['object'],
+                'list' => $tag[0]['list'],
             ];
 
             $container->removeDefinition($id);

--- a/src/Symfony/Component/JsonStreamer/Tests/DependencyInjection/StreamablePassTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/DependencyInjection/StreamablePassTest.php
@@ -25,7 +25,7 @@ class StreamablePassTest extends TestCase
         $container->register('json_streamer.stream_writer');
         $container->register('.json_streamer.cache_warmer.streamer')->setArguments([null]);
 
-        $container->register('streamable')->setClass('Foo')->addTag('json_streamer.streamable', ['object' => true, 'list' => true])->addTag('container.excluded');
+        $container->register('streamable')->setClass('Foo')->addResourceTag('json_streamer.streamable', ['object' => true, 'list' => true]);
         $container->register('notStreamable')->setClass('Baz');
 
         $pass = new StreamablePass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Leverage `ContainerBuilder::findTaggedResourceIds` and `Definition::addResourceTag` introduced in `DependencyInjection` 7.3.