### PR TITLE
[ObjectMapper] error when multiple targets and no condition

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -60,7 +60,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     private function doMap(object $source, object|string|null $target, \WeakMap $objectMap, bool $rootCall): object
     {
         $metadata = $this->metadataFactory->create($source);
-        $map = $this->getMapTarget($metadata, null, $source, null);
+        $map = $this->getMapTarget($metadata, null, $source, null, null === $target);
         $target ??= $map?->target;
         $mappingToObject = \is_object($target);
 
@@ -82,7 +82,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         if (!$metadata && $targetMetadata = $this->metadataFactory->create($mappedTarget)) {
             $metadata = $targetMetadata;
-            $map = $this->getMapTarget($metadata, null, $source, null);
+            $map = $this->getMapTarget($metadata, null, $source, null, false);
         }
 
         if ($map && $map->transform) {
@@ -243,7 +243,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         if (
             \is_object($value)
             && ($innerMetadata = $this->metadataFactory->create($value))
-            && ($mapTo = $this->getMapTarget($innerMetadata, $value, $source, $target))
+            && ($mapTo = $this->getMapTarget($innerMetadata, $value, $source, $target, true))
             && (\is_string($mapTo->target) && class_exists($mapTo->target))
         ) {
             $value = $this->applyTransforms($mapTo, $value, $source, $target);
@@ -313,12 +313,16 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     /**
      * @param Mapping[] $metadata
      */
-    private function getMapTarget(array $metadata, mixed $value, object $source, ?object $target): ?Mapping
+    private function getMapTarget(array $metadata, mixed $value, object $source, ?object $target, bool $enforceUnique = false): ?Mapping
     {
         $mapTo = null;
         foreach ($metadata as $mapAttribute) {
             if (($if = $mapAttribute->if) && ($fn = $this->getCallable($if, $this->conditionCallableLocator)) && !$this->call($fn, $value, $source, $target)) {
                 continue;
+            }
+
+            if ($enforceUnique && null !== $mapTo) {
+                throw new MappingException(\sprintf('Ambiguous mapping for "%s". Multiple #[Map] attributes match. Use the "if" parameter to specify conditions.', get_debug_type($value ?? $source)));
             }
 
             $mapTo = $mapAttribute;

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedSourceA.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedSourceA.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: NestedSourceB::class)]
+class NestedSourceA
+{
+    public function __construct(
+        public string $foo,
+        public string $bar,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedSourceB.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedSourceB.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping;
+
+class NestedSourceB
+{
+    public function __construct(
+        public string $foo,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/Source.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping;
+
+class Source
+{
+    public function __construct(
+        public NestedSourceA $item,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/TargetUnion.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/TargetUnion.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMapping;
+
+class TargetUnion
+{
+    public function __construct(
+        public NestedSourceA|NestedSourceB $item,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -675,4 +675,14 @@ final class ObjectMapperTest extends TestCase
             'Property without default value should remain uninitialized'
         );
     }
+
+    public function testMultipleTargetsWithoutConditionThrowsExceptionWhenNoTargetProvided()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Ambiguous mapping');
+
+        $source = new MultipleTargetPropertyA();
+        $mapper = new ObjectMapper();
+        $mapper->map($source);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62593
| License       | MIT

Improves the developer experience by throwing an exception when multiple targets 