### PR TITLE
 PHP CS Fixer: modernize usage of `random_api_migration`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -48,7 +48,14 @@ return (new PhpCsFixer\Config())
         'no_useless_return' => true,
         'php_unit_attributes' => true,
         'protected_to_private' => true,
-        'random_api_migration' => true,
+        'random_api_migration' =>  [
+            'replacements' => [
+                'mt_getrandmax' => 'getrandmax',
+                'mt_rand' => 'random_int',
+                'mt_srand' => 'srand',
+                'rand' => 'random_int',
+            ],
+        ],
         'static_lambda' => true,
     ])
     ->setRuleCustomisationPolicy(new class implements PhpCsFixer\Config\RuleCustomisationPolicyInterface {

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -48,7 +48,7 @@ abstract class AdapterTestCase extends CachePoolTest
         $cache = $this->createCachePool();
         $cache->clear();
 
-        $value = mt_rand();
+        $value = random_int(0, \PHP_INT_MAX);
 
         $this->assertSame($value, $cache->get('foo', function (CacheItem $item) use ($value) {
             $this->assertSame('foo', $item->getKey());

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
@@ -50,7 +50,7 @@ class ProxyAdapterAndRedisAdapterTest extends AbstractRedisAdapterTestCase
 
         $cache = $this->createCachePool(1);
         $cache->clear();
-        $value = random_int(0, getrandmax());
+        $value = random_int(0, \PHP_INT_MAX);
         $item = $cache->getItem('foo');
         $setCacheItemExpiry($item, 0);
         $cache->save($item->set($value));

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -788,7 +788,7 @@ class EnvVarProcessorTest extends TestCase
 
     public function testGetEnvShuffle()
     {
-        mt_srand(2);
+        srand(2); // to set seed for `shuffle`
 
         $this->assertSame(
             ['bar', 'foo'],

--- a/src/Symfony/Component/Translation/Tests/PseudoLocalizationTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/PseudoLocalizationTranslatorTest.php
@@ -78,3 +78,5 @@ final class PseudoLocalizationTranslatorTest extends TestCase
         ], $options);
     }
 }
+
+// @php-cs-fixer-ignore random_api_migration As logic is coupled with mt_rand() in src


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

follows #62771 but move into future-looking defaults