### PR TITLE
[FrameworkBundle] Express in array shape that strings are allowed for messenger routing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1738,6 +1738,7 @@ class Configuration implements ConfigurationInterface
                                 })
                             ->end()
                             ->prototype('array')
+                                ->acceptAndWrap(['string'], 'senders')
                                 ->performNoDeepMerging()
                                 ->children()
                                     ->arrayNode('senders')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | related to #63254 
| License       | MIT

This PR does fix the linked issue only partially.

`config/references.php` before this PR:

```php
 *         routing?: array<string, array{ // Default: []
 *             senders?: list<scalar|null|Param>,
 *         }>,
```

after:

```php
 *         routing?: array<string, string|array{ // Default: []
 *             senders?: list<scalar|null|Param>,
 *         }>,
```

I don't know how to achieve the desired array shape which should be:

```php
 *         routing?: array<string, string|array<string>|array{ // Default: []
 *             senders?: list<scalar|null|Param>,
 *         }>,
```