### PR TITLE
[HttpFoundation] BinaryFileResponse: always return 206 if Range is valid

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -260,7 +260,7 @@ class BinaryFileResponse extends Response
                         if ($start < 0 || $start > $end) {
                             $this->setStatusCode(416);
                             $this->headers->set('Content-Range', \sprintf('bytes */%s', $fileSize));
-                        } elseif ($end - $start < $fileSize - 1) {
+                        } else {
                             $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
                             $this->offset = $start;
 

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -145,6 +145,9 @@ class BinaryFileResponseTest extends ResponseTestCase
     public static function provideRanges()
     {
         return [
+            ['bytes=0-', 0, 35, 'bytes 0-34/35'],
+            ['bytes=0-34', 0, 35, 'bytes 0-34/35'],
+            ['bytes=-35', 0, 35, 'bytes 0-34/35'],
             ['bytes=1-4', 1, 4, 'bytes 1-4/35'],
             ['bytes=-5', 30, 5, 'bytes 30-34/35'],
             ['bytes=30-', 30, 5, 'bytes 30-34/35'],
@@ -199,9 +202,6 @@ class BinaryFileResponseTest extends ResponseTestCase
     public static function provideFullFileRanges()
     {
         return [
-            ['bytes=0-'],
-            ['bytes=0-34'],
-            ['bytes=-35'],
             // Syntactical invalid range-request should also return the full resource
             ['bytes=20-10'],
             ['bytes=50-40'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59159
| License       | MIT

Partial request responses:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests#partial_request_responses
- A successful range request elicits a 206 Partial Content status from the server.
- If range requests are not supported, an 200 OK status is sent back and the entire response body is transmitted.
