### PR TITLE
[PropertyInfo] Fix resolution of self/parent types in inherited DocBlocks

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -43,7 +43,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     public const MUTATOR = 2;
 
     /**
-     * @var array<string, array{DocBlock|null, int|null, string|null}>
+     * @var array<string, array{DocBlock|null, int|null, string|null, string|null}>
      */
     private array $docBlocks = [];
 
@@ -213,7 +213,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     public function getType(string $class, string $property, array $context = []): ?Type
     {
         /** @var DocBlock $docBlock */
-        [$docBlock, $source, $prefix] = $this->findDocBlock($class, $property);
+        [$docBlock, $source, $prefix, $declaringClass] = $this->findDocBlock($class, $property);
         if (!$docBlock) {
             return null;
         }
@@ -225,7 +225,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         };
 
         $types = [];
-        $typeContext = $this->typeContextFactory->createFromClassName($class);
+        $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass ?? $class);
 
         /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
         foreach ($docBlock->getTagsByName($tag) as $tag) {
@@ -325,7 +325,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     }
 
     /**
-     * @return array{DocBlock|null, int|null, string|null}
+     * @return array{DocBlock|null, int|null, string|null, string|null}
      */
     private function findDocBlock(string $class, string $property): array
     {
@@ -345,30 +345,35 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         switch (true) {
             case $reflectionProperty?->isPromoted() && $docBlock = $this->getDocBlockFromConstructor($class, $property):
-                $data = [$docBlock, self::MUTATOR, null];
+                $data = [$docBlock, self::MUTATOR, null, $reflectionProperty->getDeclaringClass()->getName()];
                 break;
 
-            case $docBlock = $this->getDocBlockFromProperty($class, $property):
-                $data = [$docBlock, self::PROPERTY, null];
+            case [$docBlock, $declaringClass] = $this->getDocBlockFromProperty($class, $property):
+                $data = [$docBlock, self::PROPERTY, null, $declaringClass];
                 break;
 
-            case [$docBlock] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
-                $data = [$docBlock, self::ACCESSOR, null];
+            case [$docBlock, , $declaringClass] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
+                $data = [$docBlock, self::ACCESSOR, null, $declaringClass];
                 break;
 
-            case [$docBlock, $prefix] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
-                $data = [$docBlock, self::MUTATOR, $prefix];
+            case [$docBlock, $prefix, $declaringClass] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
+                $data = [$docBlock, self::MUTATOR, $prefix, $declaringClass];
                 break;
 
             default:
-                $data = [null, null, null];
+                $data = [null, null, null, null];
         }
 
         return $this->docBlocks[$propertyHash] = $data;
     }
 
-    private function getDocBlockFromProperty(string $class, string $property): ?DocBlock
+    /**
+     * @return array{DocBlock, string}|null
+     */
+    private function getDocBlockFromProperty(string $class, string $property, ?string $originalClass = null): ?array
     {
+        $originalClass ??= $class;
+
         // Use a ReflectionProperty instead of $class to get the parent class if applicable
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
@@ -380,22 +385,25 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         foreach ($reflector->getTraits() as $trait) {
             if ($trait->hasProperty($property)) {
-                return $this->getDocBlockFromProperty($trait->getName(), $property);
+                return $this->getDocBlockFromProperty($trait->getName(), $property, $reflector->isTrait() ? $originalClass : $reflector->getName());
             }
         }
 
         try {
-            return $this->docBlockFactory->create($reflectionProperty, $this->createFromReflector($reflector));
+            $declaringClass = $reflector->isTrait() ? $originalClass : $reflector->getName();
+
+            return [$this->docBlockFactory->create($reflectionProperty, $this->createFromReflector($reflector)), $declaringClass];
         } catch (\InvalidArgumentException|\RuntimeException) {
             return null;
         }
     }
 
     /**
-     * @return array{DocBlock, string}|null
+     * @return array{DocBlock, string, string}|null
      */
