### PR TITLE
[ObjectMapper] Add `MappingAwareTransformCallableInterface`

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Attribute/MapCollection.php
+++ b/src/Symfony/Component/ObjectMapper/Attribute/MapCollection.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Attribute;
+
+/**
+ * Configures a how to map each item of an array.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+class MapCollection extends Map
+{
+    /**
+     * @param class-string|null                                                                                        $itemClass The class to map each collection item to
+     * @param string|class-string|null                                                                                 $source    The property or the class to map from
+     * @param string|class-string|null                                                                                 $target    The property or the class to map to
+     * @param string|bool|callable(mixed, object): bool|null                                                           $if        A boolean, a service id or a callable that instructs whether to map
+     * @param (string|callable(mixed, object, ?object): mixed)|(string|callable(mixed, object, ?object): mixed)[]|null $transform A service id or a callable that transforms the value during mapping
+     */
+    public function __construct(
+        public readonly ?string $itemClass = null,
+        ?string $target = null,
+        ?string $source = null,
+        mixed $if = null,
+        mixed $transform = \Symfony\Component\ObjectMapper\Transform\MapCollection::class,
+    ) {
+        parent::__construct($target, $source, $if, $transform);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `MapCollection` attribute with `itemClass` to specify the target class for collection items
+ * Add `MappingAwareTransformCallableInterface` to allow transforms to access the original `Map` attribute
+
 7.4
 ---
 

--- a/src/Symfony/Component/ObjectMapper/MappingAwareTransformCallableInterface.php
+++ b/src/Symfony/Component/ObjectMapper/MappingAwareTransformCallableInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * Service used by "Map::transform".
+ *
+ * @template T of object
+ * @template T2 of object
+ *
+ * {@see Symfony\Component\ObjectMapper\Attribute\Map}
+ */
+interface MappingAwareTransformCallableInterface
+{
+    /**
+     * @param mixed   $value  The value being mapped
+     * @param T       $source The object we're working on
+     * @param T2|null $target The target we're mapping to
+     * @param Map     $map    The original Map attribute
+     */
+    public function __invoke(mixed $value, object $source, ?object $target, Map $map): mixed;
+}

--- a/src/Symfony/Component/ObjectMapper/Metadata/Mapping.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/Mapping.php
@@ -22,4 +22,13 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
  */
 final class Mapping extends Map
 {
+    public function __construct(
+        ?string $target = null,
+        ?string $source = null,
+        mixed $if = null,
+        mixed $transform = null,
+        public readonly Map $map = new Map(),
+    ) {
+        parent::__construct($target, $source, $if, $transform);
+    }
 }

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
@@ -38,7 +38,7 @@ final class ReflectionObjectMapperMetadataFactory implements ObjectMapperMetadat
             $mappings = [];
             foreach ($attributes as $attribute) {
                 $map = $attribute->newInstance();
-                $mappings[] = new Mapping($map->target, $map->source, $map->if, $map->transform);
+                $mappings[] = new Mapping($map->target, $map->source, $map->if, $map->transform, $map);
             }
 
             return $this->attributesCache[$key] = $mappings;

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -331,7 +331,11 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         foreach ($transforms as $transform) {
             if ($fn = $this->getCallable($transform, $this->transformCallableLocator)) {
-                $value = $this->call($fn, $value, $source, $target);
+                if ($fn instanceof MappingAwareTransformCallableInterface) {
+                    $value = $fn($value, $source, $target, $map->map);
+                } else {
+                    $value = $this->call($fn, $value, $source, $target);
+                }
             }
         }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/Order.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/Order.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Attribute\MapCollection;
+
+/**
+ * Source order class using MapCollection attribute with itemClass.
+ */
+#[Map(target: OrderDto::class)]
+class Order
+{
+    public int $id;
+
+    /** @var OrderItem[] */
+    #[MapCollection(itemClass: OrderItemDto::class)]
+    public array $items = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/OrderDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/OrderDto.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute;
+
+/**
+ * Target order DTO.
+ */
+class OrderDto
+{
+    public int $id;
+
+    /** @var OrderItemDto[] */
+    public array $items = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/OrderItem.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/OrderItem.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute;
+
+/**
+ * Source item class without a Map attribute - requires explicit itemClass in MapCollection.
+ */
+class OrderItem
+{
+    public function __construct(
+        public string $name,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/OrderItemDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapCollectionAttribute/OrderItemDto.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute;
+
+/**
+ * Target item DTO.
+ */
+class OrderItemDto
+{
+    public function __construct(
+        public string $name,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapStruct/MapStructMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapStruct/MapStructMapperMetadataFactory.php
@@ -37,7 +37,7 @@ final class MapStructMapperMetadataFactory implements ObjectMapperMetadataFactor
         foreach (($property ? $refl->getMethod('map') : $refl)->getAttributes(Map::class) as $mappingAttribute) {
             $map = $mappingAttribute->newInstance();
             if ($map->source === $source) {
-                $mapTo[] = new Mapping(source: $map->source, target: $map->target, if: $map->if, transform: $map->transform);
+                $mapTo[] = new Mapping(source: $map->source, target: $map->target, if: $map->if, transform: $map->transform, map: $map);
 
                 continue;
             }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -52,6 +52,10 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B as Instance
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\A as InstanceCallbackWithArgumentsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\B as InstanceCallbackWithArgumentsB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\LazyFoo;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute\Order;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute\OrderDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute\OrderItem;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapCollectionAttribute\OrderItemDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -90,6 +94,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class ObjectMapperTest extends TestCase
@@ -647,5 +652,32 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(ReadOnlyPromotedPropertyBMapped::class, $out->b);
         $this->assertSame('foo', $out->var1);
         $this->assertSame('bar', $out->b->var2);
+    }
+
+    public function testMapCollectionAttributeWithItemClass()
+    {
+        $order = new Order();
+        $order->id = 1;
+        $order->items = [
+            new OrderItem('Product A', 2),
+            new OrderItem('Product B', 3),
+        ];
+
+        $mapper = new ObjectMapper(
+            transformCallableLocator: $this->getServiceLocator([
+                MapCollection::class => new MapCollection(),
+            ])
+        );
+        $result = $mapper->map($order);
+
+        $this->assertInstanceOf(OrderDto::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertCount(2, $result->items);
+        $this->assertInstanceOf(OrderItemDto::class, $result->items[0]);
+        $this->assertInstanceOf(OrderItemDto::class, $result->items[1]);
+        $this->assertSame('Product A', $result->items[0]->name);
+        $this->assertSame(2, $result->items[0]->quantity);
+        $this->assertSame('Product B', $result->items[1]->name);
+        $this->assertSame(3, $result->items[1]->quantity);
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
@@ -11,32 +11,36 @@
 
 namespace Symfony\Component\ObjectMapper\Transform;
 
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Attribute\MapCollection as MapCollectionAttribute;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
+use Symfony\Component\ObjectMapper\MappingAwareTransformCallableInterface;
 use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
-use Symfony\Component\ObjectMapper\TransformCallableInterface;
 
 /**
  * @template T of object
  *
- * @implements TransformCallableInterface<object, T>
+ * @implements MappingAwareTransformCallableInterface<object, T>
  */
-class MapCollection implements TransformCallableInterface
+class MapCollection implements MappingAwareTransformCallableInterface
 {
     public function __construct(
         private ObjectMapperInterface $objectMapper = new ObjectMapper(),
     ) {
     }
 
-    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    public function __invoke(mixed $value, object $source, ?object $target, Map $map): mixed
     {
         if (!is_iterable($value)) {
             throw new MappingException(\sprintf('The MapCollection transform expects an iterable, "%s" given.', get_debug_type($value)));
         }
 
+        $itemClass = $map instanceof MapCollectionAttribute ? $map->itemClass : null;
+
         $values = [];
         foreach ($value as $k => $v) {
-            $values[$k] = $this->objectMapper->map($v);
+            $values[$k] = $this->objectMapper->map($v, $itemClass);
         }
 
         return $values;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61957 - Follow #62908
| License       | MIT

Add a new interface to receive the original Map in the transformer

## Use case

When using Symfony, if we want to use a Transformer that use dependency injection we need to pass a className for the `transform` argument. Doing so we loose the ability to pass arguments to the transformer. Adding a way to receive the original `Map` attribute resolve this issue since we can pass extra information to the transformers using custom attribute extending the original `Map`.

This feature is needed to make the object mapper usefull for DTO with collections. If I have a Post with categories, I want to be able to convert both the Post and the Categories using specific DTO (without having to add attribute to the original class Post or Category).

```php
class PostPreviewDTO
{   
     #[MapCollection(itemClass: CategoryItemDTO::class)
     /** @var CategoryItemDTO[] */
     public array $categories;
}
```

### Concern

Adding a new attribute may complexify the ObjectMapper. I can remove this extra attribute and keep the `MapAwareTransfomerInterface` so the custom logic for collection can live in the user space.
