### PR TITLE
[String] Fix UnicodeString::startsWith()/endsWith() on strings that start/end with a zero

### DIFF
--- a/src/Symfony/Component/String/Tests/UnicodeStringTest.php
+++ b/src/Symfony/Component/String/Tests/UnicodeStringTest.php
@@ -296,6 +296,9 @@ class UnicodeStringTest extends AbstractUnicodeTestCase
             [
                 [false, "cle\u{0301} prive\u{0301}e", 'cle', UnicodeString::NFD],
                 [true, "cle\u{0301} prive\u{0301}e", 'clé', UnicodeString::NFD],
+                [true, '06', '0'],
+                [true, '0', '0'],
+                [true, '012', '01'],
             ]
         );
     }
@@ -307,6 +310,10 @@ class UnicodeStringTest extends AbstractUnicodeTestCase
             [
                 [false, "cle\u{0301} prive\u{0301}e", 'ee', UnicodeString::NFD],
                 [true, "cle\u{0301} prive\u{0301}e", 'ée', UnicodeString::NFD],
+                [false, '06', '0'],
+                [true, '06', '6'],
+                [true, '0', '0'],
+                [true, '10', '0'],
             ]
         );
     }

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -106,7 +106,9 @@ class UnicodeString extends AbstractUnicodeString
             return false;
         }
 
-        $grapheme = grapheme_extract($this->string, \strlen($suffix), \GRAPHEME_EXTR_MAXBYTES, \strlen($this->string) - \strlen($suffix)) ?: '';
+        if (false === $grapheme = grapheme_extract($this->string, \strlen($suffix), \GRAPHEME_EXTR_MAXBYTES, \strlen($this->string) - \strlen($suffix))) {
+            $grapheme = '';
+        }
 
         if ($this->ignoreCase) {
             return 0 === mb_stripos($grapheme, $suffix, 0, 'UTF-8');
@@ -357,7 +359,9 @@ class UnicodeString extends AbstractUnicodeString
             return false;
         }
 
-        $grapheme = grapheme_extract($this->string, \strlen($prefix), \GRAPHEME_EXTR_MAXBYTES) ?: '';
+        if (false === $grapheme = grapheme_extract($this->string, \strlen($prefix), \GRAPHEME_EXTR_MAXBYTES)) {
+            $grapheme = '';
+        }
 
         if ($this->ignoreCase) {
             return 0 === mb_stripos($grapheme, $prefix, 0, 'UTF-8');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63054
| License       | MIT
