### PR TITLE
[PropertyInfo] fix exception with nullable value-of phpdoc

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -916,6 +916,10 @@ class PhpDocExtractorTest extends TestCase
         yield ['false', Type::false()];
         yield ['valueOfStrings', null];
         yield ['valueOfIntegers', null];
+        yield ['valueOfIntEnum', null];
+        yield ['valueOfStringEnum', null];
+        yield ['valueOfNullableIntEnum', null];
+        yield ['valueOfNullableStringEnum', null];
         yield ['keyOfStrings', null];
         yield ['keyOfIntegers', null];
         yield ['arrayKey', null];

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IntEnumDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IntEnumDummy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+enum IntEnumDummy: int
+{
+    case A = 1;
+    case B = 2;
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PseudoTypesDummy.php
@@ -61,6 +61,18 @@ class PseudoTypesDummy
     /** @var value-of<self::INTEGERS> */
     public $valueOfIntegers;
 
+    /** @var value-of<IntEnumDummy> */
+    public $valueOfIntEnum;
+
+    /** @var value-of<StringEnumDummy> */
+    public $valueOfStringEnum;
+
+    /** @var value-of<IntEnumDummy>|null */
+    public $valueOfNullableIntEnum;
+
+    /** @var value-of<StringEnumDummy>|null */
+    public $valueOfNullableStringEnum;
+
     /** @var key-of<self::STRINGS> */
     public $keyOfStrings;
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/StringEnumDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/StringEnumDummy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+enum StringEnumDummy: string
+{
+    case A = 'A';
+    case B = 'B';
+}

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -165,6 +165,10 @@ final class PhpDocTypeHelper
             }
         }
 
+        if (!$unionTypes) {
+            return null;
+        }
+
         $type = 1 === \count($unionTypes) ? $unionTypes[0] : Type::union(...$unionTypes);
 
         return $nullable ? Type::nullable($type) : $type;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

fix exception: "Symfony\Component\TypeInfo\Type\UnionType" expects at least 2 types." when property phpdoc is "value-of&lt;Enum&gt;|null"
