### PR TITLE
[Cache] Revert "Fix DSN auth not passed to clusters in RedisTrait"

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -175,7 +175,6 @@ trait RedisTrait
         }
 
         $params += $query + $options + self::$defaultConnectionOptions;
-        $params['auth'] ??= $auth;
 
         $booleanStreamOptions = [
             'allow_self_signed',
@@ -393,12 +392,12 @@ trait RedisTrait
             if ($params['dbindex']) {
                 $params['parameters']['database'] = $params['dbindex'];
             }
-            if (\is_array($params['auth'])) {
+            if (\is_array($auth)) {
                 // ACL
-                $params['parameters']['username'] = $params['auth'][0];
-                $params['parameters']['password'] = $params['auth'][1];
-            } elseif (null !== $params['auth']) {
-                $params['parameters']['password'] = $params['auth'];
+                $params['parameters']['username'] = $auth[0];
+                $params['parameters']['password'] = $auth[1];
+            } elseif (null !== $auth) {
+                $params['parameters']['password'] = $auth;
             }
 
             if (isset($params['ssl'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63261
| License       | MIT

This reverts #62852 (preserving the CS improvements) /cc @ckrack @Vilx2
See #63261 for why.

The `auth` query parameter should be used instead.