### PR TITLE
[HttpKernel] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -503,7 +503,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', $input);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -547,7 +547,7 @@ class RequestPayloadValueResolverTest extends TestCase
     public function testItThrowsOnMissingAttributeType()
     {
         $serializer = new Serializer();
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = (new ValidatorBuilder())->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('prices', 'array', false, false, null, false, [
@@ -564,7 +564,7 @@ class RequestPayloadValueResolverTest extends TestCase
     public function testItThrowsOnInvalidAttributeTypeUsage()
     {
         $serializer = new Serializer();
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = (new ValidatorBuilder())->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('prices', null, false, false, null, false, [
@@ -886,7 +886,7 @@ class RequestPayloadValueResolverTest extends TestCase
     public function testBoolArgumentInQueryString(mixed $expectedValue, ?string $parameterValue)
     {
         $serializer = new Serializer([new ObjectNormalizer()]);
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = (new ValidatorBuilder())->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('filtered', ObjectWithBoolArgument::class, false, false, null, false, [
@@ -894,7 +894,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'GET', ['value' => $parameterValue]);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -909,7 +909,7 @@ class RequestPayloadValueResolverTest extends TestCase
     public function testBoolArgumentInBody(mixed $expectedValue, ?string $parameterValue)
     {
         $serializer = new Serializer([new ObjectNormalizer()]);
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = (new ValidatorBuilder())->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('filtered', ObjectWithBoolArgument::class, false, false, null, false, [
@@ -917,7 +917,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', ['value' => $parameterValue], server: ['CONTENT_TYPE' => 'multipart/form-data']);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -945,7 +945,7 @@ class RequestPayloadValueResolverTest extends TestCase
     public function testBoolArgumentInJsonBody()
     {
         $serializer = new Serializer([new ObjectNormalizer()]);
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = (new ValidatorBuilder())->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('filtered', ObjectWithBoolArgument::class, false, false, null, false, [
@@ -953,7 +953,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', 'POST', ['value' => 'off'], server: ['CONTENT_TYPE' => 'application/json']);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 
@@ -965,7 +965,7 @@ class RequestPayloadValueResolverTest extends TestCase
     public function testConfigKeyForQueryString()
     {
         $serializer = new Serializer([new ObjectNormalizer()]);
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = (new ValidatorBuilder())->getValidator();
         $resolver = new RequestPayloadValueResolver($serializer, $validator);
 
         $argument = new ArgumentMetadata('filtered', QueryPayload::class, false, false, null, false, [
@@ -973,7 +973,7 @@ class RequestPayloadValueResolverTest extends TestCase
         ]);
         $request = Request::create('/', Request::METHOD_GET, ['value' => ['page' => 1.0]]);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $arguments = $resolver->resolve($request, $argument);
         $event = new ControllerArgumentsEvent($kernel, function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -44,7 +44,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -76,7 +76,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -104,7 +104,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -133,7 +133,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -165,7 +165,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -197,7 +197,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -226,7 +226,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -260,7 +260,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -289,7 +289,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -323,7 +323,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             static function () {},
             $resolver->resolve($request, $argument),
             $request,
@@ -352,7 +352,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         /** @var HttpKernelInterface&MockObject $httpKernel */
-        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $httpKernel = $this->createStub(HttpKernelInterface::class);
         $event = new ControllerArgumentsEvent(
             $httpKernel,
             static function () {},
@@ -382,7 +382,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         /** @var HttpKernelInterface&MockObject $httpKernel */
-        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $httpKernel = $this->createStub(HttpKernelInterface::class);
         $event = new ControllerArgumentsEvent(
             $httpKernel,
             static function () {},
@@ -412,7 +412,7 @@ class UploadedFileValueResolverTest extends TestCase
             [$attribute::class => $attribute]
         );
         /** @var HttpKernelInterface&MockObject $httpKernel */
-        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $httpKernel = $this->createStub(HttpKernelInterface::class);
         $event = new ControllerArgumentsEvent(
             $httpKernel,
             static function () {},

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -271,12 +271,12 @@ class RouterListenerTest extends TestCase
      */
     public function testRouteMapping(array $expected, array $parameters)
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = Request::create('http://localhost/');
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
 
-        $requestMatcher = $this->createMock(RequestMatcherInterface::class);
-        $requestMatcher->expects($this->any())
+        $requestMatcher = $this->createStub(RequestMatcherInterface::class);
+        $requestMatcher
                        ->method('matchRequest')
                        ->with($this->isInstanceOf(Request::class))
                        ->willReturn($parameters);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT