### PR TITLE
[Serializer] Fix is/has/can accessor naming to strip prefix unless colliding

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AccessorCollisionResolverTrait.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AccessorCollisionResolverTrait.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Mapping\Loader;
+
+use Symfony\Component\Serializer\Attribute\Ignore;
+
+/**
+ * Provides methods to detect accessor name collisions during serialization.
+ *
+ * @internal
+ */
+trait AccessorCollisionResolverTrait
+{
+    private function getAttributeNameFromAccessor(\ReflectionClass $class, \ReflectionMethod $method, bool $andMutator): ?string
+    {
+        $methodName = $method->name;
+
+        $i = match ($methodName[0]) {
+            's' => $andMutator && str_starts_with($methodName, 'set') ? 3 : null,
+            'g' => str_starts_with($methodName, 'get') ? 3 : null,
+            'h' => str_starts_with($methodName, 'has') ? 3 : null,
+            'c' => str_starts_with($methodName, 'can') ? 3 : null,
+            'i' => str_starts_with($methodName, 'is') ? 2 : null,
+            default => null,
+        };
+
+        // ctype_lower check to find out if method looks like accessor but actually is not, e.g. hash, cancel
+        if (null === $i || ctype_lower($methodName[$i] ?? 'a') || $method->isStatic()) {
+            return null;
+        }
+
+        if ('s' === $methodName[0] ? !$method->getNumberOfParameters() : ($method->getNumberOfRequiredParameters() || \in_array((string) $method->getReturnType(), ['void', 'never'], true))) {
+            return null;
+        }
+
+        $attributeName = substr($methodName, $i);
+
+        if (!$class->hasProperty($attributeName)) {
+            $attributeName = lcfirst($attributeName);
+        }
+
+        return $attributeName;
+    }
+
+    private function hasPropertyForAccessor(\ReflectionClass $class, string $propName): bool
+    {
+        do {
+            if ($class->hasProperty($propName)) {
+                return true;
+            }
+        } while ($class = $class->getParentClass());
+
+        return false;
+    }
+
+    private function hasAttributeNameCollision(\ReflectionClass $class, string $attributeName, string $methodName): bool
+    {
+        if ($this->hasPropertyForAccessor($class, $attributeName)) {
+            return true;
+        }
+
+        if ($class->hasMethod($attributeName)) {
+            $candidate = $class->getMethod($attributeName);
+            if ($candidate->getName() !== $methodName && $this->isReadableAccessorMethod($candidate)) {
+                return true;
+            }
+        }
+
+        $ucAttributeName = ucfirst($attributeName);
+        foreach (['get', 'is', 'has', 'can'] as $prefix) {
+            $candidateName = $prefix.$ucAttributeName;
+            if ($candidateName === $methodName || !$class->hasMethod($candidateName)) {
+                continue;
+            }
+
+            if ($this->isReadableAccessorMethod($class->getMethod($candidateName))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isReadableAccessorMethod(\ReflectionMethod $method): bool
+    {
+        return $method->isPublic()
+            && !$method->isStatic()
+            && !$method->getAttributes(Ignore::class)
+            && !$method->getNumberOfRequiredParameters()
+            && !\in_array((string) $method->getReturnType(), ['void', 'never'], true);
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -18,10 +18,11 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
-use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Mapping\Loader\AccessorCollisionResolverTrait;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
@@ -33,6 +34,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  */
 class ObjectNormalizer extends AbstractObjectNormalizer
 {
+    use AccessorCollisionResolverTrait;
+
     private static $reflectionCache = [];
     private static $isReadableCache = [];
     private static $isWritableCache = [];
@@ -87,37 +90,10 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $reflClass = new \ReflectionClass($class);
 
         foreach ($reflClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflMethod) {
-            if (
-                $reflMethod->getNumberOfRequiredParameters()
-                || $reflMethod->isStatic()
-                || $reflMethod->isConstructor()
-                || $reflMethod->isDestructor()
-                || \in_array((string) $reflMethod->getReturnType(), ['void', 'never'], true)
-            ) {
-                continue;
-            }
-
             $name = $reflMethod->name;
-            $attributeName = null;
+            $attributeName = $this->getAttributeNameFromAccessor($reflClass, $reflMethod, false);
 
-            // ctype_lower check to find out if method looks like accessor but actually is not, e.g. hash, cancel
-            if (match ($name[0]) {
-                'g' => str_starts_with($name, 'get') && isset($name[$i = 3]),
-                'h' => str_starts_with($name, 'has') && isset($name[$i = 3]),
-                'c' => str_starts_with($name, 'can') && isset($name[$i = 3]),
-                'i' => str_starts_with($name, 'is') && isset($name[$i = 2]),
-                default => false,
-            } && !ctype_lower($name[$i])) {
-                if ($this->hasProperty($reflMethod->getDeclaringClass(), $name)) {
-                    $attributeName = $name;
-                } else {
-                    $attributeName = substr($name, $i);
-
-                    if (!$reflClass->hasProperty($attributeName)) {
-                        $attributeName = lcfirst($attributeName);
-                    }
-                }
-            } elseif ($this->hasProperty($reflMethod->getDeclaringClass(), $name)) {
+            if ($this->hasPropertyForAccessor($reflMethod->getDeclaringClass(), $name) && (null === $attributeName || $this->hasAttributeNameCollision($reflClass, $attributeName, $name))) {
                 $attributeName = $name;
             }
 
@@ -140,17 +116,6 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         }
 
         return array_keys($attributes);
-    }
-
-    private function hasProperty(\ReflectionClass $class, string $propName): bool
-    {
-        do {
-            if ($class->hasProperty($propName)) {
-                return true;
-            }
-        } while ($class = $class->getParentClass());
-
-        return false;
     }
 
     protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []): mixed

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1186,6 +1186,61 @@ class ObjectNormalizerTest extends TestCase
         ], $normalizedSwappedHasserIsser);
     }
 
+    public function testIsserPrefersBaseNameWhenNoCollision()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $object = new ObjectWithIsPrefixedPropertyOnly(true);
+
+        $this->assertSame(['published' => true], $normalizer->normalize($object));
+    }
+
+    public function testIsserKeepsPrefixWhenBaseNameCollides()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $object = new ObjectWithIsPrefixedPropertyAndPublishedGetter(true, 'live');
+
+        $this->assertEquals([
+            'published' => 'live',
+            'isPublished' => true,
+        ], $normalizer->normalize($object));
+    }
+
+    public function testIsserKeepsPrefixWhenPublicPropertyCollidesWithoutGetter()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $object = new ObjectWithIsserAndPublicPropertyNoGetter(true, 'live');
+
+        // Both should appear: isPublished keeps prefix because $published property exists
+        $this->assertEquals([
+            'isPublished' => true,
+            'published' => 'live',
+        ], $normalizer->normalize($object));
+    }
+
+    public function testIsserWithPublicPropertyCollision()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $object = new ObjectWithPublicPublishedPropertyAndIsser('live');
+
+        // The isser takes precedence over the public property - this documents existing behavior
+        $this->assertSame(['published' => true], $normalizer->normalize($object));
+    }
+
+    public function testIsserWithPrivatePropertyNoMethodNamedProperty()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $object = new ObjectWithPrivatePublishedAndIsser(true);
+
+        // isPublished() should normalize to 'published', not 'isPublished'
+        // because there's no $isPublished property that would cause a collision
+        $this->assertSame(['published' => true], $normalizer->normalize($object));
+    }
+
     public function testDiscriminatorWithAllowExtraAttributesFalse()
     {
         // Discriminator type property should be allowed with allow_extra_attributes=false
@@ -1258,10 +1313,25 @@ class ObjectNormalizerTest extends TestCase
         $object = new GroupDummyWithIsPrefixedProperty();
 
         $normalizedWithoutGroups = $normalizer->normalize($object);
-        $this->assertArrayHasKey('isSomething', $normalizedWithoutGroups);
+        $this->assertArrayHasKey('something', $normalizedWithoutGroups);
 
         $normalizedWithGroups = $normalizer->normalize($object, null, [AbstractNormalizer::GROUPS => ['test']]);
-        $this->assertArrayHasKey('isSomething', $normalizedWithGroups);
+        $this->assertArrayHasKey('something', $normalizedWithGroups);
+    }
+
+    public function testNormalizeObjectWithGroupsAndIsPrefixedPropertyWithCollision()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $normalizer = new ObjectNormalizer($classMetadataFactory);
+        $serializer = new Serializer([$normalizer]);
+        $normalizer->setSerializer($serializer);
+
+        $object = new GroupDummyWithIsPrefixedPropertyAndPublishedGetter();
+
+        $normalizedWithGroups = $normalizer->normalize($object, null, [AbstractNormalizer::GROUPS => ['test']]);
+
+        $this->assertArrayHasKey('isPublished', $normalizedWithGroups);
+        $this->assertArrayNotHasKey('published', $normalizedWithGroups);
     }
 
     public function testSkipVoidNeverReturnTypeAccessors()
