### PR TITLE
[HttpKernel] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -44,7 +44,7 @@ class RequestPayloadValueResolverTest extends TestCase
     {
         $resolver = new RequestPayloadValueResolver(
             new Serializer(),
-            $this->createMock(ValidatorInterface::class),
+            (new ValidatorBuilder())->getValidator(),
         );
 
         $argument = new ArgumentMetadata('notTyped', null, false, false, null, false, [
@@ -52,7 +52,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['HTTP_CONTENT_TYPE' => 'application/json']);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -77,7 +77,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json']);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -101,7 +101,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'GET');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -123,7 +123,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json']);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -145,7 +145,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'GET');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -167,7 +167,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json']);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -192,7 +192,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -214,7 +214,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'GET');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -238,7 +238,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -266,7 +266,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -297,7 +297,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -322,7 +322,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'foo/bar'], content: 'foo-bar');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -352,7 +352,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -369,7 +369,7 @@ class RequestPayloadValueResolverTest extends TestCase
     {
         $this->expectException(HttpException::class);
         $this->expectExceptionMessage('This value was of an unexpected type.');
-        $serializer = $this->createMock(SerializerDenormalizer::class);
+        $serializer = $this->createStub(SerializerDenormalizer::class);
 
         if (null === $types) {
             $exception = new NotNormalizableValueException('Error with no types');
@@ -378,13 +378,13 @@ class RequestPayloadValueResolverTest extends TestCase
         }
         $serializer->method('deserialize')->willThrowException(new PartialDenormalizationException([], [$exception]));
 
-        $resolver = new RequestPayloadValueResolver($serializer, $this->createMock(ValidatorInterface::class));
+        $resolver = new RequestPayloadValueResolver($serializer, (new ValidatorBuilder())->getValidator());
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"price": 50}');
 
         $arguments = $resolver->resolve($request, new ArgumentMetadata('valid', RequestPayload::class, false, false, null, false, [
             MapRequestPayload::class => new MapRequestPayload(),
         ]));
-        $event = new ControllerArgumentsEvent($this->createMock(HttpKernelInterface::class), function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new ControllerArgumentsEvent($this->createStub(HttpKernelInterface::class), function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
         $resolver->onKernelControllerArguments($event);
     }
@@ -408,7 +408,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'GET', $query);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -435,7 +435,7 @@ class RequestPayloadValueResolverTest extends TestCase
 
         $request = Request::create('/', 'GET', $query);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -468,7 +468,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', $input);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -495,7 +495,7 @@ class RequestPayloadValueResolverTest extends TestCase
 
         $request = Request::create('/', 'POST', $input);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -512,7 +512,7 @@ class RequestPayloadValueResolverTest extends TestCase
     public function testItThrowsOnVariadicArgument()
     {
         $serializer = new Serializer();
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = (new ValidatorBuilder())->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('variadic', RequestPayload::class, true, false, null, false, [
@@ -541,7 +541,7 @@ class RequestPayloadValueResolverTest extends TestCase
             MapRequestPayload::class => new MapRequestPayload(acceptFormat: $acceptFormat),
         ]);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -604,7 +604,7 @@ class RequestPayloadValueResolverTest extends TestCase
             MapRequestPayload::class => new MapRequestPayload(acceptFormat: $acceptFormat),
         ]);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -675,7 +675,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $attribute::class => $attribute,
         ]);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -700,7 +700,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', $method, $input);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -765,7 +765,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/?page=123');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -796,7 +796,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $content);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -248,7 +248,7 @@ class ArgumentResolverTest extends TestCase
 
     public function testGetSessionArgumentsWithInterface()
     {
-        $session = $this->createMock(SessionInterface::class);
+        $session = new Session(new MockArraySessionStorage());
         $request = Request::create('/');
         $request->setSession($session);
         $controller = (new ArgumentResolverTestController())->controllerWithSessionInterface(...);
@@ -259,7 +259,7 @@ class ArgumentResolverTest extends TestCase
     public function testGetSessionMissMatchWithInterface()
     {
         $this->expectException(\RuntimeException::class);
-        $session = $this->createMock(SessionInterface::class);
+        $session = new Session(new MockArraySessionStorage());
         $request = Request::create('/');
         $request->setSession($session);
         $controller = (new ArgumentResolverTestController())->controllerWithExtendingSession(...);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ErrorControllerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ErrorControllerTest.php
@@ -27,7 +27,7 @@ class ErrorControllerTest extends TestCase
      */
     public function testInvokeController(Request $request, \Exception $exception, int $statusCode, string $content)
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $errorRenderer = new HtmlErrorRenderer();
         $controller = new ErrorController($kernel, null, $errorRenderer);
         $response = $controller($exception);

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -222,7 +222,7 @@ class RequestDataCollectorTest extends TestCase
             'sf_redirect' => '{}',
         ]);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $c = new RequestDataCollector();
         $c->onKernelResponse(new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $this->createResponse()));
