### PR TITLE
[Security] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -272,11 +271,9 @@ class TraceableAccessDecisionManagerTest extends TestCase
     {
         $accessDecisionManager = new AccessDecisionManager();
         $traceableAccessDecisionManager = new TraceableAccessDecisionManager($accessDecisionManager);
-        /** @var TokenInterface&MockObject $tokenMock */
-        $tokenMock = $this->createMock(TokenInterface::class);
 
         $this->expectException(InvalidArgumentException::class);
-        $traceableAccessDecisionManager->decide($tokenMock, ['attr1', 'attr2']);
+        $traceableAccessDecisionManager->decide(new NullToken(), ['attr1', 'attr2']);
     }
 
     /**
@@ -286,10 +283,8 @@ class TraceableAccessDecisionManagerTest extends TestCase
     {
         $accessDecisionManager = new AccessDecisionManager();
         $traceableAccessDecisionManager = new TraceableAccessDecisionManager($accessDecisionManager);
-        /** @var TokenInterface&MockObject $tokenMock */
-        $tokenMock = $this->createMock(TokenInterface::class);
 
-        $isGranted = $traceableAccessDecisionManager->decide($tokenMock, $attributes, null, null, $allowMultipleAttributes);
+        $isGranted = $traceableAccessDecisionManager->decide(new NullToken(), $attributes, null, null, $allowMultipleAttributes);
 
         $this->assertFalse($isGranted);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ClosureVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ClosureVoterTest.php
