### PR TITLE
[Translation] Rework string deletion in Crowdin Provider

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -33,12 +33,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 final class CrowdinProvider implements ProviderInterface
 {
     public function __construct(
-        private HttpClientInterface $client,
-        private LoaderInterface $loader,
-        private LoggerInterface $logger,
-        private XliffFileDumper $xliffFileDumper,
-        private string $defaultLocale,
-        private string $endpoint,
+        private readonly HttpClientInterface $client,
+        private readonly LoaderInterface $loader,
+        private readonly LoggerInterface $logger,
+        private readonly XliffFileDumper $xliffFileDumper,
+        private readonly string $defaultLocale,
+        private readonly string $endpoint,
     ) {
     }
 
@@ -187,8 +187,6 @@ final class CrowdinProvider implements ProviderInterface
     public function delete(TranslatorBagInterface $translatorBag): void
     {
         $fileList = $this->getFileList();
-        $responses = [];
-
         $defaultCatalogue = $translatorBag->getCatalogue($this->defaultLocale);
 
         foreach ($defaultCatalogue->all() as $domain => $messages) {
@@ -198,28 +196,28 @@ final class CrowdinProvider implements ProviderInterface
                 continue;
             }
 
-            $stringsMap = $this->mapStrings($fileId);
+            $sourceFileInfo = $this->downloadSourceFile($fileId);
+            $sourceFile = $this->client->request('GET', $sourceFileInfo->toArray()['data']['url']);
 
-            foreach ($messages as $id => $message) {
-                if (!\array_key_exists($id, $stringsMap)) {
-                    continue;
+            $providerCatalogue = $this->loader->load($sourceFile->getContent(), $this->defaultLocale, $domain);
+            $existingMessages = array_diff($providerCatalogue->all($domain), $messages);
+
+            $content = $this->xliffFileDumper->formatCatalogue(
+                new MessageCatalogue($this->defaultLocale, [$domain => $existingMessages]),
+                $domain,
+                ['default_locale' => $this->defaultLocale],
+            );
+
+            try {
+                $file = $this->updateFile($fileId, $domain, $content);
+
+                if (null === $file) {
+                    $this->logger->warning(
+                        \sprintf('Unable to update file "%d" and domain "%s".', $fileId, $domain)
+                    );
                 }
-
-                $responses[] = $this->deleteString($stringsMap[$id]);
-            }
-        }
-
-        foreach ($responses as $response) {
-            if (404 === $response->getStatusCode()) {
-                continue;
-            }
-
-            if (204 !== $statusCode = $response->getStatusCode()) {
-                $this->logger->warning(\sprintf('Unable to delete string: "%s".', $response->getContent(false)));
-
-                if (500 <= $statusCode) {
-                    throw new ProviderException('Unable to delete string.', $response);
-                }
+            } catch (ProviderException $e) {
+                throw new ProviderException(\sprintf('Unable to update file "%d" and domain "%s": "%s".', $fileId, $domain, $e->getMessage()), $e->getResponse(), previous: $e);
             }
         }
     }
@@ -227,26 +225,6 @@ final class CrowdinProvider implements ProviderInterface
     private function getFileIdByDomain(array $filesMap, string $domain): ?int
     {
         return $filesMap[\sprintf('%s.%s', $domain, 'xlf')] ?? null;
-    }
-
-    private function mapStrings(int $fileId): array
-    {
-        $result = [];
-
-        $limit = 500;
-        $offset = 0;
-
-        do {
-            $strings = $this->listStrings($fileId, $limit, $offset);
-
-            foreach ($strings as $string) {
-                $result[$string['data']['text']] = $string['data']['id'];
-            }
-
-            $offset += $limit;
-        } while (\count($strings) > 0);
-
-        return $result;
     }
 
     private function addFile(string $domain, string $content): ?array
@@ -341,36 +319,6 @@ final class CrowdinProvider implements ProviderInterface
          * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.download.get (Crowdin Enterprise API)
          */
         return $this->client->request('GET', \sprintf('files/%d/download', $fileId));
-    }
-
-    private function listStrings(int $fileId, int $limit, int $offset): array
-    {
-        /**
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.strings.getMany (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.getMany (Crowdin Enterprise API)
-         */
-        $response = $this->client->request('GET', 'strings', [
-            'query' => [
-                'fileId' => $fileId,
-                'limit' => $limit,
-                'offset' => $offset,
-            ],
-        ]);
-
-        if (200 !== $response->getStatusCode()) {
-            throw new ProviderException(\sprintf('Unable to list strings for file "%d".', $fileId), $response);
-        }
-
-        return $response->toArray()['data'];
-    }
-
-    private function deleteString(int $stringId): ResponseInterface
-    {
-        /*
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.strings.delete (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2#operation/api.projects.strings.delete (Crowdin Enterprise API)
-         */
-        return $this->client->request('DELETE', 'strings/'.$stringId);
     }
 
     private function addStorage(string $domain, string $content): int

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
@@ -28,11 +28,11 @@ final class CrowdinProviderFactory extends AbstractProviderFactory
     private const HOST = 'api.crowdin.com';
 
     public function __construct(
-        private HttpClientInterface $client,
-        private LoggerInterface $logger,
-        private string $defaultLocale,
-        private LoaderInterface $loader,
-        private XliffFileDumper $xliffFileDumper,
+        private readonly HttpClientInterface $client,
+        private readonly LoggerInterface $logger,
+        private readonly string $defaultLocale,
+        private readonly LoaderInterface $loader,
+        private readonly XliffFileDumper $xliffFileDumper,
     ) {
     }
 

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -33,6 +33,11 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CrowdinProviderTest extends ProviderTestCase
 {
+    protected function getLoader(): LoaderInterface
+    {
+        return $this->loader ??= new XliffFileLoader();
+    }
+
     public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, ?TranslatorBagInterface $translatorBag = null): ProviderInterface
     {
         return new CrowdinProvider($client, $loader, $logger, new XliffFileDumper(), $defaultLocale, $endpoint);
@@ -342,7 +347,7 @@ class CrowdinProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
             'auth_bearer' => 'API_TOKEN',
-        ]), new XliffFileLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to update file in Crowdin for file ID "12" and domain "messages".');
@@ -485,7 +490,7 @@ class CrowdinProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
             'auth_bearer' => 'API_TOKEN',