@@ -280,7 +280,7 @@ class RequestDataCollectorTest extends TestCase
 
         $collector->reset();
 
-        $session = $this->createMock(SessionInterface::class);
+        $session = $this->createStub(SessionInterface::class);
         $session->method('getMetadataBag')->willReturnCallback(static function () use ($collector) {
             $collector->collectSessionUsage();
 
@@ -398,8 +398,8 @@ class RequestDataCollectorTest extends TestCase
      */
     protected function injectController($collector, $controller, $request)
     {
-        $resolver = $this->createMock(ControllerResolverInterface::class);
-        $httpKernel = new HttpKernel(new EventDispatcher(), $resolver, null, $this->createMock(ArgumentResolverInterface::class));
+        $resolver = $this->createStub(ControllerResolverInterface::class);
+        $httpKernel = new HttpKernel(new EventDispatcher(), $resolver, null, $this->createStub(ArgumentResolverInterface::class));
         $event = new ControllerEvent($httpKernel, $controller, $request, HttpKernelInterface::MAIN_REQUEST);
         $collector->onKernelController($event);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RouterDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RouterDataCollectorTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\RouterDataCollector;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class RouterDataCollectorTest extends TestCase
 {
@@ -82,7 +82,7 @@ class RouterDataCollectorTest extends TestCase
 
     protected function createControllerEvent(Request $request): ControllerEvent
     {
-        $kernel = $this->createMock(KernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         return new ControllerEvent($kernel, function () {}, $request, null);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerConfiguratorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerConfiguratorTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\HttpKernel\Tests\Debug;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\HttpKernel\Debug\ErrorHandlerConfigurator;
 
@@ -21,7 +21,7 @@ class ErrorHandlerConfiguratorTest extends TestCase
 {
     public function testConfigure()
     {
-        $logger = $this->createMock(LoggerInterface::class);
+        $logger = new NullLogger();
         $configurator = new ErrorHandlerConfigurator($logger);
         $handler = new ErrorHandler();
 
@@ -45,14 +45,14 @@ class ErrorHandlerConfiguratorTest extends TestCase
         $deprecationLogger = null;
 
         if ($hasDeprecationLogger) {
-            $deprecationLogger = $this->createMock(LoggerInterface::class);
+            $deprecationLogger = new NullLogger();
             if (null !== $expectedDeprecationLoggerLevels) {
                 $expectedCalls[] = [$deprecationLogger, $expectedDeprecationLoggerLevels, false];
             }
         }
 
         if ($hasLogger) {
-            $logger = $this->createMock(LoggerInterface::class);
+            $logger = new NullLogger();
             if (null !== $expectedLoggerLevels) {
                 $expectedCalls[] = [$logger, $expectedLoggerLevels, false];
             }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
@@ -47,7 +47,7 @@ class AddRequestFormatsListenerTest extends TestCase
     public function testSetAdditionalFormats()
     {
         $request = $this->createMock(Request::class);
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $request->expects($this->once())
             ->method('setFormat')

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -416,9 +415,9 @@ class CacheAttributeListenerTest extends TestCase
         return new ResponseEvent($this->getKernel(), $request, HttpKernelInterface::MAIN_REQUEST, $response);
     }
 
-    private function getKernel(): MockObject&HttpKernelInterface
+    private function getKernel(): HttpKernelInterface
     {
-        return $this->getMockBuilder(HttpKernelInterface::class)->getMock();
+        return $this->createStub(HttpKernelInterface::class);
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -61,7 +61,7 @@ class DebugHandlersListenerTest extends TestCase
         $listener = new DebugHandlersListener(null);
         $eHandler = new ErrorHandler();
         $event = new KernelEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             Request::create('/'),
             HttpKernelInterface::MAIN_REQUEST
         );

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DisallowRobotsIndexingListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DisallowRobotsIndexingListenerTest.php
@@ -29,7 +29,7 @@ class DisallowRobotsIndexingListenerTest extends TestCase
         $response = new Response(...$responseArgs);
         $listener = new DisallowRobotsIndexingListener();
 
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), new Request(), KernelInterface::MAIN_REQUEST, $response);
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), new Request(), KernelInterface::MAIN_REQUEST, $response);
 
         $listener->onResponse($event);
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ErrorListenerTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -210,7 +210,7 @@ class ErrorListenerTest extends TestCase
 
     public function testSubRequestFormat()
     {
-        $listener = new ErrorListener('foo', $this->createMock(LoggerInterface::class));
+        $listener = new ErrorListener('foo', new NullLogger());
 
         $kernel = $this->createMock(HttpKernelInterface::class);
         $kernel->expects($this->once())->method('handle')->willReturnCallback(fn (Request $request) => new Response($request->getRequestFormat()));
@@ -231,7 +231,7 @@ class ErrorListenerTest extends TestCase
         $kernel = $this->createMock(HttpKernelInterface::class);
         $kernel->expects($this->once())->method('handle')->willReturnCallback(fn (Request $request) => new Response($request->getRequestFormat()));
 
-        $listener = new ErrorListener('foo', $this->createMock(LoggerInterface::class), true);
+        $listener = new ErrorListener('foo', new NullLogger(), true);
 
         $dispatcher->addSubscriber($listener);
 
@@ -253,9 +253,9 @@ class ErrorListenerTest extends TestCase
      */
     public function testOnControllerArguments(callable $controller)
     {
-        $listener = new ErrorListener($controller, $this->createMock(LoggerInterface::class), true);
+        $listener = new ErrorListener($controller, new NullLogger(), true);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $kernel->method('handle')->willReturnCallback(function (Request $request) use ($listener, $controller, $kernel) {
             $this->assertSame($controller, $request->attributes->get('_controller'));
             $arguments = (new ArgumentResolver())->getArguments($request, $controller);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
@@ -114,6 +114,6 @@ class FragmentListenerTest extends TestCase
 
     private function createRequestEvent(Request $request, int $requestType = HttpKernelInterface::MAIN_REQUEST): RequestEvent
     {
-        return new RequestEvent($this->createMock(HttpKernelInterface::class), $request, $requestType);
+        return new RequestEvent($this->createStub(HttpKernelInterface::class), $request, $requestType);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
@@ -41,7 +41,7 @@ class LocaleAwareListenerTest extends TestCase
             ->method('setLocale')
             ->with($this->equalTo('fr'));
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $this->createRequest('fr'), HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $this->createRequest('fr'), HttpKernelInterface::MAIN_REQUEST);
         $this->listener->onKernelRequest($event);
     }
 
@@ -61,7 +61,7 @@ class LocaleAwareListenerTest extends TestCase
             })
         ;
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $this->createRequest('fr'), HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $this->createRequest('fr'), HttpKernelInterface::MAIN_REQUEST);
         $this->listener->onKernelRequest($event);
     }
 
@@ -75,7 +75,7 @@ class LocaleAwareListenerTest extends TestCase
         $this->requestStack->push($this->createRequest('fr'));
         $this->requestStack->push($subRequest = $this->createRequest('de'));
 
-        $event = new FinishRequestEvent($this->createMock(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
+        $event = new FinishRequestEvent($this->createStub(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
         $this->listener->onKernelFinishRequest($event);
     }
 
@@ -88,7 +88,7 @@ class LocaleAwareListenerTest extends TestCase
 
         $this->requestStack->push($subRequest = $this->createRequest('de'));
 
-        $event = new FinishRequestEvent($this->createMock(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
+        $event = new FinishRequestEvent($this->createStub(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
         $this->listener->onKernelFinishRequest($event);
     }
 
@@ -111,7 +111,7 @@ class LocaleAwareListenerTest extends TestCase
         $this->requestStack->push($this->createRequest('fr'));
         $this->requestStack->push($subRequest = $this->createRequest('de'));
 
-        $event = new FinishRequestEvent($this->createMock(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
+        $event = new FinishRequestEvent($this->createStub(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
         $this->listener->onKernelFinishRequest($event);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -101,7 +101,7 @@ class LocaleListenerTest extends TestCase
 
         $this->requestStack->expects($this->once())->method('getParentRequest')->willReturn($parentRequest);
 
-        $event = new FinishRequestEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST);
+        $event = new FinishRequestEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST);
 
         $listener = new LocaleListener($this->requestStack, 'fr', $router);
         $listener->onKernelFinishRequest($event);
@@ -221,6 +221,6 @@ class LocaleListenerTest extends TestCase
 
     private function getEvent(Request $request): RequestEvent
     {
-        return new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        return new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
@@ -39,10 +39,10 @@ class ProfilerListenerTest extends TestCase
             ->method('collect')
             ->willReturn($profile);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $mainRequest = new Request();
         $subRequest = new Request();
-        $response = $this->createMock(Response::class);
+        $response = new Response();
 
         $requestStack = new RequestStack();
         $requestStack->push($mainRequest);
@@ -76,7 +76,7 @@ class ProfilerListenerTest extends TestCase
             ->expects(null === $enable ? $this->never() : $this->once())
             ->method($enable ? 'enable' : 'disable');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $response = new Response();
 
         $requestStack = new RequestStack();

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +23,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class ResponseListenerTest extends TestCase
 {
     private EventDispatcher $dispatcher;
-    private MockObject&HttpKernelInterface $kernel;
+    private HttpKernelInterface $kernel;
 
     protected function setUp(): void
     {
@@ -32,7 +31,7 @@ class ResponseListenerTest extends TestCase
         $listener = new ResponseListener('UTF-8');
         $this->dispatcher->addListener(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
 
-        $this->kernel = $this->createMock(HttpKernelInterface::class);
+        $this->kernel = $this->createStub(HttpKernelInterface::class);
     }
 
     public function testFilterDoesNothingForSubRequests()

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -49,12 +49,12 @@ class RouterListenerTest extends TestCase
      */
     public function testPort($defaultHttpPort, $defaultHttpsPort, $uri, $expectedHttpPort, $expectedHttpsPort)
     {
-        $urlMatcher = $this->createMock(UrlMatcherInterface::class);
+        $urlMatcher = $this->createStub(UrlMatcherInterface::class);
 
         $context = new RequestContext();
         $context->setHttpPort($defaultHttpPort);
         $context->setHttpsPort($defaultHttpsPort);
-        $urlMatcher->expects($this->any())
+        $urlMatcher
             ->method('getContext')
             ->willReturn($context);
 
@@ -79,7 +79,7 @@ class RouterListenerTest extends TestCase
 
     private function createRequestEventForUri(string $uri): RequestEvent
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create($uri);
         $request->attributes->set('_controller', null); // Prevents going in to routing process
 
@@ -88,7 +88,7 @@ class RouterListenerTest extends TestCase
 
     public function testRequestMatcher()
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('http://localhost/');
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -104,12 +104,12 @@ class RouterListenerTest extends TestCase
 
     public function testSubRequestWithDifferentMethod()
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('http://localhost/', 'post');
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
 
-        $requestMatcher = $this->createMock(RequestMatcherInterface::class);
-        $requestMatcher->expects($this->any())
+        $requestMatcher = $this->createStub(RequestMatcherInterface::class);
+        $requestMatcher
                        ->method('matchRequest')
                        ->with($this->isInstanceOf(Request::class))
                        ->willReturn([]);
@@ -120,7 +120,7 @@ class RouterListenerTest extends TestCase
         $listener->onKernelRequest($event);
 
         // sub-request with another HTTP method
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('http://localhost/', 'get');
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST);
 
@@ -144,7 +144,7 @@ class RouterListenerTest extends TestCase
             ->method('info')
             ->with($this->equalTo($log), $this->equalTo($parameters));
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('http://localhost/');
 
         $listener = new RouterListener($requestMatcher, $this->requestStack, new RequestContext(), $logger);
@@ -204,12 +204,12 @@ class RouterListenerTest extends TestCase
     public function testRequestWithBadHost()
     {
         $this->expectException(BadRequestHttpException::class);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('/');
         $request->headers->set('host', 'bad host %22');
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
 
-        $requestMatcher = $this->createMock(RequestMatcherInterface::class);
+        $requestMatcher = $this->createStub(RequestMatcherInterface::class);
 
         $listener = new RouterListener($requestMatcher, $this->requestStack, new RequestContext());
         $listener->onKernelRequest($event);
@@ -222,17 +222,17 @@ class RouterListenerTest extends TestCase
 
         $context = new RequestContext();
 
-        $urlMatcher = $this->createMock(UrlMatcherInterface::class);
+        $urlMatcher = $this->createStub(UrlMatcherInterface::class);
 
-        $urlMatcher->expects($this->any())
+        $urlMatcher
             ->method('getContext')
             ->willReturn($context);
 
-        $urlMatcher->expects($this->any())
+        $urlMatcher
             ->method('match')
             ->willThrowException(new ResourceNotFoundException());
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('https://www.symfony.com/path');
         $request->headers->set('referer', 'https://www.google.com');
 
@@ -249,17 +249,17 @@ class RouterListenerTest extends TestCase
 
         $context = new RequestContext();
 
-        $urlMatcher = $this->createMock(UrlMatcherInterface::class);
+        $urlMatcher = $this->createStub(UrlMatcherInterface::class);
 
-        $urlMatcher->expects($this->any())
+        $urlMatcher
             ->method('getContext')
             ->willReturn($context);
 
-        $urlMatcher->expects($this->any())
+        $urlMatcher
             ->method('match')
             ->willThrowException(new MethodNotAllowedException(['POST']));
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('https://www.symfony.com/path');
 
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -44,7 +44,7 @@ class SessionListenerTest extends TestCase
      */
     public function testSessionCookieOptions(array $phpSessionOptions, array $sessionOptions, array $expectedSessionOptions)
     {
-        $session = $this->createMock(Session::class);
+        $session = $this->createStub(Session::class);
         $session->method('getUsageIndex')->willReturn(0, 1);
         $session->method('getId')->willReturn('123456');
         $session->method('getName')->willReturn('PHPSESSID');
@@ -57,7 +57,7 @@ class SessionListenerTest extends TestCase
         session_set_cookie_params(0, $phpSessionOptions['path'] ?? null, $phpSessionOptions['domain'] ?? null, $phpSessionOptions['secure'] ?? null, $phpSessionOptions['httponly'] ?? null);
 
         $listener = new SessionListener(new Container(), false, $sessionOptions);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
@@ -150,7 +150,7 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $listener = $this->createListener($request, new PhpBridgeSessionStorageFactory());
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener->onKernelRequest($event);
 
@@ -166,7 +166,7 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $listener = $this->createListener($request, new NativeSessionStorageFactory());
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
         $session = $request->getSession();
@@ -198,7 +198,7 @@ class SessionListenerTest extends TestCase
 
         $listener = $this->createListener($request, new NativeSessionStorageFactory());
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
 
         $session = $request->getSession();
@@ -227,7 +227,7 @@ class SessionListenerTest extends TestCase
 
         $listener = $this->createListener($request, new NativeSessionStorageFactory());
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
 
         $session = $request->getSession();
@@ -256,7 +256,7 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $request->cookies->set('PHPSESSID', $sessionId);
         $listener = $this->createListener($request, new NativeSessionStorageFactory());
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
 
@@ -288,7 +288,7 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $request->cookies->set('PHPSESSID', $sessionId);
         $listener = $this->createListener($request, new NativeSessionStorageFactory());
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
 
@@ -312,7 +312,7 @@ class SessionListenerTest extends TestCase
     {
         $request = new Request();
         $listener = $this->createListener($request, new NativeSessionStorageFactory());
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
 
@@ -370,7 +370,7 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $listener = new SessionListener($container);
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener->onKernelRequest($event);
 
@@ -391,7 +391,7 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $listener = new SessionListener($container);
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener->onKernelRequest($event);
 
@@ -412,12 +412,12 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $listener = new SessionListener($container);
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
 
         $request->getSession();
 
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, new Response());
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, new Response());
         $listener->onKernelResponse($event);
     }
 
@@ -432,10 +432,10 @@ class SessionListenerTest extends TestCase
         $request = new Request();
         $listener = new SessionListener($container);
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
 
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, new Response());
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, new Response());
         $listener->onKernelResponse($event);
     }
 
@@ -451,7 +451,7 @@ class SessionListenerTest extends TestCase
         $container->set('session_factory', $sessionFactory);
 
         $listener = new SessionListener($container);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
@@ -477,7 +477,7 @@ class SessionListenerTest extends TestCase
         $container = new Container();
 
         $listener = new SessionListener($container);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $request->setSession($session);
@@ -509,7 +509,7 @@ class SessionListenerTest extends TestCase
         $container = new Container();
 
         $listener = new SessionListener($container);
-        $kernel = $this->getMockBuilder(HttpKernelInterface::class)->disableOriginalConstructor()->getMock();
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $request->setSession($session);
@@ -526,7 +526,7 @@ class SessionListenerTest extends TestCase
 
     public function testUninitializedSessionUsingSessionFromRequest()
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $response = new Response();
         $response->setSharedMaxAge(60);
         $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 'true');
@@ -546,7 +546,7 @@ class SessionListenerTest extends TestCase
 
     public function testUninitializedSessionWithoutInitializedSession()
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $response = new Response();
         $response->setSharedMaxAge(60);
         $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 'true');
@@ -574,7 +574,7 @@ class SessionListenerTest extends TestCase
         $container->set('session_factory', $sessionFactory);
 
         $listener = new SessionListener($container);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
@@ -605,7 +605,7 @@ class SessionListenerTest extends TestCase
         $container = new Container();
 
         $listener = new SessionListener($container);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $request->setSession($session);
@@ -627,7 +627,7 @@ class SessionListenerTest extends TestCase
 
     public function testPrivateResponseMaxAgeIsRespectedIfSessionStarted()
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $session = $this->createMock(Session::class);
         $session->expects($this->once())->method('getUsageIndex')->willReturn(1);
@@ -661,7 +661,7 @@ class SessionListenerTest extends TestCase
         $container->set('session_factory', $sessionFactory);
 
         $listener = new SessionListener($container);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $response = new Response();
@@ -695,7 +695,7 @@ class SessionListenerTest extends TestCase
         $session->expects($this->exactly(1))->method('getName')->willReturn('PHPSESSID');
         $sessionFactory = $this->createMock(SessionFactory::class);
         $sessionFactory->expects($this->once())->method('createSession')->willReturn($session);
-        $kernel = $this->createMock(KernelInterface::class);
+        $kernel = $this->createStub(KernelInterface::class);
 
         $requestStack = new RequestStack();
         $requestStack->push($mainRequest = new Request([], [], [], [], [], ['HTTPS' => 'on']));
@@ -724,14 +724,14 @@ class SessionListenerTest extends TestCase
         $mainRequest = new Request();
         $listener = $this->createListener($mainRequest, new NativeSessionStorageFactory());
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $mainRequest, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $mainRequest, HttpKernelInterface::MAIN_REQUEST);
         $listener->onKernelRequest($event);
 
         $this->assertFalse($mainRequest->hasSession(true));
 
         $subRequest = $mainRequest->duplicate();
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $subRequest, HttpKernelInterface::SUB_REQUEST);
         $listener->onKernelRequest($event);
 
         $session = $subRequest->getSession();
@@ -752,7 +752,7 @@ class SessionListenerTest extends TestCase
         $container->set('session_factory', $sessionFactory);
 
         $listener = new SessionListener($container, true);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $request->attributes->set('_stateless', true);
@@ -779,7 +779,7 @@ class SessionListenerTest extends TestCase
         $container->set('logger', $logger);
 
         $listener = new SessionListener($container, false);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $request->attributes->set('_stateless', true);
@@ -804,7 +804,7 @@ class SessionListenerTest extends TestCase
         $container->set('session_factory', $sessionFactory);
 
         $listener = new SessionListener($container, true);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $request->attributes->set('_stateless', true);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SurrogateListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SurrogateListenerTest.php
@@ -26,7 +26,7 @@ class SurrogateListenerTest extends TestCase
     public function testFilterDoesNothingForSubRequests()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $response = new Response('foo <esi:include src="" />');
         $listener = new SurrogateListener(new Esi());
 
@@ -40,7 +40,7 @@ class SurrogateListenerTest extends TestCase
     public function testFilterWhenThereIsSomeEsiIncludes()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $response = new Response('foo <esi:include src="" />');
         $listener = new SurrogateListener(new Esi());
 
@@ -54,7 +54,7 @@ class SurrogateListenerTest extends TestCase
     public function testFilterWhenThereIsNoEsiIncludes()
     {
         $dispatcher = new EventDispatcher();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $response = new Response('foo');
         $listener = new SurrogateListener(new Esi());
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ValidateRequestListenerTest.php
@@ -31,7 +31,7 @@ class ValidateRequestListenerTest extends TestCase
     {
         $this->expectException(ConflictingHeadersException::class);
         $dispatcher = new EventDispatcher();
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $request = new Request();
         $request->setTrustedProxies(['1.1.1.1'], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_FORWARDED);

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -17,8 +17,12 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class KernelForTest extends Kernel
 {
-    public function __construct(string $environment, bool $debug, private readonly bool $fakeContainer = true)
-    {
+    public function __construct(
+        string $environment,
+        bool $debug,
+        private readonly bool $fakeContainer = true,
+        private array $bundlesToRegister = [],
+    ) {
         parent::__construct($environment, $debug);
     }
 
@@ -29,7 +33,7 @@ class KernelForTest extends Kernel
 
     public function registerBundles(): iterable
     {
-        return [];
+        return $this->bundlesToRegister;
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -110,11 +110,12 @@ class EsiFragmentRendererTest extends TestCase
 
     private function getInlineStrategy($called = false)
     {
-        $inline = $this->createMock(InlineFragmentRenderer::class);
-
-        if ($called) {
-            $inline->expects($this->once())->method('render');
+        if (!$called) {
+            return $this->createStub(InlineFragmentRenderer::class);
         }
+
+        $inline = $this->createMock(InlineFragmentRenderer::class);
+        $inline->expects($this->once())->method('render');
 
         return $inline;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -88,14 +88,12 @@ class FragmentHandlerTest extends TestCase
 
     protected function getHandler($returnValue, $arguments = [])
     {
-        $renderer = $this->createMock(FragmentRendererInterface::class);
+        $renderer = $this->createStub(FragmentRendererInterface::class);
         $renderer
-            ->expects($this->any())
             ->method('getName')
             ->willReturn('foo')
         ;
         $e = $renderer
-            ->expects($this->any())
             ->method('render')
             ->willReturn($returnValue)
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -119,9 +119,8 @@ class InlineFragmentRendererTest extends TestCase
 
     private function getKernel($returnValue)
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $mocker = $kernel
-            ->expects($this->any())
             ->method('handle')
         ;
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/SsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/SsiFragmentRendererTest.php
@@ -101,11 +101,12 @@ class SsiFragmentRendererTest extends TestCase
 
     private function getInlineStrategy($called = false)
     {
-        $inline = $this->createMock(InlineFragmentRenderer::class);
-
-        if ($called) {
-            $inline->expects($this->once())->method('render');
+        if (!$called) {
+            return $this->createStub(InlineFragmentRenderer::class);
         }
+
+        $inline = $this->createMock(InlineFragmentRenderer::class);
+        $inline->expects($this->once())->method('render');
 
         return $inline;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -238,7 +238,7 @@ class EsiTest extends TestCase
     protected function getCache($request, $response)
     {
         $cache = $this->getMockBuilder(HttpCache::class)->onlyMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
-        $cache->expects($this->any())
+        $cache->expects($this->atLeastOnce())
               ->method('getRequest')
               ->willReturn($request)
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -32,9 +32,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
     public function testTerminateDelegatesTerminationOnlyForTerminableInterface()
     {
-        $storeMock = $this->getMockBuilder(StoreInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $storeMock = $this->createStub(StoreInterface::class);
 
         // does not implement TerminableInterface
         $kernel = new TestKernel();
@@ -60,9 +58,8 @@ class HttpCacheTest extends HttpCacheTestCase
     {
         $terminateEvents = [];
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher = $this->createStub(EventDispatcher::class);
         $eventDispatcher
-            ->expects($this->any())
             ->method('dispatch')
             ->with($this->callback(function ($event) use (&$terminateEvents) {
                 if ($event instanceof TerminateEvent) {
@@ -1830,7 +1827,7 @@ class HttpCacheTest extends HttpCacheTestCase
     public function testUsesOriginalRequestForSurrogate()
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
-        $store = $this->createMock(StoreInterface::class);
+        $store = $this->createStub(StoreInterface::class);
 
         $kernel
             ->expects($this->exactly(2))

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -194,7 +194,7 @@ class SsiTest extends TestCase
     protected function getCache($request, $response)
     {
         $cache = $this->getMockBuilder(HttpCache::class)->onlyMethods(['getRequest', 'handle'])->disableOriginalConstructor()->getMock();
-        $cache->expects($this->any())
+        $cache->expects($this->atLeastOnce())
               ->method('getRequest')
               ->willReturn($request)
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -158,7 +158,7 @@ class HttpKernelBrowserTest extends TestCase
             ->getMock()
         ;
         /* should be modified when the getClientSize will be removed */
-        $file->expects($this->any())
+        $file->expects($this->atLeastOnce())
             ->method('getSize')
             ->willReturn(\PHP_INT_MAX)
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -165,15 +165,13 @@ class HttpKernelTest extends TestCase
             $event->setResponse(new Response($event->getThrowable()->getMessage()));
         });
 
-        $controllerResolver = $this->createMock(ControllerResolverInterface::class);
+        $controllerResolver = $this->createStub(ControllerResolverInterface::class);
         $controllerResolver
-            ->expects($this->any())
             ->method('getController')
             ->willReturn(static fn () => throw new \TypeError('foo'));
 
-        $argumentResolver = $this->createMock(ArgumentResolverInterface::class);
+        $argumentResolver = $this->createStub(ArgumentResolverInterface::class);
         $argumentResolver
-            ->expects($this->any())
             ->method('getArguments')
             ->willReturn([]);
 
@@ -499,15 +497,13 @@ class HttpKernelTest extends TestCase
     {
         $controller ??= fn () => new Response('Hello');
 
-        $controllerResolver = $this->createMock(ControllerResolverInterface::class);
+        $controllerResolver = $this->createStub(ControllerResolverInterface::class);
         $controllerResolver
-            ->expects($this->any())
             ->method('getController')
             ->willReturn($controller);
 
-        $argumentResolver = $this->createMock(ArgumentResolverInterface::class);
+        $argumentResolver = $this->createStub(ArgumentResolverInterface::class);
         $argumentResolver
-            ->expects($this->any())
             ->method('getArguments')
             ->willReturn($arguments);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT