### PR TITLE
[Console] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -931,13 +931,13 @@ class ApplicationTest extends TestCase
 
     public function testRenderExceptionLineBreaks()
     {
-        $application = $this->getMockBuilder(MockableAppliationWithTerminalWidth::class)
-            ->onlyMethods(['getTerminalWidth'])
-            ->getMock();
+        $application = new class extends MockableAppliationWithTerminalWidth {
+            public function getTerminalWidth(): int
+            {
+                return 120;
+            }
+        };
         $application->setAutoExit(false);
-        $application->expects($this->any())
-            ->method('getTerminalWidth')
-            ->willReturn(120);
         $application->register('foo')->setCode(function () {
             throw new \InvalidArgumentException("\n\nline 1 with extra spaces        \nline 2\n\nline 4\n");
         });
@@ -1521,7 +1521,7 @@ class ApplicationTest extends TestCase
         $application->setCatchExceptions(false);
 
         // Throws an exception when find fails
-        $commandLoader = $this->createMock(CommandLoaderInterface::class);
+        $commandLoader = $this->createStub(CommandLoaderInterface::class);
         $commandLoader->method('getNames')->willThrowException(new \Error('Find exception'));
         $application->setCommandLoader($commandLoader);
 

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\NullOutput;
 
 class ErrorListenerTest extends TestCase
 {
@@ -38,7 +38,7 @@ class ErrorListenerTest extends TestCase
         ;
 
         $listener = new ErrorListener($logger);
-        $listener->onConsoleError(new ConsoleErrorEvent(new ArgvInput(['console.php', 'test:run', '--foo=baz', 'buzz']), $this->createMock(OutputInterface::class), $error, new Command('test:run')));
+        $listener->onConsoleError(new ConsoleErrorEvent(new ArgvInput(['console.php', 'test:run', '--foo=baz', 'buzz']), new NullOutput(), $error, new Command('test:run')));
     }
 
     public function testOnConsoleErrorWithNoCommandAndNoInputString()
@@ -53,7 +53,7 @@ class ErrorListenerTest extends TestCase
         ;
 
         $listener = new ErrorListener($logger);
-        $listener->onConsoleError(new ConsoleErrorEvent(new NonStringInput(), $this->createMock(OutputInterface::class), $error));
+        $listener->onConsoleError(new ConsoleErrorEvent(new NonStringInput(), new NullOutput(), $error));
     }
 
     public function testOnConsoleTerminateForNonZeroExitCodeWritesToLog()