-        ]), new XliffFileLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to upload translations to Crowdin.');
@@ -595,7 +600,7 @@ class CrowdinProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
             'auth_bearer' => 'API_TOKEN',
-        ]), new XliffFileLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $provider->write($translatorBag);
     }
@@ -734,7 +739,7 @@ class CrowdinProviderTest extends ProviderTestCase
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
             'auth_bearer' => 'API_TOKEN',
-        ]), new XliffFileLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $provider->write($translatorBag);
     }
@@ -1149,6 +1154,50 @@ class CrowdinProviderTest extends ProviderTestCase
 
     public function testDelete()
     {
+        $sourceFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%1$s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                  <trans-unit id="%2$s" resname="b">
+                    <source>b</source>
+                    <target>trans_en_b</target>
+                  </trans-unit>
+                  <trans-unit id="%3$s" resname="c">
+                    <source>c</source>
+                    <target>trans_en_c</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
+        $storageFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
         $responses = [
             'listFiles' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -1156,62 +1205,119 @@ class CrowdinProviderTest extends ProviderTestCase
 
                 return new JsonMockResponse([
                     'data' => [
-                        ['data' => [
-                            'id' => 12,
-                            'name' => 'messages.xlf',
-                        ]],
+                        [
+                            'data' => [
+                                'id' => 12,
+                                'name' => 'messages.xlf',
+                            ],
+                        ],
                     ],
                 ]);
             },
-            'listStrings1' => function (string $method, string $url): ResponseInterface {
+            'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings?fileId=12&limit=500&offset=0', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12/download', $url);
 
-                return new JsonMockResponse([
-                    'data' => [
-                        ['data' => ['id' => 1, 'text' => 'en a']],
-                        ['data' => ['id' => 2, 'text' => 'en b']],
-                    ],
-                ]);
+                return new JsonMockResponse(['data' => ['url' => 'https://file.url']]);
             },
-            'listStrings2' => function (string $method, string $url): ResponseInterface {
+            'downloadFile' => function (string $method, string $url) use ($sourceFileContent): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings?fileId=12&limit=500&offset=500', $url);
+                $this->assertSame('https://file.url/', $url);
 
-                return new JsonMockResponse(['data' => []]);
+                return new MockResponse($sourceFileContent);
             },
-            'deleteString1' => function (string $method, string $url): ResponseInterface {
-                $this->assertSame('DELETE', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings/1', $url);
+            'addStorage' => function (
+                string $method,
+                string $url,
+                array $options,
+            ) use ($storageFileContent): ResponseInterface {
+                $contentType = $options['normalized_headers']['content-type'][0];
+                $crowdinApiFileName = $options['normalized_headers']['crowdin-api-filename'][0];
 
-                return new MockResponse('', ['http_code' => 204]);
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+                $this->assertSame('Content-Type: application/octet-stream', $contentType);
+                $this->assertSame('Crowdin-API-FileName: messages.xlf', $crowdinApiFileName);
+                $this->assertStringMatchesFormat($storageFileContent, $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 19]], ['http_code' => 201]);
             },
-            'deleteString2' => function (string $method, string $url): ResponseInterface {
-                $this->assertSame('DELETE', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings/2', $url);
+            'updateFile' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('PUT', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12', $url);
+                $this->assertSame('{"storageId":19}', $options['body']);
 
-                return new MockResponse('', ['http_code' => 204]);
+                return new JsonMockResponse(['data' => ['id' => 12, 'name' => 'messages.xlf']]);
             },
         ];
 
-        $translatorBag = new TranslatorBag();
-        $translatorBag->addCatalogue(new MessageCatalogue('en', [
-            'messages' => [
-                'en a' => 'en a',
-                'en b' => 'en b',
-            ],
-        ]));
+        $deletedStrings = new TranslatorBag();
+        $deletedStrings->addCatalogue(
+            new MessageCatalogue(
+                'en',
+                [
+                    'messages' => [
+                        'b' => 'trans_en_b',
+                        'c' => 'trans_en_c',
+                    ],
+                ]
+            )
+        );
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
             'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
-        $provider->delete($translatorBag);
+        $provider->delete($deletedStrings);
     }
 
-    public function testDeleteListStringServerException()
+    public function testDeleteUpdateFileReturnsNull()
     {
+        $sourceFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%1$s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                  <trans-unit id="%2$s" resname="b">
+                    <source>b</source>
+                    <target>trans_en_b</target>
+                  </trans-unit>
+                  <trans-unit id="%3$s" resname="c">
+                    <source>c</source>
+                    <target>trans_en_c</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
+        $storageFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
         $responses = [
             'listFiles' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -1219,27 +1325,192 @@ class CrowdinProviderTest extends ProviderTestCase
 
                 return new JsonMockResponse([
                     'data' => [
-                        ['data' => [
-                            'id' => 12,
-                            'name' => 'messages.xlf',
-                        ]],
+                        [
+                            'data' => [
+                                'id' => 12,
+                                'name' => 'messages.xlf',
+                            ],
+                        ],
                     ],
                 ]);
             },
-            'listStrings' => function (string $method, string $url): ResponseInterface {
+            'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings?fileId=12&limit=500&offset=0', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12/download', $url);
+
+                return new JsonMockResponse(['data' => ['url' => 'https://file.url']]);
+            },
+            'downloadFile' => function (string $method, string $url) use ($sourceFileContent): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://file.url/', $url);
+
+                return new MockResponse($sourceFileContent);
+            },
+            'addStorage' => function (
+                string $method,
+                string $url,
+                array $options,
+            ) use ($storageFileContent): ResponseInterface {
+                $contentType = $options['normalized_headers']['content-type'][0];
+                $crowdinApiFileName = $options['normalized_headers']['crowdin-api-filename'][0];
+
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+                $this->assertSame('Content-Type: application/octet-stream', $contentType);
+                $this->assertSame('Crowdin-API-FileName: messages.xlf', $crowdinApiFileName);
+                $this->assertStringMatchesFormat($storageFileContent, $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 19]], ['http_code' => 201]);
+            },
+            'updateFile' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('PUT', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12', $url);
+                $this->assertSame('{"storageId":19}', $options['body']);
+
+                return new MockResponse('', ['http_code' => 404]);
+            },
+        ];
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with('Unable to update file in Crowdin for file ID "12" and domain "messages": "".');
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with('Unable to update file "12" and domain "messages".');
+
+        $deletedStrings = new TranslatorBag();
+        $deletedStrings->addCatalogue(
+            new MessageCatalogue(
+                'en',
+                [
+                    'messages' => [
+                        'b' => 'trans_en_b',
+                        'c' => 'trans_en_c',
+                    ],
+                ]
+            )
+        );
+
+        $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'auth_bearer' => 'API_TOKEN',
+        ]), $this->getLoader(), $logger, $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+
+        $provider->delete($deletedStrings);
+    }
+
+    public function testDeleteUpdateFileServerException()
+    {
+        $sourceFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%1$s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                  <trans-unit id="%2$s" resname="b">
+                    <source>b</source>
+                    <target>trans_en_b</target>
+                  </trans-unit>
+                  <trans-unit id="%3$s" resname="c">
+                    <source>c</source>
+                    <target>trans_en_c</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
+        $storageFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
+        $responses = [
+            'listFiles' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+
+                return new JsonMockResponse([
+                    'data' => [
+                        [
+                            'data' => [
+                                'id' => 12,
+                                'name' => 'messages.xlf',
+                            ],
+                        ],
+                    ],
+                ]);
+            },
+            'downloadSource' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12/download', $url);
+
+                return new JsonMockResponse(['data' => ['url' => 'https://file.url']]);
+            },
+            'downloadFile' => function (string $method, string $url) use ($sourceFileContent): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://file.url/', $url);
+
+                return new MockResponse($sourceFileContent);
+            },
+            'addStorage' => function (
+                string $method,
+                string $url,
+                array $options,
+            ) use ($storageFileContent): ResponseInterface {
+                $contentType = $options['normalized_headers']['content-type'][0];
+                $crowdinApiFileName = $options['normalized_headers']['crowdin-api-filename'][0];
+
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+                $this->assertSame('Content-Type: application/octet-stream', $contentType);
+                $this->assertSame('Crowdin-API-FileName: messages.xlf', $crowdinApiFileName);
+                $this->assertStringMatchesFormat($storageFileContent, $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 19]], ['http_code' => 201]);
+            },
+            'updateFile' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('PUT', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12', $url);
+                $this->assertSame('{"storageId":19}', $options['body']);
 
                 return new MockResponse('', ['http_code' => 500]);
             },
         ];
 
