### PR TITLE
[FrameworkBundle] remove reverse class object mapper metadata factory service if its class does not exist

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -139,6 +139,7 @@ use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface as NotifierTransportFactoryInterface;
 use Symfony\Component\ObjectMapper\Attribute\Map;
 use Symfony\Component\ObjectMapper\ConditionCallableInterface;
+use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\TransformCallableInterface;
 use Symfony\Component\Process\Messenger\RunProcessMessageHandler;
@@ -625,6 +626,10 @@ class FrameworkExtension extends Extension
                     'target' => $attribute->target ?? $reflector->name,
                 ]);
             });
+
+            if (!class_exists(ReverseClassObjectMapperMetadataFactory::class)) {
+                $container->removeDefinition('object_mapper.metadata_factory.reverse_class');
+            }
         }
 
         $container->registerForAutoconfiguration(PackageInterface::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT