### PR TITLE
[Security] Add `this` to `#[IsGranted]` subject expression vars when available

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/Cache.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/Cache.php
@@ -76,7 +76,7 @@ final class Cache
          *
          * The result must be an instance of \DateTimeInterface.
          *
-         * @var \DateTimeInterface|string|Expression|\Closure(array<string, mixed>, Request):\DateTimeInterface|null
+         * @var \DateTimeInterface|string|Expression|\Closure(array<string, mixed>, Request, ?object):\DateTimeInterface|null
          */
         public \DateTimeInterface|string|Expression|\Closure|null $lastModified = null,
 
@@ -88,7 +88,7 @@ final class Cache
          *
          * The result must be a string that will be hashed.
          *
-         * @var string|Expression|\Closure(array<string, mixed>, Request):string|null
+         * @var string|Expression|\Closure(array<string, mixed>, Request, ?object):string|null
          */
         public string|Expression|\Closure|null $etag = null,
 
@@ -130,7 +130,7 @@ final class Cache
          *
          * The result must be a boolean. If true the attribute is applied, if false it is ignored.
          *
-         * @var bool|string|Expression|\Closure(array<string, mixed>, Request):bool
+         * @var bool|string|Expression|\Closure(array<string, mixed>, Request, ?object):bool
          */
         public bool|string|Expression|\Closure $if = true,
     ) {

--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -197,7 +197,7 @@ class CacheAttributeListener implements EventSubscriberInterface
     private function evaluate(string|Expression|\Closure $closureOrExpression, array $variables): mixed
     {
         if ($closureOrExpression instanceof \Closure) {
-            return $closureOrExpression($variables['args'], $variables['request']);
+            return $closureOrExpression($variables['args'], $variables['request'], $variables['this']);
         }
 
         return $this->getExpressionLanguage()->evaluate($closureOrExpression, $variables);
@@ -205,9 +205,17 @@ class CacheAttributeListener implements EventSubscriberInterface
 
     private function getVariables(Request $request, ControllerArgumentsEvent $event): array
     {
+        $controller = $event->getController();
+        $controller = match (true) {
+            \is_object($controller) && !$controller instanceof \Closure => $controller,
+            \is_array($controller) && \is_object($controller[0]) => $controller[0],
+            default => null,
+        };
+
         return array_merge([
             'request' => $request,
             'args' => $arguments = $event->getNamedArguments(),
+            'this' => $controller,
         ], $request->attributes->all(), $arguments);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/CacheAttributeListenerTest.php
@@ -511,7 +511,7 @@ class CacheAttributeListenerTest extends TestCase
         );
 
         $listener = new CacheAttributeListener();
-        $controllerArgumentsEvent = new ControllerArgumentsEvent($this->getKernel(), static fn (TestEntity $test) => new Response(), [$entity], $request, null);
+        $controllerArgumentsEvent = new ControllerArgumentsEvent($this->getKernel(), [new TestController(true), '__invoke'], [$entity], $request, null);
         $listener->onKernelControllerArguments($controllerArgumentsEvent);
 
         $controllerResponse = $controllerArgumentsEvent->getController()($entity);
@@ -539,9 +539,27 @@ class CacheAttributeListenerTest extends TestCase
             true,
         ];
 
+        yield 'expression accessing controller' => [
+            'this.cache',
+            'not this.cache',
+            true,
+            true,
+            false,
+            false,
+        ];
+
         yield 'closure' => [
-            static fn (array $arguments, Request $request) => $arguments['test']->getDate() <= new \DateTimeImmutable(),
-            static fn (array $arguments, Request $request) => $arguments['test']->getDate() > new \DateTimeImmutable(),
+            static fn (array $arguments, Request $request, ?object $controller) => $arguments['test']->getDate() <= new \DateTimeImmutable(),
+            static fn (array $arguments, Request $request, ?object $controller) => $arguments['test']->getDate() > new \DateTimeImmutable(),
+            true,
+            true,
+            false,
+            false,
+        ];
+
+        yield 'closure accessing controller' => [
+            static fn (array $arguments, Request $request, ?object $controller) => $controller->cache,
+            static fn (array $arguments, Request $request, ?object $controller) => !$controller->cache,
             true,
             true,
             false,
@@ -592,5 +610,17 @@ class TestEntity
     public function getId()
     {
         return '12345';
+    }
+}
+
+class TestController
+{
+    public function __construct(public bool $cache)
+    {
+    }
+
+    public function __invoke(TestEntity $test)
+    {
+        return new Response();
     }
 }

--- a/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsGranted.php
@@ -28,12 +28,12 @@ class IsGranted
     public readonly array $methods;
 
     /**
-     * @param string|Expression|\Closure(IsGrantedContext, mixed $subject):bool         $attribute     The attribute that will be checked against a given authentication token and optional subject
-     * @param array|string|Expression|\Closure(array<string,mixed>, Request):mixed|null $subject       An optional subject - e.g. the current object being voted on
-     * @param string|null                                                               $message       A custom message when access is not granted
-     * @param int|null                                                                  $statusCode    If set, will throw HttpKernel's HttpException with the given $statusCode; if null, Security\Core's AccessDeniedException will be used
-     * @param int|null                                                                  $exceptionCode If set, will add the exception code to thrown exception
-     * @param string[]|string                                                           $methods       HTTP methods to apply validation to. Empty array means all methods are allowed
+     * @param string|Expression|\Closure(IsGrantedContext, mixed $subject):bool                  $attribute     The attribute that will be checked against a given authentication token and optional subject
+     * @param array|string|Expression|\Closure(array<string,mixed>, Request, ?object):mixed|null $subject       An optional subject - e.g. the current object being voted on
+     * @param string|null                                                                        $message       A custom message when access is not granted
+     * @param int|null                                                                           $statusCode    If set, will throw HttpKernel's HttpException with the given $statusCode; if null, Security\Core's AccessDeniedException will be used
+     * @param int|null                                                                           $exceptionCode If set, will add the exception code to thrown exception
+     * @param string[]|string                                                                    $methods       HTTP methods to apply validation to. Empty array means all methods are allowed
      */
     public function __construct(
         public string|Expression|\Closure $attribute,

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for the `clientHints`, `prefetchCache`, and `prerenderCache` `ClearSite-Data` directives
+ * Add `this` to `#[IsGranted]` subject expression variables when available
 
 8.0
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -53,6 +53,13 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $arguments = $event->getNamedArguments();
 
+        $controller = $event->getController();
+        $controller = match (true) {
+            \is_object($controller) && !$controller instanceof \Closure => $controller,
+            \is_array($controller) && \is_object($controller[0]) => $controller[0],
+            default => null,
+        };
+
         foreach ($attributes as $attribute) {
             if ($attribute->methods && !\in_array($request->getMethod(), array_map('strtoupper', $attribute->methods), true)) {
                 continue;
@@ -63,10 +70,10 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
             if ($subjectRef = $attribute->subject) {
                 if (\is_array($subjectRef)) {
                     foreach ($subjectRef as $refKey => $ref) {
-                        $subject[\is_string($refKey) ? $refKey : (string) $ref] = $this->getIsGrantedSubject($ref, $request, $arguments);
+                        $subject[\is_string($refKey) ? $refKey : (string) $ref] = $this->getIsGrantedSubject($ref, $request, $arguments, $controller);
                     }
                 } else {
-                    $subject = $this->getIsGrantedSubject($subjectRef, $request, $arguments);
+                    $subject = $this->getIsGrantedSubject($subjectRef, $request, $arguments, $controller);
                 }
             }
             $accessDecision = new AccessDecision();
@@ -93,10 +100,10 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20]];
     }
 
-    private function getIsGrantedSubject(string|Expression|\Closure $subjectRef, Request $request, array $arguments): mixed
+    private function getIsGrantedSubject(string|Expression|\Closure $subjectRef, Request $request, array $arguments, ?object $controller): mixed
     {
         if ($subjectRef instanceof \Closure) {
-            return $subjectRef($arguments, $request);
+            return $subjectRef($arguments, $request, $controller);
         }
 
         if ($subjectRef instanceof Expression) {
@@ -105,6 +112,7 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
             return $this->expressionLanguage->evaluate($subjectRef, [
                 'request' => $request,
                 'args' => $arguments,
+                'this' => $controller,
             ]);
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -338,18 +338,20 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->with(new Expression('user === subject'), 'author')
             ->willReturn(true);
 
+        $controllerInstance = new IsGrantedAttributeMethodsController();
         $expressionLanguage = $this->createMock(ExpressionLanguage::class);
         $expressionLanguage->expects($this->once())
             ->method('evaluate')
             ->with(new Expression('args["post"].getAuthor()'), [
                 'args' => ['post' => 'postVal'],
                 'request' => $request,
+                'this' => $controllerInstance,
             ])
             ->willReturn('author');
 
         $event = new ControllerArgumentsEvent(
             $this->createStub(HttpKernelInterface::class),
-            [new IsGrantedAttributeMethodsController(), 'withExpressionInSubject'],
+            [$controllerInstance, 'withExpressionInSubject'],
             ['postVal'],
             $request,
             null
@@ -369,18 +371,20 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->with(new Expression('user === subject["author"]'), ['author' => 'author', 'alias' => 'arg2Val'])
             ->willReturn(true);
 
+        $controllerInstance = new IsGrantedAttributeMethodsController();
         $expressionLanguage = $this->createMock(ExpressionLanguage::class);
         $expressionLanguage->expects($this->once())
             ->method('evaluate')
             ->with(new Expression('args["post"].getAuthor()'), [
                 'args' => ['post' => 'postVal', 'arg2Name' => 'arg2Val'],
                 'request' => $request,
+                'this' => $controllerInstance,
             ])
             ->willReturn('author');
 
         $event = new ControllerArgumentsEvent(
             $this->createStub(HttpKernelInterface::class),
-            [new IsGrantedAttributeMethodsController(), 'withNestedExpressionInSubject'],
+            [$controllerInstance, 'withNestedExpressionInSubject'],
             ['postVal', 'arg2Val'],
             $request,
             null
@@ -406,6 +410,49 @@ class IsGrantedAttributeListenerTest extends TestCase
             [],
             $request,
             null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker, new ExpressionLanguage());
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsGrantedWithControllerPropertyAsSubject()
+    {
+        $controller = [new IsGrantedAttributeMethodsController(), 'withControllerPropertyAsSubject'];
+
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('SOME_VOTER', 42)
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $controller,
+            [],
+            new Request(),
+            null
+        );
+
+        $listener = new IsGrantedAttributeListener($authChecker, new ExpressionLanguage());
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsGrantedWithNonClassController()
+    {
+        $controller = #[IsGranted('SOME_VOTER', new Expression('this'))] static fn () => true;
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('SOME_VOTER', null)
+            ->willReturn(true);
+
+        $event = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $controller,
+            [],
+            new Request(),
+            null,
         );
 
         $listener = new IsGrantedAttributeListener($authChecker, new ExpressionLanguage());

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeMethodsController.php
@@ -16,6 +16,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class IsGrantedAttributeMethodsController
 {
+    public int $id = 42;
+
     public function noAttribute()
     {
     }
@@ -75,6 +77,11 @@ class IsGrantedAttributeMethodsController
 
     #[IsGranted(attribute: 'SOME_VOTER', subject: new Expression('request'))]
     public function withRequestAsSubject()
+    {
+    }
+
+    #[IsGranted(attribute: 'SOME_VOTER', subject: new Expression('this.id'))]
+    public function withControllerPropertyAsSubject()
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62446
| License       | MIT

Improve readability of live component access control rules by exposing the controller instance as `this` to `subject` expression.

Example:
```php
#[AsLiveComponent]
class Post
{
    #[LiveProp]
    public PostEntity $post;

    #[IsGranted('post:read', new Expression('this.post'))]
    public function __invoke(): void
    {
    }
}
```