### PR TITLE
[Form] Fix `OrderedHashMap` auto-increment logic with mixed keys

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
@@ -524,4 +524,36 @@ class OrderedHashMapTest extends TestCase
 
         $this->assertCount(2, $map);
     }
+
+    public function testAppendDoesNotOverwriteExistingNumericKeysWhenStringKeysExist()
+    {
+        $map = new OrderedHashMap();
+        $map[0] = 'zero';
+        $map[1] = 'one';
+        $map['foo'] = 'bar';
+        $map[] = 'new';
+
+        $this->assertSame('one', $map[1]);
+        $this->assertSame('new', $map[2]);
+    }
+
+    public function testUpdateNullValueDoesNotChangeElementPosition()
+    {
+        $map = new OrderedHashMap();
+        $map['first'] = null;
+        $map['second'] = 2;
+        $map['first'] = null;
+
+        $this->assertSame(['first' => null, 'second' => 2], iterator_to_array($map));
+    }
+
+    public function testUpdateFromNullValueDoesNotChangeElementPosition()
+    {
+        $map = new OrderedHashMap();
+        $map['first'] = null;
+        $map['second'] = 2;
+        $map['first'] = 1;
+
+        $this->assertSame(['first' => 1, 'second' => 2], iterator_to_array($map));
+    }
 }

--- a/src/Symfony/Component/Form/Util/OrderedHashMap.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMap.php
@@ -120,16 +120,11 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     public function offsetSet(mixed $key, mixed $value): void
     {
-        if (null === $key || !isset($this->elements[$key])) {
-            if (null === $key) {
-                $key = [] === $this->orderedKeys
-                    // If the array is empty, use 0 as key
-                    ? 0
-                    // Imitate PHP behavior of generating a key that equals
-                    // the highest existing integer key + 1
-                    : 1 + (int) max($this->orderedKeys);
-            }
-
+        if (null === $key) {
+            $this->elements[] = $value;
+            $key = array_key_last($this->elements);
+            $this->orderedKeys[] = (string) $key;
+        } elseif (!\array_key_exists($key, $this->elements)) {
             $this->orderedKeys[] = (string) $key;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When `OrderedHashMap` has mixed integer and string keys, appending a new element overwrites existing integer keys instead of generating a new key:

```php
$map = new OrderedHashMap();
$map[0] = 'zero';
$map[1] = 'one';
$map['foo'] = 'bar';
$map[] = 'new'; // overwrites key 1 instead of creating key 2
```
