### PR TITLE
[EventDispatcher] Use listeners' `__toString()` method as a hint to display their name in the profiler

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -55,8 +55,8 @@ final class WrappedListener
             } else {
                 $this->pretty = $this->name = $r->name;
             }
-        } elseif (\is_string($listener)) {
-            $this->pretty = $this->name = $listener;
+        } elseif (\is_string($listener) || $listener instanceof \Stringable) {
+            $this->pretty = $this->name = (string) $listener;
         } else {
             $this->name = get_debug_type($listener);
             $this->pretty = $this->name.'::__invoke';


### PR DESCRIPTION
ability to change listener name via __toString() method

reason? we are using Contributte\EventDispatcher\LazyListener and it wraps original listener, after this change they should add __toString() method to output original listenerName

<img width="1255" height="226" alt="image" src="https://github.com/user-attachments/assets/3fdb074f-be40-49aa-8448-40563da6f2f7" />


| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

