### PR TITLE
[FrameworkBundle] Fix BrowserKitAssertionsTrait compatibility with HttpBrowser

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
+use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
 use Symfony\Component\BrowserKit\Test\Constraint as BrowserKitConstraint;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -183,6 +185,14 @@ trait BrowserKitAssertionsTrait
             static::fail('A client must have an HTTP Response to make assertions. Did you forget to make an HTTP request?');
         }
 
+        if ($response instanceof BrowserKitResponse) {
+            return new Response(
+                $response->getContent(),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            );
+        }
+
         return $response;
     }
 
@@ -190,6 +200,18 @@ trait BrowserKitAssertionsTrait
     {
         if (!$request = self::getClient()->getRequest()) {
             static::fail('A client must have an HTTP Request to make assertions. Did you forget to make an HTTP request?');
+        }
+
+        if ($request instanceof BrowserKitRequest) {
+            return Request::create(
+                $request->getUri(),
+                $request->getMethod(),
+                $request->getParameters(),
+                $request->getCookies(),
+                $request->getFiles(),
+                $request->getServer(),
+                $request->getContent()
+            );
         }
 
         return $request;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62632
| License       | MIT

This PR fixes a `TypeError` thrown by `BrowserKitAssertionsTrait` when using a client that returns a `BrowserKit\Response` (such as `HttpBrowser`, often used with Panther or HttpClient tests).

### Description
Currently, `BrowserKitAssertionsTrait::getResponse()` strictly type-hints `Symfony\Component\HttpFoundation\Response`. However, the `AbstractBrowser` contract is generic and can return a `Symfony\Component\BrowserKit\Response`. This mismatch causes assertions like `assertResponseIsSuccessful()` to crash when the client is an instance of `HttpBrowser`.

This fix updates `getRequest()` and `getResponse()` within the trait to detect `BrowserKit` objects and convert them into their `HttpFoundation` counterparts on the fly. This ensures compatibility with all `AbstractBrowser` implementations while maintaining strict type safety for the assertions.

### Example (Reproduction)

```php
// This previously failed with TypeError, now passes
public function testExternalRequest(): void
{
    $client = new HttpBrowser(HttpClient::create());
    $client->request('GET', '[https://symfony.com](https://symfony.com)');
    
    // Before: TypeError: Return value must be of type ...HttpFoundation\Response
    // After: Passes with no errors
    self::assertResponseIsSuccessful();
}
```