### PR TITLE
[JsonStreamer] Fix exponential resource class memory growth

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithRepeatedOtherDummy.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithRepeatedOtherDummy.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+final class DummyWithRepeatedOtherDummy
+{
+    public ?ClassicDummy $one = null;
+    public ?ClassicDummy $two = null;
+    public ?ClassicDummy $three = null;
+    public ?ClassicDummy $four = null;
+    public ?ClassicDummy $five = null;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithRepeatedOtherDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
@@ -111,6 +112,10 @@ class StreamerDumperTest extends TestCase
         yield 'object with object properties' => [
             Type::object(DummyWithOtherDummies::class),
             [DummyWithOtherDummies::class, DummyWithNameAttributes::class, ClassicDummy::class],
+        ];
+        yield 'object with repeated object properties' => [
+            Type::object(DummyWithRepeatedOtherDummy::class),
+            [DummyWithRepeatedOtherDummy::class, ClassicDummy::class],
         ];
         yield 'object with self reference' => [Type::object(SelfReferencingDummy::class), [SelfReferencingDummy::class]];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63057
| License       | MIT

The spread operator caused array doubling when recursive calls returned early with the same array for already-seen classes. This was leading to `O(2^n)` memory usage with repeated nullable object properties.
