### PR TITLE
[Intl] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Intl\Tests\Data\Bundle\Reader;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReaderInterface;
@@ -24,9 +23,6 @@ use Symfony\Component\Intl\Exception\ResourceBundleNotFoundException;
 class BundleEntryReaderTest extends TestCase
 {
     private const RES_DIR = '/res/dir';
-
-    private BundleEntryReader $reader;
-    private MockObject&BundleEntryReaderInterface $readerImpl;
 
     private const DATA = [
         'Entries' => [
@@ -57,25 +53,21 @@ class BundleEntryReaderTest extends TestCase
         'Foo' => 'Bar',
     ];
 
-    protected function setUp(): void
-    {
-        $this->readerImpl = $this->createMock(BundleEntryReaderInterface::class);
-        $this->reader = new BundleEntryReader($this->readerImpl);
-    }
-
     public function testForwardCallToRead()
     {
-        $this->readerImpl->expects($this->once())
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
             ->willReturn(self::DATA);
 
-        $this->assertSame(self::DATA, $this->reader->read(self::RES_DIR, 'root'));
+        $this->assertSame(self::DATA, $this->getReader($readerImpl)->read(self::RES_DIR, 'root'));
     }
 
     public function testReadEntireDataFileIfNoIndicesGiven()
     {
-        $this->readerImpl->expects($this->exactly(2))
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->exactly(2))
             ->method('read')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -90,33 +82,36 @@ class BundleEntryReaderTest extends TestCase
             })
         ;
 
-        $this->assertSame(self::MERGED_DATA, $this->reader->readEntry(self::RES_DIR, 'en', []));
+        $this->assertSame(self::MERGED_DATA, $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en', []));
     }
 
     public function testReadExistingEntry()
     {
-        $this->readerImpl->expects($this->once())
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
             ->willReturn(self::DATA);
 
-        $this->assertSame('Bar', $this->reader->readEntry(self::RES_DIR, 'root', ['Entries', 'Foo']));
+        $this->assertSame('Bar', $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'root', ['Entries', 'Foo']));
     }
 
     public function testReadNonExistingEntry()
     {
         $this->expectException(MissingResourceException::class);
-        $this->readerImpl->expects($this->once())
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
             ->willReturn(self::DATA);
 
-        $this->reader->readEntry(self::RES_DIR, 'root', ['Entries', 'NonExisting']);
+        $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'root', ['Entries', 'NonExisting']);
     }
 
     public function testFallbackIfEntryDoesNotExist()
     {
-        $this->readerImpl->expects($this->exactly(2))
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->exactly(2))
             ->method('read')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -131,18 +126,19 @@ class BundleEntryReaderTest extends TestCase
             })
         ;
 
-        $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
+        $this->assertSame('Lah', $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
 
     public function testDontFallbackIfEntryDoesNotExistAndFallbackDisabled()
     {
         $this->expectException(MissingResourceException::class);
-        $this->readerImpl->expects($this->once())
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
             ->willReturn(self::DATA);
 
-        $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam'], false);
+        $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam'], false);
     }
 
     public function testFallbackIfLocaleDoesNotExist()
@@ -153,7 +149,8 @@ class BundleEntryReaderTest extends TestCase
             [[self::RES_DIR, 'en'], self::FALLBACK_DATA],
         ];
 
-        $this->readerImpl->expects($this->exactly(2))
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->exactly(2))
             ->method('read')
             ->willReturnCallback(function (...$args) use (&$series) {
                 [$expectedArgs, $return] = array_shift($series);
@@ -167,18 +164,19 @@ class BundleEntryReaderTest extends TestCase
             })
         ;
 
