### PR TITLE
[Scheduler] Fix array to string conversion in `#[AsCronTask]` arguments

### DIFF
--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -55,7 +55,10 @@ class AddScheduleMessengerPass implements CompilerPassInterface
                 $scheduleName = $tagAttributes['schedule'] ?? 'default';
 
                 if ($serviceDefinition->hasTag('console.command')) {
-                    $message = new Definition(RunCommandMessage::class, [$serviceDefinition->getClass()::getDefaultName().(empty($tagAttributes['arguments']) ? '' : " {$tagAttributes['arguments']}")]);
+                    if (\is_array($arguments = $tagAttributes['arguments'] ?? '')) {
+                        $arguments = implode(' ', array_map(static fn (string $token) => preg_match('{^[\w-]+$}', $token) ? $token : escapeshellarg($token), $arguments));
+                    }
+		    $message = new Definition(RunCommandMessage::class, [$serviceDefinition->getClass()::getDefaultName().('' !== $arguments ? " $arguments" : '')]);
                 } else {
                     $message = new Definition(ServiceCallMessage::class, [$serviceId, $tagAttributes['method'] ?? '__invoke', (array) ($tagAttributes['arguments'] ?? [])]);
                 }

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
+
+class AddScheduleMessengerPassTest extends TestCase
+{
+    /**
+     * @dataProvider processSchedulerTaskCommandProvider
+     */
+    public function testProcessSchedulerTaskCommand(array $arguments, string $expectedCommand)
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', $arguments);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $schedulerProvider = $container->getDefinition('scheduler.provider.default');
+        $calls = $schedulerProvider->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertCount(2, $calls[0]);
+
+        $messageDefinition = $calls[0][1][0];
+        $messageArguments = $messageDefinition->getArgument('$message');
+        $command = $messageArguments->getArgument(0);
+
+        $this->assertSame($expectedCommand, $command);
+    }
+
+    public static function processSchedulerTaskCommandProvider(): iterable
+    {
+        yield 'no arguments' => [['trigger' => 'every', 'frequency' => '1 hour'], 'schedulable'];
+        yield 'null arguments' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => null], 'schedulable'];
+        yield 'empty arguments' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => ''], 'schedulable'];
+        yield 'test argument' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => 'test'], 'schedulable test'];
+        yield 'array arguments' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => ['arg1', 'arg2']], 'schedulable arg1 arg2'];
+        yield 'array arguments with spaces' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => ['hello world', 'foo']], 'schedulable '.escapeshellarg('hello world').' foo'];
+        yield 'empty array arguments' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => []], 'schedulable'];
+    }
+}
+
+#[AsCommand(name: 'schedulable')]
+class SchedulableCommand
+{
+    public function __invoke(): void
+    {
+    }
+
+    public static function getDefaultName()
+    {
+        return 'schedulable';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62986
| License       | MIT

The `AsCronTask` attribute accepts `array|string|null` for the `arguments` parameter, but passing an array throws "Array to string conversion" because the compiler pass interpolates it directly into a string.

```php
#[AsCronTask('* * * * *', arguments: ['arg1', 'arg2'])]
final class MyCommand extends Command { ... }
```

```
Warning: Array to string conversion in AddScheduleMessengerPass.php
```

The fix converts array arguments to a properly escaped string using the same logic as `Input::escapeToken()`.

```php
#[AsCronTask('* * * * *', arguments: ['arg1', 'arg2'])]
// my:command arg1 arg2

#[AsCronTask('* * * * *', arguments: ['hello world', 'foo'])]
// my:command 'hello world' foo
```