### PR TITLE
[HttpFoundation] Reject invalid paths

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -404,8 +404,16 @@ class Request
             $server['PHP_AUTH_PW'] = $components['pass'];
         }
 
-        if (!isset($components['path'])) {
+        if ('' === $path = $components['path'] ?? '') {
             $components['path'] = '/';
+        } elseif (!isset($components['scheme']) && !isset($components['host']) && '/' !== $path[0]) {
+            if (false !== $pos = strpos($path, '/')) {
+                $path = substr($path, 0, $pos);
+            }
+
+            if (str_contains($path, ':')) {
+                throw new BadRequestException('Invalid URI: Path is malformed.');
+            }
         }
 
         switch (strtoupper($method)) {

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2703,6 +2703,7 @@ class RequestTest extends TestCase
             ["https\x80://example.com", 'Invalid URI: Scheme is malformed.'],
             ['http>://example.com', 'Invalid URI: Scheme is malformed.'],
             ['0http://example.com', 'Invalid URI: Scheme is malformed.'],
+            [':path', 'Invalid URI: Path is malformed.'],
         ];
     }
 
@@ -2731,7 +2732,6 @@ class RequestTest extends TestCase
             ['http://[2001:db8::1]/path'],
             ['http://[::1]'],
             ['http://example.com/path'],
-            [':path'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This is a follow up of #62324, issue spotted by @nyamsprod

Inspired by https://github.com/thephpleague/uri-src/blob/51d9bb68f4d03fd279b913cafdc3814ba98b594e/interfaces/UriString.php#L602-L627

From RFC3986:
> In absence of the scheme and authority components, the first path segment cannot contain a colon (“:”) character.