### PR TITLE
[Security] Add support for enums in `SignatureHasher::computeSignatureHash()`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/User.php
@@ -45,11 +45,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->name;
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function equals(UserInterface $user)
     {
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -248,11 +248,6 @@ final class UserWithoutEquatable implements UserInterface, PasswordAuthenticated
     {
         return $this->enabled;
     }
-
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
 }
 
 class ForceLoginController

--- a/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
@@ -35,11 +35,6 @@ final class TestLegacyPasswordAuthenticatedUser implements LegacyPasswordAuthent
         return $this->roles;
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for enums in `SignatureHasher::computeSignatureHash()`
+
 8.0
 ---
 

--- a/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
@@ -1,0 +1,420 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Signature;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Security\Core\Signature\Exception\ExpiredSignatureException;
+use Symfony\Component\Security\Core\Signature\Exception\InvalidSignatureException;
+use Symfony\Component\Security\Core\Signature\SignatureHasher;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class SignatureHasherTest extends TestCase
+{
+    public function testComputeSignatureHash()
+    {
+        $user = new TestSignatureUser('john', 'my-password');
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['password'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $this->assertIsString($hash);
+        $this->assertNotEmpty($hash);
+    }
+
+    public function testVerifySignatureHashValid()
+    {
+        $user = new TestSignatureUser('john', 'my-password');
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['password'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $hasher->verifySignatureHash($user, $expires, $hash);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testVerifySignatureHashExpired()
+    {
+        $user = new TestSignatureUser('john', 'my-password');
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['password'], 'secret');
+
+        $expires = time() - 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $this->expectException(ExpiredSignatureException::class);
+        $hasher->verifySignatureHash($user, $expires, $hash);
+    }
+
+    public function testVerifySignatureHashInvalid()
+    {
+        $user = new TestSignatureUser('john', 'my-password');
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['password'], 'secret');
+
+        $expires = time() + 3600;
+
+        $this->expectException(InvalidSignatureException::class);
+        $hasher->verifySignatureHash($user, $expires, 'invalid-hash');
+    }
+
+    public function testVerifySignatureHashChangedPropertyInvalidates()
+    {
+        $user = new TestSignatureUser('john', 'my-password');
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['password'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $userWithNewPassword = new TestSignatureUser('john', 'new-password');
+
+        $this->expectException(InvalidSignatureException::class);
+        $hasher->verifySignatureHash($userWithNewPassword, $expires, $hash);
+    }
+
+    public function testComputeSignatureHashWithDateTimeProperty()
+    {
+        $date = new \DateTimeImmutable('2024-01-15 10:30:00');
+        $user = new TestSignatureUserWithDate('john', $date);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['createdAt'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $hasher->verifySignatureHash($user, $expires, $hash);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testComputeSignatureHashWithEnumProperty()
+    {
+        $user = new TestSignatureUserWithEnum('john', TestUserStatus::Active);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['status'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $hasher->verifySignatureHash($user, $expires, $hash);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testComputeSignatureHashWithBackedEnumProperty()
+    {
+        $user = new TestSignatureUserWithBackedEnum('john', TestUserRole::Admin);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['role'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $hasher->verifySignatureHash($user, $expires, $hash);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnumPropertyChangeInvalidatesSignature()
+    {
+        $user = new TestSignatureUserWithEnum('john', TestUserStatus::Active);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['status'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $userWithNewStatus = new TestSignatureUserWithEnum('john', TestUserStatus::Inactive);
+
+        $this->expectException(InvalidSignatureException::class);
+        $hasher->verifySignatureHash($userWithNewStatus, $expires, $hash);
+    }
+
+    public function testBackedEnumPropertyChangeInvalidatesSignature()
+    {
+        $user = new TestSignatureUserWithBackedEnum('john', TestUserRole::Admin);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['role'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $userWithNewRole = new TestSignatureUserWithBackedEnum('john', TestUserRole::User);
+
+        $this->expectException(InvalidSignatureException::class);
+        $hasher->verifySignatureHash($userWithNewRole, $expires, $hash);
+    }
+
+    public function testComputeSignatureHashWithStringableProperty()
+    {
+        $stringable = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'stringable-value';
+            }
+        };
+        $user = new TestSignatureUserWithStringable('john', $stringable);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['data'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $hasher->verifySignatureHash($user, $expires, $hash);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testComputeSignatureHashWithNullProperty()
+    {
+        $user = new TestSignatureUserWithNullable('john', null);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['optionalValue'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $hasher->verifySignatureHash($user, $expires, $hash);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testComputeSignatureHashWithInvalidPropertyThrows()
+    {
+        $user = new TestSignatureUserWithArray('john', ['invalid']);
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['data'], 'secret');
+
+        $expires = time() + 3600;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must return a value that can be cast to a string');
+        $hasher->computeSignatureHash($user, $expires);
+    }
+
+    public function testAcceptSignatureHashValid()
+    {
+        $user = new TestSignatureUser('john', 'my-password');
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['password'], 'secret');
+
+        $expires = time() + 3600;
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $hasher->acceptSignatureHash('john', $expires, $hash);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAcceptSignatureHashExpired()
+    {
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), [], 'secret');
+
+        $expires = time() - 3600;
+
+        $this->expectException(ExpiredSignatureException::class);
+        $this->expectExceptionMessage('Signature has expired.');
+        $hasher->acceptSignatureHash('john', $expires, 'any-hash');
+    }
+
+    public function testAcceptSignatureHashInvalid()
+    {
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), [], 'secret');
+
+        $expires = time() + 3600;
+
+        $this->expectException(InvalidSignatureException::class);
+        $hasher->acceptSignatureHash('john', $expires, 'invalid-hash');
+    }
+
+    public function testConstructorThrowsOnEmptySecret()
+    {
+        $this->expectException(\Symfony\Component\Security\Core\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        new SignatureHasher(PropertyAccess::createPropertyAccessor(), [], '');
+    }
+}
+
+enum TestUserStatus
+{
+    case Active;
+    case Inactive;
+    case Pending;
+}
+
+enum TestUserRole: string
+{
+    case Admin = 'admin';
+    case User = 'user';
+    case Guest = 'guest';
+}
+
+class TestSignatureUser implements UserInterface
+{
+    public function __construct(
+        private string $username,
+        private string $password,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+}
+
+class TestSignatureUserWithDate implements UserInterface
+{
+    public function __construct(
+        private string $username,
+        private \DateTimeInterface $createdAt,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+}
+
+class TestSignatureUserWithEnum implements UserInterface
+{
+    public function __construct(
+        private string $username,
+        private TestUserStatus $status,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getStatus(): TestUserStatus
+    {
+        return $this->status;
+    }
+}
+
+class TestSignatureUserWithBackedEnum implements UserInterface
+{
+    public function __construct(
+        private string $username,
+        private TestUserRole $role,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getRole(): TestUserRole
+    {
+        return $this->role;
+    }
+}
+
+class TestSignatureUserWithStringable implements UserInterface
+{
+    public function __construct(
+        private string $username,
+        private \Stringable $data,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getData(): \Stringable
+    {
+        return $this->data;
+    }
+}
+
+class TestSignatureUserWithNullable implements UserInterface
+{
+    public function __construct(
+        private string $username,
+        private ?string $optionalValue,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getOptionalValue(): ?string
+    {
+        return $this->optionalValue;
+    }
+}
+
+class TestSignatureUserWithArray implements UserInterface
+{
+    public function __construct(
+        private string $username,
+        private array $data,
+    ) {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -31,6 +31,7 @@
         "symfony/expression-language": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/ldap": "^7.4|^8.0",
+        "symfony/property-access": "^7.4|^8.0",
         "symfony/string": "^7.4|^8.0",
         "symfony/translation": "^7.4|^8.0",
         "symfony/validator": "^7.4|^8.0"

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -172,7 +172,7 @@ class AuthenticatorManagerTest extends TestCase
 
         $authenticator->expects($this->once())->method('onAuthenticationFailure')->with($this->anything(), $this->callback(static fn ($exception) => 'Authentication failed; Some badges marked as required by the firewall config are not available on the passport: "'.CsrfTokenBadge::class.'".' === $exception->getMessage()));
 
-        $manager = $this->createManager([$authenticator], 'main', true, [CsrfTokenBadge::class], exposeSecurityErrors: ExposeSecurityLevel::None);
+        $manager = $this->createManager([$authenticator], 'main', [CsrfTokenBadge::class], exposeSecurityErrors: ExposeSecurityLevel::None);
         $manager->authenticateRequest($this->request);
     }
 
@@ -188,7 +188,7 @@ class AuthenticatorManagerTest extends TestCase
 
         $authenticator->expects($this->once())->method('onAuthenticationSuccess');
 
-        $manager = $this->createManager([$authenticator], 'main', true, [CsrfTokenBadge::class], exposeSecurityErrors: ExposeSecurityLevel::None);
+        $manager = $this->createManager([$authenticator], 'main', [CsrfTokenBadge::class], exposeSecurityErrors: ExposeSecurityLevel::None);
         $manager->authenticateRequest($this->request);
     }
 
@@ -379,7 +379,7 @@ class AuthenticatorManagerTest extends TestCase
             }
         };
 
-        $manager = $this->createManager([$authenticator], 'main', false, [], $logger, exposeSecurityErrors: ExposeSecurityLevel::None);
+        $manager = $this->createManager([$authenticator], 'main', [], $logger, exposeSecurityErrors: ExposeSecurityLevel::None);
         $response = $manager->authenticateRequest($this->request);
         $this->assertSame($this->response, $response);
         $this->assertStringContainsString($authenticator::class, $logger->logContexts[0]['authenticator']);
@@ -391,9 +391,9 @@ class AuthenticatorManagerTest extends TestCase
         return new DummySupportsAuthenticator($supports);
     }
 
-    private function createManager($authenticators, $firewallName = 'main', $eraseCredentials = false, array $requiredBadges = [], ?LoggerInterface $logger = null, ExposeSecurityLevel $exposeSecurityErrors = ExposeSecurityLevel::AccountStatus)
+    private function createManager($authenticators, $firewallName = 'main', array $requiredBadges = [], ?LoggerInterface $logger = null, ExposeSecurityLevel $exposeSecurityErrors = ExposeSecurityLevel::AccountStatus)
     {
-        return new AuthenticatorManager($authenticators, $this->tokenStorage, $this->eventDispatcher, $firewallName, $logger, $eraseCredentials, $exposeSecurityErrors, $requiredBadges);
+        return new AuthenticatorManager($authenticators, $this->tokenStorage, $this->eventDispatcher, $firewallName, $logger, false, $exposeSecurityErrors, $requiredBadges);
     }
 }
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -165,11 +165,6 @@ class DummyTestPasswordAuthenticatedUser extends TestPasswordAuthenticatedUser
         return [];
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getUserIdentifier(): string
     {
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -589,11 +589,6 @@ class CustomToken implements TokenInterface
         return $this->getUserIdentifier();
     }
 
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
-
     public function getAttributes(): array
     {
         return [];

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/CustomUser.php
@@ -39,10 +39,6 @@ final class CustomUser implements UserInterface, PasswordAuthenticatedUserInterf
         return $this->password ?? null;
     }
 
-    public function eraseCredentials(): void
-    {
-    }
-
     public function __serialize(): array
     {
         $data = (array) $this;

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -311,11 +311,6 @@ class TestLoginLinkHandlerUser implements UserInterface
     {
         return $this->username;
     }
-
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-    }
 }
 
 class TestLoginLinkHandlerUserProvider implements UserProviderInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | 
| Issues        | Fix #60302
| License       | MIT

Taking over #60302 which stalled and goes too far.

Contains cleanups found meanwhile.