### PR TITLE
[Contracts][DependencyInjection] Support hooked properties in ServiceMethodsSubscriberTrait

### DIFF
--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for the `max_connect_duration` option in `HttpClientInterface`
+ * Add support for hooked properties in `ServiceMethodsSubscriberTrait`
 
 3.6
 ---

--- a/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
+++ b/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 final class SubscribedService
 {
     /** @var object[] */

--- a/src/Symfony/Contracts/Tests/Service/Fixtures/HookedPropertyService.php
+++ b/src/Symfony/Contracts/Tests/Service/Fixtures/HookedPropertyService.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Tests\Service\Fixtures;
+
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceMethodsSubscriberTrait;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+final class HookedPropertyService implements ServiceSubscriberInterface
+{
+    use ServiceMethodsSubscriberTrait;
+
+    #[SubscribedService]
+    public MyDependency $myDependency {
+        get => $this->container->get(__METHOD__);
+    }
+
+    #[SubscribedService]
+    public ?MyDependency $myNullableDependency {
+        get => $this->container->has(__METHOD__) ? $this->container->get(__METHOD__) : null;
+    }
+
+    #[SubscribedService(nullable: true)]
+    public MyDependency $myTentativeDependency {
+        get => $this->container->has(__METHOD__) ? $this->container->get(__METHOD__) : throw new \LogicException('Dependency not found');
+    }
+
+    #[SubscribedService]
+    public MyDependency $myCachedDependency {
+        get => $this->myCachedDependency ??= $this->container->get(__METHOD__);
+    }
+
+    #[SubscribedService(key: 'my_key')]
+    public MyDependency $myKeyedDependency {
+        get => $this->container->get('my_key');
+    }
+}
+
+final class MyDependency
+{
+}

--- a/src/Symfony/Contracts/Tests/Service/Fixtures/NonHookedPropertyService.php
+++ b/src/Symfony/Contracts/Tests/Service/Fixtures/NonHookedPropertyService.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Tests\Service\Fixtures;
+
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceMethodsSubscriberTrait;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+final class NonHookedPropertyService implements ServiceSubscriberInterface
+{
+    use ServiceMethodsSubscriberTrait;
+
+    #[SubscribedService]
+    public \stdClass $myDependency;
+}

--- a/src/Symfony/Contracts/Tests/Service/Fixtures/WriteOnlyPropertyService.php
+++ b/src/Symfony/Contracts/Tests/Service/Fixtures/WriteOnlyPropertyService.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Tests\Service\Fixtures;
+
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceMethodsSubscriberTrait;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+final class WriteOnlyPropertyService implements ServiceSubscriberInterface
+{
+    use ServiceMethodsSubscriberTrait;
+
+    private mixed $myObject;
+
+    #[SubscribedService]
+    public \stdClass $myDependency {
+        set => $this->myObject = $value;
+    }
+}

--- a/src/Symfony/Contracts/Tests/Service/ServiceMethodsSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceMethodsSubscriberTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Contracts\Tests\Service;
 
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -18,6 +19,10 @@ use Symfony\Contracts\Service\Attribute\SubscribedService;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 use Symfony\Contracts\Service\ServiceMethodsSubscriberTrait;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Contracts\Tests\Service\Fixtures\HookedPropertyService;
+use Symfony\Contracts\Tests\Service\Fixtures\MyDependency;
+use Symfony\Contracts\Tests\Service\Fixtures\NonHookedPropertyService;
+use Symfony\Contracts\Tests\Service\Fixtures\WriteOnlyPropertyService;
 
 class ServiceMethodsSubscriberTraitTest extends TestCase
 {
@@ -31,6 +36,42 @@ class ServiceMethodsSubscriberTraitTest extends TestCase
         ];
 
         $this->assertEquals($expected, ChildTestService::getSubscribedServices());
+    }
+
+    #[RequiresPhp('>= 8.4')]
+    public function testHookedProperties()
+    {
+        $this->assertSame([
+            HookedPropertyService::class.'::$myDependency::get' => MyDependency::class,
+            HookedPropertyService::class.'::$myNullableDependency::get' => '?'.MyDependency::class,
+            HookedPropertyService::class.'::$myTentativeDependency::get' => '?'.MyDependency::class,
+            HookedPropertyService::class.'::$myCachedDependency::get' => MyDependency::class,
+            'my_key' => MyDependency::class,
+        ], HookedPropertyService::getSubscribedServices());
+
+        $container = new class([HookedPropertyService::class.'::$myDependency::get' => static fn () => new MyDependency()]) implements ContainerInterface {
+            use ServiceLocatorTrait;
+        };
+
+        $service = new HookedPropertyService();
+        $service->setContainer($container);
+
+        $this->assertInstanceOf(MyDependency::class, $service->myDependency);
+    }
+
+    public function testPropertyHookRequired()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot use "Symfony\Contracts\Service\Attribute\SubscribedService" on property "Symfony\Contracts\Tests\Service\Fixtures\NonHookedPropertyService::$myDependency" (can only be used on properties with a get hook).');
+        NonHookedPropertyService::getSubscribedServices();
+    }
+
+    #[RequiresPhp('>= 8.4')]
+    public function testPropertyWithGetHookRequired()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot use "Symfony\Contracts\Service\Attribute\SubscribedService" on property "Symfony\Contracts\Tests\Service\Fixtures\WriteOnlyPropertyService::$myDependency" (can only be used on properties with a get hook).');
+        WriteOnlyPropertyService::getSubscribedServices();
     }
 
     public function testSetContainerIsCalledOnParent()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR allows to use `ServiceMethodsSubscriberTrait` in combination with virtual/hooked properties.

#### Before

```php
final class MyService implements ServiceSubscriberInterface
{
    use ServiceMethodsSubscriberTrait;

    #[SubscribedService]
    public function getMyDependency(): MyDependency
    {
        return $this->container->get(__METHOD__);
    }
}
```

#### After

```php
final class MyService implements ServiceSubscriberInterface
{
    use ServiceMethodsSubscriberTrait;

    #[SubscribedService]
    public MyDependency $myDependency {
        get => $this->container->get(__METHOD__);
    }
}
```