### PR TITLE
[HttpKernel][WebProfilerBundle] Add error indicator to profiler list view

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add error indicator to profiler list view for profiles with errors
+
 8.0
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -25,6 +25,23 @@
         #search-results .sf-search svg {
             stroke-width: 3;
         }
+        #search-results .status-with-indicator {
+            position: relative;
+            display: inline-block;
+            padding-right: 20px;
+        }
+        #search-results .error-indicator {
+            position: absolute;
+            right: -10px;
+            top: 50%;
+            transform: translateY(-50%);
+            display: flex;
+            padding: 3px 4px;
+        }
+        #search-results .error-indicator svg {
+            width: 18px;
+            height: 18px;
+        }
     </style>
 {% endblock %}
 
@@ -98,13 +115,20 @@
                 {% for result in tokens %}
                     {% if 'command' == profile_type %}
                         {% set css_class = result.status_code == 113 ? 'status-warning' : result.status_code > 0 ? 'status-error' : 'status-success' %}
+                        {% set has_errors = result.has_errors|default(false) and result.status_code == 0 %}
                     {% else %}
                         {% set css_class = result.status_code|default(0) > 399 ? 'status-error' : result.status_code|default(0) > 299 ? 'status-warning' : 'status-success' %}
+                        {% set has_errors = result.has_errors|default(false) and result.status_code < 400 %}
                     {% endif %}
 
                     <tr>
                         <td class="text-center">
-                            <span class="label {{ css_class }}">{{ result.status_code|default('n/a') }}</span>
+                            <span class="status-with-indicator">
+                                <span class="label {{ css_class }}">{{ result.status_code|default('n/a') }}</span>
+                                {%- if has_errors -%}
+                                    <span class="label status-error error-indicator">{{ source('@WebProfiler/Icon/logger.svg') }}</span>
+                                {%- endif -%}
+                            </span>
                         </td>
                         <td>
                             <span class="nowrap">{{ result.ip }} {{ _self.profile_search_filter(request, result, 'ip') }}</span>

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `hasErrors()` method to `Profile` to track profiles with errors (exceptions or error-level logs)
  * Validate typed route parameters before calling controllers and return an HTTP error when an invalid value is provided
  * Add `ControllerAttributeEvent` et al. to dispatch events named after controller attributes
  * Add support for `UploadedFile` when using `MapRequestPayload`

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -62,7 +62,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
-            [$csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode, $csvVirtualType] = $values + [7 => null];
+            [$csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode, $csvVirtualType, $csvHasErrors] = $values + [7 => null, 8 => null];
             $csvTime = (int) $csvTime;
 
             $urlFilter = false;
@@ -91,6 +91,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 'parent' => $csvParent,
                 'status_code' => $csvStatusCode,
                 'virtual_type' => $csvVirtualType ?: 'request',
+                'has_errors' => (bool) $csvHasErrors,
             ];
 
             if ($filter && !$filter($profile)) {
@@ -159,6 +160,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
             'time' => $profile->getTime(),
             'status_code' => $profile->getStatusCode(),
             'virtual_type' => $profile->getVirtualType() ?? 'request',
+            'has_errors' => $profile->hasErrors(),
         ];
 
         $data = serialize($data);
@@ -186,6 +188,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 $profile->getParentToken(),
                 $profile->getStatusCode(),
                 $profile->getVirtualType() ?? 'request',
+                $profile->hasErrors() ? '1' : '0',
             ], ',', '"', '\\');
             fclose($file);
 
@@ -271,6 +274,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $profile->setTime($data['time']);
         $profile->setStatusCode($data['status_code']);
         $profile->setVirtualType($data['virtual_type'] ?: 'request');
+        $profile->setHasErrors($data['has_errors'] ?? false);
         $profile->setCollectors($data['data']);
 
         if (!$parent && $data['parent']) {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -32,6 +32,7 @@ class Profile
     private ?int $statusCode = null;
     private ?self $parent = null;
     private ?string $virtualType = null;
+    private bool $hasErrors = false;
 
     /**
      * @var Profile[]
@@ -155,6 +156,16 @@ class Profile
         return $this->virtualType;
     }
 
+    public function hasErrors(): bool
+    {
+        return $this->hasErrors;
+    }
+
+    public function setHasErrors(bool $hasErrors): void
+    {
+        $this->hasErrors = $hasErrors;
+    }
+
     /**
      * Finds children profilers.
      *
@@ -261,6 +272,7 @@ class Profile
             'time' => $this->time,
             'statusCode' => $this->statusCode,
             'virtualType' => $this->virtualType,
+            'hasErrors' => $this->hasErrors,
         ];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -94,6 +95,15 @@ class Profiler implements ResetInterface
             }
         }
 
+        // Update hasErrors flag to include error-level logs (available after lateCollect)
+        if (!$profile->hasErrors()
+            && $profile->hasCollector('logger')
+            && ($logger = $profile->getCollector('logger')) instanceof LoggerDataCollector
+            && $logger->countErrors() > 0
+        ) {
+            $profile->setHasErrors(true);
+        }
+
         if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
             $this->logger->warning('Unable to store the profiler information.', ['configured_storage' => $this->storage::class]);
         }
@@ -147,6 +157,8 @@ class Profiler implements ResetInterface
         if ($request->attributes->has('_virtual_type')) {
             $profile->setVirtualType($request->attributes->get('_virtual_type'));
         }
+
+        $profile->setHasErrors(null !== $exception);
 
         if ($prevToken = $response->headers->get('X-Debug-Token')) {
             $response->headers->set('X-Previous-Debug-Token', $prevToken);

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -329,6 +329,45 @@ class FileProfilerStorageTest extends TestCase
         $this->assertContains((int) $tokens[1]['status_code'], [200, 404]);
     }
 
+    public function testHasErrors()
+    {
+        $profile = new Profile('token_with_errors');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/error');
+        $profile->setMethod('GET');
+        $profile->setStatusCode(500);
+        $profile->setHasErrors(true);
+        $this->storage->write($profile);
+
+        $profile = new Profile('token_without_errors');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/success');
+        $profile->setMethod('GET');
+        $profile->setStatusCode(200);
+        $profile->setHasErrors(false);
+        $this->storage->write($profile);
+
+        $loadedProfile = $this->storage->read('token_with_errors');
+        $this->assertTrue($loadedProfile->hasErrors(), '->read() restores hasErrors=true on the Profile object');
+
+        $loadedProfile = $this->storage->read('token_without_errors');
+        $this->assertFalse($loadedProfile->hasErrors(), '->read() restores hasErrors=false on the Profile object');
+    }
+
+    public function testHasErrorsBackwardCompatibility()
+    {
+        // Test backward compatibility with old CSV lines that don't have has_errors field
+        $file = $this->tmpDir.'/index.csv';
+        $time = time();
+
+        // Write an old-format CSV line (8 fields, no has_errors)
+        file_put_contents($file, "old_token,127.0.0.1,GET,http://foo.bar/old,{$time},,200,request\n");
+
+        $tokens = $this->storage->find('', '', 10, '');
+        $this->assertCount(1, $tokens);
+        $this->assertFalse($tokens[0]['has_errors'], '->find() returns has_errors=false for old CSV lines without the field');
+    }
+
     public function testMultiRowIndexFile()
     {
         $iteration = 3;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      |no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | N/A <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Display a visual indicator next to profiles that have errors (exceptions or error-level logs) so users can identify problematic requests/commands without opening each profile individually. 

This _feature_ was inspired by having to check failing web-hooks that come in _no particular oder_ 15 at a time. 

I am not the best designer out there, so open for review, but this is how it would look like as is: 

<img width="994" height="532" alt="Screenshot 2026-02-06 at 13 25 39" src="https://github.com/user-attachments/assets/17143292-a786-4761-b0e0-545ad707afb8" />

