### PR TITLE
 PHP CS Fixer: enable `no_useless_return`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -45,6 +45,7 @@ return (new PhpCsFixer\Config())
                 '/s',
             ]),
         ],
+        'no_useless_return' => true,
         'php_unit_attributes' => true,
         'random_api_migration' => true,
         'static_lambda' => true,

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -234,7 +234,6 @@ class EntityTypeTest extends BaseTypeTestCase
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => static function () {
-                return;
             },
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS
| License       | MIT

almost already following the rule, only one cases to fix