### PR TITLE
[Serializer] Prevent excessive backtracking in name converters

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -63,7 +63,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
             throw new UnexpectedPropertyException($propertyName);
         }
 
-        $camelCasedName = preg_replace_callback('/(^|_|\.)+(.)/', static fn ($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]), $propertyName);
+        $camelCasedName = preg_replace_callback('/(^|_|\.)++(.)/', static fn ($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]), $propertyName);
 
         if ($this->lowerCamelCase) {
             $camelCasedName = lcfirst($camelCasedName);

--- a/src/Symfony/Component/Serializer/NameConverter/SnakeCaseToCamelCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/SnakeCaseToCamelCaseNameConverter.php
@@ -45,11 +45,7 @@ final class SnakeCaseToCamelCaseNameConverter implements NameConverterInterface
             return $propertyName;
         }
 
-        $camelCasedName = preg_replace_callback(
-            '/(^|_|\.)+(.)/',
-            static fn ($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]),
-            $propertyName
-        );
+        $camelCasedName = preg_replace_callback('/(^|_|\.)++(.)/', static fn ($match) => ('.' === $match[1] ? '_' : '').strtoupper($match[2]), $propertyName);
 
         if ($this->lowerCamelCase) {
             $camelCasedName = lcfirst($camelCasedName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR optimizes the regex patterns used in `SnakeCaseToCamelCaseNameConverter` and `CamelCaseToSnakeCaseNameConverter`.

It uses a possessive quantifier `++` instead of `+` to prevent excessive backtracking when parsing strings containing long sequences of delimiters (e.g. `_____`).

Before: `/(^|_|\.)+(.)/`
After:  `/(^|_|\.)++(.)/`