### PR TITLE
[Process] Fix EnvArray psalm type

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -30,7 +30,7 @@ use Symfony\Component\Process\Pipes\WindowsPipes;
  *
  * @implements \IteratorAggregate<string, string>
  *
- * @psalm-type EnvArray = array<string, array<string|\Stringable|false>>
+ * @psalm-type EnvArray = array<string, string|\Stringable|false>
  */
 class Process implements \IteratorAggregate
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

Fix a potential typo introduced in https://github.com/symfony/symfony/pull/62343.

For example, in https://github.com/symfony/symfony/pull/62343/changes#diff-edd51b05bf438c7cdca442e25d68f41dd0a51952a69fa0c5fa912dc31d833ef4L1131,
the param switched from `array<string|\Stringable>` to `array<string, array<string|\Stringable|false>>`