### PR TITLE
[Serializer] Fix NameConverter not detecting wrong input format with `allow_extra_attributes=false`

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -358,6 +358,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 if (isset($nestedData[$notConverted]) && !isset($originalNestedData[$attribute])) {
                     throw new LogicException(\sprintf('Duplicate values for key "%s" found. One value is set via the SerializedPath attribute: "%s", the other one is set via the SerializedName attribute: "%s".', $notConverted, implode('->', $nestedAttributes[$notConverted]->getElements()), $attribute));
                 }
+
+                if ($attribute === $notConverted
+                    && !($context[self::ALLOW_EXTRA_ATTRIBUTES] ?? $this->defaultContext[self::ALLOW_EXTRA_ATTRIBUTES])
+                    && (false === $allowedAttributes || \in_array($attribute, $allowedAttributes, true))
+                    && $this->nameConverter->normalize($attribute, $resolvedClass, $format, $context) !== $attribute
+                ) {
+                    // Input was in wrong format (e.g., camelCase when snake_case expected)
+                    $extraAttributes[] = $notConverted;
+                    continue;
+                }
             }
 
             $attributeContext = $this->getAttributeDenormalizationContext($resolvedClass, $attribute, $context);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\Ignore;
+use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
@@ -1202,6 +1203,51 @@ class ObjectNormalizerTest extends TestCase
         $this->assertInstanceOf(DiscriminatorDummyTypeA::class, $obj);
     }
 
+    public function testNameConverterWithWrongCaseAndAllowExtraAttributesFalse()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
+
+        $result = $normalizer->denormalize(
+            ['some_camel_case_property' => 1],
+            NameConverterTestDummy::class,
+            null,
+            [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]
+        );
+        $this->assertSame(1, $result->someCamelCaseProperty);
+
+        $this->expectException(ExtraAttributesException::class);
+        $this->expectExceptionMessage('someCamelCaseProperty');
+        $normalizer->denormalize(
+            ['someCamelCaseProperty' => 1],
+            NameConverterTestDummy::class,
+            null,
+            [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]
+        );
+    }
+
+    public function testNameConverterWithWrongCaseAndAllowExtraAttributesTrue()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
+
+        $result = $normalizer->denormalize(
+            ['someCamelCaseProperty' => 999],
+            NameConverterTestDummy::class,
+            null,
+            [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true]
+        );
+        $this->assertSame(0, $result->someCamelCaseProperty);
+
+        $result = $normalizer->denormalize(
+            ['some_camel_case_property' => 42],
+            NameConverterTestDummy::class,
+            null,
+            [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true]
+        );
+        $this->assertSame(42, $result->someCamelCaseProperty);
+    }
+
     public function testNormalizeObjectWithGroupsAndIsPrefixedProperty()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
@@ -1754,5 +1800,22 @@ class ObjectWithIgnoredMethodSameNameAsPropertyWithGroups
     public function visibleGroup()
     {
         return $this->visibleGroup;
+    }
+}
+
+class NameConverterTestDummy
+{
+    public function __construct(
+        public readonly int $someCamelCaseProperty = 0,
+    ) {
+    }
+}
+
+class NameConverterTestDummyMultiple
+{
+    public function __construct(
+        public readonly int $someCamelCaseProperty = 0,
+        public readonly int $anotherProperty = 0,
+    ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62725
| License       | MIT

When using a `NameConverter` with `allow_extra_attributes=false`, wrongly formatted input (e.g., `someCamelCaseProperty` instead of `some_camel_case_property`) was silently accepted because the unconverted attribute name happened to match the property name.

This fix detects when the `NameConverter` didn't transform the input and checks if the property requires a different serialized format. If so, it flags the input as an extra attribute and throws `ExtraAttributesException`.