### PR TITLE
[Messenger][Cache] Fix forwarding SSL settings to the redis sentinel

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -73,7 +73,7 @@ class PredisAdapterTest extends AbstractRedisAdapterTestCase
             'scheme' => 'tls',
             'host' => $redisHost[0],
             'port' => (int) ($redisHost[1] ?? 6379),
-            'ssl' => ['verify_peer' => '0'],
+            'ssl' => ['verify_peer' => false],
             'persistent' => 0,
             'timeout' => 3,
             'read_write_timeout' => 0,

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -177,6 +177,22 @@ trait RedisTrait
         $params += $query + $options + self::$defaultConnectionOptions;
         $params['auth'] ??= $auth;
 
+        $booleanStreamOptions = [
+            'allow_self_signed',
+            'capture_peer_cert',
+            'capture_peer_cert_chain',
+            'disable_compression',
+            'SNI_enabled',
+            'verify_peer',
+            'verify_peer_name',
+        ];
+
+        foreach ($params['ssl'] ?? [] as $streamOption => $value) {
+            if (\in_array($streamOption, $booleanStreamOptions, true) && \is_string($value)) {
+                $params['ssl'][$streamOption] = filter_var($value, \FILTER_VALIDATE_BOOL);
+            }
+        }
+
         if (isset($params['redis_sentinel']) && !class_exists(\Predis\Client::class) && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
             throw new CacheException('Redis Sentinel support requires one of: "predis/predis", "ext-redis >= 5.2", "ext-relay".');
         }
@@ -246,6 +262,10 @@ trait RedisTrait
                                 $options['auth'] = $params['auth'];
                             }
 
+                            if (null !== $params['ssl'] && version_compare(phpversion('redis'), '6.2.0', '>=')) {
+                                $options['ssl'] = $params['ssl'];
+                            }
+
                             $sentinel = new \RedisSentinel($options);
                         } else {
                             $extra = $passAuth ? [$params['auth']] : [];
@@ -268,21 +288,6 @@ trait RedisTrait
                     $extra = [
                         'stream' => $params['ssl'] ?? null,
                     ];
-                    $booleanStreamOptions = [
-                        'allow_self_signed',
-                        'capture_peer_cert',
-                        'capture_peer_cert_chain',
-                        'disable_compression',
-                        'SNI_enabled',
-                        'verify_peer',
-                        'verify_peer_name',
-                    ];
-
-                    foreach ($extra['stream'] ?? [] as $streamOption => $value) {
-                        if (\in_array($streamOption, $booleanStreamOptions, true) && \is_string($value)) {
-                            $extra['stream'][$streamOption] = filter_var($value, \FILTER_VALIDATE_BOOL);
-                        }
-                    }
 
                     if (null !== $params['auth']) {
                         $extra['auth'] = $params['auth'];

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -134,6 +134,10 @@ class Connection
                                     'readTimeout' => $options['read_timeout'],
                                 ];
 
+                                if (null !== $options['ssl'] && version_compare(phpversion('redis'), '6.2.0', '>=')) {
+                                    $params['ssl'] = $options['ssl'];
+                                }
+
                                 $sentinel = @new \RedisSentinel($params);
                             } else {
                                 $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? |no 
| Issues        | Fix #62718
| License       | MIT


Currently, Symfony Messenger is ignoring the TLS configuration. This PR aims to correct this error:
```
In Connection.php line 158:
                                                                    
  [Symfony\Component\Messenger\Exception\InvalidArgumentException]  
  Failed to retrieve master information from sentinel "mymaster".  
```

