### PR TITLE
[Ldap] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/EntryManagerTest.php
@@ -24,10 +24,9 @@ class EntryManagerTest extends TestCase
     {
         $this->expectException(LdapException::class);
         $this->expectExceptionMessage('Entry "$$$$$$" malformed, could not parse RDN.');
-        $connection = $this->createMock(Connection::class);
 
         $entry = new Entry('$$$$$$');
-        $entryManager = new EntryManager($connection);
+        $entryManager = new EntryManager(new Connection());
         $entryManager->move($entry, 'a');
     }
 
@@ -52,10 +51,8 @@ class EntryManagerTest extends TestCase
      */
     public function testMoveWithRFC4514DistinguishedName(string $dn, string $expectedRdn)
     {
-        $connection = $this->createMock(Connection::class);
-
         $entry = new Entry($dn);
-        $entryManager = new EntryManager($connection);
+        $entryManager = new EntryManager(new Connection());
 
         $method = (new \ReflectionClass(EntryManager::class))->getMethod('parseRdnFromEntry');
 

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Ldap\Tests;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Ldap\Adapter\AdapterInterface;
 use Symfony\Component\Ldap\Adapter\ConnectionInterface;
@@ -21,15 +20,6 @@ use Symfony\Component\Ldap\Ldap;
 
 class LdapTest extends TestCase
 {
-    private MockObject&AdapterInterface $adapter;
-    private Ldap $ldap;
-
-    protected function setUp(): void
-    {
-        $this->adapter = $this->createMock(AdapterInterface::class);
-        $this->ldap = new Ldap($this->adapter);
-    }
-
     public function testLdapBind()
     {
         $connection = $this->createMock(ConnectionInterface::class);
@@ -38,35 +28,41 @@ class LdapTest extends TestCase
             ->method('bind')
             ->with('foo', 'bar')
         ;
-        $this->adapter
+        $adapter = $this->createMock(AdapterInterface::class);
+        $adapter
             ->expects($this->once())
             ->method('getConnection')
             ->willReturn($connection)
         ;
-        $this->ldap->bind('foo', 'bar');
+        $ldap = new Ldap($adapter);
+        $ldap->bind('foo', 'bar');
     }
 
     public function testLdapEscape()
     {
-        $this->adapter
+        $adapter = $this->createMock(AdapterInterface::class);
+        $adapter
             ->expects($this->once())
             ->method('escape')
             ->with('foo', 'bar', 0)
             ->willReturn('')
         ;
 
-        $this->ldap->escape('foo', 'bar', 0);
+        $ldap = new Ldap($adapter);
+        $ldap->escape('foo', 'bar', 0);
     }
 
     public function testLdapQuery()
     {
-        $this->adapter
+        $adapter = $this->createMock(AdapterInterface::class);
+        $adapter
             ->expects($this->once())
             ->method('createQuery')
             ->with('foo', 'bar', ['baz'])
-            ->willReturn($this->createMock(QueryInterface::class))
+            ->willReturn($this->createStub(QueryInterface::class))
         ;
-        $this->ldap->query('foo', 'bar', ['baz']);
+        $ldap = new Ldap($adapter);
+        $ldap->query('foo', 'bar', ['baz']);
     }
 
     /**

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Ldap\Tests\Security;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,21 +37,15 @@ use Symfony\Contracts\Service\ServiceLocatorTrait;
 
 class CheckLdapCredentialsListenerTest extends TestCase
 {
-    private MockObject&LdapInterface $ldap;
-
-    protected function setUp(): void
-    {
-        $this->ldap = $this->createMock(LdapInterface::class);
-    }
-
     /**
      * @dataProvider provideShouldNotCheckPassport
      */
     public function testShouldNotCheckPassport($authenticator, $passport)
     {
-        $this->ldap->expects($this->never())->method('bind');
+        $ldap = $this->createMock(LdapInterface::class);
+        $ldap->expects($this->never())->method('bind');
 
-        $listener = $this->createListener();
+        $listener = $this->createListener($ldap);
         $listener->onCheckPassport(new CheckPassportEvent($authenticator, $passport));
     }
 
@@ -121,10 +114,11 @@ class CheckLdapCredentialsListenerTest extends TestCase
         $this->expectException(BadCredentialsException::class);
         $this->expectExceptionMessage('The presented password is invalid.');
 
-        $this->ldap->method('escape')->willReturnArgument(0);
-        $this->ldap->expects($this->any())->method('bind')->willThrowException(new InvalidCredentialsException());
+        $ldap = $this->createStub(LdapInterface::class);
+        $ldap->method('escape')->willReturnArgument(0);
+        $ldap->method('bind')->willThrowException(new InvalidCredentialsException());
 
-        $listener = $this->createListener();
+        $listener = $this->createListener($ldap);
         $listener->onCheckPassport($this->createEvent());
     }
 
@@ -145,7 +139,8 @@ class CheckLdapCredentialsListenerTest extends TestCase
         $query = $this->createMock(QueryInterface::class);
         $query->expects($this->once())->method('execute')->willReturn($collection);
 
-        $this->ldap
+        $ldap = $this->createMock(LdapInterface::class);
+        $ldap
             ->method('bind')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -156,10 +151,10 @@ class CheckLdapCredentialsListenerTest extends TestCase
                 $this->assertSame(array_shift($series), $args);
             })
         ;
-        $this->ldap->expects($this->any())->method('escape')->with('Wouter', '', LdapInterface::ESCAPE_FILTER)->willReturn('wouter');
-        $this->ldap->expects($this->once())->method('query')->with('{user_identifier}', 'wouter_test')->willReturn($query);
+        $ldap->expects($this->any())->method('escape')->with('Wouter', '', LdapInterface::ESCAPE_FILTER)->willReturn('wouter');
+        $ldap->expects($this->once())->method('query')->with('{user_identifier}', 'wouter_test')->willReturn($query);
 
-        $listener = $this->createListener();
+        $listener = $this->createListener($ldap);
         $listener->onCheckPassport($this->createEvent('s3cr3t', new LdapBadge('app.ldap', $dnString, 'elsa', 'test1234A$', $queryString)));
     }
 
@@ -183,7 +178,8 @@ class CheckLdapCredentialsListenerTest extends TestCase
         $query = $this->createMock(QueryInterface::class);
         $query->expects($this->once())->method('execute')->willReturn($collection);
 
-        $this->ldap
+        $ldap = $this->createMock(LdapInterface::class);
+        $ldap
             ->method('bind')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -194,10 +190,10 @@ class CheckLdapCredentialsListenerTest extends TestCase
                 $this->assertSame(array_shift($series), $args);
             })
         ;
-        $this->ldap->expects($this->any())->method('escape')->with('Wouter', '', LdapInterface::ESCAPE_FILTER)->willReturn('wouter');
-        $this->ldap->expects($this->once())->method('query')->with('{user_identifier}', 'wouter_test')->willReturn($query);
+        $ldap->expects($this->any())->method('escape')->with('Wouter', '', LdapInterface::ESCAPE_FILTER)->willReturn('wouter');
+        $ldap->expects($this->once())->method('query')->with('{user_identifier}', 'wouter_test')->willReturn($query);
 
-        $listener = $this->createListener();
+        $listener = $this->createListener($ldap);
         $listener->onCheckPassport($this->createEvent('s3cr3t', new LdapBadge('app.ldap', '{user_identifier}', 'elsa', 'test1234A$', '{user_identifier}_test')));
     }
 
@@ -206,12 +202,13 @@ class CheckLdapCredentialsListenerTest extends TestCase
         $this->expectException(BadCredentialsException::class);
         $this->expectExceptionMessage('The presented user identifier is invalid.');
 
-        $collection = $this->createMock(CollectionInterface::class);
+        $collection = $this->createStub(CollectionInterface::class);
 
         $query = $this->createMock(QueryInterface::class);
         $query->expects($this->once())->method('execute')->willReturn($collection);
 
-        $this->ldap
+        $ldap = $this->createMock(LdapInterface::class);
+        $ldap
             ->method('bind')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -222,10 +219,10 @@ class CheckLdapCredentialsListenerTest extends TestCase
                 $this->assertSame(array_shift($series), $args);
             })
         ;
-        $this->ldap->method('escape')->willReturnArgument(0);
-        $this->ldap->expects($this->once())->method('query')->willReturn($query);
+        $ldap->method('escape')->willReturnArgument(0);
+        $ldap->expects($this->once())->method('query')->willReturn($query);
 
-        $listener = $this->createListener();
+        $listener = $this->createListener($ldap);
         $listener->onCheckPassport($this->createEvent('s3cr3t', new LdapBadge('app.ldap', '{user_identifier}', 'elsa', 'test1234A$', '{user_identifier}_test')));
     }
 
@@ -237,9 +234,9 @@ class CheckLdapCredentialsListenerTest extends TestCase
         );
     }
 
-    private function createListener()
+    private function createListener(?LdapInterface $ldap = null)
     {
-        $ldapLocator = new class(['app.ldap' => fn () => $this->ldap]) implements ContainerInterface {
+        $ldapLocator = new class(['app.ldap' => fn () => $ldap ?? $this->createStub(LdapInterface::class)]) implements ContainerInterface {
             use ServiceLocatorTrait;
         };
 

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -381,7 +381,7 @@ class LdapUserProviderTest extends TestCase
 
     public function testRefreshUserShouldReturnUserWithSameProperties()
     {
-        $ldap = $this->createMock(LdapInterface::class);
+        $ldap = $this->createStub(LdapInterface::class);
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={user_identifier})', 'userpassword', ['email']);
 
         $user = new LdapUser(new Entry('foo'), 'foo', 'bar', ['ROLE_DUMMY'], ['email' => 'foo@symfony.com']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT