### PR TITLE
[HttpKernel] Fix tests not cleaning the temporary var/ folder

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -93,4 +93,9 @@ class KernelForTest extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
     }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__.'/../Fixtures';
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -618,6 +618,11 @@ class KernelTest extends TestCase
             public function registerContainerConfiguration(LoaderInterface $loader): void
             {
             }
+
+            public function getProjectDir(): string
+            {
+                return __DIR__.'/Fixtures';
+            }
         };
 
         $kernel->boot();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
