### PR TITLE
[Messenger] Fix AMQP heartbeat reconnection during in-flight message handling

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -846,6 +846,68 @@ class ConnectionTest extends TestCase
         $connection->publish('body', [], 5000);
     }
 
+    public function testItDoesNotReconnectWhileMessageIsInFlightWhenHeartbeatExpires()
+    {
+        $connected = true;
+
+        $amqpConnection = $this->createMock(\AMQPConnection::class);
+        $amqpConnection->expects($this->never())->method('disconnect');
+        $amqpConnection->expects($this->never())->method('pdisconnect');
+        $amqpConnection->method('connect')->willReturnCallback(static function () use (&$connected) {
+            $connected = true;
+        });
+
+        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpChannel->method('getConnection')->willReturn($amqpConnection);
+        $amqpChannel->method('isConnected')->willReturnCallback(static function () use (&$connected) {
+            return $connected;
+        });
+
+        $amqpExchange = $this->createMock(\AMQPExchange::class);
+        $amqpExchange->expects($this->once())->method('publish');
+
+        $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
+        $amqpEnvelope->method('getDeliveryTag')->willReturn(1);
+
+        $queue = $this->createMock(\AMQPQueue::class);
+        $queue->expects($this->once())->method('get')->willReturn($amqpEnvelope);
+        $queue->expects($this->once())->method('ack')->with(1);
+
+        $queueAfterReconnect = $this->createMock(\AMQPQueue::class);
+        $queueAfterReconnect->expects($this->never())->method('ack');
+
+        $factory = $this->createStub(AmqpFactory::class);
+        $factory->method('createConnection')->willReturn($amqpConnection);
+        $factory->method('createChannel')->willReturn($amqpChannel);
+        $factory->method('createExchange')->willReturn($amqpExchange);
+        $factory->method('createQueue')->willReturnOnConsecutiveCalls($queue, $queueAfterReconnect);
+
+        $connection = Connection::fromDsn('amqp://localhost?heartbeat=1', [], $factory);
+
+        $envelope = $connection->get(self::DEFAULT_EXCHANGE_NAME);
+
+        (new \ReflectionProperty($connection, 'lastActivityTime'))->setValue($connection, time() - 3);
+
+        $connection->publish('body');
+        $connection->ack($envelope, self::DEFAULT_EXCHANGE_NAME);
+    }
+
+    public function testClearResetsInFlightMessagesCounter()
+    {
+        $factory = $this->createStub(AmqpFactory::class);
+        $connection = Connection::fromDsn('amqp://localhost', [], $factory);
+
+        $reflection = new \ReflectionClass($connection);
+
+        $inFlightMessagesProperty = $reflection->getProperty('inFlightMessages');
+        $inFlightMessagesProperty->setValue($connection, 2);
+
+        $clearMethod = $reflection->getMethod('clear');
+        $clearMethod->invoke($connection);
+
+        $this->assertSame(0, $inFlightMessagesProperty->getValue($connection));
+    }
+
     public function testItWillRetryMaxThreeTimesWhenAMQPConnectionExceptionIsThrown()
     {
         $factory = new TestAmqpFactory(

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -97,6 +97,7 @@ class Connection
 
     private \AMQPExchange $amqpDelayExchange;
     private int $lastActivityTime = 0;
+    private int $inFlightMessages = 0;
 
     public function __construct(array $connectionOptions, array $exchangeOptions, array $queuesOptions, ?AmqpFactory $amqpFactory = null)
     {
@@ -209,7 +210,7 @@ class Connection
             $amqpOptions['auto_setup'] = filter_var($amqpOptions['auto_setup'], \FILTER_VALIDATE_BOOL);
         }
 
-        $queuesOptions = array_map(function ($queueOptions) {
+        $queuesOptions = array_map(static function ($queueOptions) {
             if (!\is_array($queueOptions)) {
                 $queueOptions = [];
             }
@@ -431,20 +432,35 @@ class Connection
         }
 
         if (false !== $message = $this->queue($queueName)->get()) {
+            ++$this->inFlightMessages;
+            $this->lastActivityTime = time();
+
             return $message;
         }
+
+        $this->lastActivityTime = time();
 
         return null;
     }
 
     public function ack(\AMQPEnvelope $message, string $queueName): bool
     {
-        return $this->queue($queueName)->ack($message->getDeliveryTag()) ?? true;
+        try {
+            return $this->queue($queueName)->ack($message->getDeliveryTag()) ?? true;
+        } finally {
+            $this->lastActivityTime = time();
+            $this->inFlightMessages = max(0, $this->inFlightMessages - 1);
+        }
     }
 
     public function nack(\AMQPEnvelope $message, string $queueName, int $flags = \AMQP_NOPARAM): bool
     {
-        return $this->queue($queueName)->nack($message->getDeliveryTag(), $flags) ?? true;
+        try {
+            return $this->queue($queueName)->nack($message->getDeliveryTag(), $flags) ?? true;
+        } finally {
+            $this->lastActivityTime = time();
+            $this->inFlightMessages = max(0, $this->inFlightMessages - 1);
+        }
     }
 
     public function setup(): void
@@ -502,7 +518,7 @@ class Connection
             }
 
             $this->lastActivityTime = time();
-        } elseif (0 < ($this->connectionOptions['heartbeat'] ?? 0) && time() > $this->lastActivityTime + 2 * $this->connectionOptions['heartbeat']) {
+        } elseif (0 < ($this->connectionOptions['heartbeat'] ?? 0) && time() > $this->lastActivityTime + 2 * $this->connectionOptions['heartbeat'] && 0 === $this->inFlightMessages) {
             $disconnectMethod = 'true' === ($this->connectionOptions['persistent'] ?? 'false') ? 'pdisconnect' : 'disconnect';
             $this->amqpChannel->getConnection()->{$disconnectMethod}();
         }
@@ -556,6 +572,7 @@ class Connection
     {
         unset($this->amqpChannel, $this->amqpExchange, $this->amqpDelayExchange);
         $this->amqpQueues = [];
+        $this->inFlightMessages = 0;
     }
 
     private function getDefaultPublishRoutingKey(): ?string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49029
| License       | MIT

## Summary

This PR fixes the `PRECONDITION_FAILED - unknown delivery tag` error that occurs when:
1. A message is retrieved from the queue (delivery tag assigned)
2. The heartbeat timeout expires during message processing
3. A publish operation (e.g., to a delay queue for retry) triggers a channel reconnection
4. The subsequent `nack()` fails because the delivery tag is invalid on the new channel

## Solution

Introduced an `inFlightMessages` counter that:
- Increments when a message is retrieved via `get()`
- Decrements in `ack()` and `nack()` (using `finally` blocks to ensure decrement even on exceptions)
- Prevents heartbeat-based reconnection while any messages are in-flight
- Resets in `clear()` to avoid a stuck state if messages are abandoned

The heartbeat reconnection logic now checks `0 === $this->inFlightMessages` before triggering a reconnect.

## Test plan

- [x] Added unit test `testItDoesNotReconnectWhileMessageIsInFlightWhenHeartbeatExpires` - verifies that `disconnect()`/`pdisconnect()` are never called while a message is in-flight, even when heartbeat expires
- [x] Added unit test `testClearResetsInFlightMessagesCounter` - verifies the counter is reset to prevent stuck state
- [x] Tested with the example repository provided in the issue (https://github.com/Jontsa/symfony_amqp_issue)