### PR TITLE
[FrameworkBundle] Revert destination file change for secrets:decrypt-to-local

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -204,7 +204,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeDisabled()
                     ->children()
                         ->scalarNode('vault_directory')->defaultValue('%kernel.project_dir%/config/secrets/%kernel.runtime_environment%')->cannotBeEmpty()->end()
-                        ->scalarNode('local_dotenv_file')->defaultValue('%kernel.project_dir%/.env.%kernel.runtime_environment%.local')->end()
+                        ->scalarNode('local_dotenv_file')->defaultValue('%kernel.project_dir%/.env.%kernel.environment%.local')->end()
                         ->scalarNode('decryption_env_var')->defaultValue('base64:default::SYMFONY_DECRYPTION_SECRET')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -856,7 +856,7 @@ class ConfigurationTest extends TestCase
             'secrets' => [
                 'enabled' => true,
                 'vault_directory' => '%kernel.project_dir%/config/secrets/%kernel.runtime_environment%',
-                'local_dotenv_file' => '%kernel.project_dir%/.env.%kernel.runtime_environment%.local',
+                'local_dotenv_file' => '%kernel.project_dir%/.env.%kernel.environment%.local',
                 'decryption_env_var' => 'base64:default::SYMFONY_DECRYPTION_SECRET',
             ],
             'http_cache' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62742
| License       | MIT

This reverts part of #62078