### PR TITLE
[Contracts] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Cache/CacheTraitTest.php
@@ -110,9 +110,7 @@ class CacheTraitTest extends TestCase
 
     public function testExceptionOnNegativeBeta()
     {
-        $cache = $this->getMockBuilder(TestPool::class)
-            ->onlyMethods(['getItem', 'save'])
-            ->getMock();
+        $cache = new TestPool();
 
         $callback = function (CacheItemInterface $item) {
             return 'computed data';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT