### PR TITLE
[Messenger] Remove legacy DBALv3-related getExtraSetupSqlForTable() methods

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -101,15 +101,4 @@ class PostgreSqlConnectionTest extends TestCase
 
         $this->assertSame(2, $wrappedConnection->countNotifyCalls());
     }
-
-    public function testGetExtraSetupSqlWrongTable()
-    {
-        $driverConnection = $this->createStub(Connection::class);
-        $driverConnection->method('executeStatement')->willReturn(1);
-        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
-
-        $table = new Table('queue_table');
-        // don't set the _symfony_messenger_table_name option
-        $this->assertSame([], $connection->getExtraSetupSqlForTable($table));
-    }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -349,14 +349,6 @@ class Connection implements ResetInterface
         $this->addTableToSchema($schema);
     }
 
-    /**
-     * @internal
-     */
-    public function getExtraSetupSqlForTable(Table $createdTable): array
-    {
-        return [];
-    }
-
     private function createAvailableMessagesQueryBuilder(): QueryBuilder
     {
         $now = new \DateTimeImmutable('UTC');

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -93,10 +93,14 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
      * Adds extra SQL if the given table was created by the Connection.
      *
      * @return string[]
+     *
+     * @deprecated since Symfony 8.1, to be removed in 9.0
      */
     public function getExtraSetupSqlForTable(Table $createdTable): array
     {
-        return $this->connection->getExtraSetupSqlForTable($createdTable);
+        trigger_deprecation('symfony/messenger', '8.1', 'The "%s()" method is deprecated and will be removed in 9.0.', __METHOD__);
+
+        return [];
     }
 
     private function getReceiver(): DoctrineReceiver

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.4",
         "doctrine/dbal": "^4.3",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/messenger": "^7.4|^8.0",
         "symfony/service-contracts": "^2.5|^3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

This is all unused code because `SchemaCreateTableEventArgs` doesn't exist on DBALv4.

I'm triggering a deprecation in DoctrineTransport but not listing it in the changelog/upgrade files because this is mostly internal.