### PR TITLE
[RemoteEvent] Fix documentation link in `README.md`

### DIFF
--- a/src/Symfony/Component/RemoteEvent/README.md
+++ b/src/Symfony/Component/RemoteEvent/README.md
@@ -6,7 +6,7 @@ Symfony RemoteEvent eases handling remote events.
 Resources
 ---------
 
- * [Documentation](https://symfony.com/doc/current/remote-event.html)
+ * [Documentation](https://symfony.com/packages/RemoteEvent)
  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

As RemoteEvent does not have a dedicated documentation page, I suggest linking to its package page on symfony.com: https://symfony.com/packages/RemoteEvent

(the current URL (https://symfony.com/doc/current/remote-event.html ) returns a 404)