### PR TITLE
[ObjectMapper] Add a SourceClass Condition Callable

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Merge nested properties when targeting the same class
  * Add a `targetClass` option to `MapCollection`
  * Add a `TransformObjectMapperAwareInterface` to inject the current object mapper instance to transformers
+ * Add a `SourceClass` condition callable to condition map rules based on source class
 
 7.4
 ---

--- a/src/Symfony/Component/ObjectMapper/Condition/SourceClass.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/SourceClass.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Condition;
+
+use Symfony\Component\ObjectMapper\ConditionCallableInterface;
+
+/**
+ * @template T of object
+ *
+ * @implements ConditionCallableInterface<T, object>
+ */
+final class SourceClass implements ConditionCallableInterface
+{
+    /**
+     * @param class-string<T> $className
+     */
+    public function __construct(private readonly string $className)
+    {
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): bool
+    {
+        return $source instanceof $this->className;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ObjectMapper;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\ObjectMapper\Condition\SourceClass;
 use Symfony\Component\ObjectMapper\Condition\TargetClass;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
@@ -151,8 +152,8 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
                 if (
                     $if
-                    && ($fn = $this->getCallable($if, $this->conditionCallableLocator, ConditionCallableInterface::class))
-                    && $fn instanceof TargetClass
+                    && ($fn = $this->getCallable($if, $this->conditionCallableLocator))
+                    && ($fn instanceof TargetClass || $fn instanceof SourceClass)
                     && !$this->call($fn, null, $source, $mappedTarget)
                 ) {
                     continue;

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/A.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Condition\SourceClass;
+
+#[Map(source: B::class)]
+#[Map(source: C::class)]
+class A
+{
+    #[Map(source: 'foo', transform: 'strtolower', if: new SourceClass(B::class))]
+    #[Map(source: 'bar', if: new SourceClass(C::class))]
+    public string $something;
+
+    public string $doesNotExistInSourceB;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/B.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty;
+
+class B
+{
+    public string $foo = 'test';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/C.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty;
+
+class C
+{
+    public string $foo = 'donotmap';
+    public string $bar = 'TEST';
+    public string $doesNotExistInSourceB = 'foo';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -70,6 +70,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Target;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\A as MapTargetToSourceA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\B as MapTargetToSourceB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\A as MultipleSourcePropertyA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\B as MultipleSourcePropertyB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\C as MultipleSourcePropertyC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\A as MultipleTargetPropertyA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as MultipleTargetPropertyB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
@@ -424,6 +427,22 @@ final class ObjectMapperTest extends TestCase
         $this->assertEquals('test', $c->bar);
         $this->assertEquals('donotmap', $c->foo);
         $this->assertEquals('foo', $c->doesNotExistInTargetB);
+    }
+
+    public function testMultipleSourceMapProperty()
+    {
+        $b = new MultipleSourcePropertyB();
+        $c = new MultipleSourcePropertyC();
+        $mapper = new ObjectMapper();
+
+        $a1 = $mapper->map($b, MultipleSourcePropertyA::class);
+        $this->assertInstanceOf(MultipleSourcePropertyA::class, $a1);
+        $this->assertEquals('test', $a1->something);
+
+        $a2 = $mapper->map($c, MultipleSourcePropertyA::class);
+        $this->assertInstanceOf(MultipleSourcePropertyA::class, $a2);
+        $this->assertEquals('TEST', $a2->something);
+        $this->assertEquals('foo', $a2->doesNotExistInSourceB);
     }
 
     public function testDefaultValueStdClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63248
| License       | MIT

Added a new condition callable class `SourceClass` to condition mapiing rules application based on the type of the class of the source object in the object mapper map call.