### PR TITLE
[Messenger] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -421,9 +421,9 @@ class ConnectionTest extends TestCase
     public function testExchangeBindingArguments()
     {
         $factory = new TestAmqpFactory(
-            $this->createMock(\AMQPConnection::class),
-            $this->createMock(\AMQPChannel::class),
-            $this->createMock(\AMQPQueue::class),
+            $this->createStub(\AMQPConnection::class),
+            $this->createStub(\AMQPChannel::class),
+            $this->createStub(\AMQPQueue::class),
             $amqpExchange = $this->createMock(\AMQPExchange::class)
         );
 
@@ -461,10 +461,10 @@ class ConnectionTest extends TestCase
         $this->expectExceptionMessage('The "binding_keys" option must be set to a non-empty array for exchange "exchange0".');
 
         $factory = new TestAmqpFactory(
-            $this->createMock(\AMQPConnection::class),
-            $this->createMock(\AMQPChannel::class),
-            $this->createMock(\AMQPQueue::class),
-            $this->createMock(\AMQPExchange::class)
+            $this->createStub(\AMQPConnection::class),
+            $this->createStub(\AMQPChannel::class),
+            $this->createStub(\AMQPQueue::class),
+            $this->createStub(\AMQPExchange::class)
         );
 
         $dsn = 'amqp://localhost?exchange[type]=headers'.

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -407,11 +407,11 @@ class ConsumeMessagesCommandTest extends TestCase
         $envelope2 = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
         $envelope3 = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
 
-        $receiver1 = $this->createMock(ReceiverInterface::class);
+        $receiver1 = $this->createStub(ReceiverInterface::class);
         $receiver1->method('get')->willReturn([$envelope1]);
-        $receiver2 = $this->createMock(ReceiverInterface::class);
+        $receiver2 = $this->createStub(ReceiverInterface::class);
         $receiver2->method('get')->willReturn([$envelope2]);
-        $receiver3 = $this->createMock(ReceiverInterface::class);
+        $receiver3 = $this->createStub(ReceiverInterface::class);
         $receiver3->method('get')->willReturn([$envelope3]);
 
         $receiverLocator = new Container();
@@ -456,13 +456,13 @@ class ConsumeMessagesCommandTest extends TestCase
         $envelope3 = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
         $envelope4 = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
 
-        $receiver1 = $this->createMock(ReceiverInterface::class);
+        $receiver1 = $this->createStub(ReceiverInterface::class);
         $receiver1->method('get')->willReturn([$envelope1]);
-        $receiver2 = $this->createMock(ReceiverInterface::class);
+        $receiver2 = $this->createStub(ReceiverInterface::class);
         $receiver2->method('get')->willReturn([$envelope2]);
-        $receiver3 = $this->createMock(ReceiverInterface::class);
+        $receiver3 = $this->createStub(ReceiverInterface::class);
         $receiver3->method('get')->willReturn([$envelope3]);
-        $receiver4 = $this->createMock(ReceiverInterface::class);
+        $receiver4 = $this->createStub(ReceiverInterface::class);
         $receiver4->method('get')->willReturn([$envelope4]);
 
         $receiverLocator = new Container();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT