### PR TITLE
[FrameworkBundle] Ensure a fresh container is used after cache warmup in `KernelTestCase`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -82,6 +82,18 @@ abstract class KernelTestCase extends TestCase
         static::$kernel = $kernel;
         static::$booted = true;
 
+        // If the cache warmer is registered, it means that the cache has been
+        // warmed up, so the current container is not fresh anymore. Let's
+        // reboot a fresh one.
+        if (self::getContainer()->initialized('cache_warmer')) {
+            static::ensureKernelShutdown();
+
+            $kernel = static::createKernel($options);
+            $kernel->boot();
+            static::$kernel = $kernel;
+            static::$booted = true;
+        }
+
         return static::$kernel;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -22,11 +22,9 @@ class TestServiceContainerTest extends AbstractWebTestCase
 {
     public function testLogicExceptionIfTestConfigIsDisabled()
     {
-        static::bootKernel(['test_case' => 'TestServiceContainer', 'root_config' => 'test_disabled.yml', 'environment' => 'test_disabled']);
-
         $this->expectException(\LogicException::class);
 
-        static::getContainer();
+        static::bootKernel(['test_case' => 'TestServiceContainer', 'root_config' => 'test_disabled.yml', 'environment' => 'test_disabled']);
     }
 
     public function testThatPrivateServicesAreAvailableIfTestConfigIsEnabled()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

When the cache is empty, and a test starts, it will compile the container, and
warm up the cache. However, this means that the container used during the test
is not fresh anymore, as it has been compiled with the cache warmer service
registered. This change ensures that if the cache warmer is detected in the
container after booting, a new kernel is booted to provide a fresh container for
the test.
