### PR TITLE
[Messenger] Fix calling nack() when ack() fails

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/Acknowledger.php
+++ b/src/Symfony/Component/Messenger/Handler/Acknowledger.php
@@ -20,7 +20,7 @@ class Acknowledger
 {
     private string $handlerClass;
     private ?\Closure $ack;
-    private ?\Throwable $error = null;
+    private \Throwable|false|null $error = null;
     private mixed $result = null;
 
     /**
@@ -47,7 +47,7 @@ class Acknowledger
 
     public function getError(): ?\Throwable
     {
-        return $this->error;
+        return $this->error ?: null;
     }
 
     public function getResult(): mixed
@@ -69,12 +69,12 @@ class Acknowledger
 
     private function doAck(?\Throwable $e = null, mixed $result = null): void
     {
-        if (!$ack = $this->ack) {
+        if (!($ack = $this->ack) || (null !== $this->error && (false !== $this->error || null === $e))) {
             throw new LogicException(\sprintf('The acknowledger cannot be called twice by the "%s" batch handler.', $this->handlerClass));
         }
-        $this->ack = null;
-        $this->error = $e;
+        $this->error = $e ?: false;
         $this->result = $result;
         $ack($e, $result);
+        $this->ack = null;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Handler/AcknowledgerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/AcknowledgerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+
+class AcknowledgerTest extends TestCase
+{
+    public function testNackAfterAckThrowsIsAllowed()
+    {
+        $ackCalls = 0;
+        $nackCalls = 0;
+        $nackError = null;
+
+        $ack = static function (?\Throwable $error = null) use (&$ackCalls, &$nackCalls, &$nackError): void {
+            if (null === $error) {
+                ++$ackCalls;
+                throw new \RuntimeException('Ack failed.');
+            }
+
+            ++$nackCalls;
+            $nackError = $error;
+        };
+
+        $acknowledger = new Acknowledger('handler', $ack);
+
+        try {
+            $acknowledger->ack();
+        } catch (\RuntimeException) {
+        }
+
+        $error = new \RuntimeException('Nack failed.');
+        $acknowledger->nack($error);
+
+        $this->assertSame(1, $ackCalls);
+        $this->assertSame(1, $nackCalls);
+        $this->assertSame($error, $nackError);
+        $this->assertTrue($acknowledger->isAcknowledged());
+        $this->assertSame($error, $acknowledger->getError());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Spotted by @jwage 