### PR TITLE
[Messenger][AMQP] Allow disabling default queue binding via queues option

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Allow setting `queues` to `false` to skip binding the default `messages` queue
+
 7.3
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -1070,6 +1070,42 @@ class ConnectionTest extends TestCase
 
         $connection->publish('body');
     }
+
+    public function testDefaultQueueBindingCanBeDisabledViaQueuesOption()
+    {
+        $this->assertEquals(
+            new Connection(
+                connectionOptions: [
+                    'host' => 'localhost',
+                    'port' => 5672,
+                    'vhost' => '/',
+                ],
+                exchangeOptions: [
+                    'name' => self::DEFAULT_EXCHANGE_NAME,
+                ],
+                queuesOptions: []
+            ),
+            Connection::fromDsn('amqp://', ['queues' => false])
+        );
+    }
+
+    public function testDefaultQueueBindingCanBeDisabledViaDsnQueuesOption()
+    {
+        $this->assertEquals(
+            new Connection(
+                connectionOptions: [
+                    'host' => 'localhost',
+                    'port' => 5672,
+                    'vhost' => '/',
+                ],
+                exchangeOptions: [
+                    'name' => self::DEFAULT_EXCHANGE_NAME,
+                ],
+                queuesOptions: []
+            ),
+            Connection::fromDsn('amqp://localhost?queues=false')
+        );
+    }
 }
 
 class TestAmqpFactory extends AmqpFactory

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -136,6 +136,7 @@ class Connection
      *     * binding_arguments: Arguments to be used while binding the queue.
      *     * flags: Queue flags (Default: AMQP_DURABLE)
      *     * arguments: Extra arguments
+     *   * queues: Set to false (or "queues=false" in the DSN query) to skip binding the default "messages" queue when no queues are defined
      *   * exchange:
      *     * name: Name of the exchange. An empty string (name: '') can be used to use the default exchange
      *     * type: Type of exchange (Default: fanout)
@@ -203,12 +204,13 @@ class Connection
             $amqpOptions['password'] = rawurldecode($params['pass']);
         }
 
-        if (!isset($amqpOptions['queues'])) {
-            $amqpOptions['queues'][$exchangeName] = [];
+        if (!\is_array($queuesOptions = $amqpOptions['queues'] ?? true)) {
+            $queuesOptions = filter_var($queuesOptions, \FILTER_VALIDATE_BOOL) ? [$exchangeName => []] : [];
+        } else {
+            $queuesOptions = $amqpOptions['queues'];
         }
 
         $exchangeOptions = $amqpOptions['exchange'];
-        $queuesOptions = $amqpOptions['queues'];
         unset($amqpOptions['queues'], $amqpOptions['exchange']);
         if (isset($amqpOptions['auto_setup'])) {
             $amqpOptions['auto_setup'] = filter_var($amqpOptions['auto_setup'], \FILTER_VALIDATE_BOOL);


### PR DESCRIPTION
[Messenger] Add option disable_default_bind to prevent the creation of or binding to the default messages queue when not defining any queue for an exchange

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63345 
| License       | MIT

When not configuring any queues for an exchange and executing the `messenger:setup` command, a default queue `messages` was created and bound to those exchanges.
This PR introduces the possibility to set the queues configuration parameter to `[]` or `false` to prevent the creation of the `messages` queue.

Example configuration (`SENDING_EXCHANGE` uses the new configuration option)
```
framework:
    messenger:
        transports:
            exchange_out_1:
                dsn: '%messenger_transport_dsn%'
                options:
                    exchange:
                        name: 'SENDING_EXCHANGE_1'
                        type: fanout
                    auto_setup: false
                    queues: false
            exchange_out_2:
                dsn: '%messenger_transport_dsn%'
                options:
                    exchange:
                        name: 'SENDING_EXCHANGE_1'
                        type: fanout
                    auto_setup: false
                    queues: []
            incoming_events:
                dsn: '%messenger_transport_dsn%'
                options:
                    exchange:
                        name: 'RECEIVING_EXCHANGE'
                        type: direct
                    queues:
                        incoming_events_queue: ~
                    auto_setup: true
```

TODO:
- [x] verify / adapt documentation => https://github.com/symfony/symfony-docs/pull/21940