### PR TITLE
[Messenger] Fix re-sending failed messages to a different failure transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2399,7 +2399,8 @@ class FrameworkExtension extends Extension
 
             $failureTransportsByTransportNameServiceLocator = ServiceLocatorTagPass::register($container, $failureTransportReferencesByTransportName);
             $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')
-                ->replaceArgument(0, $failureTransportsByTransportNameServiceLocator);
+                ->replaceArgument(0, $failureTransportsByTransportNameServiceLocator)
+                ->replaceArgument(2, $failureTransportsByName);
         } else {
             $container->removeDefinition('messenger.failure.send_failed_message_to_failure_transport_listener');
             $container->removeDefinition('console.command.messenger_failed_messages_retry');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -186,6 +186,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('failure transports'),
                 service('logger')->ignoreOnInvalid(),
+                abstract_arg('failure transports by name'),
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'messenger'])

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -26,13 +26,11 @@ use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
  */
 class SendFailedMessageToFailureTransportListener implements EventSubscriberInterface
 {
-    private ContainerInterface $failureSenders;
-    private ?LoggerInterface $logger;
-
-    public function __construct(ContainerInterface $failureSenders, ?LoggerInterface $logger = null)
-    {
-        $this->failureSenders = $failureSenders;
-        $this->logger = $logger;
+    public function __construct(
+        private ContainerInterface $failureSenders,
+        private ?LoggerInterface $logger = null,
+        private array $failureTransportsByName = [],
+    ) {
     }
 
     /**
@@ -53,7 +51,10 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
         $envelope = $event->getEnvelope();
 
         // avoid re-sending to the failed sender
-        if (null !== $envelope->last(SentToFailureTransportStamp::class)) {
+        if (!$this->failureTransportsByName && $envelope->last(SentToFailureTransportStamp::class)) {
+            return;
+        }
+        if (($this->failureTransportsByName[$event->getReceiverName()] ?? null) === $event->getReceiverName()) {
             return;
         }
 

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
@@ -35,7 +35,7 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         }))->willReturnArgument(0);
 
         $serviceLocator = new ServiceLocator([
-            $receiverName => fn () => $sender,
+            $receiverName => static fn () => $sender,
         ]);
         $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
 
@@ -60,14 +60,62 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $listener->onMessageFailed($event);
     }
 
-    public function testDoNotRedeliverToFailedWithServiceLocator()
+    public function testDoNotRedeliverToSelfReferentialFailureTransport()
     {
         $receiverName = 'my_receiver';
 
         $sender = $this->createMock(SenderInterface::class);
         $sender->expects($this->never())->method('send');
 
-        $listener = new SendFailedMessageToFailureTransportListener(new ServiceLocator([]));
+        $serviceLocator = new ServiceLocator([
+            $receiverName => static fn () => $sender,
+        ]);
+        // The failure transport for 'my_receiver' is itself: skip to prevent an infinite loop
+        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator, null, [$receiverName => $receiverName]);
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageFailedEvent($envelope, $receiverName, new \Exception());
+
+        $listener->onMessageFailed($event);
+    }
+
+    public function testItForwardsToChainedFailureTransportWhenDifferentFromReceiver()
+    {
+        $receiverName = 'failed';
+        $chainedFailureTransportName = 'super_failed';
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->once())->method('send')->with($this->callback(function ($envelope) use ($receiverName) {
+            $this->assertInstanceOf(Envelope::class, $envelope);
+            $sentToFailureTransportStamp = $envelope->last(SentToFailureTransportStamp::class);
+            $this->assertNotNull($sentToFailureTransportStamp);
+            $this->assertSame($receiverName, $sentToFailureTransportStamp->getOriginalReceiverName());
+
+            return true;
+        }))->willReturnArgument(0);
+
+        $serviceLocator = new ServiceLocator([
+            $receiverName => static fn () => $sender,
+        ]);
+        // The failure transport for 'failed' is 'super_failed' (different): it should forward
+        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator, null, [$receiverName => $chainedFailureTransportName]);
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageFailedEvent($envelope, $receiverName, new \Exception());
+
+        $listener->onMessageFailed($event);
+    }
+
+    public function testDoNotRedeliverToFailedWithStampFallback()
+    {
+        $receiverName = 'my_receiver';
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->never())->method('send');
+
+        // No $failureTransportsByName: falls back to SentToFailureTransportStamp check
+        $serviceLocator = new ServiceLocator([
+            $receiverName => static fn () => $sender,
+        ]);
+        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);
         $envelope = new Envelope(new \stdClass(), [
             new SentToFailureTransportStamp($receiverName),
         ]);
@@ -104,7 +152,7 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         }))->willReturnArgument(0);
 
         $serviceLocator = new ServiceLocator([
-            $receiverName => fn () => $sender,
+            $receiverName => static fn () => $sender,
         ]);
 
         $listener = new SendFailedMessageToFailureTransportListener($serviceLocator);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51815 #53216
| License       | MIT

As explained in issue #51815 I expect messages to succeed, retry or be deleted manually. This was fixed in PR #51848 but this PR has been reverted in PR #54050 because it caused infinite re-sending as described in #53216.
I added a check to prevent re-sending a failed retry to the same transport it already came from. When a different failure transport is configured it will now be sent there.
