### PR TITLE
[ExpressionLanguage] Prevent excessive backtracking in string parsing

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -65,7 +65,7 @@ class Lexer
 
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);
                 ++$cursor;
-            } elseif (preg_match('/"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/As', $expression, $match, 0, $cursor)) {
+            } elseif (preg_match('/"([^"\\\\]*(?>(?:\\\\.[^"\\\\]*))*)"|\'([^\'\\\\]*(?>(?:\\\\.[^\'\\\\]*))*)\'/As', $expression, $match, 0, $cursor)) {
                 // strings
                 $tokens[] = new Token(Token::STRING_TYPE, stripcslashes(substr($match[0], 1, -1)), $cursor + 1);
                 $cursor += \strlen($match[0]);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -102,6 +102,10 @@ class LexerTest extends TestCase
                 '"foo"',
             ],
             [
+                [new Token('string', 'foo"bar\\baz', 1)],
+                '"foo\"bar\\\\baz"',
+            ],
+            [
                 [new Token('number', 3, 1)],
                 '3',
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR optimizes the string parsing regex by adding atomic grouping `(?>...)`. This prevents excessive backtracking issues when parsing specific string patterns.