### PR TITLE
[FrameworkBundle] Add shortcut to run console command in tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
  * Add support for `framework.secrets.decryption_env_var` to contain dots
  * Enable mocking non-shared services in tests
+ * Add `KernelTestCase::executeCommand()` to execute a command in functional tests
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+trait ConsoleCommandAssertionsTrait
+{
+    /**
+     * Executes the command.
+     *
+     * Available execution options:
+     *
+     *  * interactive:               Sets the input interactive flag
+     *  * decorated:                 Sets the output decorated flag
+     *  * verbosity:                 Sets the output verbosity flag
+     *  * capture_stderr_separately: Make output of stdOut and stdErr separately available
+     *
+     * @param array $input   An array of command arguments and options
+     * @param array $options An array of execution options
+     */
+    public static function executeCommand(string $name, array $input, array $options = []): CommandTester
+    {
+        $application = new Application(static::getContainer()->get('kernel'));
+        $command = $application->find($name);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute($input, $options);
+
+        return $commandTester;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -25,6 +25,7 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 abstract class KernelTestCase extends TestCase
 {
+    use ConsoleCommandAssertionsTrait;
     use MailerAssertionsTrait;
     use NotificationAssertionsTrait;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

IMHO [current way](https://symfony.com/doc/current/console.html#testing-commands) to test console commands is a bit verbose and we can simplify:

```php
public function testExecute(): void
{
    # before
    self::bootKernel();
    $application = new Application(self::$kernel);

    $command = $application->find('app:create-user');
    $commandTester = new CommandTester($command);
    $commandTester->execute(['username' => 'Wouter']);

    $commandTester->assertCommandIsSuccessful();

    # after
    $commandTester = static::executeCommand('app:create-user', ['username' => 'Wouter']);

    $commandTester->assertCommandIsSuccessful();
}
```
