### PR TITLE
[Process] Add option for stripping trailing line break from output

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
+8.1
+---
 
+ * Add option to `Process::getOutput()` to strip trailing line break
 
 7.3
 ---

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -610,14 +610,20 @@ class Process implements \IteratorAggregate
     /**
      * Returns the current output of the process (STDOUT).
      *
+     * @param bool $stripTrailingLineBreak Strip trailing line break from output
+     *
      * @throws LogicException in case the output has been disabled
      * @throws LogicException In case the process is not started
      */
-    public function getOutput(): string
+    public function getOutput(bool $stripTrailingLineBreak = false): string
     {
         $this->readPipesForOutput(__FUNCTION__);
 
         if (false === $ret = stream_get_contents($this->stdout, -1, 0)) {
+            return '';
+        }
+
+        if ($stripTrailingLineBreak && !is_string($ret = preg_replace('/\n$/', '', $ret))) {
             return '';
         }
 

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -450,6 +450,10 @@ class ProcessTest extends TestCase
 
         $p->run();
         $this->assertEquals(3, preg_match_all('/foo/', $p->getOutput(), $matches));
+
+        $p = Process::fromShellCommandline('date');
+        $p->run();
+        $this->assertFalse(1 === preg_match('/\n/', $p->getOutput(true)));
     }
 
     public function testFlushOutput()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Handy-dandy option, so this kind simple filtering doesn't need to repeated every time when parsing something

```php
$result = $p->getOutput();

$result = preg_replace('/\n$/', '', $result);
```

After:
```php
$result = $p->getOutput(true);
```

