### PR TITLE
[Translation] Fix handling of empty lines in CsvFileLoader

### DIFF
--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -34,7 +34,7 @@ class CsvFileLoader extends FileLoader
             throw new NotFoundResourceException(\sprintf('Error opening file "%s".', $resource), 0, $e);
         }
 
-        $file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY);
+        $file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY | \SplFileObject::DROP_NEW_LINE);
         $file->setCsvControl($this->delimiter, $this->enclosure, $this->escape);
 
         foreach ($file as $data) {

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources.csv
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources.csv
@@ -1,4 +1,6 @@
 "foo"; "bar"
 #"bar"; "foo"
+
+# all incorrect examples:
 "incorrect"; "number"; "columns"; "will"; "be"; "ignored"
 "incorrect"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature? | no
| Deprecations? | no
| Issues        | (none)
| License       | MIT

In its current version, the `CsvFileLoader` of [symfony/translation](https://github.com/symfony/translation) does not support empty lines within the CSV file due to a missing `SplFileObject::DROP_NEW_LINE` flag (cf. [PHP documentation](https://www.php.net/manual/en/class.splfileobject.php#splfileobject.constants)). Without this change, this would result in a warning like this:

```
CsvFileLoader.php:44
str_starts_with(): Passing null to parameter #1 ($haystack) of type string is deprecated
```

This PR changes the test file `resources.csv` to contain an empty line, and adds the missing flag in `CsvFileLoader::loadResource()`. I'm not sure whether this should be handled as a bugfix or new feature. Adding the flag doesn't break backward compatibility.