### PR TITLE
[Notifier] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
@@ -64,7 +64,7 @@ final class BlueskyTransportTest extends TransportTestCase
         $transport = self::createTransport();
 
         $this->expectException(LogicException::class);
-        $transport->send($this->createMock(MessageInterface::class));
+        $transport->send($this->createStub(MessageInterface::class));
     }
 
     /**
@@ -348,7 +348,7 @@ final class BlueskyTransportTest extends TransportTestCase
             'expectedJsonResponse' => '{"repo":null,"collection":"app.bsky.feed.post","record":{"$type":"app.bsky.feed.post","text":"Hello World!","createdAt":"2024-04-28T08:40:17.000000Z","embed":{"$type":"app.bsky.embed.images","images":[{"alt":"A fixture","image":{"$type":"blob","ref":{"$link":"bafkreibabalobzn6cd366ukcsjycp4yymjymgfxcv6xczmlgpemzkz3cfa"},"mimeType":"image\/png","size":760898}}]}}}',
         ];
 
-        yield 'With website preview card and all optionnal informations' => [
+        yield 'With website preview card and all optional informations' => [
             'blueskyOptions' => (new BlueskyOptions())
                 ->attachCard(
                     'https://example.com',

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -124,7 +124,7 @@ final class GoogleChatTransportTest extends TransportTestCase
 
     public function testSendWithInvalidOptions()
     {
-        $options = $this->createMock(MessageOptionsInterface::class);
+        $options = $this->createStub(MessageOptionsInterface::class);
         $this->expectException(UnsupportedOptionsException::class);
         $this->expectExceptionMessage(\sprintf('The "%s" transport only supports instances of "%s" for options (instance of "%s" given).', GoogleChatTransport::class, GoogleChatOptions::class, get_debug_type($options)));
 

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Lox24TransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Lox24TransportTest.php
@@ -74,7 +74,7 @@ class Lox24TransportTest extends TransportTestCase
     public function testSupportWithNotSmsMessage()
     {
         $transport = new Lox24Transport('user', 'token', 'testFrom');
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createStub(MessageInterface::class);
         $this->assertFalse($transport->supports($message));
     }
 
@@ -82,7 +82,7 @@ class Lox24TransportTest extends TransportTestCase
     {
         $transport = new Lox24Transport('user', 'token', 'testFrom');
         $message = new SmsMessage('test', 'test');
-        $options = $this->createMock(MessageOptionsInterface::class);
+        $options = $this->createStub(MessageOptionsInterface::class);
         $message->options($options);
         $this->assertFalse($transport->supports($message));
     }
@@ -91,7 +91,7 @@ class Lox24TransportTest extends TransportTestCase
     {
         $this->expectException(UnsupportedMessageTypeException::class);
         $transport = new Lox24Transport('user', 'token', 'testFrom');
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createStub(MessageInterface::class);
         $transport->send($message);
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Sipgate/Tests/SipgateTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sipgate/Tests/SipgateTransportTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SipgateTransportTest extends TransportTestCase
 {
@@ -62,10 +61,7 @@ class SipgateTransportTest extends TransportTestCase
      */
     public function testExceptionIsThrownWhenSendFailed(int $statusCode, string $content, string $expectedExceptionMessage)
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('getStatusCode')->willReturn($statusCode);
-        $response->method('getContent')->willReturn($content);
-        $client = new MockHttpClient($response);
+        $client = new MockHttpClient(new MockResponse($content, ['http_code' => $statusCode]));
         $transport = $this->createTransport($client);
 
         $this->expectException(TransportException::class);

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/SmsboxTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/SmsboxTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Smsbox\Tests;
 
 use Symfony\Component\Clock\Test\ClockSensitiveTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Smsbox\Enum\Day;
 use Symfony\Component\Notifier\Bridge\Smsbox\Enum\Encoding;
 use Symfony\Component\Notifier\Bridge\Smsbox\Enum\Mode;
@@ -55,21 +56,13 @@ final class SmsboxTransportTest extends TransportTestCase
     public function testBasicQuerySucceded()
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
 
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn('OK 12345678');
-
-        $client = new MockHttpClient(function (string $method, string $url, $request) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, $request): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame('https://api.smsbox.pro/1.1/api.php', $url);
             $this->assertSame('dest=%2B33612345678&msg=Hello%21&id=1&usage=symfony&mode=Standard&strategy=4', $request['body']);
 
-            return $response;
+            return new MockResponse('OK 12345678');
         });
 
         $transport = $this->createTransport($client);
@@ -84,21 +77,13 @@ final class SmsboxTransportTest extends TransportTestCase
         $this->expectExceptionMessage('Unable to send the SMS: "ERROR 02" (400).');
 
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
 
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn('ERROR 02');
-
-        $client = new MockHttpClient(function (string $method, string $url, $request) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, $request): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame('https://api.smsbox.pro/1.1/api.php', $url);
             $this->assertSame('dest=%2B33612345678&msg=Hello%21&id=1&usage=symfony&mode=Standard&strategy=4', $request['body']);
 
-            return $response;
+            return new MockResponse('ERROR 02');
         });
 
         $transport = $this->createTransport($client);
@@ -108,21 +93,13 @@ final class SmsboxTransportTest extends TransportTestCase
     public function testQuerySuccededWithOptions()
     {
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
 
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn('OK 12345678');
-
-        $client = new MockHttpClient(function (string $method, string $url, $request) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, $request): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame('https://api.smsbox.pro/1.1/api.php', $url);
             $this->assertSame('max_parts=5&coding=unicode&callback=1&dest=%2B33612345678&msg=Hello%21&id=1&usage=symfony&mode=Standard&strategy=4&day_min=1&day_max=3', $request['body']);
 
-            return $response;
+            return new MockResponse('OK 12345678');
         });
 
         $transport = $this->createTransport($client);
@@ -143,21 +120,13 @@ final class SmsboxTransportTest extends TransportTestCase
         self::mockTime('2023-12-26');
 
         $message = new SmsMessage('+33612345678', 'Hello!');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
 
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn('OK 12345678');
-
-        $client = new MockHttpClient(function (string $method, string $url, $request) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, $request): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame('https://api.smsbox.pro/1.1/api.php', $url);
             $this->assertSame('dest=%2B33612345678&msg=Hello%21&id=1&usage=symfony&mode=Standard&strategy=4&date=05%2F12%2F2025&heure=19%3A00', $request['body']);
 
-            return $response;
+            return new MockResponse('OK 12345678');
         });
 
         $dateTime = \DateTimeImmutable::createFromFormat('d/m/Y H:i', '05/12/2025 18:00', new \DateTimeZone('UTC'));
@@ -176,21 +145,13 @@ final class SmsboxTransportTest extends TransportTestCase
     public function testQueryVariable()
     {
         $message = new SmsMessage('0612345678', 'Hello %1% %2%');
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->exactly(2))
-            ->method('getStatusCode')
-            ->willReturn(200);
 
-        $response->expects($this->once())
-            ->method('getContent')
-            ->willReturn('OK 12345678');
-
-        $client = new MockHttpClient(function (string $method, string $url, $request) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, $request): ResponseInterface {
             $this->assertSame('POST', $method);
             $this->assertSame('https://api.smsbox.pro/1.1/api.php', $url);
             $this->assertSame('dest=0612345678%3Btye%25d44%25%25d44%25t%3Be%25d59%25%25d44%25fe&msg=Hello+%251%25+%252%25&id=1&usage=symfony&mode=Standard&strategy=4&personnalise=1', $request['body']);
 
-            return $response;
+            return new MockResponse('OK 12345678');
         });
 
         $transport = $this->createTransport($client);
@@ -206,9 +167,8 @@ final class SmsboxTransportTest extends TransportTestCase
 
     public function testSmsboxOptionsInvalidDateTimeAndDate()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $client = new MockHttpClient(function () use ($response): ResponseInterface {
-            return $response;
+        $client = new MockHttpClient(function (): ResponseInterface {
+            return new MockResponse();
         });
 
         $dateTime = new \DateTimeImmutable('+1 day');
@@ -232,9 +192,8 @@ final class SmsboxTransportTest extends TransportTestCase
 
     public function testSmsboxInvalidPhoneNumber()
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $client = new MockHttpClient(function () use ($response): ResponseInterface {
-            return $response;
+        $client = new MockHttpClient(function (): ResponseInterface {
+            return new MockResponse();
         });
 
         $this->expectException(\InvalidArgumentException::class);

--- a/src/Symfony/Component/Notifier/Bridge/Smsense/Tests/SmsenseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsense/Tests/SmsenseTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Smsense\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Smsense\SmsenseTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -21,7 +22,6 @@ use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SmsenseTransportTest extends TransportTestCase
 {
@@ -73,10 +73,7 @@ class SmsenseTransportTest extends TransportTestCase
      */
     public function testExceptionIsThrownWhenSendFailed(int $statusCode, string $content, string $expectedExceptionMessage)
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('getStatusCode')->willReturn($statusCode);
-        $response->method('getContent')->willReturn($content);
-        $client = new MockHttpClient($response);
+        $client = new MockHttpClient(new MockResponse($content, ['http_code' => $statusCode]));
         $transport = $this->createTransport($client);
 
         $this->expectException(TransportException::class);

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportTest.php
@@ -49,7 +49,7 @@ final class SweegoTransportTest extends TransportTestCase
     public function testSupportWithNotSmsMessage()
     {
         $transport = new SweegoTransport('apiKey', 'REGION', 'CAMPAIGN_TYPE', false, 'CAMPAIGN_ID', true, false);
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createStub(MessageInterface::class);
         $this->assertFalse($transport->supports($message));
     }
 
@@ -57,7 +57,7 @@ final class SweegoTransportTest extends TransportTestCase
     {
         $transport = new SweegoTransport('apiKey', 'REGION', 'CAMPAIGN_TYPE', false, 'CAMPAIGN_ID', true, false);
         $message = new SmsMessage('test', 'test');
-        $options = $this->createMock(MessageOptionsInterface::class);
+        $options = $this->createStub(MessageOptionsInterface::class);
         $message->options($options);
         $this->assertFalse($transport->supports($message));
     }
@@ -66,7 +66,7 @@ final class SweegoTransportTest extends TransportTestCase
     {
         $this->expectException(UnsupportedMessageTypeException::class);
         $transport = new SweegoTransport('apiKey', 'REGION', 'CAMPAIGN_TYPE', false, 'CAMPAIGN_ID', true, false);
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createStub(MessageInterface::class);
         $transport->send($message);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT