### PR TITLE
[Form] Allow `ViolationMapperInterface` injection for `ValidatorExtension` and `FormTypeValidatorExtension`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -24,6 +24,12 @@ DoctrineBridge
 
  * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`. Namespace aliases are no longer supported in Doctrine.
 
+Form
+----
+
+ * Deprecate passing boolean as the second argument of `ValidatorExtension` and `FormTypeValidatorExtension`'s constructors; pass a `ViolationMapperInterface` instead
+ * Add argument `$violationMapper` to `ValidatorExtensionTrait` and `TypeTestCase`'s `getExtensions()` methods
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTestCase;
 use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
@@ -86,9 +87,9 @@ class EntityTypeTest extends BaseTypeTestCase
         }
     }
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
-        return array_merge(parent::getExtensions(), [
+        return array_merge(parent::getExtensions($violationMapper), [
             new DoctrineOrmExtension($this->emRegistry),
         ]);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -81,6 +81,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\Glob;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormTypeExtensionInterface;
 use Symfony\Component\Form\FormTypeGuesserInterface;
@@ -882,6 +884,11 @@ class FrameworkExtension extends Extension
     {
         $loader->load('form.php');
 
+        if (!property_exists(ValidatorExtension::class, 'violationMapper')) {
+            $container->removeDefinition('form.violation_mapper');
+            $container->removeAlias(ViolationMapperInterface::class);
+            $container->getDefinition('form.type_extension.form.validator')->replaceArgument(1, false);
+        }
         if (null === $config['form']['csrf_protection']['enabled']) {
             $this->writeConfigEnabled('form.csrf_protection', $config['csrf_protection']['enabled'], $config['form']['csrf_protection']);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
@@ -32,6 +32,8 @@ use Symfony\Component\Form\Extension\Validator\Type\RepeatedTypeValidatorExtensi
 use Symfony\Component\Form\Extension\Validator\Type\SubmitTypeValidatorExtension;
 use Symfony\Component\Form\Extension\Validator\Type\UploadValidatorExtension;
 use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormRegistry;
@@ -45,6 +47,14 @@ return static function (ContainerConfigurator $container) {
         ->set('form.resolved_type_factory', ResolvedFormTypeFactory::class)
 
         ->alias(ResolvedFormTypeFactoryInterface::class, 'form.resolved_type_factory')
+
+        ->set('form.violation_mapper', ViolationMapper::class)
+            ->args([
+                service('twig.form.renderer')->ignoreOnInvalid(),
+                service('translator')->ignoreOnInvalid(),
+            ])
+
+        ->alias(ViolationMapperInterface::class, 'form.violation_mapper')
 
         ->set('form.registry', FormRegistry::class)
             ->args([
@@ -141,7 +151,7 @@ return static function (ContainerConfigurator $container) {
         ->set('form.type_extension.form.validator', FormTypeValidatorExtension::class)
             ->args([
                 service('validator'),
-                false,
+                service('form.violation_mapper'),
                 service('twig.form.renderer')->ignoreOnInvalid(),
                 service('translator')->ignoreOnInvalid(),
             ])

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 ---
 
  * Add `ResetFlowType` button in `NavigatorFlowType` that you can display with `with_reset` option
+ * Allow injecting a `ViolationMapperInterface` into `FormTypeValidatorExtension`
+ * Deprecate passing boolean as the second argument of `ValidatorExtension` and `FormTypeValidatorExtension`'s constructors; pass a `ViolationMapperInterface` instead
+ * Add argument `$violationMapper` to `ValidatorExtensionTrait` and `TypeTestCase`'s `getExtensions()` methods
 
 8.0
 ---

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Validator\Type;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -27,15 +28,19 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class FormTypeValidatorExtension extends BaseValidatorExtension
 {
-    private ViolationMapper $violationMapper;
+    private readonly ViolationMapperInterface $violationMapper;
 
     public function __construct(
         private ValidatorInterface $validator,
-        private bool $legacyErrorMessages = true,
+        bool|ViolationMapperInterface|null $violationMapper = null,
         ?FormRendererInterface $formRenderer = null,
         ?TranslatorInterface $translator = null,
     ) {
-        $this->violationMapper = new ViolationMapper($formRenderer, $translator);
+        if (\is_bool($violationMapper)) {
+            trigger_deprecation('symfony/form', '8.1', \sprintf('Passing a boolean as a second argument of "%s"\'s constructor is deprecated; pass a "%s" instead.', self::class, ViolationMapperInterface::class));
+            $violationMapper = null;
+        }
+        $this->violationMapper = $violationMapper ?? new ViolationMapper($formRenderer, $translator);
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Extension\Validator;
 
 use Symfony\Component\Form\AbstractExtension;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Validator\Constraints\Traverse;
@@ -27,12 +28,20 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class ValidatorExtension extends AbstractExtension
 {
+    private readonly ?ViolationMapperInterface $violationMapper;
+
     public function __construct(
         private ValidatorInterface $validator,
-        private bool $legacyErrorMessages = true,
+        bool|ViolationMapperInterface|null $violationMapper = null,
         private ?FormRendererInterface $formRenderer = null,
         private ?TranslatorInterface $translator = null,
     ) {
+        if (\is_bool($violationMapper)) {
+            trigger_deprecation('symfony/form', '8.1', \sprintf('Passing a boolean as a second argument of "%s"\'s constructor is deprecated; pass a "%s" instead.', self::class, ViolationMapperInterface::class));
+            $violationMapper = null;
+        }
+        $this->violationMapper = $violationMapper;
+
         /** @var ClassMetadata $metadata */
         $metadata = $validator->getMetadataFor(\Symfony\Component\Form\Form::class);
 
@@ -53,7 +62,7 @@ class ValidatorExtension extends AbstractExtension
     protected function loadTypeExtensions(): array
     {
         return [
-            new Type\FormTypeValidatorExtension($this->validator, $this->legacyErrorMessages, $this->formRenderer, $this->translator),
+            new Type\FormTypeValidatorExtension($this->validator, $this->violationMapper, $this->formRenderer, $this->translator),
             new Type\RepeatedTypeValidatorExtension(),
             new Type\SubmitTypeValidatorExtension(),
         ];

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Test\Traits;
 
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -21,8 +22,12 @@ trait ValidatorExtensionTrait
 {
     protected ValidatorInterface $validator;
 
-    protected function getValidatorExtension(): ValidatorExtension
+    /**
+     * @param ViolationMapperInterface|null $violationMapper
+     */
+    protected function getValidatorExtension(/* ?ViolationMapperInterface $violationMapper = null */): ValidatorExtension
     {
+        $violationMapper = \func_num_args() ? func_get_arg(0) : null;
         if (!interface_exists(ValidatorInterface::class)) {
             throw new \Exception('In order to use the "ValidatorExtensionTrait", the symfony/validator component must be installed.');
         }
@@ -36,6 +41,6 @@ trait ValidatorExtensionTrait
         $this->validator->expects($this->any())->method('getMetadataFor')->willReturn($metadata);
         $this->validator->expects($this->any())->method('validate')->willReturn(new ConstraintViolationList());
 
-        return new ValidatorExtension($this->validator, false);
+        return new ValidatorExtension($this->validator, $violationMapper);
     }
 }

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Test;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
@@ -32,14 +33,17 @@ abstract class TypeTestCase extends FormIntegrationTestCase
     }
 
     /**
+     * @param ViolationMapperInterface|null $violationMapper
+     *
      * @return FormExtensionInterface[]
      */
-    protected function getExtensions(): array
+    protected function getExtensions(/* ?ViolationMapperInterface $violationMapper = null */): array
     {
+        $violationMapper = \func_num_args() ? func_get_arg(0) : null;
         $extensions = [];
 
         if (\in_array(ValidatorExtensionTrait::class, class_uses($this), true)) {
-            $extensions[] = $this->getValidatorExtension();
+            $extensions[] = $this->getValidatorExtension($violationMapper);
         }
 
         return $extensions;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Extension\Core\CoreExtension;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\NativeRequestHandler;
 use Symfony\Component\Form\RequestHandlerInterface;
 use Symfony\Component\HttpFoundation\File\File;
@@ -25,9 +26,9 @@ class FileTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = FileType::class;
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
-        return array_merge(parent::getExtensions(), [new CoreExtension(null, null, new IdentityTranslator())]);
+        return array_merge(parent::getExtensions($violationMapper), [new CoreExtension(null, null, new IdentityTranslator())]);
     }
 
     // https://github.com/symfony/symfony/pull/5028

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -45,9 +46,9 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
-        return array_merge(parent::getExtensions(), [
+        return array_merge(parent::getExtensions($violationMapper), [
             new CsrfExtension($this->tokenManager, new IdentityTranslator()),
         ]);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\HtmlSanitizer\HtmlSanitizerExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
@@ -28,7 +29,7 @@ class TextTypeHtmlSanitizerExtensionTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         $fooSanitizer = $this->createMock(HtmlSanitizerInterface::class);
         $fooSanitizer->expects($this->once())
@@ -42,7 +43,7 @@ class TextTypeHtmlSanitizerExtensionTest extends TypeTestCase
             ->with('foobar')
             ->willReturn('bar');
 
-        return array_merge(parent::getExtensions(), [
+        return array_merge(parent::getExtensions($violationMapper), [
             new HtmlSanitizerExtension(new ServiceLocator([
                 'foo' => static fn () => $fooSanitizer,
                 'bar' => static fn () => $barSanitizer,

--- a/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\PasswordHasher\EventListener\PasswordHasherListener;
 use Symfony\Component\Form\Extension\PasswordHasher\PasswordHasherExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\RepeatedPasswordField;
 use Symfony\Component\Form\Tests\Fixtures\User;
@@ -46,7 +47,7 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         return array_merge(parent::getExtensions(), [
             new PasswordHasherExtension(new PasswordHasherListener($this->passwordHasher)),

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Validator\Constraints;
 
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Test\FormPerformanceTestCase;
 use Symfony\Component\Validator\Validation;
 
@@ -21,10 +22,10 @@ use Symfony\Component\Validator\Validation;
  */
 class FormValidatorPerformanceTest extends FormPerformanceTestCase
 {
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         return [
-            new ValidatorExtension(Validation::createValidator(), false),
+            new ValidatorExtension(Validation::createValidator(), $violationMapper),
         ];
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/BaseValidatorExtensionTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Test\FormInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Constraints\GroupSequence;
@@ -93,10 +94,10 @@ abstract class BaseValidatorExtensionTestCase extends TypeTestCase
 
     abstract protected function createForm(array $options = []);
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         return [
-            new ValidatorExtension((new ValidatorBuilder())->getValidator()),
+            new ValidatorExtension((new ValidatorBuilder())->getValidator(), $violationMapper),
         ];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -78,7 +78,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTestCase
     public function testGroupSequenceWithConstraintsOption()
     {
         $form = Forms::createFormFactoryBuilder()
-            ->addExtension(new ValidatorExtension(Validation::createValidator(), false))
+            ->addExtension(new ValidatorExtension(Validation::createValidator()))
             ->getFormFactory()
             ->create(FormTypeTest::TESTED_TYPE, null, ['validation_groups' => new GroupSequence(['First', 'Second'])])
             ->add('field', TextTypeTest::TESTED_TYPE, [

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -35,7 +35,7 @@ class ValidatorExtensionTest extends TestCase
             ->setMetadataFactory($metadataFactory)
             ->getValidator();
 
-        $extension = new ValidatorExtension($validator, false);
+        $extension = new ValidatorExtension($validator);
 
         $this->assertInstanceOf(ValidatorTypeGuesser::class, $extension->loadTypeGuesser());
 

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^7.4|^8.0",
         "symfony/options-resolver": "^7.4|^8.0",
         "symfony/polyfill-ctype": "^1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

Refactors FormTypeValidatorExtension to use proper dependency injection for ViolationMapper.
The constructor now accepts ViolationMapperInterface instead of creating the ViolationMapper instance directly, improving testability and allowing for custom violation mapper implementations. 
Updated DI configuration to register the ViolationMapper service with proper interface aliasing.

Key improvements:
- Better separation of concerns through DI
- Enhanced testability via interface injection
- Support for custom ViolationMapper implementations
- Cleaner constructor signature