### PR TITLE
[HttpClient] Fix dealing with multiple levels of AsyncResponse decoration

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -64,7 +64,7 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
 
             while (true) {
                 foreach (self::stream([$response], $timeout) as $chunk) {
-                    if ($chunk->isTimeout() && $response->passthru) {
+                    if ($chunk->isTimeout() && ($response->passthru || $response = self::findInnerPassthru($response))) {
                         // Timeouts thrown during initialization are transport errors
                         foreach (self::passthru($response->client, $response, new ErrorChunk($response->offset, new TransportException($chunk->getError()))) as $chunk) {
                             if ($chunk->isFirst()) {
@@ -274,7 +274,8 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                     }
                 }
 
-                if (!$r->passthru) {
+                $innerR = null;
+                if (!$r->passthru && !$innerR = null !== $chunk->getError() ? self::findInnerPassthru($r) : null) {
                     $r->stream = (static fn () => yield $chunk)();
                     yield from self::passthruStream($response, $r, $asyncMap);
 
@@ -289,11 +290,12 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                     throw new \LogicException(\sprintf('Instance of "%s" is already consumed and cannot be managed by "%s". A decorated client should not call any of the response\'s methods in its "request()" method.', get_debug_type($response), $class ?? static::class));
                 }
 
-                foreach (self::passthru($r->client, $r, $chunk, $asyncMap) as $chunk) {
+                $innerR ??= $r;
+                foreach (self::passthru($innerR->client, $innerR, $chunk, $asyncMap) as $chunk) {
                     yield $r => $chunk;
                 }
 
-                if ($r->response !== $response && isset($asyncMap[$response])) {
+                if ($innerR->response !== $response && isset($asyncMap[$response])) {
                     break;
                 }
             }
@@ -341,6 +343,21 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
         $r->stream = $stream;
 
         yield from self::passthruStream($response, $r, $asyncMap);
+    }
+
+    private static function findInnerPassthru(self $response): ?self
+    {
+        $innerResponse = $response->response ?? null;
+
+        while ($innerResponse instanceof self) {
+            if ($innerResponse->passthru) {
+                return $innerResponse;
+            }
+
+            $innerResponse = $innerResponse->response ?? null;
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58050
| License       | MIT

When `RetryableHttpClient` is decorated with an `AsyncResponse`-based client (e.g., for logging), errors and timeouts were not propagated to the inner passthru, causing the retry strategy to never be invoked.

This PR adds `findInnerPassthru()` to walk the response chain and forward error chunks to the first inner `AsyncResponse` that has a passthru, enabling proper retry behavior with nested decorators.
