### PR TITLE
[FrameworkBundle] Fix accessing the test container when using KernelTestCase in non-debug mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -86,7 +86,7 @@ abstract class KernelTestCase extends TestCase
         // If the cache warmer is registered, it means that the cache has been
         // warmed up, so the current container is not fresh anymore. Let's
         // reboot a fresh one.
-        if (self::getContainer()->initialized('cache_warmer')) {
+        if ($kernel->getContainer()->initialized('cache_warmer')) {
             static::ensureKernelShutdown();
 
             $kernel = static::createKernel($options);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -22,9 +22,10 @@ class TestServiceContainerTest extends AbstractWebTestCase
 {
     public function testLogicExceptionIfTestConfigIsDisabled()
     {
-        $this->expectException(\LogicException::class);
-
         static::bootKernel(['test_case' => 'TestServiceContainer', 'root_config' => 'test_disabled.yml', 'environment' => 'test_disabled']);
+
+        $this->expectException(\LogicException::class);
+        static::getContainer();
     }
 
     public function testThatPrivateServicesAreAvailableIfTestConfigIsEnabled()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63232
| License       | MIT