### PR TITLE
[FrameworkBundle][Lock] Scope semaphore and flock stores by project dir by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for configuring JsonStreamer's `default_options`
+ * Add project-scoped `flock` and `semaphore` lock store services
  * Add `createFormFlowBuilder` method to `AbstractController` and `ControllerHelper`
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
  * Add support for `framework.secrets.decryption_env_var` to contain dots

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2265,6 +2265,11 @@ class FrameworkExtension extends Extension
             // Generate stores
             $storeDefinitions = [];
             foreach ($resourceStores as $resourceStore) {
+                if (\in_array($resourceStore, ['flock', 'semaphore'], true)) {
+                    $storeDefinitionId = \sprintf('.lock.%s.store', $resourceStore);
+                    $storeDefinitions[] = new Reference($storeDefinitionId);
+                    continue;
+                }
                 $usedEnvs = [];
                 $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);
                 if (!$usedEnvs && !str_contains($resourceStore, ':') && !\in_array($resourceStore, ['flock', 'semaphore', 'in-memory', 'null'], true)) {
@@ -2278,9 +2283,7 @@ class FrameworkExtension extends Extension
 
                 $container->setDefinition($storeDefinitionId = '.lock.'.$resourceName.'.store.'.$container->hash($storeDsn), $storeDefinition);
 
-                $storeDefinition = new Reference($storeDefinitionId);
-
-                $storeDefinitions[] = $storeDefinition;
+                $storeDefinitions[] = new Reference($storeDefinitionId);
             }
 
             // Wrap array of stores with CombinedStore

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/lock.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/lock.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Serializer\LockKeyNormalizer;
 use Symfony\Component\Lock\Store\CombinedStore;
+use Symfony\Component\Lock\Store\FlockStore;
+use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Lock\Strategy\ConsensusStrategy;
 
 return static function (ContainerConfigurator $container) {
@@ -30,5 +32,15 @@ return static function (ContainerConfigurator $container) {
 
         ->set('serializer.normalizer.lock_key', LockKeyNormalizer::class)
             ->tag('serializer.normalizer', ['built_in' => true, 'priority' => -880])
+
+        ->set('.lock.flock.store', FlockStore::class)
+            ->args([inline_service('string')->factory('implode')->args(['/', [
+                inline_service('string')->factory('sys_get_temp_dir'),
+                'symfony-lock',
+                inline_service('string')->factory('hash')->args(['xxh64', '%kernel.project_dir%']),
+            ]])])
+
+        ->set('.lock.semaphore.store', SemaphoreStore::class)
+            ->args(['%kernel.project_dir%'])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -67,6 +67,7 @@ use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
+use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
@@ -2750,12 +2751,16 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $container = $this->createContainerFromFile('lock');
 
         self::assertTrue($container->hasDefinition('lock.default.factory'));
-        $storeDef = $container->getDefinition($container->getDefinition('lock.default.factory')->getArgument(0));
+        $storeId = (string) $container->getDefinition('lock.default.factory')->getArgument(0);
+        $storeDef = $container->getDefinition($storeId);
 
         if (class_exists(SemaphoreStore::class) && SemaphoreStore::isSupported()) {
-            self::assertSame('semaphore', $storeDef->getArgument(0));
+            self::assertSame('.lock.semaphore.store', $storeId);
+            self::assertSame(SemaphoreStore::class, $storeDef->getClass());
+            self::assertSame('%kernel.project_dir%', $storeDef->getArgument(0));
         } else {
-            self::assertSame('flock', $storeDef->getArgument(0));
+            self::assertSame('.lock.flock.store', $storeId);
+            self::assertSame(FlockStore::class, $storeDef->getClass());
         }
     }
 
@@ -2764,20 +2769,22 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $container = $this->createContainerFromFile('lock_named');
 
         self::assertTrue($container->hasDefinition('lock.foo.factory'));
-        $storeDef = $container->getDefinition($container->getDefinition('lock.foo.factory')->getArgument(0));
-        self::assertSame('semaphore', $storeDef->getArgument(0));
+        $storeId = (string) $container->getDefinition('lock.foo.factory')->getArgument(0);
+        $storeDef = $container->getDefinition($storeId);
+        self::assertSame('.lock.semaphore.store', $storeId);
+        self::assertSame(SemaphoreStore::class, $storeDef->getClass());
+        self::assertSame('%kernel.project_dir%', $storeDef->getArgument(0));
 
         self::assertTrue($container->hasDefinition('lock.bar.factory'));
-        $storeDef = $container->getDefinition($container->getDefinition('lock.bar.factory')->getArgument(0));
-        self::assertSame('flock', $storeDef->getArgument(0));
+        $storeId = (string) $container->getDefinition('lock.bar.factory')->getArgument(0);
+        $storeDef = $container->getDefinition($storeId);
+        self::assertSame('.lock.flock.store', $storeId);
+        self::assertSame(FlockStore::class, $storeDef->getClass());
 
         self::assertTrue($container->hasDefinition('lock.baz.factory'));
         $storeDef = $container->getDefinition($container->getDefinition('lock.baz.factory')->getArgument(0));
         self::assertIsArray($storeDefArg = $storeDef->getArgument(0));
-        $storeDef1 = $container->getDefinition($storeDefArg[0]);
-        $storeDef2 = $container->getDefinition($storeDefArg[1]);
-        self::assertSame('semaphore', $storeDef1->getArgument(0));
-        self::assertSame('flock', $storeDef2->getArgument(0));
+        self::assertSame(['.lock.semaphore.store', '.lock.flock.store'], array_map('strval', $storeDefArg));
 
         self::assertTrue($container->hasDefinition('lock.qux.factory'));
         $storeDef = $container->getDefinition($container->getDefinition('lock.qux.factory')->getArgument(0));

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for scoping semaphore stores by project ID (e.g. `semaphore://<project-id>`)
+
 7.4
 ---
 

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -33,8 +33,9 @@ class SemaphoreStore implements BlockingStoreInterface
         return \extension_loaded('sysvsem');
     }
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly string $projectId = '',
+    ) {
         if (!static::isSupported()) {
             throw new InvalidArgumentException('Semaphore extension (sysvsem) is required.');
         }
@@ -56,7 +57,7 @@ class SemaphoreStore implements BlockingStoreInterface
             return;
         }
 
-        $keyId = unpack('i', hash('xxh128', $key, true))[1];
+        $keyId = unpack('i', hash('xxh64', $this->projectId.$key, true))[1];
         $resource = @sem_get($keyId);
         $acquired = $resource && @sem_acquire($resource, !$blocking);
 

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -67,6 +67,9 @@ class StoreFactory
             case 'semaphore' === $connection:
                 return new SemaphoreStore();
 
+            case str_starts_with($connection, 'semaphore://'):
+                return new SemaphoreStore(substr($connection, 12));
+
             case str_starts_with($connection, 'dynamodb://'):
                 self::requireBridgeClass(DynamoDbStore::class, 'symfony/amazon-dynamo-db-lock');
 

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -44,6 +44,24 @@ class SemaphoreStoreTest extends AbstractStoreTestCase
         $this->assertEquals($initialCount, $this->getOpenedSemaphores(), 'All semaphores should be removed');
     }
 
+    public function testProjectIdSeparatesLocks()
+    {
+        $keyName = __METHOD__;
+        $storeA = new SemaphoreStore('project-a');
+        $storeB = new SemaphoreStore('project-b');
+
+        $keyA = new Key($keyName);
+        $keyB = new Key($keyName);
+
+        $storeA->save($keyA);
+        $storeB->save($keyB);
+
+        $storeA->delete($keyA);
+        $storeB->delete($keyB);
+
+        $this->addToAssertionCount(1);
+    }
+
     private function getOpenedSemaphores()
     {
         if ('Darwin' === \PHP_OS) {

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -54,6 +54,7 @@ class StoreFactoryTest extends TestCase
         }
         if (\extension_loaded('sysvsem')) {
             yield ['semaphore', SemaphoreStore::class];
+            yield ['semaphore://project-id', SemaphoreStore::class];
         }
         if (class_exists(AbstractAdapter::class) && MemcachedAdapter::isSupported()) {
             yield ['memcached://server.com', MemcachedStore::class];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57857
| License       | MIT

This PR add support for scoping semaphore stores by project ID (e.g. `semaphore://<project-id>`)
And it uses that capability to scope them by `kernel.project_id` by default.
This also configures framework-bundle to store locks in the tmp folder with a hash of the `kernel.project_id` by default.