### PR TITLE
[PropertyInfo] Prioritize property type over is/has/can accessors

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -138,7 +138,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return $fromMutator;
         }
 
-        if ($fromAccessor = $this->extractFromAccessor($class, $property)) {
+        $allowedPrefixes = array_diff($this->accessorPrefixes, ['is', 'can', 'has']);
+        if ($fromAccessor = $this->extractFromAccessor($class, $property, $allowedPrefixes)) {
             return $fromAccessor;
         }
 
@@ -151,6 +152,11 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         if ($fromPropertyDeclaration = $this->extractFromPropertyDeclaration($class, $property)) {
             return $fromPropertyDeclaration;
+        }
+
+        $allowedPrefixes = array_diff($this->accessorPrefixes, $allowedPrefixes);
+        if ($fromAccessor = $this->extractFromAccessor($class, $property, $allowedPrefixes)) {
+            return $fromAccessor;
         }
 
         return null;
@@ -460,10 +466,14 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      *
      * @return Type[]|null
      */
-    private function extractFromAccessor(string $class, string $property): ?array
+    private function extractFromAccessor(string $class, string $property, array $allowedPrefixes): ?array
     {
         [$reflectionMethod, $prefix] = $this->getAccessorMethod($class, $property);
         if (null === $reflectionMethod) {
+            return null;
+        }
+
+        if (!\in_array($prefix, $allowedPrefixes, true)) {
             return null;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AsymmetricVisibility;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended;
@@ -836,5 +837,15 @@ class ReflectionExtractorTest extends TestCase
         $this->assertTrue($this->extractor->isReadable(VoidNeverReturnTypeDummy::class, 'normalProperty'));
         $this->assertNull($this->extractor->getReadInfo(VoidNeverReturnTypeDummy::class, 'voidProperty'));
         $this->assertNull($this->extractor->getReadInfo(VoidNeverReturnTypeDummy::class, 'neverProperty'));
+    }
+
+    public function testHasserDoesNotOverridePropertyType()
+    {
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_STRING, true)], $this->extractor->getTypes(DummyWithHasser::class, 'url'));
+    }
+
+    public function testIsserUsedForBoolPropertyWithoutOtherTypeSource()
+    {
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_BOOL)], $this->extractor->getTypes(DummyWithHasser::class, 'enabled'));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithHasser.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithHasser.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithHasser
+{
+    private $enabled;
+
+    public function __construct(
+        public readonly ?string $url,
+        private bool $active,
+    ) {
+    }
+
+    public function hasUrl(): bool
+    {
+        return '' !== ($this->url ?? '');
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57719 
| License       | MIT

Instead of #59430, try an approach that should be OK as a bugfix:

In the getType() method, only get-prefixed accessors are trusted immediately for type extraction. The is/has/can accessors are deferred to after constructor and property declaration checks, serving as a fallback when no more reliable type source exists.

This minimizes any BC breaks potential:

- Classes with a get accessor are unaffected
- Classes with is/has/can where the property is genuinely boolean and has no other type source still work (the accessor is used as fallback)
- Classes where a hasser conflicts with a typed property/constructor now correctly use the declared type (that's the fix).