### PR TITLE
[Mailer] do not use createMock() to create non-mock objects

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
@@ -120,7 +120,7 @@ class AhaSendApiTransportTest extends TestCase
 
         $expectedEvent = (new AhaSendDeliveryEvent('someone@gmil.com: Invalid recipient'));
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher
             ->method('dispatch')
             ->willReturnCallback(function ($event) use ($expectedEvent) {

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -147,7 +147,7 @@ class PostmarkApiTransportTest extends TestCase
 
         $expectedEvent = (new PostmarkDeliveryEvent('Inactive recipient', 406, $mail->getHeaders()));
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $dispatcher
             ->method('dispatch')
             ->willReturnCallback(function ($event) use ($expectedEvent) {

--- a/src/Symfony/Component/Mailer/Tests/EventListener/SmimeEncryptedMessageListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/SmimeEncryptedMessageListenerTest.php
@@ -31,7 +31,7 @@ class SmimeEncryptedMessageListenerTest extends TestCase
      */
     public function testSmimeMessageEncryptionProcess()
     {
-        $repository = $this->createMock(SmimeCertificateRepositoryInterface::class);
+        $repository = $this->createStub(SmimeCertificateRepositoryInterface::class);
         $repository->method('findCertificatePathFor')->willReturn(\dirname(__DIR__).'/Fixtures/sign.crt');
         $listener = new SmimeEncryptedMessageListener($repository);
         $message = new Message(
@@ -56,7 +56,7 @@ class SmimeEncryptedMessageListenerTest extends TestCase
      */
     public function testMessageNotEncryptedWhenOneRecipientCertificateIsMissing()
     {
-        $repository = $this->createMock(SmimeCertificateRepositoryInterface::class);
+        $repository = $this->createStub(SmimeCertificateRepositoryInterface::class);
         $repository->method('findCertificatePathFor')->willReturnOnConsecutiveCalls(\dirname(__DIR__).'/Fixtures/sign.crt', null);
         $listener = new SmimeEncryptedMessageListener($repository);
         $message = new Message(
@@ -83,7 +83,7 @@ class SmimeEncryptedMessageListenerTest extends TestCase
      */
     public function testMessageNotExplicitlyAskedForNonEncryption()
     {
-        $repository = $this->createMock(SmimeCertificateRepositoryInterface::class);
+        $repository = $this->createStub(SmimeCertificateRepositoryInterface::class);
         $repository->method('findCertificatePathFor')->willReturn(\dirname(__DIR__).'/Fixtures/sign.crt');
         $listener = new SmimeEncryptedMessageListener($repository);
         $message = new Message(

--- a/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/FailoverTransportTest.php
@@ -84,9 +84,9 @@ class FailoverTransportTest extends TestCase
 
     public function testSendOneDeadAndRecoveryWithinRetryPeriod()
     {
-        $t1 = $this->createMock(TransportInterface::class);
+        $t1 = $this->createStub(TransportInterface::class);
 
-        $t1->expects($this->any())
+        $t1
             ->method('send')
             ->willReturnCallback(function () {
                 static $call = 0;
@@ -157,8 +157,8 @@ class FailoverTransportTest extends TestCase
 
     public function testSendOneDeadButRecover()
     {
-        $t1 = $this->createMock(TransportInterface::class);
-        $t1->expects($this->any())->method('send')->willReturnCallback(function () {
+        $t1 = $this->createStub(TransportInterface::class);
+        $t1->method('send')->willReturnCallback(function () {
             static $call = 0;
 
             if (1 === ++$call) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT