### PR TITLE
[TypeInfo] Fix `ArrayShapeType::getExtraValueType()` return value

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Type/ArrayShapeTypeTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Type/ArrayShapeTypeTest.php
@@ -87,6 +87,21 @@ class ArrayShapeTypeTest extends TestCase
         $this->assertEquals(Type::bool(), $type->getCollectionValueType());
     }
 
+    public function testGetExtraKeyAndValueTypesReturnCorrectTypes()
+    {
+        $extraKeyType = Type::string();
+        $extraValueType = Type::int();
+
+        $type = new ArrayShapeType(
+            shape: ['foo' => ['type' => Type::bool(), 'optional' => false]],
+            extraKeyType: $extraKeyType,
+            extraValueType: $extraValueType,
+        );
+
+        $this->assertSame($extraKeyType, $type->getExtraKeyType());
+        $this->assertSame($extraValueType, $type->getExtraValueType());
+    }
+
     public function testAccepts()
     {
         $type = new ArrayShapeType([

--- a/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ArrayShapeType.php
@@ -90,7 +90,7 @@ final class ArrayShapeType extends CollectionType
 
     public function getExtraValueType(): ?Type
     {
-        return $this->extraKeyType;
+        return $this->extraValueType;
     }
 
     public function accepts(mixed $value): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ArrayShapeType::getExtraValueType()` incorrectly returns `$this->extraKeyType` 
instead of `$this->extraValueType`.