@@ -1740,6 +1810,100 @@ class ObjectWithPropertyIsserAndHasser
     public function hasFoo()
     {
         return 'hasFoo';
+    }
+}
+
+class ObjectWithIsPrefixedPropertyOnly
+{
+    public function __construct(
+        private bool $isPublished,
+    ) {
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->isPublished;
+    }
+}
+
+class ObjectWithIsPrefixedPropertyAndPublishedGetter
+{
+    public function __construct(
+        private bool $isPublished,
+        private string $published,
+    ) {
+    }
+
+    public function getPublished(): string
+    {
+        return $this->published;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->isPublished;
+    }
+}
+
+class GroupDummyWithIsPrefixedPropertyAndPublishedGetter
+{
+    private bool $isPublished = true;
+    private string $published = 'live';
+
+    #[Groups(['test'])]
+    public function isPublished(): bool
+    {
+        return $this->isPublished;
+    }
+
+    public function getPublished(): string
+    {
+        return $this->published;
+    }
+}
+
+class ObjectWithPublicPublishedPropertyAndIsser
+{
+    public string $published;
+
+    public function __construct(string $published)
+    {
+        $this->published = $published;
+    }
+
+    public function isPublished(): bool
+    {
+        return '' !== $this->published;
+    }
+}
+
+class ObjectWithPrivatePublishedAndIsser
+{
+    public function __construct(
+        private bool $published,
+    ) {
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->published;
+    }
+}
+
+class ObjectWithIsserAndPublicPropertyNoGetter
+{
+    public string $published;
+
+    public function __construct(
+        private bool $isPublished,
+        string $published,
+    ) {
+        $this->published = $published;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->isPublished;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62353
| License       | MIT

Before PR #61097 (Symfony 6.4.26/7.3.5), methods like `isPublished()` would serialize using the base name "published" by default.

PR #61097 fixed an issue where objects with both `$isPublished` property and `isPublished()` method couldn't round-trip properly. However, it caused a regression: ALL is/has/can accessors started using the prefixed form ("isPublished") when a matching property exists, even when there's no actual collision.

This PR fixes the regression by:

1. Only using the full method name (e.g., "isPublished") when there's an actual collision - another property or accessor that would map to the same base name ("published")
2. Keeping the base name ("published") when no collision exists, matching pre-6.4.26 behavior for the common case
3. Extracting shared collision detection logic into `AccessorCollisionResolverTrait` to ensure consistent behavior between `ObjectNormalizer` and `AttributeLoader`