### PR TITLE
[ObjectMapper] Fix Map attribute PHPDoc for $if param

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Attribute/Map.php
+++ b/src/Symfony/Component/ObjectMapper/Attribute/Map.php
@@ -22,7 +22,7 @@ class Map
     /**
      * @param string|class-string|null                                                                                 $source    The property or the class to map from
      * @param string|class-string|null                                                                                 $target    The property or the class to map to
-     * @param string|bool|callable(mixed, object): bool|null                                                           $if        A boolean, a service id or a callable that instructs whether to map
+     * @param string|bool|callable(mixed, object, ?object): bool|null                                                  $if        A boolean, a service id or a callable that instructs whether to map
      * @param (string|callable(mixed, object, ?object): mixed)|(string|callable(mixed, object, ?object): mixed)[]|null $transform A service id or a callable that transforms the value during mapping
      */
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63273
| License       | MIT

The callable signature for the `$if` parameter in the `Map` attribute PHPDoc was `callable(mixed, object): bool`, but the actual `ConditionCallableInterface::__invoke` signature takes 3 parameters: `(mixed, object, ?object)`.

This mismatch caused PHPStan to report errors when using built-in conditions like `TargetClass`.

This PR fixes the callable signature to `callable(mixed, object, ?object): bool` to match the actual interface.