### PR TITLE
[HttpKernel] Remove redundant code from `CacheAttributeListener`

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -49,8 +49,6 @@ class CacheAttributeListener implements EventSubscriberInterface
         $request->attributes->set('_cache', $attributes);
         $variables = null;
         $response = null;
-        $lastModified = null;
-        $etag = null;
 
         foreach ($attributes as $cache) {
             if (!\is_bool($cache->if)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #63089.

The vars are no longer used outside the loop.