### PR TITLE
[Finder] Fix SortableIterator inadvertently and inconsistently deduplicating appended iterators

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -87,17 +87,29 @@ class SortableIterator implements \IteratorAggregate
     public function getIterator(): \Traversable
     {
         if (1 === $this->sort) {
-            return $this->iterator;
+            yield from $this->iterator;
+
+            return;
         }
 
-        $array = iterator_to_array($this->iterator, true);
+        $keys = $values = [];
+        foreach ($this->iterator as $key => $value) {
+            $keys[] = $key;
+            $values[] = $value;
+        }
 
         if (-1 === $this->sort) {
-            $array = array_reverse($array);
-        } else {
-            uasort($array, $this->sort);
+            for ($i = \count($values) - 1; $i >= 0; --$i) {
+                yield $keys[$i] => $values[$i];
+            }
+
+            return;
         }
 
-        return new \ArrayIterator($array);
+        uasort($values, $this->sort);
+
+        foreach ($values as $i => $v) {
+            yield $keys[$i] => $v;
+        }
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -57,9 +57,8 @@ abstract class RealIteratorTestCase extends IteratorTestCase
 
         if (is_dir(self::$tmpDir)) {
             self::tearDownAfterClass();
-        } else {
-            mkdir(self::$tmpDir);
         }
+        mkdir(self::$tmpDir);
 
         foreach (self::$files as $file) {
             if (\DIRECTORY_SEPARATOR === $file[\strlen($file) - 1]) {
@@ -99,27 +98,7 @@ abstract class RealIteratorTestCase extends IteratorTestCase
 
     public static function tearDownAfterClass(): void
     {
-        try {
-            $paths = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator(self::$tmpDir, \RecursiveDirectoryIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::CHILD_FIRST
-            );
-        } catch (\UnexpectedValueException $exception) {
-            // open_basedir restriction in effect
-            return;
-        }
-
-        foreach ($paths as $path) {
-            if ($path->isDir()) {
-                if ($path->isLink()) {
-                    @unlink($path);
-                } else {
-                    @rmdir($path);
-                }
-            } else {
-                @unlink($path);
-            }
-        }
+        (new Filesystem())->remove(self::$tmpDir);
     }
 
     protected static function toAbsolute($files = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63190
| License       | MIT

As explained in https://github.com/symfony/symfony/issues/63190#issuecomment-3799123840