### PR TITLE
[Scheduler] Add option to order recurring messages by next run date in debug command

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `--sort` option to `debug:command` to order recurring messages by next run date
+
 7.3
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR adds a `--sort` option to `debug:scheduler` to sort recurring messages by their next run date.


This can be especially helpful when working with a large number of scheduled tasks, as it makes overlapping or closely scheduled executions easier to spot.

### Before
```
Scheduler
=========

default
-------

 --------------- --------------------------------------------------------------------- --------------------------------- 
  Trigger         Provider                                                              Next Run                         
 --------------- --------------------------------------------------------------------- --------------------------------- 
  30 4 * * 1      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Mon, 26 Jan 2026 04:30:00 +0000  
  20 * * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:20:00 +0000  
  30 1 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 01:30:00 +0000  
  0 3 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 03:00:00 +0000  
  30 */6 * * *    Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 18:30:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  0 10 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 10:00:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  0 * * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  0 8 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 08:00:00 +0000  
  15,45 * * * *   Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:45:00 +0000  
  0 7 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 07:00:00 +0000  
  0 * * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  0 */1 * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  0 5 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 05:00:00 +0000  
  15 * * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:15:00 +0000  
  0 9 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 09:00:00 +0000  
  0 14 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 14:00:00 +0000  
  30 9 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 09:30:00 +0000  
  0 7 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 07:00:00 +0000  
  5 6 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 06:05:00 +0000  
  0 2 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 02:00:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  30 8 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 08:30:00 +0000  
  */15 * * * *    Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:45:00 +0000  
  30 5 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 05:30:00 +0000  
  5 0 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 00:05:00 +0000  
  0 10 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 10:00:00 +0000  
  0 * * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  30 4 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:30:00 +0000  
 --------------- --------------------------------------------------------------------- --------------------------------- 

```

### After

```

Scheduler
=========

default
-------

 --------------- --------------------------------------------------------------------- --------------------------------- 
  Trigger         Provider                                                              Next Run                         
 --------------- --------------------------------------------------------------------- --------------------------------- 
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  */5 * * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:35:00 +0000  
  15,45 * * * *   Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:45:00 +0000  
  */15 * * * *    Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 14:45:00 +0000  
  0 * * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  0 * * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  0 */1 * * *     Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  0 * * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:00:00 +0000  
  15 * * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:15:00 +0000  
  20 * * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 15:20:00 +0000  
  30 */6 * * *    Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Tue, 20 Jan 2026 18:30:00 +0000  
  5 0 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 00:05:00 +0000  
  30 1 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 01:30:00 +0000  
  0 2 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 02:00:00 +0000  
  0 3 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 03:00:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  0 4 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:00:00 +0000  
  30 4 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 04:30:00 +0000  
  0 5 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 05:00:00 +0000  
  30 5 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 05:30:00 +0000  
  5 6 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 06:05:00 +0000  
  0 7 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 07:00:00 +0000  
  0 7 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 07:00:00 +0000  
  0 8 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 08:00:00 +0000  
  30 8 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 08:30:00 +0000  
  0 9 * * *       Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 09:00:00 +0000  
  30 9 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 09:30:00 +0000  
  0 10 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 10:00:00 +0000  
  0 10 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 10:00:00 +0000  
  0 14 * * *      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Wed, 21 Jan 2026 14:00:00 +0000  
  30 4 * * 1      Symfony\Component\Console\Messenger\RunCommandMessage (app:command)   Mon, 26 Jan 2026 04:30:00 +0000  
 --------------- --------------------------------------------------------------------- --------------------------------- 

```
