### PR TITLE
[Intl] Add "UK" to regions list

### DIFF
--- a/src/Symfony/Component/Intl/Resources/data/regions/en.php
+++ b/src/Symfony/Component/Intl/Resources/data/regions/en.php
@@ -236,6 +236,7 @@ return [
         'TZ' => 'Tanzania',
         'UA' => 'Ukraine',
         'UG' => 'Uganda',
+        'UK' => 'United Kingdom',
         'UM' => 'U.S. Outlying Islands',
         'US' => 'United States',
         'UY' => 'Uruguay',


### PR DESCRIPTION
.uk ccTLD is more popular than .gb, i think both should be supported

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no
| License       | MIT


