### PR TITLE
[Semaphore][WIP] Add serializable Semaphore Key support

### DIFF
--- a/src/Symfony/Component/Semaphore/CHANGELOG.md
+++ b/src/Symfony/Component/Semaphore/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+* Add serializable Semaphore Key support to align with `Lock`
+* Added `UnserializableKeyException`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Semaphore/Exception/UnserializableKeyException.php
+++ b/src/Symfony/Component/Semaphore/Exception/UnserializableKeyException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Exception;
+
+/**
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+class UnserializableKeyException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Semaphore/Key.php
+++ b/src/Symfony/Component/Semaphore/Key.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Semaphore;
 
 use Symfony\Component\Semaphore\Exception\InvalidArgumentException;
+use Symfony\Component\Semaphore\Exception\UnserializableKeyException;
 
 /**
  * Key is a container for the state of the semaphores in stores.
@@ -23,6 +24,7 @@ final class Key
 {
     private ?float $expiringTime = null;
     private array $state = [];
+    private bool $serializable = true;
 
     public function __construct(
         private string $resource,
@@ -75,6 +77,11 @@ final class Key
         return $this->state[$stateKey];
     }
 
+    public function markUnserializable(): void
+    {
+        $this->serializable = false;
+    }
+
     public function resetLifetime(): void
     {
         $this->expiringTime = null;
@@ -100,5 +107,29 @@ final class Key
     public function isExpired(): bool
     {
         return null !== $this->expiringTime && $this->expiringTime <= microtime(true);
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->resource = $data['resource'] ?? $data["\0".self::class."\0resource"];
+        $this->limit = $data['limit'] ?? $data["\0".self::class."\0limit"];
+        $this->weight = $data['weight'] ?? $data["\0".self::class."\0weight"];
+        $this->expiringTime = $data['expiringTime'] ?? $data["\0".self::class."\0expiringTime"] ?? null;
+        $this->state = $data['state'] ?? $data["\0".self::class."\0state"] ?? [];
+    }
+
+    public function __serialize(): array
+    {
+        if (!$this->serializable) {
+            throw new UnserializableKeyException('The key cannot be serialized.');
+        }
+
+        return [
+            'resource' => $this->resource,
+            'limit' => $this->limit,
+            'weight' => $this->weight,
+            'expiringTime' => $this->expiringTime,
+            'state' => $this->state,
+        ];
     }
 }

--- a/src/Symfony/Component/Semaphore/Tests/KeyTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/KeyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Semaphore\Exception\UnserializableKeyException;
+use Symfony\Component\Semaphore\Key;
+use Symfony\Component\Semaphore\Store\RedisStore;
+
+/**
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+class KeyTest extends TestCase
+{
+    public function testSerialize()
+    {
+        $key = new Key(__METHOD__, 5, 2);
+        $key->setState(RedisStore::class, base64_encode(random_bytes(32)));
+
+        $copy = unserialize(serialize($key));
+        $this->assertSame(5, $copy->getLimit());
+        $this->assertSame(2, $copy->getWeight());
+        $this->assertEquals($key->getState(RedisStore::class), $copy->getState(RedisStore::class));
+        $this->assertEqualsWithDelta($key->getRemainingLifetime(), $copy->getRemainingLifetime(), 0.001);
+    }
+
+    public function testCannotSerializeUnserializableKey()
+    {
+        $key = new Key(__METHOD__, 1);
+        $key->markUnserializable();
+
+        $this->expectException(UnserializableKeyException::class);
+        serialize($key);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | o
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

Adds explicit serialization support for `Semaphore\Key`, matching the `Lock ` component. The docs mention “lock a resource across several requests,” but there was no documented way to persist the permit token; serializing the key provides a supported path while still allowing opt‑out via `markUnserializable()`.

```php
$key       = new Key('workflow-slot', 1);
$semaphore = $factory->createSemaphoreFromKey($key, 300, false);

if ($semaphore->acquire()) {
    file_put_contents('/tmp/key.txt', serialize($key));
}
```
Restore

```php
$key = unserialize(
    file_get_contents('/tmp/key.txt'),
    ['allowed_classes' => [Key::class]]
);

$semaphore = $factory->createSemaphoreFromKey($key, 300, false);
```

Previously: Key serialization relied on PHP’s default and had no opt‑out
After: Key has explicit `__serialize()`/`__unserialize()` with a supported payload format, legacy fallback, and `markUnserializable()` throwing `UnserializableKeyException.`

- [ ] gather feedback
- [ ] update documentation
