### PR TITLE
[Translation][FramworkBundle] Allow using env vars in the list of enabled locales

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -61,7 +61,7 @@ class AppVariable
 
     public function setEnabledLocales(array $enabledLocales): void
     {
-        $this->enabledLocales = $enabledLocales;
+        $this->enabledLocales = array_filter($enabledLocales);
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -301,6 +301,15 @@ class AppVariableTest extends TestCase
         $tokenStorage->setToken($token);
     }
 
+    public function testSetEnabledLocalesFiltersEmptyValues()
+    {
+        $this->appVariable->setEnabledLocales(['en', '', 'fr', null, 'de']);
+
+        $enabledLocales = $this->appVariable->getEnabled_locales();
+
+        $this->assertEquals(['en', 'fr', 'de'], array_values($enabledLocales));
+    }
+
     private function setFlashMessages($sessionHasStarted = true)
     {
         $flashMessages = [

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -60,6 +60,7 @@ class TranslationDebugCommand extends Command
         private array $codePaths = [],
         private array $enabledLocales = [],
     ) {
+        $this->enabledLocales = array_filter($enabledLocales);
         parent::__construct();
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
@@ -59,6 +59,7 @@ class TranslationExtractCommand extends Command
         private array $codePaths = [],
         private array $enabledLocales = [],
     ) {
+        $this->enabledLocales = array_filter($enabledLocales);
         parent::__construct();
 
         if (!method_exists($writer, 'getFormats')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/router_enabled_locales_env.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/router_enabled_locales_env.php
@@ -1,0 +1,10 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'secret' => 's3cr3t',
+    'default_locale' => 'en',
+    'enabled_locales' => ['%env(ROUTER_ENABLED_LOCALE)%', 'fr'],
+    'router' => [
+        'resource' => '%kernel.project_dir%/config/routing.xml',
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/router_enabled_locales_env.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/router_enabled_locales_env.yml
@@ -1,0 +1,6 @@
+framework:
+    secret: s3cr3t
+    default_locale: en
+    enabled_locales: ['%env(ROUTER_ENABLED_LOCALE)%', 'fr']
+    router:
+        resource: '%kernel.project_dir%/config/routing.xml'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -809,6 +809,26 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame(['_locale' => 'fr|en'], $container->getDefinition('routing.loader')->getArgument(2));
     }
 
+    public function testRouterEnabledLocalesWithEnvPlaceholders()
+    {
+        $container = $this->createContainerFromFile('router_enabled_locales_env');
+        $requirements = $container->getDefinition('routing.loader')->getArgument(2);
+
+        $this->assertIsArray($requirements);
+        $this->assertArrayHasKey('_locale', $requirements);
+
+        $requirementDefinition = $requirements['_locale'];
+        $this->assertInstanceOf(Definition::class, $requirementDefinition);
+        $this->assertSame('implode', $requirementDefinition->getFactory());
+
+        $this->assertSame('|', $requirementDefinition->getArgument(0));
+
+        $arrayMap = $requirementDefinition->getArgument(1);
+        $this->assertInstanceOf(Definition::class, $arrayMap);
+        $this->assertSame('array_map', $arrayMap->getFactory());
+        $this->assertSame('preg_quote', $arrayMap->getArgument(0));
+    }
+
     public function testRouterRequiresResourceOption()
     {
         $container = $this->createContainer();

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -36,6 +36,7 @@ class LocaleListener implements EventSubscriberInterface
         private bool $useAcceptLanguageHeader = false,
         private array $enabledLocales = [],
     ) {
+        $this->enabledLocales = array_filter($enabledLocales);
     }
 
     public function setDefaultLocale(KernelEvent $event): void

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -215,6 +215,20 @@ class LocaleListenerTest extends TestCase
         $this->assertEquals('it', $request->getLocale());
     }
 
+    public function testEnabledLocalesFiltersEmptyValues()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', 'es,fr;q=0.8,en;q=0.5');
+
+        $listener = new LocaleListener(new RequestStack(), 'de', null, true, ['', null, 'en', 'fr']);
+        $event = $this->getEvent($request);
+
+        $listener->setDefaultLocale($event);
+        $listener->onKernelRequest($event);
+
+        $this->assertSame('fr', $request->getLocale());
+    }
+
     private function getEvent(Request $request): RequestEvent
     {
         return new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);

--- a/src/Symfony/Component/Translation/Command/TranslationLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationLintCommand.php
@@ -37,6 +37,7 @@ class TranslationLintCommand extends Command
         private TranslatorInterface&TranslatorBagInterface $translator,
         private array $enabledLocales = [],
     ) {
+        $this->enabledLocales = array_filter($enabledLocales);
         parent::__construct();
     }
 

