### PR TITLE
[Serializer] Fix TypeError in removeNestedValue with null intermediate values

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -857,6 +857,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     private function removeNestedValue(array $path, array $data): array
     {
         $element = array_shift($path);
+        if ($path && !\is_array($data[$element] ?? null)) {
+            return $data;
+        }
         if (!$path || !$data[$element] = $this->removeNestedValue($path, $data[$element])) {
             unset($data[$element]);
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -205,6 +205,20 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame('notfoo', $test->notfoo);
     }
 
+    public function testRemoveNestedValueHandlesNullIntermediateValues()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+        $r = new \ReflectionMethod($normalizer, 'removeNestedValue');
+
+        // When intermediate value is null, the method should return data unchanged
+        $data = ['entity' => null, 'other' => 'keep'];
+        $this->assertSame($data, $r->invoke($normalizer, ['entity', 'id'], $data));
+
+        // When intermediate value is a scalar, the method should return data unchanged
+        $data = ['entity' => 'scalar', 'other' => 'keep'];
+        $this->assertSame($data, $r->invoke($normalizer, ['entity', 'id'], $data));
+    }
+
     public function testDenormalizeWithNestedAttributesDuplicateKeys()
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63175
| License       | MIT

## Summary

When using `SerializedPath` with nested properties (e.g. `#[SerializedPath('[entity][id]')]`), the private `removeNestedValue()` method could throw a `TypeError` if an intermediate value in the data was `null` or not an array:

```
AbstractObjectNormalizer::removeNestedValue(): Argument #2 ($data) must be of type array, null given
```

This occurs because the recursive call at line `$this->removeNestedValue($path, $data[$element])` passes `$data[$element]` without checking if it's actually an array.

This PR adds a guard clause: if we still have path elements to traverse but the current element is not an array, return the data unchanged instead of recursing into a non-array value.