@@ -12,11 +12,12 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\ClosureVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\Attribute\IsGrantedContext;
 
 /**
@@ -29,14 +30,14 @@ class ClosureVoterTest extends TestCase
     protected function setUp(): void
     {
         $this->voter = new ClosureVoter(
-            $this->createMock(AuthorizationCheckerInterface::class),
+            $this->createStub(AuthorizationCheckerInterface::class),
         );
     }
 
     public function testEmptyAttributeAbstains()
     {
         $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $this->voter->vote(
-            $this->createMock(TokenInterface::class),
+            new NullToken(),
             null,
             [])
         );
@@ -44,9 +45,7 @@ class ClosureVoterTest extends TestCase
 
     public function testClosureReturningFalseDeniesAccess()
     {
-        $token = $this->createMock(TokenInterface::class);
-        $token->method('getRoleNames')->willReturn([]);
-        $token->method('getUser')->willReturn($this->createMock(UserInterface::class));
+        $token = new UsernamePasswordToken(new InMemoryUser('john', 'password'), 'main', []);
 
         $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote(
             $token,
@@ -57,9 +56,7 @@ class ClosureVoterTest extends TestCase
 
     public function testClosureReturningTrueGrantsAccess()
     {
-        $token = $this->createMock(TokenInterface::class);
-        $token->method('getRoleNames')->willReturn([]);
-        $token->method('getUser')->willReturn($this->createMock(UserInterface::class));
+        $token = new UsernamePasswordToken(new InMemoryUser('john', 'password'), 'main', []);
 
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->voter->vote(
             $token,
@@ -70,9 +67,7 @@ class ClosureVoterTest extends TestCase
 
     public function testArgumentsContent()
     {
-        $token = $this->createMock(TokenInterface::class);
-        $token->method('getRoleNames')->willReturn(['MY_ROLE', 'ANOTHER_ROLE']);
-        $token->method('getUser')->willReturn($this->createMock(UserInterface::class));
+        $token = new UsernamePasswordToken(new InMemoryUser('john', 'password'), 'main', ['MY_ROLE', 'ANOTHER_ROLE']);
 
         $outerSubject = new \stdClass();
 

--- a/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
@@ -13,10 +13,12 @@ namespace Symfony\Component\Security\Csrf\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -24,33 +26,23 @@ use Symfony\Component\Security\Csrf\SameOriginCsrfTokenManager;
 
 class SameOriginCsrfTokenManagerTest extends TestCase
 {
-    private $requestStack;
-    private $logger;
-    private $csrfTokenManager;
-
-    protected function setUp(): void
-    {
-        $this->requestStack = new RequestStack();
-        $this->logger = $this->createMock(LoggerInterface::class);
-        $this->csrfTokenManager = new SameOriginCsrfTokenManager($this->requestStack, $this->logger);
-    }
-
     public function testInvalidCookieName()
     {
         $this->expectException(\InvalidArgumentException::class);
-        new SameOriginCsrfTokenManager($this->requestStack, $this->logger, null, [], SameOriginCsrfTokenManager::CHECK_NO_HEADER, '');
+        new SameOriginCsrfTokenManager(new RequestStack(), new NullLogger(), null, [], SameOriginCsrfTokenManager::CHECK_NO_HEADER, '');
     }
 
     public function testInvalidCookieNameCharacters()
     {
         $this->expectException(\InvalidArgumentException::class);
-        new SameOriginCsrfTokenManager($this->requestStack, $this->logger, null, [], SameOriginCsrfTokenManager::CHECK_NO_HEADER, 'invalid name!');
+        new SameOriginCsrfTokenManager(new RequestStack(), new NullLogger(), null, [], SameOriginCsrfTokenManager::CHECK_NO_HEADER, 'invalid name!');
     }
 
     public function testGetToken()
     {
+        $csrfTokenManager = new SameOriginCsrfTokenManager(new RequestStack(), new NullLogger());
         $tokenId = 'test_token';
-        $token = $this->csrfTokenManager->getToken($tokenId);
+        $token = $csrfTokenManager->getToken($tokenId);
 
         $this->assertInstanceOf(CsrfToken::class, $token);
         $this->assertSame($tokenId, $token->getId());
@@ -58,45 +50,57 @@ class SameOriginCsrfTokenManagerTest extends TestCase
 
     public function testNoRequest()
     {
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager(new RequestStack(), $logger);
         $token = new CsrfToken('test_token', 'test_value');
 
-        $this->logger->expects($this->once())->method('error')->with('CSRF validation failed: No request found.');
-        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('error')->with('CSRF validation failed: No request found.');
+        $this->assertFalse($csrfTokenManager->isTokenValid($token));
     }
 
     public function testInvalidTokenLength()
     {
+        $logger = $this->createMock(LoggerInterface::class);
         $request = new Request();
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', '');
 
-        $this->logger->expects($this->once())->method('warning')->with('Invalid double-submit CSRF token.');
-        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('warning')->with('Invalid double-submit CSRF token.');
+        $this->assertFalse($csrfTokenManager->isTokenValid($token));
     }
 
     public function testInvalidOrigin()
     {
         $request = new Request();
         $request->headers->set('Origin', 'http://malicious.com');
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $this->logger->expects($this->once())->method('warning')->with('CSRF validation failed: origin info doesn\'t match.');
-        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('warning')->with('CSRF validation failed: origin info doesn\'t match.');
+        $this->assertFalse($csrfTokenManager->isTokenValid($token));
     }
 
     public function testValidOrigin()
     {
         $request = new Request();
         $request->headers->set('Origin', $request->getSchemeAndHttpHost());
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
-        $this->assertTrue($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
+        $this->assertTrue($csrfTokenManager->isTokenValid($token));
         $this->assertSame(1 | (1 << 8), $request->attributes->get('csrf-token'));
     }
 
@@ -105,78 +109,89 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $request = new Request();
         $request->headers->set('Origin', 'http://localhost:1234');
         $request->headers->set('Referer', $request->getSchemeAndHttpHost());
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
-        $this->assertTrue($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
+        $this->assertTrue($csrfTokenManager->isTokenValid($token));
         $this->assertSame(1 | (1 << 8), $request->attributes->get('csrf-token'));
     }
 
     public function testValidOriginAfterDoubleSubmit()
     {
-        $session = $this->createMock(Session::class);
+        $session = new Session(new MockArraySessionStorage('sess'));
         $request = new Request();
         $request->setSession($session);
         $request->headers->set('Origin', $request->getSchemeAndHttpHost());
         $request->cookies->set('sess', 'id');
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $session->expects($this->once())->method('getName')->willReturn('sess');
-        $session->expects($this->once())->method('get')->with('csrf-token')->willReturn(2 << 8);
-        $this->logger->expects($this->once())->method('warning')->with('CSRF validation failed: double-submit info was used in a previous request but is now missing.');
-        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+        $session->set('csrf-token', 2 << 8);
+        $logger->expects($this->once())->method('warning')->with('CSRF validation failed: double-submit info was used in a previous request but is now missing.');
+        $this->assertFalse($csrfTokenManager->isTokenValid($token));
     }
 
     public function testMissingPreviousOrigin()
     {
-        $session = $this->createMock(Session::class);
+        $session = new Session(new MockArraySessionStorage('sess'));
         $request = new Request();
         $request->cookies->set('csrf-token_'.str_repeat('a', 24), 'csrf-token');
         $request->setSession($session);
         $request->cookies->set('sess', 'id');
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $session->expects($this->once())->method('getName')->willReturn('sess');
-        $session->expects($this->once())->method('get')->with('csrf-token')->willReturn(1 << 8);
-        $this->logger->expects($this->once())->method('warning')->with('CSRF validation failed: origin info was used in a previous request but is now missing.');
-        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+        $session->set('csrf-token', 1 << 8);
+        $logger->expects($this->once())->method('warning')->with('CSRF validation failed: origin info was used in a previous request but is now missing.');
+        $this->assertFalse($csrfTokenManager->isTokenValid($token));
     }
 
     public function testValidDoubleSubmit()
     {
         $request = new Request();
         $request->cookies->set('csrf-token_'.str_repeat('a', 24), 'csrf-token');
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using double-submit info.');
-        $this->assertTrue($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('debug')->with('CSRF validation accepted using double-submit info.');
+        $this->assertTrue($csrfTokenManager->isTokenValid($token));
         $this->assertSame(2 << 8, $request->attributes->get('csrf-token'));
     }
 
     public function testCheckOnlyHeader()
     {
-        $csrfTokenManager = new SameOriginCsrfTokenManager($this->requestStack, $this->logger, null, [], SameOriginCsrfTokenManager::CHECK_ONLY_HEADER);
-
         $request = new Request();
         $tokenValue = str_repeat('a', 24);
         $request->headers->set('csrf-token', $tokenValue);
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger, null, [], SameOriginCsrfTokenManager::CHECK_ONLY_HEADER);
 
         $token = new CsrfToken('test_token', $tokenValue);
 
-        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using double-submit info.');
+        $logger->expects($this->once())->method('debug')->with('CSRF validation accepted using double-submit info.');
         $this->assertTrue($csrfTokenManager->isTokenValid($token));
         $this->assertSame('csrf-token', $request->cookies->get('csrf-token_'.$tokenValue));
 
-        $this->logger->expects($this->once())->method('warning')->with('CSRF validation failed: wrong token found in header info.');
+        $logger->expects($this->once())->method('warning')->with('CSRF validation failed: wrong token found in header info.');
         $this->assertFalse($csrfTokenManager->isTokenValid(new CsrfToken('test_token', str_repeat('b', 24))));
     }
 
@@ -187,74 +202,84 @@ class SameOriginCsrfTokenManagerTest extends TestCase
      */
     public function testValidOriginMissingDoubleSubmit(int $checkHeader)
     {
-        $csrfTokenManager = new SameOriginCsrfTokenManager($this->requestStack, $this->logger, null, [], $checkHeader);
-
         $request = new Request();
         $tokenValue = str_repeat('a', 24);
         $request->headers->set('Origin', $request->getSchemeAndHttpHost());
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger, null, [], $checkHeader);
 
         $token = new CsrfToken('test_token', $tokenValue);
 
