### PR TITLE
[AssetMapper] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperCompilerTest.php
@@ -59,10 +59,10 @@ class AssetMapperCompilerTest extends TestCase
 
         $compiler = new AssetMapperCompiler(
             [$compiler1, $compiler2, $compiler3],
-            fn () => $this->createMock(AssetMapperInterface::class),
+            fn () => $this->createStub(AssetMapperInterface::class),
         );
         $asset = new MappedAsset('foo.js', publicPathWithoutDigest: '/assets/foo.js');
-        $actualContents = $compiler->compile('starting contents', $asset, $this->createMock(AssetMapperInterface::class));
+        $actualContents = $compiler->compile('starting contents', $asset);
         $this->assertSame('starting contents compiler2 called compiler3 called', $actualContents);
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
@@ -90,12 +90,12 @@ class AssetMapperTest extends TestCase
     {
         $dirs = ['dir1' => '', 'dir2' => '', 'dir3' => ''];
         $repository = new AssetMapperRepository($dirs, __DIR__.'/Fixtures');
-        $compiledConfigReader = $this->createMock(CompiledAssetMapperConfigReader::class);
-        $compiledConfigReader->expects($this->any())
+        $compiledConfigReader = $this->createStub(CompiledAssetMapperConfigReader::class);
+        $compiledConfigReader
             ->method('configExists')
             ->with(AssetMapper::MANIFEST_FILE_NAME)
             ->willReturn(true);
-        $compiledConfigReader->expects($this->any())
+        $compiledConfigReader
             ->method('loadConfig')
             ->willReturn(['file4.js' => '/final-assets/file4.checksumfrommanifest.js']);
 

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/CssAssetUrlCompilerTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\AssetMapper\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\Compiler\AssetCompilerInterface;
 use Symfony\Component\AssetMapper\Compiler\CssAssetUrlCompiler;
@@ -25,8 +25,8 @@ class CssAssetUrlCompilerTest extends TestCase
      */
     public function testCompile(string $input, string $expectedOutput, array $expectedDependencies)
     {
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -220,8 +220,8 @@ class CssAssetUrlCompilerTest extends TestCase
 
     public function testCompileFindsRelativeFilesViaSourcePath()
     {
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -266,8 +266,8 @@ class CssAssetUrlCompilerTest extends TestCase
 
         $asset = new MappedAsset($sourceLogicalName, '/path/to/styles.css');
 
-        $compiler = new CssAssetUrlCompiler(AssetCompilerInterface::MISSING_IMPORT_STRICT, $this->createMock(LoggerInterface::class));
-        $this->assertSame($input, $compiler->compile($input, $asset, $this->createMock(AssetMapperInterface::class)));
+        $compiler = new CssAssetUrlCompiler(AssetCompilerInterface::MISSING_IMPORT_STRICT, new NullLogger());
+        $this->assertSame($input, $compiler->compile($input, $asset, $this->createStub(AssetMapperInterface::class)));
     }
 
     public static function provideStrictModeTests(): iterable

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\AssetMapper\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\Compiler\AssetCompilerInterface;
 use Symfony\Component\AssetMapper\Compiler\JavaScriptImportPathCompiler;
@@ -32,8 +32,8 @@ class JavaScriptImportPathCompilerTest extends TestCase
     {
         $asset = new MappedAsset('app.js', '/project/assets/app.js', publicPathWithoutDigest: '/assets/app.js');
 
-        $importMapConfigReader = $this->createMock(ImportMapConfigReader::class);
-        $importMapConfigReader->expects($this->any())
+        $importMapConfigReader = $this->createStub(ImportMapConfigReader::class);
+        $importMapConfigReader
             ->method('findRootImportMapEntry')
             ->willReturnCallback(function ($importName) {
                 return match ($importName) {
@@ -43,7 +43,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
                     default => null,
                 };
             });
-        $importMapConfigReader->expects($this->any())
+        $importMapConfigReader
             ->method('convertPathToFilesystemPath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -53,8 +53,8 @@ class JavaScriptImportPathCompilerTest extends TestCase
                 };
             });
 
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAsset')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -63,7 +63,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
                 };
             });
 
