### PR TITLE
[DependencyInjection] Throw exception when `#[Required]` attribute on non-public(set) property

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -47,6 +48,13 @@ class AutowireRequiredPropertiesPass extends AbstractRecursivePass
             }
             if (\array_key_exists($name = $reflectionProperty->getName(), $properties)) {
                 continue;
+            }
+            if (
+                $reflectionProperty->isPrivateSet()
+                || $reflectionProperty->isProtectedSet()
+                || !$reflectionProperty->isPublic()
+            ) {
+                throw new InvalidArgumentException(\sprintf('Cannot autowire non-public(set) property "%s::$%s" with #[%s].', $reflectionClass->getName(), $reflectionProperty->getName(), Required::class));
             }
 
             $type = $type->getName();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredPropertiesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
 
@@ -35,5 +36,31 @@ class AutowireRequiredPropertiesPassTest extends TestCase
 
         $this->assertArrayHasKey('foo', $properties);
         $this->assertEquals(Foo::class, (string) $properties['foo']);
+    }
+
+    public function testAttributeWithReadonlyProperty()
+    {
+        $container = new ContainerBuilder();
+        $container->register(Foo::class);
+        $container->register('property_injection', AutowireReadonlyProperty::class)
+            ->setAutowired(true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot autowire non-public(set) property "Symfony\Component\DependencyInjection\Tests\Compiler\AutowireReadonlyProperty::$foo" with #[Symfony\Contracts\Service\Attribute\Required].');
+
+        (new AutowireRequiredPropertiesPass())->process($container);
+    }
+
+    public function testAttributeWithPrivateProperty()
+    {
+        $container = new ContainerBuilder();
+        $container->register(Foo::class);
+        $container->register('property_injection', AutowirePrivateProperty::class)
+            ->setAutowired(true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot autowire non-public(set) property "Symfony\Component\DependencyInjection\Tests\Compiler\AutowirePrivateProperty::$foo" with #[Symfony\Contracts\Service\Attribute\Required].');
+
+        (new AutowireRequiredPropertiesPass())->process($container);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -35,6 +35,18 @@ class AutowireProperty
     public Foo $foo;
 }
 
+class AutowireReadonlyProperty
+{
+    #[Required]
+    public readonly Foo $foo;
+}
+
+class AutowirePrivateProperty
+{
+    #[Required]
+    private Foo $foo;
+}
+
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 class CustomAutowire extends Autowire
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Throws a helpful exception at compile time instead of runtime.
