### PR TITLE
[Lock] Update UnserializableKeyException message

### DIFF
--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -99,7 +99,7 @@ final class Key implements \Stringable
     public function __serialize(): array
     {
         if (!$this->serializable) {
-            throw new UnserializableKeyException('The key cannot be serialized.');
+            throw new UnserializableKeyException('The current lock store doesn\'t support serialization of Key objects.');
         }
 
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When trying to implement DeduplicateStamp with Symfony Messenger, I had to require Symfony Lock component inside my project. Once it was done, I got the following error message: `The key cannot be serialized.`. For a time I misunderstood the message and thought that the key string I was providing had special characters or something. Then I saw a bunch of issues that led me to the Lock component documentation, pointing out that the default flock store wasn't supporting serialization.

Using another compatible store fixed my issue, but I thought that maybe a more complete message giving more clues about what's happening could help figuring out the solution faster. I also noticed that only the incompatible stores were calling `Key::markUnserializable`, so a message pointing directly to the store issue wouldn't mislead in other cases.

This PR proposes `The Key object cannot be serialized with the current Lock store.` as a new message.