### PR TITLE
[HttpFoundation] Fix backslash handling in uploaded filename sanitization

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -133,9 +133,14 @@ class File extends \SplFileInfo
      */
     protected function getName(string $name): string
     {
-        $originalName = str_replace('\\', '/', $name);
-        $pos = strrpos($originalName, '/');
+        // Normalize backslashes to forward slashes only on Windows
+        // where backslash is a directory separator
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $name = str_replace('\\', '/', $name);
+        }
 
-        return false === $pos ? $originalName : substr($originalName, $pos + 1);
+        $pos = strrpos($name, '/');
+
+        return false === $pos ? $name : substr($name, $pos + 1);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -93,14 +93,24 @@ class FileTest extends TestCase
 
     public static function getFilenameFixtures()
     {
-        return [
+        $fixtures = [
             ['original.gif', 'original.gif'],
-            ['..\\..\\original.gif', 'original.gif'],
             ['../../original.gif', 'original.gif'],
             ['файлfile.gif', 'файлfile.gif'],
-            ['..\\..\\файлfile.gif', 'файлfile.gif'],
             ['../../файлfile.gif', 'файлfile.gif'],
         ];
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            // Windows: backslash is a directory separator
+            $fixtures[] = ['..\\..\\original.gif', 'original.gif'];
+            $fixtures[] = ['..\\..\\файлfile.gif', 'файлfile.gif'];
+        } else {
+            // Unix: backslash is a valid filename character
+            $fixtures[] = ['..\\..\\original.gif', '..\\..\\original.gif'];
+            $fixtures[] = ['..\\..\\файлfile.gif', '..\\..\\файлfile.gif'];
+        }
+
+        return $fixtures;
     }
 
     #[DataProvider('getFilenameFixtures')]

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -91,26 +91,22 @@ class FileTest extends TestCase
         $this->assertStringEqualsFile(__FILE__, $file->getContent());
     }
 
-    public static function getFilenameFixtures()
+    public static function getFilenameFixtures(): iterable
     {
-        $fixtures = [
-            ['original.gif', 'original.gif'],
-            ['../../original.gif', 'original.gif'],
-            ['файлfile.gif', 'файлfile.gif'],
-            ['../../файлfile.gif', 'файлfile.gif'],
-        ];
+        yield ['original.gif', 'original.gif'];
+        yield ['../../original.gif', 'original.gif'];
+        yield ['файлfile.gif', 'файлfile.gif'];
+        yield ['../../файлfile.gif', 'файлfile.gif'];
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
             // Windows: backslash is a directory separator
-            $fixtures[] = ['..\\..\\original.gif', 'original.gif'];
-            $fixtures[] = ['..\\..\\файлfile.gif', 'файлfile.gif'];
+            yield ['..\\..\\original.gif', 'original.gif'];
+            yield ['..\\..\\файлfile.gif', 'файлfile.gif'];
         } else {
             // Unix: backslash is a valid filename character
-            $fixtures[] = ['..\\..\\original.gif', '..\\..\\original.gif'];
-            $fixtures[] = ['..\\..\\файлfile.gif', '..\\..\\файлfile.gif'];
+            yield ['..\\..\\original.gif', '..\\..\\original.gif'];
+            yield ['..\\..\\файлfile.gif', '..\\..\\файлfile.gif'];
         }
-
-        return $fixtures;
     }
 
     #[DataProvider('getFilenameFixtures')]

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -225,6 +225,23 @@ class UploadedFileTest extends TestCase
         $this->assertEquals('original.gif', $file->getClientOriginalName());
     }
 
+    public function testGetClientOriginalNameWithBackslash()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'prefix\\original.gif',
+            'image/gif'
+        );
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            // Windows: backslash is treated as directory separator
+            $this->assertEquals('original.gif', $file->getClientOriginalName());
+        } else {
+            // Unix: backslash is a valid filename character
+            $this->assertEquals('prefix\\original.gif', $file->getClientOriginalName());
+        }
+    }
+
     public function testGetSize()
     {
         $file = new UploadedFile(

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -235,10 +235,10 @@ class UploadedFileTest extends TestCase
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
             // Windows: backslash is treated as directory separator
-            $this->assertEquals('original.gif', $file->getClientOriginalName());
+            $this->assertSame('original.gif', $file->getClientOriginalName());
         } else {
             // Unix: backslash is a valid filename character
-            $this->assertEquals('prefix\\original.gif', $file->getClientOriginalName());
+            $this->assertSame('prefix\\original.gif', $file->getClientOriginalName());
         }
     }
 


### PR DESCRIPTION
## Summary
The getName() method in File.php unconditionally converts backslashes to forward slashes before extracting the basename. This breaks on Unix systems where backslash is a valid filename character, not a directory separator.

Uploading a file named prefix\\original.gif on Linux currently returns original.gif from getClientOriginalName() instead of the actual filename.

This patch makes backslash normalization conditional only applied on Windows where backslash is a directory separator.

Fix #62255
 
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=105917501