### PR TITLE
[AssetMapper] Use #[AllowMockObjectsWithoutExpectations] attribute when you do not expect a mock

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
@@ -11,17 +11,18 @@
 
 namespace Symfony\Component\AssetMapper\Tests\ImportMap;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
-use Symfony\Component\AssetMapper\ImportMap\ImportMapEntries;
-use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
-use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
-use Symfony\Component\AssetMapper\ImportMap\ImportMapUpdateChecker;
-use Symfony\Component\AssetMapper\ImportMap\PackageUpdateInfo;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpClient\MockHttpClient;
-use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapEntries;
+use Symfony\Component\AssetMapper\ImportMap\PackageUpdateInfo;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapUpdateChecker;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
 class ImportMapUpdateCheckerTest extends TestCase
 {
@@ -115,6 +116,7 @@ class ImportMapUpdateCheckerTest extends TestCase
      * @param PackageUpdateInfo[] $expectedUpdateInfo
      */
     #[DataProvider('provideImportMapEntry')]
+    #[AllowMockObjectsWithoutExpectations]
     public function testGetAvailableUpdatesForSinglePackage(array $entries, array $expectedUpdateInfo, ?\Exception $expectedException)
     {
         $this->importMapConfigReader->method('getEntries')->willReturn(new ImportMapEntries($entries));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no
| Issues        | #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
