### PR TITLE
[PhpUnitBridge] add logic for checking for dist.xml, xml.dist and xml phpunit config

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for `phpunit.dist.xml` suffix
+
 7.4
 ---
 

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -33,15 +33,15 @@ $getEnvVar = static function ($name, $default = false) use ($argv) {
             if (!$probableConfig) {
                 return null;
             }
+
             if (is_dir($probableConfig)) {
-                return $getPhpUnitConfig($probableConfig.\DIRECTORY_SEPARATOR.'phpunit.xml');
+                return $getPhpUnitConfig($probableConfig.\DIRECTORY_SEPARATOR.'phpunit');
             }
 
-            if (file_exists($probableConfig)) {
-                return $probableConfig;
-            }
-            if (file_exists($probableConfig.'.dist')) {
-                return $probableConfig.'.dist';
+            foreach (['.xml', '.xml.dist', '.dist.xml'] as $suffix) {
+                if (file_exists($candidate = $probableConfig.$suffix)) {
+                    return $candidate;
+                }
             }
 
             return null;
@@ -67,7 +67,7 @@ $getEnvVar = static function ($name, $default = false) use ($argv) {
             }
         }
 
-        $phpunitConfigFilename = $phpunitConfigFilename ?: $getPhpUnitConfig('phpunit.xml');
+        $phpunitConfigFilename = $phpunitConfigFilename ?: $getPhpUnitConfig('phpunit');
 
         if ($phpunitConfigFilename) {
             $phpunitConfig = new DOMDocument();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

PhpUnit 10 added `dist.xml` as an alternative `phpunit.xml` suffix. See https://github.com/sebastianbergmann/phpunit/commit/07a022ad0548823b04c8fab073a7bff2fbcf9c8c.
The symfony phpunit-bridge does not support `phpunit.dist.xml` as a valid phpunit config.

This PR changes that.
