### PR TITLE
[DoctrineBridge] Fix custom type based on Uid on entity loader

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Bridge\Doctrine\Types\AbstractUidType;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
@@ -68,7 +69,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
             // Filter out non-integer values (e.g. ""). If we don't, some
             // databases such as PostgreSQL fail.
             $values = array_values(array_filter($values, static fn ($v) => \is_string($v) && ctype_digit($v) || (string) $v === (string) (int) $v));
-        } elseif (\in_array($type, ['ulid', 'uuid', 'guid'])) {
+        } elseif (null !== $type && (\in_array($type, ['ulid', 'uuid', 'guid']) || (Type::hasType($type) && is_subclass_of(Type::getType($type), AbstractUidType::class)))) {
             $parameterType = class_exists(ArrayParameterType::class) ? ArrayParameterType::STRING : Connection::PARAM_STR_ARRAY;
 
             // Like above, but we just filter out empty strings.

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUuidId.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUuidId.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Symfony\Component\Uid\Uuid;
+
+final class CustomUuidId extends Uuid
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUuidIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUuidIdEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class CustomUuidIdEntity
+{
+    public function __construct(
+        #[Id, Column(type: CustomUuidIdType::class)]
+        protected CustomUuidId $id,
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUuidIdType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUuidIdType.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Symfony\Bridge\Doctrine\Types\AbstractUidType;
+
+final class CustomUuidIdType extends AbstractUidType
+{
+    public function getName(): string
+    {
+        return self::class;
+    }
+
+    protected function getUidClass(): string
+    {
+        return CustomUuidId::class;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
 use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\CustomUuidIdType;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\EmbeddedIdentifierEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\LegacyQueryMock;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
@@ -159,6 +160,9 @@ class ORMQueryBuilderLoaderTest extends TestCase
         if (!Type::hasType('ulid')) {
             Type::addType('ulid', UlidType::class);
         }
+        if (!Type::hasType(CustomUuidIdType::class)) {
+            Type::addType(CustomUuidIdType::class, CustomUuidIdType::class);
+        }
 
         $em = DoctrineTestHelper::createTestEntityManager();
 
@@ -202,6 +206,9 @@ class ORMQueryBuilderLoaderTest extends TestCase
         if (!Type::hasType('ulid')) {
             Type::addType('ulid', UlidType::class);
         }
+        if (!Type::hasType(CustomUuidIdType::class)) {
+            Type::addType(CustomUuidIdType::class, CustomUuidIdType::class);
+        }
 
         $em = DoctrineTestHelper::createTestEntityManager();
 
@@ -219,7 +226,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
         $loader = new ORMQueryBuilderLoader($qb);
 
         $this->expectException(TransformationFailedException::class);
-        $this->expectExceptionMessageMatches('/^Failed to transform "hello" into "(uuid|ulid)"\.$/');
+        $this->expectExceptionMessageMatches('/^Failed to transform "hello" into "(uuid|ulid|Symfony\\\\Bridge\\\\Doctrine\\\\Tests\\\\Fixtures\\\\CustomUuidIdType)"\.$/');
 
         $loader->getEntitiesByIds('id', ['hello']);
     }
@@ -267,6 +274,7 @@ class ORMQueryBuilderLoaderTest extends TestCase
         return [
             ['Symfony\Bridge\Doctrine\Tests\Fixtures\UuidIdEntity'],
             ['Symfony\Bridge\Doctrine\Tests\Fixtures\UlidIdEntity'],
+            ['Symfony\Bridge\Doctrine\Tests\Fixtures\CustomUuidIdEntity'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Issues        | Fix #63026
| License       | MIT

I'm experimenting with type-safe identifier (https://sensiolabs.com/blog/2025/type-safe-identifiers-symfony-doctrine) and use it with autocomplete (https://symfony.com/bundles/ux-autocomplete/current/index.html#usage-in-a-form-with-ajax), I'm using PostgreSQL for the database

I have followed each steps and once I open the site i get an errror

```
An exception occurred while executing a query: SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for type uuid: ""
CONTEXT: unnamed portal parameter $1 = ''"
```

and from log
```
{"sql":"SELECT ... FROM ... p0_ WHERE p0_.id IN (?) ORDER BY p0_.name ASC","params":{"1":""}
```

I found out that `getEntitiesByIds` method this class https://github.com/symfony/symfony/blob/8.0/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php#L38-L101

the value of `$values` is `[ 0 => '' ]`