### PR TITLE
[Validator] Fix AbstractComparison deprecation triggered for array values

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -32,7 +32,7 @@ abstract class AbstractComparison extends Constraint
     #[HasNamedArguments]
     public function __construct(mixed $value = null, ?string $propertyPath = null, ?string $message = null, ?array $groups = null, mixed $payload = null, ?array $options = null)
     {
-        if (\is_array($value)) {
+        if (\is_array($value) && !array_is_list($value)) {
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
 
             $options = array_merge($value, $options ?? []);

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
@@ -20,6 +20,15 @@ use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class NotIdenticalToTest extends TestCase
 {
+    public function testArrayValueDoesNotTriggerDeprecation()
+    {
+        $constraint = new NotIdenticalTo(value: []);
+        self::assertSame([], $constraint->value);
+
+        $constraint = new NotIdenticalTo(value: [1, 2, 3]);
+        self::assertSame([1, 2, 3], $constraint->value);
+    }
+
     public function testAttributes()
     {
         $metadata = new ClassMetadata(NotIdenticalToDummy::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #62358
| License       | MIT

When passing an array as the comparison value using named arguments (e.g. `new NotIdenticalTo(value: [])`), the deprecation for the old options-array constructor style was incorrectly triggered.

The root cause is that `is_array($value)` cannot distinguish between the legacy options array format (`new NotIdenticalTo(['value' => 5, 'message' => '...'])`) and a legitimate array value passed via named arguments (`new NotIdenticalTo(value: [])`).

This PR adds an `array_is_list()` check: list arrays (empty `[]` or sequential `[1,2,3]`) are treated as actual comparison values, while associative arrays are treated as the deprecated options format.