### PR TITLE
[BrowserKit] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -36,7 +36,7 @@ class HttpBrowserTest extends AbstractBrowserTest
             ->expects($this->once())
             ->method('request')
             ->with(...$expectedArguments)
-            ->willReturn($this->createMock(ResponseInterface::class));
+            ->willReturn($this->createStub(ResponseInterface::class));
 
         $browser = new HttpBrowser($client);
         $browser->request(...$requestArguments);
@@ -104,7 +104,7 @@ class HttpBrowserTest extends AbstractBrowserTest
 
                 return true;
             }))
-            ->willReturn($this->createMock(ResponseInterface::class));
+            ->willReturn($this->createStub(ResponseInterface::class));
 
         $browser = new HttpBrowser($client);
         $path = tempnam(sys_get_temp_dir(), 'http');
@@ -196,7 +196,7 @@ class HttpBrowserTest extends AbstractBrowserTest
             ->expects($this->once())
             ->method('request')
             ->with('GET', 'http://localhost'.$requestPath)
-            ->willReturn($this->createMock(ResponseInterface::class));
+            ->willReturn($this->createStub(ResponseInterface::class));
         $browser = new HttpBrowser($client);
         $browser->request('GET', $requestPath);
     }
@@ -272,7 +272,7 @@ class HttpBrowserTest extends AbstractBrowserTest
 
                 return true;
             }))
-            ->willReturn($this->createMock(ResponseInterface::class));
+            ->willReturn($this->createStub(ResponseInterface::class));
     }
 
     protected function expectClientToNotSendRequestWithFiles(HttpClientInterface $client, $fileContents)
@@ -290,6 +290,6 @@ class HttpBrowserTest extends AbstractBrowserTest
 
                 return true;
             }))
-            ->willReturn($this->createMock(ResponseInterface::class));
+            ->willReturn($this->createStub(ResponseInterface::class));
     }
 }

--- a/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserCookieValueSameTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserCookieValueSameTest.php
@@ -44,10 +44,10 @@ class BrowserCookieValueSameTest extends TestCase
 
     private function getBrowser(): AbstractBrowser
     {
-        $browser = $this->createMock(AbstractBrowser::class);
+        $browser = $this->createStub(AbstractBrowser::class);
         $jar = new CookieJar();
         $jar->set(new Cookie('foo', 'bar', null, '/path', 'example.com'));
-        $browser->expects($this->any())->method('getCookieJar')->willReturn($jar);
+        $browser->method('getCookieJar')->willReturn($jar);
 
         return $browser;
     }

--- a/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserHasCookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserHasCookieTest.php
@@ -74,10 +74,10 @@ class BrowserHasCookieTest extends TestCase
 
     private function getBrowser(): AbstractBrowser
     {
-        $browser = $this->createMock(AbstractBrowser::class);
+        $browser = $this->createStub(AbstractBrowser::class);
         $jar = new CookieJar();
         $jar->set(new Cookie('foo', 'bar', null, '/path', 'example.com'));
-        $browser->expects($this->any())->method('getCookieJar')->willReturn($jar);
+        $browser->method('getCookieJar')->willReturn($jar);
 
         return $browser;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT