### PR TITLE
[Workflow] Fix swapped workflow/transition names in `WorkflowValidator`

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/Validator/WorkflowValidatorTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Validator/WorkflowValidatorTest.php
@@ -94,7 +94,7 @@ class WorkflowValidatorTest extends TestCase
         $definition = new Definition($places, $transitions);
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectExceptionMessage('The marking store of workflow "t1" cannot store many places. But the transition "foo" has an arc from the transition to "a" with a weight equals to 2.');
+        $this->expectExceptionMessage('The marking store of workflow "foo" cannot store many places. But the transition "t1" has an arc from "a" to the transition with a weight equals to 2.');
 
         (new WorkflowValidator(true))->validate($definition, 'foo');
     }
@@ -108,7 +108,7 @@ class WorkflowValidatorTest extends TestCase
         $definition = new Definition($places, $transitions);
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectExceptionMessage('The marking store of workflow "t1" cannot store many places. But the transition "foo" has an arc from "b" to the transition with a weight equals to 2.');
+        $this->expectExceptionMessage('The marking store of workflow "foo" cannot store many places. But the transition "t1" has an arc from the transition to "b" with a weight equals to 2.');
 
         (new WorkflowValidator(true))->validate($definition, 'foo');
     }

--- a/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
@@ -50,12 +50,12 @@ class WorkflowValidator implements DefinitionValidatorInterface
 
             foreach ($transition->getFroms(true) as $arc) {
                 if (1 < $arc->weight) {
-                    throw new InvalidDefinitionException(\sprintf('The marking store of workflow "%s" cannot store many places. But the transition "%s" has an arc from the transition to "%s" with a weight equals to %d.', $transition->getName(), $name, $arc->place, $arc->weight));
+                    throw new InvalidDefinitionException(\sprintf('The marking store of workflow "%s" cannot store many places. But the transition "%s" has an arc from "%s" to the transition with a weight equals to %d.', $name, $transition->getName(), $arc->place, $arc->weight));
                 }
             }
             foreach ($transition->getTos(true) as $arc) {
                 if (1 < $arc->weight) {
-                    throw new InvalidDefinitionException(\sprintf('The marking store of workflow "%s" cannot store many places. But the transition "%s" has an arc from "%s" to the transition with a weight equals to %d.', $transition->getName(), $name, $arc->place, $arc->weight));
+                    throw new InvalidDefinitionException(\sprintf('The marking store of workflow "%s" cannot store many places. But the transition "%s" has an arc from the transition to "%s" with a weight equals to %d.', $name, $transition->getName(), $arc->place, $arc->weight));
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fix swapped workflow/transition names and inverted arc directions in WorkflowValidator error messages.