### PR TITLE
[Finder] Fix appending empty iterators

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -681,7 +681,7 @@ class Finder implements \IteratorAggregate, \Countable
             }
 
             foreach ($this->iterators as $it) {
-                $iterator->append((static function () use ($it) {
+                $iterator->append(new \IteratorIterator(new LazyIterator(static function () use ($it) {
                     foreach ($it as $file) {
                         if (!$file instanceof \SplFileInfo) {
                             $file = new \SplFileInfo($file);
@@ -693,7 +693,7 @@ class Finder implements \IteratorAggregate, \Countable
 
                         yield $key => $file;
                     }
-                })());
+                })));
             }
         }
 

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1417,6 +1417,13 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertInstanceOf(Finder::class, Finder::create()->append([]));
     }
 
+    public function testAppendEmptyIterableAllowsIteration()
+    {
+        $finder = Finder::create()->files()->name('*.php')->append([]);
+
+        $this->assertSame([], iterator_to_array($finder->getIterator()));
+    }
+
     public function testAppendDoesNotRequireIn()
     {
         $finder = $this->buildFinder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63188
| License       | MIT
