### PR TITLE
[Asset] Fix JsonManifestVersionStrategy exception on missing manifest in non-strict mode

### DIFF
--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -56,12 +56,20 @@ class JsonManifestVersionStrategyTest extends TestCase
     }
 
     /**
-     * @dataProvider provideMissingStrategies
+     * @dataProvider provideMissingStrictStrategies
      */
     public function testMissingManifestFileThrowsException(JsonManifestVersionStrategy $strategy)
     {
         $this->expectException(RuntimeException::class);
         $strategy->getVersion('main.js');
+    }
+
+    /**
+     * @dataProvider provideMissingStrategies
+     */
+    public function testMissingManifestFileReturnsOriginalPathInNonStrictMode(JsonManifestVersionStrategy $strategy)
+    {
+        $this->assertSame('main.js', $strategy->applyVersion('main.js'));
     }
 
     /**
@@ -97,9 +105,14 @@ class JsonManifestVersionStrategyTest extends TestCase
         yield from static::provideStrategies('non-existent-file.json');
     }
 
-    public static function provideStrategies(string $manifestPath): \Generator
+    public static function provideMissingStrictStrategies(): \Generator
     {
-        $httpClient = new MockHttpClient(function ($method, $url, $options) {
+        yield from static::provideStrategies('non-existent-file.json', true);
+    }
+
+    public static function provideStrategies(string $manifestPath, bool $strictMode = false): \Generator
+    {
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) {
             $filename = __DIR__.'/../Fixtures/'.basename($url);
 
             if (file_exists($filename)) {
@@ -109,9 +122,9 @@ class JsonManifestVersionStrategyTest extends TestCase
             return new MockResponse('{}', ['http_code' => 404]);
         });
 
-        yield [new JsonManifestVersionStrategy('https://cdn.example.com/'.$manifestPath, $httpClient)];
+        yield [new JsonManifestVersionStrategy('https://cdn.example.com/'.$manifestPath, $httpClient, $strictMode)];
 
-        yield [new JsonManifestVersionStrategy(__DIR__.'/../Fixtures/'.$manifestPath)];
+        yield [new JsonManifestVersionStrategy(__DIR__.'/../Fixtures/'.$manifestPath, null, $strictMode)];
     }
 
     public static function provideStrictStrategies(): \Generator

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -77,17 +77,23 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
                 } catch (DecodingExceptionInterface $e) {
                     throw new RuntimeException(\sprintf('Error parsing JSON from asset manifest URL "%s".', $this->manifestPath), 0, $e);
                 } catch (ClientExceptionInterface $e) {
-                    throw new RuntimeException(\sprintf('Error loading JSON from asset manifest URL "%s".', $this->manifestPath), 0, $e);
+                    if ($this->strictMode) {
+                        throw new RuntimeException(\sprintf('Error loading JSON from asset manifest URL "%s".', $this->manifestPath), 0, $e);
+                    }
+                    $this->manifestData = [];
                 }
             } else {
                 if (!is_file($this->manifestPath)) {
-                    throw new RuntimeException(\sprintf('Asset manifest file "%s" does not exist. Did you forget to build the assets with npm or yarn?', $this->manifestPath));
-                }
-
-                try {
-                    $this->manifestData = json_decode(file_get_contents($this->manifestPath), true, flags: \JSON_THROW_ON_ERROR);
-                } catch (\JsonException $e) {
-                    throw new RuntimeException(\sprintf('Error parsing JSON from asset manifest file "%s": ', $this->manifestPath).$e->getMessage(), previous: $e);
+                    if ($this->strictMode) {
+                        throw new RuntimeException(\sprintf('Asset manifest file "%s" does not exist. Did you forget to build the assets with npm or yarn?', $this->manifestPath));
+                    }
+                    $this->manifestData = [];
+                } else {
+                    try {
+                        $this->manifestData = json_decode(file_get_contents($this->manifestPath), true, flags: \JSON_THROW_ON_ERROR);
+                    } catch (\JsonException $e) {
+                        throw new RuntimeException(\sprintf('Error parsing JSON from asset manifest file "%s": ', $this->manifestPath).$e->getMessage(), previous: $e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a manifest file does not exist (local file or remote URL returning 404), a RuntimeException was thrown regardless of the strictMode setting. In non-strict mode, the strategy should gracefully return null from getManifestPath and fall back to the original path, consistent with how missing keys are handled.

https://claude.ai/code/session_01Qqa1kBRoYKzHbrCPBAzHoB

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
