### PR TITLE
[ObjectMapper] apply conditions to constructor arguments

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -140,16 +140,20 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     $sourcePropertyName = $mapping->source;
                 }
 
+                $targetPropertyName = $mapping->target ?? $propertyName;
                 if (false === $if = $mapping->if) {
+                    unset($ctorArguments[$targetPropertyName]);
+
                     continue;
                 }
 
                 $value = $this->getRawValue($source, $sourcePropertyName);
                 if ($if && ($fn = $this->getCallable($if, $this->conditionCallableLocator)) && !$this->call($fn, $value, $source, $mappedTarget)) {
+                    unset($ctorArguments[$targetPropertyName]);
+
                     continue;
                 }
 
-                $targetPropertyName = $mapping->target ?? $propertyName;
                 $value = $this->getSourceValue($source, $mappedTarget, $value, $objectMap, $mapping);
                 $this->storeValue($targetPropertyName, $mapToProperties, $ctorArguments, $value);
             }
@@ -169,7 +173,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
         }
 
-        if ((!$mappingToObject || !$rootCall) && !$map?->transform && $targetConstructor) {
+        if ((!$mappingToObject || !$rootCall) && !$map?->transform && $targetConstructor
+            && ($ctorArguments || !$targetConstructor->getNumberOfRequiredParameters())
+        ) {
             try {
                 $mappedTarget->__construct(...$ctorArguments);
             } catch (\ReflectionException $e) {

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/ConstructorTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/ConstructorTarget.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalConstructorArgument;
+
+class ConstructorTarget
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/InputSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/InputSource.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalConstructorArgument;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(ConstructorTarget::class)]
+class InputSource
+{
+    #[Map(if: new NotNullCondition)]
+    public ?string $name = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/NotNullCondition.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/NotNullCondition.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalConstructorArgument;
+
+use Symfony\Component\ObjectMapper\ConditionCallableInterface;
+
+final class NotNullCondition implements ConditionCallableInterface
+{
+    public function __invoke(mixed $value, object $source, ?object $target): bool
+    {
+        return null !== $value;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -91,6 +91,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalConstructorArgument\InputSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalConstructorArgument\ConstructorTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalConstructorArgument\NotNullCondition;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class ObjectMapperTest extends TestCase
@@ -684,5 +687,19 @@ final class ObjectMapperTest extends TestCase
         $source = new MultipleTargetPropertyA();
         $mapper = new ObjectMapper();
         $mapper->map($source);
+    }
+
+    public function testConditionalMappingAppliedToConstructorArguments()
+    {
+        $mapper = new ObjectMapper();
+
+        $sourceWithNull = new InputSource();
+        $targetWithNull = $mapper->map($sourceWithNull);
+        $this->assertFalse((new \ReflectionProperty($targetWithNull, 'name'))->isInitialized($targetWithNull));
+
+        $sourceWithValue = new InputSource();
+        $sourceWithValue->name = 'test';
+        $targetWithValue = $mapper->map($sourceWithValue);
+        $this->assertSame('test', $targetWithValue->name);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63134
| License       | MIT

This PR enables the use of #[Map(if: ...)] attributes on constructor arguments in the ObjectMapper component. This allows for conditional mapping of constructor parameters see attached issue.
