### PR TITLE
[Cache] Fix DSN auth not passed to Redis/RedisCluster/Relay in RedisTrait

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -192,7 +192,9 @@ trait RedisTrait
             }
         }
 
-        if (isset($params['redis_sentinel']) && !class_exists(\Predis\Client::class) && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
+        if (!isset($params['redis_sentinel'])) {
+            $params['auth'] ??= $auth;
+        } elseif (!class_exists(\Predis\Client::class) && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
             throw new CacheException('Redis Sentinel support requires one of: "predis/predis", "ext-redis >= 5.2", "ext-relay".');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62765 #63261
| License       | MIT


Populate $params["auth"] from DSN-parsed credentials for classes that
receive auth via their constructor or connect call (Redis, RedisCluster,
Relay), while explicitly excluding Sentinel mode where auth is applied
post-connect to the resolved master node (also using `Redis` or `Relay` classes).

This re-applies the fix from #62852 which was reverted in #63306 due to
a regression for Redis Sentinel users (#63261). The original fix
unconditionally set $params["auth"] from DSN credentials, which caused
them to be incorrectly passed to Sentinel servers that do not require
authentication.

As documented at https://symfony.com/doc/current/components/cache/adapters/redis_adapter.html#configure-the-connection,
the DSN supports password authentication (e.g. redis://user:password@host),
which should work without requiring the undocumented auth query parameter.