-        $assetMapper->expects($this->any())
+        $assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -406,8 +406,8 @@ class JavaScriptImportPathCompilerTest extends TestCase
     {
         $inputAsset = new MappedAsset('app.js', '/project/assets/app.js', publicPathWithoutDigest: '/assets/app.js');
 
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -424,7 +424,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             import '../root_asset.js';
             EOF;
 
-        $compiler = new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class));
+        $compiler = new JavaScriptImportPathCompiler($this->createStub(ImportMapConfigReader::class));
         $compiler->compile($input, $inputAsset, $assetMapper);
         $this->assertCount(3, $inputAsset->getJavaScriptImports());
         $this->assertSame('other.js', $inputAsset->getJavaScriptImports()[0]->assetLogicalPath);
@@ -439,8 +439,8 @@ class JavaScriptImportPathCompilerTest extends TestCase
         }
         $inputAsset = new MappedAsset('app.js', 'C:\\\\project\\assets\\app.js', publicPathWithoutDigest: '/assets/app.js');
 
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -457,7 +457,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             import '../root_asset.js';
             EOF;
 
-        $compiler = new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class));
+        $compiler = new JavaScriptImportPathCompiler($this->createStub(ImportMapConfigReader::class));
         $compiler->compile($input, $inputAsset, $assetMapper);
         $this->assertCount(3, $inputAsset->getJavaScriptImports());
         $this->assertSame('other.js', $inputAsset->getJavaScriptImports()[0]->assetLogicalPath);
@@ -478,7 +478,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             ->method('getAssetFromSourcePath')
             ->willReturn($importedAsset);
 
-        $compiler = new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class));
+        $compiler = new JavaScriptImportPathCompiler($this->createStub(ImportMapConfigReader::class));
         $this->assertSame($expectedOutput, $compiler->compile($input, $asset, $assetMapper));
     }
 
@@ -532,7 +532,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
         $appAsset = new MappedAsset('app.js', '/project/assets/app.js', '/assets/app.js');
         $otherAsset = new MappedAsset('other.js', '/project/assets/other.js', '/assets/other.js');
 
-        $importMapConfigReader = $this->createMock(ImportMapConfigReader::class);
+        $importMapConfigReader = $this->createStub(ImportMapConfigReader::class);
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper->expects($this->once())
             ->method('getAssetFromSourcePath')
@@ -614,14 +614,13 @@ class JavaScriptImportPathCompilerTest extends TestCase
 
         $asset = new MappedAsset($sourceLogicalName, '/path/to/app.js');
 
-        $logger = $this->createMock(LoggerInterface::class);
         $compiler = new JavaScriptImportPathCompiler(
-            $this->createMock(ImportMapConfigReader::class),
+            $this->createStub(ImportMapConfigReader::class),
             AssetCompilerInterface::MISSING_IMPORT_STRICT,
-            $logger
+            new NullLogger()
         );
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($sourcePath) {
                 return match ($sourcePath) {
@@ -663,8 +662,8 @@ class JavaScriptImportPathCompilerTest extends TestCase
 
     public function testErrorMessageAvoidsCircularException()
     {
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAsset')
             ->willReturnCallback(function ($logicalPath) {
                 if ('htmx' === $logicalPath) {
@@ -677,7 +676,7 @@ class JavaScriptImportPathCompilerTest extends TestCase
             });
 
         $asset = new MappedAsset('htmx.js', '/path/to/app.js');
-        $compiler = new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class));
+        $compiler = new JavaScriptImportPathCompiler($this->createStub(ImportMapConfigReader::class));
         $content = '//** @type {import("./htmx").HtmxApi} */';
         $compiled = $compiler->compile($content, $asset, $assetMapper);
         // To form a good exception message, the compiler will check for the
@@ -688,10 +687,10 @@ class JavaScriptImportPathCompilerTest extends TestCase
 
     public function testCompilerThrowsExceptionOnPcreError()
     {
-        $compiler = new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class));
+        $compiler = new JavaScriptImportPathCompiler($this->createStub(ImportMapConfigReader::class));
         $content = str_repeat('foo "import *  ', 50);
         $javascriptAsset = new MappedAsset('app.js', '/project/assets/app.js', publicPathWithoutDigest: '/assets/app.js');
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failed to compile JavaScript import paths in "/project/assets/app.js". Error: "Backtrack limit exhausted".');

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/SourceMappingUrlsCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/SourceMappingUrlsCompilerTest.php
@@ -23,8 +23,8 @@ class SourceMappingUrlsCompilerTest extends TestCase
      */
     public function testCompile(string $sourceLogicalName, string $input, string $expectedOutput, $expectedDependencies)
     {
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\AssetMapper\Tests\Factory;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\AssetMapper\AssetMapperCompiler;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
@@ -28,7 +27,7 @@ class MappedAssetFactoryTest extends TestCase
 {
     private const DEFAULT_FIXTURES = __DIR__.'/../Fixtures/assets/vendor';
 
-    private AssetMapperInterface&MockObject $assetMapper;
+    private AssetMapperInterface $assetMapper;
 
     public function testCreateMappedAsset()
     {
@@ -150,7 +149,7 @@ class MappedAssetFactoryTest extends TestCase
     private function createFactory(?AssetCompilerInterface $extraCompiler = null, ?string $vendorDir = self::DEFAULT_FIXTURES): MappedAssetFactory
     {
         $compilers = [
-            new JavaScriptImportPathCompiler($this->createMock(ImportMapConfigReader::class)),
+            new JavaScriptImportPathCompiler($this->createStub(ImportMapConfigReader::class)),
             new CssAssetUrlCompiler(),
         ];
         if ($extraCompiler) {
@@ -162,8 +161,8 @@ class MappedAssetFactoryTest extends TestCase
             fn () => $this->assetMapper,
         );
 
-        $pathResolver = $this->createMock(PublicAssetsPathResolverInterface::class);
-        $pathResolver->expects($this->any())
+        $pathResolver = $this->createStub(PublicAssetsPathResolverInterface::class);
+        $pathResolver
             ->method('resolvePublicPath')
             ->willReturnCallback(function (string $logicalPath) {
                 return '/final-assets/'.$logicalPath;
@@ -176,8 +175,8 @@ class MappedAssetFactoryTest extends TestCase
         );
 
         // mock the AssetMapper to behave like normal: by calling back to the factory
-        $this->assetMapper = $this->createMock(AssetMapperInterface::class);
-        $this->assetMapper->expects($this->any())
+        $this->assetMapper = $this->createStub(AssetMapperInterface::class);
+        $this->assetMapper
             ->method('getAssetFromSourcePath')
             ->willReturnCallback(function (string $sourcePath) use ($factory) {
                 if (str_contains($sourcePath, 'dir1')) {

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapAuditorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapAuditorTest.php
@@ -33,7 +33,7 @@ class ImportMapAuditorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->importMapConfigReader = $this->createMock(ImportMapConfigReader::class);
+        $this->importMapConfigReader = $this->createStub(ImportMapConfigReader::class);
         $this->httpClient = new MockHttpClient();
         $this->importMapAuditor = new ImportMapAuditor($this->importMapConfigReader, $this->httpClient);
     }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -62,8 +62,8 @@ return [
 EOF;
         file_put_contents(__DIR__.'/../Fixtures/importmap_config_reader/importmap.php', $importMap);
 
-        $remotePackageStorage = $this->createMock(RemotePackageStorage::class);
-        $remotePackageStorage->expects($this->any())
+        $remotePackageStorage = $this->createStub(RemotePackageStorage::class);
+        $remotePackageStorage
             ->method('getDownloadPath')
             ->willReturnCallback(static function (string $packageModuleSpecifier, ImportMapType $type) {
                 return '/path/to/vendor/'.$packageModuleSpecifier.'.'.$type->value;
@@ -111,7 +111,7 @@ EOF;
      */
     public function testConvertPathToFilesystemPath(string $path, string $expectedPath)
     {
-        $configReader = new ImportMapConfigReader(realpath(__DIR__.'/../Fixtures/importmap.php'), $this->createMock(RemotePackageStorage::class));
+        $configReader = new ImportMapConfigReader(realpath(__DIR__.'/../Fixtures/importmap.php'), new RemotePackageStorage(sys_get_temp_dir()));
         // normalize path separators for comparison
         $expectedPath = str_replace('\\', '/', $expectedPath);
         $this->assertSame($expectedPath, $configReader->convertPathToFilesystemPath($path));
@@ -135,7 +135,7 @@ EOF;
      */
     public function testConvertFilesystemPathToPath(string $path, ?string $expectedPath)
     {
-        $configReader = new ImportMapConfigReader(__DIR__.'/../Fixtures/importmap.php', $this->createMock(RemotePackageStorage::class));
+        $configReader = new ImportMapConfigReader(__DIR__.'/../Fixtures/importmap.php', new RemotePackageStorage(sys_get_temp_dir()));
         $this->assertSame($expectedPath, $configReader->convertFilesystemPathToPath($path));
     }
 
@@ -154,7 +154,7 @@ EOF;
 
     public function testFindRootImportMapEntry()
     {
-        $configReader = new ImportMapConfigReader(__DIR__.'/../Fixtures/importmap.php', $this->createMock(RemotePackageStorage::class));
+        $configReader = new ImportMapConfigReader(__DIR__.'/../Fixtures/importmap.php', new RemotePackageStorage(sys_get_temp_dir()));
         $entry = $configReader->findRootImportMapEntry('file2');
         $this->assertSame('file2', $entry->importName);
         $this->assertSame('file2.js', $entry->path);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -60,8 +60,8 @@ class ImportMapRendererTest extends TestCase
                 ],
             ]);
 
-        $assetPackages = $this->createMock(Packages::class);
-        $assetPackages->expects($this->any())
+        $assetPackages = $this->createStub(Packages::class);
+        $assetPackages
             ->method('getUrl')
             ->willReturnCallback(function ($path) {
                 // try to imitate the behavior of the real service
@@ -116,7 +116,7 @@ class ImportMapRendererTest extends TestCase
 
         $renderer = new ImportMapRenderer(
             $importMapGenerator,
-            $this->createMock(Packages::class),
+            $this->createStub(Packages::class),
             polyfillImportName: 'es-module-shims',
         );
         $html = $renderer->render(['app']);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapUpdateCheckerTest.php
@@ -29,7 +29,7 @@ class ImportMapUpdateCheckerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->importMapConfigReader = $this->createMock(ImportMapConfigReader::class);
+        $this->importMapConfigReader = $this->createStub(ImportMapConfigReader::class);
         $httpClient = new MockHttpClient();
         $httpClient->setResponseFactory(self::responseFactory(...));
         $this->updateChecker = new ImportMapUpdateChecker($this->importMapConfigReader, $httpClient);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageDownloaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageDownloaderTest.php
@@ -172,8 +172,8 @@ class RemotePackageDownloaderTest extends TestCase
         $remotePackageStorage = new RemotePackageStorage('/foo/assets/vendor');
         $downloader = new RemotePackageDownloader(
             $remotePackageStorage,
-            $this->createMock(ImportMapConfigReader::class),
-            $this->createMock(PackageResolverInterface::class),
+            $this->createStub(ImportMapConfigReader::class),
+            $this->createStub(PackageResolverInterface::class),
         );
         $this->assertSame('/foo/assets/vendor', $downloader->getVendorDir());
     }

--- a/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
@@ -26,7 +26,7 @@ class MapperAwareAssetPackageTest extends TestCase
             ->with('foo')
             ->willReturn('2.0');
 
-        $assetMapperPackage = new MapperAwareAssetPackage($inner, $this->createMock(AssetMapperInterface::class));
+        $assetMapperPackage = new MapperAwareAssetPackage($inner, $this->createStub(AssetMapperInterface::class));
 
         $this->assertSame('2.0', $assetMapperPackage->getVersion('foo'));
     }
@@ -43,8 +43,8 @@ class MapperAwareAssetPackageTest extends TestCase
             ->willReturnCallback(function ($path) {
                 return '/'.$path;
             });
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $assetMapper->expects($this->any())
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper
             ->method('getPublicPath')
             ->willReturnCallback(function ($path) {
                 switch ($path) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT