### PR TITLE
[HttpKernel] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -79,7 +79,7 @@ class DumpListenerTest extends TestCase
         $dumper = new MockDumper();
         $profilerDumper = new MockProfilerDumper();
 
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createStub(InputInterface::class);
         $input->method('hasOption')->willReturn($hasOption);
         $input->method('getOption')->willReturn($option);
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/IsSignatureValidAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/IsSignatureValidAttributeListenerTest.php
@@ -29,7 +29,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
 
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->once())->method('verify')->with($request);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $event = new ControllerArgumentsEvent(
             $kernel,
@@ -45,7 +45,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
 
     public function testNoAttributeSkipsValidation()
     {
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->never())->method('verify');
 
@@ -66,7 +66,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
         $request = new Request();
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->once())->method('verify')->with($request);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $event = new ControllerArgumentsEvent(
             $kernel,
@@ -85,7 +85,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
         $request = new Request();
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->once())->method('verify')->willThrowException(new UnsignedUriException());
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $event = new ControllerArgumentsEvent(
             $kernel,
@@ -107,7 +107,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
 
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->exactly(2))->method('verify')->with($request);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $event = new ControllerArgumentsEvent(
             $kernel,
@@ -127,7 +127,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
 
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->once())->method('verify')->with($request);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $event = new ControllerArgumentsEvent(
             $kernel,
@@ -147,7 +147,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
 
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->once())->method('verify')->with($request);
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
 
         $event = new ControllerArgumentsEvent(
             $kernel,
@@ -165,7 +165,7 @@ class IsSignatureValidAttributeListenerTest extends TestCase
     {
         $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'GET']);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $signer = $this->createMock(UriSigner::class);
         $signer->expects($this->never())->method('verify');
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -752,7 +752,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
         $primedStore = $this->store;
 
-        $this->store = $this->createMock(Store::class);
+        $this->store = $this->createStub(Store::class);
         $this->store->method('lookup')->willReturnCallback(fn (Request $request) => $primedStore->lookup($request));
         // Assume the cache is locked at the first attempt, but immediately treat the lock as released afterwards
         $this->store->method('lock')->willReturnOnConsecutiveCalls(false, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT