### PR TITLE
[Console] Add TesterTrait::assertCommandFailed and TesterTrait::assertCommandIsInvalid helpers

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -8,6 +8,11 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/8.1/
 
 If you're upgrading from a version below 8.0, follow the [8.0 upgrade guide](UPGRADE-8.0.md) first.
 
+Console
+-------
+
+ * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`
+
 DependencyInjection
 -------------------
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,11 +4,13 @@ CHANGELOG
 8.1
 ---
 
+ * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`
  * Add `#[AskChoice]` attribute for interactive choice questions in invokable commands
  * Add support for method-based commands with `#[AsCommand]` attribute
  * Add argument resolver support
  * Add `BackedEnum` and `DateTimeInterface` support to `#[MapInput]`
- * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`
+ * Add `TesterTrait::assertCommandFailed()` to test command
+ * Add `TesterTrait::assertCommandIsInvalid()` to test command
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Tester/Constraint/CommandFailed.php
+++ b/src/Symfony/Component/Console/Tester/Constraint/CommandFailed.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Console\Command\Command;
+
+final class CommandFailed extends Constraint
+{
+    public function toString(): string
+    {
+        return 'failed';
+    }
+
+    protected function matches($other): bool
+    {
+        return Command::FAILURE === $other;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'the command '.$this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        $mapping = [
+            Command::SUCCESS => 'Command was successful.',
+            Command::INVALID => 'Command was invalid.',
+        ];
+
+        return $mapping[$other] ?? \sprintf('Command returned exit status %d.', $other);
+    }
+}

--- a/src/Symfony/Component/Console/Tester/Constraint/CommandIsInvalid.php
+++ b/src/Symfony/Component/Console/Tester/Constraint/CommandIsInvalid.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Console\Command\Command;
+
+final class CommandIsInvalid extends Constraint
+{
+    public function toString(): string
+    {
+        return 'is invalid';
+    }
+
+    protected function matches($other): bool
+    {
+        return Command::INVALID === $other;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'the command '.$this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        $mapping = [
+            Command::SUCCESS => 'Command was successful.',
+            Command::FAILURE => 'Command failed.',
+        ];
+
+        return $mapping[$other] ?? \sprintf('Command returned exit status %d.', $other);
+    }
+}

--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -16,6 +16,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\Constraint\CommandFailed;
+use Symfony\Component\Console\Tester\Constraint\CommandIsInvalid;
 use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 
 /**
@@ -106,6 +108,16 @@ trait TesterTrait
     public function assertCommandIsSuccessful(string $message = ''): void
     {
         Assert::assertThat($this->statusCode, new CommandIsSuccessful(), $message);
+    }
+
+    public function assertCommandFailed(string $message = ''): void
+    {
+        Assert::assertThat($this->statusCode, new CommandFailed(), $message);
+    }
+
+    public function assertCommandIsInvalid(string $message = ''): void
+    {
+        Assert::assertThat($this->statusCode, new CommandIsInvalid(), $message);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandFailedTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandFailedTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Tester\Constraint;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\Constraint\CommandFailed;
+
+final class CommandFailedTest extends TestCase
+{
+    public function testConstraint()
+    {
+        $constraint = new CommandFailed();
+
+        $this->assertFalse($constraint->evaluate(Command::SUCCESS, '', true));
+        $this->assertTrue($constraint->evaluate(Command::FAILURE, '', true));
+        $this->assertFalse($constraint->evaluate(Command::INVALID, '', true));
+    }
+
+    #[DataProvider('providesUnsuccessful')]
+    public function testUnsuccessfulCommand(string $expectedException, int $exitCode)
+    {
+        $constraint = new CommandFailed();
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that the command failed\..*'.$expectedException.'/s');
+        $constraint->evaluate($exitCode);
+    }
+
+    public static function providesUnsuccessful(): iterable
+    {
+        yield 'Successful' => ['Command was successful.', Command::SUCCESS];
+        yield 'Invalid' => ['Command was invalid.', Command::INVALID];
+        yield 'Exit code 3' => ['Command returned exit status 3.', 3];
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsInvalidTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsInvalidTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Tester\Constraint;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\Constraint\CommandIsInvalid;
+
+final class CommandIsInvalidTest extends TestCase
+{
+    public function testConstraint()
+    {
+        $constraint = new CommandIsInvalid();
+
+        $this->assertFalse($constraint->evaluate(Command::SUCCESS, '', true));
+        $this->assertFalse($constraint->evaluate(Command::FAILURE, '', true));
+        $this->assertTrue($constraint->evaluate(Command::INVALID, '', true));
+    }
+
+    #[DataProvider('providesUnsuccessful')]
+    public function testUnsuccessfulCommand(string $expectedException, int $exitCode)
+    {
+        $constraint = new CommandIsInvalid();
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that the command is invalid\..*'.$expectedException.'/s');
+        $constraint->evaluate($exitCode);
+    }
+
+    public static function providesUnsuccessful(): iterable
+    {
+        yield 'Successful' => ['Command was successful.', Command::SUCCESS];
+        yield 'Failed' => ['Command failed.', Command::FAILURE];
+        yield 'Exit code 3' => ['Command returned exit status 3.', 3];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Adds two new helpers to complement `TestTrait::assertCommandIsSuccessful()`:
- `TesterTrait::assertCommandFailed()`
- `TesterTrait::assertCommandIsInvalid()`

Allows developers to explicitly check that a command failed or was invalid. I find myself re-implementing these in my projects for my own use.

Use it just as you would `assertCommandIsSuccessful()`:
```php
...
$this->command->execute($args);

$this->command->assertCommandIsInvalid(); //or
$this->command->assertCommandFailed();
...
```
