### PR TITLE
[Mailer] Fix Mailjet SMTP relay X-MJ-TemplateErrorReporting header format to MailjetApiTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -430,4 +430,50 @@ class MailjetApiTransportTest extends TestCase
             $method->invoke($transport, $email, $envelope)
         );
     }
+
+    public function testTemplateErrorReportingHeaderSupportsSmtpRelayFormat()
+    {
+        $email = (new Email())
+            ->subject('Sending email to mailjet API')
+            ->replyTo(new Address('qux@example.com', 'Qux'));
+        $email->getHeaders()
+            ->addTextHeader('X-MJ-TemplateErrorReporting', 'errors@mailjet.com');
+        $envelope = new Envelope(new Address('foo@example.com', 'Foo'), [
+            new Address('bar@example.com', 'Bar'),
+        ]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        self::assertSame(
+            [
+                'Messages' => [
+                    [
+                        'From' => [
+                            'Email' => 'foo@example.com',
+                            'Name' => 'Foo',
+                        ],
+                        'To' => [
+                            [
+                                'Email' => 'bar@example.com',
+                                'Name' => '',
+                            ],
+                        ],
+                        'Subject' => 'Sending email to mailjet API',
+                        'Attachments' => [],
+                        'InlinedAttachments' => [],
+                        'ReplyTo' => [
+                            'Email' => 'qux@example.com',
+                            'Name' => 'Qux',
+                        ],
+                        'TemplateErrorReporting' => [
+                            'Email' => 'errors@mailjet.com',
+                            'Name' => '',
+                        ],
+                    ],
+                ],
+                'SandBoxMode' => false,
+            ],
+            $method->invoke($transport, $email, $envelope)
+        );
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -39,7 +39,7 @@ class MailjetApiTransport extends AbstractApiTransport
     private const HEADER_TO_MESSAGE = [
         'x-mj-templatelanguage' => ['TemplateLanguage', 'bool'],
         'x-mj-templateid' => ['TemplateID', 'int'],
-        'x-mj-templateerrorreporting' => ['TemplateErrorReporting', 'json'],
+        'x-mj-templateerrorreporting' => ['TemplateErrorReporting', 'templateerrorreporting'],
         'x-mj-templateerrordeliver' => ['TemplateErrorDeliver', 'bool'],
         'x-mj-vars' => ['Variables', 'json'],
         'x-mj-customid' => ['CustomID', 'string'],
@@ -207,6 +207,9 @@ class MailjetApiTransport extends AbstractApiTransport
             'int' => (int) $value,
             'json' => json_decode($value, true, 512, \JSON_THROW_ON_ERROR),
             'string' => $value,
+
+            // The API transport supports a richer address format than the SMTP relay. Use a special case to support both with BC.
+            'templateerrorreporting' => false !== filter_var($value, \FILTER_VALIDATE_EMAIL) ? ['Email' => $value, 'Name' => ''] : $this->castCustomHeader($value, 'json'),
         };
     }
 }


### PR DESCRIPTION
… 

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The MailjetApiTransport currently requires a json format (`{"Address": "...", "Name": "..."}`) for the `X-MJ-TemplateErrorReporting` header, whereas the Mailjet SMTP Relay supports only a direct email address as value. This change adds support for both, so users desiring compatibility with both smtp and api transport can use the smtp format. 