### PR TITLE
[DoctrineBridge] Respect `schema_filter` in schema listeners

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\SchemaListener;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -20,6 +21,35 @@ use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 abstract class AbstractSchemaListener
 {
     abstract public function postGenerateSchema(GenerateSchemaEventArgs $event): void;
+
+    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator): void
+    {
+        $filter = $connection->getConfiguration()->getSchemaAssetsFilter();
+
+        if (null === $filter) {
+            $configurator();
+
+            return;
+        }
+
+        $getNames = static fn ($array) => array_map(static fn ($object) => $object->getName(), $array);
+        $previousTableNames = $getNames($schema->getTables());
+        $previousSequenceNames = $getNames($schema->getSequences());
+
+        $configurator();
+
+        foreach (array_diff($getNames($schema->getTables()), $previousTableNames) as $addedTable) {
+            if (!$filter($addedTable)) {
+                $schema->dropTable($addedTable);
+            }
+        }
+
+        foreach (array_diff($getNames($schema->getSequences()), $previousSequenceNames) as $addedSequence) {
+            if (!$filter($addedSequence)) {
+                $schema->dropSequence($addedSequence);
+            }
+        }
+    }
 
     protected function getIsSameDatabaseChecker(Connection $connection): \Closure
     {

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
@@ -31,9 +31,13 @@ class DoctrineDbalCacheAdapterSchemaListener extends AbstractSchemaListener
     public function postGenerateSchema(GenerateSchemaEventArgs $event): void
     {
         $connection = $event->getEntityManager()->getConnection();
+        $schema = $event->getSchema();
 
         foreach ($this->dbalAdapters as $dbalAdapter) {
-            $dbalAdapter->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
+            $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
+            $this->filterSchemaChanges($schema, $connection, static function () use ($dbalAdapter, $schema, $connection, $isSameDatabaseChecker) {
+                $dbalAdapter->configureSchema($schema, $connection, $isSameDatabaseChecker);
+            });
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
@@ -28,13 +28,17 @@ final class LockStoreSchemaListener extends AbstractSchemaListener
     public function postGenerateSchema(GenerateSchemaEventArgs $event): void
     {
         $connection = $event->getEntityManager()->getConnection();
+        $schema = $event->getSchema();
 
         foreach ($this->stores as $store) {
             if (!$store instanceof DoctrineDbalStore) {
                 continue;
             }
 
-            $store->configureSchema($event->getSchema(), $this->getIsSameDatabaseChecker($connection));
+            $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
+            $this->filterSchemaChanges($schema, $connection, static function () use ($store, $schema, $isSameDatabaseChecker) {
+                $store->configureSchema($schema, $isSameDatabaseChecker);
+            });
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
@@ -34,13 +34,17 @@ class MessengerTransportDoctrineSchemaListener extends AbstractSchemaListener
     public function postGenerateSchema(GenerateSchemaEventArgs $event): void
     {
         $connection = $event->getEntityManager()->getConnection();
+        $schema = $event->getSchema();
 
         foreach ($this->transports as $transport) {
             if (!$transport instanceof DoctrineTransport) {
                 continue;
             }
 
-            $transport->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
+            $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
+            $this->filterSchemaChanges($schema, $connection, static function () use ($transport, $schema, $connection, $isSameDatabaseChecker) {
+                $transport->configureSchema($schema, $connection, $isSameDatabaseChecker);
+            });
         }
     }
 

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
@@ -32,7 +32,12 @@ final class PdoSessionHandlerSchemaListener extends AbstractSchemaListener
         }
 
         $connection = $event->getEntityManager()->getConnection();
+        $schema = $event->getSchema();
+        $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
+        $sessionHandler = $this->sessionHandler;
 
-        $this->sessionHandler->configureSchema($event->getSchema(), $this->getIsSameDatabaseChecker($connection));
+        $this->filterSchemaChanges($schema, $connection, static function () use ($sessionHandler, $schema, $isSameDatabaseChecker) {
+            $sessionHandler->configureSchema($schema, $isSameDatabaseChecker);
+        });
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
@@ -32,13 +32,18 @@ class RememberMeTokenProviderDoctrineSchemaListener extends AbstractSchemaListen
     public function postGenerateSchema(GenerateSchemaEventArgs $event): void
     {
         $connection = $event->getEntityManager()->getConnection();
+        $schema = $event->getSchema();
 
         foreach ($this->rememberMeHandlers as $rememberMeHandler) {
             if (
                 $rememberMeHandler instanceof PersistentRememberMeHandler
                 && ($tokenProvider = $rememberMeHandler->getTokenProvider()) instanceof DoctrineTokenProvider
             ) {
-                $tokenProvider->configureSchema($event->getSchema(), $connection, $this->getIsSameDatabaseChecker($connection));
+                $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
+                $this->filterSchemaChanges($schema, $connection, static function () use ($tokenProvider, $schema, $connection, $isSameDatabaseChecker) {
+                    /* @var DoctrineTokenProvider $tokenProvider */
+                    $tokenProvider->configureSchema($schema, $connection, $isSameDatabaseChecker);
+                });
             }
         }
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,6 +26,7 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
     {
         $schema = new Schema();
         $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn(new Configuration());
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')
@@ -35,9 +37,36 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
         $dbalAdapter = $this->createMock(DoctrineDbalAdapter::class);
         $dbalAdapter->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection, fn () => true);
+            ->with($schema, $dbalConnection, static fn () => true);
 
         $subscriber = new DoctrineDbalCacheAdapterSchemaListener([$dbalAdapter]);
         $subscriber->postGenerateSchema($event);
+    }
+
+    public function testPostGenerateSchemaRespectsSchemaFilter()
+    {
+        $schema = new Schema();
+
+        $configuration = new Configuration();
+        $configuration->setSchemaAssetsFilter(static fn (string $tableName) => 'cache_items' !== $tableName);
+
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn($configuration);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $dbalAdapter = $this->createStub(DoctrineDbalAdapter::class);
+        $dbalAdapter->method('configureSchema')
+            ->willReturnCallback(static function (Schema $schema) {
+                $table = $schema->createTable('cache_items');
+                $table->addColumn('item_id', 'string');
+            });
+
+        $listener = new DoctrineDbalCacheAdapterSchemaListener([$dbalAdapter]);
+        $listener->postGenerateSchema($event);
+
+        $this->assertFalse($schema->hasTable('cache_items'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,6 +26,7 @@ class LockStoreSchemaListenerTest extends TestCase
     {
         $schema = new Schema();
         $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn(new Configuration());
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')
@@ -34,9 +36,36 @@ class LockStoreSchemaListenerTest extends TestCase
         $lockStore = $this->createMock(DoctrineDbalStore::class);
         $lockStore->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, fn () => true);
+            ->with($schema, static fn () => true);
 
         $subscriber = new LockStoreSchemaListener((static fn () => yield $lockStore)());
         $subscriber->postGenerateSchema($event);
+    }
+
+    public function testPostGenerateSchemaRespectsSchemaFilter()
+    {
+        $schema = new Schema();
+
+        $configuration = new Configuration();
+        $configuration->setSchemaAssetsFilter(static fn (string $tableName) => 'lock_keys' !== $tableName);
+
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn($configuration);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $lockStore = $this->createStub(DoctrineDbalStore::class);
+        $lockStore->method('configureSchema')
+            ->willReturnCallback(static function (Schema $schema) {
+                $table = $schema->createTable('lock_keys');
+                $table->addColumn('key_id', 'string');
+            });
+
+        $listener = new LockStoreSchemaListener([$lockStore]);
+        $listener->postGenerateSchema($event);
+
+        $this->assertFalse($schema->hasTable('lock_keys'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -29,6 +30,7 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
     {
         $schema = new Schema();
         $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn(new Configuration());
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')
@@ -38,7 +40,7 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
         $doctrineTransport = $this->createMock(DoctrineTransport::class);
         $doctrineTransport->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection, fn () => true);
+            ->with($schema, $dbalConnection, static fn () => true);
         $otherTransport = $this->createMock(TransportInterface::class);
         $otherTransport->expects($this->never())
             ->method($this->anything());
@@ -105,5 +107,94 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
 
         $subscriber->onSchemaCreateTable($event);
         $this->assertFalse($event->isDefaultPrevented());
+    }
+
+    public function testPostGenerateSchemaRespectsSchemaFilter()
+    {
+        $schema = new Schema();
+
+        $configuration = new Configuration();
+        $configuration->setSchemaAssetsFilter(static fn (string $tableName) => 'messenger_messages' !== $tableName);
+
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn($configuration);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $doctrineTransport = $this->createStub(DoctrineTransport::class);
+        $doctrineTransport->method('configureSchema')
+            ->willReturnCallback(static function (Schema $schema) {
+                $table = $schema->createTable('messenger_messages');
+                $table->addColumn('id', 'integer', ['autoincrement' => true]);
+            });
+
+        $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
+        $listener->postGenerateSchema($event);
+
+        $this->assertFalse($schema->hasTable('messenger_messages'));
+    }
+
+    public function testPostGenerateSchemaRespectsSchemaFilterIncludingSequences()
+    {
+        $schema = new Schema();
+
+        $configuration = new Configuration();
+        $excluded = ['messenger_messages', 'messenger_messages_seq'];
+        $configuration->setSchemaAssetsFilter(static fn (string $assetName) => !\in_array($assetName, $excluded, true));
+
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn($configuration);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $doctrineTransport = $this->createStub(DoctrineTransport::class);
+        $doctrineTransport->method('configureSchema')
+            ->willReturnCallback(static function (Schema $schema) {
+                $table = $schema->createTable('messenger_messages');
+                $table->addColumn('id', 'integer', ['autoincrement' => true]);
+                $schema->createSequence('messenger_messages_seq');
+            });
+
+        $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
+        $listener->postGenerateSchema($event);
+
+        $this->assertFalse($schema->hasTable('messenger_messages'));
+        $this->assertFalse($schema->hasSequence('messenger_messages_seq'));
+    }
+
+    public function testPostGenerateSchemaFilterDoesNotAffectPreExistingSequences()
+    {
+        $schema = new Schema();
+        $schema->createSequence('existing_seq');
+
+        $configuration = new Configuration();
+        $excluded = ['messenger_messages', 'messenger_messages_seq', 'existing_seq'];
+        $configuration->setSchemaAssetsFilter(static fn (string $assetName) => !\in_array($assetName, $excluded, true));
+
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn($configuration);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $doctrineTransport = $this->createStub(DoctrineTransport::class);
+        $doctrineTransport->method('configureSchema')
+            ->willReturnCallback(static function (Schema $schema) {
+                $table = $schema->createTable('messenger_messages');
+                $table->addColumn('id', 'integer', ['autoincrement' => true]);
+                $schema->createSequence('messenger_messages_seq');
+            });
+
+        $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
+        $listener->postGenerateSchema($event);
+
+        $this->assertFalse($schema->hasTable('messenger_messages'));
+        $this->assertFalse($schema->hasSequence('messenger_messages_seq'));
+        $this->assertTrue($schema->hasSequence('existing_seq'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,6 +26,7 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
     {
         $schema = new Schema();
         $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn(new Configuration());
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())
             ->method('getConnection')
@@ -34,9 +36,36 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
         $pdoSessionHandler = $this->createMock(PdoSessionHandler::class);
         $pdoSessionHandler->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, fn () => true);
+            ->with($schema, static fn () => true);
 
         $subscriber = new PdoSessionHandlerSchemaListener($pdoSessionHandler);
         $subscriber->postGenerateSchema($event);
+    }
+
+    public function testPostGenerateSchemaRespectsSchemaFilter()
+    {
+        $schema = new Schema();
+
+        $configuration = new Configuration();
+        $configuration->setSchemaAssetsFilter(static fn (string $tableName) => 'sessions' !== $tableName);
+
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn($configuration);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $pdoSessionHandler = $this->createStub(PdoSessionHandler::class);
+        $pdoSessionHandler->method('configureSchema')
+            ->willReturnCallback(static function (Schema $schema) {
+                $table = $schema->createTable('sessions');
+                $table->addColumn('sess_id', 'string');
+            });
+
+        $listener = new PdoSessionHandlerSchemaListener($pdoSessionHandler);
+        $listener->postGenerateSchema($event);
+
+        $this->assertFalse($schema->hasTable('sessions'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/RememberMeTokenProviderDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/RememberMeTokenProviderDoctrineSchemaListenerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\SchemaListener\RememberMeTokenProviderDoctrineSchemaListener;
+use Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler;
+
+class RememberMeTokenProviderDoctrineSchemaListenerTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(PersistentRememberMeHandler::class)) {
+            self::markTestSkipped('This test requires symfony/security-http.');
+        }
+    }
+
+    public function testPostGenerateSchema()
+    {
+        $schema = new Schema();
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn(new Configuration());
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $tokenProvider = new DoctrineTokenProvider($dbalConnection);
+        $rememberMeHandler = new PersistentRememberMeHandler(
+            $tokenProvider,
+            $this->createStub(UserProviderInterface::class),
+            new RequestStack(),
+            []
+        );
+
+        $listener = new RememberMeTokenProviderDoctrineSchemaListener([$rememberMeHandler]);
+        $listener->postGenerateSchema($event);
+
+        $this->assertTrue($schema->hasTable('rememberme_token'));
+    }
+
+    public function testPostGenerateSchemaRespectsSchemaFilter()
+    {
+        $schema = new Schema();
+
+        $configuration = new Configuration();
+        $configuration->setSchemaAssetsFilter(static fn (string $tableName) => 'rememberme_token' !== $tableName);
+
+        $dbalConnection = $this->createStub(Connection::class);
+        $dbalConnection->method('getConfiguration')->willReturn($configuration);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $tokenProvider = new DoctrineTokenProvider($dbalConnection);
+        $rememberMeHandler = new PersistentRememberMeHandler(
+            $tokenProvider,
+            $this->createStub(UserProviderInterface::class),
+            new RequestStack(),
+            []
+        );
+
+        $listener = new RememberMeTokenProviderDoctrineSchemaListener([$rememberMeHandler]);
+        $listener->postGenerateSchema($event);
+
+        $this->assertFalse($schema->hasTable('rememberme_token'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #38398
| License       | MIT

All 5 schema listeners in `DoctrineBridge` unconditionally add tables (and sequences) to the schema during `postGenerateSchema`, bypassing `doctrine.dbal.schema_filter`. This causes `doctrine:schema:update --dump-sql` to always include these tables in its diff, even when the user explicitly excludes them via `schema_filter`.

This PR adds a `filterSchemaChanges()` helper to `AbstractSchemaListener` that:

1. Snapshots table and sequence names before the `configureSchema()` call
2. Executes the configurator
3. Checks newly added tables and sequences against the configured `schemaAssetsFilter`
4. Removes those that the filter excludes

All 5 listeners are updated to use this helper:
- `MessengerTransportDoctrineSchemaListener`
- `DoctrineDbalCacheAdapterSchemaListener`
- `LockStoreSchemaListener`
- `PdoSessionHandlerSchemaListener`
- `RememberMeTokenProviderDoctrineSchemaListener`