### PR TITLE
[Routing][SecurityBundle] Add a `firewall` option to route definitions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -218,6 +218,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *     format?: string,
  *     utf8?: bool,
  *     stateless?: bool,
+ *     firewall?: string,
  * }
  * @psalm-type ImportConfig = array{
  *     resource: string,
@@ -238,6 +239,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *     format?: string,
  *     utf8?: bool,
  *     stateless?: bool,
+ *     firewall?: string,
  * }
  * @psalm-type AliasConfig = array{
  *     alias: string,

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -24,6 +24,10 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
  */
 class FirewallMap implements FirewallMapInterface
 {
+    private const ATTRIBUTE_FIREWALL = '_firewall';
+    private const ATTRIBUTE_FIREWALL_CONTEXT = '_firewall_context';
+    private const FIREWALL_CONTEXT_PREFIX = 'security.firewall.map.context.';
+
     public function __construct(
         private ContainerInterface $container,
         private iterable $map,
@@ -48,20 +52,39 @@ class FirewallMap implements FirewallMapInterface
 
     private function getFirewallContext(Request $request): ?FirewallContext
     {
-        if ($request->attributes->has('_firewall_context')) {
-            $storedContextId = $request->attributes->get('_firewall_context');
+        if (!$request->attributes->has(self::ATTRIBUTE_FIREWALL_CONTEXT) && $request->attributes->has(self::ATTRIBUTE_FIREWALL)) {
+            $firewall = $request->attributes->get(self::ATTRIBUTE_FIREWALL);
+            if (!\is_string($firewall) || '' === $firewall) {
+                throw new \LogicException(\sprintf('The "_firewall" route default must be a non-empty string, "%s" given.', get_debug_type($firewall)));
+            }
+
+            $contextId = self::FIREWALL_CONTEXT_PREFIX.$firewall;
+            foreach ($this->map as $mapContextId => $requestMatcher) {
+                if ($mapContextId === $contextId) {
+                    $request->attributes->set(self::ATTRIBUTE_FIREWALL_CONTEXT, $contextId);
+
+                    return $this->container->get($contextId);
+                }
+            }
+
+            // falling back to the request matchers would silently authenticate with another firewall
+            throw new \LogicException(\sprintf('Invalid firewall "%s" requested by the route: no firewall with this name is configured.', $firewall));
+        }
+
+        if ($request->attributes->has(self::ATTRIBUTE_FIREWALL_CONTEXT)) {
+            $storedContextId = $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT);
             foreach ($this->map as $contextId => $requestMatcher) {
                 if ($contextId === $storedContextId) {
                     return $this->container->get($contextId);
                 }
             }
 
-            $request->attributes->remove('_firewall_context');
+            $request->attributes->remove(self::ATTRIBUTE_FIREWALL_CONTEXT);
         }
 
         foreach ($this->map as $contextId => $requestMatcher) {
             if (null === $requestMatcher || $requestMatcher->matches($request)) {
-                $request->attributes->set('_firewall_context', $contextId);
+                $request->attributes->set(self::ATTRIBUTE_FIREWALL_CONTEXT, $contextId);
 
                 return $this->container->get($contextId);
             }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -58,6 +58,52 @@ class FirewallMapTest extends TestCase
         $this->assertFalse($request->attributes->has('_stateless'));
     }
 
+    public function testGetListenersWithFirewallAttribute()
+    {
+        $request = new Request(attributes: ['_firewall' => 'main']);
+
+        $firewallConfig = new FirewallConfig('main', 'user_checker');
+        $listener = static function () {};
+        $exceptionListener = $this->createStub(ExceptionListener::class);
+        $logoutListener = $this->createStub(LogoutListener::class);
+        $firewallContext = new FirewallContext([$listener], $exceptionListener, $logoutListener, $firewallConfig);
+
+        $matcher = $this->createMock(RequestMatcherInterface::class);
+        $matcher->expects($this->never())
+            ->method('matches');
+
+        $container = new Container();
+        $container->set('security.firewall.map.context.main', $firewallContext);
+
+        $firewallMap = new FirewallMap($container, ['security.firewall.map.context.main' => $matcher]);
+
+        $this->assertEquals([[$listener], $exceptionListener, $logoutListener], $firewallMap->getListeners($request));
+        $this->assertEquals($firewallConfig, $firewallMap->getFirewallConfig($request));
+        $this->assertEquals('security.firewall.map.context.main', $request->attributes->get(self::ATTRIBUTE_FIREWALL_CONTEXT));
+    }
+
+    public function testGetListenersWithUnknownFirewallAttributeThrows()
+    {
+        $request = new Request(attributes: ['_firewall' => 'mian']);
+
+        $map = new FirewallMap(new Container(), ['security.firewall.map.context.main' => null]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Invalid firewall "mian" requested by the route: no firewall with this name is configured.');
+        $map->getListeners($request);
+    }
+
+    public function testGetListenersWithNonStringFirewallAttributeThrows()
+    {
+        $request = new Request(attributes: ['_firewall' => ['main']]);
+
+        $map = new FirewallMap(new Container(), []);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The "_firewall" route default must be a non-empty string, "array" given.');
+        $map->getListeners($request);
+    }
+
     #[DataProvider('providesStatefulStatelessRequests')]
     public function testGetListeners(Request $request, bool $expectedState)
     {

--- a/src/Symfony/Component/Routing/Attribute/Route.php
+++ b/src/Symfony/Component/Routing/Attribute/Route.php
@@ -45,6 +45,7 @@ class Route
      * @param string|null                                       $format       The format returned by the route (i.e. "json", "xml")
      * @param bool|null                                         $utf8         Whether the route accepts UTF-8 in its parameters
      * @param bool|null                                         $stateless    Whether the route is defined as stateless or stateful, @see https://symfony.com/doc/current/routing.html#stateless-routes
+     * @param string|null                                       $firewall     The firewall name to use for matching this route
      * @param string|string[]|null                              $env          The env(s) in which the route is defined (i.e. "dev", "test", "prod", ["dev", "test"])
      * @param string|DeprecatedAlias|(string|DeprecatedAlias)[] $alias        The list of aliases for this route
      */
@@ -63,6 +64,7 @@ class Route
         ?string $format = null,
         ?bool $utf8 = null,
         ?bool $stateless = null,
+        ?string $firewall = null,
         string|array|null $env = null,
         string|DeprecatedAlias|array $alias = [],
     ) {
@@ -86,6 +88,10 @@ class Route
 
         if (null !== $stateless) {
             $this->defaults['_stateless'] = $stateless;
+        }
+
+        if (null !== $firewall) {
+            $this->defaults['_firewall'] = $firewall;
         }
     }
 }

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add a `firewall` option to route definitions, exposed as the `_firewall` route default
  * Allow defining default query parameters with the `_query` route default
  * Add `RequestContext::runWith()` to generate and match URLs for another host, scheme or base URL without leaking the change
 

--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutesReference.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutesReference.php
@@ -45,6 +45,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *     format?: string,
  *     utf8?: bool,
  *     stateless?: bool,
+ *     firewall?: string,
  * }
  * @psalm-type ImportConfig = array{
  *     resource: string,
@@ -65,6 +66,7 @@ namespace Symfony\Component\Routing\Loader\Configurator;
  *     format?: string,
  *     utf8?: bool,
  *     stateless?: bool,
+ *     firewall?: string,
  * }
  * @psalm-type AliasConfig = array{
  *     alias: string,

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -169,4 +169,16 @@ trait RouteTrait
 
         return $this;
     }
+
+    /**
+     * Adds the "_firewall" entry to defaults.
+     *
+     * @return $this
+     */
+    final public function firewall(string $firewall): static
+    {
+        $this->route->addDefaults(['_firewall' => $firewall]);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Routing/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/Routing/Loader/ContentLoaderTrait.php
@@ -29,7 +29,7 @@ trait ContentLoaderTrait
      * Config keys accepted at the route or import level by {@see validate()}.
      */
     private const AVAILABLE_KEYS = [
-        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix', 'trailing_slash_on_root', 'locale', 'format', 'utf8', 'exclude', 'stateless',
+        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix', 'trailing_slash_on_root', 'locale', 'format', 'utf8', 'exclude', 'stateless', 'firewall',
     ];
 
     /**
@@ -103,6 +103,9 @@ trait ContentLoaderTrait
         if (isset($config['stateless'])) {
             $defaults['_stateless'] = $config['stateless'];
         }
+        if (isset($config['firewall'])) {
+            $defaults['_firewall'] = $config['firewall'];
+        }
 
         $routes = $this->createLocalizedRoute(new RouteCollection(), $name, $config['path']);
         $routes->addDefaults($defaults);
@@ -151,6 +154,9 @@ trait ContentLoaderTrait
         }
         if (isset($config['stateless'])) {
             $defaults['_stateless'] = $config['stateless'];
+        }
+        if (isset($config['firewall'])) {
+            $defaults['_firewall'] = $config['firewall'];
         }
 
         $this->setCurrentDir(\dirname($path));
@@ -219,6 +225,9 @@ trait ContentLoaderTrait
         }
         if (isset($config['stateless']) && isset($config['defaults']['_stateless'])) {
             throw new \InvalidArgumentException(\sprintf('The routing file "%s" must not specify both the "stateless" key and the defaults key "_stateless" for "%s".', $path, $name));
+        }
+        if (isset($config['firewall']) && isset($config['defaults']['_firewall'])) {
+            throw new \InvalidArgumentException(\sprintf('The routing file "%s" must not specify both the "firewall" key and the defaults key "_firewall" for "%s".', $path, $name));
         }
     }
 

--- a/src/Symfony/Component/Routing/Loader/schema/routing.schema.json
+++ b/src/Symfony/Component/Routing/Loader/schema/routing.schema.json
@@ -63,6 +63,7 @@
         "format": { "type": "string" },
         "utf8": { "type": "boolean" },
         "stateless": { "type": "boolean" },
+        "firewall": { "type": "string" },
         "deprecated": {
           "type": "object",
           "properties": {
@@ -134,6 +135,7 @@
         "utf8": { "type": "boolean" },
         "exclude": { "oneOf": [ { "type": "string" }, { "type": "array", "items": { "type": "string" } } ] },
         "stateless": { "type": "boolean" },
+        "firewall": { "type": "string" },
         "controller": { "type": "string" }
       },
       "required": ["resource"],

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -67,6 +67,7 @@
     <xsd:attribute name="format" type="xsd:string" />
     <xsd:attribute name="utf8" type="xsd:boolean" />
     <xsd:attribute name="stateless" type="xsd:boolean" />
+    <xsd:attribute name="firewall" type="xsd:string" />
     <xsd:attribute name="alias" type="xsd:string" />
   </xsd:complexType>
 
@@ -92,6 +93,7 @@
     <xsd:attribute name="trailing-slash-on-root" type="xsd:boolean" />
     <xsd:attribute name="utf8" type="xsd:boolean" />
     <xsd:attribute name="stateless" type="xsd:boolean" />
+    <xsd:attribute name="firewall" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="resource">

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -35,7 +35,7 @@ class RouteCompiler implements RouteCompilerInterface
     public const VARIABLE_MAXIMUM_LENGTH = 32;
 
     /**
-     * @throws \InvalidArgumentException if a path variable is named _fragment
+     * @throws \InvalidArgumentException if a path variable is named _fragment or _firewall
      * @throws \LogicException           if a variable is referenced more than once
      * @throws \DomainException          if a variable name starts with a digit or if it is too long to be successfully used as
      *                                   a PCRE subpattern
@@ -74,8 +74,9 @@ class RouteCompiler implements RouteCompilerInterface
         $pathVariables = $result['variables'];
 
         foreach ($pathVariables as $pathParam) {
-            if ('_fragment' === $pathParam) {
-                throw new \InvalidArgumentException(\sprintf('Route pattern "%s" cannot contain "_fragment" as a path parameter.', $route->getPath()));
+            // "_firewall" selects the firewall handling the route; as a path parameter it would let the URL choose it
+            if ('_fragment' === $pathParam || '_firewall' === $pathParam) {
+                throw new \InvalidArgumentException(\sprintf('Route pattern "%s" cannot contain "%s" as a path parameter.', $route->getPath(), $pathParam));
             }
         }
 

--- a/src/Symfony/Component/Routing/Tests/Attribute/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Attribute/RouteTest.php
@@ -40,6 +40,7 @@ class RouteTest extends TestCase
             ['host', 'host', '{locale}.example.com'],
             ['condition', 'condition', 'context.getMethod() == \'GET\''],
             ['alias', 'aliases', ['alias', 'completely_different_name']],
+            ['firewall', 'defaults', ['_firewall' => 'api']],
         ];
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/FooController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/FooController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
 
 use Symfony\Component\Routing\Attribute\Route;
@@ -58,6 +67,11 @@ class FooController
 
     #[Route(alias: ['alias', 'completely_different_name'])]
     public function alias()
+    {
+    }
+
+    #[Route('/secured', firewall: 'api')]
+    public function firewall()
     {
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
@@ -1,6 +1,7 @@
 blog_show:
     path:         /blog/{slug}
     defaults:     { _controller: "MyBundle:Blog:show", _stateless: true }
+    firewall:     api
     host:         "{locale}.example.com"
     requirements: { 'locale': '\w+' }
     methods:      ['GET','POST','put','OpTiOnS']

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -100,6 +100,7 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(['https'], $route->getSchemes());
         $this->assertEquals('context.getMethod() == "GET"', $route->getCondition());
         $this->assertTrue($route->getDefault('_stateless'));
+        $this->assertSame('api', $route->getDefault('_firewall'));
     }
 
     public function testLoadWithResource()

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -282,6 +282,16 @@ class RouteCompilerTest extends TestCase
         $route->compile();
     }
 
+    public function testRouteWithFirewallAsPathParameter()
+    {
+        $route = new Route('/{_firewall}');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot contain "_firewall" as a path parameter');
+
+        $route->compile();
+    }
+
     #[DataProvider('getVariableNamesStartingWithADigit')]
     public function testRouteWithVariableNameStartingWithADigit(string $name)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62703
| License       | MIT

A route can declare which firewall handles it, so modular code can ship authentication wiring next to its routes instead of central `security.firewalls` patterns. The design follows @stof's suggestion in the issue: the option is stored as the `_firewall` route default, which the router sets before the firewall listener runs, and `FirewallMap` resolves it ahead of the request matchers.

```php
#[Route('/api/orders', name: 'api_orders', firewall: 'api_jwt')]
public function orders(): Response
```

```yaml
api_orders:
    path: /api/orders
    controller: App\Controller\OrderController::orders
    firewall: api_jwt
```

```php
$routes->add('api_orders', '/api/orders')->controller([OrderController::class, 'orders'])->firewall('api_jwt');
```

The named firewall must exist in `security.firewalls`; it is used **instead of** the pattern matchers for that route. Semantics, each covered by a test:

* a route without the option behaves exactly as today: the request matchers decide;
* naming a firewall that is not configured throws (`Invalid firewall "mian" requested by the route`), it does not silently fall back to pattern matching, which would authenticate with whatever firewall matches the path;
* `_firewall` is rejected as a path parameter by `RouteCompiler`, like `_fragment`, so a URL can never choose the firewall;
* every configured firewall has a context, including `security: false` ones, so routes can also opt out of security by naming such a firewall;
* `access_control` is unchanged and keeps matching by path or route: it runs on whatever firewall authenticated the request.

Documentation should cover: the three declaration styles, that the option wins over the matchers, the throw on unknown names, the `_firewall` path-parameter rejection, and the audit story, which is `debug:router` showing the option in the route defaults next to `debug:firewall`.
