### PR TITLE
[Messenger] Add idle timeout option to `BatchHandlerTrait`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add regex support for transport name patterns in the `messenger:consume` command
+ * Add an idle timeout option to the `BatchHandlerTrait`
 
 8.0
 ---

--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -17,9 +17,14 @@ namespace Symfony\Component\Messenger\Handler;
 trait BatchHandlerTrait
 {
     private array $jobs = [];
+    private ?int $lastMessageAt = null;
 
     public function flush(bool $force): void
     {
+        if (!$force && !$this->shouldFlush()) {
+            return;
+        }
+
         if ($jobs = $this->jobs) {
             $this->jobs = [];
             $this->process($jobs);
@@ -35,6 +40,8 @@ trait BatchHandlerTrait
      */
     private function handle(object $message, ?Acknowledger $ack): mixed
     {
+        $this->lastMessageAt = time();
+
         if (null === $ack) {
             $ack = new Acknowledger(get_debug_type($this));
             $this->jobs[] = [$message, $ack];
@@ -55,7 +62,16 @@ trait BatchHandlerTrait
 
     private function shouldFlush(): bool
     {
-        return $this->getBatchSize() <= \count($this->jobs);
+        if ($this->getBatchSize() <= \count($this->jobs)) {
+            return true;
+        }
+
+        $idleTimeout = $this->getIdleTimeout();
+        if (null !== $idleTimeout && null !== $this->lastMessageAt) {
+            return (time() - $this->lastMessageAt) >= $idleTimeout;
+        }
+
+        return false;
     }
 
     /**
@@ -68,5 +84,13 @@ trait BatchHandlerTrait
     private function getBatchSize(): int
     {
         return 10;
+    }
+
+    /**
+     * @return int|null The idle timeout in seconds
+     */
+    private function getIdleTimeout(): ?int
+    {
+        return 1;
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\MessageSentToTransportsEvent;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Exception\NoSenderForMessageException;
+use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
@@ -46,7 +47,9 @@ class SendMessageMiddleware implements MiddlewareInterface
 
         if ($envelope->all(ReceivedStamp::class)) {
             // it's a received message, do not send it back
-            $this->logger?->info('Received message {class}', $context);
+            if (!$envelope->all(FlushBatchHandlersStamp::class)) {
+                $this->logger?->info('Received message {class}', $context);
+            }
         } else {
             $senders = $this->sendersLocator->getSenders($envelope);
             $senders = \is_array($senders) ? $senders : iterator_to_array($senders);

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -320,6 +320,54 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $this->assertSame([$message], $handler->processedMessages);
     }
 
+    public function testBatchHandlerFlushFalseDoesNotFlushPartialBatch()
+    {
+        $handler = new class implements BatchHandlerInterface {
+            public array $processedMessages = [];
+
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function getBatchSize(): int
+            {
+                return 3;
+            }
+
+            private function process(array $jobs): void
+            {
+                $this->processedMessages = array_column($jobs, 0);
+
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $ack = static function () {};
+
+        $message = new DummyMessage('Hey');
+        $envelope = $middleware->handle(new Envelope($message, [new AckStamp($ack)]), new StackMiddleware());
+
+        $this->assertSame([], $handler->processedMessages);
+        $this->assertCount(1, $envelope->all(NoAutoAckStamp::class));
+
+        $handler->flush(false);
+
+        $this->assertSame([], $handler->processedMessages);
+
+        $handler->flush(true);
+
+        $this->assertSame([$message], $handler->processedMessages);
+    }
+
     public function testHandlerArgumentsStamp()
     {
         $message = new DummyMessage('Hey');

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -513,6 +513,8 @@ class WorkerTest extends TestCase
 
     public function testFlushBatchOnIdle()
     {
+        ClockMock::withClockMock(false);
+
         $expectedMessages = [
             new DummyMessage('Hey'),
         ];
@@ -538,11 +540,95 @@ class WorkerTest extends TestCase
                 $this->assertSame(1, $receiver->getAcknowledgeCount());
             } else {
                 $this->assertSame(0, $receiver->getAcknowledgeCount());
+                sleep(1);
             }
         });
 
         $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
         $worker->run();
+
+        $this->assertSame($expectedMessages, $handler->processedMessages);
+    }
+
+    public function testFlushBatchWithIdleTimeout()
+    {
+        ClockMock::withClockMock(false);
+
+        $expectedMessages = [
+            new DummyMessage('Hey'),
+            new DummyMessage('Bob'),
+            new DummyMessage('Hello'),
+            new DummyMessage('John'),
+        ];
+
+        $receiver = new DummyReceiver([
+            [new Envelope($expectedMessages[0])],
+            [new Envelope($expectedMessages[1])],
+            [new Envelope($expectedMessages[2])],
+            [new Envelope($expectedMessages[3])],
+        ]);
+
+        $handler = new DummyBatchHandler(batchSize: 5, idleTimeout: 3);
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $bus = new MessageBus([$middleware]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver) {
+            static $i = 0;
+            if (6 < ++$i) { // 6 seconds = 4 messages + 3 idle timeout - 1 sec that overlaps (last message)
+                $this->assertSame(4, $receiver->getAcknowledgeCount());
+                $event->getWorker()->stop();
+            } else {
+                $this->assertSame(0, $receiver->getAcknowledgeCount());
+                sleep(1);
+            }
+        });
+
+        $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
+        $worker->run();
+
+        $this->assertSame($expectedMessages, $handler->processedMessages);
+    }
+
+    public function testFlushBatchWithoutIdleTimeout()
+    {
+        ClockMock::withClockMock(false);
+
+        $expectedMessages = [
+            new DummyMessage('Hey'),
+        ];
+
+        $receiver = new DummyReceiver([
+            [new Envelope($expectedMessages[0])],
+            [],
+        ]);
+
+        $handler = new DummyBatchHandler(idleTimeout: null);
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $bus = new MessageBus([$middleware]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver) {
+            static $i = 0;
+            if (2 < ++$i) {
+                $event->getWorker()->stop();
+            }
+            $this->assertSame(0, $receiver->getAcknowledgeCount());
+            sleep(1);
+        });
+
+        $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
+        $worker->run();
+
+        $this->assertSame(1, $receiver->getAcknowledgeCount());
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
     }
@@ -655,7 +741,7 @@ class WorkerTest extends TestCase
         $unacks = $unacksProperty->getValue($worker);
         $dummyHandler = new DummyBatchHandler();
         $envelopeWithNoAutoAck = $envelope->with(new NoAutoAckStamp(new HandlerDescriptor($dummyHandler)));
-        $unacks[$dummyHandler] = [$envelopeWithNoAutoAck, 'transport'];
+        $unacks[$dummyHandler] = [$envelopeWithNoAutoAck, 'transport', false];
 
         $worker->run();
 
@@ -811,8 +897,11 @@ class DummyBatchHandler implements BatchHandlerInterface
 
     public array $processedMessages;
 
-    public function __construct(private ?int $delay = null)
-    {
+    public function __construct(
+        private ?int $delay = null,
+        private int $batchSize = 2,
+        private ?int $idleTimeout = 1,
+    ) {
     }
 
     public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
@@ -820,9 +909,14 @@ class DummyBatchHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
-    private function shouldFlush(): bool
+    private function getBatchSize(): int
     {
-        return 2 <= \count($this->jobs);
+        return $this->batchSize;
+    }
+
+    private function getIdleTimeout(): ?int
+    {
+        return $this->idleTimeout;
     }
 
     private function process(array $jobs): void
@@ -852,9 +946,9 @@ class SecondDummyBatchHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
-    private function shouldFlush(): bool
+    private function getBatchSize(): int
     {
-        return 5 <= \count($this->jobs);
+        return 5;
     }
 
     private function process(array $jobs): void

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -176,7 +176,7 @@ class Worker
         if (!$acked && !$noAutoAckStamp) {
             $this->acks[] = [$transportName, $envelope, $e];
         } elseif ($noAutoAckStamp) {
-            $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName];
+            $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName, &$acked];
         }
 
         $this->ack();
@@ -269,12 +269,22 @@ class Worker
         $this->unacks = new \SplObjectStorage();
 
         foreach ($unacks as $batchHandler) {
-            [$envelope, $transportName] = $unacks[$batchHandler];
+            [$envelope, $transportName, $acked] = $unacks[$batchHandler];
             try {
+                $e = null;
                 $this->bus->dispatch($envelope->with(new FlushBatchHandlersStamp($force)));
             } catch (\Throwable $e) {
                 $envelope = $envelope->withoutAll(NoAutoAckStamp::class);
                 $this->acks[] = [$transportName, $envelope, $e];
+                continue;
+            }
+
+            $noAutoAckStamp = $envelope->last(NoAutoAckStamp::class);
+
+            if (!$acked && !$noAutoAckStamp) {
+                $this->acks[] = [$transportName, $envelope, $e];
+            } elseif ($noAutoAckStamp) {
+                $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName, &$acked];
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | maybe?
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63205
| License       | MIT

This PR adds a `getIdleTimeout()` method to `BatchHandlerTrait`, allowing batches to be flushed after a configured idle time when the required batch size is not reached.

This ensures that low-throughput workloads are processed regardless of batch size, rather than waiting indefinitely for the batch to fill up.

For older Symfony versions, users can copy this updated `BatchHandlerTrait` implementation and use it directly in their projects.