### PR TITLE
[Console] Fix SymfonyStyle block output with \r\n line endings

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -104,7 +104,7 @@ class SymfonyStyle extends OutputStyle
     public function listing(array $elements)
     {
         $this->autoPrependText();
-        $elements = array_map(fn ($element) => \sprintf(' * %s', $element), $elements);
+        $elements = array_map(static fn ($element) => \sprintf(' * %s', $element), $elements);
 
         $this->writeln($elements);
         $this->newLine();
@@ -475,12 +475,14 @@ class SymfonyStyle extends OutputStyle
                 $message = OutputFormatter::escape($message);
             }
 
+            $message = str_replace("\r\n", "\n", $message);
+
             $lines = array_merge(
                 $lines,
-                explode(\PHP_EOL, $outputWrapper->wrap(
+                explode("\n", $outputWrapper->wrap(
                     $message,
                     $this->lineLength - $prefixLength - $indentLength,
-                    \PHP_EOL
+                    "\n"
                 ))
             );
 

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -96,6 +96,22 @@ class SymfonyStyleTest extends TestCase
         $this->assertStringEqualsFile($outputFilepath, $this->tester->getDisplay(true));
     }
 
+    public function testBlockWithWindowsLineEndings()
+    {
+        $code = static function (InputInterface $input, OutputInterface $output) {
+            $io = new SymfonyStyle($input, $output);
+            $io->block("First line.\r\nSecond line.", 'INFO', 'fg=white;bg=blue', ' ', true);
+        };
+
+        $this->command->setCode($code);
+        $this->tester->execute([], ['interactive' => false, 'decorated' => false]);
+
+        $display = $this->tester->getDisplay(true);
+        $this->assertStringNotContainsString("\r", $display);
+        $this->assertStringContainsString('First line.', $display);
+        $this->assertStringContainsString('Second line.', $display);
+    }
+
     public function testGetErrorStyle()
     {
         $input = $this->createStub(InputInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61524
| License       | MIT

## Summary

On Windows, `SymfonyStyle::block()` (and related methods like `error()`, `success()`, etc.) produced broken output when the message contained `\r\n` newline characters.

**Root cause:** In `createBlock()`, the `OutputWrapper::wrap()` regex matches `\r` as part of the content (since `.` matches `\r` but not `\n` in PCRE), then appends `\PHP_EOL` (`\r\n` on Windows) as the line break. This results in `\r\r\n` sequences — a double carriage return that causes the cursor to jump back to the beginning of the line, overwriting previous output.

**Fix:** Normalize `\r\n` to `\n` in messages before wrapping, and use `"\n"` consistently as the internal line break character for wrapping and splitting. The actual terminal line ending is handled by `writeln()`.