### PR TITLE
[DependencyInjection] Add `target` parameter to `#[AsAlias]` attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsAlias.php
@@ -28,11 +28,13 @@ class AsAlias
      * @param string|null         $id     The id of the alias
      * @param bool                $public Whether to declare the alias public
      * @param string|list<string> $when   The environments under which the class will be registered as a service (i.e. "dev", "test", "prod")
+     * @param string|null         $target The name of the target to bind the alias to
      */
     public function __construct(
         public ?string $id = null,
         public bool $public = false,
         string|array $when = [],
+        public ?string $target = null,
     ) {
         $this->when = (array) $when;
     }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
  * Allow environment variables with `.` in them
  * Add argument `exclude` to `ContainerConfigurator::import()`
+ * Add `target` parameter to `#[AsAlias]` to create target-specific autowiring aliases
 
 8.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -44,6 +44,8 @@ abstract class FileLoader extends BaseFileLoader
     protected array $singlyImplemented = [];
     /** @var array<string, Alias> */
     protected array $aliases = [];
+    /** @var array<string, string> */
+    protected array $aliasedTargets = [];
     protected bool $autoRegisterAliasesForSinglyImplementedInterfaces = true;
     protected array $extensionConfigs = [];
     protected int $importing = 0;
@@ -229,13 +231,26 @@ abstract class FileLoader extends BaseFileLoader
                     throw new LogicException(\sprintf('Alias cannot be automatically determined for class "%s". If you have used the #[AsAlias] attribute with a class implementing multiple interfaces, add the interface you want to alias to the first parameter of #[AsAlias].', $class));
                 }
 
-                if (!$attribute->when || \in_array($this->env, $attribute->when, true)) {
+                if ($attribute->when && !\in_array($this->env, $attribute->when, true)) {
+                    continue;
+                }
+                if (!$attribute->target) {
                     if (isset($this->aliases[$alias])) {
                         throw new LogicException(\sprintf('The "%s" alias has already been defined with the #[AsAlias] attribute in "%s".', $alias, $this->aliases[$alias]));
                     }
 
                     $this->aliases[$alias] = new Alias($class, $public);
+                    continue;
                 }
+                if ($public) {
+                    throw new LogicException(\sprintf('#[AsAlias] attributes with a target cannot be public in "%s".', $class));
+                }
+                $this->container->registerAliasForArgument($class, $alias, $attribute->target);
+                $alias = array_key_last($this->container->getAliases());
+                if (isset($this->aliasedTargets[$alias])) {
+                    throw new LogicException(\sprintf('The "%s" alias has already been defined with the #[AsAlias] attribute in "%s".', $alias, $class));
+                }
+                $this->aliasedTargets[$alias] = $class;
             }
         }
 
@@ -256,7 +271,7 @@ abstract class FileLoader extends BaseFileLoader
             }
         }
 
-        $this->interfaces = $this->singlyImplemented = $this->aliases = [];
+        $this->interfaces = $this->singlyImplemented = $this->aliases = $this->aliasedTargets = [];
     }
 
     final protected function loadExtensionConfig(string $namespace, array $config, string $file = '?'): void

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasTargetOne.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasTargetOne.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(AliasFooInterface::class, target: 'one')]
+final class WithAsAliasTargetOne implements AliasFooInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasTargetTwo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAsAlias/WithAsAliasTargetTwo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(AliasFooInterface::class, target: 'two')]
+final class WithAsAliasTargetTwo implements AliasFooInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -45,6 +45,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAs
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasMultiple;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasProdEnv;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasTargetOne;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasTargetTwo;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithCustomAsAlias;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
 
@@ -427,6 +429,22 @@ class FileLoaderTest extends TestCase
             'Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\\',
             'PrototypeAsAlias/{WithAsAliasMultipleInterface,AliasBarInterface,AliasFooInterface}.php'
         );
+    }
+
+    public function testRegisterClassesWithAsAliasTarget()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured(true),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\\',
+            'PrototypeAsAlias/{WithAsAliasTargetOne,WithAsAliasTargetTwo,AliasFooInterface}.php'
+        );
+        // Verify target-specific aliases are created
+        $this->assertTrue($container->hasAlias(AliasFooInterface::class.' $one'));
+        $this->assertTrue($container->hasAlias(AliasFooInterface::class.' $two'));
+        $this->assertSame(WithAsAliasTargetOne::class, (string) $container->getAlias(AliasFooInterface::class.' $one'));
+        $this->assertSame(WithAsAliasTargetTwo::class, (string) $container->getAlias(AliasFooInterface::class.' $two'));
     }
 
     public function testRegisterClassesWithStaticConstructor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60158
| License       | MIT

this PR extends `#[AsAlias]` to make the usable with `#[Target]`

```php
#[AsAlias(MyInterface::class, target: 'one')]
class One implements MyInterface {}
```