### PR TITLE
[Scheduler] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
@@ -33,14 +33,14 @@ class DispatchSchedulerEventListenerTest extends TestCase
 {
     public function testDispatchSchedulerEvents()
     {
-        $trigger = $this->createMock(TriggerInterface::class);
+        $trigger = $this->createStub(TriggerInterface::class);
         $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
 
         $schedulerProvider = new SomeScheduleProvider([$defaultRecurringMessage]);
         $scheduleProviderLocator = new Container();
         $scheduleProviderLocator->set('default', $schedulerProvider);
 
-        $context = new MessageContext('default', 'default', $trigger, $this->createMock(\DateTimeImmutable::class));
+        $context = new MessageContext('default', 'default', $trigger, $this->createStub(\DateTimeImmutable::class));
         $envelope = (new Envelope(new \stdClass()))->with(new ScheduledStamp($context));
 
         $listener = new DispatchSchedulerEventListener($scheduleProviderLocator, $eventDispatcher = new EventDispatcher());

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -366,7 +366,7 @@ class MessageGeneratorTest extends TestCase
         sort($runs);
 
         $ticks = [self::makeDateTime(''), 0];
-        $trigger = $this->createMock(TriggerInterface::class);
+        $trigger = $this->createStub(TriggerInterface::class);
         $trigger
             ->method('getNextRunDate')
             ->willReturnCallback(function (\DateTimeImmutable $lastTick) use ($runs, &$ticks): \DateTimeImmutable {

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportFactoryTest.php
@@ -29,9 +29,9 @@ class SchedulerTransportFactoryTest extends TestCase
 {
     public function testCreateTransport()
     {
-        $trigger = $this->createMock(TriggerInterface::class);
-        $serializer = $this->createMock(SerializerInterface::class);
-        $clock = $this->createMock(ClockInterface::class);
+        $trigger = $this->createStub(TriggerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
+        $clock = $this->createStub(ClockInterface::class);
 
         $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
         $customRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'custom']);
@@ -58,7 +58,7 @@ class SchedulerTransportFactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The given Schedule DSN "schedule://#wrong" is invalid.');
 
-        $factory->createTransport('schedule://#wrong', [], $this->createMock(SerializerInterface::class));
+        $factory->createTransport('schedule://#wrong', [], $this->createStub(SerializerInterface::class));
     }
 
     public function testNoName()
@@ -68,7 +68,7 @@ class SchedulerTransportFactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The Schedule DSN must contains a name, e.g. "schedule://default".');
 
-        $factory->createTransport('schedule://', [], $this->createMock(SerializerInterface::class));
+        $factory->createTransport('schedule://', [], $this->createStub(SerializerInterface::class));
     }
 
     public function testNotFound()
@@ -78,7 +78,7 @@ class SchedulerTransportFactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The schedule "not-exists" is not found.');
 
-        $factory->createTransport('schedule://not-exists', [], $this->createMock(SerializerInterface::class));
+        $factory->createTransport('schedule://not-exists', [], $this->createStub(SerializerInterface::class));
     }
 
     public function testSupports()
@@ -95,9 +95,9 @@ class SchedulerTransportFactoryTest extends TestCase
     {
         return new SchedulerTransportFactory(
             new Container([
-                'default' => fn () => $this->createMock(ScheduleProviderInterface::class),
+                'default' => fn () => $this->createStub(ScheduleProviderInterface::class),
             ]),
-            $this->createMock(ClockInterface::class),
+            $this->createStub(ClockInterface::class),
         );
     }
 }

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -29,9 +29,9 @@ class SchedulerTransportTest extends TestCase
             (object) ['id' => 'first'],
             (object) ['id' => 'second'],
         ];
