### PR TITLE
[DependencyInjection][HttpKernel] Fix parsing Target attributes on properties and on controllers

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autowire.php
@@ -21,7 +21,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_PARAMETER)]
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 class Autowire
 {
     public readonly string|array|Expression|Reference|ArgumentInterface|null $value;

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireDecorated.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireDecorated.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Attribute;
 
-#[\Attribute(\Attribute::TARGET_PARAMETER)]
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 class AutowireDecorated
 {
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/Target.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Target.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-#[\Attribute(\Attribute::TARGET_PARAMETER)]
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 final class Target
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredPropertiesPass.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\TypedReference;
@@ -56,7 +59,11 @@ class AutowireRequiredPropertiesPass extends AbstractRecursivePass
             }
 
             $type = $type->getName();
-            $value->setProperty($name, new TypedReference($type, $type, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $name));
+            $value->setProperty($name, new TypedReference($type, $type, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $name, array_map(static fn ($a) => $a->newInstance(), array_merge(
+                $reflectionProperty->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF),
+                $reflectionProperty->getAttributes(AutowireDecorated::class),
+                $reflectionProperty->getAttributes(Target::class),
+            ))));
         }
 
         return $value;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredPropertiesPassTest.php
@@ -13,9 +13,11 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredPropertiesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\TypedReference;
 
 require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
 require_once __DIR__.'/../Fixtures/includes/autowiring_classes_74.php';
@@ -61,5 +63,25 @@ class AutowireRequiredPropertiesPassTest extends TestCase
 
         $this->assertArrayHasKey('foo', $properties);
         $this->assertEquals(Foo::class, (string) $properties['foo']);
+    }
+
+    public function testTargetAttributeIsPropagatedOnRequiredProperty()
+    {
+        $container = new ContainerBuilder();
+        $container->register(Foo::class);
+
+        $container->register('property_injection_with_target', AutowirePropertyWithTarget::class)
+            ->setAutowired(true);
+
+        (new ResolveClassPass())->process($container);
+        (new AutowireRequiredPropertiesPass())->process($container);
+
+        $properties = $container->getDefinition('property_injection_with_target')->getProperties();
+
+        $this->assertArrayHasKey('foo', $properties);
+        $this->assertInstanceOf(TypedReference::class, $properties['foo']);
+        $attributes = array_values(array_filter($properties['foo']->getAttributes(), static fn ($attribute) => $attribute instanceof Target));
+        $this->assertCount(1, $attributes);
+        $this->assertSame('foo.target', $attributes[0]->name);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -30,6 +31,13 @@ class AutowireWither
 class AutowireProperty
 {
     #[Required]
+    public Foo $foo;
+}
+
+class AutowirePropertyWithTarget
+{
+    #[Required]
+    #[Target('foo.target')]
     public Foo $foo;
 }
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -203,8 +203,10 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
 
                         $args[$p->name] = new Reference($erroredId, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE);
                     } else {
-                        $target = preg_replace('/(^|[(|&])\\\\/', '\1', $target);
-                        $args[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, Target::parseName($p)) : new Reference($target, $invalidBehavior);
+                        $targetAttribute = null;
+                        $name = Target::parseName($p, $targetAttribute);
+                        $target = preg_replace('/(^|[(|&])\\\\/', '\\1', $target);
+                        $args[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, $name, $targetAttribute ? [$targetAttribute] : []) : new Reference($target, $invalidBehavior);
                     }
                 }
                 // register the maps as a per-method service-locators

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -458,10 +458,33 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $expected = [
             'apiKey' => new ServiceClosureArgument(new Reference('the_api_key')),
-            'service1' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'imageStorage')),
+            'service1' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'imageStorage', [new Target('image.storage')])),
             'service2' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'service2')),
         ];
         $this->assertEquals($expected, $locator->getArgument(0));
+    }
+
+    public function testTargetAttributeUsesShortNameForControllerArguments()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service')->addArgument([]);
+
+        $container->register('limiter.anonymous_action', DummyRateLimiterFactory::class);
+        $container->registerAliasForArgument('limiter.anonymous_action', DummyLimiterFactoryInterface::class, 'anonymous_action.limiter', 'anonymous_action');
+
+        $container->register('foo', WithTargetShortName::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
+        $locator = $container->getDefinition((string) $locator['foo::fooAction']->getValues()[0]);
+
+        $argument = $locator->getArgument(0)['limiterFactory']->getValues()[0];
+        $this->assertInstanceOf(TypedReference::class, $argument);
+        $this->assertSame(DummyLimiterFactoryInterface::class, $argument->getType());
+        $this->assertSame('anonymous_action', $argument->getName());
+        $this->assertEquals([new Target('anonymous_action')], $argument->getAttributes());
     }
 
     public function testResponseArgumentIsIgnored()
@@ -681,6 +704,28 @@ class WithTarget
         ControllerDummy $service1,
         ControllerDummy $service2,
     ) {
+    }
+}
+
+class WithTargetShortName
+{
+    public function fooAction(
+        #[Target('anonymous_action')]
+        DummyLimiterFactoryInterface $limiterFactory,
+    ) {
+    }
+}
+
+interface DummyLimiterFactoryInterface
+{
+    public function create(mixed $key = null): object;
+}
+
+class DummyRateLimiterFactory implements DummyLimiterFactoryInterface
+{
+    public function create(mixed $key = null): object
+    {
+        throw new \BadMethodCallException('Not used in tests.');
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -30,7 +30,7 @@
         "symfony/config": "^6.1|^7.0",
         "symfony/console": "^5.4|^6.0|^7.0",
         "symfony/css-selector": "^5.4|^6.0|^7.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/dependency-injection": "^6.4.1|^7.0.1",
         "symfony/dom-crawler": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63132
| License       | MIT

When creating `TypedReference` objects, we forgot to convey `Target` attributes with them.