--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -42,6 +42,7 @@ final class TranslationPullCommand extends Command
         private array $transPaths = [],
         private array $enabledLocales = [],
     ) {
+        $this->enabledLocales = array_filter($enabledLocales);
         parent::__construct();
     }
 

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -40,6 +40,7 @@ final class TranslationPushCommand extends Command
         private array $transPaths = [],
         private array $enabledLocales = [],
     ) {
+        $this->enabledLocales = array_filter($enabledLocales);
         parent::__construct();
     }
 

--- a/src/Symfony/Component/Translation/Provider/FilteringProvider.php
+++ b/src/Symfony/Component/Translation/Provider/FilteringProvider.php
@@ -26,6 +26,7 @@ class FilteringProvider implements ProviderInterface
         private array $locales,
         private array $domains = [],
     ) {
+        $this->locales = array_filter($locales);
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Translation/Tests/Provider/FilteringProviderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Provider/FilteringProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Provider\FilteringProvider;
+use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Component\Translation\TranslatorBag;
+
+class FilteringProviderTest extends TestCase
+{
+    public function testReadDelegatesWithFilteredLocales()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $expectedBag = new TranslatorBag();
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages'], ['en', 'fr'])
+            ->willReturn($expectedBag);
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en', 'fr', null, ''],
+            ['messages', 'validators']
+        );
+
+        $result = $filteringProvider->read(['messages', 'custom'], ['', null, 'en', 'fr']);
+
+        $this->assertSame($expectedBag, $result);
+    }
+}

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -435,7 +435,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         }
 
         foreach ($this->fallbackLocales as $fallback) {
-            if ($fallback === $originLocale) {
+            if (!$fallback || $fallback === $originLocale) {
                 continue;
             }
 

--- a/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharactersValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NoSuspiciousCharactersValidator.php
@@ -51,8 +51,9 @@ class NoSuspiciousCharactersValidator extends ConstraintValidator
     /**
      * @param string[] $defaultLocales
      */
-    public function __construct(private readonly array $defaultLocales = [])
+    public function __construct(private array $defaultLocales = [])
     {
+        $this->defaultLocales = array_filter($defaultLocales);
     }
 
     public function validate(mixed $value, Constraint $constraint): void

--- a/src/Symfony/Component/Validator/Tests/Constraints/NoSuspiciousCharactersValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NoSuspiciousCharactersValidatorTest.php
@@ -166,4 +166,14 @@ class NoSuspiciousCharactersValidatorTest extends ConstraintValidatorTestCase
         $this->assertSame(\Spoofchecker::MINIMALLY_RESTRICTIVE, NoSuspiciousCharacters::RESTRICTION_LEVEL_MINIMAL);
         $this->assertSame(\Spoofchecker::UNRESTRICTIVE, NoSuspiciousCharacters::RESTRICTION_LEVEL_NONE);
     }
+
+    public function testValidatorFiltersEmptyDefaultLocales()
+    {
+        $validator = new NoSuspiciousCharactersValidator(['en', '', 'fr', null, 'de']);
+        $validator->initialize($this->context);
+
+        $validator->validate('abc', new NoSuspiciousCharacters());
+
+        $this->assertNoViolation();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62108
| License       | MIT

This is my take at https://github.com/symfony/symfony/discussions/61745

This PR allows using env vars in the list of enabled locales.

It does NOT allow the list of allowed locales to be defined as an env var. That'd require too much disruption with the way things works nowadays.

But as a workaround, this allows empty locales to be filtered out, so that one could configure the list of locales using eg numbered env vars:

```yaml
enabled_locales:
    - '%env(LOCALE_1)%'
    - '%env(LOCALE_2)%'
    - '%env(LOCALE_3)%'
    - '%env(LOCALE_4)%'
```

I think this can be fine for this config option. The list of locales to enable is always bounded.