### PR TITLE
[ObjectMapper] Add `targetClass` on `MapCollection` transform

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add reverse class-map based on Map attribute
  * Merge nested properties when targeting the same class
+ * Add a `targetClass` option to `MapCollection`
+ * Add a `TransformObjectMapperAwareInterface` to inject the current object mapper instance to transformers
 
 7.4
 ---

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -356,6 +356,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         foreach ($transforms as $transform) {
             $fn = $this->getCallable($transform, $this->transformCallableLocator, TransformCallableInterface::class);
+            if ($fn instanceof ObjectMapperAwareInterface) {
+                $fn = $fn->withObjectMapper($this->objectMapper ?? $this);
+            }
             $value = $this->call($fn, $value, $source, $target);
         }
 

--- a/src/Symfony/Component/ObjectMapper/ObjectMapperAwareInterface.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapperAwareInterface.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\ObjectMapper;
 interface ObjectMapperAwareInterface
 {
     /**
-     * Sets the owning ObjectMapper object.
+     * Returns a clone of the original instance, configured with the given object mapper.
      */
     public function withObjectMapper(ObjectMapperInterface $objectMapper): static;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/LineItemSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/LineItemSource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: LineItemTarget::class)]
+class LineItemSource
+{
+    public function __construct(
+        public string $productName = '',
+        public int $quantity = 0,
+        #[Map(target: 'amount')]
+        public float $price = 0.0,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/LineItemTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/LineItemTarget.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping;
+
+class LineItemTarget
+{
+    public function __construct(
+        public string $productName = '',
+        public int $quantity = 0,
+        public float $amount = 0.0,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/OrderSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/OrderSource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
+
+#[Map(target: OrderTarget::class)]
+class OrderSource
+{
+    #[Map(transform: new MapCollection(targetClass: LineItemTarget::class))]
+    public array $items = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/OrderTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedCollectionMapping/OrderTarget.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping;
+
+class OrderTarget
+{
+    public array $items = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -72,6 +72,10 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as Mu
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping\LineItemSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping\LineItemTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping\OrderSource as NestedCollectionOrderSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping\OrderTarget as NestedCollectionOrderTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping\NestedBankDataDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping\NestedBankDataResource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping\NestedBankDto;
@@ -594,6 +598,29 @@ final class ObjectMapperTest extends TestCase
         $transformed = $mapper->map($u, TransformCollectionB::class);
 
         $this->assertEquals([new TransformCollectionD('a'), new TransformCollectionD('b')], $transformed->foo);
+    }
+
+    public function testMapCollectionWithTargetClass()
+    {
+        $source = new NestedCollectionOrderSource();
+        $source->items = [
+            new LineItemSource('Product A', 2, 19.99),
+            new LineItemSource('Product B', 1, 49.99),
+        ];
+
+        $mapper = new ObjectMapper();
+        $target = $mapper->map($source);
+
+        $this->assertInstanceOf(NestedCollectionOrderTarget::class, $target);
+        $this->assertCount(2, $target->items);
+        $this->assertInstanceOf(LineItemTarget::class, $target->items[0]);
+        $this->assertInstanceOf(LineItemTarget::class, $target->items[1]);
+        $this->assertSame('Product A', $target->items[0]->productName);
+        $this->assertSame(2, $target->items[0]->quantity);
+        $this->assertSame(19.99, $target->items[0]->amount);
+        $this->assertSame('Product B', $target->items[1]->productName);
+        $this->assertSame(1, $target->items[1]->quantity);
+        $this->assertSame(49.99, $target->items[1]->amount);
     }
 
     public function testEmbedsAreLazyLoadedByDefault()

--- a/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\ObjectMapper\Transform;
 
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\ObjectMapperAwareInterface;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\TransformCallableInterface;
 
@@ -21,11 +22,20 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
  *
  * @implements TransformCallableInterface<object, T>
  */
-class MapCollection implements TransformCallableInterface
+class MapCollection implements TransformCallableInterface, ObjectMapperAwareInterface
 {
     public function __construct(
-        private ObjectMapperInterface $objectMapper = new ObjectMapper(),
+        private ?ObjectMapperInterface $objectMapper = null,
+        public readonly ?string $targetClass = null,
     ) {
+    }
+
+    public function withObjectMapper(ObjectMapperInterface $objectMapper): static
+    {
+        $clone = clone $this;
+        $clone->objectMapper = $objectMapper;
+
+        return $clone;
     }
 
     public function __invoke(mixed $value, object $source, ?object $target): mixed
@@ -34,9 +44,10 @@ class MapCollection implements TransformCallableInterface
             throw new MappingException(\sprintf('The MapCollection transform expects an iterable, "%s" given.', get_debug_type($value)));
         }
 
+        $objectMapper = $this->objectMapper ??= new ObjectMapper();
         $values = [];
         foreach ($value as $k => $v) {
-            $values[$k] = $this->objectMapper->map($v);
+            $values[$k] = $objectMapper->map($v, $this->targetClass);
         }
 
         return $values;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61957
| License       | MIT

Fixes #61957 (also reimplementing #62254) 

Needs a doc PR

This allows to change the target class of a mapped collection without having to add a `Map` attribute on the collection's class: 

```php
#[Map(target: OrderTarget::class)]
class OrderSource
{
    #[Map(transform: new MapCollection(targetClass: LineItemTarget::class))]
    public array $items = [];
}
```