### PR TITLE
 Release v5.4.51

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -7,6 +7,10 @@ in 5.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.4.0...v5.4.1
 
+* 5.4.51 (2026-01-28)
+
+ * security #cve-2026-24739 [Process] Fix escaping for MSYS on Windows (nicolas-grekas)
+
 * 5.4.50 (2025-11-12)
 
  * security #cve-2025-64500 [HttpFoundation] Fix parsing pathinfo with no leading slash (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,11 +78,11 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static $freshCache = [];
 
-    public const VERSION = '5.4.50';
-    public const VERSION_ID = 50450;
+    public const VERSION = '5.4.51';
+    public const VERSION_ID = 50451;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 4;
-    public const RELEASE_VERSION = 50;
+    public const RELEASE_VERSION = 51;
     public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2024';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.4.50...v5.4.51)

 * security #cve-2026-24739 [Process] Fix escaping for MSYS on Windows (@nicolas-grekas)
