### PR TITLE
[HttpKernel] Bypass mapping construction when `RedirectController::urlRedirectAction` is triggered

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/RedirectableCompiledUrlMatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/RedirectableCompiledUrlMatcher.php
@@ -31,6 +31,7 @@ class RedirectableCompiledUrlMatcher extends CompiledUrlMatcher implements Redir
             'httpPort' => $this->context->getHttpPort(),
             'httpsPort' => $this->context->getHttpsPort(),
             '_route' => $route,
+            '_route_mapping' => [],
         ];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableCompiledUrlMatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RedirectableCompiledUrlMatcherTest.php
@@ -36,6 +36,7 @@ class RedirectableCompiledUrlMatcherTest extends TestCase
                 'httpPort' => $context->getHttpPort(),
                 'httpsPort' => $context->getHttpsPort(),
                 '_route' => 'foo',
+                '_route_mapping' => [],
             ],
             $matcher->match('/foo')
         );
@@ -57,6 +58,7 @@ class RedirectableCompiledUrlMatcherTest extends TestCase
                 'httpPort' => $context->getHttpPort(),
                 'httpsPort' => $context->getHttpsPort(),
                 '_route' => 'foo',
+                '_route_mapping' => [],
             ],
             $matcher->match('/foo')
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63100
| License       | MIT

We tried to implement a fix for #63100. 
We choose to bypass the route mapping array construction because it's "just" a redirection to an url, the process will be triggered again on the real path.

It's a first step toward a solution, there probably are some other use cases. For example, we reproduce the bug without redirection when we have an argument called `_controller` in our route. For that point, maybe we need to create another issue ?