-    private function getDocBlockFromMethod(string $class, string $ucFirstProperty, int $type): ?array
+    private function getDocBlockFromMethod(string $class, string $ucFirstProperty, int $type, ?string $originalClass = null): ?array
     {
+        $originalClass ??= $class;
         $prefixes = self::ACCESSOR === $type ? $this->accessorPrefixes : $this->mutatorPrefixes;
         $prefix = null;
         $method = null;
@@ -432,12 +440,14 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         foreach ($reflector->getTraits() as $trait) {
             if ($trait->hasMethod($methodName)) {
-                return $this->getDocBlockFromMethod($trait->getName(), $ucFirstProperty, $type);
+                return $this->getDocBlockFromMethod($trait->getName(), $ucFirstProperty, $type, $reflector->isTrait() ? $originalClass : $reflector->getName());
             }
         }
 
         try {
-            return [$this->docBlockFactory->create($method, $this->createFromReflector($reflector)), $prefix];
+            $declaringClass = $reflector->isTrait() ? $originalClass : $reflector->getName();
+
+            return [$this->docBlockFactory->create($method, $this->createFromReflector($reflector)), $prefix, $declaringClass];
         } catch (\InvalidArgumentException|\RuntimeException) {
             return null;
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -21,6 +21,14 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyCollection;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildOfParentUsingTrait;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildOfParentWithPromotedSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildWithSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ClassUsingNestedTrait;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ClassUsingTraitWithSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentUsingTraitWithSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithPromotedSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithSelfDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\InvalidDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php80Dummy;
@@ -870,6 +878,39 @@ class PhpDocExtractorTest extends TestCase
     public function testPropertiesParentType(string $class, string $property, ?Type $type)
     {
         $this->assertEquals($type, $this->extractor->getType($class, $property));
+    }
+
+    /**
+     * @param class-string $class
+     * @param class-string $expectedResolvedClass
+     *
+     * @dataProvider selfDocBlockResolutionProvider
+     */
+    public function testSelfDocBlockResolvesToDeclaringClass(string $class, string $property, string $expectedResolvedClass)
+    {
+        $this->assertEquals(Type::object($expectedResolvedClass), $this->extractor->getType($class, $property));
+    }
+
+    /**
+     * @return iterable<string, array{0: class-string, 1: string, 2: class-string}>
+     */
+    public static function selfDocBlockResolutionProvider(): iterable
+    {
+        yield 'parent property' => [ParentWithSelfDocBlock::class, 'selfProp', ParentWithSelfDocBlock::class];
+        yield 'parent property from child' => [ChildWithSelfDocBlock::class, 'selfProp', ParentWithSelfDocBlock::class];
+        yield 'parent accessor' => [ParentWithSelfDocBlock::class, 'selfAccessor', ParentWithSelfDocBlock::class];
+        yield 'parent accessor from child' => [ChildWithSelfDocBlock::class, 'selfAccessor', ParentWithSelfDocBlock::class];
+        yield 'parent mutator' => [ParentWithSelfDocBlock::class, 'selfMutator', ParentWithSelfDocBlock::class];
+        yield 'parent mutator from child' => [ChildWithSelfDocBlock::class, 'selfMutator', ParentWithSelfDocBlock::class];
+        yield 'trait property' => [ClassUsingTraitWithSelfDocBlock::class, 'selfTraitProp', ClassUsingTraitWithSelfDocBlock::class];
+        yield 'trait accessor' => [ClassUsingTraitWithSelfDocBlock::class, 'selfTraitAccessor', ClassUsingTraitWithSelfDocBlock::class];
+        yield 'trait mutator' => [ClassUsingTraitWithSelfDocBlock::class, 'selfTraitMutator', ClassUsingTraitWithSelfDocBlock::class];
+        yield 'trait property from child' => [ChildOfParentUsingTrait::class, 'selfTraitProp', ParentUsingTraitWithSelfDocBlock::class];
+        yield 'trait accessor from child' => [ChildOfParentUsingTrait::class, 'selfTraitAccessor', ParentUsingTraitWithSelfDocBlock::class];
+        yield 'trait mutator from child' => [ChildOfParentUsingTrait::class, 'selfTraitMutator', ParentUsingTraitWithSelfDocBlock::class];
+        yield 'nested trait property' => [ClassUsingNestedTrait::class, 'innerSelfProp', ClassUsingNestedTrait::class];
+        yield 'promoted property' => [ParentWithPromotedSelfDocBlock::class, 'promotedSelfProp', ParentWithPromotedSelfDocBlock::class];
+        yield 'promoted property from child' => [ChildOfParentWithPromotedSelfDocBlock::class, 'promotedSelfProp', ParentWithPromotedSelfDocBlock::class];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/ParentWithSelfDocBlock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/ParentWithSelfDocBlock.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor;
+
+class ParentWithSelfDocBlock
+{
+    /**
+     * @var self
+     */
+    public $selfProp;
+
+    /**
+     * @return self
+     */
+    public function getSelfAccessor()
+    {
+        return $this;
+    }
+
+    /**
+     * @param self $value
+     */
+    public function setSelfMutator($value)
+    {
+    }
+}
+
+class ChildWithSelfDocBlock extends ParentWithSelfDocBlock
+{
+}
+
+trait TraitWithSelfDocBlock
+{
+    /**
+     * @var self
+     */
+    public $selfTraitProp;
+
+    /**
+     * @return self
+     */
+    public function getSelfTraitAccessor()
+    {
+        return $this;
+    }
+
+    /**
+     * @param self $value
+     */
+    public function setSelfTraitMutator($value)
+    {
+    }
+}
+
+class ClassUsingTraitWithSelfDocBlock
+{
+    use TraitWithSelfDocBlock;
+}
+
+class ParentUsingTraitWithSelfDocBlock
+{
+    use TraitWithSelfDocBlock;
+}
+
+class ChildOfParentUsingTrait extends ParentUsingTraitWithSelfDocBlock
+{
+}
+
+trait InnerTraitWithSelf
+{
+    /**
+     * @var self
+     */
+    public $innerSelfProp;
+}
+
+trait OuterTrait
+{
+    use InnerTraitWithSelf;
+}
+
+class ClassUsingNestedTrait
+{
+    use OuterTrait;
+}
+
+class ParentWithPromotedSelfDocBlock
+{
+    /**
+     * @param self $promotedSelfProp
+     */
+    public function __construct(
+        public $promotedSelfProp = null,
+    ) {
+    }
+}
+
+class ChildOfParentWithPromotedSelfDocBlock extends ParentWithPromotedSelfDocBlock
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PhpDocExtractor::getType()` resolves `self` and `parent` keywords against the class being analyzed, rather than the class declaring the property/method