### PR TITLE
[Console] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
@@ -76,7 +76,7 @@ class LockableTraitTest extends TestCase
 
         $tester = new CommandTester($command);
 
-        $lock = $this->createMock(SharedLockInterface::class);
+        $lock = $this->createStub(SharedLockInterface::class);
         $lock->method('acquire')->willReturn(false);
 
         $lockFactory->expects(static::once())->method('createLock')->willReturn($lock);

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -158,12 +158,12 @@ class SymfonyStyleTest extends TestCase
 
     public function testCreateTree()
     {
-        $output = $this->createMock(OutputInterface::class);
+        $output = $this->createStub(OutputInterface::class);
         $output
             ->method('getFormatter')
             ->willReturn(new OutputFormatter());
 
-        $style = new SymfonyStyle($this->createMock(InputInterface::class), $output);
+        $style = new SymfonyStyle($this->createStub(InputInterface::class), $output);
 
         $tree = $style->createTree([]);
         $this->assertInstanceOf(TreeHelper::class, $tree);
@@ -171,7 +171,7 @@ class SymfonyStyleTest extends TestCase
 
     public function testTree()
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
         $output = new BufferedOutput();
         $style = new SymfonyStyle($input, $output);
 
@@ -192,7 +192,7 @@ TREE, self::normalizeLineBreaks(trim($output->fetch())));
 
     public function testCreateTreeWithArray()
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
         $output = new BufferedOutput();
         $style = new SymfonyStyle($input, $output);
 
@@ -213,7 +213,7 @@ TREE, self::normalizeLineBreaks(trim($output->fetch())));
 
     public function testCreateTreeWithIterable()
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
         $output = new BufferedOutput();
         $style = new SymfonyStyle($input, $output);
 
@@ -234,7 +234,7 @@ TREE, self::normalizeLineBreaks(trim($output->fetch())));
 
     public function testCreateTreeWithConsoleOutput()
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
         $output = $this->createMock(ConsoleOutputInterface::class);
         $output
             ->method('getFormatter')
@@ -242,7 +242,7 @@ TREE, self::normalizeLineBreaks(trim($output->fetch())));
         $output
             ->expects($this->once())
             ->method('section')
-            ->willReturn($this->createMock(ConsoleSectionOutput::class));
+            ->willReturn($this->createStub(ConsoleSectionOutput::class));
 
         $style = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT