### PR TITLE
 PHP CS Fixer: enable `void_return`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -47,7 +47,9 @@ return (new PhpCsFixer\Config())
         ],
         'declare_strict_types' => false, // part of PHP?x?Migration:risky, awaits https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9384
         'php_unit_attributes' => true,
-        'void_return' => false, // part of PHP?x?Migration:risky, usage to be concluded
+        'void_return' => [
+            'fix_lambda' => false,
+        ],
     ])
     ->setRuleCustomisationPolicy(new class implements PhpCsFixer\Config\RuleCustomisationPolicyInterface {
         public function getPolicyVersionForCache(): string
@@ -81,6 +83,24 @@ return (new PhpCsFixer\Config())
                     }
 
                     // Keep the default configuration for other files
+                    return true;
+                },
+                'void_return' => static function (SplFileInfo $file) {
+                    // temporary hack due to bug: https://github.com/symfony/symfony/issues/62734
+                    if (!$file instanceof Symfony\Component\Finder\SplFileInfo) {
+                        return false;
+                    }
+
+                    $relativePathname = $file->getRelativePathname();
+
+                    if (
+                     str_contains($relativePathname, '/Tests/') // don't touch test files, as massive change with little benefit - as outside of public contract anyway
+                        || str_contains($relativePathname, '/Test/') // public namespace not following the rule, do not mistake it with `/Tests/`
+                        || str_starts_with($relativePathname, 'Symfony/Contracts/') // rule not yet followed in current MAJOR
+                    ) {
+                        return false;
+                    }
+
                     return true;
                 },
             ];

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -65,7 +65,7 @@ class DeprecationErrorHandler
      *
      * @param int|string|false $mode The reporting mode, defaults to not allowing any deprecations
      */
-    public static function register($mode = 0)
+    public static function register($mode = 0): void
     {
         if (self::$isRegistered) {
             return;
@@ -93,7 +93,7 @@ class DeprecationErrorHandler
         }
     }
 
-    public static function collectDeprecations($outputFile)
+    public static function collectDeprecations($outputFile): void
     {
         $deprecations = [];
         $previousErrorHandler = set_error_handler(static function ($type, $msg, $file, $line, $context = []) use (&$deprecations, &$previousErrorHandler) {
@@ -194,7 +194,7 @@ class DeprecationErrorHandler
     /**
      * @internal
      */
-    public function shutdown()
+    public function shutdown(): void
     {
         $configuration = $this->getConfiguration();
 
@@ -242,7 +242,7 @@ class DeprecationErrorHandler
         });
     }
 
-    private function resetDeprecationGroups()
+    private function resetDeprecationGroups(): void
     {
         $this->deprecationGroups = [
             'unsilenced' => new DeprecationGroup(),

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationGroup.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationGroup.php
@@ -35,7 +35,7 @@ final class DeprecationGroup
         $this->addNotice();
     }
 
-    public function addNotice()
+    public function addNotice(): void
     {
         ++$this->count;
     }

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationNotice.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationNotice.php
@@ -23,7 +23,7 @@ final class DeprecationNotice
      */
     private $countsByCaller = [];
 
-    public function addObjectOccurrence($class, $method)
+    public function addObjectOccurrence($class, $method): void
     {
         if (!isset($this->countsByCaller["$class::$method"])) {
             $this->countsByCaller["$class::$method"] = 0;
@@ -32,7 +32,7 @@ final class DeprecationNotice
         ++$this->count;
     }
 
-    public function addProceduralOccurrence()
+    public function addProceduralOccurrence(): void
     {
         ++$this->count;
     }

--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -17,7 +17,7 @@ define('LINE_WIDTH', 75);
 
 define('LINE', str_repeat('-', LINE_WIDTH)."\n");
 
-function bailout(string $message)
+function bailout(string $message): void
 {
     echo wordwrap($message, LINE_WIDTH)." Aborting.\n";
 

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -145,7 +145,7 @@ function isTranslationCompleted(array $translationStatus): bool
     return $translationStatus['total'] === $translationStatus['translated'] && 0 === count($translationStatus['mismatches']);
 }
 
-function printTranslationStatus($originalFilePath, $translationStatus, $verboseOutput, $includeCompletedLanguages)
+function printTranslationStatus($originalFilePath, $translationStatus, $verboseOutput, $includeCompletedLanguages): void
 {
     printTitle($originalFilePath);
     printTable($translationStatus, $verboseOutput, $includeCompletedLanguages);
@@ -196,13 +196,13 @@ function findTransUnitMismatches(array $baseTranslationKeys, array $translatedKe
     return $mismatches;
 }
 
-function printTitle($title)
+function printTitle($title): void
 {
     echo $title.\PHP_EOL;
     echo str_repeat('=', strlen($title)).\PHP_EOL.\PHP_EOL;
 }
 
-function printTable($translations, $verboseOutput, bool $includeCompletedLanguages)
+function printTable($translations, $verboseOutput, bool $includeCompletedLanguages): void
 {
     if (0 === count($translations)) {
         echo 'No translations found';
@@ -258,17 +258,17 @@ function printTable($translations, $verboseOutput, bool $includeCompletedLanguag
     }
 }
 
-function textColorGreen()
+function textColorGreen(): void
 {
     echo "\033[32m";
 }
 
-function textColorRed()
+function textColorRed(): void
 {
     echo "\033[31m";
 }
 
-function textColorNormal()
+function textColorNormal(): void
 {
     echo "\033[0m";
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix CS <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Apply for public namespace except /Test/ and Contracts.
Ignore Tests and lambdas, based on feedback in #63250 

If agreed, please confirm and let's merge dependency before this PR itself:
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9417

Best to review commit by commit
