### PR TITLE
[Messenger] do not use PHPUnit mock objects without configured expectations

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -857,7 +857,7 @@ class ConnectionTest extends TestCase
             $connected = true;
         });
 
-        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpChannel = $this->createStub(\AMQPChannel::class);
         $amqpChannel->method('getConnection')->willReturn($amqpConnection);
         $amqpChannel->method('isConnected')->willReturnCallback(static function () use (&$connected) {
             return $connected;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT