### PR TITLE
[Security] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
@@ -126,12 +126,15 @@ class SameOriginCsrfTokenManagerTest extends TestCase
     {
         $request = new Request();
         $request->headers->set('Sec-Fetch-Site', 'same-origin');
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $this->logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
-        $this->assertTrue($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('debug')->with('CSRF validation accepted using origin info.');
+        $this->assertTrue($csrfTokenManager->isTokenValid($token));
         $this->assertSame(1 | (1 << 8), $request->attributes->get('csrf-token'));
     }
 
@@ -139,12 +142,15 @@ class SameOriginCsrfTokenManagerTest extends TestCase
     {
         $request = new Request();
         $request->headers->set('Sec-Fetch-Site', 'cross-site');
-        $this->requestStack->push($request);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+        $logger = $this->createMock(LoggerInterface::class);
+        $csrfTokenManager = new SameOriginCsrfTokenManager($requestStack, $logger);
 
         $token = new CsrfToken('test_token', str_repeat('a', 24));
 
-        $this->logger->expects($this->once())->method('warning')->with('CSRF validation failed: origin info doesn\'t match.');
-        $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
+        $logger->expects($this->once())->method('warning')->with('CSRF validation failed: origin info doesn\'t match.');
+        $this->assertFalse($csrfTokenManager->isTokenValid($token));
     }
 
     public function testValidOriginAfterDoubleSubmit()

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
@@ -348,7 +348,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsCsrfTokenValidAttributeMethodsController(), $attributeMethod],
             [],
             $request,

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -473,7 +473,7 @@ class IsGrantedAttributeListenerTest extends TestCase
         $authChecker->expects($this->once())->method('isGranted')->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'adminWithMethodGet'],
             [],
             new Request([], [], [], [], [], ['REQUEST_METHOD' => 'GET']),
@@ -491,7 +491,7 @@ class IsGrantedAttributeListenerTest extends TestCase
         $authChecker->expects($this->once())->method('isGranted')->willReturn(false);
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'adminWithMethodGetAndPost'],
             [],
             new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']),
@@ -509,7 +509,7 @@ class IsGrantedAttributeListenerTest extends TestCase
         $authChecker->expects($this->never())->method('isGranted');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'adminWithMethodGetAndPost'],
             [],
             new Request([], [], [], [], [], ['REQUEST_METHOD' => 'PUT']),
@@ -526,7 +526,7 @@ class IsGrantedAttributeListenerTest extends TestCase
         $authChecker->expects($this->never())->method('isGranted');
 
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             [new IsGrantedAttributeMethodsController(), 'adminWithMethodGet'],
             [],
             new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']),
@@ -547,7 +547,7 @@ class IsGrantedAttributeListenerTest extends TestCase
 
         $controller = [new IsGrantedAttributeMethodsController(), 'admin'];
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             $controller,
             [],
             new Request(),
@@ -574,7 +574,7 @@ class IsGrantedAttributeListenerTest extends TestCase
 
         $controller = [new IsGrantedAttributeMethodsController(), 'admin'];
         $event = new ControllerArgumentsEvent(
-            $this->createMock(HttpKernelInterface::class),
+            $this->createStub(HttpKernelInterface::class),
             $controller,
             [],
             new Request(),

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -269,7 +269,7 @@ class AccessListenerTest extends TestCase
         $listener = new AccessListener($tokenStorage, $this->createStub(AccessDecisionManagerInterface::class), $accessMap, false);
 
         $this->assertNull($listener->supports($request));
-        $listener->authenticate(new LazyResponseEvent(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
+        $listener->authenticate(new LazyResponseEvent(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
     }
 
     public function testConstructWithTrueExceptionOnNoToken()

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -176,7 +175,7 @@ class FirewallTest extends TestCase
 
         $callableListener = static function () use (&$calledListeners) { $calledListeners[] = 'callableListener'; };
 
-        $request = $this->createMock(Request::class);
+        $request = new Request();
 
         $map = $this->createMock(FirewallMapInterface::class);
         $map
@@ -186,9 +185,9 @@ class FirewallTest extends TestCase
             ->willReturn([[$callableListener], null, null])
         ;
 
-        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
 
-        $firewall = new Firewall($map, $this->createMock(EventDispatcherInterface::class));
+        $firewall = new Firewall($map, new EventDispatcher());
 
         $this->expectUserDeprecationMessage('Since symfony/security-http 7.4: Using a callable as firewall listener is deprecated, extend "Symfony\Component\Security\Http\Firewall\AbstractListener" or implement "Symfony\Component\Security\Http\Firewall\FirewallListenerInterface" instead.');
         $firewall->onKernelRequest($event);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT