### PR TITLE
[Semaphore] Add `SemaphoreKeyNormalizer`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -170,6 +170,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Semaphore\PersistingStoreInterface as SemaphoreStoreInterface;
 use Symfony\Component\Semaphore\Semaphore;
 use Symfony\Component\Semaphore\SemaphoreFactory;
+use Symfony\Component\Semaphore\Serializer\SemaphoreKeyNormalizer;
 use Symfony\Component\Semaphore\Store\StoreFactory as SemaphoreStoreFactory;
 use Symfony\Component\Serializer\Attribute as SerializerMapping;
 use Symfony\Component\Serializer\Attribute\ExtendsSerializationFor;
@@ -2246,6 +2247,11 @@ class FrameworkExtension extends Extension
     private function registerSemaphoreConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void
     {
         $loader->load('semaphore.php');
+
+        // BC layer Semaphore < 7.4
+        if (!interface_exists(DenormalizerInterface::class) || !class_exists(SemaphoreKeyNormalizer::class)) {
+            $container->removeDefinition('serializer.normalizer.semaphore_key');
+        }
 
         foreach ($config['resources'] as $resourceName => $resourceStore) {
             $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/semaphore.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/semaphore.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Semaphore\SemaphoreFactory;
+use Symfony\Component\Semaphore\Serializer\SemaphoreKeyNormalizer;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -19,5 +20,8 @@ return static function (ContainerConfigurator $container) {
             ->args([abstract_arg('Store')])
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])
             ->tag('monolog.logger', ['channel' => 'semaphore'])
+
+        ->set('serializer.normalizer.semaphore_key', SemaphoreKeyNormalizer::class)
+            ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -880])
     ;
 };

--- a/src/Symfony/Component/Semaphore/CHANGELOG.md
+++ b/src/Symfony/Component/Semaphore/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `SemaphoreKeyNormalizer`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Semaphore/Exception/UnserializableKeyException.php
+++ b/src/Symfony/Component/Semaphore/Exception/UnserializableKeyException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Exception;
+
+/**
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+class UnserializableKeyException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Semaphore/Serializer/SemaphoreKeyNormalizer.php
+++ b/src/Symfony/Component/Semaphore/Serializer/SemaphoreKeyNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Serializer;
+
+use Symfony\Component\Semaphore\Key;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalize {@see Key} instances for transferring between processes.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+class SemaphoreKeyNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    /**
+     * @return array<string, bool|null>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Key::class => true];
+    }
+
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return $data->__serialize();
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Key;
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Key
+    {
+        $key = (new \ReflectionClass(Key::class))->newInstanceWithoutConstructor();
+        $key->__unserialize($data);
+
+        return $key;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return Key::class === $type;
+    }
+}

--- a/src/Symfony/Component/Semaphore/Tests/KeyTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/KeyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Semaphore\Exception\UnserializableKeyException;
+use Symfony\Component\Semaphore\Key;
+use Symfony\Component\Semaphore\Store\RedisStore;
+
+/**
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+class KeyTest extends TestCase
+{
+    public function testSerialize()
+    {
+        $key = new Key(__METHOD__, 5, 2);
+        $key->setState(RedisStore::class, base64_encode(random_bytes(32)));
+
+        $copy = unserialize(serialize($key));
+        $this->assertSame(5, $copy->getLimit());
+        $this->assertSame(2, $copy->getWeight());
+        $this->assertEquals($key->getState(RedisStore::class), $copy->getState(RedisStore::class));
+        $this->assertEqualsWithDelta($key->getRemainingLifetime(), $copy->getRemainingLifetime(), 0.001);
+    }
+
+    public function testCannotSerializeUnserializableKey()
+    {
+        $key = new Key(__METHOD__, 1);
+        $key->markUnserializable();
+
+        $this->expectException(UnserializableKeyException::class);
+        serialize($key);
+    }
+}

--- a/src/Symfony/Component/Semaphore/Tests/Serializer/SemaphoreKeyNormalizerTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Serializer/SemaphoreKeyNormalizerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Semaphore\Tests\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Semaphore\Key;
+use Symfony\Component\Semaphore\Serializer\SemaphoreKeyNormalizer;
+use Symfony\Component\Semaphore\Store\RedisStore;
+
+class SemaphoreKeyNormalizerTest extends TestCase
+{
+    public function testNormalizeAndDenormalize()
+    {
+        $key = new Key(__METHOD__, 5, 2);
+        $key->setState(RedisStore::class, base64_encode(random_bytes(32)));
+        $key->reduceLifetime(1);
+
+        $normalizer = new SemaphoreKeyNormalizer();
+        $copy = $normalizer->denormalize($normalizer->normalize($key), Key::class);
+
+        $this->assertSame(5, $copy->getLimit());
+        $this->assertSame(2, $copy->getWeight());
+        $this->assertSame($key->getState(RedisStore::class), $copy->getState(RedisStore::class));
+        $this->assertEqualsWithDelta($key->getRemainingLifetime(), $copy->getRemainingLifetime(), 0.001);
+    }
+}

--- a/src/Symfony/Component/Semaphore/composer.json
+++ b/src/Symfony/Component/Semaphore/composer.json
@@ -24,7 +24,8 @@
         "psr/log": "^1|^2|^3"
     },
     "require-dev": {
-        "predis/predis": "^1.1|^2.0"
+        "predis/predis": "^1.1|^2.0",
+        "symfony/serializer": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Semaphore\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

Follow up from #63045 

Mirrors functionality added to `Lock` in #60023 

Adds `SemaphoreKeyNormalizer` to allow a `Key` to be transferred across processes/services. Once the approach is approved I'll update the documentation

- [x] update documentation to mirror Lock

Documentation PR: https://github.com/symfony/symfony-docs/pull/21726