### PR TITLE
[Serializer] TranslatableNormalizer before BackedEnumNormalizer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -119,7 +119,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('serializer.normalizer.translatable', TranslatableNormalizer::class)
             ->args(['$translator' => service('translator')])
-            ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -920])
+            ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -910])
 
         ->set('serializer.normalizer.form_error', FormErrorNormalizer::class)
             ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -915])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1863,7 +1863,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $tag = $definition->getTag('serializer.normalizer');
 
         $this->assertSame(TranslatableNormalizer::class, $definition->getClass());
-        $this->assertSame(-920, $tag[0]['priority']);
+        $this->assertSame(-910, $tag[0]['priority']);
         $this->assertEquals(new Reference('translator'), $definition->getArgument('$translator'));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TranslatableBackedEnum;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\app\AppKernel;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Serializer\Normalizer\TranslatableNormalizer;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -60,6 +61,18 @@ class SerializerTest extends AbstractWebTestCase
         }
     }
 
+    public function testSerializeTranslatableBackedEnum()
+    {
+        static::bootKernel(['test_case' => 'Serializer']);
+
+        $serializer = static::getContainer()->get('serializer.alias');
+
+        $this->assertEquals('custom_get_string', $serializer->serialize(TranslatableBackedEnum::Get, 'yaml'));
+        $this->assertEquals('GET', $serializer->serialize(TranslatableBackedEnum::Get, 'yaml', [
+            TranslatableNormalizer::NORMALIZATION_LOCALE_KEY => false,
+        ]));
+    }
+
     protected static function getKernelClass(): string
     {
         return SerializerKernel::class;
@@ -90,15 +103,6 @@ class SerializerKernel extends AppKernel implements CompilerPassInterface
                 }
             }
         }
-    }
-
-    public function testSerializeTranslatableBackedEnum()
-    {
-        static::bootKernel(['test_case' => 'Serializer']);
-
-        $serializer = static::getContainer()->get('serializer.alias');
-
-        $this->assertEquals('GET', $serializer->serialize(TranslatableBackedEnum::Get, 'yaml'));
     }
 }
 

--- a/src/Symfony/Component/Serializer/Normalizer/TranslatableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/TranslatableNormalizer.php
@@ -45,11 +45,12 @@ final class TranslatableNormalizer implements NormalizerInterface
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return $data instanceof TranslatableInterface;
+        return $data instanceof TranslatableInterface
+            && false !== ($context[self::NORMALIZATION_LOCALE_KEY] ?? $this->defaultContext[self::NORMALIZATION_LOCALE_KEY]);
     }
 
     public function getSupportedTypes(?string $format): array
     {
-        return [TranslatableInterface::class => true];
+        return [TranslatableInterface::class => false];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix https://github.com/symfony/symfony/issues/63038
| License       | MIT

Reverting `TranslatableNormalizer` to be called before `BackedEnumNormalizer` + add the ability to set `NORMALIZATION_LOCALE_KEY` to `false` in order to disable translation on purpose (and fallback on `BackedEnumNormalizer`).
