### PR TITLE
[ObjectMapper] improve test expectations

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -370,7 +370,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             return $callable;
         }
 
-        throw new NoSuchCallableException(\sprintf('"%s" is not a valid callable.', $fn));
+        throw new NoSuchCallableException(\sprintf('"%s" is not a valid callable.', $fn).($expectedInterface ? \sprintf(' If you use a class, make sure it implements "%s".', $expectedInterface) : ''));
     }
 
     /**

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToStdClass.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToStdClass.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Transform;
+
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+class TransformToStdClass implements TransformCallableInterface
+{
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        return new \stdClass();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToString.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToString.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Transform;
+
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+class TransformToString implements TransformCallableInterface
+{
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        return 'str';
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -94,6 +94,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\ConditionCallab
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\TransformCallable;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\SourceEntity;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\TargetDto as TargetTransformTargetDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Transform\TransformToStdClass;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Transform\TransformToString;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
@@ -358,7 +360,7 @@ final class ObjectMapperTest extends TestCase
         $u->foo = 'bar';
 
         $metadata = $this->createStub(ObjectMapperMetadataFactoryInterface::class);
-        $metadata->method('create')->with($u)->willReturn([new Mapping(target: \stdClass::class, transform: static fn () => 'str')]);
+        $metadata->method('create')->with($u)->willReturn([new Mapping(target: \stdClass::class, transform: new TransformToString())]);
         $mapper = new ObjectMapper($metadata);
         $mapper->map($u);
     }
@@ -380,7 +382,7 @@ final class ObjectMapperTest extends TestCase
         $u->foo = 'bar';
 
         $metadata = $this->createStub(ObjectMapperMetadataFactoryInterface::class);
-        $metadata->method('create')->with($u)->willReturn([new Mapping(target: ClassWithoutTarget::class, transform: static fn () => new \stdClass())]);
+        $metadata->method('create')->with($u)->willReturn([new Mapping(target: ClassWithoutTarget::class, transform: new TransformToStdClass())]);
         $mapper = new ObjectMapper($metadata);
         $mapper->map($u);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62938
| License       | MIT

Since https://github.com/symfony/symfony/commit/9d1aaf407973a6a2a002ea359d89f8ae18afce0e there are some failures as expectations are not the same. This PR changes the static transform to valid transforms to be sure we test the same behavior. 