### PR TITLE
[TypeInfo] Fix type resolution when called class is in other namespace

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyPropertyAndGetterWithDiff
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyUnionType;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithTemplateAndParent;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyInDifferentNs;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyWithStaticGetterInDifferentNs;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\DummyWithTemplateAndParentInDifferentNs;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IFace;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IntRangeDummy;
@@ -928,6 +929,7 @@ class PhpStanExtractorTest extends TestCase
     {
         yield [ParentDummy::class, 'propertyTypeStatic', Type::object(ParentDummy::class)];
         yield [Dummy::class, 'propertyTypeStatic', Type::object(Dummy::class)];
+        yield [DummyWithStaticGetterInDifferentNs::class, 'static', Type::object(DummyWithStaticGetterInDifferentNs::class)];
     }
 
     public function testPropertiesParentType()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithStaticGetter.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithStaticGetter.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithStaticGetter
+{
+    /**
+     * @return static
+     */
+    public function getStatic(): static
+    {
+        return $this;
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyWithStaticGetterInDifferentNs.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/DummyWithStaticGetterInDifferentNs.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor;
+
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithStaticGetter;
+
+class DummyWithStaticGetterInDifferentNs extends DummyWithStaticGetter
+{
+}

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -26,7 +26,7 @@
         "php": ">=8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/string": "^6.4|^7.0",
-        "symfony/type-info": "~7.3.8|^7.4.1"
+        "symfony/type-info": "~7.3.10|^7.4.4"
     },
     "require-dev": {
         "symfony/serializer": "^6.4|^7.0",

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -44,24 +44,24 @@ class TypeContextFactoryTest extends TestCase
     public function testCollectClassNames()
     {
         $typeContext = $this->typeContextFactory->createFromClassName(Dummy::class, AbstractDummy::class);
-        $this->assertSame('Dummy', $typeContext->calledClassName);
-        $this->assertSame('AbstractDummy', $typeContext->declaringClassName);
+        $this->assertSame(Dummy::class, $typeContext->calledClassName);
+        $this->assertSame(AbstractDummy::class, $typeContext->declaringClassName);
 
         $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionClass(Dummy::class));
-        $this->assertSame('Dummy', $typeContext->calledClassName);
-        $this->assertSame('Dummy', $typeContext->declaringClassName);
+        $this->assertSame(Dummy::class, $typeContext->calledClassName);
+        $this->assertSame(Dummy::class, $typeContext->declaringClassName);
 
         $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionProperty(Dummy::class, 'id'));
-        $this->assertSame('Dummy', $typeContext->calledClassName);
-        $this->assertSame('Dummy', $typeContext->declaringClassName);
+        $this->assertSame(Dummy::class, $typeContext->calledClassName);
+        $this->assertSame(Dummy::class, $typeContext->declaringClassName);
 
         $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionMethod(Dummy::class, 'getId'));
-        $this->assertSame('Dummy', $typeContext->calledClassName);
-        $this->assertSame('Dummy', $typeContext->declaringClassName);
+        $this->assertSame(Dummy::class, $typeContext->calledClassName);
+        $this->assertSame(Dummy::class, $typeContext->declaringClassName);
 
         $typeContext = $this->typeContextFactory->createFromReflection(new \ReflectionParameter([Dummy::class, 'setId'], 'id'));
-        $this->assertSame('Dummy', $typeContext->calledClassName);
-        $this->assertSame('Dummy', $typeContext->declaringClassName);
+        $this->assertSame(Dummy::class, $typeContext->calledClassName);
+        $this->assertSame(Dummy::class, $typeContext->declaringClassName);
     }
 
     public function testCollectNamespace()

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\TypeInfo\Tests\TypeContext;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Exception\LogicException;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace\DummyInDifferentNs;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyExtendingStdClass;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithUses;
@@ -47,6 +48,14 @@ class TypeContextTest extends TestCase
     {
         $this->assertSame(Dummy::class, (new TypeContextFactory())->createFromClassName(Dummy::class)->getCalledClass());
         $this->assertSame(Dummy::class, (new TypeContextFactory())->createFromClassName(Dummy::class, AbstractDummy::class)->getCalledClass());
+    }
+
+    public function testGetCalledClassInDifferentNamespace()
+    {
+        $this->assertSame(
+            DummyInDifferentNs::class,
+            (new TypeContextFactory())->createFromClassName(DummyInDifferentNs::class, AbstractDummy::class)->getCalledClass()
+        );
     }
 
     public function testGetParentClass()

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContext.php
@@ -77,7 +77,7 @@ final class TypeContext
      */
     public function getDeclaringClass(): string
     {
-        return $this->normalize($this->declaringClassName);
+        return $this->declaringClassName;
     }
 
     /**
@@ -85,7 +85,7 @@ final class TypeContext
      */
     public function getCalledClass(): string
     {
-        return $this->normalize($this->calledClassName);
+        return $this->calledClassName;
     }
 
     /**

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -53,22 +53,19 @@ final class TypeContextFactory
     {
         $declaringClassName ??= $calledClassName;
 
-        $calledClassPath = explode('\\', $calledClassName);
-        $declaringClassPath = explode('\\', $declaringClassName);
-
         $calledClassNameReflection = self::$reflectionClassCache[$calledClassName] ??= new \ReflectionClass($calledClassName);
         $declaringClassReflection = self::$reflectionClassCache[$declaringClassName] ??= new \ReflectionClass($declaringClassName);
 
         $calledClassTypeContext = new TypeContext(
-            end($calledClassPath),
-            end($declaringClassPath),
+            $calledClassName,
+            $declaringClassName,
             trim($calledClassNameReflection->getNamespaceName(), '\\'),
             $this->collectUses($calledClassNameReflection),
         );
 
         $typeContext = new TypeContext(
-            end($calledClassPath),
-            end($declaringClassPath),
+            $calledClassName,
+            $declaringClassName,
             trim($declaringClassReflection->getNamespaceName(), '\\'),
             $this->collectUses($declaringClassReflection),
         );
@@ -107,8 +104,8 @@ final class TypeContextFactory
         }
 
         $typeContext = new TypeContext(
-            $declaringClassReflection->getShortName(),
-            $declaringClassReflection->getShortName(),
+            $declaringClassReflection->getName(),
+            $declaringClassReflection->getName(),
             $declaringClassReflection->getNamespaceName(),
             $this->collectUses($declaringClassReflection),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62922
| License       | MIT

When resolving `static` return type for a child class in a different namespace than the parent class where the method is declared, the wrong namespace was used.

The fix adds the called class to the uses array when its namespace differs from the declaring class, allowing `normalize()` to resolve it correctly.

