### PR TITLE
[DependencyInjection] Add argument `exclude` to `ContainerConfigurator::import()`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
  * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
  * Allow environment variables with `.` in them
+ * Add argument `exclude` to `ContainerConfigurator::import()`
 
 8.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -61,10 +61,10 @@ class ContainerConfigurator extends AbstractConfigurator
         $this->container->loadFromExtension($namespace, static::processValue($config));
     }
 
-    final public function import(string $resource, ?string $type = null, bool|string $ignoreErrors = false): void
+    final public function import(string $resource, ?string $type = null, bool|string $ignoreErrors = false, string|array|null $exclude = null): void
     {
         $this->loader->setCurrentDir(\dirname($this->path));
-        $this->loader->import($resource, $type, $ignoreErrors, $this->file);
+        $this->loader->import($resource, $type, $ignoreErrors, $this->file, $exclude);
     }
 
     final public function parameters(): ParametersConfigurator

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/ContainerConfiguratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/ContainerConfiguratorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Loader\Configurator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+class ContainerConfiguratorTest extends TestCase
+{
+    public function testImportForwardsExcludeAndIgnoreErrors()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = $this->getMockBuilder(PhpFileLoader::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setCurrentDir', 'import'])
+            ->getMock();
+
+        $path = '/path/file.php';
+        $expectedDir = '/path';
+
+        $resource = 'services/*.php';
+        $type = null;
+        $ignoreErrors = 'not_found';
+        $exclude = ['services/excluded/*'];
+
+        $loader->expects($this->once())
+            ->method('setCurrentDir')
+            ->with($this->equalTo($expectedDir));
+
+        $loader->expects($this->once())
+            ->method('import')
+            ->with(
+                $this->equalTo($resource),
+                $this->equalTo($type),
+                $this->equalTo($ignoreErrors),
+                $this->equalTo($path),
+                $this->equalTo($exclude)
+            );
+
+        $instanceof = [];
+        $configurator = new ContainerConfigurator($container, $loader, $instanceof, $path, $path);
+        $configurator->import($resource, $type, $ignoreErrors, $exclude);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Add support for "exclude" option in ContainerConfigurator's import method
