### PR TITLE
[Console] Allow object as default for input options and arguments

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -21,7 +21,7 @@ use Symfony\Component\String\UnicodeString;
 #[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 class Argument
 {
-    public string|bool|int|float|array|null $default = null;
+    public mixed $default = null;
     public array|\Closure $suggestedValues;
 
     /**

--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -22,7 +22,7 @@ use Symfony\Component\String\UnicodeString;
 class Option
 {
     public const ALLOWED_UNION_TYPES = ['bool|string', 'bool|int', 'bool|float'];
-    public string|bool|int|float|array|null $default = null;
+    public mixed $default = null;
     public array|\Closure $suggestedValues;
 
     /**

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support for method-based commands with `#[AsCommand]` attribute
  * Add argument resolver support
  * Add `BackedEnum` and `DateTimeInterface` support to `#[MapInput]`
+ * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -41,13 +41,13 @@ class InputArgument
     public const IS_ARRAY = 4;
 
     private int $mode;
-    private string|int|bool|array|float|null $default;
+    private mixed $default;
 
     /**
      * @param string                                                                        $name            The argument name
      * @param int-mask-of<InputArgument::*>|null                                            $mode            The argument mode: a bit mask of self::REQUIRED, self::OPTIONAL and self::IS_ARRAY
      * @param string                                                                        $description     A description text
-     * @param string|bool|int|float|array|null                                              $default         The default value (for self::OPTIONAL mode only)
+     * @param mixed                                                                         $default         The default value (for self::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @throws InvalidArgumentException When argument mode is not valid
@@ -56,7 +56,7 @@ class InputArgument
         private string $name,
         ?int $mode = null,
         private string $description = '',
-        string|bool|int|float|array|null $default = null,
+        mixed $default = null,
         private \Closure|array $suggestedValues = [],
     ) {
         if (null === $mode) {
@@ -101,7 +101,7 @@ class InputArgument
     /**
      * Sets the default value.
      */
-    public function setDefault(string|bool|int|float|array|null $default): void
+    public function setDefault(mixed $default): void
     {
         if ($this->isRequired() && null !== $default) {
             throw new LogicException('Cannot set a default value except for InputArgument::OPTIONAL mode.');
@@ -121,7 +121,7 @@ class InputArgument
     /**
      * Returns the default value.
      */
-    public function getDefault(): string|bool|int|float|array|null
+    public function getDefault(): mixed
     {
         return $this->default;
     }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -53,12 +53,12 @@ class InputOption
     private string $name;
     private ?string $shortcut;
     private int $mode;
-    private string|int|bool|array|float|null $default;
+    private mixed $default;
 
     /**
      * @param string|array|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param int-mask-of<InputOption::*>|null                                              $mode            The option mode: One of the VALUE_* constants
-     * @param string|bool|int|float|array|null                                              $default         The default value (must be null for self::VALUE_NONE)
+     * @param mixed                                                                         $default         The default value (must be null for self::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
@@ -68,7 +68,7 @@ class InputOption
         string|array|null $shortcut = null,
         ?int $mode = null,
         private string $description = '',
-        string|bool|int|float|array|null $default = null,
+        mixed $default = null,
         private array|\Closure $suggestedValues = [],
     ) {
         if (str_starts_with($name, '--')) {
@@ -188,7 +188,7 @@ class InputOption
     /**
      * Sets the default value.
      */
-    public function setDefault(string|bool|int|float|array|null $default): void
+    public function setDefault(mixed $default): void
     {
         if (self::VALUE_NONE === (self::VALUE_NONE & $this->mode) && null !== $default) {
             throw new LogicException('Cannot set a default value when using InputOption::VALUE_NONE mode.');
@@ -208,7 +208,7 @@ class InputOption
     /**
      * Returns the default value.
      */
-    public function getDefault(): string|bool|int|float|array|null
+    public function getDefault(): mixed
     {
         return $this->default;
     }

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -84,6 +84,17 @@ class InputArgumentTest extends TestCase
         $this->assertSame([1, 2], $argument->getDefault(), '->setDefault() changes the default value');
     }
 
+    public function testSetDefaultWithObject()
+    {
+        $default = new \DateTimeImmutable('2024-01-01');
+        $argument = new InputArgument('foo', InputArgument::OPTIONAL, '', $default);
+        $this->assertSame($default, $argument->getDefault(), '->getDefault() returns the object default value');
+
+        $newDefault = new \DateTimeImmutable('2024-06-01');
+        $argument->setDefault($newDefault);
+        $this->assertSame($newDefault, $argument->getDefault(), '->setDefault() changes the default value to an object');
+    }
+
     public function testSetDefaultWithRequiredArgument()
     {
         $argument = new InputArgument('foo', InputArgument::REQUIRED);

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -174,6 +174,17 @@ class InputOptionTest extends TestCase
         $this->assertSame([1, 2], $option->getDefault(), '->setDefault() changes the default value');
     }
 
+    public function testSetDefaultWithObject()
+    {
+        $default = new \DateTimeImmutable('2024-01-01');
+        $option = new InputOption('foo', null, InputOption::VALUE_REQUIRED, '', $default);
+        $this->assertSame($default, $option->getDefault(), '->getDefault() returns the object default value');
+
+        $newDefault = new \DateTimeImmutable('2024-06-01');
+        $option->setDefault($newDefault);
+        $this->assertSame($newDefault, $option->getDefault(), '->setDefault() changes the default value to an object');
+    }
+
     public function testDefaultValueWithValueNoneMode()
     {
         $option = new InputOption('foo', 'f', InputOption::VALUE_NONE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

With the argument resolver added in #62917 Console commands can take objects as input options/arguments values, but the `$default` property of both classes doesn't allow objects for now. Therefore, this fails:

```php
#[AsCommand('foo')]
class Foo
{
    public function __invoke(
        SymfonyStyle $io,
        #[Argument] string $bar,
        #[Option] \DateTimeImmutable $from = new \DateTimeImmutable(),
    )
    {
        $io->info('Doing '.$bar.' stuff from '.$from->format('Y-m-d H:i:s'));

        return 0;
    }
} 
```

> PHP Fatal error:  Uncaught TypeError: Cannot assign DateTimeImmutable to property Symfony\Component\Console\Attribute\Option::$default of type array|string|int|float|bool|null in /Users/robinchalas/Workspace/tests/cli-arg-resolver-standalone/vendor/symfony/console/Attribute/Option.php:83

Note that options must have a default value using modern ("invokable'") commands so there's no relevant way to work around the issue in userland. This is a minor BC break, we did it when adding those type declarations and I can't think of a BC layer that makes sense. I never encountered a class extending `InputOption` or `InputArgument` so far though, those could probably be final and the BC impact of this should be quite low.

Fabbot report is false positives only.