### PR TITLE
[Webhook] Document AbstractRequestParser::doParse

### DIFF
--- a/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
+++ b/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
@@ -41,6 +41,11 @@ abstract class AbstractRequestParser implements RequestParserInterface
 
     abstract protected function getRequestMatcher(): RequestMatcherInterface;
 
+    /**
+     * @return RemoteEvent|RemoteEvent[]|null
+     *
+     * @throws RejectWebhookException When the payload is rejected (signature issue, parse issue, ...)
+     */
     abstract protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null;
 
     protected function validate(Request $request): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Since `AbstractRequestParser::doParse` is meant to be implemented, it's useful to add details about param and throw types:
- `RemoteEvent[]` will document the type of the array returned, it can allow tools like PHPStan to detect a wrong returned values.
- The `@throws` type precise the expected thrown exception. This ensure to be covariant with the expected throw type of `RequestParserInterface::parse` ; this is again useful for PHPStan user since the tool is able to check for throw type covariance

Multiple PR improving the PHPDoc was asked on the feature branch so I opened it on 8.1, but it could still be useful on previous versions.