### PR TITLE
[Messenger] Optimize serialized size of ErrorDetailsStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Stamp;
 
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
 
 /**
  * Stamp applied when a messages fails due to an exception in the handler.
@@ -39,8 +40,9 @@ final class ErrorDetailsStamp implements StampInterface
         }
 
         $flattenException = null;
-        if (class_exists(FlattenException::class)) {
+        if (!$throwable instanceof RecoverableExceptionInterface && class_exists(FlattenException::class)) {
             $flattenException = FlattenException::createFromThrowable($throwable);
+            $flattenException->setTrace([], $throwable->getFile(), $throwable->getLine());
         }
 
         return new self($throwable::class, $throwable->getCode(), $throwable->getMessage(), $flattenException);
@@ -75,7 +77,8 @@ final class ErrorDetailsStamp implements StampInterface
         if ($this->flattenException && $that->flattenException) {
             return $this->flattenException->getClass() === $that->flattenException->getClass()
                 && $this->flattenException->getCode() === $that->flattenException->getCode()
-                && $this->flattenException->getMessage() === $that->flattenException->getMessage();
+                && $this->flattenException->getFile() === $that->flattenException->getFile()
+                && $this->flattenException->getLine() === $that->flattenException->getLine();
         }
 
         return $this->exceptionClass === $that->exceptionClass

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -316,16 +316,10 @@ RuntimeException {
   file: "%s"
   line: %d
   trace: {
-    %%s%%eTests%%eCommand%%eFailedMessagesShowCommandTest.php:%d {
-      Symfony\Component\Messenger\Tests\Command\FailedMessagesShowCommandTest->testVeryVerboseOutputForSingleMessageContainsExceptionWithTraceWithServiceLocator()
-      › {
-      ›     $exception = new \RuntimeException('Things are bad!');
-      ›     $exceptionLine = __LINE__ - 1;
-    }
 %%A
 EOF
             ,
-            __FILE__, $exceptionLine, $exceptionLine),
+            __FILE__, $exceptionLine),
             $tester->getDisplay(true));
     }
 

--- a/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
@@ -177,7 +177,7 @@ class FailureIntegrationTest extends TestCase
         /** @var ErrorDetailsStamp $errorDetailsStamp */
         $errorDetailsStamp = $failedEnvelope->last(ErrorDetailsStamp::class);
         $this->assertNotNull($errorDetailsStamp);
-        $this->assertSame('Failure from call 2', $errorDetailsStamp->getExceptionMessage());
+        $this->assertSame('Failure from call 1', $errorDetailsStamp->getExceptionMessage());
 
         /*
          * Failed message is handled, fails, and sent for a retry

--- a/src/Symfony/Component/Messenger/Tests/Stamp/ErrorDetailsStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/ErrorDetailsStampTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Transport\Serialization\Normalizer\FlattenExceptionNormalizer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
@@ -29,6 +30,7 @@ class ErrorDetailsStampTest extends TestCase
     {
         $exception = new \Exception('exception message');
         $flattenException = FlattenException::createFromThrowable($exception);
+        $flattenException->setTrace([], $exception->getFile(), $exception->getLine());
 
         $stamp = ErrorDetailsStamp::create($exception);
 
@@ -43,6 +45,7 @@ class ErrorDetailsStampTest extends TestCase
         $envelope = new Envelope(new \stdClass());
         $exception = new HandlerFailedException($envelope, [$wrappedException]);
         $flattenException = FlattenException::createFromThrowable($wrappedException);
+        $flattenException->setTrace([], $wrappedException->getFile(), $wrappedException->getLine());
 
         $stamp = ErrorDetailsStamp::create($exception);
 
@@ -70,4 +73,42 @@ class ErrorDetailsStampTest extends TestCase
         $this->assertInstanceOf(ErrorDetailsStamp::class, $deserializedStamp);
         $this->assertEquals($stamp, $deserializedStamp);
     }
+
+    public function testRecoverableExceptionSkipsFlattenException()
+    {
+        $exception = new RecoverableTestException('recoverable message', 10);
+
+        $stamp = ErrorDetailsStamp::create($exception);
+
+        $this->assertSame($exception::class, $stamp->getExceptionClass());
+        $this->assertSame('recoverable message', $stamp->getExceptionMessage());
+        $this->assertSame(10, $stamp->getExceptionCode());
+        $this->assertNull($stamp->getFlattenException());
+    }
+
+    public function testEqualsUsesFlattenExceptionLocation()
+    {
+        $exceptionA = new \RuntimeException('same');
+        $exceptionB = new \RuntimeException('same');
+
+        $stampA = ErrorDetailsStamp::create($exceptionA);
+        $stampB = ErrorDetailsStamp::create($exceptionB);
+
+        $this->assertFalse($stampA->equals($stampB));
+    }
+
+    public function testEqualsFallsBackToExceptionDetailsWithoutFlattenException()
+    {
+        $exceptionA = new RecoverableTestException('recoverable', 123);
+        $exceptionB = new RecoverableTestException('recoverable', 123);
+
+        $stampA = ErrorDetailsStamp::create($exceptionA);
+        $stampB = ErrorDetailsStamp::create($exceptionB);
+
+        $this->assertTrue($stampA->equals($stampB));
+    }
+}
+
+class RecoverableTestException extends \RuntimeException implements RecoverableExceptionInterface
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #45944, fix #44943
| License       | MIT

Instead of #53454

As described in the linked issues, retrying errors can lead to huge message payloads.

This PR implements 3 fixes for this concern:
- As proposed in #45944, we just don't create a `FlattenException` when a `RecoverableExceptionInterface` is found: those are user initiated so that's not really an error anymore but intended behaviour.
- We just remove the trace from generated `FlattenException` objects. This keeps only its "as string" version, which to me is enough to start a debugging session when needed. Ppl that need more can always use a logger to get the full detailed trace.
- I updated the `ErrorDetailsStamp::equals()` method to not consider the message anymore but the file+line instead. This should provide more dedup opportunities.