-        $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
+        $this->assertSame('Lah', $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
 
     public function testDontFallbackIfLocaleDoesNotExistAndFallbackDisabled()
     {
         $this->expectException(MissingResourceException::class);
-        $this->readerImpl->expects($this->once())
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
             ->willThrowException(new ResourceBundleNotFoundException());
 
-        $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam'], false);
+        $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam'], false);
     }
 
     public static function provideMergeableValues()
@@ -199,13 +197,15 @@ class BundleEntryReaderTest extends TestCase
      */
     public function testMergeDataWithFallbackData($childData, $parentData, $result)
     {
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+
         if (null === $childData || \is_array($childData)) {
             $series = [
                 [[self::RES_DIR, 'en'], $childData],
                 [[self::RES_DIR, 'root'], $parentData],
             ];
 
-            $this->readerImpl->expects($this->exactly(2))
+            $readerImpl->expects($this->exactly(2))
                 ->method('read')
                 ->willReturnCallback(function (...$args) use (&$series) {
                     [$expectedArgs, $return] = array_shift($series);
@@ -215,13 +215,13 @@ class BundleEntryReaderTest extends TestCase
                 })
             ;
         } else {
-            $this->readerImpl->expects($this->once())
+            $readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
                 ->willReturn($childData);
         }
 
-        $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en', [], true));
+        $this->assertSame($result, $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en', [], true));
     }
 
     /**
@@ -229,12 +229,13 @@ class BundleEntryReaderTest extends TestCase
      */
     public function testDontMergeDataIfFallbackDisabled($childData, $parentData, $result)
     {
-        $this->readerImpl->expects($this->once())
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+        $readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
             ->willReturn($childData);
 
-        $this->assertSame($childData, $this->reader->readEntry(self::RES_DIR, 'en_GB', [], false));
+        $this->assertSame($childData, $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', [], false));
     }
 
     /**
@@ -242,13 +243,15 @@ class BundleEntryReaderTest extends TestCase
      */
     public function testMergeExistingEntryWithExistingFallbackEntry($childData, $parentData, $result)
     {
+        $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+
         if (null === $childData || \is_array($childData)) {
             $series = [
                 [[self::RES_DIR, 'en'], ['Foo' => ['Bar' => $childData]]],
                 [[self::RES_DIR, 'root'], ['Foo' => ['Bar' => $parentData]]],
             ];
 
-            $this->readerImpl->expects($this->exactly(2))
+            $readerImpl->expects($this->exactly(2))
                 ->method('read')
                 ->willReturnCallback(function (...$args) use (&$series) {
                     [$expectedArgs, $return] = array_shift($series);
@@ -258,13 +261,13 @@ class BundleEntryReaderTest extends TestCase
                 })
             ;
         } else {
-            $this->readerImpl->expects($this->once())
+            $readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en')
                 ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
-        $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en', ['Foo', 'Bar'], true));
+        $this->assertSame($result, $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en', ['Foo', 'Bar'], true));
     }
 
     /**
@@ -277,7 +280,8 @@ class BundleEntryReaderTest extends TestCase
             [[self::RES_DIR, 'en'], ['Foo' => ['Bar' => $parentData]]],
         ];
 
-        $this->readerImpl
+        $readerImpl = $this->createStub(BundleEntryReaderInterface::class);
+        $readerImpl
             ->method('read')
             ->willReturnCallback(function (...$args) use (&$series) {
                 [$expectedArgs, $return] = array_shift($series);
@@ -286,7 +290,7 @@ class BundleEntryReaderTest extends TestCase
             })
         ;
 
-        $this->assertSame($parentData, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
+        $this->assertSame($parentData, $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
     }
 
     /**
@@ -300,7 +304,8 @@ class BundleEntryReaderTest extends TestCase
                 [[self::RES_DIR, 'en'], ['Foo' => 'Bar']],
             ];
 
-            $this->readerImpl
+            $readerImpl = $this->createStub(BundleEntryReaderInterface::class);
+            $readerImpl
                 ->method('read')
                 ->willReturnCallback(function (...$args) use (&$series) {
                     [$expectedArgs, $return] = array_shift($series);
@@ -309,20 +314,22 @@ class BundleEntryReaderTest extends TestCase
                 })
             ;
         } else {
-            $this->readerImpl->expects($this->once())
+            $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+            $readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
                 ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
-        $this->assertSame($childData, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
+        $this->assertSame($childData, $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
     }
 
     public function testFailIfEntryFoundNeitherInParentNorChild()
     {
         $this->expectException(MissingResourceException::class);
 
-        $this->readerImpl
+        $readerImpl = $this->createStub(BundleEntryReaderInterface::class);
+        $readerImpl
             ->method('read')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -336,7 +343,7 @@ class BundleEntryReaderTest extends TestCase
             })
         ;
 
-        $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true);
+        $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true);
     }
 
     /**
@@ -353,7 +360,8 @@ class BundleEntryReaderTest extends TestCase
                 [[self::RES_DIR, 'en'], ['Foo' => ['Bar' => $parentData]]],
             ];
 
-            $this->readerImpl
+            $readerImpl = $this->createStub(BundleEntryReaderInterface::class);
+            $readerImpl
                 ->method('read')
                 ->willReturnCallback(function (...$args) use (&$series) {
                     [$expectedArgs, $return] = array_shift($series);
@@ -362,13 +370,14 @@ class BundleEntryReaderTest extends TestCase
                 })
             ;
         } else {
-            $this->readerImpl->expects($this->once())
+            $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+            $readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'en_GB')
                 ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
-        $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
+        $this->assertSame($result, $this->getReader($readerImpl)->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
     }
 
     /**
@@ -376,8 +385,6 @@ class BundleEntryReaderTest extends TestCase
      */
     public function testFollowLocaleAliases($childData, $parentData, $result)
     {
-        $this->reader->setLocaleAliases(['mo' => 'ro_MD']);
-
         if (null === $childData || \is_array($childData)) {
             $series = [
                 [[self::RES_DIR, 'ro_MD'], ['Foo' => ['Bar' => $childData]]],
@@ -385,7 +392,8 @@ class BundleEntryReaderTest extends TestCase
                 [[self::RES_DIR, 'ro'], ['Foo' => ['Bar' => $parentData]]],
             ];
 
-            $this->readerImpl
+            $readerImpl = $this->createStub(BundleEntryReaderInterface::class);
+            $readerImpl
                 ->method('read')
                 ->willReturnCallback(function (...$args) use (&$series) {
                     [$expectedArgs, $return] = array_shift($series);
@@ -394,12 +402,21 @@ class BundleEntryReaderTest extends TestCase
                 })
             ;
         } else {
-            $this->readerImpl->expects($this->once())
+            $readerImpl = $this->createMock(BundleEntryReaderInterface::class);
+            $readerImpl->expects($this->once())
                 ->method('read')
                 ->with(self::RES_DIR, 'ro_MD')
                 ->willReturn(['Foo' => ['Bar' => $childData]]);
         }
 
-        $this->assertSame($result, $this->reader->readEntry(self::RES_DIR, 'mo', ['Foo', 'Bar'], true));
+        $reader = $this->getReader($readerImpl);
+        $reader->setLocaleAliases(['mo' => 'ro_MD']);
+
+        $this->assertSame($result, $reader->readEntry(self::RES_DIR, 'mo', ['Foo', 'Bar'], true));
+    }
+
+    private function getReader(?BundleEntryReaderInterface $entryReader = null): BundleEntryReader
+    {
+        return new BundleEntryReader($entryReader ?? $this->createStub(BundleEntryReaderInterface::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT