### PR TITLE
[Messenger] Only send `UNLISTEN` query if we are actively listening

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -119,7 +119,13 @@ class PostgreSqlConnectionTest extends TestCase
         $connection->get();
         $connection->get();
 
+        $this->assertTrue($connection->isListening());
+
         $this->assertSame(2, $wrappedConnection->countNotifyCalls());
+
+        $connection->__destruct();
+
+        $this->assertFalse($connection->isListening());
     }
 
     public function testGetExtraSetupSqlWrongTable()
@@ -131,5 +137,13 @@ class PostgreSqlConnectionTest extends TestCase
         $table = new Table('queue_table');
         // don't set the _symfony_messenger_table_name option
         $this->assertSame([], $connection->getExtraSetupSqlForTable($table));
+    }
+
+    public function testIsListeningReturnsFalseWhenGetHasNotBeenCalled()
+    {
+        $driverConnection = $this->createStub(\Doctrine\DBAL\Connection::class);
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+
+        $this->assertFalse($connection->isListening());
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -22,6 +22,8 @@ namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
  */
 final class PostgreSqlConnection extends Connection
 {
+    private bool $listening = false;
+
     /**
      * * check_delayed_interval: The interval to check for delayed messages, in milliseconds. Set to 0 to disable checks. Default: 60000 (1 minute)
      * * get_notify_timeout: The length of time to wait for a response when calling PDO::pgsqlGetNotify (or Pdo\Pgsql::getNotify on PHP 8.4+), in milliseconds. Default: 0.
@@ -46,6 +48,11 @@ final class PostgreSqlConnection extends Connection
         $this->unlisten();
     }
 
+    public function isListening(): bool
+    {
+        return $this->listening;
+    }
+
     public function reset(): void
     {
         parent::reset();
@@ -61,6 +68,8 @@ final class PostgreSqlConnection extends Connection
         // This is secure because the table name must be a valid identifier:
         // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
         $this->executeStatement(\sprintf('LISTEN "%s"', $this->configuration['table_name']));
+
+        $this->listening = true;
 
         // The condition should be removed once support for DBAL <3.3 is dropped
         if (method_exists($this->driverConnection, 'getNativeConnection')) {
@@ -91,6 +100,11 @@ final class PostgreSqlConnection extends Connection
 
     private function unlisten(): void
     {
+        if (!$this->listening) {
+            return;
+        }
+
         $this->executeStatement(\sprintf('UNLISTEN "%s"', $this->configuration['table_name']));
+        $this->listening = false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes (maybe?)
| New feature?  | no
| Deprecations? | no
| License       | MIT

I was looking at some slow traces and noticed PostgreSqlConnection::unlisten() being called in the __destruct even when we are using the connection to publish only and we're not consuming, yet on the __destruct() it still send a transaction to pgsql to UNLISTEN when we're not listening.

<img width="1885" height="952" alt="Screenshot 2026-01-26 at 3 38 03 PM" src="https://github.com/user-attachments/assets/666370c8-cea1-4981-bcc6-9f71b50d32bf" />

