### PR TITLE
[DependencyInjection] Fix alias chain inversion when deprecated alias points to decorated service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -41,7 +41,15 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
         $seenAliasTargets = [];
         $replacements = [];
 
-        foreach ($container->getAliases() as $definitionId => $target) {
+        // Sort aliases so non-deprecated ones come first. This ensures that when
+        // multiple aliases point to the same private definition, non-deprecated
+        // aliases get priority for renaming. Otherwise, the definition might be
+        // renamed to a deprecated alias ID, causing the original service ID to
+        // become an alias to the deprecated one (inverting the alias chain).
+        $aliases = $container->getAliases();
+        uasort($aliases, static fn ($a, $b) => $a->isDeprecated() <=> $b->isDeprecated());
+
+        foreach ($aliases as $definitionId => $target) {
             $targetId = (string) $target;
             // Special case: leave this target alone
             if ('service_container' === $targetId) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -36,7 +36,11 @@ class ResolveReferencesToAliasesPass extends AbstractRecursivePass
             $this->currentId = $id;
 
             if ($aliasId !== $defId = $this->getDefinitionId($aliasId, $container)) {
-                $container->setAlias($id, $defId)->setPublic($alias->isPublic());
+                $newAlias = $container->setAlias($id, $defId)->setPublic($alias->isPublic());
+
+                if ($alias->isDeprecated()) {
+                    $newAlias->setDeprecated(...array_values($alias->getDeprecation('%alias_id%')));
+                }
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
@@ -62,6 +62,50 @@ class ReplaceAliasByActualDefinitionPassTest extends TestCase
         $this->process($container);
     }
 
+    public function testProcessDoesNotInvertAliasChainWithDeprecatedAlias()
+    {
+        $container = new ContainerBuilder();
+
+        // Original service (will be decorated)
+        $container->register('my_service', \stdClass::class);
+
+        // Private decorator that decorates the service
+        $container->register('my_decorator', \stdClass::class)
+            ->setDecoratedService('my_service')
+            ->setPublic(false);
+
+        // After DecoratorServicePass runs, we'll have:
+        // - my_service -> my_decorator (alias created by decorator)
+        // - my_decorator (the decorator definition, private)
+        // - my_decorator.inner (the original service)
+        //
+        // Simulate this state:
+        $container->removeDefinition('my_service');
+        $container->setAlias('my_service', 'my_decorator')->setPublic(true);
+
+        // Deprecated alias pointing to the original service ID
+        // After ResolveReferencesToAliasesPass, this would point to my_decorator
+        $container->setAlias('MyServiceInterface', 'my_decorator')
+            ->setPublic(true)
+            ->setDeprecated('my/package', '1.0', 'The "%alias_id%" alias is deprecated.');
+
+        // Now both aliases point to the same private definition:
+        // - my_service -> my_decorator (not deprecated)
+        // - MyServiceInterface -> my_decorator (deprecated)
+
+        $this->process($container);
+
+        // The non-deprecated alias (my_service) should be used for renaming,
+        // NOT the deprecated one (MyServiceInterface)
+        $this->assertTrue($container->hasDefinition('my_service'), 'my_service should be the definition, not an alias');
+        $this->assertFalse($container->hasAlias('my_service'), 'my_service should not be an alias');
+
+        // The deprecated alias should remain an alias pointing to my_service
+        $this->assertTrue($container->hasAlias('MyServiceInterface'), 'MyServiceInterface should be an alias');
+        $this->assertSame('my_service', (string) $container->getAlias('MyServiceInterface'));
+        $this->assertTrue($container->getAlias('MyServiceInterface')->isDeprecated());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ReplaceAliasByActualDefinitionPass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
@@ -165,6 +165,30 @@ class ResolveReferencesToAliasesPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testDeprecationIsPreservedWhenResolvingAliasChain()
+    {
+        $container = new ContainerBuilder();
+
+        // Create a chain: deprecated_alias -> intermediate_alias -> service
+        $container->register('service', 'stdClass');
+
+        $container->setAlias('intermediate_alias', 'service');
+
+        $deprecatedAlias = new Alias('intermediate_alias');
+        $deprecatedAlias->setPublic(true);
+        $deprecatedAlias->setDeprecated('my/package', '1.0', 'The "%alias_id%" alias is deprecated.');
+        $container->setAlias('deprecated_alias', $deprecatedAlias);
+
+        $this->process($container);
+
+        // After resolving, deprecated_alias should point directly to service
+        // but should still be deprecated
+        $resolvedAlias = $container->getAlias('deprecated_alias');
+        $this->assertSame('service', (string) $resolvedAlias);
+        $this->assertTrue($resolvedAlias->isDeprecated(), 'Deprecation should be preserved when resolving alias chain');
+        $this->assertSame('my/package', $resolvedAlias->getDeprecation('deprecated_alias')['package']);
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ResolveReferencesToAliasesPass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a service is decorated with a private decorator, and there is a deprecated alias pointing to the original service, the compiler passes could invert the alias chain. This caused the original service ID to become an alias pointing to the deprecated interface, triggering false deprecation warnings.

**Two issues fixed:**

1. `ResolveReferencesToAliasesPass` was not preserving the deprecation flag when resolving alias chains
2. `ReplaceAliasByActualDefinitionPass` used non-deterministic iteration order, allowing deprecated aliases to "win" when renaming definitions

**Example scenario:**
```yaml
services:
  my_service:
    class: App\MyService

  App\MyServiceInterface:
    alias: my_service
    deprecated:
      package: 'my/package'
      version: '1.0'

  App\MyServiceDecorator:
    decorates: my_service
    public: false
```

Before fix: `$container->get('my_service')` would trigger deprecation warning
After fix: Only `$container->get('App\MyServiceInterface')` triggers deprecation warning