### PR TITLE
[DependencyInjection] Fix stale binding lookup in `ResolveBindingsPass` error message

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -222,7 +222,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
                     continue;
                 }
 
-                if (isset($bindingNames[$name]) || isset($bindingNames[$parsedName]) || isset($bindingNames[$parameter->name])) {
+                if (null !== $binding = $bindingNames[$name] ?? $bindingNames[$parsedName] ?? $bindingNames[$parameter->name] ?? null) {
                     $bindingKey = array_search($binding, $bindings, true);
                     $argumentType = substr($bindingKey, 0, strpos($bindingKey, ' '));
                     $this->errorMessages[] = \sprintf('Did you forget to add the type "%s" to argument "$%s" of method "%s::%s()"?', $argumentType, $parameter->name, $reflectionMethod->class, $reflectionMethod->name);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedEnumArgumentDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedIterableArgumentDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\UntypedWithTarget;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget;
 use Symfony\Component\DependencyInjection\TypedReference;
 
@@ -230,6 +231,76 @@ class ResolveBindingsPassTest extends TestCase
         $definition->setBindings($bindings);
         $pass = new ResolveBindingsPass();
         $pass->process($container);
+    }
+
+    /**
+     * @dataProvider provideEmptyBindingTypehintWithMultipleBindingsCases
+     */
+    public function testEmptyBindingTypehintWithMultipleBindings(string $expectedType, string $expectedArgument, string $class, array $bindings)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Did you forget to add the type "%s" to argument "$%s"', $expectedType, $expectedArgument));
+
+        $container = new ContainerBuilder();
+        $definition = $container->register($class, $class);
+        $definition->setBindings($bindings);
+
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+    }
+
+    public static function provideEmptyBindingTypehintWithMultipleBindingsCases(): iterable
+    {
+        yield 'multiple bindings with matching first' => [
+            'string',
+            'apiKey',
+            NamedArgumentsDummy::class,
+            [
+                'string $apiKey' => new BoundArgument('foo'),
+                'int $hostName' => new BoundArgument(80),
+            ],
+        ];
+
+        yield 'multiple bindings with matching last' => [
+            'string',
+            'apiKey',
+            NamedArgumentsDummy::class,
+            [
+                'int $hostName' => new BoundArgument(80),
+                'string $apiKey' => new BoundArgument('foo'),
+            ],
+        ];
+
+        yield 'three bindings with matching in the middle' => [
+            'string',
+            'apiKey',
+            NamedArgumentsDummy::class,
+            [
+                'bool $debug' => new BoundArgument(true),
+                'string $apiKey' => new BoundArgument('foo'),
+                'int $hostName' => new BoundArgument(80),
+            ],
+        ];
+
+        yield 'class type binding' => [
+            'Psr\Log\LoggerInterface',
+            'apiKey',
+            NamedArgumentsDummy::class,
+            [
+                'int $hostName' => new BoundArgument(80),
+                'Psr\Log\LoggerInterface $apiKey' => new BoundArgument(new Reference('logger')),
+            ],
+        ];
+
+        yield 'binding matching parameter name with #[Target] attribute' => [
+            'string',
+            'key',
+            UntypedWithTarget::class,
+            [
+                'int $other' => new BoundArgument(80),
+                'string $key' => new BoundArgument('secret'),
+            ],
+        ];
     }
 
     public function testIterableBindingTypehint()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/UntypedWithTarget.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/UntypedWithTarget.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Target;
+
+class UntypedWithTarget
+{
+    public function __construct(
+        #[Target('apiKey')]
+        $key
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fix incorrect error message in `ResolveBindingsPass` when multiple bindings are defined.

The pass was using a stale `$binding` value from a previous loop iteration, causing `array_search()` to resolve the wrong binding key and suggest an incorrect type (e.g. `int` instead of `string` for `$apiKey`).


```
Did you forget to add the type "int" to argument "$apiKey"?
```
