### PR TITLE
[DependencyInjection] Add `#[MapParameters]` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -38,6 +38,7 @@ final class ContainerLintCommand extends Command
         $this
             ->setHelp('This command parses service definitions and ensures that injected values match the type declarations of each services\' class.')
             ->addOption('resolve-env-vars', null, InputOption::VALUE_NONE, 'Resolve environment variables and fail if one is missing.')
+            ->addOption('validate-map-parameters', null, InputOption::VALUE_NONE, 'Validate services using #[MapParameters] attributes.')
         ;
     }
 
@@ -47,6 +48,13 @@ final class ContainerLintCommand extends Command
         $errorIo = $io->getErrorStyle();
 
         $resolveEnvVars = $input->getOption('resolve-env-vars');
+        $validateMapParameters = $input->getOption('validate-map-parameters');
+
+        // Auto-enable env var resolution if validating MapParameters
+        if ($validateMapParameters && !$resolveEnvVars) {
+            $resolveEnvVars = true;
+            $io->note('Automatically enabling environment variable resolution for MapParameters validation.');
+        }
 
         try {
             $container = $this->getContainerBuilder($resolveEnvVars);
@@ -58,6 +66,26 @@ final class ContainerLintCommand extends Command
 
         $container->setParameter('container.build_time', time());
 
+        $mapParametersServiceIds = [];
+        if ($validateMapParameters) {
+            foreach ($container->findTaggedServiceIds('di.map_parameters') as $serviceId => $tags) {
+                $mapParametersServiceIds[] = $serviceId;
+                if ($container->hasDefinition($serviceId)) {
+                    $container->getDefinition($serviceId)->setPublic(true);
+                } elseif ($container->hasAlias($serviceId)) {
+                    $container->getAlias($serviceId)->setPublic(true);
+                }
+            }
+
+            if ($validatorId = $container->has('validator') ? 'validator' : ($container->has('debug.validator') ? 'debug.validator' : null)) {
+                if ($container->hasDefinition($validatorId)) {
+                    $container->getDefinition($validatorId)->setPublic(true);
+                } elseif ($container->hasAlias($validatorId)) {
+                    $container->getAlias($validatorId)->setPublic(true);
+                }
+            }
+        }
+
         try {
             $container->compile($resolveEnvVars);
         } catch (InvalidArgumentException $e) {
@@ -66,9 +94,45 @@ final class ContainerLintCommand extends Command
             return 1;
         }
 
+        if ($validateMapParameters) {
+            $validator = $container->has('validator') ? $container->get('validator') : ($container->has('debug.validator') ? $container->get('debug.validator') : null);
+
+            if (!$validator) {
+                $io->warning('Validator service not available. Constraint validation will be skipped.');
+            } else {
+                $mapParametersErrors = $this->validateMapParametersServices($container, $mapParametersServiceIds, $validator);
+                if ($mapParametersErrors) {
+                    $errorIo->error($mapParametersErrors);
+
+                    return 1;
+                }
+            }
+        }
+
         $io->success('The container was linted successfully: all services are injected with values that are compatible with their type declarations.');
 
         return 0;
+    }
+
+    private function validateMapParametersServices(ContainerBuilder $container, array $serviceIds, object $validator): array
+    {
+        $errors = [];
+
+        foreach ($serviceIds as $serviceId) {
+            try {
+                $service = $container->get($serviceId);
+                $violations = $validator->validate($service);
+
+                if (\count($violations) > 0) {
+                    $message = implode("\n", array_map(static fn ($v) => \sprintf('  - %s: %s', $v->getPropertyPath(), $v->getMessage()), iterator_to_array($violations)));
+                    $errors[] = \sprintf('Service "%s" validation failed:'."\n\n%s", $serviceId, $message);
+                }
+            } catch (\Throwable $e) {
+                $errors[] = \sprintf('Service "%s": %s', $serviceId, $e->getMessage());
+            }
+        }
+
+        return $errors;
     }
 
     private function getContainerBuilder(bool $resolveEnvVars): ContainerBuilder

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -49,6 +49,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'controller.service_arguments',
         'controller.targeted_value_resolver',
         'data_collector',
