### PR TITLE
[JsonStreamer] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\JsonStreamer\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\JsonStreamer\JsonStreamReader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
@@ -181,7 +181,7 @@ class JsonStreamReaderTest extends TestCase
 
     public function testReadObjectWithSyntheticProperties()
     {
-        $reader = new JsonStreamReader($this->createMock(ContainerInterface::class), new SyntheticPropertyMetadataLoader(), $this->streamReadersDir, $this->lazyGhostsDir);
+        $reader = new JsonStreamReader(new Container(), new SyntheticPropertyMetadataLoader(), $this->streamReadersDir, $this->lazyGhostsDir);
 
         $this->assertRead($reader, function (mixed $read) {
             $this->assertInstanceOf(DummyWithSyntheticProperties::class, $read);

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\JsonStreamer\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\JsonStreamer\Exception\NotEncodableValueException;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
@@ -312,7 +312,7 @@ class JsonStreamWriterTest extends TestCase
 
     public function testWriteObjectWithSyntheticProperty()
     {
-        $writer = new JsonStreamWriter($this->createMock(ContainerInterface::class), new SyntheticPropertyMetadataLoader(), $this->streamWritersDir);
+        $writer = new JsonStreamWriter(new Container(), new SyntheticPropertyMetadataLoader(), $this->streamWritersDir);
 
         $this->assertSame('{"synthetic":true}', (string) $writer->write(new DummyWithSyntheticProperties(), Type::object(DummyWithSyntheticProperties::class)));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT