### PR TITLE
[String] Treat emoji VS16 as wide in width calc

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -2086,8 +2086,6 @@ TABLE,
             ->setHeaders(['Title', 'Author'])
             ->setRows([
                 ['🎭 💫 ☯ Divine Comedy', 'Dante Alighieri'],
-                // the snowflake (e2 9d 84 ef b8 8f) has a variant selector
-                ['👑 ❄️  🗡 Game of Thrones', 'George R.R. Martin'],
                 // the snowflake in text style (e2 9d 84 ef b8 8e) has a variant selector
                 ['❄︎❄︎❄︎ snowflake in text style ❄︎❄︎❄︎', ''],
                 ['And a very long line to show difference in previous lines', ''],
@@ -2100,7 +2098,6 @@ TABLE,
 | Title                                                     | Author             |
 +-----------------------------------------------------------+--------------------+
 | 🎭 💫 ☯ Divine Comedy                                     | Dante Alighieri    |
-| 👑 ❄️  🗡 Game of Thrones                                   | George R.R. Martin |
 | ❄︎❄︎❄︎ snowflake in text style ❄︎❄︎❄︎                           |                    |
 | And a very long line to show difference in previous lines |                    |
 +-----------------------------------------------------------+--------------------+

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -530,6 +530,8 @@ abstract class AbstractUnicodeString extends AbstractString
     private function wcswidth(string $string): int
     {
         $width = 0;
+        $lastChar = null;
+        $lastWidth = null;
 
         foreach (preg_split('//u', $string, -1, \PREG_SPLIT_NO_EMPTY) as $c) {
             $codePoint = mb_ord($c, 'UTF-8');
@@ -550,6 +552,15 @@ abstract class AbstractUnicodeString extends AbstractString
                 || (0x07F <= $codePoint && 0x0A0 > $codePoint) // C1 control characters and DEL
             ) {
                 return -1;
+            }
+
+            if (0xFE0F === $codePoint) {
+                if (null !== $lastChar && 1 === $lastWidth && preg_match('/\p{Emoji}/u', $lastChar)) {
+                    ++$width;
+                    $lastWidth = 2;
+                }
+
+                continue;
             }
 
             self::$tableZero ??= require __DIR__.'/Resources/data/wcswidth_table_zero.php';
@@ -582,6 +593,8 @@ abstract class AbstractUnicodeString extends AbstractString
                         $ubound = $mid - 1;
                     } else {
                         $width += 2;
+                        $lastChar = $c;
+                        $lastWidth = 2;
 
                         continue 2;
                     }
@@ -589,6 +602,8 @@ abstract class AbstractUnicodeString extends AbstractString
             }
 
             ++$width;
+            $lastChar = $c;
+            $lastWidth = 1;
         }
 
         return $width;

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -20,6 +20,7 @@ abstract class AbstractUnicodeTestCase extends AbstractAsciiTestCase
         return array_merge(
             parent::provideWidth(),
             [
+                [2, '⚠️'],
                 [14, '<<<END
 This is a
 multiline text


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | refs #60038
| License       | MIT

The width calculation iterates code points. Previously, U+FE0F (VARIATION SELECTOR-16) was treated as zero-width because it’s in the zero-width table, so ⚠️ ended up the same width as ⚠.

I added tracking of the previous visible character ($lastChar) and its width ($lastWidth). When the loop encounters U+FE0F, it now checks: the previous character exists, it was counted as width 1, it matches the Unicode \p{Emoji} property.

If those conditions hold, it increments the total width by 1, effectively upgrading the base emoji from width 1 to width 2. This matches mb_strwidth() behavior for emoji presentation via VS16 in terminals.

So, ⚠️ becomes width 2, while plain ⚠ stays width 1. The added test asserts this behavior.