-        $generator = $this->createMock(MessageGeneratorInterface::class);
+        $generator = $this->createStub(MessageGeneratorInterface::class);
         $generator->method('getMessages')->willReturnCallback(function () use ($messages): \Generator {
-            $trigger = $this->createMock(TriggerInterface::class);
+            $trigger = $this->createStub(TriggerInterface::class);
             $triggerAt = new \DateTimeImmutable('2020-02-20T02:00:00', new \DateTimeZone('UTC'));
             yield (new MessageContext('default', 'id1', $trigger, $triggerAt)) => $messages[0];
             yield (new MessageContext('default', 'id2', $trigger, $triggerAt)) => $messages[1];
@@ -51,9 +51,9 @@ class SchedulerTransportTest extends TestCase
 
     public function testAddsStampToInnerRedispatchMessageEnvelope()
     {
-        $generator = $this->createMock(MessageGeneratorInterface::class);
+        $generator = $this->createStub(MessageGeneratorInterface::class);
         $generator->method('getMessages')->willReturnCallback(function (): \Generator {
-            yield new MessageContext('default', 'id', $this->createMock(TriggerInterface::class), new \DateTimeImmutable()) => new RedispatchMessage(new \stdClass(), ['transport']);
+            yield new MessageContext('default', 'id', $this->createStub(TriggerInterface::class), new \DateTimeImmutable()) => new RedispatchMessage(new \stdClass(), ['transport']);
         });
         $envelopes = iterator_to_array((new SchedulerTransport($generator))->get());
 
@@ -66,7 +66,7 @@ class SchedulerTransportTest extends TestCase
 
     public function testAckIgnored()
     {
-        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
+        $transport = new SchedulerTransport($this->createStub(MessageGeneratorInterface::class));
 
         $this->expectNotToPerformAssertions();
         $transport->ack(new Envelope(new \stdClass()));
@@ -74,7 +74,7 @@ class SchedulerTransportTest extends TestCase
 
     public function testRejectException()
     {
-        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
+        $transport = new SchedulerTransport($this->createStub(MessageGeneratorInterface::class));
 
         $this->expectNotToPerformAssertions();
         $transport->reject(new Envelope(new \stdClass()));
@@ -82,7 +82,7 @@ class SchedulerTransportTest extends TestCase
 
     public function testSendException()
     {
-        $transport = new SchedulerTransport($this->createMock(MessageGeneratorInterface::class));
+        $transport = new SchedulerTransport($this->createStub(MessageGeneratorInterface::class));
 
         $this->expectException(LogicException::class);
         $transport->send(new Envelope(new \stdClass()));

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/AbstractDecoratedTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/AbstractDecoratedTriggerTest.php
@@ -20,7 +20,7 @@ class AbstractDecoratedTriggerTest extends TestCase
 {
     public function testCanGetInnerTrigger()
     {
-        $trigger = new JitterTrigger($inner = $this->createMock(TriggerInterface::class));
+        $trigger = new JitterTrigger($inner = $this->createStub(TriggerInterface::class));
 
         $this->assertSame($inner, $trigger->inner());
         $this->assertSame([$trigger], iterator_to_array($trigger->decorators()));
@@ -29,7 +29,7 @@ class AbstractDecoratedTriggerTest extends TestCase
     public function testCanGetNestedInnerTrigger()
     {
         $trigger = new ExcludeTimeTrigger(
-            $jitter = new JitterTrigger($inner = $this->createMock(TriggerInterface::class)),
+            $jitter = new JitterTrigger($inner = $this->createStub(TriggerInterface::class)),
             new \DateTimeImmutable(),
             new \DateTimeImmutable(),
         );

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackMessageProviderTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackMessageProviderTest.php
@@ -20,7 +20,7 @@ class CallbackMessageProviderTest extends TestCase
 {
     public function testToString()
     {
-        $context = new MessageContext('test', 'test', $this->createMock(TriggerInterface::class), $this->createMock(\DateTimeImmutable::class));
+        $context = new MessageContext('test', 'test', $this->createStub(TriggerInterface::class), $this->createStub(\DateTimeImmutable::class));
         $messageProvider = new CallbackMessageProvider(fn () => []);
         $this->assertEquals([], $messageProvider->getMessages($context));
         $this->assertEquals('', $messageProvider->getId());

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/ExcludeTimeTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/ExcludeTimeTriggerTest.php
@@ -19,7 +19,7 @@ class ExcludeTimeTriggerTest extends TestCase
 {
     public function testGetNextRun()
     {
-        $inner = $this->createMock(TriggerInterface::class);
+        $inner = $this->createStub(TriggerInterface::class);
         $inner
             ->method('getNextRunDate')
             ->willReturnCallback(static fn (\DateTimeImmutable $d) => $d->modify('+1 sec'));

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
@@ -20,7 +20,7 @@ class JitterTriggerTest extends TestCase
     public function testCanAddJitter()
     {
         $time = new \DateTimeImmutable();
-        $inner = $this->createMock(TriggerInterface::class);
+        $inner = $this->createStub(TriggerInterface::class);
         $inner->method('getNextRunDate')->willReturn($time);
 
         $trigger = new JitterTrigger($inner);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 for features / 6.4, 7.3, 7.4, 8.0 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
