### PR TITLE
[FrameworkBundle] Fix JsonStreamer forward compatibility

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2238,9 +2238,15 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('.json_streamer.cache_warmer.lazy_ghost');
         }
 
-        // forward compatibility with "symfony/json-streamer" 8.1+
+        // forward compatibility with "symfony/json-streamer" 8.0+
         if (!method_exists(PropertyMetadata::class, 'getNativeToStreamValueTransformer')) {
-            $container->getDefinition('json_streamer.stream_reader')->replaceArgument(4, []);
+            $reader = $container->getDefinition('json_streamer.stream_reader');
+
+            $args = $reader->getArguments();
+            unset($args[4]);
+
+            $reader->setArguments($args);
+            $container->removeDefinition('.json_streamer.cache_warmer.lazy_ghost');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The forward-compat block for JsonStreamer 8.0+ was using `replaceArgument(4, [])` which fails when argument 4 doesn't exist in the service definition.

Instead, remove the argument entirely since `$lazyGhostsDir` was dropped in 8.0, and `$defaultOptions` (added in 8.1) defaults to `[]`.
