### PR TITLE
[Uid] Add argument `$format` to `Ulid::isValid()`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -23,3 +23,8 @@ FrameworkBundle
 ---------------
 
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
+
+Uid
+---
+
+ * Add argument `$format` to `Ulid::isValid()`

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add argument `$format` to `Ulid::isValid()`
+
 8.0
 ---
 

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -107,7 +107,52 @@ class UlidTest extends TestCase
     {
         $this->assertFalse(Ulid::isValid('not a ulid'));
         $this->assertTrue(Ulid::isValid('00000000000000000000000000'));
+        $this->assertTrue(Ulid::isValid('1BVXue8CnY8ogucrHX3TeF', Ulid::FORMAT_BASE_58));
+        $this->assertFalse(Ulid::isValid('1BVXue8CnY8ogucrHX3TeF', Ulid::FORMAT_BASE_32));
+        $this->assertTrue(Ulid::isValid('0177058f-4dac-d0b2-a990-a49af02bc008', Ulid::FORMAT_RFC_4122));
+        $this->assertFalse(Ulid::isValid('0177058f-4dac-d0b2-a990-a49af02bc008', Ulid::FORMAT_BASE_32));
+        $this->assertTrue(Ulid::isValid("\x01\x77\x05\x8F\x4D\xAC\xD0\xB2\xA9\x90\xA4\x9A\xF0\x2B\xC0\x08", Ulid::FORMAT_BINARY));
+        $this->assertTrue(Ulid::isValid(new Ulid()->toString()));
+        $this->assertTrue(Ulid::isValid(new Ulid()->toRfc4122(), Ulid::FORMAT_RFC_4122));
     }
+
+    public function testIsValidWithVariousFormat()
+    {
+        $ulid = new Ulid();
+
+        $this->assertTrue(Ulid::isValid($ulid->toBase32(), Ulid::FORMAT_BASE_32));
+        $this->assertFalse(Ulid::isValid($ulid->toBase58(), Ulid::FORMAT_BASE_32));
+        $this->assertFalse(Ulid::isValid($ulid->toBinary(), Ulid::FORMAT_BASE_32));
+        $this->assertFalse(Ulid::isValid($ulid->toRfc4122(), Ulid::FORMAT_BASE_32));
+
+        $this->assertFalse(Ulid::isValid($ulid->toBase32(), Ulid::FORMAT_BASE_58));
+        $this->assertTrue(Ulid::isValid($ulid->toBase58(), Ulid::FORMAT_BASE_58));
+        $this->assertFalse(Ulid::isValid($ulid->toBinary(), Ulid::FORMAT_BASE_58));
+        $this->assertFalse(Ulid::isValid($ulid->toRfc4122(), Ulid::FORMAT_BASE_58));
+
+        $this->assertFalse(Ulid::isValid($ulid->toBase32(), Ulid::FORMAT_BINARY));
+        $this->assertFalse(Ulid::isValid($ulid->toBase58(), Ulid::FORMAT_BINARY));
+        $this->assertTrue(Ulid::isValid($ulid->toBinary(), Ulid::FORMAT_BINARY));
+        $this->assertFalse(Ulid::isValid($ulid->toRfc4122(), Ulid::FORMAT_BINARY));
+
+        $this->assertFalse(Ulid::isValid($ulid->toBase32(), Ulid::FORMAT_RFC_4122));
+        $this->assertFalse(Ulid::isValid($ulid->toBase58(), Ulid::FORMAT_RFC_4122));
+        $this->assertFalse(Ulid::isValid($ulid->toBinary(), Ulid::FORMAT_RFC_4122));
+        $this->assertTrue(Ulid::isValid($ulid->toRfc4122(), Ulid::FORMAT_RFC_4122));
+
+        $this->assertFalse(Ulid::isValid($ulid->toBase32(), Ulid::FORMAT_RFC_9562));
+        $this->assertFalse(Ulid::isValid($ulid->toBase58(), Ulid::FORMAT_RFC_9562));
+        $this->assertFalse(Ulid::isValid($ulid->toBinary(), Ulid::FORMAT_RFC_9562));
+        $this->assertTrue(Ulid::isValid($ulid->toRfc4122(), Ulid::FORMAT_RFC_9562));
+
+        $this->assertTrue(Ulid::isValid($ulid->toBase32(), Ulid::FORMAT_ALL));
+        $this->assertTrue(Ulid::isValid($ulid->toBase58(), Ulid::FORMAT_ALL));
+        $this->assertTrue(Ulid::isValid($ulid->toBinary(), Ulid::FORMAT_ALL));
+        $this->assertTrue(Ulid::isValid($ulid->toRfc4122(), Ulid::FORMAT_ALL));
+
+        $this->assertFalse(Ulid::isValid('30J7CNpDMfXPZrCsn4Cgey', Ulid::FORMAT_BASE_58), 'Fake base-58 string with the "O" forbidden char is not valid');
+    }
+
 
     public function testEquals()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61589
| License       | MIT

This extends `Ulid::isValid()` with multiple formats, as `Uuid::isValid()` does. The default format is `Ulid::FORMAT_BASE_32` since this is the one generated and returned in `AbstractUid::toString()`.

So while this still does not work (as in the current implementation):
```php
$ulid = new Ulid();
$string = $ulid->toRfc4122();
Ulid::isValid($string); // returns false since the wrong format is tested
```
this now does:
```php
$ulid = new Ulid();
$string = $ulid->toRfc4122();
Ulid::isValid($string, Ulid::FORMAT_RFC_4122); // returns true
```