### PR TITLE
[Config] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -156,7 +156,7 @@ class ResourceCheckerConfigCacheTest extends TestCase
     {
         $this->assertStringEqualsFile($this->metaFile, '');
 
-        $checker = $this->createMock(ResourceCheckerInterface::class);
+        $checker = $this->createStub(ResourceCheckerInterface::class);
         $cache = new ResourceCheckerConfigCache($this->cacheFile, [$checker], $this->metaFile);
         $cache->write('foo', [new FileResource(__FILE__)]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT