### PR TITLE
[Serializer] the component does not work with PropertyInfo < 7.3

### DIFF
--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -46,7 +46,8 @@
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.2.2",
-        "phpdocumentor/type-resolver": "<1.4.0"
+        "phpdocumentor/type-resolver": "<1.4.0",
+        "symfony/property-info": "<7.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Serializer\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT