### PR TITLE
 PHP CS Fixer: enable `@PHP8x1Migration:risky`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -31,6 +31,7 @@ return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@PHP8x1Migration' => true, // take lowest version from `git grep -h '"php"' **/composer.json | uniq | sort`
+        '@PHP8x1Migration:risky' => true,
         '@PHPUnit9x1Migration:risky' => true, // take version from src/Symfony/Bridge/PhpUnit/phpunit.xml.dist#L4
         '@Symfony' => true,
         '@Symfony:risky' => true,
@@ -44,15 +45,9 @@ return (new PhpCsFixer\Config())
                 '/s',
             ]),
         ],
+        'declare_strict_types' => false, // part of PHP?x?Migration:risky, awaits https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9384
         'php_unit_attributes' => true,
-        'random_api_migration' => [ // PHP migration awaits
-            'replacements' => [
-                'mt_getrandmax' => 'getrandmax',
-                'mt_rand' => 'random_int',
-                'mt_srand' => 'srand',
-                'rand' => 'random_int',
-            ],
-        ],
+        'void_return' => false, // part of PHP?x?Migration:risky, usage to be concluded
     ])
     ->setRuleCustomisationPolicy(new class implements PhpCsFixer\Config\RuleCustomisationPolicyInterface {
         public function getPolicyVersionForCache(): string

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -211,14 +211,10 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
 
         if ($withExpectations) {
             $registry->expects($this->any())->method('getManagerNames')->willReturn(array_combine(array_keys($managers), array_keys($managers)));
-            $registry->expects($this->any())->method('getManager')->willReturnCallback(static function (?string $name) use ($managers, $defaultName): ?EntityManagerInterface {
-                return $managers[$name ?? $defaultName] ?? null;
-            });
+            $registry->expects($this->any())->method('getManager')->willReturnCallback(static fn (?string $name): ?EntityManagerInterface => $managers[$name ?? $defaultName] ?? null);
         } else {
             $registry->method('getManagerNames')->willReturn(array_combine(array_keys($managers), array_keys($managers)));
-            $registry->method('getManager')->willReturnCallback(static function (?string $name) use ($managers, $defaultName): ?EntityManagerInterface {
-                return $managers[$name ?? $defaultName] ?? null;
-            });
+            $registry->method('getManager')->willReturnCallback(static fn (?string $name): ?EntityManagerInterface => $managers[$name ?? $defaultName] ?? null);
         }
 
         return $registry;

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -302,9 +302,7 @@ class DeprecationErrorHandler
      */
     private function displayDeprecations(array $groups, Configuration $configuration): void
     {
-        $cmp = static function ($a, $b) {
-            return $b->count() - $a->count();
-        };
+        $cmp = static fn ($a, $b) => $b->count() - $a->count();
 
         if ($configuration->shouldWriteToLogFile()) {
             if (false === $handle = @fopen($file = $configuration->getLogFile(), 'a')) {
@@ -398,7 +396,7 @@ class DeprecationErrorHandler
             }
         }
 
-        return static function () { return false; };
+        return static fn () => false;
     }
 
     /**

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -218,9 +218,7 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
         'requires' => ['php' => '*'],
     ];
 
-    $stableVersions = array_filter($info['versions'], static function ($v) {
-        return !preg_match('/-dev$|^dev-/', $v);
-    });
+    $stableVersions = array_filter($info['versions'], static fn ($v) => !preg_match('/-dev$|^dev-/', $v));
 
     if (!$stableVersions) {
         $passthruOrFail("$COMPOSER create-project --ignore-platform-reqs --no-install --prefer-dist --no-scripts --no-plugins --no-progress -s dev phpunit/phpunit $PHPUNIT_VERSION_DIR \"$PHPUNIT_VERSION.*\"");

--- a/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Factory/HttpFoundationFactory.php
@@ -96,7 +96,7 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
      */
     private function createUploadedFile(UploadedFileInterface $psrUploadedFile): UploadedFile
     {
-        return new UploadedFile($psrUploadedFile, function () { return $this->getTemporaryPath(); });
+        return new UploadedFile($psrUploadedFile, fn () => $this->getTemporaryPath());
     }
 
     /**

--- a/src/Symfony/Bridge/PsrHttpMessage/Tests/Functional/CovertTest.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Tests/Functional/CovertTest.php
@@ -145,9 +145,7 @@ class CovertTest extends TestCase
 
         return array_merge([
             [$sfRequest, $psr17Factory, $symfonyFactory],
-        ], array_map(static function ($psr7Request) use ($symfonyFactory, $psr17Factory) {
-            return [$psr7Request, $symfonyFactory, $psr17Factory];
-        }, $psr7Requests));
+        ], array_map(static fn ($psr7Request) => [$psr7Request, $symfonyFactory, $psr17Factory], $psr7Requests));
     }
 
     #[DataProvider('responseProvider')]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
@@ -100,9 +100,7 @@ class FormExtensionFieldHelpersTest extends FormIntegrationTestCase
                     'yes',
                     'no',
                 ],
-                'choice_label' => static function (string $choice) {
-                    return new TranslatableMessage('parametrized.%value%', ['%value%' => $choice], 'forms');
-                },
+                'choice_label' => static fn (string $choice) => new TranslatableMessage('parametrized.%value%', ['%value%' => $choice], 'forms'),
             ])
             ->getForm()
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -848,21 +848,15 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->validate()
-                        ->ifTrue(static function ($v) {
-                            return isset($v['version_strategy']) && isset($v['version']);
-                        })
+                        ->ifTrue(static fn ($v) => isset($v['version_strategy']) && isset($v['version']))
                         ->thenInvalid('You cannot use both "version_strategy" and "version" at the same time under "assets".')
                     ->end()
                     ->validate()
-                        ->ifTrue(static function ($v) {
-                            return isset($v['version_strategy']) && isset($v['json_manifest_path']);
-                        })
+                        ->ifTrue(static fn ($v) => isset($v['version_strategy']) && isset($v['json_manifest_path']))
                         ->thenInvalid('You cannot use both "version_strategy" and "json_manifest_path" at the same time under "assets".')
                     ->end()
                     ->validate()
-                        ->ifTrue(static function ($v) {
-                            return isset($v['version']) && isset($v['json_manifest_path']);
-                        })
+                        ->ifTrue(static fn ($v) => isset($v['version']) && isset($v['json_manifest_path']))
                         ->thenInvalid('You cannot use both "version" and "json_manifest_path" at the same time under "assets".')
                     ->end()
                     ->children()
@@ -892,21 +886,15 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                                 ->validate()
-                                    ->ifTrue(static function ($v) {
-                                        return isset($v['version_strategy']) && isset($v['version']);
-                                    })
+                                    ->ifTrue(static fn ($v) => isset($v['version_strategy']) && isset($v['version']))
                                     ->thenInvalid('You cannot use both "version_strategy" and "version" at the same time under "assets" packages.')
                                 ->end()
                                 ->validate()
-                                    ->ifTrue(static function ($v) {
-                                        return isset($v['version_strategy']) && isset($v['json_manifest_path']);
-                                    })
+                                    ->ifTrue(static fn ($v) => isset($v['version_strategy']) && isset($v['json_manifest_path']))
                                     ->thenInvalid('You cannot use both "version_strategy" and "json_manifest_path" at the same time under "assets" packages.')
                                 ->end()
                                 ->validate()
-                                    ->ifTrue(static function ($v) {
-                                        return isset($v['version']) && isset($v['json_manifest_path']);
-                                    })
+                                    ->ifTrue(static fn ($v) => isset($v['version']) && isset($v['json_manifest_path']))
                                     ->thenInvalid('You cannot use both "version" and "json_manifest_path" at the same time under "assets" packages.')
                                 ->end()
                             ->end()
@@ -1685,9 +1673,7 @@ class Configuration implements ConfigurationInterface
                                             ];
                                         } else {
                                             $newConfig[$v['message-class']]['senders'] = array_map(
-                                                static function ($a) {
-                                                    return \is_string($a) ? $a : $a['service'];
-                                                },
+                                                static fn ($a) => \is_string($a) ? $a : $a['service'],
                                                 array_values($v['sender'])
                                             );
                                         }
@@ -2423,9 +2409,7 @@ class Configuration implements ConfigurationInterface
                                         })
                                     ->end()
                                     ->validate()
-                                        ->ifTrue(static function ($v) {
-                                            return \extension_loaded('openssl') && null !== $v && !\defined('OPENSSL_CIPHER_'.$v);
-                                        })
+                                        ->ifTrue(static fn ($v) => \extension_loaded('openssl') && null !== $v && !\defined('OPENSSL_CIPHER_'.$v))
                                         ->thenInvalid('You must provide a valid cipher.')
                                     ->end()
                                 ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -284,9 +284,7 @@ class SecurityDataCollectorTest extends TestCase
 
         $this->assertEquals($actualDecisionLog, $expectedDecisionLog, 'Wrong value returned by getAccessDecisionLog');
 
-        $actualVoterClasses = array_map(static function (ClassStub $classStub): string {
-            return (string) $classStub;
-        }, $dataCollector->getVoters());
+        $actualVoterClasses = array_map(static fn (ClassStub $classStub): string => (string) $classStub, $dataCollector->getVoters());
 
         $expectedVoterClasses = [
             $voter1::class,
@@ -385,9 +383,7 @@ class SecurityDataCollectorTest extends TestCase
 
         $this->assertEquals($actualDecisionLog, $expectedDecisionLog, 'Wrong value returned by getAccessDecisionLog');
 
-        $actualVoterClasses = array_map(static function (ClassStub $classStub): string {
-            return (string) $classStub;
-        }, $dataCollector->getVoters());
+        $actualVoterClasses = array_map(static fn (ClassStub $classStub): string => (string) $classStub, $dataCollector->getVoters());
 
         $expectedVoterClasses = [
             $voter1::class,

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/RouterControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/RouterControllerTest.php
@@ -39,9 +39,7 @@ class RouterControllerTest extends WebTestCase
 
         $matchedRouteCell = $crawler
             ->filter('#router-logs .status-success td')
-            ->reduce(static function (Crawler $td) use ($path): bool {
-                return $td->text() === $path;
-            });
+            ->reduce(static fn (Crawler $td): bool => $td->text() === $path);
 
         $this->assertSame(1, $matchedRouteCell->count());
     }

--- a/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/DebugAssetMapperCommand.php
@@ -102,9 +102,7 @@ final class DebugAssetMapperCommand extends Command
                 }
                 $pathRows[] = [$path, $namespace];
             }
-            uasort($pathRows, static function (array $a, array $b): int {
-                return [(bool) $a[1], ...$a] <=> [(bool) $b[1], ...$b];
-            });
+            uasort($pathRows, static fn (array $a, array $b): int => [(bool) $a[1], ...$a] <=> [(bool) $b[1], ...$b]);
             if ($pathRows) {
                 $io->table(['Path', 'Namespace prefix'], $pathRows);
             } else {
@@ -121,9 +119,7 @@ final class DebugAssetMapperCommand extends Command
                     $this->shortenPath($row[1]),
                 ], $rows);
             }
-            uasort($rows, static function (array $a, array $b): int {
-                return [$a] <=> [$b];
-            });
+            uasort($rows, static fn (array $a, array $b): int => [$a] <=> [$b]);
             $io->table(['Logical Path', 'Filesystem Path'], $rows);
             if ($this->didShortenPaths) {
                 $io->note('To see the full paths, re-run with the --full option.');

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -165,9 +165,7 @@ class MappedAssetFactoryTest extends TestCase
         $pathResolver = $this->createStub(PublicAssetsPathResolverInterface::class);
         $pathResolver
             ->method('resolvePublicPath')
-            ->willReturnCallback(static function (string $logicalPath) {
-                return '/final-assets/'.$logicalPath;
-            });
+            ->willReturnCallback(static fn (string $logicalPath) => '/final-assets/'.$logicalPath);
 
         $factory = new MappedAssetFactory(
             $pathResolver,

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -66,9 +66,7 @@ class ImportMapConfigReaderTest extends TestCase
         $remotePackageStorage = $this->createStub(RemotePackageStorage::class);
         $remotePackageStorage
             ->method('getDownloadPath')
-            ->willReturnCallback(static function (string $packageModuleSpecifier, ImportMapType $type) {
-                return '/path/to/vendor/'.$packageModuleSpecifier.'.'.$type->value;
-            });
+            ->willReturnCallback(static fn (string $packageModuleSpecifier, ImportMapType $type) => '/path/to/vendor/'.$packageModuleSpecifier.'.'.$type->value);
         $reader = new ImportMapConfigReader(
             __DIR__.'/../Fixtures/importmap_config_reader/importmap.php',
             $remotePackageStorage,

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -125,9 +125,7 @@ class ImportMapManagerTest extends TestCase
 
         $this->packageResolver->expects($this->exactly(0 === $expectedProviderPackageArgumentCount ? 0 : 1))
             ->method('resolvePackages')
-            ->with($this->callback(static function (array $packages) use ($expectedProviderPackageArgumentCount) {
-                return \count($packages) === $expectedProviderPackageArgumentCount;
-            }))
+            ->with($this->callback(static fn (array $packages) => \count($packages) === $expectedProviderPackageArgumentCount))
             ->willReturn($resolvedPackages)
         ;
 

--- a/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
@@ -39,9 +39,7 @@ class MapperAwareAssetPackageTest extends TestCase
         $inner->expects($this->once())
             ->method('getUrl')
             ->with($expectedPathSentToInner)
-            ->willReturnCallback(static function ($path) {
-                return '/'.$path;
-            });
+            ->willReturnCallback(static fn ($path) => '/'.$path);
         $assetMapper = $this->createStub(AssetMapperInterface::class);
         $assetMapper
             ->method('getPublicPath')

--- a/src/Symfony/Component/Console/Attribute/Ask.php
+++ b/src/Symfony/Component/Console/Attribute/Ask.php
@@ -95,9 +95,7 @@ class Ask implements InteractiveAttributeInterface
             $question->setTimeout($self->timeout);
 
             if (!$self->validator && $reflection->isProperty() && 'array' !== $type->getName()) {
-                $self->validator = function (mixed $value) use ($reflection): mixed {
-                    return $this->{$reflection->getName()} = $value;
-                };
+                $self->validator = fn (mixed $value): mixed => $this->{$reflection->getName()} = $value;
             }
 
             $question->setValidator($self->validator);

--- a/src/Symfony/Component/Console/Attribute/AskChoice.php
+++ b/src/Symfony/Component/Console/Attribute/AskChoice.php
@@ -96,9 +96,7 @@ class AskChoice implements InteractiveAttributeInterface
             $question->setMaxAttempts($self->maxAttempts);
 
             if (!$self->validator && $reflection->isProperty() && !$isBackedEnum && 'array' !== $type->getName()) {
-                $self->validator = function (mixed $value) use ($reflection): mixed {
-                    return $this->{$reflection->getName()} = $value;
-                };
+                $self->validator = fn (mixed $value): mixed => $this->{$reflection->getName()} = $value;
             }
 
             if ($self->validator) {

--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -63,9 +63,7 @@ final class TraceableCommand extends Command
         parent::__construct($command->getName());
 
         // init below enables calling {@see parent::run()}
-        [$code, $processTitle, $ignoreValidationErrors] = \Closure::bind(function () {
-            return [$this->code, $this->processTitle, $this->ignoreValidationErrors];
-        }, $command, Command::class)();
+        [$code, $processTitle, $ignoreValidationErrors] = \Closure::bind(fn () => [$this->code, $this->processTitle, $this->ignoreValidationErrors], $command, Command::class)();
 
         if (\is_callable($code)) {
             $this->setCode($code);
@@ -169,9 +167,7 @@ final class TraceableCommand extends Command
     public function setCode(callable $code): static
     {
         if ($code instanceof InvokableCommand) {
-            $r = \Closure::bind(function () {
-                return $this->invokable;
-            }, $code, InvokableCommand::class)();
+            $r = \Closure::bind(fn () => $this->invokable, $code, InvokableCommand::class)();
 
             $this->invokableCommandInfo = [
                 'class' => $r->getClosureScopeClass()->name,

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1324,9 +1324,7 @@ class ApplicationTest extends TestCase
             ->register('foo')
             ->setAliases(['f'])
             ->setDefinition([new InputOption('survey', 'e', InputOption::VALUE_REQUIRED, 'My option with a shortcut.')])
-            ->setCode(static function (InputInterface $input, OutputInterface $output): int {
-                return 0;
-            })
+            ->setCode(static fn (InputInterface $input, OutputInterface $output): int => 0)
         ;
 
         $input = new ArrayInput(['command' => 'foo']);
@@ -1347,9 +1345,7 @@ class ApplicationTest extends TestCase
         $application
             ->register('foo')
             ->setDefinition([$def])
-            ->setCode(static function (InputInterface $input, OutputInterface $output): int {
-                return 0;
-            })
+            ->setCode(static fn (InputInterface $input, OutputInterface $output): int => 0)
         ;
 
         $input = new ArrayInput(['command' => 'foo']);
@@ -1946,12 +1942,12 @@ class ApplicationTest extends TestCase
             'foo:bar' => static function () use (&$loaded) {
                 $loaded['foo:bar'] = true;
 
-                return (new Command('foo:bar'))->setCode(static function (): int { return 0; });
+                return (new Command('foo:bar'))->setCode(static fn (): int => 0);
             },
             'foo' => static function () use (&$loaded) {
                 $loaded['foo'] = true;
 
-                return (new Command('foo'))->setCode(static function (): int { return 0; });
+                return (new Command('foo'))->setCode(static fn (): int => 0);
             },
         ]));
 

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -632,12 +632,10 @@ class CommandTesterTest extends TestCase
         $this->expectExceptionMessage('requires either explicit choices or a BackedEnum type');
 
         $command = new Command('foo');
-        $command->setCode(static function (
+        $command->setCode(static fn (
             #[Argument, AskChoice('Select a color')]
             string $color,
-        ): int {
-            return 0;
-        });
+        ): int => 0);
 
         $command->getDefinition();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -425,9 +425,7 @@ class ContainerTest extends TestCase
         $container = new Container();
         $container->setParameter('env(FOO)', null);
         $container->set('container.env_var_processors_locator', new ServiceLocator([
-            'string' => static function () use ($container): EnvVarProcessor {
-                return new EnvVarProcessor($container);
-            },
+            'string' => static fn (): EnvVarProcessor => new EnvVarProcessor($container),
         ]));
         $container->compile();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -970,9 +970,7 @@ class EnvVarProcessorTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        (new EnvVarProcessor(new Container()))->getEnv('url', 'foo', static function () use ($url): string {
-            return $url;
-        });
+        (new EnvVarProcessor(new Container()))->getEnv('url', 'foo', static fn (): string => $url);
     }
 
     #[TestWith(['', 'string'])]
@@ -985,11 +983,7 @@ class EnvVarProcessorTest extends TestCase
     {
         $processor = new EnvVarProcessor(new Container());
 
-        $this->assertSame($expected, $processor->getEnv($prefix, 'default::FOO', static function () use ($processor) {
-            return $processor->getEnv('default', ':FOO', static function () {
-                return null;
-            });
-        }));
+        $this->assertSame($expected, $processor->getEnv($prefix, 'default::FOO', static fn () => $processor->getEnv('default', ':FOO', static fn () => null)));
     }
 
     public function testGetEnvWithEmptyStringPrefixCastsToString()
@@ -1015,9 +1009,7 @@ class EnvVarProcessorTest extends TestCase
     {
         $processor = new EnvVarProcessor(new Container());
 
-        $result = $processor->getEnv('urlencode', 'URLENCODETEST', static function () {
-            return 'foo: Data123!@-_ + bar: Not the same content as Data123!@-_ +';
-        });
+        $result = $processor->getEnv('urlencode', 'URLENCODETEST', static fn () => 'foo: Data123!@-_ + bar: Not the same content as Data123!@-_ +');
 
         $this->assertSame('foo%3A%20Data123%21%40-_%20%2B%20bar%3A%20Not%20the%20same%20content%20as%20Data123%21%40-_%20%2B', $result);
     }

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerAnySelectorTextContains.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerAnySelectorTextContains.php
@@ -49,9 +49,7 @@ final class CrawlerAnySelectorTextContains extends Constraint
         $this->hasNode = true;
 
         $nodes = $other->each(static fn (Crawler $node) => $node->text(null, true));
-        $matches = array_filter($nodes, function (string $node): bool {
-            return str_contains($node, $this->expectedText);
-        });
+        $matches = array_filter($nodes, fn (string $node): bool => str_contains($node, $this->expectedText));
 
         return 0 < \count($matches);
     }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -258,9 +258,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
             // remove main pre/code tags
             $code = preg_replace('#^<pre.*?>\s*<code.*?>(.*)</code>\s*</pre>#s', '\\1', $code);
             // split multiline span tags
-            $code = preg_replace_callback('#<span ([^>]++)>((?:[^<\\n]*+\\n)++[^<]*+)</span>#', static function ($m) {
-                return "<span $m[1]>".str_replace("\n", "</span>\n<span $m[1]>", $m[2]).'</span>';
-            }, $code);
+            $code = preg_replace_callback('#<span ([^>]++)>((?:[^<\\n]*+\\n)++[^<]*+)</span>#', static fn ($m) => "<span $m[1]>".str_replace("\n", "</span>\n<span $m[1]>", $m[2]).'</span>', $code);
             $content = explode("\n", $code);
 
             $lines = [];

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/FileLinkFormatterTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/FileLinkFormatterTest.php
@@ -90,9 +90,7 @@ class FileLinkFormatterTest extends TestCase
     #[DataProvider('providePathMappings')]
     public function testIdeFileLinkFormatWithPathMappingParameters($mappings)
     {
-        $params = array_reduce($mappings, static function ($c, $m) {
-            return "$c&".implode('>', $m);
-        }, '');
+        $params = array_reduce($mappings, static fn ($c, $m) => "$c&".implode('>', $m), '');
         $sut = new FileLinkFormatter("vscode://file/%f:%l$params");
         foreach ($mappings as $mapping) {
             $fileGuest = $mapping['guest'].'file.php';

--- a/src/Symfony/Component/Form/Flow/FormFlowBuilder.php
+++ b/src/Symfony/Component/Form/Flow/FormFlowBuilder.php
@@ -202,9 +202,7 @@ class FormFlowBuilder extends FormBuilder implements FormFlowBuilderInterface
             throw new InvalidArgumentException('Steps not configured.');
         }
 
-        uasort($this->steps, static function (StepFlowBuilderConfigInterface $a, StepFlowBuilderConfigInterface $b) {
-            return $b->getPriority() <=> $a->getPriority();
-        });
+        uasort($this->steps, static fn (StepFlowBuilderConfigInterface $a, StepFlowBuilderConfigInterface $b) => $b->getPriority() <=> $a->getPriority());
 
         $currentStep = $this->resolveCurrentStep();
 

--- a/src/Symfony/Component/Form/Flow/Type/ButtonFlowType.php
+++ b/src/Symfony/Component/Form/Flow/Type/ButtonFlowType.php
@@ -49,13 +49,9 @@ class ButtonFlowType extends AbstractType implements ButtonFlowTypeInterface
             ->default(false)
             ->allowedTypes('bool');
 
-        $resolver->setDefault('validate', static function (Options $options) {
-            return !$options['clear_submission'];
-        });
+        $resolver->setDefault('validate', static fn (Options $options) => !$options['clear_submission']);
 
-        $resolver->setDefault('validation_groups', static function (Options $options) {
-            return $options['clear_submission'] ? false : null;
-        });
+        $resolver->setDefault('validation_groups', static fn (Options $options) => $options['clear_submission'] ? false : null);
     }
 
     public function getParent(): string

--- a/src/Symfony/Component/Form/Flow/Type/FormFlowType.php
+++ b/src/Symfony/Component/Form/Flow/Type/FormFlowType.php
@@ -97,18 +97,14 @@ class FormFlowType extends AbstractFlowType
         $resolver->define('step_property_path')
             ->info('Required if the default step_accessor is being used')
             ->allowedTypes('string', PropertyPathInterface::class)
-            ->normalize(static function (Options $options, string|PropertyPathInterface $value): PropertyPathInterface {
-                return \is_string($value) ? new PropertyPath($value) : $value;
-            });
+            ->normalize(static fn (Options $options, string|PropertyPathInterface $value): PropertyPathInterface => \is_string($value) ? new PropertyPath($value) : $value);
 
         $resolver->define('auto_reset')
             ->info('Whether the FormFlow will be reset automatically when it is finished')
             ->default(true)
             ->allowedTypes('bool');
 
-        $resolver->setDefault('validation_groups', static function (FormFlowInterface $flow) {
-            return ['Default', $flow->getCursor()->getCurrentStep()];
-        });
+        $resolver->setDefault('validation_groups', static fn (FormFlowInterface $flow) => ['Default', $flow->getCursor()->getCurrentStep()]);
     }
 
     public function getParent(): string

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
@@ -412,9 +412,7 @@ class DataMapperTest extends TestCase
             ->getFormFactory()
             ->createBuilder(FormType::class, $person)
             ->add('name', TextType::class, [
-                'getter' => static function (DummyPerson $person) {
-                    return $person->myName();
-                },
+                'getter' => static fn (DummyPerson $person) => $person->myName(),
             ])
             ->getForm();
         $form->submit([

--- a/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
@@ -114,9 +114,7 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         $form = $this->factory
             ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', null, [
                 'data_class' => User::class,
-                'empty_data' => static function () use ($user) {
-                    return $user;
-                },
+                'empty_data' => static fn () => $user,
             ])
             ->add('plainPassword', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', [
                 'hash_property_path' => 'password',

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -101,9 +101,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
         $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = $options['headers'];
 
         if (isset($options['normalized_headers']['host']) || isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {
-            $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static function ($h) {
-                return 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:');
-            });
+            $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
         }
 
         return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use (&$method, &$options, $maxRedirects, &$redirectHeaders, $subnets, $ipFlags, $dnsCache): \Generator {
@@ -133,9 +131,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
                 unset($options['body'], $options['json']);
 
                 if (isset($options['normalized_headers']['content-length']) || isset($options['normalized_headers']['content-type']) || isset($options['normalized_headers']['transfer-encoding'])) {
-                    $filterContentHeaders = static function ($h) {
-                        return 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:') && 0 !== stripos($h, 'Transfer-Encoding:');
-                    };
+                    $filterContentHeaders = static fn ($h) => 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:') && 0 !== stripos($h, 'Transfer-Encoding:');
                     $options['headers'] = array_filter($options['headers'], $filterContentHeaders);
                     $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], $filterContentHeaders);
                     $redirectHeaders['with_auth'] = array_filter($redirectHeaders['with_auth'], $filterContentHeaders);

--- a/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
@@ -302,15 +302,13 @@ class HttplugClientTest extends TestCase
 
     public function testAutoUpgradeHttpVersion()
     {
-        $clientWithoutOption = new HttplugClient(new MockHttpClient(static function (string $method, string $url, array $options) {
-            return new MockResponse(json_encode([
-                'SERVER_PROTOCOL' => 'HTTP/'.$options['http_version'] ?? '',
-            ]), [
-                'response_headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-            ]);
-        }));
+        $clientWithoutOption = new HttplugClient(new MockHttpClient(static fn (string $method, string $url, array $options) => new MockResponse(json_encode([
+            'SERVER_PROTOCOL' => 'HTTP/'.$options['http_version'] ?? '',
+        ]), [
+            'response_headers' => [
+                'Content-Type' => 'application/json',
+            ],
+        ])));
         $clientWithOptionFalse = $clientWithoutOption->withOptions(['auto_upgrade_http_version' => false]);
 
         foreach (['1.0', '1.1', '2.0', '3.0'] as $httpVersion) {

--- a/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
@@ -121,15 +121,13 @@ class Psr18ClientTest extends TestCase
 
     public function testAutoUpgradeHttpVersion()
     {
-        $clientWithoutOption = new Psr18Client(new MockHttpClient(static function (string $method, string $url, array $options) {
-            return new MockResponse(json_encode([
-                'SERVER_PROTOCOL' => 'HTTP/'.$options['http_version'] ?? '',
-            ]), [
-                'response_headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-            ]);
-        }));
+        $clientWithoutOption = new Psr18Client(new MockHttpClient(static fn (string $method, string $url, array $options) => new MockResponse(json_encode([
+            'SERVER_PROTOCOL' => 'HTTP/'.$options['http_version'] ?? '',
+        ]), [
+            'response_headers' => [
+                'Content-Type' => 'application/json',
+            ],
+        ])));
         $clientWithOptionFalse = $clientWithoutOption->withOptions(['auto_upgrade_http_version' => false]);
 
         foreach (['1.0', '1.1', '2.0', '3.0'] as $httpVersion) {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -342,21 +342,13 @@ class CacheAttributeListenerTest extends TestCase
     public static function provideLastModifiedHeaderAndEtagClosureCases(): iterable
     {
         yield 'using arguments' => [
-            static function (array $arguments, Request $request) {
-                return $arguments['test']->getDate();
-            },
-            static function (array $arguments, Request $request) {
-                return $arguments['test']->getId();
-            },
+            static fn (array $arguments, Request $request) => $arguments['test']->getDate(),
+            static fn (array $arguments, Request $request) => $arguments['test']->getId(),
         ];
 
         yield 'using request attributes' => [
-            static function (array $arguments, Request $request) {
-                return $request->attributes->get('date');
-            },
-            static function (array $arguments, Request $request) {
-                return $request->attributes->get('id');
-            },
+            static fn (array $arguments, Request $request) => $request->attributes->get('date'),
+            static fn (array $arguments, Request $request) => $request->attributes->get('id'),
         ];
     }
 

--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -1096,9 +1096,7 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private function normalizeStorage(\stdClass|array $data): array
     {
-        return array_map(function ($value) {
-            return $value instanceof \stdClass || $value && \is_array($value) ? $this->normalizeStorage($value) : $value;
-        }, (array) $data);
+        return array_map(fn ($value) => $value instanceof \stdClass || $value && \is_array($value) ? $this->normalizeStorage($value) : $value, (array) $data);
     }
 
     private function isValidMixedBracketExpression(string $expr): bool

--- a/src/Symfony/Component/JsonPath/Tests/JsonPathComplianceTestSuiteTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonPathComplianceTestSuiteTest.php
@@ -117,9 +117,7 @@ final class JsonPathComplianceTestSuiteTest extends TestCase
     private static function convertToArray(mixed $value): mixed
     {
         if ($value instanceof \stdClass) {
-            return array_map(static function ($val) {
-                return self::convertToArray($val);
-            }, get_object_vars($value));
+            return array_map(static fn ($val) => self::convertToArray($val), get_object_vars($value));
         }
 
         if (\is_array($value)) {

--- a/src/Symfony/Component/Mailer/Bridge/MailPace/Tests/Transport/MailPaceApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailPace/Tests/Transport/MailPaceApiTransportTest.php
@@ -118,19 +118,17 @@ final class MailPaceApiTransportTest extends TestCase
 
     public function testSendThrowsForErrorsResponse()
     {
-        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new JsonMockResponse([
-                'errors' => [
-                    'to' => [
-                        'contains a blocked address',
-                        'number of email addresses exceeds maximum volume',
-                    ],
-                    'attachments.name' => ['Extension file type blocked, see Docs for full list of allowed file types'],
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse([
+            'errors' => [
+                'to' => [
+                    'contains a blocked address',
+                    'number of email addresses exceeds maximum volume',
                 ],
-            ], [
-                'http_code' => 400,
-            ]);
-        });
+                'attachments.name' => ['Extension file type blocked, see Docs for full list of allowed file types'],
+            ],
+        ], [
+            'http_code' => 400,
+        ]));
         $transport = new MailPaceApiTransport('KEY', $client);
         $transport->setPort(8984);
 
@@ -147,9 +145,7 @@ final class MailPaceApiTransportTest extends TestCase
 
     public function testSendThrowsForInternalServerErrorResponse()
     {
-        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new MockResponse('', ['http_code' => 500]);
-        });
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new MockResponse('', ['http_code' => 500]));
         $transport = new MailPaceApiTransport('KEY', $client);
         $transport->setPort(8984);
 

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
@@ -128,11 +128,9 @@ class MailerSendApiTransportTest extends TestCase
 
     public function testSendThrowsForErrorResponse()
     {
-        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new JsonMockResponse(['message' => 'i\'m a teapot'], [
-                'http_code' => 418,
-            ]);
-        });
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse(['message' => 'i\'m a teapot'], [
+            'http_code' => 418,
+        ]));
 
         $transport = new MailerSendApiTransport('ACCESS_KEY', $client);
 
@@ -149,18 +147,16 @@ class MailerSendApiTransportTest extends TestCase
 
     public function testSendThrowsForAllSuppressed()
     {
-        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new JsonMockResponse([
-                'message' => 'There are some warnings for your request.',
-                'warnings' => [
-                    [
-                        'type' => 'ALL_SUPPRESSED',
-                    ],
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse([
+            'message' => 'There are some warnings for your request.',
+            'warnings' => [
+                [
+                    'type' => 'ALL_SUPPRESSED',
                 ],
-            ], [
-                'http_code' => 202,
-            ]);
-        });
+            ],
+        ], [
+            'http_code' => 202,
+        ]));
 
         $transport = new MailerSendApiTransport('ACCESS_KEY', $client);
 
@@ -177,11 +173,9 @@ class MailerSendApiTransportTest extends TestCase
 
     public function testSendThrowsForBadResponse()
     {
-        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new MockResponse('test', [
-                'http_code' => 202,
-            ]);
-        });
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new MockResponse('test', [
+            'http_code' => 202,
+        ]));
 
         $transport = new MailerSendApiTransport('ACCESS_KEY', $client);
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Transport/MailomatApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Transport/MailomatApiTransport.php
@@ -62,9 +62,7 @@ final class MailomatApiTransport extends AbstractApiTransport
         }
 
         if (202 !== $statusCode) {
-            $violations = array_map(static function (array $violation) {
-                return ($violation['propertyPath'] ? '('.$violation['propertyPath'].') ' : '').$violation['message'];
-            }, $result['violations']);
+            $violations = array_map(static fn (array $violation) => ($violation['propertyPath'] ? '('.$violation['propertyPath'].') ' : '').$violation['message'], $result['violations']);
 
             throw new HttpTransportException(\sprintf('Unable to send an email: %s (code %d).', implode('; ', $violations), $statusCode), $response);
         }

--- a/src/Symfony/Component/Mailer/Bridge/Postal/Tests/Transport/PostalApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postal/Tests/Transport/PostalApiTransportTest.php
@@ -86,11 +86,9 @@ class PostalApiTransportTest extends TestCase
 
     public function testSendThrowsForErrorResponse()
     {
-        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new JsonMockResponse(['message' => 'i\'m a teapot'], [
-                'http_code' => 418,
-            ]);
-        });
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse(['message' => 'i\'m a teapot'], [
+            'http_code' => 418,
+        ]));
         $transport = new PostalApiTransport('TOKEN', 'postal.localhost', $client);
 
         $mail = new Email();

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Transport/ScalewayApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Transport/ScalewayApiTransportTest.php
@@ -93,11 +93,9 @@ class ScalewayApiTransportTest extends TestCase
 
     public function testSendThrowsForErrorResponse()
     {
-        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
-            return new JsonMockResponse(['message' => 'i\'m a teapot'], [
-                'http_code' => 418,
-            ]);
-        });
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse(['message' => 'i\'m a teapot'], [
+            'http_code' => 418,
+        ]));
         $transport = new ScalewayApiTransport('PROJECT_ID', 'TOKEN', 'fr-par', $client);
 
         $mail = new Email();

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Transport/ScalewayApiTransport.php
@@ -153,9 +153,7 @@ final class ScalewayApiTransport extends AbstractApiTransport
 
     protected function formatAddresses(array $addresses): array
     {
-        return array_map(function (Address $address) {
-            return $this->formatAddress($address);
-        }, $addresses);
+        return array_map(fn (Address $address) => $this->formatAddress($address), $addresses);
     }
 
     private function getEndpoint(): ?string

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -130,9 +130,7 @@ class ConnectionTest extends TestCase
             ->method('update');
         $driverConnection
             ->method('executeQuery')
-            ->with($this->callback(static function ($sql) {
-                return str_contains($sql, 'SKIP LOCKED');
-            }))
+            ->with($this->callback(static fn ($sql) => str_contains($sql, 'SKIP LOCKED')))
             ->willReturn($stmt);
 
         $connection = new Connection(['skip_locked' => true], $driverConnection);
@@ -626,9 +624,7 @@ class ConnectionTest extends TestCase
         $driverConnection
             ->expects($this->once())
             ->method('executeQuery')
-            ->with($this->callback(static function ($sql) use ($expectedSql) {
-                return trim($expectedSql) === trim($sql);
-            }))
+            ->with($this->callback(static fn ($sql) => trim($expectedSql) === trim($sql)))
             ->willReturn($result)
         ;
         $driverConnection->expects($this->once())->method('commit');
@@ -731,9 +727,7 @@ class ConnectionTest extends TestCase
     {
         $driverConnection = $this->createMock(DBALConnection::class);
         $driverConnection->method('getDatabasePlatform')->willReturn($platform);
-        $driverConnection->method('createQueryBuilder')->willReturnCallback(static function () use ($driverConnection) {
-            return new QueryBuilder($driverConnection);
-        });
+        $driverConnection->method('createQueryBuilder')->willReturnCallback(static fn () => new QueryBuilder($driverConnection));
 
         $result = $this->createStub(Result::class);
         $result->method('fetchAllAssociative')->willReturn([]);

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
@@ -332,9 +332,7 @@ class SendFailedMessageForRetryListenerTest extends TestCase
         $envelope = new Envelope(new \stdClass());
 
         $sender = $this->createMock(SenderInterface::class);
-        $sender->expects($this->once())->method('send')->willReturnCallback(static function (Envelope $envelope) {
-            return $envelope->with(new TransportMessageIdStamp(123));
-        });
+        $sender->expects($this->once())->method('send')->willReturnCallback(static fn (Envelope $envelope) => $envelope->with(new TransportMessageIdStamp(123)));
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher->expects($this->once())->method('dispatch')->willReturnCallback(

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/Tests/BlueskyTransportTest.php
@@ -326,12 +326,10 @@ final class BlueskyTransportTest extends TransportTestCase
         $recordUri = 'at://did:plc:u5cwb2mwiv2bfq53cjufe6yn/app.bsky.feed.post/3k4duaz5vfs2b';
         $recordCid = 'bafyreibjifzpqj6o6wcq3hejh7y4z4z2vmiklkvykc57tw3pcbx3kxifpm';
 
-        $client = new MockHttpClient(static function () use ($recordUri, $recordCid) {
-            return new JsonMockResponse([
-                'uri' => $recordUri,
-                'cid' => $recordCid,
-            ]);
-        });
+        $client = new MockHttpClient(static fn () => new JsonMockResponse([
+            'uri' => $recordUri,
+            'cid' => $recordCid,
+        ]));
 
         $transport = self::createTransport($client);
         $message = $transport->send(new ChatMessage('Hello!'));

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -78,7 +78,7 @@ final class SlackTransport extends AbstractTransport
         }
 
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/'.$apiMethod, [
-            'json' => array_filter($options, static function ($value): bool { return !\in_array($value, ['', [], null], true); }),
+            'json' => array_filter($options, static fn ($value): bool => !\in_array($value, ['', [], null], true)),
             'auth_bearer' => $this->accessToken,
             'headers' => [
                 'Content-Type' => 'application/json; charset=utf-8',

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/SmsboxTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/SmsboxTransportTest.php
@@ -167,9 +167,7 @@ final class SmsboxTransportTest extends TransportTestCase
 
     public function testSmsboxOptionsInvalidDateTimeAndDate()
     {
-        $client = new MockHttpClient(static function (): ResponseInterface {
-            return new MockResponse();
-        });
+        $client = new MockHttpClient(static fn (): ResponseInterface => new MockResponse());
 
         $dateTime = new \DateTimeImmutable('+1 day');
 
@@ -192,9 +190,7 @@ final class SmsboxTransportTest extends TransportTestCase
 
     public function testSmsboxInvalidPhoneNumber()
     {
-        $client = new MockHttpClient(static function (): ResponseInterface {
-            return new MockResponse();
-        });
+        $client = new MockHttpClient(static fn (): ResponseInterface => new MockResponse());
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid phone number');

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -2584,9 +2584,7 @@ class OptionsResolverTest extends TestCase
     public function testResolveLazyOptionUsingNestedOption()
     {
         $this->resolver
-            ->setDefault('version', static function (Options $options) {
-                return $options['database']['server_version'];
-            })
+            ->setDefault('version', static fn (Options $options) => $options['database']['server_version'])
             ->setOptions('database', static function (OptionsResolver $resolver) {
                 $resolver->setDefault('server_version', '3.15');
             });
@@ -2689,9 +2687,7 @@ class OptionsResolverTest extends TestCase
             $resolver->define('bar')->allowedTypes('int');
         });
         // defined by subclass
-        $this->resolver->setDefault('foo', static function (Options $options) {
-            return ['bar' => 'invalid'];
-        });
+        $this->resolver->setDefault('foo', static fn (Options $options) => ['bar' => 'invalid']);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The option "foo[bar]" with value "invalid" is expected to be of type "int", but is of type "string".');
@@ -2729,9 +2725,7 @@ class OptionsResolverTest extends TestCase
     public function testFailsIfCyclicDependencyBetweenNestedOptionAndParentLazyOption()
     {
         $this->resolver
-            ->setDefault('version', static function (Options $options) {
-                return $options['database']['server_version'];
-            })
+            ->setDefault('version', static fn (Options $options) => $options['database']['server_version'])
             ->setOptions('database', static function (OptionsResolver $resolver, Options $parent) {
                 $resolver->setDefault('server_version', $parent['version']);
             });
@@ -2787,9 +2781,7 @@ class OptionsResolverTest extends TestCase
         $this->resolver
             ->setDefaults([
                 'ip' => null,
-                'secondary_replica' => static function (Options $options) {
-                    return $options['database']['primary_replica']['host'];
-                },
+                'secondary_replica' => static fn (Options $options) => $options['database']['primary_replica']['host'],
             ])
             ->setOptions('database', static function (OptionsResolver $resolver, Options $parent) {
                 $resolver

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1659,9 +1659,7 @@ class ProcessTest extends TestCase
     public function testMultipleCallsToProcGetStatus()
     {
         $process = $this->getProcess('echo foo');
-        $process->start(static function () use ($process) {
-            return $process->isRunning();
-        });
+        $process->start(static fn () => $process->isRunning());
         while ($process->isRunning()) {
             usleep(1000);
         }
@@ -1671,9 +1669,7 @@ class ProcessTest extends TestCase
     public function testFailingProcessWithMultipleCallsToProcGetStatus()
     {
         $process = $this->getProcess('exit 123');
-        $process->start(static function () use ($process) {
-            return $process->isRunning();
-        });
+        $process->start(static fn () => $process->isRunning());
         while ($process->isRunning()) {
             usleep(1000);
         }
@@ -1684,9 +1680,7 @@ class ProcessTest extends TestCase
     public function testLongRunningProcessWithMultipleCallsToProcGetStatus()
     {
         $process = $this->getProcess('sleep 1 && echo "done" && php -r "exit(0);"');
-        $process->start(static function () use ($process) {
-            return $process->isRunning();
-        });
+        $process->start(static fn () => $process->isRunning());
         while ($process->isRunning()) {
             usleep(1000);
         }
@@ -1697,9 +1691,7 @@ class ProcessTest extends TestCase
     public function testLongRunningProcessWithMultipleCallsToProcGetStatusError()
     {
         $process = $this->getProcess('sleep 1 && echo "failure" && php -r "exit(123);"');
-        $process->start(static function () use ($process) {
-            return $process->isRunning();
-        });
+        $process->start(static fn () => $process->isRunning());
         while ($process->isRunning()) {
             usleep(1000);
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -50,12 +50,10 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
             'stub' => $this->stub ??= class_exists(ClassStub::class) ? new ClassStub($this->authenticator::class) : $this->authenticator::class,
             'authenticated' => $this->authenticated,
             'badges' => array_map(
-                static function (BadgeInterface $badge): array {
-                    return [
-                        'stub' => class_exists(ClassStub::class) ? new ClassStub($badge::class) : $badge::class,
-                        'resolved' => $badge->isResolved(),
-                    ];
-                },
+                static fn (BadgeInterface $badge): array => [
+                    'stub' => class_exists(ClassStub::class) ? new ClassStub($badge::class) : $badge::class,
+                    'resolved' => $badge->isResolved(),
+                ],
                 $this->passport?->getBadges() ?? [],
             ),
             'exception' => $this->exception,

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -82,9 +82,7 @@ class LogoutListenerTest extends TestCase
 
         $this->csrfTokenManager->expects($this->once())
             ->method('isTokenValid')
-            ->with($this->callback(static function ($token) {
-                return $token instanceof CsrfToken && 'token2' === $token->getValue();
-            }))
+            ->with($this->callback(static fn ($token) => $token instanceof CsrfToken && 'token2' === $token->getValue()))
             ->willReturn(true);
 
         $response = new Response();

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1394,15 +1394,13 @@ class SerializerTest extends TestCase
         $this->assertTrue($object->bool);
         $this->assertSame(1, $object->int);
 
-        $exceptionsAsArray = array_map(static function (NotNormalizableValueException $e): array {
-            return [
-                'currentType' => $e->getCurrentType(),
-                'expectedTypes' => $e->getExpectedTypes(),
-                'path' => $e->getPath(),
-                'useMessageForUser' => $e->canUseMessageForUser(),
-                'message' => $e->getMessage(),
-            ];
-        }, $th->getErrors());
+        $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $e): array => [
+            'currentType' => $e->getCurrentType(),
+            'expectedTypes' => $e->getExpectedTypes(),
+            'path' => $e->getPath(),
+            'useMessageForUser' => $e->canUseMessageForUser(),
+            'message' => $e->getMessage(),
+        ], $th->getErrors());
 
         $expected = [
             [
@@ -1539,13 +1537,11 @@ class SerializerTest extends TestCase
             $this->assertInstanceOf(PartialDenormalizationException::class, $e);
         }
 
-        $exceptionsAsArray = array_map(static function (NotNormalizableValueException $e): array {
-            return [
-                'currentType' => $e->getCurrentType(),
-                'useMessageForUser' => $e->canUseMessageForUser(),
-                'message' => $e->getMessage(),
-            ];
-        }, $e->getErrors());
+        $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $e): array => [
+            'currentType' => $e->getCurrentType(),
+            'useMessageForUser' => $e->canUseMessageForUser(),
+            'message' => $e->getMessage(),
+        ], $e->getErrors());
 
         $expected = [
             [
@@ -1705,15 +1701,13 @@ class SerializerTest extends TestCase
         $this->assertFalse(isset($object->two));
         $this->assertSame('three string', $object->three);
 
-        $exceptionsAsArray = array_map(static function (NotNormalizableValueException $e): array {
-            return [
-                'currentType' => $e->getCurrentType(),
-                'expectedTypes' => $e->getExpectedTypes(),
-                'path' => $e->getPath(),
-                'useMessageForUser' => $e->canUseMessageForUser(),
-                'message' => $e->getMessage(),
-            ];
-        }, $th->getErrors());
+        $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $e): array => [
+            'currentType' => $e->getCurrentType(),
+            'expectedTypes' => $e->getExpectedTypes(),
+            'path' => $e->getPath(),
+            'useMessageForUser' => $e->canUseMessageForUser(),
+            'message' => $e->getMessage(),
+        ], $th->getErrors());
 
         $expected = [
             [
@@ -1786,15 +1780,13 @@ class SerializerTest extends TestCase
             $this->assertIsArray($e->getErrors());
             $this->assertCount(2, $e->getErrors(), 'Expected two denormalization errors');
 
-            $exceptionsAsArray = array_map(static function (NotNormalizableValueException $ex): array {
-                return [
-                    'currentType' => $ex->getCurrentType(),
-                    'expectedTypes' => $ex->getExpectedTypes(),
-                    'path' => $ex->getPath(),
-                    'useMessageForUser' => $ex->canUseMessageForUser(),
-                    'message' => $ex->getMessage(),
-                ];
-            }, $e->getErrors());
+            $exceptionsAsArray = array_map(static fn (NotNormalizableValueException $ex): array => [
+                'currentType' => $ex->getCurrentType(),
+                'expectedTypes' => $ex->getExpectedTypes(),
+                'path' => $ex->getPath(),
+                'useMessageForUser' => $ex->canUseMessageForUser(),
+                'message' => $ex->getMessage(),
+            ], $e->getErrors());
 
             $expected = [
                 [

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -166,9 +166,7 @@ final class LokaliseProvider implements ProviderInterface
         }
 
         // Lokalise returns languages with "-" separator, we need to reformat them to "_" separator.
-        $reformattedLanguages = array_map(static function ($language) {
-            return str_replace('-', '_', $language);
-        }, array_keys($responseContent['files']));
+        $reformattedLanguages = array_map(static fn ($language) => str_replace('-', '_', $language), array_keys($responseContent['files']));
 
         return array_combine($reformattedLanguages, $responseContent['files']);
     }

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -699,22 +699,16 @@ class LokaliseProviderTest extends ProviderTestCase
     public function testReadWithExportAsync()
     {
         $zipLocation = __DIR__.\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR.'Symfony-locale.zip';
-        $firstResponse = static function (): ResponseInterface {
-            return new JsonMockResponse(
-                ['error' => ['code' => 413, 'message' => 'test']],
-                ['http_code' => 406],
-            );
-        };
-        $secondResponse = static function (): ResponseInterface {
-            return new JsonMockResponse(
-                ['process_id' => 123],
-            );
-        };
-        $thirdResponse = static function (): ResponseInterface {
-            return new JsonMockResponse(
-                ['process' => ['status' => 'finished', 'details' => ['download_url' => 'https://api.lokalise.com/Symfony-locale.zip']]],
-            );
-        };
+        $firstResponse = static fn (): ResponseInterface => new JsonMockResponse(
+            ['error' => ['code' => 413, 'message' => 'test']],
+            ['http_code' => 406],
+        );
+        $secondResponse = static fn (): ResponseInterface => new JsonMockResponse(
+            ['process_id' => 123],
+        );
+        $thirdResponse = static fn (): ResponseInterface => new JsonMockResponse(
+            ['process' => ['status' => 'finished', 'details' => ['download_url' => 'https://api.lokalise.com/Symfony-locale.zip']]],
+        );
         $fourResponse = function (string $method, string $url, array $options = []) use ($zipLocation): ResponseInterface {
             $this->assertSame('GET', $method);
             $this->assertSame('https://api.lokalise.com/Symfony-locale.zip', $url);
@@ -759,22 +753,16 @@ class LokaliseProviderTest extends ProviderTestCase
     #[RequiresPhpExtension('zip')]
     public function testReadWithExportAsyncFailedProcess()
     {
-        $firstResponse = static function (): ResponseInterface {
-            return new JsonMockResponse(
-                ['error' => ['code' => 413, 'message' => 'test']],
-                ['http_code' => 406],
-            );
-        };
-        $secondResponse = static function (): ResponseInterface {
-            return new JsonMockResponse(
-                ['process_id' => 123],
-            );
-        };
-        $thirdResponse = static function (): ResponseInterface {
-            return new JsonMockResponse(
-                ['process' => ['status' => 'failed']],
-            );
-        };
+        $firstResponse = static fn (): ResponseInterface => new JsonMockResponse(
+            ['error' => ['code' => 413, 'message' => 'test']],
+            ['http_code' => 406],
+        );
+        $secondResponse = static fn (): ResponseInterface => new JsonMockResponse(
+            ['process_id' => 123],
+        );
+        $thirdResponse = static fn (): ResponseInterface => new JsonMockResponse(
+            ['process' => ['status' => 'failed']],
+        );
 
         $provider = self::createProvider((new MockHttpClient([$firstResponse, $secondResponse, $thirdResponse]))->withOptions([
             'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -196,11 +196,9 @@ trait TypeFactoryTrait
      */
     public static function arrayShape(array $shape, bool $sealed = true, ?Type $extraKeyType = null, ?Type $extraValueType = null): ArrayShapeType
     {
-        $shape = array_map(static function (array|Type $item): array {
-            return $item instanceof Type
+        $shape = array_map(static fn (array|Type $item): array => $item instanceof Type
                 ? ['type' => $item, 'optional' => false]
-                : ['type' => $item['type'], 'optional' => $item['optional'] ?? false];
-        }, $shape);
+                : ['type' => $item['type'], 'optional' => $item['optional'] ?? false], $shape);
 
         if ($extraKeyType || $extraValueType) {
             $sealed = false;

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageProvider.php
@@ -19,14 +19,10 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
     public function getFunctions(): array
     {
         return [
-            new ExpressionFunction('is_valid', static function (...$arguments) {
-                return \sprintf(
-                    '0 === $context->getValidator()->inContext($context)->validate(%s)->getViolations()->count()',
-                    implode(', ', $arguments)
-                );
-            }, static function (array $variables, ...$arguments): bool {
-                return 0 === $variables['context']->getValidator()->inContext($variables['context'])->validate(...$arguments)->getViolations()->count();
-            }),
+            new ExpressionFunction('is_valid', static fn (...$arguments) => \sprintf(
+                '0 === $context->getValidator()->inContext($context)->validate(%s)->getViolations()->count()',
+                implode(', ', $arguments)
+            ), static fn (array $variables, ...$arguments): bool => 0 === $variables['context']->getValidator()->inContext($variables['context'])->validate(...$arguments)->getViolations()->count()),
         ];
     }
 }

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -907,9 +907,7 @@ class HtmlDumper extends CliDumper
         );
 
         if (!($attr['binary'] ?? false)) {
-            $v = preg_replace_callback(static::$unicodeCharsRx, static function ($c) {
-                return '<span class=sf-dump-default>\u{'.strtoupper(dechex(mb_ord($c[0]))).'}</span>';
-            }, $v);
+            $v = preg_replace_callback(static::$unicodeCharsRx, static fn ($c) => '<span class=sf-dump-default>\u{'.strtoupper(dechex(mb_ord($c[0]))).'}</span>', $v);
         }
 
         if (isset($attr['file']) && $href = $this->getSourceLink($attr['file'], $attr['line'] ?? 0)) {

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -374,16 +374,12 @@ class LazyProxyTraitTest extends TestCase
 
     public function testAsymmetricVisibility()
     {
-        $object = $this->createLazyProxy(AsymmetricVisibility::class, static function () {
-            return new AsymmetricVisibility(123, 234);
-        });
+        $object = $this->createLazyProxy(AsymmetricVisibility::class, static fn () => new AsymmetricVisibility(123, 234));
 
         $this->assertSame(123, $object->foo);
         $this->assertSame(234, $object->getBar());
 
-        $object = $this->createLazyProxy(AsymmetricVisibility::class, static function () {
-            return new AsymmetricVisibility(123, 234);
-        });
+        $object = $this->createLazyProxy(AsymmetricVisibility::class, static fn () => new AsymmetricVisibility(123, 234));
 
         $this->assertSame(234, $object->getBar());
         $this->assertSame(123, $object->foo);

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -379,9 +379,7 @@ abstract class HttpClientTestCase extends TestCase
             'Content-Type: application/json',
         ];
 
-        $filteredHeaders = array_values(array_filter($response->getInfo('response_headers'), static function ($h) {
-            return \in_array(substr($h, 0, 4), ['HTTP', 'Loca', 'Cont'], true) && 'Content-Encoding: gzip' !== $h;
-        }));
+        $filteredHeaders = array_values(array_filter($response->getInfo('response_headers'), static fn ($h) => \in_array(substr($h, 0, 4), ['HTTP', 'Loca', 'Cont'], true) && 'Content-Encoding: gzip' !== $h));
 
         $this->assertSame($expected, $filteredHeaders);
     }
@@ -467,9 +465,7 @@ abstract class HttpClientTestCase extends TestCase
             'Content-Type: application/json',
         ];
 
-        $filteredHeaders = array_values(array_filter($response->getInfo('response_headers'), static function ($h) {
-            return \in_array(substr($h, 0, 4), ['HTTP', 'Loca', 'Cont'], true);
-        }));
+        $filteredHeaders = array_values(array_filter($response->getInfo('response_headers'), static fn ($h) => \in_array(substr($h, 0, 4), ['HTTP', 'Loca', 'Cont'], true)));
 
         $this->assertSame($expected, $filteredHeaders);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

