### PR TITLE
[FrameworkBundle] Fix `debug:container --tag` not showing priority of `#[AsTaggedItem]`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\Console\Descriptor\DescriptorInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\ServiceReferenceGraphEdge;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -256,6 +257,70 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         return $sortedTags;
+    }
+
+    /**
+     * Resolves service tags by merging priorities and indices from #[AsTaggedItem] attributes
+     * or static getDefaultPriority()/getDefaultName() methods into the tag data.
+     *
+     * This ensures debug output shows the same priority values that are used during container compilation.
+     */
+    protected function resolveServiceTags(ContainerBuilder $container, Definition $definition, ?string $tagName = null): array
+    {
+        if (null === $tagName) {
+            $tags = $definition->getTags();
+            foreach ($tags as $name => $tag) {
+                $tags[$name] = $this->resolveServiceTags($container, $definition, $name);
+            }
+
+            return $tags;
+        }
+
+        $tags = $definition->getTag($tagName);
+
+        if ($definition->hasTag('container.ignore_attributes')) {
+            return $tags;
+        }
+
+        $class = $container->getParameterBag()->resolveValue($definition->getClass());
+
+        if (!$class || !($r = $container->getReflectionClass($class))) {
+            return $tags;
+        }
+
+        $priority = $index = null;
+
+        // Check for static getDefaultPriority() method
+        if ($r->hasMethod('getDefaultPriority') && ($m = $r->getMethod('getDefaultPriority'))->isStatic() && $m->isPublic()) {
+            $priority = $m->invoke(null);
+        }
+
+        // Check for static getDefaultName() method
+        if ($r->hasMethod('getDefaultName') && ($m = $r->getMethod('getDefaultName'))->isStatic() && $m->isPublic()) {
+            $index = $m->invoke(null);
+        }
+
+        // Check for #[AsTaggedItem] attribute
+        if ($attr = $r->getAttributes(AsTaggedItem::class)[0] ?? null) {
+            $attribute = $attr->newInstance();
+            $priority ??= $attribute->priority;
+            $index ??= $attribute->index;
+        }
+
+        if (null === $priority && null === $index) {
+            return $tags;
+        }
+
+        foreach ($tags as $i => $tag) {
+            if (null !== $priority) {
+                $tags[$i]['priority'] ??= $priority;
+            }
+            if (null !== $index) {
+                $tags[$i]['index'] ??= $index;
+            }
+        }
+
+        return $tags;
     }
 
     protected function sortByPriority(array $tag): array

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -300,7 +300,7 @@ class JsonDescriptor extends Descriptor
 
         if (!$omitTags) {
             $data['tags'] = [];
-            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($container ? $this->resolveServiceTags($container, $definition) : $definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $data['tags'][] = ['name' => $tagName, 'parameters' => $parameters];
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -260,7 +260,7 @@ class MarkdownDescriptor extends Descriptor
         }
 
         if (!(isset($options['omit_tags']) && $options['omit_tags'])) {
-            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($container ? $this->resolveServiceTags($container, $definition) : $definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $output .= "\n".'- Tag: `'.$tagName.'`';
                     foreach ($parameters as $name => $value) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -197,9 +197,16 @@ class TextDescriptor extends Descriptor
 
         $options['output']->title($title);
 
-        $serviceIds = isset($options['tag']) && $options['tag']
-            ? $this->sortTaggedServicesByPriority($container->findTaggedServiceIds($options['tag']))
-            : $this->sortServiceIds($container->getServiceIds());
+        if (isset($options['tag']) && $options['tag']) {
+            $services = [];
+            foreach ($container->findTaggedServiceIds($options['tag']) as $serviceId => $tags) {
+                $definition = $container->getDefinition($serviceId);
+                $services[$serviceId] = $this->resolveServiceTags($container, $definition, $options['tag']);
+            }
+            $serviceIds = $this->sortTaggedServicesByPriority($services);
+        } else {
+            $serviceIds = $this->sortServiceIds($container->getServiceIds());
+        }
         $maxTags = [];
 
         if (isset($options['filter'])) {
@@ -221,7 +228,7 @@ class TextDescriptor extends Descriptor
                     continue;
                 }
                 if ($showTag) {
-                    $tags = $definition->getTag($showTag);
+                    $tags = $services[$serviceId];
                     foreach ($tags as $tag) {
                         foreach ($tag as $key => $value) {
                             if (!isset($maxTags[$key])) {
@@ -252,7 +259,7 @@ class TextDescriptor extends Descriptor
             $styledServiceId = $rawOutput ? $serviceId : \sprintf('<fg=cyan>%s</fg=cyan>', OutputFormatter::escape($serviceId));
             if ($definition instanceof Definition) {
                 if ($showTag) {
-                    foreach ($this->sortByPriority($definition->getTag($showTag)) as $key => $tag) {
+                    foreach ($this->sortByPriority($services[$serviceId]) as $key => $tag) {
                         $tagValues = [];
                         foreach ($tagsNames as $tagName) {
                             if (\is_array($tagValue = $tag[$tagName] ?? '')) {
@@ -297,7 +304,7 @@ class TextDescriptor extends Descriptor
         $tableRows[] = ['Class', $definition->getClass() ?: '-'];
 
         $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
-        if (!$omitTags && ($tags = $definition->getTags())) {
+        if (!$omitTags && ($tags = $container ? $this->resolveServiceTags($container, $definition) : $definition->getTags())) {
             $tagInformation = [];
             foreach ($tags as $tagName => $tagData) {
                 foreach ($tagData as $tagParameters) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -275,7 +275,7 @@ class XmlDescriptor extends Descriptor
         if ($service instanceof Alias) {
             $dom->appendChild($dom->importNode($this->getContainerAliasDocument($service, $id)->childNodes->item(0), true));
             if ($container) {
-                $dom->appendChild($dom->importNode($this->getContainerDefinitionDocument($container->getDefinition((string) $service), (string) $service, false, $showArguments, $container)->childNodes->item(0), true));
+                $dom->appendChild($dom->importNode($this->getContainerDefinitionDocument($container->findDefinition($id), (string) $service, false, $showArguments, $container)->childNodes->item(0), true));
             }
         } elseif ($service instanceof Definition) {
             $dom->appendChild($dom->importNode($this->getContainerDefinitionDocument($service, $id, false, $showArguments, $container)->childNodes->item(0), true));
@@ -311,7 +311,7 @@ class XmlDescriptor extends Descriptor
                 continue;
             }
 
-            $serviceXML = $this->getContainerServiceDocument($service, $serviceId, null, $showArguments);
+            $serviceXML = $this->getContainerServiceDocument($service, $serviceId, $service instanceof Definition ? $container : null, $showArguments);
             $containerXML->appendChild($containerXML->ownerDocument->importNode($serviceXML->childNodes->item(0), true));
         }
 
@@ -385,7 +385,7 @@ class XmlDescriptor extends Descriptor
         }
 
         if (!$omitTags) {
-            if ($tags = $this->sortTagsByPriority($definition->getTags())) {
+            if ($tags = $this->sortTagsByPriority($container ? $this->resolveServiceTags($container, $definition) : $definition->getTags())) {
                 $serviceXML->appendChild($tagsXML = $dom->createElement('tags'));
                 foreach ($tags as $tagName => $tagData) {
                     foreach ($tagData as $parameters) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix -
| License       | MIT

`debug:container --tag=some.tag` command does not display the priority value set via `#[AsTaggedItem]`

```Yaml
    App\SomeService:
        tags:
            - { name: 'some.tag'}
```

```php
#[AsTaggedItem(priority: 120)]
class SomeService
```

 `> php bin/console debug:container --tag=some.tag`

<img width="647" height="178" alt="image" src="https://github.com/user-attachments/assets/d5410eff-3351-4616-89a6-370ef4731469" />


But if i use `#[AutoconfigureTag]`  or set priority in `services.yaml`, it becomes : 


<img width="866" height="120" alt="image" src="https://github.com/user-attachments/assets/2c57348f-77b8-428c-92d4-2dc4b75ed87a" />


