### PR TITLE
[AssetMapper] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/Command/ImportMapRequireCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/ImportMapRequireCommandTest.php
@@ -37,7 +37,7 @@ class ImportMapRequireCommandTest extends KernelTestCase
      */
     public function testDryRunOptionToShowInformationBeforeApplyInstallation(int $verbosity, array $packageEntries, array $packagesToInstall, string $expected, ?string $path = null)
     {
-        $importMapManager = $this->createMock(ImportMapManager::class);
+        $importMapManager = $this->createStub(ImportMapManager::class);
         $importMapManager
             ->method('requirePackages')
             ->willReturn($packageEntries)
@@ -45,7 +45,7 @@ class ImportMapRequireCommandTest extends KernelTestCase
 
         $command = new ImportMapRequireCommand(
             $importMapManager,
-            $this->createMock(ImportMapVersionChecker::class),
+            $this->createStub(ImportMapVersionChecker::class),
             '/path/to/project/dir',
         );
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapOutdatedCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapOutdatedCommandTest.php
@@ -23,7 +23,7 @@ class ImportMapOutdatedCommandTest extends TestCase
      */
     public function testCommandWhenNoOutdatedPackages(string $display, ?string $format = null)
     {
-        $updateChecker = $this->createMock(ImportMapUpdateChecker::class);
+        $updateChecker = $this->createStub(ImportMapUpdateChecker::class);
         $command = new ImportMapOutdatedCommand($updateChecker);
 
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT