### PR TITLE
[PropertyInfo] Fix DocBlock resolution for inherited promoted properties

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -245,8 +245,8 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         $ucFirstProperty = ucfirst($property);
 
         switch (true) {
-            case $reflectionProperty?->isPromoted() && $docBlock = $this->getDocBlockFromConstructor($class, $property):
-                $data = [$docBlock, self::MUTATOR, null, $reflectionProperty->getDeclaringClass()->getName()];
+            case $reflectionProperty?->isPromoted() && $docBlock = $this->getDocBlockFromConstructor($reflectionProperty->class, $property):
+                $data = [$docBlock, self::MUTATOR, null, $reflectionProperty->class];
                 break;
 
             case [$docBlock, $declaringClass] = $this->getDocBlockFromProperty($class, $property):

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -19,10 +19,13 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyCollection;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildOfParentUsingTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildOfParentWithPromotedSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildWithConstructorOverride;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildWithoutConstructorOverride;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildWithSelfDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ClassUsingNestedTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ClassUsingTraitWithSelfDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentUsingTraitWithSelfDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithPromotedPropertyDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithPromotedSelfDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ParentWithSelfDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
@@ -541,6 +544,33 @@ class PhpDocExtractorTest extends TestCase
         yield 'nested trait property' => [ClassUsingNestedTrait::class, 'innerSelfProp', ClassUsingNestedTrait::class];
         yield 'promoted property' => [ParentWithPromotedSelfDocBlock::class, 'promotedSelfProp', ParentWithPromotedSelfDocBlock::class];
         yield 'promoted property from child' => [ChildOfParentWithPromotedSelfDocBlock::class, 'promotedSelfProp', ParentWithPromotedSelfDocBlock::class];
+    }
+
+    /**
+     * @dataProvider inheritedPromotedPropertyWithConstructorOverrideProvider
+     */
+    public function testInheritedPromotedPropertyWithConstructorOverride(string $class, string $property, ?array $expectedTypes)
+    {
+        $this->assertEquals($expectedTypes, $this->extractor->getTypes($class, $property));
+    }
+
+    /**
+     * @return iterable<string, array{0: class-string, 1: string, 2: ?array}>
+     */
+    public static function inheritedPromotedPropertyWithConstructorOverrideProvider(): iterable
+    {
+        $expectedItemsType = [new Type(
+            Type::BUILTIN_TYPE_ARRAY,
+            false,
+            null,
+            true,
+            new Type(Type::BUILTIN_TYPE_STRING),
+            new Type(Type::BUILTIN_TYPE_INT)
+        )];
+
+        yield 'parent promoted property' => [ParentWithPromotedPropertyDocBlock::class, 'items', $expectedItemsType,];
+        yield 'child without constructor override' => [ChildWithoutConstructorOverride::class, 'items', $expectedItemsType];
+        yield 'child with constructor override' => [ChildWithConstructorOverride::class, 'items', $expectedItemsType];
     }
 }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/ParentWithPromotedPropertyDocBlock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Extractor/ParentWithPromotedPropertyDocBlock.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor;
+
+class ParentWithPromotedPropertyDocBlock
+{
+    /**
+     * @param array<string, int> $items
+     */
+    public function __construct(
+        public $items = [],
+    ) {
+    }
+}
+
+class ChildWithoutConstructorOverride extends ParentWithPromotedPropertyDocBlock
+{
+}
+
+class ChildWithConstructorOverride extends ParentWithPromotedPropertyDocBlock
+{
+    public function __construct(
+        public $extraProp = null,
+    ) {
+        parent::__construct();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PhpDocExtractor` currently looks for promoted property DocBlocks on the constructor of the class being analyzed

This PR fixes a bug where types are lost when a child class overrides `__construct`, by using the declaring class of the property to locate the correct constructor DocBlock