### PR TITLE
[PropertyInfo] Conflict with phpdocumentor/reflection-docblock >= 6 (branch 6.4 only)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -172,7 +172,7 @@
         "doctrine/orm": "<2.15",
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",
-        "phpdocumentor/reflection-docblock": "<5.2",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
         "phpdocumentor/type-resolver": "<1.5.1",
         "phpunit/phpunit": "<7.5|9.1.2"
     },

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -36,7 +36,7 @@
     },
     "conflict": {
         "doctrine/annotations": "<1.12",
-        "phpdocumentor/reflection-docblock": "<5.2",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
         "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/dependency-injection": "<5.4|>=6.0,<6.4",
         "symfony/cache": "<5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63179
| License       | MIT
