### PR TITLE
[Cache] Update ext-redis version to 6.1 in upgrade notes

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -17,7 +17,7 @@ BrowserKit
 Cache
 -----
 
- * Bump ext-redis to 6.2 and ext-relay to 0.11 minimum
+ * Bump ext-redis to 6.1 and ext-relay to 0.11 minimum
 
 Config
 ------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

support for php-redis 6.1 was added back, but upgrade guide was never revised here: https://github.com/symfony/symfony/pull/62326

This fixes it so the changelog in the components matches up with the general upgrade guide