+        'di.map_parameters',
         'event_dispatcher.dispatcher',
         'form.type',
         'form.type_extension',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -59,6 +59,7 @@ use Symfony\Component\Console\Messenger\RunCommandMessageHandler;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Attribute\MapParameters;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
@@ -830,6 +831,9 @@ class FrameworkExtension extends Extension
                 'object' => $attribute->asObject,
                 'list' => $attribute->asList,
             ])->addTag('container.excluded', ['source' => 'because it\'s a streamable JSON']);
+        });
+        $container->registerAttributeForAutoconfiguration(MapParameters::class, static function (ChildDefinition $definition, MapParameters $attribute): void {
+            $definition->addTag('di.map_parameters');
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -40,6 +40,7 @@ use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\Console\DependencyInjection\RegisterCommandArgumentLocatorsPass;
 use Symfony\Component\Console\DependencyInjection\RemoveEmptyCommandArgumentLocatorsPass;
+use Symfony\Component\DependencyInjection\Compiler\MapParametersPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Compiler\RegisterReverseContainerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -171,6 +172,8 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
         $this->addCompilerPassIfExists($container, AttributeMetadataPass::class);
         $this->addCompilerPassIfExists($container, AddConsoleCommandPass::class, PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new MapParametersPass());
+
         // must be registered before the AddConsoleCommandPass
         $container->addCompilerPass(new TranslationLintCommandPass(), PassConfig::TYPE_BEFORE_REMOVING, 10);
         // must be registered as late as possible to get access to all Twig paths registered in

--- a/src/Symfony/Component/DependencyInjection/Attribute/MapParameters.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/MapParameters.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * Maps parameters from the container to a DTO class.
+ *
+ * Classes annotated with this attribute will have their properties automatically populated from a container parameter path.
+ *
+ * @author Ayyoub AFW-ALLAH <ayyoub.afwallah@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class MapParameters
+{
+    /**
+     * @param string $path Container parameter path (e.g., 'S3.Archive' maps from parameters.S3.Archive)
+     */
+    public function __construct(
+        public readonly string $path,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
  * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
  * Allow environment variables with `.` in them
+ * Add `#[MapParameters]` attribute to map and validate Parameter DTOs
 
 8.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/MapParametersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MapParametersPass.php
@@ -1,0 +1,366 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Resource\ClassExistenceResource;
+use Symfony\Component\DependencyInjection\Attribute\MapParameters;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * Processes classes with the MapParameters attribute to map parameters.
+ *
+ * Supports scalar types (string, int, float, bool), arrays, backed enums,
+ * DateTimeInterface objects, and nested object types.
+ *
+ * @author Ayyoub AFW-ALLAH <ayyoub.afwallah@gmail.com>
+ */
+class MapParametersPass implements CompilerPassInterface
+{
+    private array $hydrationStack = [];
+    private array $reflectionCache = [];
+    private array $errors = [];
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('di.map_parameters', true) as $serviceId => $attributes) {
+            $definition = $container->getDefinition($serviceId);
+            $class = $definition->getClass() ?: $serviceId;
+            $definition->setClass($class);
+
+            if (!$reflectionClass = $container->getReflectionClass($class)) {
+                continue;
+            }
+
+            if (!$mapConfigAttributes = $reflectionClass->getAttributes(MapParameters::class)) {
+                continue;
+            }
+
+            try {
+                $this->hydrationStack = [];
+                $this->configureDefinition($container, $definition, $reflectionClass, $mapConfigAttributes[0]->newInstance());
+            } catch (\RuntimeException $e) {
+                throw $e;
+            } catch (\Exception $e) {
+                $this->errors[] = $e->getMessage();
+            } finally {
+                $this->hydrationStack = [];
+            }
+        }
+
+        if ($this->errors) {
+            throw new InvalidArgumentException(\sprintf("Parameter Mapping errors found:\n\n%s.", implode("\n\n", $this->errors)));
+        }
+    }
+
+    private function configureDefinition(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflectionClass, MapParameters $attribute): void
+    {
+        $definition->setAutowired(true);
+        $configArray = $this->resolveConfigPath($container, $attribute->path);
+        $container->addResource(new ClassExistenceResource($reflectionClass->getName()));
+
+        if (\is_array($configArray)) {
+            $this->hydrateDefinition($container, $definition, $reflectionClass, $configArray, $attribute->path);
+        } else {
+            $this->mapFlatParameters($container, $definition, $reflectionClass, $attribute->path);
+        }
+    }
+
+    private function hydrateDefinition(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflectionClass, array $configArray, string $contextPath): void
+    {
+        if (isset($this->hydrationStack[$className = $reflectionClass->getName()])) {
+            throw new \RuntimeException(\sprintf('Circular reference detected for class "%s".', $className));
+        }
+
+        $this->hydrationStack[$className] = true;
+
+        try {
+            $normalizedConfig = [];
+            foreach ($configArray as $key => $value) {
+                $normalizedConfig[$this->normalizeKey($key)] = ['originalKey' => $key, 'value' => $value];
+            }
+
+            $usedKeys = $reflectionClass->getConstructor()
+                ? $this->mapConstructorParams($container, $definition, $reflectionClass->getConstructor(), $normalizedConfig, $contextPath)
+                : [];
+
+            $this->mapProperties($container, $definition, $reflectionClass, $normalizedConfig, $usedKeys, $contextPath);
+        } finally {
+            unset($this->hydrationStack[$className]);
+        }
+    }
+
+    private function mapConstructorParams(ContainerBuilder $container, Definition $definition, \ReflectionMethod $constructor, array $normalizedConfig, string $path): array
+    {
+        $usedKeys = [];
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $paramName = $parameter->getName();
+
+            if (\array_key_exists($paramName, $definition->getArguments()) || \array_key_exists('$'.$paramName, $definition->getArguments())) {
+                continue;
+            }
+
+            $normalizedParamName = $this->normalizeKey($paramName);
+
+            if (\array_key_exists($normalizedParamName, $normalizedConfig)) {
+                $match = $normalizedConfig[$normalizedParamName];
+
+                if (null === $match['value'] && $parameter->isDefaultValueAvailable()) {
+                    $usedKeys[$match['originalKey']] = true;
+                    continue;
+                }
+
+                $definition->setArgument('$'.$paramName, $this->resolveValue($container, $match['value'], $parameter, $path.'.'.$match['originalKey']));
+                $usedKeys[$match['originalKey']] = true;
+            } elseif (!$parameter->isDefaultValueAvailable()) {
+                throw new InvalidArgumentException(\sprintf('The parameter "$%s" is missing in path "%s".', $paramName, $path));
+            }
+        }
+
+        return $usedKeys;
+    }
+
+    private function mapProperties(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflectionClass, array $normalizedConfig, array $usedKeys, string $contextPath): void
+    {
+        $extraKeys = [];
+        $inaccessibleKeys = [];
+
+        foreach ($normalizedConfig as $camelCaseKey => $info) {
+            if (isset($usedKeys[$info['originalKey']])) {
+                continue;
+            }
+
+            if ($this->tryMapSetter($container, $definition, $reflectionClass, $camelCaseKey, $info, $contextPath)) {
+                continue;
+            }
+
+            if ($this->tryMapProperty($container, $definition, $reflectionClass, $camelCaseKey, $info['originalKey'], $info['value'], $contextPath)) {
+                continue;
+            }
+
+            // Check if property exists but is inaccessible
+            $propertyExists = false;
+            foreach ([$info['originalKey'], $camelCaseKey] as $propName) {
+                if ($reflectionClass->hasProperty($propName)) {
+                    $propertyExists = true;
+                    $prop = $reflectionClass->getProperty($propName);
+                    $visibility = $prop->isPrivate() ? 'private' : ($prop->isProtected() ? 'protected' : 'public');
+                    $inaccessibleKeys[$info['originalKey']] = \sprintf(
+                        'property is %s and has no setter',
+                        $visibility
+                    );
+                    break;
+                }
+            }
+
+            if (!$propertyExists) {
+                $extraKeys[] = $info['originalKey'];
+            }
+        }
+
+        if ($extraKeys) {
+            $count = \count($extraKeys);
+            throw new InvalidArgumentException(\sprintf(
+                'Cannot configure service "%s": the parameter%s "%s" in path "%s" %s not recognized.',
+                $reflectionClass->getName(),
+                $count > 1 ? 's' : '',
+                implode('", "', $extraKeys),
+                $contextPath,
+                $count > 1 ? 'are' : 'is'
+            ));
+        }
+
+        if ($inaccessibleKeys) {
+            $key = array_key_first($inaccessibleKeys);
+            $reason = $inaccessibleKeys[$key];
+            throw new InvalidArgumentException(\sprintf('Cannot configure service "%s": parameter "%s" in path "%s" is not accessible (%s).', $reflectionClass->getName(), $key, $contextPath, $reason));
+        }
+    }
+
+    private function tryMapSetter(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflectionClass, string $camelCaseKey, array $info, string $contextPath): bool
+    {
+        $setterName = 'set'.ucfirst($camelCaseKey);
+
+        if (!$reflectionClass->hasMethod($setterName)) {
+            return false;
+        }
+
+        $method = $reflectionClass->getMethod($setterName);
+        if (!$method->isPublic() || $method->isStatic() || 1 !== $method->getNumberOfParameters()) {
+            return false;
+        }
+
+        $definition->addMethodCall($setterName, [$this->resolveValue($container, $info['value'], $method->getParameters()[0], $contextPath.'.'.$info['originalKey'])]);
+
+        return true;
+    }
+
+    private function tryMapProperty(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflectionClass, string $camelCaseKey, string $originalKey, mixed $value, string $contextPath): bool
+    {
+        foreach ([$originalKey, $camelCaseKey] as $propName) {
+            if (!$reflectionClass->hasProperty($propName)) {
+                continue;
+            }
+
+            $prop = $reflectionClass->getProperty($propName);
+
+            if ($prop->isPublic() && !$prop->isReadOnly() && !$prop->isProtectedSet() && !$prop->isPrivateSet()) {
+                $definition->setProperty($propName, $this->resolveValue($container, $value, $prop, $contextPath.'.'.$originalKey));
+
+                return true;
+            }
+
+            if ($prop->isPublic() && method_exists($prop, 'hasHooks') && $prop->hasHooks() && $prop->hasHook(\PropertyHookType::Set)) {
+                $definition->setProperty($propName, $this->resolveValue($container, $value, $prop, $contextPath.'.'.$originalKey));
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function resolveValue(ContainerBuilder $container, mixed $value, \ReflectionParameter|\ReflectionProperty $target, string $contextPath): mixed
+    {
+        $className = $this->getClassName($target);
+
+        // Handle backed enums
+        if ($className && enum_exists($className) && $this->getEnumReflection($className)?->isBacked()) {
+            return (new Definition($className))->setFactory([$className, 'from'])->setArguments([$value]);
+        }
+
+        // Handle DateTime classes
+        if (is_a($className, \DateTimeInterface::class, true)) {
+            if (\is_string($value) && ctype_digit($value) && 4 === \strlen($value)) {
+                $value .= '-01-01';
+            }
+
+            return new Definition(
+                \DateTimeInterface::class === $className ? \DateTimeImmutable::class : $className,
+                [$value]
+            );
+        }
+
+        // Handle nested objects
+        if (\is_array($value) && $className && (class_exists($className) || interface_exists($className, false))) {
+            return $this->resolveNestedObject($container, $value, $className, $contextPath);
+        }
+
+        // Type mismatch check
+        if (!\is_array($value) && $className && (class_exists($className) || interface_exists($className, false))) {
+            throw new InvalidArgumentException(\sprintf('The path "%s" must be an array, got "%s".', $contextPath, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    private function getClassName(\ReflectionParameter|\ReflectionProperty $target): ?string
+    {
+        $type = $target->getType();
+
+        return ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) ? $type->getName() : null;
+    }
+
+    private function resolveNestedObject(ContainerBuilder $container, array $value, string $className, string $contextPath): Definition
+    {
+        if (!$nestedClass = $container->getReflectionClass($className)) {
+            return new Definition($className);
+        }
+
+        $nestedDefinition = (new Definition($className))->setAutowired(true);
+        $this->hydrateDefinition($container, $nestedDefinition, $nestedClass, $value, $contextPath);
+
+        return $nestedDefinition;
+    }
+
+    private function resolveConfigPath(ContainerBuilder $container, string $path): mixed
+    {
+        $parameterBag = $container->getParameterBag();
+
+        if ($parameterBag->has($path)) {
+            return $parameterBag->get($path);
+        }
+
+        if (str_contains($path, '.')) {
+            [$paramName, $subPath] = explode('.', $path, 2);
+            if ($parameterBag->has($paramName)) {
+                return $this->getNestedValue($parameterBag->get($paramName), $subPath);
+            }
+        }
+
+        return null;
+    }
+
+    private function getNestedValue(mixed $array, string $path): mixed
+    {
+        if (!\is_array($array)) {
+            return null;
+        }
+
+        foreach (explode('.', $path) as $key) {
+            if (!\is_array($array)) {
+                return null;
+            }
+
+            // Handle both string and numeric keys
+            if (!\array_key_exists($key, $array) && !\array_key_exists((int) $key, $array)) {
+                return null;
+            }
+
+            $array = $array[$key] ?? $array[(int) $key];
+        }
+
+        return $array;
+    }
+
+    private function mapFlatParameters(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflectionClass, string $path): void
+    {
+        if (!$constructor = $reflectionClass->getConstructor()) {
+            return;
+        }
+
+        $parameterBag = $container->getParameterBag();
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $paramName = $parameter->getName();
+
+            if (\array_key_exists($paramName, $definition->getArguments()) || \array_key_exists('$'.$paramName, $definition->getArguments())) {
+                continue;
+            }
+
+            $candidates = [$path.'.'.$paramName, $path.'.'.strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $paramName))];
+
+            foreach ($candidates as $key) {
+                if ($parameterBag->has($key)) {
+                    $definition->setArgument('$'.$paramName, $parameterBag->get($key));
+                    continue 2;
+                }
+            }
+
+            if (!$parameter->isDefaultValueAvailable()) {
+                throw new InvalidArgumentException(\sprintf('The parameter "$%s" of the class "%s" cannot be resolved: the container parameter "%s" was not found.', $paramName, $reflectionClass->getName(), $candidates[0]));
+            }
+        }
+    }
+
+    private function normalizeKey(string $input): string
+    {
+        return lcfirst(str_replace(['_', '-'], '', ucwords($input, '_-')));
+    }
+
+    private function getEnumReflection(string $className): ?\ReflectionEnum
+    {
+        return $this->reflectionCache[$className] ??= enum_exists($className) ? new \ReflectionEnum($className) : null;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MapParametersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MapParametersPassTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\MapParameters;
+use Symfony\Component\DependencyInjection\Compiler\MapParametersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+class MapParametersPassTest extends TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('app.config', [
+            'name' => 'myapp',
+            'timeout' => 30,
+        ]);
+
+        $container->register(BasicParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $definition = $container->getDefinition(BasicParams::class);
+        $this->assertEquals('myapp', $definition->getArgument('$name'));
+        $this->assertEquals(30, $definition->getArgument('$timeout'));
+    }
+
+    public function testNestedObjects()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('app.nested', [
+            'name' => 'parent',
+            'database' => ['host' => 'localhost', 'port' => 5432],
+        ]);
+
+        $container->register(NestedParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $definition = $container->getDefinition(NestedParams::class);
+        $dbArg = $definition->getArgument('$database');
+        $this->assertInstanceOf(Definition::class, $dbArg);
+        $this->assertEquals(DatabaseParams::class, $dbArg->getClass());
+        $this->assertEquals('localhost', $dbArg->getArgument('$host'));
+    }
+
+    public function testPublicProperty()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('props.config', ['name' => 'value']);
+
+        $container->register(PropertyParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $definition = $container->getDefinition(PropertyParams::class);
+        $this->assertEquals('value', $definition->getProperties()['name']);
+    }
+
+    public function testSetterMethod()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('setter.config', ['value' => 'test']);
+
+        $container->register(SetterParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $methodCalls = $container->getDefinition(SetterParams::class)->getMethodCalls();
+        $this->assertEquals('setValue', $methodCalls[0][0]);
+    }
+
+    public function testBackedEnum()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('enum.config', ['level' => 'error']);
+
+        $container->register(EnumParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $levelArg = $container->getDefinition(EnumParams::class)->getArgument('$level');
+        $this->assertInstanceOf(Definition::class, $levelArg);
+        $this->assertEquals([LogLevel::class, 'from'], $levelArg->getFactory());
+    }
+
+    public function testDateTimeInterface()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('date.config', ['date' => '2023-01-01']);
+
+        $container->register(DateTimeParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $dateArg = $container->getDefinition(DateTimeParams::class)->getArgument('$date');
+        $this->assertEquals(\DateTimeImmutable::class, $dateArg->getClass());
+    }
+
+    public function testYearOnlyDateNormalization()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('year.config', ['date' => '2025']);
+
+        $container->register(YearParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $dateArg = $container->getDefinition(YearParams::class)->getArgument('$date');
+        $this->assertEquals(['2025-01-01'], $dateArg->getArguments());
+    }
+
+    public function testSnakeCaseNormalization()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('snake.config', ['database_host' => 'localhost']);
+
+        $container->register(SnakeCaseParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $this->assertEquals('localhost', $container->getDefinition(SnakeCaseParams::class)->getArgument('$databaseHost'));
+    }
+
+    public function testFlatParameterMode()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('flat.name', 'myapp');
+        $container->setParameter('flat.timeout', 30);
+
+        $container->register(FlatParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $definition = $container->getDefinition(FlatParams::class);
+        $this->assertEquals('myapp', $definition->getArgument('$name'));
+        $this->assertEquals(30, $definition->getArgument('$timeout'));
+    }
+
+    public function testDefaultValue()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('default.config', ['required' => 'value']);
+
+        $container->register(DefaultValueParams::class)->addTag('di.map_parameters');
+        (new MapParametersPass())->process($container);
+
+        $definition = $container->getDefinition(DefaultValueParams::class);
+        $this->assertEquals('value', $definition->getArgument('$required'));
+        $this->assertArrayNotHasKey('$optional', $definition->getArguments());
+    }
+
+    public function testMissingRequiredParameter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The parameter "$required" is missing');
+
+        $container = new ContainerBuilder();
+        $container->setParameter('incomplete', ['name' => 'test']);
+        $container->register(MissingRequiredParams::class)->addTag('di.map_parameters');
+
+        (new MapParametersPass())->process($container);
+    }
+
+    public function testUnrecognizedKeys()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not recognized');
+
+        $container = new ContainerBuilder();
+        $container->setParameter('extra', ['name' => 'ok', 'unknown' => 'bad']);
+        $container->register(UnrecognizedParams::class)->addTag('di.map_parameters');
+
+        (new MapParametersPass())->process($container);
+    }
+
+    public function testCircularReference()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Circular reference detected');
+
+        $container = new ContainerBuilder();
+        $container->setParameter('circular', ['child' => ['parent' => []]]);
+        $container->register(CircularA::class)->addTag('di.map_parameters');
+
+        (new MapParametersPass())->process($container);
+    }
+}
+
+// Fixtures
+
+#[MapParameters(path: 'app.config')]
+class BasicParams
+{
+    public function __construct(public string $name, public int $timeout)
+    {
+    }
+}
+
+#[MapParameters(path: 'app.nested')]
+class NestedParams
+{
+    public function __construct(public string $name, public DatabaseParams $database)
+    {
+    }
+}
+
+class DatabaseParams
+{
+    public function __construct(public string $host, public int $port)
+    {
+    }
+}
+
+#[MapParameters(path: 'props.config')]
+class PropertyParams
+{
+    public string $name;
+}
+
+#[MapParameters(path: 'setter.config')]
+class SetterParams
+{
+    private string $value;
+
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+}
+
+enum LogLevel: string
+{
+    case DEBUG = 'debug';
+    case ERROR = 'error';
+}
+
+#[MapParameters(path: 'enum.config')]
+class EnumParams
+{
+    public function __construct(public LogLevel $level)
+    {
+    }
+}
+
+#[MapParameters(path: 'date.config')]
+class DateTimeParams
+{
+    public function __construct(public \DateTimeInterface $date)
+    {
+    }
+}
+
+#[MapParameters(path: 'year.config')]
+class YearParams
+{
+    public function __construct(public \DateTimeImmutable $date)
+    {
+    }
+}
+
+#[MapParameters(path: 'snake.config')]
+class SnakeCaseParams
+{
+    public function __construct(public string $databaseHost)
+    {
+    }
+}
+
+#[MapParameters(path: 'flat')]
+class FlatParams
+{
+    public function __construct(public string $name, public int $timeout)
+    {
+    }
+}
+
+#[MapParameters(path: 'default.config')]
+class DefaultValueParams
+{
+    public function __construct(public string $required, public string $optional = 'default')
+    {
+    }
+}
+
+#[MapParameters(path: 'incomplete')]
+class MissingRequiredParams
+{
+    public function __construct(public string $name, public string $required)
+    {
+    }
+}
+
+#[MapParameters(path: 'extra')]
+class UnrecognizedParams
+{
+    public function __construct(public string $name)
+    {
+    }
+}
+
+#[MapParameters(path: 'circular')]
+class CircularA
+{
+    public function __construct(public CircularB $child)
+    {
+    }
+}
+
+class CircularB
+{
+    public function __construct(public CircularA $parent)
+    {
+    }
+}


### PR DESCRIPTION
## [DependencyInjection] Add `#[MapParameters]` attribute

| Q | A |
|---|---|
| Branch? | 8.1 |
| Bug fix? | no |
| New feature? | yes |
| Deprecations? | no |
| License | MIT |

Adds `#[MapParameters]` to the `#[Map*]` family. Maps container parameters to type-safe, validated DTOs at compile-time, inspired by Spring's [@ConfigurationProperties](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties).

> [!NOTE]
> Naming is open to discussion. `#[AutowireParameters]` is an alternative if `Map*` should stay reserved for ArgumentValueResolver.

### Example

```yaml
parameters:
    storage:
        region: '%env(AWS_REGION)%'
        uploads:
            bucket: '%env(S3_BUCKET)%'
            max_file_size: 10485760
        archives:
            bucket: '%env(S3_ARCHIVE_BUCKET)%'
            storage_class: glacier
            retention_until: '2030-01-01'
```

```php
#[MapParameters(path: 'storage')]
readonly class StorageConfig
{
    public function __construct(
        public string $region,
        public UploadConfig $uploads,
        public ArchiveConfig $archives,
    ) {}
}

class ArchiveConfig
{
    public function __construct(
        public string $bucket,
        public StorageClass $storageClass,
        public \DateTimeImmutable $retentionUntil,
    ) {}
}

enum StorageClass: string
{
    case Standard = 'standard';
    case Glacier = 'glacier';
}
```

Inject `StorageConfig` anywhere. No bind entries. No `#[Autowire]` per parameter.

Also Supports deep path selection :

```yaml
# config/services.yaml
parameters:
    app.storage:
        s3:
            backups:
                bucket_name: '%env(S3_BACKUP_BUCKET)%'
                region: 'us-east-1'
                versioning: true
                lifecycle_rule: 'archive_after_90_days'
```
```php
#[MapParameters(path: 'app.storage.s3.backups')]
readonly class S3BackupConfig
```
### Features

- Constructor, setter, and public property injection
- Recursive nested object hydration
- Backed enum resolution via `::from()`
- `DateTimeInterface` instantiation
- Key normalization: `snake_case`/`kebab-case` → `camelCase`
- Default values respected
- Strict mode: unrecognized keys throw
- Circular reference detection
- Error aggregation: all config errors reported together

### Validation

Compile-time Validation :

- Missing parameter
- Unrecognized configuration key
- Type mismatch (expected array, got scalar)
- Circular reference detection
- Inaccessible property (private/protected with no setter)

Constraint validation (`#[Assert\*]`) runs only via `lint:container --validate-map-parameters`.

```php
class UploadConfig
{
    public function __construct(
        #[Assert\NotBlank]
        public string $bucket,
        
        #[Assert\Positive]
        public int $maxFileSize,
    ) {}
}
```

Runtime constraint validation is intentionally omitted to avoid performance overhead.
