### PR TITLE
[Mailer][Resend] Deprecate usage of the params header in favor of variables for resend

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Resend/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+8.1
+---
+
+ * Deprecate usage of the "params" header use "variables" header instead
 
 7.1
 ---

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
@@ -51,7 +51,7 @@ class ResendApiTransportTest extends TestCase
         ];
     }
 
-    public function testCustomHeaderWithParams()
+    public function testCustomHeader()
     {
         $params = ['param1' => 'foo', 'param2' => 'bar'];
         $json = json_encode(['custom_header_1' => 'custom_value_1']);
@@ -76,66 +76,6 @@ class ResendApiTransportTest extends TestCase
         $this->assertArrayHasKey('template', $payload);
         $this->assertEquals('1', $payload['template']['id']);
         $this->assertEquals($params, $payload['template']['variables']);
-        $this->assertArrayHasKey('foo', $payload['headers']);
-        $this->assertEquals('bar', $payload['headers']['foo']);
-    }
-
-    public function testCustomHeaderWithVariables()
-    {
-        $variables = ['param1' => 'foo', 'param2' => 'bar'];
-        $json = json_encode(['custom_header_1' => 'custom_value_1']);
-
-        $email = new Email();
-        $email->getHeaders()
-            ->add(new MetadataHeader('custom', $json))
-            ->add(new TagHeader('TagInHeaders'))
-            ->addTextHeader('templateId', 1)
-            ->addParameterizedHeader('variables', 'variables', $variables)
-            ->addTextHeader('foo', 'bar');
-        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
-
-        $transport = new ResendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
-        $payload = $method->invoke($transport, $email, $envelope);
-
-        $this->assertArrayHasKey('X-Metadata-custom', $payload['headers']);
-        $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
-        $this->assertArrayHasKey('tags', $payload);
-        $this->assertEquals(['X-Tag' => 'TagInHeaders'], current($payload['tags']));
-        $this->assertArrayHasKey('template', $payload);
-        $this->assertEquals('1', $payload['template']['id']);
-        $this->assertEquals($variables, $payload['template']['variables']);
-        $this->assertArrayHasKey('foo', $payload['headers']);
-        $this->assertEquals('bar', $payload['headers']['foo']);
-    }
-
-    public function testCustomHeaderWithVariablesOverrideParams()
-    {
-        $params = ['paramA' => 'foo', 'paramB' => 'bar', 'params1' => 'baz'];
-        $variables = ['param1' => 'foo', 'param2' => 'bar'];
-        $json = json_encode(['custom_header_1' => 'custom_value_1']);
-
-        $email = new Email();
-        $email->getHeaders()
-              ->add(new MetadataHeader('custom', $json))
-              ->add(new TagHeader('TagInHeaders'))
-              ->addTextHeader('templateId', 1)
-              ->addParameterizedHeader('params', 'params', $params)
-              ->addParameterizedHeader('variables', 'variables', $variables)
-              ->addTextHeader('foo', 'bar');
-        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
-
-        $transport = new ResendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
-        $payload = $method->invoke($transport, $email, $envelope);
-
-        $this->assertArrayHasKey('X-Metadata-custom', $payload['headers']);
-        $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
-        $this->assertArrayHasKey('tags', $payload);
-        $this->assertEquals(['X-Tag' => 'TagInHeaders'], current($payload['tags']));
-        $this->assertArrayHasKey('template', $payload);
-        $this->assertEquals('1', $payload['template']['id']);
-        $this->assertEquals($variables, $payload['template']['variables']);
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
@@ -51,9 +51,38 @@ class ResendApiTransportTest extends TestCase
         ];
     }
 
-    public function testCustomHeader()
+    public function testCustomHeaderWithParams()
     {
         $params = ['param1' => 'foo', 'param2' => 'bar'];
+        $json = json_encode(['custom_header_1' => 'custom_value_1']);
+
+        $email = new Email();
+        $email->getHeaders()
+              ->add(new MetadataHeader('custom', $json))
+              ->add(new TagHeader('TagInHeaders'))
+              ->addTextHeader('templateId', 1)
+              ->addParameterizedHeader('params', 'params', $params)
+              ->addTextHeader('foo', 'bar');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new ResendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('X-Metadata-custom', $payload['headers']);
+        $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
+        $this->assertArrayHasKey('tags', $payload);
+        $this->assertEquals(['X-Tag' => 'TagInHeaders'], current($payload['tags']));
+        $this->assertArrayHasKey('template', $payload);
+        $this->assertEquals('1', $payload['template']['id']);
+        $this->assertEquals($params, $payload['template']['variables']);
+        $this->assertArrayHasKey('foo', $payload['headers']);
+        $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testCustomHeaderWithVariables()
+    {
+        $variables = ['param1' => 'foo', 'param2' => 'bar'];
         $json = json_encode(['custom_header_1' => 'custom_value_1']);
 
         $email = new Email();
@@ -61,7 +90,7 @@ class ResendApiTransportTest extends TestCase
             ->add(new MetadataHeader('custom', $json))
             ->add(new TagHeader('TagInHeaders'))
             ->addTextHeader('templateId', 1)
-            ->addParameterizedHeader('params', 'params', $params)
+            ->addParameterizedHeader('variables', 'variables', $variables)
             ->addTextHeader('foo', 'bar');
         $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
 
@@ -73,10 +102,40 @@ class ResendApiTransportTest extends TestCase
         $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
         $this->assertArrayHasKey('tags', $payload);
         $this->assertEquals(['X-Tag' => 'TagInHeaders'], current($payload['tags']));
-        $this->assertArrayHasKey('templateId', $payload['headers']);
-        $this->assertEquals('1', $payload['headers']['templateId']);
-        $this->assertArrayHasKey('params', $payload['headers']);
-        $this->assertEquals('params; param1=foo; param2=bar', $payload['headers']['params']);
+        $this->assertArrayHasKey('template', $payload);
+        $this->assertEquals('1', $payload['template']['id']);
+        $this->assertEquals($variables, $payload['template']['variables']);
+        $this->assertArrayHasKey('foo', $payload['headers']);
+        $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testCustomHeaderWithVariablesOverrideParams()
+    {
+        $params = ['paramA' => 'foo', 'paramB' => 'bar', 'params1' => 'baz'];
+        $variables = ['param1' => 'foo', 'param2' => 'bar'];
+        $json = json_encode(['custom_header_1' => 'custom_value_1']);
+
+        $email = new Email();
+        $email->getHeaders()
+              ->add(new MetadataHeader('custom', $json))
+              ->add(new TagHeader('TagInHeaders'))
+              ->addTextHeader('templateId', 1)
+              ->addParameterizedHeader('params', 'params', $params)
+              ->addParameterizedHeader('variables', 'variables', $variables)
+              ->addTextHeader('foo', 'bar');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new ResendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('X-Metadata-custom', $payload['headers']);
+        $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
+        $this->assertArrayHasKey('tags', $payload);
+        $this->assertEquals(['X-Tag' => 'TagInHeaders'], current($payload['tags']));
+        $this->assertArrayHasKey('template', $payload);
+        $this->assertEquals('1', $payload['template']['id']);
+        $this->assertEquals($variables, $payload['template']['variables']);
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
@@ -51,7 +51,7 @@ class ResendApiTransportTest extends TestCase
         ];
     }
 
-    public function testCustomHeader()
+    public function testCustomHeaderWithParams()
     {
         $params = ['param1' => 'foo', 'param2' => 'bar'];
         $json = json_encode(['custom_header_1' => 'custom_value_1']);
@@ -76,6 +76,66 @@ class ResendApiTransportTest extends TestCase
         $this->assertArrayHasKey('template', $payload);
         $this->assertEquals('1', $payload['template']['id']);
         $this->assertEquals($params, $payload['template']['variables']);
+        $this->assertArrayHasKey('foo', $payload['headers']);
+        $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testCustomHeaderWithVariables()
+    {
+        $variables = ['param1' => 'foo', 'param2' => 'bar'];
+        $json = json_encode(['custom_header_1' => 'custom_value_1']);
+
+        $email = new Email();
+        $email->getHeaders()
+              ->add(new MetadataHeader('custom', $json))
+              ->add(new TagHeader('TagInHeaders'))
+              ->addTextHeader('templateId', 1)
+              ->addParameterizedHeader('variables', 'variables', $variables)
+              ->addTextHeader('foo', 'bar');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new ResendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('X-Metadata-custom', $payload['headers']);
+        $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
+        $this->assertArrayHasKey('tags', $payload);
+        $this->assertEquals(['X-Tag' => 'TagInHeaders'], current($payload['tags']));
+        $this->assertArrayHasKey('template', $payload);
+        $this->assertEquals('1', $payload['template']['id']);
+        $this->assertEquals($variables, $payload['template']['variables']);
+        $this->assertArrayHasKey('foo', $payload['headers']);
+        $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testCustomHeaderWithVariablesOverrideParams()
+    {
+        $params = ['paramA' => 'foo', 'paramB' => 'bar', 'params1' => 'baz'];
+        $variables = ['param1' => 'foo', 'param2' => 'bar'];
+        $json = json_encode(['custom_header_1' => 'custom_value_1']);
+
+        $email = new Email();
+        $email->getHeaders()
+              ->add(new MetadataHeader('custom', $json))
+              ->add(new TagHeader('TagInHeaders'))
+              ->addTextHeader('templateId', 1)
+              ->addParameterizedHeader('params', 'params', $params)
+              ->addParameterizedHeader('variables', 'variables', $variables)
+              ->addTextHeader('foo', 'bar');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new ResendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('X-Metadata-custom', $payload['headers']);
+        $this->assertEquals($json, $payload['headers']['X-Metadata-custom']);
+        $this->assertArrayHasKey('tags', $payload);
+        $this->assertEquals(['X-Tag' => 'TagInHeaders'], current($payload['tags']));
+        $this->assertArrayHasKey('template', $payload);
+        $this->assertEquals('1', $payload['template']['id']);
+        $this->assertEquals($variables, $payload['template']['variables']);
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
@@ -151,6 +151,25 @@ final class ResendApiTransport extends AbstractApiTransport
                 continue;
             }
 
+            if ('templateid' === $name) {
+                $headersAndTags['template']['id'] = $header->getValue();
+
+                continue;
+            }
+
+            if ('params' === $name) {
+                trigger_deprecation('symfony/resend-mailer', '7.3', 'Usage of params is deprecated use variables instead.');
+                $headersAndTags['template']['variables'] = $header->getParameters();
+
+                continue;
+            }
+
+            if ('variables' === $name) {
+                $headersAndTags['template'][$header->getName()] = $header->getParameters();
+
+                continue;
+            }
+
             $headersAndTags['headers'][$header->getName()] = $header->getBodyAsString();
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
@@ -158,7 +158,14 @@ final class ResendApiTransport extends AbstractApiTransport
             }
 
             if ('params' === $name) {
+                trigger_deprecation('symfony/resend-mailer', '8.1', 'The "params" header name is deprecated, use the "variables" header name instead');
                 $headersAndTags['template']['variables'] = $header->getParameters();
+
+                continue;
+            }
+
+            if ('variables' === $name) {
+                $headersAndTags['template'][$header->getName()] = $header->getParameters();
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
@@ -158,14 +158,7 @@ final class ResendApiTransport extends AbstractApiTransport
             }
 
             if ('params' === $name) {
-                trigger_deprecation('symfony/resend-mailer', '7.3', 'Usage of params is deprecated use variables instead.');
                 $headersAndTags['template']['variables'] = $header->getParameters();
-
-                continue;
-            }
-
-            if ('variables' === $name) {
-                $headersAndTags['template'][$header->getName()] = $header->getParameters();
 
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Deprecate usage of the "params" header use "variables" header instead to be compliant with Resend API documentation #63196 

@welcoMattic @nicolas-grekas 
