### PR TITLE
[Mailer] Fix invalid encoding of custom headers in SES API

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Amazon\Tests\Transport;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Ses\SesClient;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -124,9 +125,45 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $this->assertSame('foobar', $message->getMessageId());
     }
 
+    public function testSendWithNonAsciiCustomHeaders()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            $content = json_decode($options['body'], true);
+
+            $headers = [];
+            foreach ($content['Content']['Simple']['Headers'] as $header) {
+                $headers[$header['Name']] = $header['Value'];
+            }
+
+            // ASCII header should be sent as-is
+            Assert::assertSame('foobar', $headers['X-Ascii-Header']);
+
+            // Non-ASCII header should be base64-encoded per RFC 2047
+            Assert::assertSame('=?UTF-8?B?'.base64_encode('éééééééé').'?=', $headers['X-NonAscii-Header']);
+
+            // Ensure the encoded value only contains printable ASCII characters (char codes 32-126)
+            Assert::assertMatchesRegularExpression('/^[\x20-\x7E]+$/', $headers['X-NonAscii-Header']);
+
+            return new MockResponse('{"MessageId": "foobar"}', ['http_code' => 200]);
+        });
+
+        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), $client));
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $mail->getHeaders()->addTextHeader('X-Ascii-Header', 'foobar');
+        $mail->getHeaders()->addTextHeader('X-NonAscii-Header', 'éééééééé');
+
+        $transport->send($mail);
+    }
+
     public function testSendThrowsForErrorResponse()
     {
-        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
             $json = json_encode([
                 'message' => 'i\'m a teapot',
                 'type' => 'sender',

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -100,7 +100,7 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         }
         if ($header = $email->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
             if (preg_match('/^(contactListName=)*(?<ContactListName>[^;]+)(;\s?topicName=(?<TopicName>.+))?$/ix', $header->getBodyAsString(), $listManagementOptions)) {
-                $request['ListManagementOptions'] = array_filter($listManagementOptions, fn ($e) => \in_array($e, ['ContactListName', 'TopicName'], true), \ARRAY_FILTER_USE_KEY);
+                $request['ListManagementOptions'] = array_filter($listManagementOptions, static fn ($e) => \in_array($e, ['ContactListName', 'TopicName'], true), \ARRAY_FILTER_USE_KEY);
             }
         }
         if ($email->getReturnPath()) {
@@ -124,7 +124,7 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
     {
         $emailRecipients = array_merge($email->getCc(), $email->getBcc());
 
-        return array_filter($envelope->getRecipients(), fn (Address $address) => !\in_array($address, $emailRecipients, true));
+        return array_filter($envelope->getRecipients(), static fn (Address $address) => !\in_array($address, $emailRecipients, true));
     }
 
     private function getCustomHeaders(Headers $headers): array
@@ -141,9 +141,18 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
                 continue;
             }
 
+            $value = $header->getBodyAsString();
+
+            // AWS SES Simple message headers only accept printable ASCII (char codes 32-126).
+            // getBodyAsString() may produce encoded words with \r\n line folding, so we
+            // re-encode using RFC 2047 base64 encoding when non-printable characters are present.
+            if (preg_match('/[^\x20-\x7E]/', $value)) {
+                $value = '=?UTF-8?B?'.base64_encode($header->getBody()).'?=';
+            }
+
             $headersPrepared[] = [
                 'Name' => $header->getName(),
-                'Value' => $header->getBodyAsString(),
+                'Value' => $value,
             ];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63146
| License       | MIT

When sending emails via `ses+api` with custom headers containing non-ASCII characters (e.g. accented letters), `HeaderInterface::getBodyAsString()` produces encoded words with `\r\n` line folding. However, AWS SES Simple message headers only accept printable ASCII characters (char codes 32-126), causing a `BadRequestException`.

This PR detects non-printable ASCII characters in header values and re-encodes them using RFC 2047 base64 encoding (`=?UTF-8?B?...?=`), which only produces printable ASCII output. This is consistent with the existing `stringifyAddress()` method which already uses the same approach for non-ASCII address names.