### PR TITLE
 [Serializer] Apply `#[Ignore]` to the right metadata

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -134,6 +134,7 @@ class AttributeLoader implements LoaderInterface
             $attributeName = $this->getAttributeNameFromAccessor($reflectionClass, $method, true);
             $accessorOrMutator = null !== $attributeName;
             $hasProperty = $this->hasPropertyForAccessor($method->getDeclaringClass(), $name);
+            $attributeMetadata = null;
 
             if ($hasProperty || $accessorOrMutator) {
                 if (null === $attributeName || 's' !== $name[0] && $hasProperty && $this->hasAttributeNameCollision($reflectionClass, $attributeName, $name)) {
@@ -150,7 +151,7 @@ class AttributeLoader implements LoaderInterface
 
             foreach ($this->loadAttributes($method) as $annotation) {
                 if ($annotation instanceof Groups) {
-                    if (!$accessorOrMutator && !$hasProperty) {
+                    if (!$attributeMetadata) {
                         throw new MappingException(\sprintf('Groups on "%s::%s()" cannot be added. Groups can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
@@ -158,27 +159,29 @@ class AttributeLoader implements LoaderInterface
                         $attributeMetadata->addGroup($group);
                     }
                 } elseif ($annotation instanceof MaxDepth) {
-                    if (!$accessorOrMutator && !$hasProperty) {
+                    if (!$attributeMetadata) {
                         throw new MappingException(\sprintf('MaxDepth on "%s::%s()" cannot be added. MaxDepth can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
                     $attributeMetadata->setMaxDepth($annotation->getMaxDepth());
                 } elseif ($annotation instanceof SerializedName) {
-                    if (!$accessorOrMutator && !$hasProperty) {
+                    if (!$attributeMetadata) {
                         throw new MappingException(\sprintf('SerializedName on "%s::%s()" cannot be added. SerializedName can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
                     $attributeMetadata->setSerializedName($annotation->getSerializedName());
                 } elseif ($annotation instanceof SerializedPath) {
-                    if (!$accessorOrMutator && !$hasProperty) {
+                    if (!$attributeMetadata) {
                         throw new MappingException(\sprintf('SerializedPath on "%s::%s()" cannot be added. SerializedPath can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 
                     $attributeMetadata->setSerializedPath($annotation->getSerializedPath());
                 } elseif ($annotation instanceof Ignore) {
-                    $attributeMetadata->setIgnore(true);
+                    if ($attributeMetadata) {
+                        $attributeMetadata->setIgnore(true);
+                    }
                 } elseif ($annotation instanceof Context) {
-                    if (!$accessorOrMutator && !$hasProperty) {
+                    if (!$attributeMetadata) {
                         throw new MappingException(\sprintf('Context on "%s::%s()" cannot be added. Context can only be added on methods beginning with "get", "is", "has", "can" or "set".', $className, $method->name));
                     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1343,6 +1343,15 @@ class ObjectNormalizerTest extends TestCase
         $this->assertArrayNotHasKey('neverProperty', $normalized);
         $this->assertEquals('value', $normalized['normalProperty']);
     }
+
+    public function testMetadataIsAppliedToTheRightValue()
+    {
+        $obj = new ObjectWithMetadata();
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+        $normalized = $normalizer->normalize($obj);
+
+        $this->assertSame(['name' => 'John', 'foo' => 42, 'hello' => 'Hello i am John'], $normalized);
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy
@@ -1981,5 +1990,38 @@ class NameConverterTestDummyMultiple
         public readonly int $someCamelCaseProperty = 0,
         public readonly int $anotherProperty = 0,
     ) {
+    }
+}
+
+class ObjectWithMetadata
+{
+    private int $foo;
+    private string $name;
+
+    public function __construct()
+    {
+        $this->foo = 42;
+        $this->name = 'John';
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getFoo(): int
+    {
+        return $this->foo;
+    }
+
+    #[Ignore]
+    public function isEqualTo(self $test): bool
+    {
+        return $this->name === $test->getName();
+    }
+
+    public function getHello(): string
+    {
+        return 'Hello i am '.$this->getName();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63187
| License       | MIT

See https://github.com/symfony/symfony/issues/63187#issuecomment-3798419273

This could be solve with a 
```
if ($accessorOrMutator || $hasProperty) {
```
condition in the Ignore section, but I feel like this way is more bugproof in the futur

cc @nicolas-grekas 