-        $translatorBag = new TranslatorBag();
-        $translatorBag->addCatalogue(new MessageCatalogue('en', [
-            'messages' => [
-                'en a' => 'en a',
-            ],
-        ]));
+        $deletedStrings = new TranslatorBag();
+        $deletedStrings->addCatalogue(
+            new MessageCatalogue(
+                'en',
+                [
+                    'messages' => [
+                        'b' => 'trans_en_b',
+                        'c' => 'trans_en_c',
+                    ],
+                ]
+            )
+        );
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
@@ -1247,67 +1518,11 @@ class CrowdinProviderTest extends ProviderTestCase
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Unable to list strings for file "12".');
+        $this->expectExceptionMessage(
+            'Unable to update file "12" and domain "messages": '.
+            '"Unable to update file in Crowdin for file ID "12" and domain "messages"."'
+        );
 
-        $provider->delete($translatorBag);
-    }
-
-    public function testDeleteDeleteStringServerException()
-    {
-        $responses = [
-            'listFiles' => function (string $method, string $url): ResponseInterface {
-                $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
-
-                return new JsonMockResponse([
-                    'data' => [
-                        ['data' => [
-                            'id' => 12,
-                            'name' => 'messages.xlf',
-                        ]],
-                    ],
-                ]);
-            },
-            'listStrings' => function (string $method, string $url): ResponseInterface {
-                $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings?fileId=12&limit=500&offset=0', $url);
-
-                return new JsonMockResponse([
-                    'data' => [
-                        ['data' => ['id' => 1, 'text' => 'en a']],
-                        ['data' => ['id' => 2, 'text' => 'en b']],
-                    ],
-                ]);
-            },
-            'listStrings2' => function (string $method, string $url): ResponseInterface {
-                $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings?fileId=12&limit=500&offset=500', $url);
-
-                return new JsonMockResponse(['data' => []]);
-            },
-            'deleteString1' => function (string $method, string $url): ResponseInterface {
-                $this->assertSame('DELETE', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/strings/1', $url);
-
-                return new MockResponse('', ['http_code' => 500]);
-            },
-        ];
-
-        $translatorBag = new TranslatorBag();
-        $translatorBag->addCatalogue(new MessageCatalogue('en', [
-            'messages' => [
-                'en a' => 'en a',
-            ],
-        ]));
-
-        $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-            'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
-
-        $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Unable to delete string.');
-
-        $provider->delete($translatorBag);
+        $provider->delete($deletedStrings);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT


### Description

Before the changes, string deletions were handled one by one by invoking the corresponding API endpoint each time. This was far from efficient. After my changes, the original file is downloaded from Crowdin, parsed, deleted strings are removed, and a newly created file is uploaded back to the server.

Tests were updated accordingly, and no backward-incompatible changes were made. Constructors in `CrowdinProvider` and `CrowdinProviderFactory` were updated to use promoted properties.