### PR TITLE
[Cache] Add query parameter `sentinel_auth` for RedisSentinel authentication

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -50,6 +50,7 @@ trait RedisTrait
         'cluster_command_timeout' => 0,
         'cluster_relay_context' => [],
         'sentinel' => null,
+        'sentinel_auth' => false,
         'dbindex' => 0,
         'failover' => 'none',
         'ssl' => null, // see https://php.net/context.ssl
@@ -199,7 +200,7 @@ trait RedisTrait
             throw new CacheException('Redis Sentinel support requires one of: "predis/predis", "ext-redis >= 6.1", "ext-relay".');
         }
 
-        foreach (['lazy', 'persistent', 'cluster'] as $option) {
+        foreach (['lazy', 'persistent', 'cluster', 'sentinel_auth'] as $option) {
             if (!\is_bool($params[$option] ?? false)) {
                 $params[$option] = filter_var($params[$option], \FILTER_VALIDATE_BOOLEAN);
             }
@@ -243,7 +244,7 @@ trait RedisTrait
                 do {
                     $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
                     $port = $hosts[$hostIndex]['port'] ?? 0;
-                    $passAuth = null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
+                    $passAuth = $params['sentinel_auth'] && null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     $address = false;
 
                     if (isset($hosts[$hostIndex]['host']) && $tls) {
@@ -292,7 +293,7 @@ trait RedisTrait
                         'stream' => self::filterSslOptions($params['ssl'] ?? []) ?: null,
                     ];
 
-                    if (null !== $params['auth']) {
+                    if ($params['sentinel_auth'] && null !== $params['auth']) {
                         $extra['auth'] = $params['auth'];
                     }
                     @$redis->{$connect}($host, $port, (float) $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...\defined('Redis::SCAN_PREFIX') || !$isRedisExt ? [$extra] : []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 and 8.0, probably 6.4 too (I havn't check)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63261
| License       | MIT

Regarding #62852, a change in the behavior of how to connect to a Redis cluster via Sentinel occured. Previously, the user@password given in the DSN was about the Redis master, but after the changes, it was about the Redis Sentinel, causing every instance of Redis cluster with Sentinel without authentication defined (delegated to the Redis master) to fail to connect.

v7.4.4 and v8.0.4 (and possibly 6.4.4) brought the new feature of defining a password for Redis Sentinel, but without having a way to keep the original behavior. This current PR provides a new DSN query parameter `sentinel_auth` to explicitly declares whether the given credentials in the DSN are about Sentinel (new behavior) or the Redis master (old behavior).
Default value has been given to `false` to keep the old behavior from v7.4.3 / v8.0.3 and not to cause BC Break. If the will is to force Redis Sentinel to be secured by authentication rather than Redis master, changing this default value could be done, but should be in a BC Break dedicated version IMO.
