### PR TITLE
[DependencyInjection] Fix lazy proxy type resolution for decorated services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -335,11 +335,6 @@ class AutowirePass extends AbstractRecursivePass
                         $value = $this->doProcessValue($value);
                     } elseif ($lazy = $attribute->lazy) {
                         $value ??= $getValue();
-                        $type = $this->resolveProxyType($type, $value->getType());
-                        $definition = (new Definition($type))
-                            ->setFactory('current')
-                            ->setArguments([[$value]])
-                            ->setLazy(true);
 
                         if (!\is_array($lazy)) {
                             if (str_contains($type, '|')) {
@@ -348,8 +343,14 @@ class AutowirePass extends AbstractRecursivePass
                             $lazy = str_contains($type, '&') ? explode('&', $type) : [];
                         }
 
+                        $proxyType = $lazy ? $type : $this->resolveProxyType($type, $value);
+                        $definition = (new Definition($proxyType))
+                            ->setFactory('current')
+                            ->setArguments([[$value]])
+                            ->setLazy(true);
+
                         if ($lazy) {
-                            if (!class_exists($type) && !interface_exists($type, false)) {
+                            if (!$this->container->getReflectionClass($proxyType, false)) {
                                 $definition->setClass('object');
                             }
                             foreach ($lazy as $v) {
@@ -772,7 +773,7 @@ class AutowirePass extends AbstractRecursivePass
         $resolvedType = $this->container->findDefinition($serviceId)->getClass();
         $resolvedType = $this->container->getParameterBag()->resolveValue($resolvedType);
 
-        if (!$resolvedType || !class_exists($resolvedType, false) && !interface_exists($resolvedType, false)) {
+        if (!$resolvedType || !$this->container->getReflectionClass($resolvedType, false)) {
             return $originalType;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1452,4 +1452,30 @@ class AutowirePassTest extends TestCase
         $dep = $service->getDependency()->getSelf();
         $this->assertInstanceOf(ExtendedLazyProxyClass::class, $dep);
     }
+
+    public function testLazyProxyForDecoratedService()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('some_service', SomeServiceClass::class)
+            ->setPublic(true);
+
+        $container->register('some_service.decorated', DecoratedSomeServiceClass::class)
+            ->setDecoratedService('some_service')
+            ->addArgument(new Reference('.inner'));
+
+        $container->register(LazyDecoratedServiceConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true);
+
+        $container->setAlias(SomeServiceInterface::class, 'some_service');
+
+        $container->compile();
+
+        $service = $container->get(LazyDecoratedServiceConsumer::class);
+        $this->assertInstanceOf(LazyDecoratedServiceConsumer::class, $service);
+
+        $result = $service->getValue();
+        $this->assertSame('decorated:original', $result);
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -605,3 +605,42 @@ class ListenerResolver
     {
     }
 }
+
+interface SomeServiceInterface
+{
+    public function getValue(): string;
+}
+
+class SomeServiceClass implements SomeServiceInterface
+{
+    public function getValue(): string
+    {
+        return 'original';
+    }
+}
+
+class DecoratedSomeServiceClass implements SomeServiceInterface
+{
+    public function __construct(private SomeServiceInterface $inner)
+    {
+    }
+
+    public function getValue(): string
+    {
+        return 'decorated:'.$this->inner->getValue();
+    }
+}
+
+class LazyDecoratedServiceConsumer
+{
+    public function __construct(
+        #[Autowire(service: 'some_service', lazy: true)]
+        private SomeServiceInterface $service,
+    ) {
+    }
+
+    public function getValue(): string
+    {
+        return $this->service->getValue();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61877
| License       | MIT

When using `#[Autowire(service: 'cache.app', lazy: true)`] on a service that is decorated (e.g., `TraceableAdapter` decorates `FilesystemAdapter`), the lazy proxy was incorrectly created based on the PHP type hint (`FilesystemAdapter`) instead of the actual service class (`TraceableAdapter`).
