### PR TITLE
[HttpClient] Add `const` for `HttpOptions`

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -22,6 +22,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class HttpOptions
 {
+    public const JSON = 'json';
+
     private array $options = [];
 
     public function toArray(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | none
| License       | MIT

Motivation: The string `'json'` in the example taken from https://symfony.com/doc/current/http_client.html#uploading-data looks somewhat arbitrary: 
```php
$response = $client->request('POST', 'https://...', [
    'json' => ['param1' => 'value1', '...'],
]);
```

I think the fact that this isn't just some fieldname for the POST payload (but rather switches to "JSON mode", so to say) would better be conveyed with a constant:
```php
$response = $client->request('POST', 'https://...', [
    HttpOptions::JSON => ['param1' => 'value1', '...'],
]);
```

What do you think?