### PR TITLE
[Mailer][MicrosoftGraph] Also bypass Sender header within MicrosoftGraphApiTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphApiTransportTest.php
@@ -263,6 +263,7 @@ class MicrosoftGraphApiTransportTest extends TestCase
             ['received', 'from localhost'],
             ['dkim-signature', 'signature'],
             ['content-transfer-encoding', 'quoted-printable'],
+            ['sender', 'hugo@example.com'],
             ['cc', 'alice@example.com'],
             ['bcc', 'bob@example.com'],
             ['content-type', 'text/plain'],

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
@@ -171,7 +171,7 @@ class MicrosoftGraphApiTransport extends AbstractApiTransport
     {
         $headers = [];
 
-        $headersToBypass = ['x-ms-client-request-id', 'operation-id', 'authorization', 'x-ms-content-sha256', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to', 'return-path'];
+        $headersToBypass = ['x-ms-client-request-id', 'operation-id', 'authorization', 'x-ms-content-sha256', 'received', 'dkim-signature', 'content-transfer-encoding', 'sender', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to', 'return-path'];
 
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | -
| License       | MIT

It is not possible to set the `Sender` neither via `->sender()` on a message, nor via configuration `envelope: sender:` as written in the Documentation. Microsoft Graph API responds with an error in this case:

```
"InvalidInternetMessageHeader","message":"The internet message header name 'Sender' should start with 'x-' or 'X-'
```

Same problem and fix as in #62984
