### PR TITLE
[HttpClient] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
@@ -125,7 +125,7 @@ TXT
             return true;
         };
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
 
         $httpClient->method('request')->with('POST', 'http://localhost:8080/events', $this->callback($hasCorrectHeaders))->willReturn($response);
 
@@ -154,7 +154,7 @@ TXT
             return true;
         };
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $httpClient->method('request')->with('GET', 'http://localhost:8080/events', $this->callback($hasCorrectHeaders))->willReturn($response);
 
         $httpClient->method('stream')->willReturn($responseStream);

--- a/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
@@ -41,7 +41,7 @@ ERROR;
      */
     public function testParseError(string $mimeType, string $json, string $expectedMessage)
     {
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response
             ->method('getInfo')
             ->willReturnMap([

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -438,7 +438,7 @@ class MockHttpClientTest extends HttpClientTestCase
                 break;
 
             case 'testInformationalResponseStream':
-                $client = $this->createMock(HttpClientInterface::class);
+                $client = $this->createStub(HttpClientInterface::class);
                 $response = new MockResponse('Here the body', ['response_headers' => [
                     'HTTP/1.1 103 ',
                     'Link: </style.css>; rel=preload; as=style',
@@ -448,23 +448,23 @@ class MockHttpClientTest extends HttpClientTestCase
                 ]]);
                 $client->method('request')->willReturn($response);
                 $client->method('stream')->willReturn(new ResponseStream((function () use ($response) {
-                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk = $this->createStub(ChunkInterface::class);
                     $chunk->method('getInformationalStatus')
                         ->willReturn([103, ['link' => ['</style.css>; rel=preload; as=style', '</script.js>; rel=preload; as=script']]]);
 
                     yield $response => $chunk;
 
-                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk = $this->createStub(ChunkInterface::class);
                     $chunk->method('isFirst')->willReturn(true);
 
                     yield $response => $chunk;
 
-                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk = $this->createStub(ChunkInterface::class);
                     $chunk->method('getContent')->willReturn('Here the body');
 
                     yield $response => $chunk;
 
-                    $chunk = $this->createMock(ChunkInterface::class);
+                    $chunk = $this->createStub(ChunkInterface::class);
                     $chunk->method('isLast')->willReturn(true);
 
                     yield $response => $chunk;

--- a/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
@@ -31,9 +31,8 @@ class TraceableHttpClientTest extends TestCase
 
     public function testItTracesRequest()
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient = $this->createStub(HttpClientInterface::class);
         $httpClient
-            ->expects($this->any())
             ->method('request')
             ->with(
                 'GET',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT