### PR TITLE
[Config] add back missing enabled key in normalization step

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -378,7 +378,7 @@ class Configuration implements ConfigurationInterface
                     ->beforeNormalization()
                         ->ifArray()
                         ->then(static function ($v) {
-                            if (false !== ($v['enabled'] ?? true)) {
+                            if (true === $v['enabled']) {
                                 $workflows = $v;
                                 unset($workflows['enabled']);
 

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -353,6 +353,14 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             ->treatFalseLike(['enabled' => false])
             ->treatTrueLike(['enabled' => true])
             ->treatNullLike(['enabled' => true])
+            ->beforeNormalization()
+                ->ifArray()
+                ->then(static function ($v) {
+                    $v['enabled'] ??= true;
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->booleanNode('enabled')
                     ->defaultFalse()

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -378,11 +378,6 @@ class ArrayNodeDefinitionTest extends TestCase
         };
 
         return [
-            'canBeEnabled keeps explicit false' => [
-                ['enabled' => false],
-                ['enabled' => false, 'foo' => 'baz'],
-                static fn () => $factory(static fn ($node) => $node->canBeEnabled()),
-            ],
             'canBeEnabled keeps explicit true' => [
                 ['enabled' => true],
                 ['enabled' => true, 'foo' => 'baz'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | following #63002
| License       | MIT

Our tests on 6.4 and 7.3 are failing because of this. If we rely on the enabled key being available in the before normalization step when having a node that can be enabled, there will be other packages out there doing the same.