### PR TITLE
[PropertyInfo] Conflict with phpdocumentor/reflection-docblock >= 6 (all branches)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,7 @@
         "doctrine/orm": "<2.15",
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",
-        "phpdocumentor/reflection-docblock": "<5.2",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
         "phpdocumentor/type-resolver": "<1.5.1",
         "phpunit/phpunit": "<7.5|9.1.2"
     },

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "egulias/email-validator": "^2.1.10|^3|^4",
         "league/html-to-markdown": "^5.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+        "phpdocumentor/reflection-docblock": "^5.2",
         "symfony/asset": "^6.4|^7.0",
         "symfony/asset-mapper": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",
@@ -57,8 +57,8 @@
         "twig/markdown-extra": "^3"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<3.2.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
+        "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/console": "<6.4",
         "symfony/form": "<6.4.32|>7,<7.3.10|>7.4,<7.4.4",
         "symfony/http-foundation": "<6.4",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -35,6 +35,7 @@
     "require-dev": {
         "doctrine/persistence": "^1.3|^2|^3",
         "dragonmantank/cron-expression": "^3.1",
+        "phpdocumentor/reflection-docblock": "^5.2",
         "seld/jsonlint": "^1.10",
         "symfony/asset": "^6.4|^7.0",
         "symfony/asset-mapper": "^6.4|^7.0",
@@ -74,13 +75,12 @@
         "symfony/uid": "^6.4|^7.0",
         "symfony/web-link": "^6.4|^7.0",
         "symfony/webhook": "^7.2",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "twig/twig": "^3.12"
     },
     "conflict": {
         "doctrine/persistence": "<1.3",
-        "phpdocumentor/reflection-docblock": "<3.2.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
+        "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/asset": "<6.4",
         "symfony/asset-mapper": "<6.4",
         "symfony/clock": "<6.4",

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "egulias/email-validator": "^2.1.10|^3.1|^4",
         "league/html-to-markdown": "^5.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+        "phpdocumentor/reflection-docblock": "^5.2",
         "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/process": "^6.4|^7.0",
         "symfony/property-access": "^6.4|^7.0",
@@ -32,8 +32,8 @@
     },
     "conflict": {
         "egulias/email-validator": "~3.0.0",
-        "phpdocumentor/reflection-docblock": "<3.2.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
+        "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/mailer": "<6.4",
         "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
     },

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\PropertyInfo\Extractor;
 
 use phpDocumentor\Reflection\DocBlock;
-use phpDocumentor\Reflection\DocBlock\Tags\Factory\StaticMethod;
-use phpDocumentor\Reflection\DocBlock\Tags\Generic;
 use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
@@ -69,10 +67,6 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     {
         if (!class_exists(DocBlockFactory::class)) {
             throw new \LogicException(\sprintf('Unable to use the "%s" class as the "phpdocumentor/reflection-docblock" package is not installed. Try running composer require "phpdocumentor/reflection-docblock".', __CLASS__));
-        }
-
-        if (!is_subclass_of(Generic::class, StaticMethod::class)) {
-            throw new \LogicException('symfony/property-info v6 does not support phpdocumentor/reflection-docblock v6. Please stick to ^5.2 in your composer.json file.');
         }
 
         $this->docBlockFactory = $docBlockFactory ?: DocBlockFactory::createInstance();

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -36,7 +36,7 @@
         "phpstan/phpdoc-parser": "^1.0|^2.0"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<5.2",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
         "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/dependency-injection": "<6.4",
         "symfony/cache": "<6.4",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -22,7 +22,7 @@
         "symfony/polyfill-php84": "^1.30"
     },
     "require-dev": {
-        "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+        "phpdocumentor/reflection-docblock": "^5.2",
         "phpstan/phpdoc-parser": "^1.0|^2.0",
         "seld/jsonlint": "^1.10",
         "symfony/cache": "^6.4|^7.0",
@@ -47,8 +47,8 @@
         "symfony/yaml": "^6.4|^7.0"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<3.2.2",
-        "phpdocumentor/type-resolver": "<1.4.0",
+        "phpdocumentor/reflection-docblock": "<5.2|>=6",
+        "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/dependency-injection": "<6.4",
         "symfony/property-access": "<6.4",
         "symfony/property-info": "<6.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63179
| License       | MIT

Same as #63193 for newest branches.

Support for v6 should be provided by #62887 once its ready.