### PR TITLE
[FrameworkBundle] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -428,9 +428,9 @@ class WebTestCaseTest extends TestCase
     private function createHistoryTester(string $method, bool $returnValue): WebTestCase
     {
         /** @var KernelBrowser&MockObject $client */
-        $client = $this->createMock(KernelBrowser::class);
+        $client = $this->createStub(KernelBrowser::class);
         /** @var History&MockObject $history */
-        $history = $this->createMock(History::class);
+        $history = $this->createStub(History::class);
 
         $history->method($method)->willReturn($returnValue);
         $client->method('getHistory')->willReturn($history);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT