### PR TITLE
[Serializer] Normalize static methods when they have groups

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AccessorCollisionResolverTrait.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AccessorCollisionResolverTrait.php
@@ -34,7 +34,7 @@ trait AccessorCollisionResolverTrait
         };
 
         // ctype_lower check to find out if method looks like accessor but actually is not, e.g. hash, cancel
-        if (null === $i || ctype_lower($methodName[$i] ?? 'a') || $method->isStatic()) {
+        if (null === $i || ctype_lower($methodName[$i] ?? 'a') || (!$andMutator && $method->isStatic())) {
             return null;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -713,6 +713,13 @@ class ObjectNormalizerTest extends TestCase
         $this->assertEquals(['foo' => 'K'], $this->normalizer->normalize(new ObjectWithStaticPropertiesAndMethods()));
     }
 
+    public function testNormalizeStaticWithGroups()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $this->createNormalizer([], $classMetadataFactory);
+        $this->assertEquals(['baz' => 'L'], $this->normalizer->normalize(new ObjectWithStaticMethodWithGroups(), null, [AbstractNormalizer::GROUPS => ['test']]));
+    }
+
     public function testNormalizeUpperCaseAttributes()
     {
         $this->assertEquals(['Foo' => 'Foo', 'Bar' => 'BarBar'], $this->normalizer->normalize(new ObjectWithUpperCaseAttributeNames()));
@@ -1453,6 +1460,15 @@ class ObjectWithStaticPropertiesAndMethods
     public $foo = 'K';
     public static $bar = 'A';
 
+    public static function getBaz()
+    {
+        return 'L';
+    }
+}
+
+class ObjectWithStaticMethodWithGroups
+{
+    #[Groups('test')]
     public static function getBaz()
     {
         return 'L';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/pull/63136/files#r2761176730
| License       | MIT

PR #63136 introduced a regression that stopped normalization of static methods when they had explicit groups defined. Before that changes, static methods with groups were normalized. Afterwards, these static methods are not normalized anymore.

The regression was caused because previously `ObjectNormalizer::extractAttributes()` ignored static methods while `AttributeLoader::loadClassMetadata()` did not, and the PR introduced a new `getAttributeNameFromAccessor()` method that is shared across those two methods. As a result the `AttributeLoader::loadClassMetadata()` method is now also ignoring static methods.

You can verify this regression by adding the test case from this PR to a commit before the PR was merged (e.g. `1db906a6802c54f8a28f79fbb928d5cb1d5a642c^`)
