### PR TITLE
[Yaml] Prevent excessive backtracking in leading comments

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -995,7 +995,7 @@ class Parser
         $this->offset += $count;
 
         // remove leading comments
-        $trimmedValue = preg_replace('#^(\#.*?\n)+#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^(?>(\#.*?\n))+#s', '', $value, -1, $count);
         if (1 === $count) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1065,6 +1065,17 @@ class ParserTest extends TestCase
         $this->assertSame(['hash' => null], Yaml::parse($input));
     }
 
+    public function testLeadingCommentBlockIsIgnored()
+    {
+        $yaml = <<<'EOF'
+            # comment 1
+            # comment 2
+            foo: bar
+            EOF;
+
+        $this->assertSame(['foo' => 'bar'], Yaml::parse($yaml));
+    }
+
     public function testCommentAtTheRootIndent()
     {
         $this->assertSame([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR optimizes the regex used for removing leading comments by adding atomic grouping `(?>...)`. This prevents excessive backtracking issues on certain comment blocks.