### PR TITLE
[JsonStreamer] Fix test

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -181,7 +181,7 @@ class JsonStreamReaderTest extends TestCase
 
     public function testReadUnion()
     {
-        $reader = JsonStreamReader::create(streamReadersDir: $this->streamReadersDir, lazyGhostsDir: $this->lazyGhostsDir);
+        $reader = JsonStreamReader::create([], $this->streamReadersDir);
 
         $this->assertRead($reader, function (mixed $read) {
             $this->assertInstanceOf(DummyWithNameAttributes::class, $read);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Fix test that is using the unexisting `lazyGhostsDir` named parameter.