-        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
+        $logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
         $this->assertTrue($csrfTokenManager->isTokenValid($token));
     }
 
     public function testMissingEverything()
     {
         $request = new Request();
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $this->logger->expects($this->once())->method('warning')->with('CSRF validation failed: double-submit and origin info not found.');
-        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('warning')->with('CSRF validation failed: double-submit and origin info not found.');
+        $this->assertFalse($csrfTokenManager->isTokenValid($token));
     }
 
     public function testClearCookies()
     {
+        $csrfTokenManager = new SameOriginCsrfTokenManager(new RequestStack(), new NullLogger());
+
         $request = new Request([], [], ['csrf-token' => 2], ['csrf-token_test' => 'csrf-token']);
         $response = new Response();
 
-        $this->csrfTokenManager->clearCookies($request, $response);
+        $csrfTokenManager->clearCookies($request, $response);
 
         $this->assertTrue($response->headers->has('Set-Cookie'));
     }
 
     public function testPersistStrategyWithStartedSession()
     {
-        $session = $this->createMock(Session::class);
-        $session->method('isStarted')->willReturn(true);
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
 
         $request = new Request();
         $request->setSession($session);
         $request->attributes->set('csrf-token', 2 << 8);
 
-        $session->expects($this->once())->method('set')->with('csrf-token', 2 << 8);
+        $csrfTokenManager = new SameOriginCsrfTokenManager(new RequestStack(), new NullLogger());
 
-        $this->csrfTokenManager->persistStrategy($request);
+        $csrfTokenManager->persistStrategy($request);
+        $this->assertSame(2 << 8, $session->get('csrf-token'));
     }
 
     public function testPersistStrategyWithSessionNotStarted()
     {
-        $session = $this->createMock(Session::class);
+        $session = new Session(new MockArraySessionStorage());
 
         $request = new Request();
         $request->setSession($session);
         $request->attributes->set('csrf-token', 2 << 8);
 
-        $session->expects($this->never())->method('set');
+        $csrfTokenManager = new SameOriginCsrfTokenManager(new RequestStack(), new NullLogger());
+        $csrfTokenManager->persistStrategy($request);
 
-        $this->csrfTokenManager->persistStrategy($request);
+        $this->assertSame([], $session->all());
     }
 
     public function testOnKernelResponse()
     {
+        $csrfTokenManager = new SameOriginCsrfTokenManager(new RequestStack(), new NullLogger());
+
         $request = new Request([], [], ['csrf-token' => 2], ['csrf-token_test' => 'csrf-token']);
         $response = new Response();
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
-        $this->csrfTokenManager->onKernelResponse($event);
+        $csrfTokenManager->onKernelResponse($event);
 
         $this->assertTrue($response->headers->has('Set-Cookie'));
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerBCTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerBCTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Tests\Authentication;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
@@ -19,6 +18,7 @@ use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -42,22 +42,21 @@ class AuthenticatorManagerBCTest extends TestCase
 {
     use ExpectUserDeprecationMessageTrait;
 
-    private MockObject&TokenStorageInterface $tokenStorage;
+    private TokenStorageInterface $tokenStorage;
     private EventDispatcher $eventDispatcher;
     private Request $request;
     private InMemoryUser $user;
-    private MockObject&TokenInterface $token;
+    private TokenInterface $token;
     private Response $response;
 
     protected function setUp(): void
     {
-        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->tokenStorage = new TokenStorage();
         $this->eventDispatcher = new EventDispatcher();
         $this->request = new Request();
         $this->user = new InMemoryUser('wouter', null);
-        $this->token = $this->createMock(TokenInterface::class);
-        $this->token->expects($this->any())->method('getUser')->willReturn($this->user);
-        $this->response = $this->createMock(Response::class);
+        $this->token = new UsernamePasswordToken($this->user, 'main');
+        $this->response = new Response();
     }
 
     /**
@@ -106,7 +105,8 @@ class AuthenticatorManagerBCTest extends TestCase
         // the attribute stores the supported authenticators, returning false now
         // means support changed between calling supports() and authenticateRequest()
         // (which is the case with lazy firewalls)
-        $authenticator = $this->createAuthenticator(false);
+        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
+        $authenticator->expects($this->atLeastOnce())->method('supports')->willReturn(false);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
         $authenticator->expects($this->never())->method('authenticate');
@@ -122,13 +122,26 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testAuthenticateRequest($matchingAuthenticatorIndex)
     {
-        $authenticators = [$this->createAuthenticator(0 === $matchingAuthenticatorIndex), $this->createAuthenticator(1 === $matchingAuthenticatorIndex)];
+        $matchingAuthenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
+        $matchingAuthenticator->method('supports')->willReturn(true);
+        $notMatchingAuthenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
+        $notMatchingAuthenticator->method('supports')->willReturn(false);
+        $notMatchingAuthenticator->expects($this->never())->method('authenticate');
+
+        if (0 === $matchingAuthenticatorIndex) {
+            $authenticators = [
+                $matchingAuthenticator,
+                $notMatchingAuthenticator,
+            ];
+        } else {
+            $authenticators = [
+                $notMatchingAuthenticator,
+                $matchingAuthenticator,
+            ];
+        }
         $this->request->attributes->set('_security_authenticators', $authenticators);
-        $matchingAuthenticator = $authenticators[$matchingAuthenticatorIndex];
 
-        $authenticators[($matchingAuthenticatorIndex + 1) % 2]->expects($this->never())->method('authenticate');
-
-        $matchingAuthenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $matchingAuthenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
 
         $listenerCalled = false;
         $this->eventDispatcher->addListener(CheckPassportEvent::class, function (CheckPassportEvent $event) use (&$listenerCalled, $matchingAuthenticator) {
@@ -136,13 +149,12 @@ class AuthenticatorManagerBCTest extends TestCase
                 $listenerCalled = true;
             }
         });
-        $matchingAuthenticator->expects($this->any())->method('createToken')->willReturn($this->token);
-
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
+        $matchingAuthenticator->method('createToken')->willReturn($this->token);
 
         $manager = $this->createManager($authenticators, hideUserNotFoundExceptions: true);
         $this->assertNull($manager->authenticateRequest($this->request));
         $this->assertTrue($listenerCalled, 'The CheckPassportEvent listener is not called');
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     public static function provideMatchingAuthenticatorIndex()
@@ -156,7 +168,7 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testNoCredentialsValidated()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
         $authenticator->expects($this->any())->method('authenticate')->willReturn(new Passport(new UserBadge('wouter', fn () => $this->user), new PasswordCredentials('pass')));
@@ -174,7 +186,7 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testRequiredBadgeMissing()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
         $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter')));
@@ -190,7 +202,7 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testAllRequiredBadgesPresent()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
         $csrfBadge = new CsrfTokenBadge('csrfid', 'csrftoken');
@@ -211,14 +223,14 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testEraseCredentials($eraseCredentials)
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
 
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
-
-        $this->token->expects($eraseCredentials ? $this->once() : $this->never())->method('eraseCredentials');
+        $token = $this->createMock(TokenInterface::class);
+        $token->expects($eraseCredentials ? $this->once() : $this->never())->method('eraseCredentials');
+        $authenticator->method('createToken')->willReturn($token);
 
         $manager = $this->createManager([$authenticator], 'main', $eraseCredentials, hideUserNotFoundExceptions: true);
         $manager->authenticateRequest($this->request);
@@ -235,26 +247,24 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testAuthenticateRequestCanModifyTokenFromEvent()
     {
-        $authenticator = $this->createAuthenticator();
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
 
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $modifiedToken = $this->createMock(TokenInterface::class);
-        $modifiedToken->expects($this->any())->method('getUser')->willReturn($this->user);
+        $modifiedToken = new UsernamePasswordToken($this->user, 'main');
         $listenerCalled = false;
         $this->eventDispatcher->addListener(AuthenticationTokenCreatedEvent::class, function (AuthenticationTokenCreatedEvent $event) use (&$listenerCalled, $modifiedToken) {
             $event->setAuthenticatedToken($modifiedToken);
             $listenerCalled = true;
         });
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->identicalTo($modifiedToken));
-
         $manager = $this->createManager([$authenticator], hideUserNotFoundExceptions: true);
         $this->assertNull($manager->authenticateRequest($this->request));
         $this->assertTrue($listenerCalled, 'The AuthenticationTokenCreatedEvent listener is not called');
+        $this->assertSame($modifiedToken, $this->tokenStorage->getToken());
     }
 
     /**
@@ -262,13 +272,12 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testAuthenticateUser()
     {
-        $authenticator = $this->createAuthenticator();
-        $authenticator->expects($this->any())->method('onAuthenticationSuccess')->willReturn($this->response);
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
+        $authenticator->method('onAuthenticationSuccess')->willReturn($this->response);
 
         $badge = new UserBadge('alex');
 
         $authenticator
-            ->expects($this->any())
             ->method('createToken')
             ->willReturnCallback(function (Passport $passport) use ($badge) {
                 $this->assertSame(['attr' => 'foo', 'attr2' => 'bar'], $passport->getAttributes());
@@ -277,10 +286,9 @@ class AuthenticatorManagerBCTest extends TestCase
                 return $this->token;
             });
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
         $manager = $this->createManager([$authenticator], hideUserNotFoundExceptions: true);
         $manager->authenticateUser($this->user, $authenticator, $this->request, [$badge], ['attr' => 'foo', 'attr2' => 'bar']);
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     /**
@@ -288,23 +296,21 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testAuthenticateUserCanModifyTokenFromEvent()
     {
-        $authenticator = $this->createAuthenticator();
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
-        $authenticator->expects($this->any())->method('onAuthenticationSuccess')->willReturn($this->response);
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
+        $authenticator->method('createToken')->willReturn($this->token);
+        $authenticator->method('onAuthenticationSuccess')->willReturn($this->response);
 
-        $modifiedToken = $this->createMock(TokenInterface::class);
-        $modifiedToken->expects($this->any())->method('getUser')->willReturn($this->user);
+        $modifiedToken = new UsernamePasswordToken($this->user, 'main');
         $listenerCalled = false;
         $this->eventDispatcher->addListener(AuthenticationTokenCreatedEvent::class, function (AuthenticationTokenCreatedEvent $event) use (&$listenerCalled, $modifiedToken) {
             $event->setAuthenticatedToken($modifiedToken);
             $listenerCalled = true;
         });
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->identicalTo($modifiedToken));
-
         $manager = $this->createManager([$authenticator], hideUserNotFoundExceptions: true);
         $manager->authenticateUser($this->user, $authenticator, $this->request);
         $this->assertTrue($listenerCalled, 'The AuthenticationTokenCreatedEvent listener is not called');
+        $this->assertSame($modifiedToken, $this->tokenStorage->getToken());
     }
 
     /**
@@ -312,16 +318,14 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testInteractiveAuthenticator()
     {
-        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
-        $authenticator->expects($this->any())->method('isInteractive')->willReturn(true);
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
+        $authenticator->method('isInteractive')->willReturn(true);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
@@ -329,6 +333,7 @@ class AuthenticatorManagerBCTest extends TestCase
         $manager = $this->createManager([$authenticator], hideUserNotFoundExceptions: true);
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     /**
@@ -336,16 +341,14 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testLegacyInteractiveAuthenticator()
     {
-        $authenticator = $this->createMock(InteractiveAuthenticatorInterface::class);
-        $authenticator->expects($this->any())->method('isInteractive')->willReturn(true);
+        $authenticator = $this->createStub(InteractiveAuthenticatorInterface::class);
+        $authenticator->method('isInteractive')->willReturn(true);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
@@ -353,6 +356,7 @@ class AuthenticatorManagerBCTest extends TestCase
         $manager = $this->createManager([$authenticator], hideUserNotFoundExceptions: true);
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     /**
@@ -361,12 +365,12 @@ class AuthenticatorManagerBCTest extends TestCase
     public function testAuthenticateRequestHidesInvalidUserExceptions()
     {
         $invalidUserException = new UserNotFoundException();
-        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willThrowException($invalidUserException);
+        $authenticator->method('authenticate')->willThrowException($invalidUserException);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationFailure')
             ->with($this->equalTo($this->request), $this->callback(fn ($e) => $e instanceof BadCredentialsException && $invalidUserException === $e->getPrevious()))
             ->willReturn($this->response);
@@ -382,12 +386,12 @@ class AuthenticatorManagerBCTest extends TestCase
     public function testAuthenticateRequestShowsAccountStatusException()
     {
         $invalidUserException = new LockedException();
-        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willThrowException($invalidUserException);
+        $authenticator->method('authenticate')->willThrowException($invalidUserException);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationFailure')
             ->with($this->equalTo($this->request), $this->callback(fn ($e) => $e === $invalidUserException))
             ->willReturn($this->response);
@@ -403,12 +407,12 @@ class AuthenticatorManagerBCTest extends TestCase
     public function testAuthenticateRequestHidesInvalidAccountStatusException()
     {
         $invalidUserException = new LockedException();
-        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willThrowException($invalidUserException);
+        $authenticator->method('authenticate')->willThrowException($invalidUserException);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationFailure')
             ->with($this->equalTo($this->request), $this->callback(fn ($e) => $e instanceof BadCredentialsException && $invalidUserException === $e->getPrevious()))
             ->willReturn($this->response);
@@ -423,21 +427,19 @@ class AuthenticatorManagerBCTest extends TestCase
      */
     public function testLogsUseTheDecoratedAuthenticatorWhenItIsTraceable()
     {
-        $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
-        $authenticator->expects($this->any())->method('isInteractive')->willReturn(true);
+        $authenticator = $this->createStub(TestInteractiveBCAuthenticator::class);
+        $authenticator->method('isInteractive')->willReturn(true);
         $this->request->attributes->set('_security_authenticators', [new TraceableAuthenticator($authenticator)]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
-        $authenticator->expects($this->any())->method('createToken')->willReturn($this->token);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
 
-        $this->tokenStorage->expects($this->once())->method('setToken')->with($this->token);
-
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationSuccess')
             ->with($this->anything(), $this->token, 'main')
             ->willReturn($this->response);
@@ -457,12 +459,13 @@ class AuthenticatorManagerBCTest extends TestCase
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
         $this->assertStringContainsString($authenticator::class, $logger->logContexts[0]['authenticator']);
+        $this->assertSame($this->token, $this->tokenStorage->getToken());
     }
 
     private function createAuthenticator(?bool $supports = true)
     {
         $authenticator = $this->createMock(TestInteractiveBCAuthenticator::class);
-        $authenticator->expects($this->any())->method('supports')->willReturn($supports);
+        $authenticator->expects($this->atLeastOnce())->method('supports')->willReturn($supports);
 
         return $authenticator;
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -362,12 +362,12 @@ class AuthenticatorManagerTest extends TestCase
     public function testAuthenticateRequestShowsAccountStatusException()
     {
         $invalidUserException = new LockedException();
-        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willThrowException($invalidUserException);
+        $authenticator->method('authenticate')->willThrowException($invalidUserException);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationFailure')
             ->with($this->equalTo($this->request), $this->callback(fn ($e) => $e === $invalidUserException))
             ->willReturn($this->response);
@@ -380,12 +380,12 @@ class AuthenticatorManagerTest extends TestCase
     public function testAuthenticateRequestHidesInvalidAccountStatusException()
     {
         $invalidUserException = new LockedException();
-        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willThrowException($invalidUserException);
+        $authenticator->method('authenticate')->willThrowException($invalidUserException);
 
-        $authenticator->expects($this->any())
+        $authenticator
             ->method('onAuthenticationFailure')
             ->with($this->equalTo($this->request), $this->callback(fn ($e) => $e instanceof BadCredentialsException && $invalidUserException === $e->getPrevious()))
             ->willReturn($this->response);

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
@@ -37,7 +37,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             new IsCsrfTokenValidAttributeController(),
             [],
             $request,
@@ -55,7 +55,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->method('isTokenValid');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'noAttribute'],
             [],
             new Request(),
@@ -77,7 +77,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withDefaultTokenKey'],
             [],
             $request,
@@ -99,7 +99,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withDefaultTokenKey'],
             [],
             $request,
@@ -130,7 +130,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn('foo_123');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withCustomExpressionId'],
             ['123'],
             $request,
@@ -152,7 +152,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withCustomTokenKey'],
             [],
             $request,
@@ -174,7 +174,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withInvalidTokenKey'],
             [],
             $request,
@@ -196,7 +196,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withDefaultTokenKey'],
             [],
             new Request(),
@@ -219,7 +219,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withDeleteMethod'],
             [],
             $request,
@@ -241,7 +241,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->with(new CsrfToken('foo', 'bar'));
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withDeleteMethod'],
             [],
             $request,
@@ -264,7 +264,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withGetOrPostMethod'],
             [],
             $request,
@@ -286,7 +286,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->with(new CsrfToken('foo', 'bar'));
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withGetOrPostMethod'],
             [],
             $request,
@@ -311,7 +311,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withPostMethodAndInvalidTokenKey'],
             [],
             $request,
@@ -333,7 +333,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->withAnyParameters();
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), 'withPostMethodAndInvalidTokenKey'],
             [],
             $request,

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -201,8 +201,6 @@ class IsGrantedAttributeListenerTest extends TestCase
     {
         $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
 
-        $this->expectException(\RuntimeException::class);
-
         $event = new ControllerArgumentsEvent(
             $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'withMissingSubject'],

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeWithClosureListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeWithClosureListenerTest.php
@@ -39,7 +39,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeWithClosureController(), 'foo'],
             [],
             new Request(),
@@ -55,7 +55,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeWithClosureController(), 'bar'],
             [],
             new Request(),
@@ -73,7 +73,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->method('isGranted');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'noAttribute'],
             [],
             new Request(),
@@ -93,7 +93,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'admin'],
             [],
             new Request(),
@@ -114,7 +114,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'withSubject'],
             ['arg1Value', 'arg2Value'],
             new Request(),
@@ -139,7 +139,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'withSubjectArray'],
             ['arg1Value', 'arg2Value'],
             new Request(),
@@ -160,7 +160,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'withSubject'],
             ['arg1Value', null],
             new Request(),
@@ -183,7 +183,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'withSubjectArray'],
             ['arg1Value', null],
             new Request(),
@@ -196,10 +196,10 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
 
     public function testExceptionWhenMissingSubjectAttribute()
     {
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'withMissingSubject'],
             [],
             new Request(),
@@ -227,7 +227,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
         $listener = new IsGrantedAttributeListener($authChecker);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), $method],
             $arguments,
             new Request(),
@@ -259,13 +259,13 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
 
     public function testNotFoundHttpException()
     {
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authChecker->expects($this->any())
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authChecker
             ->method('isGranted')
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'notFound'],
             [],
             new Request(),
@@ -291,7 +291,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'withClosureAsSubject'],
             ['postVal'],
             $request,
@@ -313,7 +313,7 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'withNestArgsInSubject'],
             ['postVal', 'bar'],
             $request,
@@ -326,13 +326,13 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
 
     public function testHttpExceptionWithExceptionCode()
     {
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authChecker->expects($this->any())
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authChecker
             ->method('isGranted')
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'exceptionCodeInHttpException'],
             [],
             new Request(),
@@ -350,13 +350,13 @@ class IsGrantedAttributeWithClosureListenerTest extends TestCase
 
     public function testAccessDeniedExceptionWithExceptionCode()
     {
-        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authChecker->expects($this->any())
+        $authChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authChecker
             ->method('isGranted')
             ->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsWithClosureController(), 'exceptionCodeInAccessDeniedException'],
             [],
             new Request(),

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -38,7 +38,7 @@ class AccessListenerTest extends TestCase
 
         $accessMap = $this->createMock(AccessMapInterface::class);
         $accessMap
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([['foo' => 'bar'], null])
@@ -74,7 +74,7 @@ class AccessListenerTest extends TestCase
 
         $accessMap = $this->createMock(AccessMapInterface::class);
         $accessMap
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([null, null])
@@ -101,7 +101,7 @@ class AccessListenerTest extends TestCase
 
         $accessMap = $this->createMock(AccessMapInterface::class);
         $accessMap
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([[], null])
@@ -130,7 +130,7 @@ class AccessListenerTest extends TestCase
         $request = new Request();
 
         $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap->expects($this->any())
+        $accessMap->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([['foo' => 'bar'], null])
@@ -160,7 +160,7 @@ class AccessListenerTest extends TestCase
         $request = new Request();
 
         $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap->expects($this->any())
+        $accessMap->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([[AuthenticatedVoter::PUBLIC_ACCESS], null])
@@ -190,7 +190,7 @@ class AccessListenerTest extends TestCase
         $request = new Request();
 
         $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap->expects($this->any())
+        $accessMap->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([[AuthenticatedVoter::PUBLIC_ACCESS], null])
@@ -218,7 +218,7 @@ class AccessListenerTest extends TestCase
 
         $accessMap = $this->createMock(AccessMapInterface::class);
         $accessMap
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([['foo' => 'bar', 'bar' => 'baz'], null])
@@ -243,7 +243,7 @@ class AccessListenerTest extends TestCase
             $accessMap
         );
 
-        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
     public function testLazyPublicPagesShouldNotAccessTokenStorage()
@@ -253,7 +253,7 @@ class AccessListenerTest extends TestCase
 
         $request = new Request();
         $accessMap = $this->createMock(AccessMapInterface::class);
-        $accessMap->expects($this->any())
+        $accessMap->expects($this->once())
             ->method('getPatterns')
             ->with($this->equalTo($request))
             ->willReturn([[AuthenticatedVoter::PUBLIC_ACCESS], null])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT