### PR TITLE
[HttpFoundation] Fix double-prefixing of session keys when using redis/memcached

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
@@ -62,6 +62,7 @@ class SessionHandlerFactory
                     throw new \InvalidArgumentException('Unsupported Redis or Memcached DSN. Try running "composer require symfony/cache".');
                 }
                 $handlerClass = str_starts_with($connection, 'memcached:') ? MemcachedSessionHandler::class : RedisSessionHandler::class;
+                $connection = preg_replace('/([?&])prefix=[^&]*+&?/', '\1', $connection);
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);
 
                 return new $handlerClass($connection, array_intersect_key($options, ['prefix' => 1, 'ttl' => 1]));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use Predis\Client;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory;
 
 /**
  * @group integration
@@ -21,5 +23,24 @@ class PredisSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
     protected function createRedisClient(string $host): Client
     {
         return new Client(array_combine(['host', 'port'], explode(':', getenv('REDIS_HOST')) + [1 => 6379]));
+    }
+
+    public function testNoDuplicatePrefixWhenUsingDsn()
+    {
+        $host = getenv('REDIS_HOST') ?: 'localhost';
+        $dsn = 'redis://'.$host.'?prefix=my_session_prefix_&class='.urlencode(Client::class);
+
+        $handler = SessionHandlerFactory::createHandler($dsn);
+        $this->assertInstanceOf(RedisSessionHandler::class, $handler);
+
+        $handler->write('test_id', 'test_data');
+        $rawClient = new Client(array_combine(['host', 'port'], explode(':', $host) + [1 => 6379]));
+
+        try {
+            $this->assertSame(0, $rawClient->exists('my_session_prefix_my_session_prefix_test_id'));
+            $this->assertEquals('test_data', $rawClient->get('my_session_prefix_test_id'));
+        } finally {
+            $rawClient->flushdb();
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62060
| License       | MIT
