### PR TITLE
[Messenger] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
 use Symfony\Component\Messenger\Exception\TransportException;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ConnectionTest extends TestCase
 {
@@ -409,7 +408,7 @@ class ConnectionTest extends TestCase
 
     public function testQueueAttributesAndTagsFromDsn()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient();
 
         $queueName = 'queueName';
         $queueAttributes = [

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -86,7 +86,7 @@ class AmqpReceiverTest extends TestCase
         $id = '01946fcb-4bcb-7aa7-9727-dac1c0374443';
         $amqpEnvelope = $this->createAMQPEnvelope($id);
 
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
 
@@ -119,7 +119,7 @@ class AmqpReceiverTest extends TestCase
 
         $amqpEnvelope = $this->createAMQPEnvelope();
 
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpSenderTest.php
@@ -128,7 +128,7 @@ class AmqpSenderTest extends TestCase
         $envelope = (new Envelope(new DummyMessage('Oy')))->with($stamp);
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);
@@ -149,7 +149,7 @@ class AmqpSenderTest extends TestCase
         $envelope = (new Envelope(new DummyMessage('Oy')))->with($stamp);
         $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $connection = $this->createMock(Connection::class);

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/BeanstalkdSenderTest.php
@@ -54,7 +54,7 @@ final class BeanstalkdSenderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')->with($encoded['body'], $encoded['headers'], 500, null);
 
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new BeanstalkdSender($connection, $serializer);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -379,7 +379,7 @@ class ConnectionTest extends TestCase
 
         $driverConnection->expects($this->once())
             ->method('executeStatement')
-            ->willThrowException($this->createMock(DBALException::class));
+            ->willThrowException($this->createStub(DBALException::class));
 
         $driverConnection->expects($this->never())
             ->method('commit');
@@ -904,7 +904,7 @@ class ConnectionTest extends TestCase
         $driverConnection->method('getDatabasePlatform')->willReturn(new OraclePlatform());
 
         // Mock the result returned by executeQuery to be an Oracle version 12.1.0 or higher.
-        $result = $this->createMock(Result::class);
+        $result = $this->createStub(Result::class);
         $result->method('fetchOne')->willReturn('12.1.0');
         $driverConnection->method('executeQuery')->willReturn($result);
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -92,7 +92,7 @@ class PostgreSqlConnectionTest extends TestCase
             ->method('getNativeConnection')
             ->willReturn($wrappedConnection);
 
-        $driverResult = $this->createMock(DriverResult::class);
+        $driverResult = $this->createStub(DriverResult::class);
         $driverResult->method('fetchAssociative')
             ->willReturn(false);
         $driverConnection

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
@@ -253,9 +252,9 @@ class ConsumeMessagesCommandTest extends TestCase
         $envelope1 = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
         $envelope2 = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
 
-        $receiver1 = $this->createMock(ReceiverInterface::class);
+        $receiver1 = $this->createStub(ReceiverInterface::class);
         $receiver1->method('get')->willReturn([$envelope1]);
-        $receiver2 = $this->createMock(ReceiverInterface::class);
+        $receiver2 = $this->createStub(ReceiverInterface::class);
         $receiver2->method('get')->willReturn([$envelope2]);
 
         $receiverLocator = new Container();

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -191,13 +191,9 @@ class FailedMessagesRemoveCommandTest extends TestCase
             })
         ;
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
-        $serviceLocator->expects($this->once())->method('has')->with($globalFailureReceiverName)->willReturn(true);
-        $serviceLocator->expects($this->any())->method('get')->with($globalFailureReceiverName)->willReturn($receiver);
-
         $command = new FailedMessagesRemoveCommand(
             $globalFailureReceiverName,
-            $serviceLocator
+            new ServiceLocator([$globalFailureReceiverName => fn () => $receiver])
         );
 
         $tester = new CommandTester($command);

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -205,7 +205,7 @@ EOF;
         $this->assertSame(['2ab50dfa1fbf', '78c2da843723'], $suggestions);
     }
 
-   public function testSuccessMessageGoesToStdout()
+    public function testSuccessMessageGoesToStdout()
     {
         $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp('some_id')]);
         $receiver = $this->createStub(ListableReceiverInterface::class);
@@ -309,14 +309,9 @@ EOF;
         $failureTransportName = 'failure_receiver';
         $originalTransportName = 'original_receiver';
 
-        $serviceLocator = $this->createMock(ServiceLocator::class);
         $receiver = $this->createMock(ListableReceiverInterface::class);
 
         $dispatcher = new EventDispatcher();
-        $bus = $this->createMock(MessageBusInterface::class);
-
-        $serviceLocator->method('has')->willReturn(true);
-        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
 
         $receiver->expects($this->once())->method('find')
             ->willReturn(Envelope::wrap(new \stdClass(), [
@@ -328,8 +323,8 @@ EOF;
 
         $command = new FailedMessagesRetryCommand(
             $failureTransportName,
-            $serviceLocator,
-            $bus,
+            new ServiceLocator([$failureTransportName => fn () => $receiver]),
+            new MessageBus(),
             $dispatcher
         );
 

--- a/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
+++ b/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
@@ -61,7 +61,7 @@ class HandleTraitTest extends TestCase
     {
         $bus = $this->createMock(MessageBus::class);
         $queryBus = new TestQueryBus($bus);
-        $stamp = $this->createMock(StampInterface::class);
+        $stamp = $this->createStub(StampInterface::class);
 
         $query = new DummyMessage('Hello');
         $bus->expects($this->once())->method('dispatch')->with($query, [$stamp])->willReturn(

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -62,10 +62,10 @@ class SendersLocatorTest extends TestCase
      */
     public function testItReturnsTheSenderBasedOnAsMessageAttribute(string $messageClass, array $expectedSenders)
     {
-        $firstSender = $this->createMock(SenderInterface::class);
-        $secondSender = $this->createMock(SenderInterface::class);
-        $thirdSender = $this->createMock(SenderInterface::class);
-        $otherSender = $this->createMock(SenderInterface::class);
+        $firstSender = $this->createStub(SenderInterface::class);
+        $secondSender = $this->createStub(SenderInterface::class);
+        $thirdSender = $this->createStub(SenderInterface::class);
+        $otherSender = $this->createStub(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'first_sender' => $firstSender,
             'second_sender' => $secondSender,
@@ -80,9 +80,9 @@ class SendersLocatorTest extends TestCase
 
     public function testAsMessageAttributeIsOverridenByTransportNamesStamp()
     {
-        $firstSender = $this->createMock(SenderInterface::class);
-        $secondSender = $this->createMock(SenderInterface::class);
-        $otherSender = $this->createMock(SenderInterface::class);
+        $firstSender = $this->createStub(SenderInterface::class);
+        $secondSender = $this->createStub(SenderInterface::class);
+        $otherSender = $this->createStub(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'first_sender' => $firstSender,
             'second_sender' => $secondSender,
@@ -96,9 +96,9 @@ class SendersLocatorTest extends TestCase
 
     public function testAsMessageAttributeIsOverridenByUserConfiguration()
     {
-        $firstSender = $this->createMock(SenderInterface::class);
-        $secondSender = $this->createMock(SenderInterface::class);
-        $otherSender = $this->createMock(SenderInterface::class);
+        $firstSender = $this->createStub(SenderInterface::class);
+        $secondSender = $this->createStub(SenderInterface::class);
+        $otherSender = $this->createStub(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'first_sender' => $firstSender,
             'second_sender' => $secondSender,

--- a/src/Symfony/Component/Messenger/Tests/Transport/TransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/TransportFactoryTest.php
@@ -29,10 +29,10 @@ class TransportFactoryTest extends TestCase
             $this->expectException(InvalidArgumentException::class);
             $this->expectExceptionMessage($expectedMessage);
         }
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $factories = [];
         foreach ($transportSupport as $supported) {
-            $factory = $this->createMock(TransportFactoryInterface::class);
+            $factory = $this->createStub(TransportFactoryInterface::class);
             $factory->method('supports', $dsn, [])->willReturn($supported);
             $factories[] = $factory;
         }

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -625,8 +625,6 @@ class WorkerTest extends TestCase
 
         $receiver = new DummyReceiver([[new Envelope($apiMessage)]]);
 
-        $bus = $this->createMock(MessageBusInterface::class);
-
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new ResetMemoryUsageListener());
         $before = 0;
@@ -649,7 +647,7 @@ class WorkerTest extends TestCase
             ++$i;
         }, \PHP_INT_MIN);
 
-        $worker = new Worker(['transport' => $receiver], $bus, $dispatcher);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher);
 
         gc_collect_cycles();
         $before = gc_status()['runs'];
@@ -665,8 +663,6 @@ class WorkerTest extends TestCase
 
         $receiver = new DummyReceiver([[new Envelope($apiMessage)]]);
 
-        $bus = $this->createMock(MessageBusInterface::class);
-
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new ResetMemoryUsageListener());
         $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
@@ -678,7 +674,7 @@ class WorkerTest extends TestCase
 
         $before = memory_get_peak_usage();
 
-        $worker = new Worker(['transport' => $receiver], $bus, $dispatcher);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher);
         $worker->run();
 
         // This should be roughly 4 MB smaller than $before.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT