### PR TITLE
[TypeInfo] Fix nested union null type detection in `TypeFactoryTrait::union()`

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeFactoryTest.php
@@ -179,6 +179,24 @@ class TypeFactoryTest extends TestCase
         $this->assertEquals(new UnionType(new BuiltinType(TypeIdentifier::INT), new BuiltinType(TypeIdentifier::STRING)), Type::union(Type::int(), Type::union(Type::int(), Type::string())));
     }
 
+    public function testUnionWithNestedNullTypeIsProperlyNullable()
+    {
+        $nestedUnion = Type::union(Type::int(), Type::string(), Type::null());
+        $result = Type::union($nestedUnion, Type::float());
+
+        $this->assertInstanceOf(NullableType::class, $result);
+
+        $wrappedType = $result->getWrappedType();
+        $this->assertInstanceOf(UnionType::class, $wrappedType);
+
+        $types = $wrappedType->getTypes();
+        $this->assertCount(3, $types);
+
+        $typeStrings = array_map(static fn ($t) => (string) $t, $types);
+        sort($typeStrings);
+        $this->assertSame(['float', 'int', 'string'], $typeStrings);
+    }
+
     public function testCreateIntersection()
     {
         $this->assertEquals(new IntersectionType(new ObjectType(\DateTime::class), new ObjectType(self::class)), Type::intersection(Type::object(\DateTime::class), Type::object(self::class)));

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -304,7 +304,7 @@ trait TypeFactoryTrait
 
             if ($type instanceof UnionType) {
                 foreach ($type->getTypes() as $unionType) {
-                    if ($isNullable($type)) {
+                    if ($isNullable($unionType)) {
                         $nullableUnion = true;
 
                         continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When flattening nested unions, the loop checks `$isNullable($type)` 
but should check `$isNullable($unionType)`

This causes null types in nested unions to not be extracted properly