### PR TITLE
[Lock] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Lock/Tests/LockFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Lock\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\PersistingStoreInterface;
@@ -37,9 +37,8 @@ class LockFactoryTest extends TestCase
                 return true;
             }));
 
-        $logger = $this->createMock(LoggerInterface::class);
         $factory = new LockFactory($store);
-        $factory->setLogger($logger);
+        $factory->setLogger(new NullLogger());
 
         $lock1 = $factory->createLock('foo');
         $lock2 = $factory->createLock('foo');
@@ -66,9 +65,8 @@ class LockFactoryTest extends TestCase
                 return true;
             }));
 
-        $logger = $this->createMock(LoggerInterface::class);
         $factory = new LockFactory($store);
-        $factory->setLogger($logger);
+        $factory->setLogger(new NullLogger());
 
         $key = new Key('foo');
         $lock1 = $factory->createLockFromKey($key);

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -81,11 +81,10 @@ class LockTest extends TestCase
     public function testAcquireBlockingRetryWithPersistingStoreInterface()
     {
         $key = new Key(uniqid(__METHOD__, true));
-        $store = $this->createMock(PersistingStoreInterface::class);
+        $store = $this->createStub(PersistingStoreInterface::class);
         $lock = new Lock($key, $store);
 
         $store
-            ->expects($this->any())
             ->method('save')
             ->willReturnCallback(static function () {
                 if (1 === random_int(0, 1)) {
@@ -210,7 +209,7 @@ class LockTest extends TestCase
     public function testIsAquired()
     {
         $key = new Key(uniqid(__METHOD__, true));
-        $store = $this->createMock(PersistingStoreInterface::class);
+        $store = $this->createStub(PersistingStoreInterface::class);
         $lock = new Lock($key, $store, 10);
 
         $store
@@ -403,7 +402,7 @@ class LockTest extends TestCase
     public function testExpiration($ttls, $expected)
     {
         $key = new Key(uniqid(__METHOD__, true));
-        $store = $this->createMock(PersistingStoreInterface::class);
+        $store = $this->createStub(PersistingStoreInterface::class);
         $lock = new Lock($key, $store, 10);
 
         foreach ($ttls as $ttl) {
@@ -422,7 +421,7 @@ class LockTest extends TestCase
     public function testExpirationStoreInterface($ttls, $expected)
     {
         $key = new Key(uniqid(__METHOD__, true));
-        $store = $this->createMock(PersistingStoreInterface::class);
+        $store = $this->createStub(PersistingStoreInterface::class);
         $lock = new Lock($key, $store, 10);
 
         foreach ($ttls as $ttl) {
@@ -569,11 +568,10 @@ class LockTest extends TestCase
     public function testAcquireReadBlockingWithSharedLockStoreInterface()
     {
         $key = new Key(uniqid(__METHOD__, true));
-        $store = $this->createMock(SharedLockStoreInterface::class);
+        $store = $this->createStub(SharedLockStoreInterface::class);
         $lock = new Lock($key, $store);
 
         $store
-            ->expects($this->any())
             ->method('saveRead')
             ->willReturnCallback(static function () {
                 if (1 === random_int(0, 1)) {
@@ -607,11 +605,10 @@ class LockTest extends TestCase
     public function testAcquireReadBlockingWithPersistingStoreInterface()
     {
         $key = new Key(uniqid(__METHOD__, true));
-        $store = $this->createMock(PersistingStoreInterface::class);
+        $store = $this->createStub(PersistingStoreInterface::class);
         $lock = new Lock($key, $store);
 
         $store
-            ->expects($this->any())
             ->method('save')
             ->willReturnCallback(static function () {
                 if (1 === random_int(0, 1)) {

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -259,8 +259,8 @@ class CombinedStoreTest extends AbstractStoreTestCase
 
     public function testPutOffExpirationIgnoreNonExpiringStorage()
     {
-        $store1 = $this->createMock(PersistingStoreInterface::class);
-        $store2 = $this->createMock(PersistingStoreInterface::class);
+        $store1 = $this->createStub(PersistingStoreInterface::class);
+        $store2 = $this->createStub(PersistingStoreInterface::class);
 
         $store = new CombinedStore([$store1, $store2], $this->strategy);
 

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -132,7 +132,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $conn = $this->createMock(Connection::class);
 
         $series = [
-            [$this->stringContains('INSERT INTO'), $this->createMock(TableNotFoundException::class)],
+            [$this->stringContains('INSERT INTO'), $this->createStub(TableNotFoundException::class)],
             [$this->matches('create sql stmt'), 1],
             [$this->stringContains('INSERT INTO'), 1],
         ];
@@ -155,7 +155,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $conn->method('isTransactionActive')
             ->willReturn(true);
 
-        $platform = $this->createMock($platform);
+        $platform = $this->createStub($platform);
         $platform->method(method_exists(AbstractPlatform::class, 'getCreateTablesSQL') ? 'getCreateTablesSQL' : 'getCreateTableSQL')
             ->willReturn(['create sql stmt']);
 
@@ -192,7 +192,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $conn = $this->createMock(Connection::class);
 
         $series = [
-            [$this->stringContains('INSERT INTO'), $this->createMock(TableNotFoundException::class)],
+            [$this->stringContains('INSERT INTO'), $this->createStub(TableNotFoundException::class)],
             [$this->stringContains('INSERT INTO'), 1],
         ];
 
@@ -214,7 +214,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $conn->method('isTransactionActive')
             ->willReturn(true);
 
-        $platform = $this->createMock(AbstractPlatform::class);
+        $platform = $this->createStub(AbstractPlatform::class);
         $platform->method(method_exists(AbstractPlatform::class, 'getCreateTablesSQL') ? 'getCreateTablesSQL' : 'getCreateTableSQL')
             ->willReturn(['create sql stmt']);
 
@@ -233,7 +233,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $conn = $this->createMock(Connection::class);
 
         $series = [
-            [$this->stringContains('INSERT INTO'), $this->createMock(TableNotFoundException::class)],
+            [$this->stringContains('INSERT INTO'), $this->createStub(TableNotFoundException::class)],
             [$this->matches('create sql stmt'), 1],
             [$this->stringContains('INSERT INTO'), 1],
         ];
@@ -256,7 +256,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $conn->method('isTransactionActive')
             ->willReturn(false);
 
-        $platform = $this->createMock(AbstractPlatform::class);
+        $platform = $this->createStub(AbstractPlatform::class);
         $platform->method(method_exists(AbstractPlatform::class, 'getCreateTablesSQL') ? 'getCreateTablesSQL' : 'getCreateTableSQL')
             ->willReturn(['create sql stmt']);
 
@@ -272,7 +272,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
 
     public function testConfigureSchemaDifferentDatabase()
     {
-        $conn = $this->createMock(Connection::class);
+        $conn = $this->createStub(Connection::class);
         $someFunction = fn () => false;
         $schema = new Schema();
 
@@ -283,7 +283,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
 
     public function testConfigureSchemaSameDatabase()
     {
-        $conn = $this->createMock(Connection::class);
+        $conn = $this->createStub(Connection::class);
         $someFunction = fn () => true;
         $schema = new Schema();
 
@@ -294,7 +294,7 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
 
     public function testConfigureSchemaTableExists()
     {
-        $conn = $this->createMock(Connection::class);
+        $conn = $this->createStub(Connection::class);
         $schema = new Schema();
         $schema->createTable('lock_keys');
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisProxyStoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisProxyStoreFactoryTest.php
@@ -27,7 +27,7 @@ class RedisProxyStoreFactoryTest extends TestCase
             $this->markTestSkipped();
         }
 
-        $store = StoreFactory::createStore($this->createMock(RedisProxy::class));
+        $store = StoreFactory::createStore($this->createStub(RedisProxy::class));
 
         $this->assertInstanceOf(RedisStore::class, $store);
     }

--- a/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreFactoryTest.php
@@ -24,7 +24,7 @@ class ZookeeperStoreFactoryTest extends TestCase
 {
     public function testCreateZooKeeperStore()
     {
-        $store = StoreFactory::createStore($this->createMock(\Zookeeper::class));
+        $store = StoreFactory::createStore($this->createStub(\Zookeeper::class));
 
         $this->assertInstanceOf(ZookeeperStore::class, $store);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT