### PR TITLE
[Messenger] Add support for custom `type` in `Serializer` Transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -810,8 +810,9 @@ class FrameworkExtension extends Extension
             ->addTag('container.excluded', ['source' => 'because it\'s a test case']);
         $container->registerForAutoconfiguration(\UnitEnum::class)
             ->addTag('container.excluded', ['source' => 'because it\'s an enum']);
-        $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition) {
+        $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition, AsMessage $attribute): void {
             $definition->addTag('container.excluded', ['source' => 'because it\'s a messenger message']);
+            $definition->addTag('messenger.message', ['serializedTypeName' => $attribute->serializedTypeName]);
         });
         $container->registerAttributeForAutoconfiguration(\Attribute::class, static function (ChildDefinition $definition) {
             $definition->addTag('container.excluded', ['source' => 'because it\'s a PHP attribute']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -73,6 +73,7 @@ return static function (ContainerConfigurator $container) {
                 service('serializer'),
                 abstract_arg('format'),
                 abstract_arg('context'),
+                abstract_arg('message type to serialized type map'),
             ])
 
         ->set('serializer.normalizer.flatten_exception', FlattenExceptionNormalizer::class)

--- a/src/Symfony/Component/Messenger/Attribute/AsMessage.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessage.php
@@ -24,6 +24,10 @@ class AsMessage
          * Name of the transports to which the message should be routed.
          */
         public string|array|null $transport = null,
+        /**
+         * The serialized type to use when sending or receiving the message.
+         */
+        public ?string $serializedTypeName = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithSerializedTypeName.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithSerializedTypeName.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage(serializedTypeName: 'dummy.interface.message')]
+interface DummyMessageInterfaceWithSerializedTypeName
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithInterfaceWithSerializedTypeName.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithInterfaceWithSerializedTypeName.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyMessageWithInterfaceWithSerializedTypeName implements DummyMessageInterfaceWithSerializedTypeName
+{
+    public function __construct(
+        private string $message,
+    ) {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithSerializedTypeName.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithSerializedTypeName.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessage;
+
+#[AsMessage(serializedTypeName: 'dummy.message')]
+class DummyMessageWithSerializedTypeName
+{
+    public function __construct(
+        private string $message,
+    ) {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63060, Fix #59317
| License       | MIT


---

### Description

When two applications communicate through a message broker (for example
RabbitMQ), and one of them uses Symfony Messenger, it can be difficult to ensure
that both applications can correctly serialize and deserialize messages.

I already wrote [an article about this topic](https://jolicode.com/blog/about-symfony-messenger-and-interoperability), as this is a common pain point.

I am facing this issue again today. I took some time to look at the **Serializer
Transport Serializer**, but it does not solve the problem either. The PHP class
name is still embedded in the payload (serializer output):

```
Serializer.php on line 111:
array:2 [▼
  "body" => "{"crawlId":"796cd86a-1ba4-4713-be25-1e7749f1cc7b"}"
  "headers" => array:3 [▼
    "type" => "App\CrawlUrl\Messenger\Message\VectorizationFinished"
    "X-Message-Stamp-Symfony\Component\Messenger\Stamp\BusNameStamp" => "[{"busName":"messenger.bus.default"}]"
    "Content-Type" => "application/json"
  ]
]
```

The `headers.type` value may not be understood by other applications, as it is a
PHP class name. Even between two Symfony applications, the FQCN may differ.

---

### Proposal

This is why I would like to propose an RFC.

I patched a very small part of the `Serializer` class to support a configurable
message `type` via the `AsMessage` attribute.

```php
<?php

namespace App\CrawlUrl\Messenger\Message;

use Symfony\Component\Messenger\Attribute\AsMessage;

#[AsMessage(serializedTypeName: 'foobar')]
final readonly class VectorizationFinished
{
    public function __construct(
        public string $crawlId,
    ) {
    }
}
```

With this change, the `headers.type` value is now set to `foobar` instead of the
FQCN:

```
Serializer.php on line 111:
array:2 [▼
  "body" => "{"crawlId":"796cd86a-1ba4-4713-be25-1e7749f1cc7b"}"
  "headers" => array:3 [▼
    "type" => "foobar"
    "X-Message-Stamp-Symfony\Component\Messenger\Stamp\BusNameStamp" => "[{"busName":"messenger.bus.default"}]"
    "Content-Type" => "application/json"
  ]
]
```
