### PR TITLE
[Cache] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -66,7 +66,7 @@ class ChainAdapterTest extends AdapterTestCase
 
         $cache = new ChainAdapter([
             $this->getPruneableMock(),
-            $this->getNonPruneableMock(),
+            $this->createStub(AdapterInterface::class),
             $this->getPruneableMock(),
         ]);
         $this->assertTrue($cache->prune());
@@ -260,11 +260,6 @@ class ChainAdapterTest extends AdapterTestCase
             ->willReturn(false);
 
         return $pruneable;
-    }
-
-    private function getNonPruneableMock(): AdapterInterface
-    {
-        return $this->createMock(AdapterInterface::class);
     }
 
     public function testSetCallbackWrapperPropagation()

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -57,7 +57,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
             $this->markTestSkipped('doctrine/dbal v2 does not support custom drivers using middleware');
         }
 
-        $middleware = $this->createMock(Middleware::class);
+        $middleware = $this->createStub(Middleware::class);
         $middleware
             ->method('wrap')
             ->willReturn(new DriverWrapper($connection->getDriver()));
@@ -95,7 +95,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
             @unlink(self::$dbFile);
         }
 
-        $otherConnection = $this->createConnectionMock();
+        $otherConnection = $this->createConnection();
         $schema = new Schema();
 
         $adapter = $this->createCachePool();
@@ -180,11 +180,11 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         return 1 !== (int) $result->fetchOne();
     }
 
-    private function createConnectionMock()
+    private function createConnection(): Connection
     {
-        $connection = $this->createMock(Connection::class);
-        $driver = $this->createMock(AbstractMySQLDriver::class);
-        $connection->expects($this->any())
+        $connection = $this->createStub(Connection::class);
+        $driver = $this->createStub(AbstractMySQLDriver::class);
+        $connection
             ->method('getDriver')
             ->willReturn($driver);
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -43,7 +43,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $cache = new TagAwareAdapter($this->getPruneableMock());
         $this->assertTrue($cache->prune());
 
-        $cache = new TagAwareAdapter($this->getNonPruneableMock());
+        $cache = new TagAwareAdapter($this->createStub(AdapterInterface::class));
         $this->assertFalse($cache->prune());
 
         $cache = new TagAwareAdapter($this->getFailingPruneableMock());
@@ -121,11 +121,6 @@ class TagAwareAdapterTest extends AdapterTestCase
             ->willReturn(false);
 
         return $pruneable;
-    }
-
-    private function getNonPruneableMock(): AdapterInterface&MockObject
-    {
-        return $this->createMock(AdapterInterface::class);
     }
 
     /**

--- a/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
+++ b/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
@@ -168,7 +168,7 @@ class CacheDataCollectorTest extends TestCase
 
     private function getCacheDataCollectorStatisticsFromEvents(array $traceableAdapterEvents)
     {
-        $traceableAdapterMock = $this->createMock(TraceableAdapter::class);
+        $traceableAdapterMock = $this->createStub(TraceableAdapter::class);
         $traceableAdapterMock->method('getCalls')->willReturn($traceableAdapterEvents);
 
         $cacheDataCollector = new CacheDataCollector();

--- a/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationDispatcherTest.php
+++ b/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationDispatcherTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\ReverseContainer;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 class EarlyExpirationDispatcherTest extends TestCase
@@ -54,9 +55,7 @@ class EarlyExpirationDispatcherTest extends TestCase
 
         $reverseContainer = new ReverseContainer($container, new ServiceLocator([]));
 
-        $bus = $this->createMock(MessageBusInterface::class);
-
-        $dispatcher = new EarlyExpirationDispatcher($bus, $reverseContainer);
+        $dispatcher = new EarlyExpirationDispatcher(new MessageBus(), $reverseContainer);
 
         $saveResult = null;
         $pool->setCallbackWrapper(function (callable $callback, CacheItem $item, bool &$save, AdapterInterface $pool, \Closure $setMetadata, ?LoggerInterface $logger) use ($dispatcher, &$saveResult) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT