### PR TITLE
[RateLimiter] Persist state when consuming negative tokens

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -79,7 +79,7 @@ final class FixedWindowLimiter implements LimiterInterface
                 $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
             }
 
-            if (0 < $tokens) {
+            if (0 !== $tokens) {
                 $this->storage->save($window);
             }
         } finally {

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -88,7 +88,7 @@ final class SlidingWindowLimiter implements LimiterInterface
                 $reservation = new Reservation($now + $waitDuration, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
             }
 
-            if (0 < $tokens) {
+            if (0 !== $tokens) {
                 $this->storage->save($window);
             }
         } finally {

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -103,7 +103,7 @@ final class TokenBucketLimiter implements LimiterInterface
                 $reservation = new Reservation($now + $waitDuration, new RateLimit(0, \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->maxBurst));
             }
 
-            if (0 < $tokens) {
+            if (0 !== $tokens) {
                 $this->storage->save($bucket);
             }
         } finally {

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -140,6 +140,19 @@ class FixedWindowLimiterTest extends TestCase
         );
     }
 
+    public function testNegativeConsume()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->consume(10);
+
+        for ($i = 1; $i <= 3; ++$i) {
+            $rateLimit = $limiter->consume(-1);
+            $this->assertEquals($i, $rateLimit->getRemainingTokens());
+            $this->assertTrue($rateLimit->isAccepted());
+        }
+    }
+
     public static function provideConsumeOutsideInterval(): \Generator
     {
         yield ['PT15S'];

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -110,6 +110,19 @@ class SlidingWindowLimiterTest extends TestCase
         );
     }
 
+    public function testNegativeConsume()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->consume(10);
+
+        for ($i = 1; $i <= 3; ++$i) {
+            $rateLimit = $limiter->consume(-1);
+            $this->assertEquals($i, $rateLimit->getRemainingTokens());
+            $this->assertTrue($rateLimit->isAccepted());
+        }
+    }
+
     private function createLimiter(): SlidingWindowLimiter
     {
         return new SlidingWindowLimiter('test', 10, new \DateInterval('PT12S'), $this->storage);

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -168,6 +168,19 @@ class TokenBucketLimiterTest extends TestCase
         );
     }
 
+    public function testNegativeConsume()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->consume(10);
+
+        for ($i = 1; $i <= 3; ++$i) {
+            $rateLimit = $limiter->consume(-1);
+            $this->assertEquals($i, $rateLimit->getRemainingTokens());
+            $this->assertTrue($rateLimit->isAccepted());
+        }
+    }
+
     public function testBucketRefilledWithStrictFrequency()
     {
         $limiter = $this->createLimiter(1000, new Rate(\DateInterval::createFromDateString('15 seconds'), 100));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes*
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63150
| License       | MIT

This PR fixes an issue where consuming negative tokens returns the correct `RateLimit` with increased remaining tokens, but the state is not persisted to storage.

The fix changes `0 < $tokens` to `0 !== $tokens` in the three limiter policies. This preserves the performance optimization from #46110 (avoiding storage writes when using `consume(0)` to check current state) while correctly handling negative values.

> [!NOTE]
> ∗ I'm not entirely sure whether this should be classified as a bug fix or a new feature. I've submitted it as a bug fix because the new behavior doesn't contradict existing documentation or test cases, and logically one would expect `consume()` to persist state regardless of the sign of the token amount.
>
> If you consider it a new feature instead, I'd be happy to update the PR's target branch and add updates to the `CHANGELOG` and docs.

### Example
```php
$factory = new RateLimiterFactory([
    'id' => 'test',
    'policy' => 'fixed_window',
    'limit' => 10,
    'interval' => '1 hour',
], new InMemoryStorage());

$limiter = $factory->create();
```

#### Before
```php
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(9) ✅
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(8) ✅
var_dump($limiter->consume(-1)->getRemainingTokens()); // int(9) ✅ (but not persisted!)
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(7) ❌
```

#### After
```php
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(9) ✅
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(8) ✅
var_dump($limiter->consume(-1)->getRemainingTokens()); // int(9) ✅ (persisted correctly)
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(8) ✅
```