### PR TITLE
 PHP CS Fixer: re-apply no_unneeded_control_parentheses

### DIFF
--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -242,11 +242,11 @@ class CachePoolPassTest extends TestCase
         $container->register('cache.adapter.chain', ChainAdapter::class)
             ->setAbstract(true);
 
-        $container->setDefinition('cache.parent.chain', (new ChildDefinition('cache.adapter.chain')))
+        $container->setDefinition('cache.parent.chain', new ChildDefinition('cache.adapter.chain'))
             ->addArgument(['cache.adapter.filesystem'])
             ->addTag('cache.pool');
 
-        $container->setDefinition('foobar.chained.cache', (new ChildDefinition('cache.parent.chain')))
+        $container->setDefinition('foobar.chained.cache', new ChildDefinition('cache.parent.chain'))
             ->addTag('cache.pool');
 
         $this->cachePoolPass->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

I was looking to enable negative_instanceof and looks it's already followed and nothing to fix.
I will extend the ruleset officially: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9336

Then, i found some case for no_unneeded_control_parentheses to fix, accidentally