### PR TITLE
[HttpKernel] Add `ControllerEvent::evaluate()` et al. to help with evaluating expressions or closures in controller attributes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -151,6 +151,7 @@ return static function (ContainerConfigurator $container) {
         ->set('kernel.controller_attributes_listener', ControllerAttributesListener::class)
             ->args([
                 abstract_arg('attributes with listeners by event'),
+                service('controller.expression_language')->nullOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Pass `request` and `args` variables to `Cache` attribute expressions containing the `Request` object and controller arguments
  * Allow using closures with the `Cache` attribute
  * Allow setting a condition when the `Cache` attribute should be applied
+ * Add `ControllerEvent::evaluate()` et al. to help with evaluating expressions or closures in controller attributes
  * Deprecate passing a non-flat list of attributes to `Controller::setController()`
  * Deprecate the `Symfony\Component\HttpKernel\DependencyInjection\Extension` class, use the parent `Symfony\Component\DependencyInjection\Extension\Extension` class instead
  * Allow using Expression or \Closure for `validationGroups` in `#[MapRequestPayload]` and `#[MapQueryString]`

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -272,23 +272,8 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function resolveValidationGroups(Expression|string|GroupSequence|\Closure|array|null $validationGroups, ControllerArgumentsEvent $event): string|GroupSequence|array|null
     {
-        $controller = $event->getController();
-        $controller = match (true) {
-            \is_object($controller) => $controller,
-            \is_array($controller) && \is_object($controller[0]) => $controller[0],
-            default => null,
-        };
-
-        if ($validationGroups instanceof Expression) {
-            $validationGroups = $this->getExpressionLanguage()->evaluate($validationGroups, [
-                'request' => $event->getRequest(),
-                'args' => $event->getNamedArguments(),
-                'this' => $controller,
-            ]);
-        }
-
-        if ($validationGroups instanceof \Closure) {
-            $validationGroups = $validationGroups($event->getNamedArguments(), $event->getRequest(), $controller);
+        if ($validationGroups instanceof Expression || $validationGroups instanceof \Closure) {
+            $validationGroups = $event->evaluate($validationGroups, $this->expressionLanguage);
         }
 
         if (null === $validationGroups || \is_string($validationGroups) || $validationGroups instanceof GroupSequence) {
@@ -318,14 +303,5 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         }
 
         return $validationGroups;
-    }
-
-    private function getExpressionLanguage(): ExpressionLanguage
-    {
-        if (!class_exists(ExpressionLanguage::class)) {
-            throw new \LogicException('You cannot use expressions in controller attributes as the ExpressionLanguage component is not available. Try running "composer require symfony/expression-language".');
-        }
-
-        return $this->expressionLanguage ??= new ExpressionLanguage();
     }
 }

--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -115,5 +117,14 @@ final class ControllerArgumentsEvent extends KernelEvent
     public function getAttributes(?string $className = null): array
     {
         return $this->controllerEvent->getAttributes($className);
+    }
+
+    public function evaluate(mixed $value, ?ExpressionLanguage $expressionLanguage): mixed
+    {
+        if (!$value instanceof \Closure && !$value instanceof Expression) {
+            return $value;
+        }
+
+        return $this->controllerEvent->evaluate($value, $expressionLanguage, $this->getNamedArguments());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsMetadata.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsMetadata.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
 /**
  * Provides read-only access to controller metadata.
  *
@@ -39,5 +41,10 @@ class ControllerArgumentsMetadata extends ControllerMetadata
     public function getNamedArguments(): array
     {
         return $this->controllerArgumentsEvent->getNamedArguments();
+    }
+
+    public function evaluate(mixed $value, ?ExpressionLanguage $expressionLanguage): mixed
+    {
+        return $this->controllerArgumentsEvent->evaluate($value, $expressionLanguage);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Event/ControllerAttributeEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerAttributeEvent.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpKernel\Event;
 
 use Psr\EventDispatcher\StoppableEventInterface;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
  * Event dispatched for each controller attribute.
@@ -31,6 +33,7 @@ final class ControllerAttributeEvent implements StoppableEventInterface
         /** @var T */
         public readonly object $attribute,
         public readonly KernelEvent $kernelEvent,
+        private readonly ?ExpressionLanguage $expressionLanguage = null,
     ) {
         $this->controller = match (true) {
             $kernelEvent instanceof ControllerEvent => $kernelEvent->getController(),
@@ -41,7 +44,9 @@ final class ControllerAttributeEvent implements StoppableEventInterface
 
     public function isPropagationStopped(): bool
     {
-        if ($this->kernelEvent->isPropagationStopped()) {
+        $event = $this->kernelEvent;
+
+        if ($event->isPropagationStopped()) {
             return true;
         }
 
@@ -50,10 +55,26 @@ final class ControllerAttributeEvent implements StoppableEventInterface
         }
 
         $controller = match (true) {
-            $this->kernelEvent instanceof ControllerEvent => $this->kernelEvent->getController(),
-            $this->kernelEvent instanceof ControllerArgumentsEvent => $this->kernelEvent->getController(),
+            $event instanceof ControllerEvent => $event->getController(),
+            $event instanceof ControllerArgumentsEvent => $event->getController(),
         };
 
         return $controller instanceof \Closure ? $controller != $this->controller : $controller !== $this->controller;
+    }
+
+    public function evaluate(mixed $value, ?ExpressionLanguage $expressionLanguage = null): mixed
+    {
+        if (!$value instanceof \Closure && !$value instanceof Expression) {
+            return $value;
+        }
+
+        $event = $this->kernelEvent;
+        $expressionLanguage ??= $this->expressionLanguage;
+
+        return match (true) {
+            $event instanceof ControllerEvent => $event->evaluate($value, $expressionLanguage),
+            $event instanceof ControllerArgumentsEvent => $event->evaluate($value, $expressionLanguage),
+            ($m = $event->controllerMetadata ?? null) instanceof ControllerMetadata => $m->evaluate($value, $expressionLanguage),
+        };
     }
 }

--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -122,5 +124,33 @@ final class ControllerEvent extends KernelEvent
         }
 
         return $grouped;
+    }
+
+    public function evaluate(mixed $value, ?ExpressionLanguage $expressionLanguage, array $args = []): mixed
+    {
+        if (!$value instanceof \Closure && !$value instanceof Expression) {
+            return $value;
+        }
+
+        $controller = $this->getController();
+        $controller = match (true) {
+            \is_object($controller) && !$controller instanceof \Closure => $controller,
+            \is_array($controller) && \is_object($controller[0]) => $controller[0],
+            default => null,
+        };
+
+        if ($value instanceof \Closure) {
+            return $value($args, $this->getRequest(), $controller);
+        }
+
+        if (!$expressionLanguage) {
+            throw new \LogicException('Cannot evaluate Expression for controllers since no ExpressionLanguage service was configured.');
+        }
+
+        return $expressionLanguage->evaluate($value, [
+            'request' => $this->getRequest(),
+            'args' => $args,
+            'this' => $controller,
+        ]);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Event/ControllerMetadata.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerMetadata.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
 /**
  * Provides read-only access to controller metadata.
  *
@@ -43,5 +45,10 @@ class ControllerMetadata
     public function getAttributes(?string $className = null): array
     {
         return $this->controllerEvent->getAttributes($className);
+    }
+
+    public function evaluate(mixed $value, ?ExpressionLanguage $expressionLanguage): mixed
+    {
+        return $this->controllerEvent->evaluate($value, $expressionLanguage);
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/ControllerAttributesListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ControllerAttributesListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -21,6 +22,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 // Help opcache.preload discover always-needed symbols
 class_exists(ControllerAttributeEvent::class);
+class_exists(ExpressionLanguage::class);
 
 /**
  * Dispatches events for controller attributes.
@@ -34,7 +36,9 @@ class ControllerAttributesListener implements EventSubscriberInterface
      */
     public function __construct(
         private readonly array $attributesWithListenersByEvent,
+        private ?ExpressionLanguage $expressionLanguage = null,
     ) {
+        $this->expressionLanguage ??= class_exists(ExpressionLanguage::class, false) ? new ExpressionLanguage() : null;
     }
 
     private static array $attributeHierarchyCache = [];
@@ -50,7 +54,7 @@ class ControllerAttributesListener implements EventSubscriberInterface
             }
 
             foreach ($attributeEventNames as $attributeEventName) {
-                $dispatcher->dispatch(new ControllerAttributeEvent($attribute, $event), $attributeEventName);
+                $dispatcher->dispatch(new ControllerAttributeEvent($attribute, $event, $this->expressionLanguage), $attributeEventName);
 
                 if ($event->isPropagationStopped()) {
                     return;
@@ -74,7 +78,7 @@ class ControllerAttributesListener implements EventSubscriberInterface
             $attributeEventNames = $this->getAttributeEventNames($attribute, $eventName);
 
             for ($j = \count($attributeEventNames) - 1; $j >= 0; --$j) {
-                $dispatcher->dispatch(new ControllerAttributeEvent($attribute, $event), $attributeEventNames[$j]);
+                $dispatcher->dispatch(new ControllerAttributeEvent($attribute, $event, $this->expressionLanguage), $attributeEventNames[$j]);
 
                 if ($event->isPropagationStopped()) {
                     return;

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerArgumentsEventTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpKernel\Tests\Event;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -113,5 +115,43 @@ class ControllerArgumentsEventTest extends TestCase
         ];
         $this->assertEquals($expectedAfterSet, $event->getAttributes(Bar::class));
         $this->assertSame($controllerEvent->getAttributes(Bar::class), $event->getAttributes(Bar::class));
+    }
+
+    public function testEvaluateWithClosureUsesNamedArguments()
+    {
+        $request = new Request();
+        $controller = [new AttributeController(), 'action'];
+        $controllerEvent = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new ControllerArgumentsEvent(new TestHttpKernel(), $controllerEvent, ['value'], $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $closure = function (array $args, Request $requestArg, ?object $controllerArg) use ($request): string {
+            $this->assertSame(['baz' => 'value'], $args);
+            $this->assertSame($request, $requestArg);
+            $this->assertInstanceOf(AttributeController::class, $controllerArg);
+
+            return 'ok';
+        };
+
+        $this->assertSame('ok', $event->evaluate($closure, null));
+    }
+
+    public function testEvaluateWithExpressionDelegatesToExpressionLanguage()
+    {
+        $request = new Request();
+        $controller = [new AttributeController(), 'action'];
+        $controllerEvent = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+        $event = new ControllerArgumentsEvent(new TestHttpKernel(), $controllerEvent, ['value'], $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
+        $expressionLanguage->expects($this->once())
+            ->method('evaluate')
+            ->with(new Expression('args["baz"]'), [
+                'request' => $request,
+                'args' => ['baz' => 'value'],
+                'this' => $controller[0],
+            ])
+            ->willReturn('value');
+
+        $this->assertSame('value', $event->evaluate(new Expression('args["baz"]'), $expressionLanguage));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerAttributeEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerAttributeEventTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsMetadata;
+use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
+use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
+
+class ControllerAttributeEventTest extends TestCase
+{
+    public function testEvaluateReturnsValueForNonExpressionOrClosure()
+    {
+        $controllerEvent = new ControllerEvent(new TestHttpKernel(), static function () {}, new Request(), HttpKernelInterface::MAIN_REQUEST);
+        $event = new ControllerAttributeEvent(new \stdClass(), $controllerEvent);
+
+        $this->assertSame('value', $event->evaluate('value'));
+    }
+
+    public function testEvaluateDelegatesToControllerEvent()
+    {
+        $request = new Request();
+        $controller = [new AttributeController(), 'action'];
+        $controllerEvent = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
+        $expressionLanguage->expects($this->once())
+            ->method('evaluate')
+            ->with(new Expression('request'), [
+                'request' => $request,
+                'args' => [],
+                'this' => $controller[0],
+            ])
+            ->willReturn($request);
+
+        $event = new ControllerAttributeEvent(new \stdClass(), $controllerEvent, $expressionLanguage);
+
+        $this->assertSame($request, $event->evaluate(new Expression('request')));
+    }
+
+    public function testEvaluateDelegatesToControllerArgumentsEvent()
+    {
+        $request = new Request();
+        $controller = [new AttributeController(), 'action'];
+        $controllerEvent = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+        $argumentsEvent = new ControllerArgumentsEvent(new TestHttpKernel(), $controllerEvent, ['value'], $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
+        $expressionLanguage->expects($this->once())
+            ->method('evaluate')
+            ->with(new Expression('args["baz"]'), [
+                'request' => $request,
+                'args' => ['baz' => 'value'],
+                'this' => $controller[0],
+            ])
+            ->willReturn('value');
+
+        $event = new ControllerAttributeEvent(new \stdClass(), $argumentsEvent, $expressionLanguage);
+
+        $this->assertSame('value', $event->evaluate(new Expression('args["baz"]')));
+    }
+
+    public function testEvaluateDelegatesToControllerMetadata()
+    {
+        $request = new Request();
+        $controller = [new AttributeController(), 'action'];
+        $kernel = new TestHttpKernel();
+        $controllerEvent = new ControllerEvent($kernel, $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+        $argumentsEvent = new ControllerArgumentsEvent($kernel, $controllerEvent, ['value'], $request, HttpKernelInterface::MAIN_REQUEST);
+        $metadata = new ControllerArgumentsMetadata($controllerEvent, $argumentsEvent);
+        $responseEvent = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, new Response(), $metadata);
+
+        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
+        $expressionLanguage->expects($this->once())
+            ->method('evaluate')
+            ->with(new Expression('args["baz"]'), [
+                'request' => $request,
+                'args' => ['baz' => 'value'],
+                'this' => $controller[0],
+            ])
+            ->willReturn('value');
+
+        $event = new ControllerAttributeEvent(new \stdClass(), $responseEvent, $expressionLanguage);
+
+        $this->assertSame('value', $event->evaluate(new Expression('args["baz"]')));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Event/ControllerEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/ControllerEventTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -143,5 +145,51 @@ class ControllerEventTest extends TestCase
         yield [new AttributeController()];
         yield [(new AttributeController())->__invoke(...)];
         yield [#[Bar('class'), Bar('method'), Baz] static function () {}];
+    }
+
+    public function testEvaluateWithClosureUsesArgsRequestAndController()
+    {
+        $request = new Request();
+        $controller = [new AttributeController(), 'action'];
+        $event = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $closure = function (array $args, Request $requestArg, ?object $controllerArg): string {
+            $this->assertSame(['baz' => 'value'], $args);
+            $this->assertInstanceOf(Request::class, $requestArg);
+            $this->assertInstanceOf(AttributeController::class, $controllerArg);
+
+            return 'ok';
+        };
+
+        $this->assertSame('ok', $event->evaluate($closure, null, ['baz' => 'value']));
+    }
+
+    public function testEvaluateWithExpressionUsesExpressionLanguage()
+    {
+        $request = new Request();
+        $controller = [new AttributeController(), 'action'];
+        $event = new ControllerEvent(new TestHttpKernel(), $controller, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
+        $expressionLanguage->expects($this->once())
+            ->method('evaluate')
+            ->with(new Expression('args["baz"]'), [
+                'request' => $request,
+                'args' => ['baz' => 'value'],
+                'this' => $controller[0],
+            ])
+            ->willReturn('value');
+
+        $this->assertSame('value', $event->evaluate(new Expression('args["baz"]'), $expressionLanguage, ['baz' => 'value']));
+    }
+
+    public function testEvaluateWithExpressionRequiresExpressionLanguage()
+    {
+        $event = new ControllerEvent(new TestHttpKernel(), static function () {}, new Request(), HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot evaluate Expression for controllers since no ExpressionLanguage service was configured.');
+
+        $event->evaluate(new Expression('args["foo"]'), null, ['foo' => 'bar']);
     }
 }

--- a/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
+++ b/src/Symfony/Component/Security/Http/Attribute/IsCsrfTokenValid.php
@@ -24,7 +24,7 @@ final class IsCsrfTokenValid
         /**
          * Sets the id, or an Expression evaluated to the id, used when generating the token.
          */
-        public string|Expression $id,
+        public string|Expression|\Closure $id,
 
         /**
          * Sets the key of the request that contains the actual token value that should be validated.

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for the `clientHints`, `prefetchCache`, and `prerenderCache` `ClearSite-Data` directives
  * Add `this` to `#[IsGranted]` subject expression variables when available
+ * Add support for closures and `this` in `#[IsCsrfTokenValid]` when evaluating its `id`
 
 8.0
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsCsrfTokenValidAttributeListener.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
@@ -42,22 +41,20 @@ final class IsCsrfTokenValidAttributeListener implements EventSubscriberInterfac
             return;
         }
 
-        $this->processAttribute($event->attribute, $kernelEvent->getRequest(), $kernelEvent->getNamedArguments());
+        $this->processAttribute($event->attribute, $kernelEvent);
     }
 
     public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
     {
-        $request = $event->getRequest();
-        $arguments = $event->getNamedArguments();
-
         foreach ($event->getAttributes(IsCsrfTokenValid::class) as $attribute) {
-            $this->processAttribute($attribute, $request, $arguments);
+            $this->processAttribute($attribute, $event);
         }
     }
 
-    private function processAttribute(IsCsrfTokenValid $attribute, Request $request, array $arguments): void
+    private function processAttribute(IsCsrfTokenValid $attribute, ControllerArgumentsEvent $event): void
     {
-        $id = $this->getTokenId($attribute->id, $request, $arguments);
+        $request = $event->getRequest();
+        $id = $event->evaluate($attribute->id, $this->expressionLanguage);
         $methods = array_map('strtoupper', (array) $attribute->methods);
 
         if ($methods && !\in_array($request->getMethod(), $methods, true)) {
@@ -82,20 +79,6 @@ final class IsCsrfTokenValidAttributeListener implements EventSubscriberInterfac
         return [
             KernelEvents::CONTROLLER_ARGUMENTS.'.'.IsCsrfTokenValid::class => 'onKernelControllerAttribute',
         ];
-    }
-
-    private function getTokenId(string|Expression $id, Request $request, array $arguments): string
-    {
-        if (!$id instanceof Expression) {
-            return $id;
-        }
-
-        $this->expressionLanguage ??= new ExpressionLanguage();
-
-        return (string) $this->expressionLanguage->evaluate($id, [
-            'request' => $request,
-            'args' => $arguments,
-        ]);
     }
 
     private function getTokenValue(Request $request, int $tokenSource, string $tokenKey): ?string

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
@@ -47,14 +46,7 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
             return;
         }
 
-        $controller = $kernelEvent->getController();
-        $controller = match (true) {
-            \is_object($controller) && !$controller instanceof \Closure => $controller,
-            \is_array($controller) && \is_object($controller[0]) => $controller[0],
-            default => null,
-        };
-
-        $this->processAttribute($event->attribute, $kernelEvent->getRequest(), $kernelEvent->getNamedArguments(), $controller);
+        $this->processAttribute($event->attribute, $kernelEvent);
     }
 
     /**
@@ -73,23 +65,15 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
             return;
         }
 
-        $request = $event->getRequest();
-        $arguments = $event->getNamedArguments();
-
-        $controller = $event->getController();
-        $controller = match (true) {
-            \is_object($controller) && !$controller instanceof \Closure => $controller,
-            \is_array($controller) && \is_object($controller[0]) => $controller[0],
-            default => null,
-        };
-
         foreach ($attributes as $attribute) {
-            $this->processAttribute($attribute, $request, $arguments, $controller);
+            $this->processAttribute($attribute, $event);
         }
     }
 
-    private function processAttribute(IsGranted $attribute, Request $request, array $arguments, ?object $controller): void
+    private function processAttribute(IsGranted $attribute, ControllerArgumentsEvent $event): void
     {
+        $request = $event->getRequest();
+
         if ($attribute->methods && !\in_array($request->getMethod(), array_map('strtoupper', $attribute->methods), true)) {
             return;
         }
@@ -99,10 +83,10 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         if ($subjectRef = $attribute->subject) {
             if (\is_array($subjectRef)) {
                 foreach ($subjectRef as $refKey => $ref) {
-                    $subject[\is_string($refKey) ? $refKey : (string) $ref] = $this->getIsGrantedSubject($ref, $request, $arguments, $controller);
+                    $subject[\is_string($refKey) ? $refKey : (string) $ref] = $this->getIsGrantedSubject($ref, $event);
                 }
             } else {
-                $subject = $this->getIsGrantedSubject($subjectRef, $request, $arguments, $controller);
+                $subject = $this->getIsGrantedSubject($subjectRef, $event);
             }
         }
         $accessDecision = new AccessDecision();
@@ -134,21 +118,13 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
         ];
     }
 
-    private function getIsGrantedSubject(string|Expression|\Closure $subjectRef, Request $request, array $arguments, ?object $controller): mixed
+    private function getIsGrantedSubject(string|Expression|\Closure $subjectRef, ControllerArgumentsEvent $event): mixed
     {
-        if ($subjectRef instanceof \Closure) {
-            return $subjectRef($arguments, $request, $controller);
+        if ($subjectRef instanceof \Closure || $subjectRef instanceof Expression) {
+            return $event->evaluate($subjectRef, $this->expressionLanguage);
         }
 
-        if ($subjectRef instanceof Expression) {
-            $this->expressionLanguage ??= new ExpressionLanguage();
-
-            return $this->expressionLanguage->evaluate($subjectRef, [
-                'request' => $request,
-                'args' => $arguments,
-                'this' => $controller,
-            ]);
-        }
+        $arguments = $event->getNamedArguments();
 
         if (!\array_key_exists($subjectRef, $arguments)) {
             throw new RuntimeException(\sprintf('Could not find the subject "%s" for the #[IsGranted] attribute. Try adding a "$%s" argument to your controller method.', $subjectRef, $subjectRef));

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsCsrfTokenValidAttributeListenerTest.php
@@ -119,6 +119,7 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
     public function testIsCsrfTokenValidCalledCorrectlyWithCustomExpressionId()
     {
         $request = new Request(query: ['id' => '123'], request: ['_token' => 'bar']);
+        $controller = new IsCsrfTokenValidAttributeMethodsController();
 
         $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfTokenManager->expects($this->once())
@@ -132,8 +133,31 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             ->with(new Expression('"foo_" ~ args.id'), [
                 'args' => ['id' => '123'],
                 'request' => $request,
+                'this' => $controller,
             ])
             ->willReturn('foo_123');
+
+        $event = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            [$controller, 'withCustomExpressionId'],
+            ['123'],
+            $request,
+            null
+        );
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager, $expressionLanguage);
+        $listener->onKernelControllerArguments($event);
+    }
+
+    public function testIsCsrfTokenValidCalledCorrectlyWithClosureId()
+    {
+        $request = new Request(request: ['_token' => 'bar']);
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')
+            ->with(new CsrfToken('foo_123', 'bar'))
+            ->willReturn(true);
 
         $event = new ControllerArgumentsEvent(
             $this->createStub(HttpKernelInterface::class),
@@ -143,8 +167,10 @@ class IsCsrfTokenValidAttributeListenerTest extends TestCase
             null
         );
 
-        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager, $expressionLanguage);
-        $listener->onKernelControllerArguments($event);
+        $attribute = new IsCsrfTokenValid(static fn (array $args, Request $request, ?object $controller): string => 'foo_'.$args['id']);
+
+        $listener = new IsCsrfTokenValidAttributeListener($csrfTokenManager);
+        $listener->onKernelControllerAttribute(new ControllerAttributeEvent($attribute, $event));
     }
 
     public function testIsCsrfTokenValidCalledCorrectlyWithCustomTokenKey()

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4",
         "symfony/http-foundation": "^7.4|^8.0",
-        "symfony/http-kernel": "^7.4|^8.0",
+        "symfony/http-kernel": "^8.1",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/property-access": "^7.4|^8.0",
         "symfony/security-core": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This patch generalizes the evaluation of `Expression` / `Closure` objects in attributes by providing `evaluate()` helper methods on the various event/metadata classes available when processing attributes. This should help provide consistency for all attributes that need evaluation: providing vars `args`, `request` and `this` to all of them.