### PR TITLE
[Serializer] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/CacheWarmer/CompiledClassMetadataCacheWarmerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/CacheWarmer/CompiledClassMetadataCacheWarmerTest.php
@@ -15,35 +15,28 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\Serializer\CacheWarmer\CompiledClassMetadataCacheWarmer;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryCompiler;
-use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 
 final class CompiledClassMetadataCacheWarmerTest extends TestCase
 {
     public function testItImplementsCacheWarmerInterface()
     {
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-        $filesystem = $this->createMock(Filesystem::class);
-
-        $compiledClassMetadataCacheWarmer = new CompiledClassMetadataCacheWarmer([], $classMetadataFactory, new ClassMetadataFactoryCompiler(), $filesystem);
+        $compiledClassMetadataCacheWarmer = new CompiledClassMetadataCacheWarmer([], new ClassMetadataFactory(new AttributeLoader()), new ClassMetadataFactoryCompiler(), new Filesystem());
 
         $this->assertInstanceOf(CacheWarmerInterface::class, $compiledClassMetadataCacheWarmer);
     }
 
     public function testItIsAnOptionalCacheWarmer()
     {
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-        $filesystem = $this->createMock(Filesystem::class);
-
-        $compiledClassMetadataCacheWarmer = new CompiledClassMetadataCacheWarmer([], $classMetadataFactory, new ClassMetadataFactoryCompiler(), $filesystem);
+        $compiledClassMetadataCacheWarmer = new CompiledClassMetadataCacheWarmer([], new ClassMetadataFactory(new AttributeLoader()), new ClassMetadataFactoryCompiler(), new Filesystem());
 
         $this->assertTrue($compiledClassMetadataCacheWarmer->isOptional());
     }
 
     public function testItDumpCompiledClassMetadatas()
     {
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-
         $code = <<<EOF
 <?php
 
@@ -60,7 +53,7 @@ EOF;
             ->with('/var/cache/prod/serializer.class.metadata.php', $code)
         ;
 
-        $compiledClassMetadataCacheWarmer = new CompiledClassMetadataCacheWarmer([], $classMetadataFactory, new ClassMetadataFactoryCompiler(), $filesystem);
+        $compiledClassMetadataCacheWarmer = new CompiledClassMetadataCacheWarmer([], new ClassMetadataFactory(new AttributeLoader()), new ClassMetadataFactoryCompiler(), $filesystem);
 
         $compiledClassMetadataCacheWarmer->warmUp('/var/cache/prod');
     }

--- a/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Command/DebugCommandTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Serializer\Command\DebugCommand;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
-use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Tests\Dummy\DummyClassOne;
 
@@ -79,9 +78,7 @@ class DebugCommandTest extends TestCase
 
     public function testOutputWithInvalidClassArgument()
     {
-        $serializer = $this->createMock(ClassMetadataFactoryInterface::class);
-
-        $command = new DebugCommand($serializer);
+        $command = new DebugCommand(new ClassMetadataFactory(new AttributeLoader()));
 
         $tester = new CommandTester($command);
         $tester->execute(['class' => 'App\\NotFoundResource'], ['decorated' => false]);

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableEncoderTest.php
@@ -42,8 +42,8 @@ class TraceableEncoderTest extends TestCase
 
     public function testCollectEncodingData()
     {
-        $encoder = $this->createMock(EncoderInterface::class);
-        $decoder = $this->createMock(DecoderInterface::class);
+        $encoder = $this->createStub(EncoderInterface::class);
+        $decoder = $this->createStub(DecoderInterface::class);
 
         $dataCollector = $this->createMock(SerializerDataCollector::class);
         $dataCollector
@@ -61,8 +61,8 @@ class TraceableEncoderTest extends TestCase
 
     public function testNotCollectEncodingDataIfNoDebugTraceId()
     {
-        $encoder = $this->createMock(EncoderInterface::class);
-        $decoder = $this->createMock(DecoderInterface::class);
+        $encoder = $this->createStub(EncoderInterface::class);
+        $decoder = $this->createStub(DecoderInterface::class);
 
         $dataCollector = $this->createMock(SerializerDataCollector::class);
         $dataCollector->expects($this->never())->method('collectEncoding');
@@ -76,22 +76,22 @@ class TraceableEncoderTest extends TestCase
     {
         $this->expectException(\BadMethodCallException::class);
 
-        (new TraceableEncoder($this->createMock(DecoderInterface::class), new SerializerDataCollector()))->encode('data', 'format');
+        (new TraceableEncoder($this->createStub(DecoderInterface::class), new SerializerDataCollector()))->encode('data', 'format');
     }
 
     public function testCannotDecodeIfNotDecoder()
     {
         $this->expectException(\BadMethodCallException::class);
 
-        (new TraceableEncoder($this->createMock(EncoderInterface::class), new SerializerDataCollector()))->decode('data', 'format');
+        (new TraceableEncoder($this->createStub(EncoderInterface::class), new SerializerDataCollector()))->decode('data', 'format');
     }
 
     public function testSupports()
     {
-        $encoder = $this->createMock(EncoderInterface::class);
+        $encoder = $this->createStub(EncoderInterface::class);
         $encoder->method('supportsEncoding')->willReturn(true);
 
-        $decoder = $this->createMock(DecoderInterface::class);
+        $decoder = $this->createStub(DecoderInterface::class);
         $decoder->method('supportsDecoding')->willReturn(true);
 
         $traceableEncoder = new TraceableEncoder($encoder, new SerializerDataCollector());

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableNormalizerTest.php
@@ -44,9 +44,9 @@ class TraceableNormalizerTest extends TestCase
 
     public function testCollectNormalizationData()
     {
-        $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer = $this->createStub(NormalizerInterface::class);
         $normalizer->method('getSupportedTypes')->willReturn(['*' => false]);
-        $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer = $this->createStub(DenormalizerInterface::class);
         $denormalizer->method('getSupportedTypes')->willReturn(['*' => false]);
 
         $dataCollector = $this->createMock(SerializerDataCollector::class);
@@ -65,9 +65,9 @@ class TraceableNormalizerTest extends TestCase
 
     public function testNotCollectNormalizationDataIfNoDebugTraceId()
     {
-        $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer = $this->createStub(NormalizerInterface::class);
         $normalizer->method('getSupportedTypes')->willReturn(['*' => false]);
-        $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer = $this->createStub(DenormalizerInterface::class);
         $denormalizer->method('getSupportedTypes')->willReturn(['*' => false]);
 
         $dataCollector = $this->createMock(SerializerDataCollector::class);
@@ -82,23 +82,23 @@ class TraceableNormalizerTest extends TestCase
     {
         $this->expectException(\BadMethodCallException::class);
 
-        (new TraceableNormalizer($this->createMock(DenormalizerInterface::class), new SerializerDataCollector()))->normalize('data');
+        (new TraceableNormalizer($this->createStub(DenormalizerInterface::class), new SerializerDataCollector()))->normalize('data');
     }
 
     public function testCannotDenormalizeIfNotDenormalizer()
     {
         $this->expectException(\BadMethodCallException::class);
 
-        (new TraceableNormalizer($this->createMock(NormalizerInterface::class), new SerializerDataCollector()))->denormalize('data', 'type');
+        (new TraceableNormalizer($this->createStub(NormalizerInterface::class), new SerializerDataCollector()))->denormalize('data', 'type');
     }
 
     public function testSupports()
     {
-        $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer = $this->createStub(NormalizerInterface::class);
         $normalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $normalizer->method('supportsNormalization')->willReturn(true);
 
-        $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer = $this->createStub(DenormalizerInterface::class);
         $denormalizer->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer->method('supportsDenormalization')->willReturn(true);
 

--- a/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Debug/TraceableSerializerTest.php
@@ -106,7 +106,7 @@ class TraceableSerializerTest extends TestCase
 
     public function testAddDebugTraceIdInContext()
     {
-        $serializer = $this->createMock(Serializer::class);
+        $serializer = $this->createStub(Serializer::class);
 
         foreach (['serialize', 'deserialize', 'normalize', 'denormalize', 'encode', 'decode'] as $method) {
             $serializer->method($method)->willReturnCallback(function (): string {

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CacheMetadataFactoryTest.php
@@ -16,7 +16,9 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
 /**
@@ -59,8 +61,7 @@ class CacheMetadataFactoryTest extends TestCase
     public function testInvalidClassThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $decorated = $this->createMock(ClassMetadataFactoryInterface::class);
-        $factory = new CacheClassMetadataFactory($decorated, new ArrayAdapter());
+        $factory = new CacheClassMetadataFactory(new ClassMetadataFactory(new AttributeLoader()), new ArrayAdapter());
 
         $factory->getMetadataFor('Not\Exist');
     }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
@@ -14,8 +14,10 @@ namespace Symfony\Component\Serializer\Tests\Mapping\Factory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Factory\CompiledClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\SerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
@@ -26,8 +28,7 @@ final class CompiledClassMetadataFactoryTest extends TestCase
 {
     public function testItImplementsClassMetadataFactoryInterface()
     {
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-        $compiledClassMetadataFactory = new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/serializer.class.metadata.php', $classMetadataFactory);
+        $compiledClassMetadataFactory = new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/serializer.class.metadata.php', new ClassMetadataFactory(new AttributeLoader()));
 
         $this->assertInstanceOf(ClassMetadataFactoryInterface::class, $compiledClassMetadataFactory);
     }
@@ -37,8 +38,7 @@ final class CompiledClassMetadataFactoryTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('#File ".*/Fixtures/not-found-serializer.class.metadata.php" could not be found.#');
 
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-        new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/not-found-serializer.class.metadata.php', $classMetadataFactory);
+        new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/not-found-serializer.class.metadata.php', new ClassMetadataFactory(new AttributeLoader()));
     }
 
     public function testItThrowAnExceptionWhenMetadataIsNotOfTypeArray()
@@ -46,8 +46,7 @@ final class CompiledClassMetadataFactoryTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Compiled metadata must be of the type array, object given.');
 
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-        new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/object-metadata.php', $classMetadataFactory);
+        new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/object-metadata.php', new ClassMetadataFactory(new AttributeLoader()));
     }
 
     /**
@@ -91,8 +90,7 @@ final class CompiledClassMetadataFactoryTest extends TestCase
 
     public function testItReturnsTheSameInstance()
     {
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-        $compiledClassMetadataFactory = new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/serializer.class.metadata.php', $classMetadataFactory);
+        $compiledClassMetadataFactory = new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/serializer.class.metadata.php', new ClassMetadataFactory(new AttributeLoader()));
 
         $this->assertSame($compiledClassMetadataFactory->getMetadataFor(Dummy::class), $compiledClassMetadataFactory->getMetadataFor(Dummy::class));
     }

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Serializer\Attribute\SerializedName;
 use Symfony\Component\Serializer\Attribute\SerializedPath;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
-use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
@@ -30,8 +29,7 @@ final class MetadataAwareNameConverterTest extends TestCase
 {
     public function testInterface()
     {
-        $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
-        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $nameConverter = new MetadataAwareNameConverter(new ClassMetadataFactory(new AttributeLoader()));
         $this->assertInstanceOf(NameConverterInterface::class, $nameConverter);
     }
 
@@ -54,7 +52,7 @@ final class MetadataAwareNameConverterTest extends TestCase
     {
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
 
-        $fallback = $this->createMock(NameConverterInterface::class);
+        $fallback = $this->createStub(NameConverterInterface::class);
         $fallback
             ->method('normalize')
             ->willReturnCallback(static fn ($propertyName) => strtoupper($propertyName))
@@ -84,7 +82,7 @@ final class MetadataAwareNameConverterTest extends TestCase
     {
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
 
-        $fallback = $this->createMock(NameConverterInterface::class);
+        $fallback = $this->createStub(NameConverterInterface::class);
         $fallback
             ->method('denormalize')
             ->willReturnCallback(static fn ($propertyName) => strtolower($propertyName))

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -19,9 +18,7 @@ use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
-use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
-use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -46,12 +43,11 @@ use Symfony\Component\Serializer\Tests\Fixtures\VariadicConstructorTypedArgsDumm
 class AbstractNormalizerTest extends TestCase
 {
     private AbstractNormalizerDummy $normalizer;
-    private MockObject&ClassMetadataFactoryInterface $classMetadata;
+    private ClassMetadataFactoryInterface $classMetadata;
 
     protected function setUp(): void
     {
-        $loader = $this->getMockBuilder(LoaderChain::class)->setConstructorArgs([[]])->getMock();
-        $this->classMetadata = $this->getMockBuilder(ClassMetadataFactory::class)->setConstructorArgs([$loader])->getMock();
+        $this->classMetadata = $this->createStub(ClassMetadataFactoryInterface::class);
         $this->normalizer = new AbstractNormalizerDummy($this->classMetadata);
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -422,7 +422,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     private function getDenormalizerForDummyCollection()
     {
-        $extractor = $this->createMock(PhpDocExtractor::class);
+        $extractor = $this->createStub(PhpDocExtractor::class);
         $extractor->method('getTypes')
             ->willReturn(
                 [new Type('array', false, null, true, new Type('int'), new Type('object', false, DummyChild::class))],
@@ -477,7 +477,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     private function getDenormalizerForStringCollection()
     {
-        $extractor = $this->createMock(PhpDocExtractor::class);
+        $extractor = $this->createStub(PhpDocExtractor::class);
         $extractor->method('getTypes')
             ->willReturn(
                 [new Type('array', false, null, true, new Type('int'), new Type('string'))],
@@ -664,7 +664,7 @@ class AbstractObjectNormalizerTest extends TestCase
 
     private function getDenormalizerForObjectWithBasicProperties()
     {
-        $extractor = $this->createMock(PhpDocExtractor::class);
+        $extractor = $this->createStub(PhpDocExtractor::class);
         $extractor->method('getTypes')
             ->willReturn(
                 [new Type('bool')],

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -11,23 +11,12 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\UpcomingDenormalizerInterface as DenormalizerInterface;
 
 class ArrayDenormalizerTest extends TestCase
 {
-    private ArrayDenormalizer $denormalizer;
-    private MockObject&DenormalizerInterface $serializer;
-
-    protected function setUp(): void
-    {
-        $this->serializer = $this->createMock(DenormalizerInterface::class);
-        $this->denormalizer = new ArrayDenormalizer();
-        $this->denormalizer->setDenormalizer($this->serializer);
-    }
-
     public function testDenormalize()
     {
         $series = [
@@ -35,7 +24,8 @@ class ArrayDenormalizerTest extends TestCase
             [[['foo' => 'three', 'bar' => 'four']], new ArrayDummy('three', 'four')],
         ];
 
-        $this->serializer->expects($this->exactly(2))
+        $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
+        $nestedDenormalizer->expects($this->exactly(2))
             ->method('denormalize')
             ->willReturnCallback(function ($data) use (&$series) {
                 [$expectedArgs, $return] = array_shift($series);
@@ -45,7 +35,9 @@ class ArrayDenormalizerTest extends TestCase
             })
         ;
 
-        $result = $this->denormalizer->denormalize(
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($nestedDenormalizer);
+        $result = $denormalizer->denormalize(
             [
                 ['foo' => 'one', 'bar' => 'two'],
                 ['foo' => 'three', 'bar' => 'four'],
@@ -64,13 +56,16 @@ class ArrayDenormalizerTest extends TestCase
 
     public function testSupportsValidArray()
     {
-        $this->serializer->expects($this->once())
+        $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
+        $nestedDenormalizer->expects($this->once())
             ->method('supportsDenormalization')
             ->with($this->anything(), ArrayDummy::class, 'json', ['con' => 'text'])
             ->willReturn(true);
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($nestedDenormalizer);
 
         $this->assertTrue(
-            $this->denormalizer->supportsDenormalization(
+            $denormalizer->supportsDenormalization(
                 [
                     ['foo' => 'one', 'bar' => 'two'],
                     ['foo' => 'three', 'bar' => 'four'],
@@ -84,12 +79,15 @@ class ArrayDenormalizerTest extends TestCase
 
     public function testSupportsInvalidArray()
     {
-        $this->serializer->expects($this->any())
+        $nestedDenormalizer = $this->createStub(DenormalizerInterface::class);
+        $nestedDenormalizer
             ->method('supportsDenormalization')
             ->willReturn(false);
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($nestedDenormalizer);
 
         $this->assertFalse(
-            $this->denormalizer->supportsDenormalization(
+            $denormalizer->supportsDenormalization(
                 [
                     ['foo' => 'one', 'bar' => 'two'],
                     ['foo' => 'three', 'bar' => 'four'],
@@ -101,8 +99,11 @@ class ArrayDenormalizerTest extends TestCase
 
     public function testSupportsNoArray()
     {
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($this->createStub(DenormalizerInterface::class));
+
         $this->assertFalse(
-            $this->denormalizer->supportsDenormalization(
+            $denormalizer->supportsDenormalization(
                 ['foo' => 'one', 'bar' => 'two'],
                 ArrayDummy::class
             )

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/FormErrorNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/FormErrorNormalizerTest.php
@@ -26,7 +26,7 @@ class FormErrorNormalizerTest extends TestCase
     {
         $this->normalizer = new FormErrorNormalizer();
 
-        $this->form = $this->createMock(FormInterface::class);
+        $this->form = $this->createStub(FormInterface::class);
         $this->form->method('isSubmitted')->willReturn(true);
         $this->form->method('all')->willReturn([]);
 
@@ -45,7 +45,7 @@ class FormErrorNormalizerTest extends TestCase
 
     public function testSupportsNormalizationWithNotSubmittedForm()
     {
-        $form = $this->createMock(FormInterface::class);
+        $form = $this->createStub(FormInterface::class);
         $this->assertFalse($this->normalizer->supportsNormalization($form));
     }
 
@@ -77,7 +77,7 @@ class FormErrorNormalizerTest extends TestCase
 
     public function testNormalizeWithChildren()
     {
-        $exptected = [
+        $expected = [
             'code' => null,
             'title' => 'Validation Failed',
             'type' => 'https://symfony.com/errors/form',
@@ -117,7 +117,7 @@ class FormErrorNormalizerTest extends TestCase
             ],
         ];
 
-        $form = clone $form1 = clone $form2 = clone $form3 = $this->createMock(FormInterface::class);
+        $form = clone $form1 = clone $form2 = clone $form3 = $this->createStub(FormInterface::class);
 
         $form1->method('getErrors')
             ->willReturn(new FormErrorIterator($form1, [
@@ -142,7 +142,7 @@ class FormErrorNormalizerTest extends TestCase
 
         $form2->method('all')->willReturn([$form3]);
 
-        $form = $this->createMock(FormInterface::class);
+        $form = $this->createStub(FormInterface::class);
         $form->method('isSubmitted')->willReturn(true);
         $form->method('all')->willReturn([$form1, $form2]);
         $form->method('getErrors')
@@ -151,6 +151,6 @@ class FormErrorNormalizerTest extends TestCase
             ])
             );
 
-        $this->assertEquals($exptected, $this->normalizer->normalize($form));
+        $this->assertEquals($expected, $this->normalizer->normalize($form));
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -395,7 +395,7 @@ class GetSetMethodNormalizerTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot normalize attribute "object" because the injected serializer is not a normalizer');
-        $this->normalizer->setSerializer($this->createMock(SerializerInterface::class));
+        $this->normalizer->setSerializer($this->createStub(SerializerInterface::class));
 
         $obj = new GetSetDummy();
         $object = new \stdClass();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -295,7 +295,7 @@ class ObjectNormalizerTest extends TestCase
 
     public function testConstructorWithObjectDenormalizeUsingPropertyInfoExtractor()
     {
-        $serializer = $this->createMock(ObjectSerializerNormalizer::class);
+        $serializer = $this->createStub(ObjectSerializerNormalizer::class);
         $normalizer = new ObjectNormalizer(null, null, null, null, null, null, [], new PropertyInfoExtractor());
         $normalizer->setSerializer($serializer);
 
@@ -684,7 +684,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot normalize attribute "object" because the injected serializer is not a normalizer');
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $this->normalizer->setSerializer($serializer);
 
         $obj = new ObjectDummy();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -72,7 +72,7 @@ class PropertyNormalizerTest extends TestCase
 
     private function createNormalizer(array $defaultContext = []): void
     {
-        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->serializer = $this->createStub(SerializerInterface::class);
         $this->normalizer = new PropertyNormalizer(null, null, null, null, null, $defaultContext);
         $this->normalizer->setSerializer($this->serializer);
     }
@@ -437,7 +437,7 @@ class PropertyNormalizerTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot normalize attribute "bar" because the injected serializer is not a normalizer');
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
         $this->normalizer->setSerializer($serializer);
 
         $obj = new PropertyDummy();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TranslatableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TranslatableNormalizerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\TranslatableNormalizer;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorTrait;
 
 class TranslatableNormalizerTest extends TestCase
 {
@@ -22,7 +23,7 @@ class TranslatableNormalizerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->normalizer = new TranslatableNormalizer($this->createMock(TranslatorInterface::class));
+        $this->normalizer = new TranslatableNormalizer(new IdentityTranslator());
     }
 
     public function testSupportsNormalization()
@@ -43,7 +44,7 @@ class TranslatableNormalizerTest extends TestCase
     public function testNormalizeWithNormalizationLocalePassedInConstructor()
     {
         $normalizer = new TranslatableNormalizer(
-            $this->createMock(TranslatorInterface::class),
+            new IdentityTranslator(),
             ['translatable_normalization_locale' => 'es'],
         );
         $message = new TestMessage();
@@ -60,4 +61,9 @@ class TestMessage implements TranslatableInterface
     {
         return 'key_'.($locale ?? 'null');
     }
+}
+
+class IdentityTranslator implements TranslatorInterface
+{
+    use TranslatorTrait;
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/UnwrappingDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/UnwrappingDenormalizerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -20,23 +19,16 @@ use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectDummy;
 /**
  * @author Eduard Bulava <bulavaeduard@gmail.com>
  */
-class UnwrappinDenormalizerTest extends TestCase
+class UnwrappingDenormalizerTest extends TestCase
 {
-    private UnwrappingDenormalizer $denormalizer;
-    private MockObject&Serializer $serializer;
-
-    protected function setUp(): void
-    {
-        $this->serializer = $this->createMock(Serializer::class);
-        $this->denormalizer = new UnwrappingDenormalizer();
-        $this->denormalizer->setSerializer($this->serializer);
-    }
-
     public function testSupportsNormalization()
     {
-        $this->assertTrue($this->denormalizer->supportsDenormalization([], 'stdClass', 'any', [UnwrappingDenormalizer::UNWRAP_PATH => '[baz][inner]']));
-        $this->assertFalse($this->denormalizer->supportsDenormalization([], 'stdClass', 'any', [UnwrappingDenormalizer::UNWRAP_PATH => '[baz][inner]', 'unwrapped' => true]));
-        $this->assertFalse($this->denormalizer->supportsDenormalization([], 'stdClass', 'any', []));
+        $denormalizer = new UnwrappingDenormalizer();
+        $denormalizer->setSerializer($this->createStub(Serializer::class));
+
+        $this->assertTrue($denormalizer->supportsDenormalization([], 'stdClass', 'any', [UnwrappingDenormalizer::UNWRAP_PATH => '[baz][inner]']));
+        $this->assertFalse($denormalizer->supportsDenormalization([], 'stdClass', 'any', [UnwrappingDenormalizer::UNWRAP_PATH => '[baz][inner]', 'unwrapped' => true]));
+        $this->assertFalse($denormalizer->supportsDenormalization([], 'stdClass', 'any', []));
     }
 
     public function testDenormalize()
@@ -46,12 +38,15 @@ class UnwrappinDenormalizerTest extends TestCase
         $expected->bar = 'bar';
         $expected->setFoo('foo');
 
-        $this->serializer->expects($this->exactly(1))
+        $serializer = $this->createMock(Serializer::class);
+        $serializer->expects($this->exactly(1))
             ->method('denormalize')
             ->with(['foo' => 'foo', 'bar' => 'bar', 'baz' => true])
             ->willReturn($expected);
+        $denormalizer = new UnwrappingDenormalizer();
+        $denormalizer->setSerializer($serializer);
 
-        $result = $this->denormalizer->denormalize(
+        $result = $denormalizer->denormalize(
             ['data' => ['foo' => 'foo', 'bar' => 'bar', 'baz' => true]],
             ObjectDummy::class,
             'any',
@@ -65,12 +60,15 @@ class UnwrappinDenormalizerTest extends TestCase
 
     public function testDenormalizeInvalidPath()
     {
-        $this->serializer->expects($this->exactly(1))
+        $serializer = $this->createMock(Serializer::class);
+        $serializer->expects($this->exactly(1))
             ->method('denormalize')
             ->with(null)
             ->willReturn(new ObjectDummy());
+        $denormalizer = new UnwrappingDenormalizer();
+        $denormalizer->setSerializer($serializer);
 
-        $obj = $this->denormalizer->denormalize(
+        $obj = $denormalizer->denormalize(
             ['data' => ['foo' => 'foo', 'bar' => 'bar', 'baz' => true]],
             ObjectDummy::class,
             'any',

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -102,7 +102,7 @@ class SerializerTest extends TestCase
     public function testNormalizeNoMatch()
     {
         $this->expectException(UnexpectedValueException::class);
-        $serializer = new Serializer([$this->createMock(CustomNormalizer::class)]);
+        $serializer = new Serializer([$this->createStub(NormalizerInterface::class)]);
         $serializer->normalize(new \stdClass(), 'xml');
     }
 
@@ -130,7 +130,7 @@ class SerializerTest extends TestCase
     public function testDenormalizeNoMatch()
     {
         $this->expectException(UnexpectedValueException::class);
-        $serializer = new Serializer([$this->createMock(CustomNormalizer::class)]);
+        $serializer = new Serializer([$this->createStub(NormalizerInterface::class)]);
         $serializer->denormalize('foo', 'stdClass');
     }
 
@@ -161,13 +161,13 @@ class SerializerTest extends TestCase
 
     public function testNormalizeWithSupportOnData()
     {
-        $normalizer1 = $this->createMock(NormalizerInterface::class);
+        $normalizer1 = $this->createStub(NormalizerInterface::class);
         $normalizer1->method('getSupportedTypes')->willReturn(['*' => false]);
         $normalizer1->method('supportsNormalization')
             ->willReturnCallback(fn ($data, $format) => isset($data->test));
         $normalizer1->method('normalize')->willReturn('test1');
 
-        $normalizer2 = $this->createMock(NormalizerInterface::class);
+        $normalizer2 = $this->createStub(NormalizerInterface::class);
         $normalizer2->method('getSupportedTypes')->willReturn(['*' => false]);
         $normalizer2->method('supportsNormalization')
             ->willReturn(true);
@@ -184,13 +184,13 @@ class SerializerTest extends TestCase
 
     public function testDenormalizeWithSupportOnData()
     {
-        $denormalizer1 = $this->createMock(DenormalizerInterface::class);
+        $denormalizer1 = $this->createStub(DenormalizerInterface::class);
         $denormalizer1->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer1->method('supportsDenormalization')
             ->willReturnCallback(fn ($data, $type, $format) => isset($data['test1']));
         $denormalizer1->method('denormalize')->willReturn('test1');
 
-        $denormalizer2 = $this->createMock(DenormalizerInterface::class);
+        $denormalizer2 = $this->createStub(DenormalizerInterface::class);
         $denormalizer2->method('getSupportedTypes')->willReturn(['*' => false]);
         $denormalizer2->method('supportsDenormalization')
             ->willReturn(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT