### PR TITLE
[HttpKernel] Dispatch events named after controller attributes

### DIFF
--- a/src/Symfony/Bridge/Twig/EventListener/TemplateAttributeListener.php
+++ b/src/Symfony/Bridge/Twig/EventListener/TemplateAttributeListener.php
@@ -18,7 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsMetadata;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Twig\Environment;
 
@@ -29,6 +31,22 @@ class TemplateAttributeListener implements EventSubscriberInterface
     ) {
     }
 
+    public function onKernelControllerAttribute(ControllerAttributeEvent $event): void
+    {
+        if (!$event->kernelEvent instanceof ViewEvent) {
+            return;
+        }
+
+        if (!$event->kernelEvent->getRequest()->attributes->has('_template')) {
+            $event->kernelEvent->getRequest()->attributes->set('_template', $event->attribute);
+        }
+
+        $this->onKernelView($event->kernelEvent);
+    }
+
+    /**
+     * @internal since Symfony 8.1, use onKernelControllerAttribute() instead
+     */
     public function onKernelView(ViewEvent $event): void
     {
         $parameters = $event->getControllerResult();
@@ -71,8 +89,14 @@ class TemplateAttributeListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
+        if (!class_exists(ControllerAttributesListener::class, false)) {
+            return [
+                KernelEvents::VIEW => ['onKernelView', -128],
+            ];
+        }
+
         return [
-            KernelEvents::VIEW => ['onKernelView', -128],
+            KernelEvents::VIEW.'.'.Template::class => 'onKernelControllerAttribute',
         ];
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -104,6 +104,7 @@ use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\JsonStreamer\Attribute\JsonStreamable;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
@@ -256,6 +257,10 @@ class FrameworkExtension extends Extension
         $loader->load('services.php');
         $loader->load('fragment_renderer.php');
         $loader->load('error_renderer.php');
+
+        if (!class_exists(ControllerAttributesListener::class)) {
+            $container->removeDefinition('kernel.controller_attributes_listener');
+        }
 
         if (!ContainerBuilder::willBeAvailable('symfony/clock', ClockInterface::class, ['symfony/framework-bundle'])) {
             $container->removeDefinition('clock');

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -52,6 +52,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\DependencyInjection\ControllerArgumentValueResolverPass;
+use Symfony\Component\HttpKernel\DependencyInjection\ControllerAttributesListenerPass;
 use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
 use Symfony\Component\HttpKernel\DependencyInjection\RegisterControllerArgumentLocatorsPass;
@@ -167,6 +168,7 @@ class FrameworkBundle extends Bundle
         // must be registered before removing private services as some might be listeners/subscribers
         // but as late as possible to get resolved parameters
         $container->addCompilerPass($registerListenersPass, PassConfig::TYPE_BEFORE_REMOVING);
+        $this->addCompilerPassIfExists($container, ControllerAttributesListenerPass::class, PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
         $this->addCompilerPassIfExists($container, AttributeMetadataPass::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolv
 use Symfony\Component\HttpKernel\Controller\ErrorController;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
 use Symfony\Component\HttpKernel\EventListener\CacheAttributeListener;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
 use Symfony\Component\HttpKernel\EventListener\DisallowRobotsIndexingListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
@@ -146,6 +147,12 @@ return static function (ContainerConfigurator $container) {
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'request'])
+
+        ->set('kernel.controller_attributes_listener', ControllerAttributesListener::class)
+            ->args([
+                abstract_arg('attributes with listeners by event'),
+            ])
+            ->tag('kernel.event_subscriber')
 
         ->set('controller.cache_attribute_listener', CacheAttributeListener::class)
             ->tag('kernel.event_subscriber')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CacheAttributeListenerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CacheAttributeListenerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class CacheAttributeListenerTest extends AbstractWebTestCase
 {
-    public function testAnonimousUserWithEtag()
+    public function testAnonymousUserWithEtag()
     {
         $client = self::createClient(['test_case' => 'CacheAttributeListener']);
 
@@ -30,7 +30,7 @@ class CacheAttributeListenerTest extends AbstractWebTestCase
         self::assertTrue($client->getResponse()->isRedirect('http://localhost/login'));
     }
 
-    public function testAnonimousUserWithoutEtag()
+    public function testAnonymousUserWithoutEtag()
     {
         $client = self::createClient(['test_case' => 'CacheAttributeListener']);
 

--- a/src/Symfony/Component/HttpKernel/Attribute/Cache.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/Cache.php
@@ -26,6 +26,11 @@ use Symfony\Component\HttpFoundation\Request;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::IS_REPEATABLE)]
 final class Cache
 {
+    /**
+     * @internal
+     */
+    public public(set) readonly array $variables;
+
     public function __construct(
         /**
          * The expiration date as a valid date for the strtotime() function.

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `ControllerAttributeEvent` et al. to dispatch events named after controller attributes
  * Add support for `UploadedFile` when using `MapRequestPayload`
  * Add support for bundles as compiler pass
  * Add support for `SOURCE_DATE_EPOCH` environment variable

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerAttributesListenerPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerAttributesListenerPass.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Collects attribute listeners and registers them for ControllerAttributesListener.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ControllerAttributesListenerPass implements CompilerPassInterface
+{
+    private const ATTRIBUTE_EVENTS = [
+        KernelEvents::CONTROLLER,
+        KernelEvents::CONTROLLER_ARGUMENTS,
+        KernelEvents::VIEW,
+        KernelEvents::RESPONSE,
+        KernelEvents::EXCEPTION,
+        KernelEvents::FINISH_REQUEST,
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('event_dispatcher') || !$container->hasDefinition('kernel.controller_attributes_listener')) {
+            return;
+        }
+
+        $dispatcherDefinition = $container->findDefinition('event_dispatcher');
+        $attributesWithListeners = [];
+
+        foreach ($dispatcherDefinition->getMethodCalls() as [$method, $arguments]) {
+            if ('addListener' !== $method || !\is_string($eventName = $arguments[0] ?? null)) {
+                continue;
+            }
+
+            foreach (self::ATTRIBUTE_EVENTS as $kernelEvent) {
+                if ('.' === ($eventName[\strlen($kernelEvent)] ?? null) && str_starts_with($eventName, $kernelEvent)) {
+                    $attributesWithListeners[$kernelEvent][substr($eventName, \strlen($kernelEvent) + 1)] = true;
+                    break;
+                }
+            }
+        }
+
+        $container->getDefinition('kernel.controller_attributes_listener')->replaceArgument(0, $attributesWithListeners);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Event/ControllerAttributeEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerAttributeEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+
+/**
+ * Event dispatched for each controller attribute.
+ *
+ * @template T of object
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class ControllerAttributeEvent implements StoppableEventInterface
+{
+    private string|array|object|null $controller;
+
+    /**
+     * @param T $attribute
+     */
+    public function __construct(
+        /** @var T */
+        public readonly object $attribute,
+        public readonly KernelEvent $kernelEvent,
+    ) {
+        $this->controller = match (true) {
+            $kernelEvent instanceof ControllerEvent => $kernelEvent->getController(),
+            $kernelEvent instanceof ControllerArgumentsEvent => $kernelEvent->getController(),
+            default => null,
+        };
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        if ($this->kernelEvent->isPropagationStopped()) {
+            return true;
+        }
+
+        if (!$this->controller) {
+            return false;
+        }
+
+        $controller = match (true) {
+            $this->kernelEvent instanceof ControllerEvent => $this->kernelEvent->getController(),
+            $this->kernelEvent instanceof ControllerArgumentsEvent => $this->kernelEvent->getController(),
+        };
+
+        return $controller instanceof \Closure ? $controller != $this->controller : $controller !== $this->controller;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -34,8 +35,37 @@ class CacheAttributeListener implements EventSubscriberInterface
     ) {
     }
 
+    public function onKernelControllerAttribute(ControllerAttributeEvent $event): void
+    {
+        $cache = $event->attribute;
+        $kernelEvent = $event->kernelEvent;
+        $request = $event->kernelEvent->getRequest();
+
+        if ($kernelEvent instanceof ControllerArgumentsEvent) {
+            if (null !== $variables = $this->getVariables($cache, $request, $kernelEvent)) {
+                $cache->variables = $variables;
+            }
+            $this->processAttributeBeforeController($cache, $request, $kernelEvent);
+
+            return;
+        }
+
+        if ($kernelEvent instanceof ResponseEvent) {
+            $response = $kernelEvent->getResponse();
+
+            // http://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional-12#section-3.1
+            if (!\in_array($response->getStatusCode(), [200, 203, 300, 301, 302, 304, 404, 410], true)) {
+                return;
+            }
+
+            $this->processAttributeAfterController($cache, $request, $response);
+
+            return;
+        }
+    }
+
     /**
-     * Handles HTTP validation headers.
+     * @internal since Symfony 8.1, use onKernelControllerAttribute() instead
      */
     public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
     {
@@ -48,43 +78,17 @@ class CacheAttributeListener implements EventSubscriberInterface
 
         $request->attributes->set('_cache', $attributes);
         $variables = null;
-        $response = null;
 
         foreach ($attributes as $cache) {
-            if (!\is_bool($cache->if)) {
-                if (!\is_bool($if = $this->evaluate($cache->if, $variables ??= $this->getVariables($request, $event)))) {
-                    throw new \TypeError(\sprintf('The value of the "$if" option of the "%s" attribute must evaluate to a boolean, "%s" given.', Cache::class, get_debug_type($if)));
-                }
-
-                $cache->if = $if;
+            if (null !== $variables ??= $this->getVariables($cache, $request, $event)) {
+                $cache->variables = $variables;
             }
-            if (!$cache->if) {
-                continue;
-            }
-
-            if (null !== $cache->lastModified && !$cache->lastModified instanceof \DateTimeInterface) {
-                $lastModified = $this->evaluate($cache->lastModified, $variables ??= $this->getVariables($request, $event));
-                ($response ??= new Response())->setLastModified($lastModified);
-                $cache->lastModified = $lastModified;
-            }
-
-            if (null !== $cache->etag) {
-                $etag = hash('sha256', $this->evaluate($cache->etag, $variables ??= $this->getVariables($request, $event)));
-                ($response ??= new Response())->setEtag($etag);
-                $cache->etag = $etag;
-            }
-        }
-
-        if ($response?->isNotModified($request)) {
-            $event->setController(static fn () => $response);
-            $event->stopPropagation();
-
-            return;
+            $this->processAttributeBeforeController($cache, $request, $event);
         }
     }
 
     /**
-     * Modifies the response to apply HTTP cache headers when needed.
+     * @internal since Symfony 8.1, use onKernelControllerAttribute() instead
      */
     public function onKernelResponse(ResponseEvent $event): void
     {
@@ -101,11 +105,78 @@ class CacheAttributeListener implements EventSubscriberInterface
             return;
         }
 
+        $hasVary = null;
+        $hasCacheControlDirective = null;
+
+        for ($i = \count($attributes) - 1; 0 <= $i; --$i) {
+            $this->processAttributeAfterController($attributes[$i], $request, $response, $hasVary, $hasCacheControlDirective);
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        if (!class_exists(ControllerAttributesListener::class, false)) {
+            return [
+                KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 10],
+                KernelEvents::RESPONSE => ['onKernelResponse', -10],
+            ];
+        }
+
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.Cache::class => 'onKernelControllerAttribute',
+            KernelEvents::RESPONSE.'.'.Cache::class => 'onKernelControllerAttribute',
+        ];
+    }
+
+    public function reset(): void
+    {
+    }
+
+    private function processAttributeBeforeController(Cache $cache, Request $request, ControllerArgumentsEvent $event): void
+    {
+        if (!\is_bool($cache->if)) {
+            if (!\is_bool($if = $this->evaluate($cache->if, $cache->variables))) {
+                throw new \TypeError(\sprintf('The value of the "$if" option of the "%s" attribute must evaluate to a boolean, "%s" given.', Cache::class, get_debug_type($if)));
+            }
+
+            $cache->if = $if;
+        }
+
+        if (!$cache->if) {
+            return;
+        }
+
+        $response = null;
+
+        if (null !== $cache->lastModified && !$cache->lastModified instanceof \DateTimeInterface) {
+            $lastModified = $this->evaluate($cache->lastModified, $cache->variables);
+            ($response ??= new Response())->setLastModified($lastModified);
+            $cache->lastModified = $lastModified;
+        }
+
+        if (null !== $cache->etag) {
+            $etag = hash('sha256', $this->evaluate($cache->etag, $cache->variables));
+            ($response ??= new Response())->setEtag($etag);
+            $cache->etag = $etag;
+        }
+
+        if ($response?->isNotModified($request)) {
+            $event->setController(static fn () => $response);
+            $event->stopPropagation();
+        }
+    }
+
+    private function processAttributeAfterController(Cache $cache, Request $request, Response $response, ?bool &$hasVary = null, ?callable &$hasCacheControlDirective = null): void
+    {
+        if (!$cache->if) {
+            return;
+        }
+
         // Check if the response has a Vary header that should be considered, ignoring cases where
         // it's only 'Accept-Language' and the request has the '_vary_by_language' attribute
-        $hasVary = ['Accept-Language'] === $response->getVary() ? !$request->attributes->get('_vary_by_language') : $response->hasVary();
+        $hasVary ??= ['Accept-Language'] === $response->getVary() ? !$request->attributes->get('_vary_by_language') : $response->hasVary();
         // Check if cache-control directive was set manually in cacheControl (not auto computed)
-        $hasCacheControlDirective = new class($response->headers) extends HeaderBag {
+        $hasCacheControlDirective ??= new class($response->headers) extends HeaderBag {
             public function __construct(private parent $headerBag)
             {
             }
@@ -115,96 +186,72 @@ class CacheAttributeListener implements EventSubscriberInterface
                 return \array_key_exists($key, $this->headerBag->cacheControl);
             }
         };
-        $hasPublicOrPrivateCacheControlDirective = $hasCacheControlDirective('public') || $hasCacheControlDirective('private');
 
-        for ($i = \count($attributes) - 1; 0 <= $i; --$i) {
-            $cache = $attributes[$i];
+        if (null !== $cache->lastModified && !$response->headers->has('Last-Modified')) {
+            $response->setLastModified($cache->lastModified);
+        }
 
-            if (!$cache->if) {
-                continue;
-            }
+        if (null !== $cache->etag && !$response->headers->has('ETag')) {
+            $response->setEtag($cache->etag);
+        }
 
-            if (null !== $cache->lastModified && !$response->headers->has('Last-Modified')) {
-                $response->setLastModified($cache->lastModified);
-            }
+        if (null !== $cache->smaxage && !$hasCacheControlDirective('s-maxage')) {
+            $response->setSharedMaxAge($this->toSeconds($cache->smaxage));
+        }
 
-            if (null !== $cache->etag && !$response->headers->has('ETag')) {
-                $response->setEtag($cache->etag);
-            }
+        if ($cache->mustRevalidate) {
+            $response->headers->addCacheControlDirective('must-revalidate');
+        }
 
-            if (null !== $cache->smaxage && !$hasCacheControlDirective('s-maxage')) {
-                $response->setSharedMaxAge($this->toSeconds($cache->smaxage));
-            }
+        if (null !== $cache->maxage && !$hasCacheControlDirective('max-age')) {
+            $response->setMaxAge($this->toSeconds($cache->maxage));
+        }
 
-            if ($cache->mustRevalidate) {
-                $response->headers->addCacheControlDirective('must-revalidate');
-            }
+        if (null !== $cache->maxStale && !$hasCacheControlDirective('max-stale')) {
+            $response->headers->addCacheControlDirective('max-stale', $this->toSeconds($cache->maxStale));
+        }
 
-            if (null !== $cache->maxage && !$hasCacheControlDirective('max-age')) {
-                $response->setMaxAge($this->toSeconds($cache->maxage));
-            }
+        if (null !== $cache->staleWhileRevalidate && !$hasCacheControlDirective('stale-while-revalidate')) {
+            $response->headers->addCacheControlDirective('stale-while-revalidate', $this->toSeconds($cache->staleWhileRevalidate));
+        }
 
-            if (null !== $cache->maxStale && !$hasCacheControlDirective('max-stale')) {
-                $response->headers->addCacheControlDirective('max-stale', $this->toSeconds($cache->maxStale));
-            }
+        if (null !== $cache->staleIfError && !$hasCacheControlDirective('stale-if-error')) {
+            $response->headers->addCacheControlDirective('stale-if-error', $this->toSeconds($cache->staleIfError));
+        }
 
-            if (null !== $cache->staleWhileRevalidate && !$hasCacheControlDirective('stale-while-revalidate')) {
-                $response->headers->addCacheControlDirective('stale-while-revalidate', $this->toSeconds($cache->staleWhileRevalidate));
-            }
+        if (null !== $cache->expires && !$response->headers->has('Expires')) {
+            $response->setExpires(new \DateTimeImmutable('@'.strtotime($cache->expires, time())));
+        }
 
-            if (null !== $cache->staleIfError && !$hasCacheControlDirective('stale-if-error')) {
-                $response->headers->addCacheControlDirective('stale-if-error', $this->toSeconds($cache->staleIfError));
-            }
+        if (!$hasVary && $cache->vary) {
+            $response->setVary($cache->vary, false);
+        }
 
-            if (null !== $cache->expires && !$response->headers->has('Expires')) {
-                $response->setExpires(new \DateTimeImmutable('@'.strtotime($cache->expires, time())));
-            }
+        $hasPublicOrPrivateCacheControlDirective = \is_bool($cache->public) && ($hasCacheControlDirective('public') || $hasCacheControlDirective('private'));
 
-            if (!$hasVary && $cache->vary) {
-                $response->setVary($cache->vary, false);
-            }
+        if (true === $cache->public && !$hasPublicOrPrivateCacheControlDirective) {
+            $response->setPublic();
+        }
 
-            if (true === $cache->public && !$hasPublicOrPrivateCacheControlDirective) {
-                $response->setPublic();
-            }
+        if (false === $cache->public && !$hasPublicOrPrivateCacheControlDirective) {
+            $response->setPrivate();
+        }
 
-            if (false === $cache->public && !$hasPublicOrPrivateCacheControlDirective) {
-                $response->setPrivate();
-            }
+        if (true === $cache->noStore) {
+            $response->headers->addCacheControlDirective('no-store');
+        }
 
-            if (true === $cache->noStore) {
-                $response->headers->addCacheControlDirective('no-store');
-            }
-
-            if (false === $cache->noStore) {
-                $response->headers->removeCacheControlDirective('no-store');
-            }
+        if (false === $cache->noStore) {
+            $response->headers->removeCacheControlDirective('no-store');
         }
     }
 
-    public static function getSubscribedEvents(): array
+    private function getVariables(Cache $cache, Request $request, ControllerArgumentsEvent $event): ?array
     {
-        return [
-            KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 10],
-            KernelEvents::RESPONSE => ['onKernelResponse', -10],
-        ];
-    }
-
-    public function reset(): void
-    {
-    }
-
-    private function evaluate(string|Expression|\Closure $closureOrExpression, array $variables): mixed
-    {
-        if ($closureOrExpression instanceof \Closure) {
-            return $closureOrExpression($variables['args'], $variables['request'], $variables['this']);
+        if (\is_bool($cache->if) && null === $cache->lastModified && null === $cache->etag) {
+            return null;
         }
 
-        return $this->getExpressionLanguage()->evaluate($closureOrExpression, $variables);
-    }
-
-    private function getVariables(Request $request, ControllerArgumentsEvent $event): array
-    {
         $controller = $event->getController();
         $controller = match (true) {
             \is_object($controller) && !$controller instanceof \Closure => $controller,
@@ -217,6 +264,15 @@ class CacheAttributeListener implements EventSubscriberInterface
             'args' => $arguments = $event->getNamedArguments(),
             'this' => $controller,
         ], $request->attributes->all(), $arguments);
+    }
+
+    private function evaluate(string|Expression|\Closure $closureOrExpression, array $variables): mixed
+    {
+        if ($closureOrExpression instanceof \Closure) {
+            return $closureOrExpression($variables['args'], $variables['request'], $variables['this']);
+        }
+
+        return $this->getExpressionLanguage()->evaluate($closureOrExpression, $variables);
     }
 
     private function getExpressionLanguage(): ExpressionLanguage

--- a/src/Symfony/Component/HttpKernel/EventListener/ControllerAttributesListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ControllerAttributesListener.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(ControllerAttributeEvent::class);
+
+/**
+ * Dispatches events for controller attributes.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ControllerAttributesListener implements EventSubscriberInterface
+{
+    /**
+     * @param array<string, array<class-string, true>> $attributesWithListenersByEvent
+     */
+    public function __construct(
+        private readonly array $attributesWithListenersByEvent,
+    ) {
+    }
+
+    private static array $attributeHierarchyCache = [];
+
+    public function beforeController(ControllerEvent|ControllerArgumentsEvent $event, string $eventName, EventDispatcherInterface $dispatcher): void
+    {
+        $controller = $event->getController();
+
+        dispatch_attributes:
+        foreach ($event->getAttributes('*') as $attribute) {
+            if (!$attributeEventNames = $this->getAttributeEventNames($attribute, $eventName)) {
+                continue;
+            }
+
+            foreach ($attributeEventNames as $attributeEventName) {
+                $dispatcher->dispatch(new ControllerAttributeEvent($attribute, $event), $attributeEventName);
+
+                if ($event->isPropagationStopped()) {
+                    return;
+                }
+            }
+
+            $c = $event->getController();
+            if ($c instanceof \Closure ? $c != $controller : $c !== $controller) {
+                $controller = $c;
+                goto dispatch_attributes;
+            }
+        }
+    }
+
+    public function afterController(KernelEvent $event, string $eventName, EventDispatcherInterface $dispatcher): void
+    {
+        $attributes = $event->controllerMetadata?->getAttributes('*') ?? [];
+
+        for ($i = \count($attributes) - 1; $i >= 0; --$i) {
+            $attribute = $attributes[$i];
+            $attributeEventNames = $this->getAttributeEventNames($attribute, $eventName);
+
+            for ($j = \count($attributeEventNames) - 1; $j >= 0; --$j) {
+                $dispatcher->dispatch(new ControllerAttributeEvent($attribute, $event), $attributeEventNames[$j]);
+
+                if ($event->isPropagationStopped()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private function getAttributeEventNames(object $attribute, string $eventName): array
+    {
+        if (!$attributesWithListeners = $this->attributesWithListenersByEvent[$eventName] ?? []) {
+            return [];
+        }
+
+        $names = [];
+        $class = $attribute::class;
+        $hierarchy = self::$attributeHierarchyCache[$class] ??= [$class => $class] + class_parents($class) + class_implements($class);
+
+        foreach ($hierarchy as $class) {
+            if (isset($attributesWithListeners[$class])) {
+                $names[] = $eventName.'.'.$class;
+            }
+        }
+
+        return $names;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => ['beforeController', -10000],
+            KernelEvents::CONTROLLER_ARGUMENTS => ['beforeController', -10000],
+            KernelEvents::VIEW => ['afterController', 10000],
+            KernelEvents::RESPONSE => ['afterController', 10000],
+            KernelEvents::EXCEPTION => ['afterController', 10000],
+            KernelEvents::FINISH_REQUEST => ['afterController', 10000],
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/IsSignatureValidAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/IsSignatureValidAttributeListener.php
@@ -12,9 +12,11 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\Attribute\IsSignatureValid;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -29,25 +31,49 @@ class IsSignatureValidAttributeListener implements EventSubscriberInterface
     ) {
     }
 
-    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    public function onKernelControllerAttribute(ControllerAttributeEvent $event): void
     {
-        if (!$attributes = $event->getAttributes(IsSignatureValid::class)) {
+        $kernelEvent = $event->kernelEvent;
+
+        if (!$kernelEvent instanceof ControllerArgumentsEvent) {
             return;
         }
 
-        $request = $event->getRequest();
-        foreach ($attributes as $attribute) {
-            $methods = array_map('strtoupper', $attribute->methods);
-            if ($methods && !\in_array($request->getMethod(), $methods, true)) {
-                continue;
-            }
+        $this->processAttribute($event->attribute, $kernelEvent->getRequest());
+    }
 
-            $this->uriSigner->verify($request);
+    /**
+     * @internal since Symfony 8.1, use onKernelControllerAttribute() instead
+     */
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        foreach ($event->getAttributes(IsSignatureValid::class) as $attribute) {
+            $this->processAttribute($attribute, $request);
         }
+    }
+
+    private function processAttribute(IsSignatureValid $attribute, Request $request): void
+    {
+        $methods = array_map('strtoupper', $attribute->methods);
+        if ($methods && !\in_array($request->getMethod(), $methods, true)) {
+            return;
+        }
+
+        $this->uriSigner->verify($request);
     }
 
     public static function getSubscribedEvents(): array
     {
-        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 30]];
+        if (!class_exists(ControllerAttributesListener::class, false)) {
+            return [
+                KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 30],
+            ];
+        }
+
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.IsSignatureValid::class => 'onKernelControllerAttribute',
+        ];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ControllerAttributesListenerPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ControllerAttributesListenerPassTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\ControllerAttributesListenerPass;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ControllerAttributesListenerPassTest extends TestCase
+{
+    public function testCollectsAttributeListenersByKernelEvent()
+    {
+        $container = new ContainerBuilder();
+
+        $dispatcher = new Definition();
+        $dispatcher->addMethodCall('addListener', [KernelEvents::CONTROLLER.'.'.TestAttribute::class, [new Reference('listener.service'), 'onKernelController'], 0]);
+        $dispatcher->addMethodCall('addListener', [KernelEvents::RESPONSE.'.'.AnotherAttribute::class, [new Reference('listener.service'), 'onKernelResponse'], 0]);
+        $dispatcher->addMethodCall('addListener', [KernelEvents::REQUEST, [new Reference('other.service'), 'onKernelRequest'], 0]);
+        $container->setDefinition('event_dispatcher', $dispatcher);
+
+        $listener = new Definition(ControllerAttributesListener::class, [[]]);
+        $container->setDefinition('kernel.controller_attributes_listener', $listener);
+
+        $pass = new ControllerAttributesListenerPass();
+        $pass->process($container);
+
+        $this->assertSame([
+            KernelEvents::CONTROLLER => [TestAttribute::class => true],
+            KernelEvents::RESPONSE => [AnotherAttribute::class => true],
+        ], $listener->getArgument(0));
+    }
+
+    public function testSetsEmptyConfigurationWhenNoAttributeListenersAreRegistered()
+    {
+        $container = new ContainerBuilder();
+
+        $dispatcher = new Definition();
+        $dispatcher->addMethodCall('addListener', [KernelEvents::REQUEST, [new Reference('listener.service'), 'onKernelRequest'], 0]);
+        $container->setDefinition('event_dispatcher', $dispatcher);
+
+        $listener = new Definition(ControllerAttributesListener::class, [[]]);
+        $container->setDefinition('kernel.controller_attributes_listener', $listener);
+
+        $pass = new ControllerAttributesListenerPass();
+        $pass->process($container);
+
+        $this->assertSame([], $listener->getArgument(0));
+    }
+}
+
+#[\Attribute]
+class TestAttribute
+{
+}
+
+#[\Attribute]
+class AnotherAttribute extends TestAttribute
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerAttributesListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerAttributesListenerTest.php
@@ -1,0 +1,296 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsMetadata;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Buz;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Qux;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\ControllerAttributesController;
+
+class ControllerAttributesListenerTest extends TestCase
+{
+    public function testOnKernelControllerArgumentsDispatchesEventsForEachAttribute()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Qux::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+
+        $listener = $this->createListener();
+        $event = $this->createControllerArgumentsEvent('buzQuxAction');
+
+        $listener->beforeController($event, KernelEvents::CONTROLLER_ARGUMENTS, $dispatcher);
+
+        $this->assertSame([
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class,
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class,
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.Qux::class,
+        ], $dispatchedEvents);
+    }
+
+    public function testOnKernelResponseDispatchesEventsInReverseOrder()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::RESPONSE.'.'.Buz::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+        $dispatcher->addListener(KernelEvents::RESPONSE.'.'.Qux::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+
+        $listener = $this->createListener();
+        $event = $this->createResponseEvent('buzQuxAction');
+
+        $listener->afterController($event, KernelEvents::RESPONSE, $dispatcher);
+
+        $this->assertSame([
+            KernelEvents::RESPONSE.'.'.Qux::class,
+            KernelEvents::RESPONSE.'.'.Buz::class,
+            KernelEvents::RESPONSE.'.'.Buz::class,
+        ], $dispatchedEvents);
+    }
+
+    public function testOnKernelResponseDoesNothingWhenNoControllerEvent()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::RESPONSE.'.'.Buz::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+
+        $listener = $this->createListener();
+
+        $event = new ResponseEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response()
+        );
+
+        $listener->afterController($event, KernelEvents::RESPONSE, $dispatcher);
+
+        $this->assertSame([], $dispatchedEvents);
+    }
+
+    public function testDispatchedEventIsTheSameInstance()
+    {
+        $capturedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function (ControllerAttributeEvent $event) use (&$capturedEvents) {
+            $capturedEvents[] = $event;
+        });
+
+        $listener = $this->createListener();
+        $event = $this->createControllerArgumentsEvent('buzAction');
+
+        $listener->beforeController($event, KernelEvents::CONTROLLER_ARGUMENTS, $dispatcher);
+
+        $this->assertCount(2, $capturedEvents);
+        $this->assertSame($event, $capturedEvents[0]->kernelEvent);
+        $this->assertSame($event, $capturedEvents[1]->kernelEvent);
+    }
+
+    public function testClassLevelAttributesAreIncluded()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+
+        $listener = $this->createListener();
+        $event = $this->createControllerArgumentsEvent('noAttributeAction');
+
+        $listener->beforeController($event, KernelEvents::CONTROLLER_ARGUMENTS, $dispatcher);
+
+        $this->assertSame([KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class], $dispatchedEvents);
+    }
+
+    public function testBeforeControllerDispatchesParentAttributeListeners()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+
+        $listener = $this->createListener([
+            KernelEvents::CONTROLLER_ARGUMENTS => [
+                Buz::class => true,
+            ],
+        ]);
+        $event = $this->createControllerArgumentsEvent('subBuzAction');
+
+        $listener->beforeController($event, KernelEvents::CONTROLLER_ARGUMENTS, $dispatcher);
+
+        $this->assertSame([
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class,
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class,
+        ], $dispatchedEvents);
+    }
+
+    public function testBeforeControllerSkipsWhenNoAttributeListenersAreRegistered()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function () use (&$dispatchedEvents) {
+            $dispatchedEvents[] = true;
+        });
+
+        $listener = $this->createListener([]);
+        $event = $this->createControllerArgumentsEvent('buzAction');
+
+        $listener->beforeController($event, KernelEvents::CONTROLLER_ARGUMENTS, $dispatcher);
+
+        $this->assertEmpty($dispatchedEvents);
+    }
+
+    public function testOnKernelControllerHandlesControllerChanges()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::CONTROLLER.'.'.Buz::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+        $dispatcher->addListener(KernelEvents::CONTROLLER.'.'.Qux::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+
+        $originalControllerSet = false;
+        $dispatcher->addListener(KernelEvents::CONTROLLER.'.'.Buz::class, static function (ControllerAttributeEvent $event) use (&$originalControllerSet, &$dispatchedEvents) {
+            if (!$originalControllerSet) {
+                $event->kernelEvent->setController([new ControllerAttributesController(), 'buzQuxAction']);
+                $originalControllerSet = true;
+            }
+        }, -1);
+
+        $listener = $this->createListener();
+
+        $event = new ControllerEvent(
+            $this->createStub(HttpKernelInterface::class),
+            [new ControllerAttributesController(), 'buzAction'],
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $listener->beforeController($event, KernelEvents::CONTROLLER, $dispatcher);
+
+        $this->assertContains(KernelEvents::CONTROLLER.'.'.Qux::class, $dispatchedEvents);
+    }
+
+    public function testOnKernelControllerArgumentsHandlesControllerChanges()
+    {
+        $dispatchedEvents = [];
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Qux::class, static function ($event, $name) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $name;
+        });
+
+        $listener = $this->createListener();
+        $event = $this->createControllerArgumentsEvent('buzAction');
+
+        $originalControllerSet = false;
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function (ControllerAttributeEvent $event) use (&$originalControllerSet, &$dispatchedEvents) {
+            if (!$originalControllerSet) {
+                $event->kernelEvent->setController([new ControllerAttributesController(), 'buzQuxAction']);
+                $originalControllerSet = true;
+            }
+        }, -1);
+
+        $listener->beforeController($event, KernelEvents::CONTROLLER_ARGUMENTS, $dispatcher);
+
+        $this->assertContains(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Qux::class, $dispatchedEvents);
+    }
+
+    private function createListener(?array $attributesWithListenersByEvent = null): ControllerAttributesListener
+    {
+        return new ControllerAttributesListener($attributesWithListenersByEvent ?? [
+            KernelEvents::CONTROLLER => [
+                Buz::class => true,
+                Qux::class => true,
+            ],
+            KernelEvents::CONTROLLER_ARGUMENTS => [
+                Buz::class => true,
+                Qux::class => true,
+            ],
+            KernelEvents::VIEW => [
+                Buz::class => true,
+                Qux::class => true,
+            ],
+            KernelEvents::RESPONSE => [
+                Buz::class => true,
+                Qux::class => true,
+            ],
+            KernelEvents::FINISH_REQUEST => [
+                Buz::class => true,
+                Qux::class => true,
+            ],
+        ]);
+    }
+
+    private function createControllerArgumentsEvent(string $method): ControllerArgumentsEvent
+    {
+        return new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            [new ControllerAttributesController(), $method],
+            [],
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+
+    private function createResponseEvent(string $method): ResponseEvent
+    {
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $request = new Request();
+        $controller = [new ControllerAttributesController(), $method];
+        $controllerEvent = new ControllerEvent($kernel, $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($kernel, $controllerEvent, [], $request, HttpKernelInterface::MAIN_REQUEST);
+        $controllerMetadata = new ControllerArgumentsMetadata($controllerEvent, $controllerArgumentsEvent);
+
+        return new ResponseEvent(
+            $kernel,
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response(),
+            $controllerMetadata
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/IsSignatureValidAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/IsSignatureValidAttributeListenerTest.php
@@ -15,14 +15,46 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Exception\UnsignedUriException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpKernel\Attribute\IsSignatureValid;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\EventListener\IsSignatureValidAttributeListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Tests\Fixtures\IsSignatureValidAttributeController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\IsSignatureValidAttributeMethodsController;
 
 class IsSignatureValidAttributeListenerTest extends TestCase
 {
+    public function testSubscribedEvents()
+    {
+        $events = IsSignatureValidAttributeListener::getSubscribedEvents();
+
+        $eventName = KernelEvents::CONTROLLER_ARGUMENTS.'.'.IsSignatureValid::class;
+
+        $this->assertArrayHasKey($eventName, $events);
+        $this->assertSame('onKernelControllerAttribute', $events[$eventName]);
+    }
+
+    public function testControllerAttributeEventValidatesSignature()
+    {
+        $request = new Request();
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $controllerEvent = new ControllerArgumentsEvent(
+            $kernel,
+            [new IsSignatureValidAttributeController(), '__invoke'],
+            [],
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $signer = $this->createMock(UriSigner::class);
+        $signer->expects($this->once())->method('verify')->with($request);
+
+        $listener = new IsSignatureValidAttributeListener($signer);
+        $listener->onKernelControllerAttribute(new ControllerAttributeEvent(new IsSignatureValid(), $controllerEvent));
+    }
+
     public function testInvokableControllerWithValidSignature()
     {
         $request = new Request();

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Buz.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Buz.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class Buz
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Qux.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Qux.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class Qux
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/SubBuz.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/SubBuz.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class SubBuz extends Buz
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/ControllerAttributesController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/ControllerAttributesController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
+
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Buz;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Qux;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\SubBuz;
+
+#[Buz]
+class ControllerAttributesController
+{
+    #[Buz]
+    #[Qux]
+    public function buzQuxAction()
+    {
+    }
+
+    #[Buz]
+    public function buzAction()
+    {
+    }
+
+    #[SubBuz]
+    public function subBuzAction()
+    {
+    }
+
+    public function noAttributeAction()
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -33,36 +34,54 @@ final class IsCsrfTokenValidAttributeListener implements EventSubscriberInterfac
     ) {
     }
 
-    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    public function onKernelControllerAttribute(ControllerAttributeEvent $event): void
     {
-        if (!$attributes = $event->getAttributes(IsCsrfTokenValid::class)) {
+        $kernelEvent = $event->kernelEvent;
+
+        if (!$kernelEvent instanceof ControllerArgumentsEvent) {
             return;
         }
 
+        $this->processAttribute($event->attribute, $kernelEvent->getRequest(), $kernelEvent->getNamedArguments());
+    }
+
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
         $request = $event->getRequest();
         $arguments = $event->getNamedArguments();
 
-        foreach ($attributes as $attribute) {
-            $id = $this->getTokenId($attribute->id, $request, $arguments);
-            $methods = array_map('strtoupper', (array) $attribute->methods);
+        foreach ($event->getAttributes(IsCsrfTokenValid::class) as $attribute) {
+            $this->processAttribute($attribute, $request, $arguments);
+        }
+    }
 
-            if ($methods && !\in_array($request->getMethod(), $methods, true)) {
-                continue;
-            }
+    private function processAttribute(IsCsrfTokenValid $attribute, Request $request, array $arguments): void
+    {
+        $id = $this->getTokenId($attribute->id, $request, $arguments);
+        $methods = array_map('strtoupper', (array) $attribute->methods);
 
-            $tokenValue = $this->getTokenValue($request, $attribute->tokenSource, $attribute->tokenKey);
-            if (
-                null === $tokenValue
-                || !$this->csrfTokenManager->isTokenValid(new CsrfToken($id, $tokenValue))
-            ) {
-                throw new InvalidCsrfTokenException('Invalid CSRF token.');
-            }
+        if ($methods && !\in_array($request->getMethod(), $methods, true)) {
+            return;
+        }
+
+        $tokenValue = $this->getTokenValue($request, $attribute->tokenSource, $attribute->tokenKey);
+        if (
+            null === $tokenValue
+            || !$this->csrfTokenManager->isTokenValid(new CsrfToken($id, $tokenValue))
+        ) {
+            throw new InvalidCsrfTokenException('Invalid CSRF token.');
         }
     }
 
     public static function getSubscribedEvents(): array
     {
-        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 25]];
+        if (!class_exists(ControllerAttributeEvent::class)) {
+            return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 25]];
+        }
+
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.IsCsrfTokenValid::class => 'onKernelControllerAttribute',
+        ];
     }
 
     private function getTokenId(string|Expression $id, Request $request, array $arguments): string

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -16,6 +16,8 @@ use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
@@ -37,6 +39,27 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
     ) {
     }
 
+    public function onKernelControllerAttribute(ControllerAttributeEvent $event): void
+    {
+        $kernelEvent = $event->kernelEvent;
+
+        if (!$kernelEvent instanceof ControllerArgumentsEvent) {
+            return;
+        }
+
+        $controller = $kernelEvent->getController();
+        $controller = match (true) {
+            \is_object($controller) && !$controller instanceof \Closure => $controller,
+            \is_array($controller) && \is_object($controller[0]) => $controller[0],
+            default => null,
+        };
+
+        $this->processAttribute($event->attribute, $kernelEvent->getRequest(), $kernelEvent->getNamedArguments(), $controller);
+    }
+
+    /**
+     * @internal since Symfony 8.1, use onKernelControllerAttribute() instead
+     */
     public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
     {
         $attributes = [];
@@ -61,43 +84,54 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         };
 
         foreach ($attributes as $attribute) {
-            if ($attribute->methods && !\in_array($request->getMethod(), array_map('strtoupper', $attribute->methods), true)) {
-                continue;
-            }
+            $this->processAttribute($attribute, $request, $arguments, $controller);
+        }
+    }
 
-            $subject = null;
+    private function processAttribute(IsGranted $attribute, Request $request, array $arguments, ?object $controller): void
+    {
+        if ($attribute->methods && !\in_array($request->getMethod(), array_map('strtoupper', $attribute->methods), true)) {
+            return;
+        }
 
-            if ($subjectRef = $attribute->subject) {
-                if (\is_array($subjectRef)) {
-                    foreach ($subjectRef as $refKey => $ref) {
-                        $subject[\is_string($refKey) ? $refKey : (string) $ref] = $this->getIsGrantedSubject($ref, $request, $arguments, $controller);
-                    }
-                } else {
-                    $subject = $this->getIsGrantedSubject($subjectRef, $request, $arguments, $controller);
+        $subject = null;
+
+        if ($subjectRef = $attribute->subject) {
+            if (\is_array($subjectRef)) {
+                foreach ($subjectRef as $refKey => $ref) {
+                    $subject[\is_string($refKey) ? $refKey : (string) $ref] = $this->getIsGrantedSubject($ref, $request, $arguments, $controller);
                 }
+            } else {
+                $subject = $this->getIsGrantedSubject($subjectRef, $request, $arguments, $controller);
             }
-            $accessDecision = new AccessDecision();
+        }
+        $accessDecision = new AccessDecision();
 
-            if (!$accessDecision->isGranted = $this->authChecker->isGranted($attribute->attribute, $subject, $accessDecision)) {
-                $message = $attribute->message ?: $accessDecision->getMessage();
+        if (!$accessDecision->isGranted = $this->authChecker->isGranted($attribute->attribute, $subject, $accessDecision)) {
+            $message = $attribute->message ?: $accessDecision->getMessage();
 
-                if ($statusCode = $attribute->statusCode) {
-                    throw new HttpException($statusCode, $message, code: $attribute->exceptionCode ?? 0);
-                }
-
-                $e = new AccessDeniedException($message, code: $attribute->exceptionCode ?? 403);
-                $e->setAttributes([$attribute->attribute]);
-                $e->setSubject($subject);
-                $e->setAccessDecision($accessDecision);
-
-                throw $e;
+            if ($statusCode = $attribute->statusCode) {
+                throw new HttpException($statusCode, $message, code: $attribute->exceptionCode ?? 0);
             }
+
+            $e = new AccessDeniedException($message, code: $attribute->exceptionCode ?? 403);
+            $e->setAttributes([$attribute->attribute]);
+            $e->setSubject($subject);
+            $e->setAccessDecision($accessDecision);
+
+            throw $e;
         }
     }
 
     public static function getSubscribedEvents(): array
     {
-        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20]];
+        if (!class_exists(ControllerAttributesListener::class, false)) {
+            return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20]];
+        }
+
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS.'.'.IsGranted::class => 'onKernelControllerAttribute',
+        ];
     }
 
     private function getIsGrantedSubject(string|Expression|\Closure $subjectRef, Request $request, array $arguments, ?object $controller): mixed

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
@@ -12,15 +12,20 @@
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Http\Attribute\IsCsrfTokenValid;
 use Symfony\Component\Security\Http\EventListener\IsCsrfTokenValidAttributeListener;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsCsrfTokenValidAttributeController;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsCsrfTokenValidAttributeMethodsController;
@@ -395,5 +400,45 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             'withCustomTokenSourceHeaderAndCustomSourceToken',
             'bar_header',
         ];
+    }
+
+    #[RequiresMethod(ControllerAttributeEvent::class, '__construct')]
+    public function testonKernelControllerAttributeDelegatesControllerArgumentsEvent()
+    {
+        $request = new Request(request: ['_token' => 'bar']);
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')
+            ->with(new CsrfToken('foo', 'bar'))
+            ->willReturn(true);
+
+        $controllerEvent = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new IsCsrfTokenValidAttributeController(),
+            [],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerAttribute(new ControllerAttributeEvent(new IsCsrfTokenValid('foo'), $controllerEvent));
+    }
+
+    #[RequiresMethod(ControllerAttributeEvent::class, '__construct')]
+    public function testonKernelControllerAttributeIgnoresResponseEvent()
+    {
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->never())->method('isTokenValid');
+
+        $event = new ResponseEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response()
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerAttribute(new ControllerAttributeEvent(new IsCsrfTokenValid('foo'), $event));
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -643,5 +646,43 @@ class IsGrantedAttributeListenerTest extends TestCase
 
         $listener = new IsGrantedAttributeListener($authChecker);
         $listener->onKernelControllerArguments($event);
+    }
+
+    #[RequiresMethod(ControllerAttributeEvent::class, '__construct')]
+    public function testonKernelControllerAttributeDelegatesControllerArgumentsEvent()
+    {
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->exactly(2))
+            ->method('isGranted')
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            [new IsGrantedAttributeController(), 'foo'],
+            [],
+            new Request(),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener->onKernelControllerAttribute(new ControllerAttributeEvent(new IsGranted('ROLE_ADMIN'), $event));
+        $listener->onKernelControllerAttribute(new ControllerAttributeEvent(new IsGranted('ROLE_USER'), $event));
+    }
+
+    #[RequiresMethod(ControllerAttributeEvent::class, '__construct')]
+    public function testonKernelControllerAttributeIgnoresResponseEvent()
+    {
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->never())->method('isGranted');
+
+        $event = new ResponseEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response()
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker);
+        $listener->onKernelControllerAttribute(new ControllerAttributeEvent(new IsGranted('ROLE_ADMIN'), $event));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62074
| License       | MIT

This is my proposal at solving #62074. It's derived from a discussion we had with @TimoBakx during SymfonyCon's hackday and it builds on #62850 and on #63092.

This PR introduces a new `ControllerAttributesListener` that dispatches subevents of regular requests' lifecycle events: each controller attribute triggers an event named after the kernel event concatenated with the attribute's FQCN.

For example, if attribute `#[Cache]` is found on a controller, this will trigger the following events (depending on the processing):
- `KernelEvents::CONTROLLER.'.'.Cache::class`
- `KernelEvents::CONTROLLER_ARGUMENTS.'.'.Cache::class`
- `KernelEvents::VIEW.'.'.Cache::class`
- `KernelEvents::RESPONSE.'.'.Cache::class`
- `KernelEvents::EXCEPTION.'.'.Cache::class`
- `KernelEvents::FINISH_REQUEST.'.'.Cache::class`

When a controller has several attributes, the events are triggered in declaration order for CONTROLLER and CONTROLLER_ARGUMENTS events, and in reverse order for the other ones. This follows the principle that led to this proposal: these subevents should help write logic that could be thought of as decorators around controllers. This principle also drove the priority of these events: all these subevents are triggered as very late CONTROLLER and CONTROLLER_ARGUMENTS events, and as very early for the other ones.

Each dispatched subevent is an instance of `ControllerAttributeEvent`. It bundles the attribute instance with the underlying kernel event so listeners can inspect and mutate request/response data without re-reflecting the controller. It also implements `StoppableEventInterface`: if a listener switches the controller (e.g. in a decorator scenario), propagation stops for the previous controller automatically, avoiding duplicate work.

This provides:

- Cleaner event-based architecture: attribute listeners now subscribe to their own attribute class names as events.
- Reduced unnecessary listener calls: previously, every attribute listener was triggered on e.g. `kernel.controller_arguments` even if its attribute wasn't present. Now, the central `ControllerAttributesListener` only dispatches events for attributes that actually exist on the controller. No-op listeners are a common performance issue in Symfony apps and this design allows instantiating and triggering them lazily.
- An easy way to hook before and after a controller, thus the linked issue.

In order to help with performance and also to help account for attribute inheritance, `ControllerAttributesListener` comes with a companion compiler pass that collects the listeners that are actually registered for each attributes. In practice this means 1. that no subevent will be triggered if it has no listeners, and 2. that if `#[FooChild]` is found on a controller and a listener exists for `#[Foo]`, the listener will be called.

As a corollary, this updates existing attribute listeners to this new subsystem.