### PR TITLE
[Console] Fall back to 0 when getCode() does not provide an integer

### DIFF
--- a/src/Symfony/Component/Console/Exception/RunCommandFailedException.php
+++ b/src/Symfony/Component/Console/Exception/RunCommandFailedException.php
@@ -22,7 +22,7 @@ final class RunCommandFailedException extends RuntimeException
     {
         parent::__construct(
             $exception instanceof \Throwable ? $exception->getMessage() : $exception,
-            $exception instanceof \Throwable ? $exception->getCode() : 0,
+            $exception instanceof \Throwable && \is_int($exception->getCode()) ? $exception->getCode() : 0,
             $exception instanceof \Throwable ? $exception : null,
         );
     }

--- a/src/Symfony/Component/Console/Tests/Exception/RunCommandFailedExceptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Exception/RunCommandFailedExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RunCommandFailedException;
+use Symfony\Component\Console\Messenger\RunCommandContext;
+use Symfony\Component\Console\Messenger\RunCommandMessage;
+
+class RunCommandFailedExceptionTest extends TestCase
+{
+    public function testDefaultExceptionProvidesCode()
+    {
+        $exception = self::createException(new \Exception('Boom!', 42));
+
+        self::assertSame(42, $exception->getCode());
+    }
+
+    public function testNonIntegerCodeProvidesZero()
+    {
+        $exception = self::createException(new class() extends \Exception {
+            protected $code = 'non-integer-code';
+        });
+
+        self::assertSame(0, $exception->getCode());
+    }
+
+    private static function createException(\Throwable $inner): RunCommandFailedException
+    {
+        return new RunCommandFailedException(
+            $inner,
+            new RunCommandContext(
+                new RunCommandMessage('foo'),
+                exitCode: Command::FAILURE,
+                output: 'bar'
+            )
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
@@ -46,7 +46,7 @@ class ExceptionDataCollector extends DataCollector
         return $this->data['exception']->getMessage();
     }
 
-    public function getCode(): int
+    public function getCode(): int|string
     {
         return $this->data['exception']->getCode();
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
@@ -36,6 +36,12 @@ class ExceptionDataCollectorTest extends TestCase
         $this->assertSame(500, $c->getCode());
         $this->assertSame('exception', $c->getName());
         $this->assertSame($trace, $c->getTrace());
+
+        $c->collect(new Request(), new Response(), new class() extends \Exception {
+            protected $code = 'non-integer-code';
+        });
+
+        $this->assertSame('non-integer-code', $c->getCode());
     }
 
     public function testCollectWithoutException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62116
| License       | MIT

Fall back to **0** when `getCode()` does not provide an integer value.\
This is certainly the case for classes such as 🔗 [PDOException](https://www.php.net/manual/en/exception.getcode.php#refsect1-exception.getcode-returnvalues).