@@ -122,7 +122,7 @@ class ErrorListenerTest extends TestCase
 
     private function getConsoleTerminateEvent(InputInterface $input, $exitCode)
     {
-        return new ConsoleTerminateEvent(new Command('test:run'), $input, $this->createMock(OutputInterface::class), $exitCode);
+        return new ConsoleTerminateEvent(new Command('test:run'), $input, new NullOutput(), $exitCode);
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTestCase.php
+++ b/src/Symfony/Component/Console/Tests/Helper/AbstractQuestionHelperTestCase.php
@@ -18,13 +18,13 @@ abstract class AbstractQuestionHelperTestCase extends TestCase
 {
     protected function createStreamableInputInterfaceMock($stream = null, $interactive = true)
     {
-        $mock = $this->createMock(StreamableInputInterface::class);
-        $mock->expects($this->any())
+        $mock = $this->createStub(StreamableInputInterface::class);
+        $mock
             ->method('isInteractive')
             ->willReturn($interactive);
 
         if ($stream) {
-            $mock->expects($this->any())
+            $mock
                 ->method('getStream')
                 ->willReturn($stream);
         }

--- a/src/Symfony/Component/Console/Tests/Helper/DumperNativeFallbackTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DumperNativeFallbackTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Console\Tests\Helper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClassExistsMock;
 use Symfony\Component\Console\Helper\Dumper;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 
 class DumperNativeFallbackTest extends TestCase
@@ -37,7 +37,7 @@ class DumperNativeFallbackTest extends TestCase
      */
     public function testInvoke($variable, $primitiveString)
     {
-        $dumper = new Dumper($this->createMock(OutputInterface::class));
+        $dumper = new Dumper(new NullOutput());
 
         $this->assertSame($primitiveString, $dumper($variable));
     }

--- a/src/Symfony/Component/Console/Tests/Helper/DumperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DumperTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Helper\Dumper;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 
 class DumperTest extends TestCase
@@ -37,10 +37,7 @@ class DumperTest extends TestCase
      */
     public function testInvoke($variable)
     {
-        $output = $this->createMock(OutputInterface::class);
-        $output->method('isDecorated')->willReturn(false);
-
-        $dumper = new Dumper($output);
+        $dumper = new Dumper(new NullOutput());
 
         $this->assertDumpMatchesFormat($dumper($variable), $variable);
     }

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -89,13 +89,13 @@ class HelperSetTest extends TestCase
 
     private function getGenericMockHelper($name, ?HelperSet $helperset = null)
     {
-        $mock_helper = $this->createMock(HelperInterface::class);
-        $mock_helper->expects($this->any())
+        $mock_helper = $this->createStub(HelperInterface::class);
+        $mock_helper
             ->method('getName')
             ->willReturn($name);
 
         if ($helperset) {
-            $mock_helper->expects($this->any())
+            $mock_helper
                 ->method('setHelperSet')
                 ->with($this->equalTo($helperset));
         }

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -987,8 +987,8 @@ EOD;
 
     protected function createInputInterfaceMock($interactive = true)
     {
-        $mock = $this->createMock(InputInterface::class);
-        $mock->expects($this->any())
+        $mock = $this->createStub(InputInterface::class);
+        $mock
             ->method('isInteractive')
             ->willReturn($interactive);
 

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -202,8 +202,8 @@ EOT
 
     protected function createInputInterfaceMock($interactive = true)
     {
-        $mock = $this->createMock(InputInterface::class);
-        $mock->expects($this->any())
+        $mock = $this->createStub(InputInterface::class);
+        $mock
             ->method('isInteractive')
             ->willReturn($interactive);
 

--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -151,14 +151,7 @@ class ConsoleLoggerTest extends TestCase
 
     public function testObjectCastToString()
     {
-        if (method_exists($this, 'createPartialMock')) {
-            $dummy = $this->createPartialMock(DummyTest::class, ['__toString']);
-        } else {
-            $dummy = $this->createPartialMock(DummyTest::class, ['__toString']);
-        }
-        $dummy->method('__toString')->willReturn('DUMMY');
-
-        $this->getLogger()->warning($dummy);
+        $this->getLogger()->warning(new DummyTest());
 
         $expected = ['warning DUMMY'];
         $this->assertEquals($expected, $this->getLogs());
@@ -201,5 +194,6 @@ class DummyTest
 {
     public function __toString(): string
     {
+        return 'DUMMY';
     }
 }

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -98,7 +98,7 @@ class SymfonyStyleTest extends TestCase
 
     public function testGetErrorStyle()
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
 
         $errorOutput = $this->createMock(OutputInterface::class);
         $errorOutput
@@ -123,7 +123,7 @@ class SymfonyStyleTest extends TestCase
 
     public function testCreateTableWithConsoleOutput()
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
         $output = $this->createMock(ConsoleOutputInterface::class);
         $output
             ->method('getFormatter')
@@ -131,7 +131,7 @@ class SymfonyStyleTest extends TestCase
         $output
             ->expects($this->once())
             ->method('section')
-            ->willReturn($this->createMock(ConsoleSectionOutput::class));
+            ->willReturn($this->createStub(ConsoleSectionOutput::class));
 
         $style = new SymfonyStyle($input, $output);
 
@@ -140,8 +140,8 @@ class SymfonyStyleTest extends TestCase
 
     public function testCreateTableWithoutConsoleOutput()
     {
-        $input = $this->createMock(InputInterface::class);
-        $output = $this->createMock(OutputInterface::class);
+        $input = $this->createStub(InputInterface::class);
+        $output = $this->createStub(OutputInterface::class);
         $output
             ->method('getFormatter')
             ->willReturn(new OutputFormatter());
@@ -156,12 +156,12 @@ class SymfonyStyleTest extends TestCase
 
     public function testGetErrorStyleUsesTheCurrentOutputIfNoErrorOutputIsAvailable()
     {
-        $output = $this->createMock(OutputInterface::class);
+        $output = $this->createStub(OutputInterface::class);
         $output
             ->method('getFormatter')
             ->willReturn(new OutputFormatter());
 
-        $style = new SymfonyStyle($this->createMock(InputInterface::class), $output);
+        $style = new SymfonyStyle($this->createStub(InputInterface::class), $output);
 
         $this->assertInstanceOf(SymfonyStyle::class, $style->getErrorStyle());
     }
@@ -186,7 +186,7 @@ class SymfonyStyleTest extends TestCase
         $inputStream = fopen('php://memory', 'r+');
         fwrite($inputStream, $answer.\PHP_EOL);
         rewind($inputStream);
-        $input = $this->createMock(Input::class);
+        $input = $this->createStub(Input::class);
         $sections = [];
         $output = new ConsoleSectionOutput(fopen('php://memory', 'r+', false), $sections, StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter());
         $input


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT