### PR TITLE
[Messenger] Add `CompressStamp`

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\RetryableException;
+use Symfony\Component\Messenger\CompressorTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -29,6 +30,8 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  */
 class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareInterface, KeepaliveReceiverInterface
 {
+    use CompressorTrait;
+
     private const MAX_RETRIES = 3;
     private int $retryingSafetyCounter = 0;
     private SerializerInterface $serializer;
@@ -137,6 +140,9 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
     private function createEnvelopeFromData(array $data): Envelope
     {
         try {
+            if ($data['headers'][self::COMPRESS_HEADER_KEY] ?? false) {
+                $data['body'] = $this->uncompress(base64_decode($data['body']));
+            }
             $envelope = $this->serializer->decode([
                 'body' => $data['body'],
                 'headers' => $data['headers'],

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
 use Doctrine\DBAL\Exception as DBALException;
+use Symfony\Component\Messenger\CompressorTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Stamp\CompressStamp;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
@@ -25,6 +27,8 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  */
 class DoctrineSender implements SenderInterface
 {
+    use CompressorTrait;
+
     private SerializerInterface $serializer;
 
     public function __construct(
@@ -42,8 +46,14 @@ class DoctrineSender implements SenderInterface
         $delayStamp = $envelope->last(DelayStamp::class);
         $delay = null !== $delayStamp ? $delayStamp->getDelay() : 0;
 
+        $encodedMessage['headers'] ??= [];
+        if ($envelope->last(CompressStamp::class)) {
+            $encodedMessage['body'] = base64_encode($this->compress($encodedMessage['body']));
+            $encodedMessage['headers'] += [self::COMPRESS_HEADER_KEY => true];
+        }
+
         try {
-            $id = $this->connection->send($encodedMessage['body'], $encodedMessage['headers'] ?? [], $delay);
+            $id = $this->connection->send($encodedMessage['body'], $encodedMessage['headers'], $delay);
         } catch (DBALException $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
         }

--- a/src/Symfony/Component/Messenger/CompressorTrait.php
+++ b/src/Symfony/Component/Messenger/CompressorTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+use Symfony\Component\Messenger\Exception\RuntimeException;
+
+/**
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+trait CompressorTrait
+{
+    private const string COMPRESS_HEADER_KEY = 'sf_compress';
+
+    private function compress(string $body, int $level = -1, int $encoding = \FORCE_GZIP): string
+    {
+        if (!\extension_loaded('zlib')) {
+            throw new RuntimeException('Unable to compress the body. Make sure that the "zlib" extension is enabled.');
+        }
+
+        return gzencode($body, $level, $encoding);
+    }
+
+    private function uncompress(string $body, int $maxLength = 0): string
+    {
+        if (!\extension_loaded('zlib')) {
+            throw new RuntimeException('Unable to uncompress the body. Make sure that the "zlib" extension is enabled.');
+        }
+
+        return gzdecode($body, $maxLength);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/CompressStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/CompressStamp.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Stamp applied to messages to indicate that the message body will be compressed
+ * before being sent, optimizing transmission and storage efficiency.
+ *
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+final class CompressStamp implements StampInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #45944 and #44943
| License       | MIT

Hi everyone,

This is an RFC for a potential change. Before I invest more time and effort into enhancing this solution, I’d like to get feedback from the core team to see if you think it’s a good direction to take.

Here’s the idea:
Some of the bridges  have limitations on the size of the message body. This approach proposes to compress the message body when it's published and then decompress it when the message is received.

If you like the direction of this idea, there will be some extra work involved, including:

* Improving the current code
* Extending the solution to all bridges (not just `DoctrineBridge`)
* Adding tests
* Updating the `CHANGELOG.md`
* Manual testing for all bridges

I’m happy to do all of that, but first, I’d appreciate it if the core team could confirm if this is a viable approach. If so, I’ll continue working on the PR and add the tag “Needs Work”.

Please feel free to close this PR if you think this isn't a good approach. If you think it's worth exploring, let me know, and I'll move forward with the implementation!

Thanks a lot!