### PR TITLE
[JsonStreamer] Fix memory leak by caching stream readers/writers

### DIFF
--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -42,6 +42,11 @@ final class JsonStreamReader implements StreamReaderInterface
     private Instantiator $instantiator;
     private LazyInstantiator $lazyInstantiator;
 
+    /**
+     * @var array<string, callable>
+     */
+    private array $streamReaders = [];
+
     public function __construct(
         private ContainerInterface $valueTransformers,
         PropertyMetadataLoaderInterface $propertyMetadataLoader,
@@ -63,7 +68,7 @@ final class JsonStreamReader implements StreamReaderInterface
         $isStream = \is_resource($input);
         $path = $this->streamReaderGenerator->generate($type, $isStream, $options);
 
-        return (require $path)($input, $this->valueTransformers, $isStream ? $this->lazyInstantiator : $this->instantiator, $options);
+        return ($this->streamReaders[$path] ??= require $path)($input, $this->valueTransformers, $isStream ? $this->lazyInstantiator : $this->instantiator, $options);
     }
 
     /**

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -38,6 +38,11 @@ final class JsonStreamWriter implements StreamWriterInterface
 {
     private StreamWriterGenerator $streamWriterGenerator;
 
+    /**
+     * @var array<string, callable>
+     */
+    private array $streamWriters = [];
+
     public function __construct(
         private ContainerInterface $valueTransformers,
         PropertyMetadataLoaderInterface $propertyMetadataLoader,
@@ -50,7 +55,7 @@ final class JsonStreamWriter implements StreamWriterInterface
     public function write(mixed $data, Type $type, array $options = []): \Traversable&\Stringable
     {
         $path = $this->streamWriterGenerator->generate($type, $options);
-        $chunks = (require $path)($data, $this->valueTransformers, $options);
+        $chunks = ($this->streamWriters[$path] ??= require $path)($data, $this->valueTransformers, $options);
 
         return new
         /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62952
| License       | MIT

Each call to `JsonStreamReader::read()` and `JsonStreamWriter::write()` was executing `require $path`, which re-evaluated the generated PHP file and created new closures.

And these closures contain circular references (`&$providers`) that weren't being garbage collected, causing memory to grow unbounded.

The fix caches the closure returned by `require $path` so it's reused on subsequent calls with the same type.

- Before: Memory grows from 12MB to 118MB+ after ~7000 iterations.
- After: Memory stays stable at ~18MB regardless of iterations.
