### PR TITLE
[Security] Adjust deprecated messages in `SameOriginCsrfTokenManager`

### DIFF
--- a/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/SameOriginCsrfTokenManager.php
@@ -191,11 +191,11 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
     }
 
     /**
-     * @deprecated since Symfony 8.1, logic is handled by SameOriginCsrfListener.
+     * @deprecated since Symfony 8.1, use SameOriginCsrfListener instead.
      */
     public function clearCookies(Request $request, Response $response): void
     {
-        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated and will be removed in 9.0, use "%s::clearCookies()" instead.', __METHOD__, SameOriginCsrfListener::class);
+        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated, use "%s" instead.', __METHOD__, SameOriginCsrfListener::class);
 
         if (!$request->attributes->has($this->cookieName)) {
             return;
@@ -211,11 +211,11 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
     }
 
     /**
-     * @deprecated since Symfony 8.1, logic is handled by SameOriginCsrfListener.
+     * @deprecated since Symfony 8.1, use SameOriginCsrfListener instead.
      */
     public function persistStrategy(Request $request): void
     {
-        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated and will be removed in 9.0, use "%s::persistStrategy()" instead.', __METHOD__, SameOriginCsrfListener::class);
+        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated, use "%s" instead.', __METHOD__, SameOriginCsrfListener::class);
 
         if (!$request->attributes->has($this->cookieName)
             || !$request->hasSession(true)
@@ -231,11 +231,11 @@ final class SameOriginCsrfTokenManager implements CsrfTokenManagerInterface
     }
 
     /**
-     * @deprecated since Symfony 8.1, logic is handled by SameOriginCsrfListener.
+     * @deprecated since Symfony 8.1, use SameOriginCsrfListener instead.
      */
     public function onKernelResponse(ResponseEvent $event): void
     {
-        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated and will be removed in 9.0, use "%s::onKernelResponse()" instead.', __METHOD__, SameOriginCsrfListener::class);
+        trigger_deprecation('symfony/security-csrf', '8.1', 'The "%s()" method is deprecated, use "%s" instead.', __METHOD__, SameOriginCsrfListener::class);
 
         if (!$event->isMainRequest()) {
             return;


### PR DESCRIPTION
| Q             | A          
|---------------|------------
| Branch?       | 8.1        
| Bug fix?      | yes        
| New feature?  | no         
| Deprecations? | yes        
| Issues        | Fix #62881 
| License       | MIT        

New PR after @Spomky  feedbacks on the already merged PR https://github.com/symfony/symfony/pull/63097.
