### PR TITLE
[Security] Decouple `SameOriginCsrfTokenManager` from event listening

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -29,6 +29,11 @@ HttpKernel
 
  * Deprecate passing a non-flat list of attributes to `Controller::setController()`
 
+Security
+--------
+
+ * Deprecate `SameOriginCsrfTokenManager::onKernelResponse()`, `SameOriginCsrfTokenManager::clearCookies()` and `SameOriginCsrfTokenManager::persistStrategy()`; this logic is now handled automatically by `SameOriginCsrfListener`
+
 Uid
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1992,6 +1992,7 @@ class FrameworkExtension extends Extension
 
         if (!$config['stateless_token_ids']) {
             $container->removeDefinition('security.csrf.same_origin_token_manager');
+            $container->removeDefinition('security.csrf.same_origin_listener');
 
             return;
         }
@@ -2000,6 +2001,9 @@ class FrameworkExtension extends Extension
             ->replaceArgument(3, $config['stateless_token_ids'])
             ->replaceArgument(4, $config['check_header'])
             ->replaceArgument(5, $config['cookie_name']);
+
+        $container->getDefinition('security.csrf.same_origin_listener')
+            ->replaceArgument(0, $config['cookie_name']);
 
         if (!$this->isInitializedConfigEnabled('session')) {
             $container->setAlias('security.csrf.token_manager', 'security.csrf.same_origin_token_manager');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
@@ -15,6 +15,7 @@ use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bridge\Twig\Extension\CsrfRuntime;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\SameOriginCsrfListener;
 use Symfony\Component\Security\Csrf\SameOriginCsrfTokenManager;
 use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
 use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
@@ -59,6 +60,11 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('framework.csrf_protection.cookie_name'),
             ])
             ->tag('monolog.logger', ['channel' => 'request'])
+
+        ->set('security.csrf.same_origin_listener', SameOriginCsrfListener::class)
+            ->args([
+                abstract_arg('framework.csrf_protection.cookie_name'),
+            ])
             ->tag('kernel.event_listener', ['event' => 'kernel.response', 'method' => 'onKernelResponse'])
     ;
 };

--- a/src/Symfony/Component/Security/Csrf/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Csrf/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Extract `SameOriginCsrfListener` from `SameOriginCsrfTokenManager` to handle cookie persistence and clearing
+ * Deprecate `SameOriginCsrfTokenManager::onKernelResponse()`, `SameOriginCsrfTokenManager::clearCookies()` and `SameOriginCsrfTokenManager::persistStrategy()`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Security/Csrf/SameOriginCsrfListener.php
+++ b/src/Symfony/Component/Security/Csrf/SameOriginCsrfListener.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+final class SameOriginCsrfListener
+{
+    public function __construct(
+        private readonly string $cookieName = 'csrf-token')
+    {
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $this->clearCookies($event->getRequest(), $event->getResponse());
+        $this->persistStrategy($event->getRequest());
+    }
+
+    private function clearCookies(Request $request, Response $response): void
+    {
+        if (!$request->attributes->has($this->cookieName)) {
+            return;
+        }
+
+        $cookieName = ($request->isSecure() ? '__Host-' : '').$this->cookieName;
+
+        foreach ($request->cookies->all() as $name => $value) {
+            if ($this->cookieName === $value && str_starts_with($name, $cookieName.'_')) {
+                $response->headers->clearCookie($name, '/', null, $request->isSecure(), false, 'strict');
+            }
+        }
+    }
+
+    private function persistStrategy(Request $request): void
+    {
+        if (!$request->attributes->has($this->cookieName)
+            || !$request->hasSession(true)
+            || !($session = $request->getSession())->isStarted()
+        ) {
+            return;
+        }
+
+        $usageIndexValue = $session instanceof Session ? $usageIndexReference = &$session->getUsageIndex() : 0;
+        $usageIndexReference = \PHP_INT_MIN;
+        $session->set($this->cookieName, $request->attributes->get($this->cookieName));
+        $usageIndexReference = $usageIndexValue;
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
@@ -190,8 +190,13 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
         return true;
     }
 
+    /**
+     * @deprecated since Symfony 8.1, logic is handled by SameOriginCsrfListener.
+     */
     public function clearCookies(Request $request, Response $response): void
     {
+        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated and will be removed in 9.0, use "%s::clearCookies()" instead.', __METHOD__, SameOriginCsrfListener::class);
+
         if (!$request->attributes->has($this->cookieName)) {
             return;
         }
@@ -205,8 +210,13 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
         }
     }
 
+    /**
+     * @deprecated since Symfony 8.1, logic is handled by SameOriginCsrfListener.
+     */
     public function persistStrategy(Request $request): void
     {
+        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated and will be removed in 9.0, use "%s::persistStrategy()" instead.', __METHOD__, SameOriginCsrfListener::class);
+
         if (!$request->attributes->has($this->cookieName)
             || !$request->hasSession(true)
             || !($session = $request->getSession())->isStarted()
@@ -220,8 +230,13 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
         $usageIndexReference = $usageIndexValue;
     }
 
+    /**
+     * @deprecated since Symfony 8.1, logic is handled by SameOriginCsrfListener.
+     */
     public function onKernelResponse(ResponseEvent $event): void
     {
+        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated and will be removed in 9.0, use "%s::onKernelResponse()" instead.', __METHOD__, SameOriginCsrfListener::class);
+
         if (!$event->isMainRequest()) {
             return;
         }

--- a/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfListenerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfListenerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Csrf\SameOriginCsrfListener;
+
+class SameOriginCsrfListenerTest extends TestCase
+{
+    private SameOriginCsrfListener $sameOriginCsrfListener;
+
+    protected function setUp(): void
+    {
+        $this->sameOriginCsrfListener = new SameOriginCsrfListener('csrf-token');
+    }
+
+    public function testOnKernelResponseClearsCookies()
+    {
+        $request = new Request([], [], ['csrf-token' => 2], ['csrf-token_test' => 'csrf-token']);
+        $response = new Response();
+        $eventMainRequest = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $this->sameOriginCsrfListener->onKernelResponse($eventMainRequest);
+
+        $this->assertTrue($response->headers->has('Set-Cookie'));
+    }
+
+    public function testOnKernelResponsePersistsStrategy()
+    {
+        $session = $this->createMock(Session::class);
+        $session->method('isStarted')->willReturn(true);
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->attributes->set('csrf-token', 2 << 8);
+
+        $response = new Response();
+        $eventMainRequest = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $session->expects($this->once())->method('set')->with('csrf-token', 2 << 8);
+
+        $this->sameOriginCsrfListener->onKernelResponse($eventMainRequest);
+    }
+
+    public function testOnKernelResponseDoesNothingIfSessionNotStarted()
+    {
+        $session = $this->createMock(Session::class);
+        $session->method('isStarted')->willReturn(false);
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->attributes->set('csrf-token', 2 << 8);
+
+        $response = new Response();
+        $eventMainRequest = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $session->expects($this->never())->method('set');
+
+        $this->sameOriginCsrfListener->onKernelResponse($eventMainRequest);
+    }
+
+    public function testOnKernelResponseIgnoresSubRequests()
+    {
+        $request = new Request([], [], ['csrf-token' => 2]);
+        $response = new Response();
+        $eventSubRequest = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::SUB_REQUEST, $response);
+
+        $this->sameOriginCsrfListener->onKernelResponse($eventSubRequest);
+
+        $this->assertFalse($response->headers->has('Set-Cookie'));
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/SameOriginCsrfTokenManagerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Csrf\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -235,6 +237,8 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $this->assertFalse($this->csrfTokenManager->isTokenValid($token));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testClearCookies()
     {
         $request = new Request([], [], ['csrf-token' => 2], ['csrf-token_test' => 'csrf-token']);
@@ -245,6 +249,8 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $this->assertTrue($response->headers->has('Set-Cookie'));
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testPersistStrategyWithStartedSession()
     {
         $session = $this->createMock(Session::class);
@@ -259,6 +265,8 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $this->csrfTokenManager->persistStrategy($request);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testPersistStrategyWithSessionNotStarted()
     {
         $session = $this->createMock(Session::class);
@@ -272,6 +280,8 @@ class SameOriginCsrfTokenManagerTest extends TestCase
         $this->csrfTokenManager->persistStrategy($request);
     }
 
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testOnKernelResponse()
     {
         $request = new Request([], [], ['csrf-token' => 2], ['csrf-token_test' => 'csrf-token']);

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/security-core": "^7.4|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A          
|---------------|------------
| Branch?       | 8.1        
| Bug fix?      | yes        
| New feature?  | no         
| Deprecations? | yes        
| Issues        | Fix #62881 
| License       | MIT        

Here is the result after we exchanged ideas with @syl20b 🚀

## Description

The `SameOriginCsrfTokenManager` currently violates the Single Responsibility Principle by handling both CSRF token management and listening to the `kernel.response` event to manage cookies.

This causes issues when testing: if a developer replaces the `security.csrf.token_manager` service with a Stub or Mock that implements `CsrfTokenManagerInterface` (but does not implement `onKernelResponse`), tests fail because the container expects the manager to also act as a listener.

Error encountered:

```
Error: Call to undefined method App\Security\Csrf\StubTokenManager::onKernelResponse()
```

This PR extracts the event listening logic (cookie clearing and persistence) into a dedicated `SameOriginCsrfListener`. This decouples the infrastructure logic from the token management logic, allowing for proper mocking of the TokenManager in tests.

## Reproduction Case

I have provided a full reproduction case with a minimal application structure in the linked issue. Please see the detailed comments in #62881.

## Backward Compatibility

To ensure backward compatibility in 8.1, the methods `onKernelResponse`, `clearCookies`, and `persistStrategy` have been kept in `SameOriginCsrfTokenManager`. They are marked as `@deprecated` and trigger a deprecation notice.
