### PR TITLE
[Ldap] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/Adapter/AbstractQueryTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/AbstractQueryTest.php
@@ -28,7 +28,7 @@ class AbstractQueryTest extends TestCase
     {
         $this->expectUserDeprecationMessage('Since symfony/ldap 7.2: The "sizeLimit" option is deprecated and will be removed in Symfony 8.0.');
 
-        new class($this->createMock(ConnectionInterface::class), '', '', ['filter' => '*', 'sizeLimit' => 1]) extends AbstractQuery {
+        new class($this->createStub(ConnectionInterface::class), '', '', ['filter' => '*', 'sizeLimit' => 1]) extends AbstractQuery {
             public function execute(): CollectionInterface
             {
             }

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -394,13 +394,13 @@ class LdapUserProviderTest extends TestCase
     public function testLoadUserWithCorrectRoles()
     {
         // Given
-        $result = $this->createMock(CollectionInterface::class);
-        $query = $this->createMock(QueryInterface::class);
+        $result = $this->createStub(CollectionInterface::class);
+        $query = $this->createStub(QueryInterface::class);
         $query
             ->method('execute')
             ->willReturn($result)
         ;
-        $ldap = $this->createMock(LdapInterface::class);
+        $ldap = $this->createStub(LdapInterface::class);
         $result
             ->method('offsetGet')
             ->with(0)
@@ -418,7 +418,7 @@ class LdapUserProviderTest extends TestCase
             ->method('query')
             ->willReturn($query)
         ;
-        $roleFetcher = $this->createMock(RoleFetcherInterface::class);
+        $roleFetcher = $this->createStub(RoleFetcherInterface::class);
         $roleFetcher
             ->method('fetchRoles')
             ->willReturn(['ROLE_FOO', 'ROLE_BAR'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT