### PR TITLE
[Validator] Add ValidatorBuilder::enablePropertyMetadataExistenceCheck()

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -41,6 +41,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Exception\RuntimeException;
+use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\ObjectInitializerInterface;
@@ -2374,5 +2375,47 @@ final class TestConstraintHashesDoNotCollideValidator extends ConstraintValidato
             ->inContext($this->context)
             ->validate($value, null, new GroupSequence(['should_pass']))
             ->validate($value, null, new GroupSequence(['should_fail']));
+    }
+
+    public function testValidatePropertyWithExistenceCheckThrowsOnNonExistentProperty()
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('The property "nonExistent" has not metadata associated and may not exist.');
+
+        $translator = new IdentityTranslator();
+        $translator->setLocale('en');
+
+        $contextFactory = new ExecutionContextFactory($translator);
+        $validatorFactory = new ConstraintValidatorFactory();
+
+        $validator = new RecursiveValidator($contextFactory, $this->metadataFactory, $validatorFactory, [], null, true);
+
+        $entity = new Entity();
+        $validator->validateProperty($entity, 'nonExistent');
+    }
+
+    public function testValidatePropertyValueWithExistenceCheckThrowsOnNonExistentProperty()
+    {
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('The property "nonExistent" does not exist');
+
+        $translator = new IdentityTranslator();
+        $translator->setLocale('en');
+
+        $contextFactory = new ExecutionContextFactory($translator);
+        $validatorFactory = new ConstraintValidatorFactory();
+
+        $validator = new RecursiveValidator($contextFactory, $this->metadataFactory, $validatorFactory, [], null, true);
+
+        $entity = new Entity();
+        $validator->validatePropertyValue($entity, 'nonExistent', 'foo');
+    }
+
+    public function testValidatePropertyWithoutExistenceCheckDoesNotThrowOnNonExistentProperty()
+    {
+        $entity = new Entity();
+        $violations = $this->validator->validateProperty($entity, 'nonExistent');
+
+        $this->assertCount(0, $violations);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -102,6 +102,11 @@ class ValidatorBuilderTest extends TestCase
         $this->assertSame($this->builder, $this->builder->disableTranslation());
     }
 
+    public function testEnablePropertyMetadataExistenceCheck()
+    {
+        $this->assertSame($this->builder, $this->builder->enablePropertyMetadataExistenceCheck());
+    }
+
     public function testGetValidator()
     {
         $this->assertInstanceOf(RecursiveValidator::class, $this->builder->getValidator());

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -60,6 +60,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         private ConstraintValidatorFactoryInterface $validatorFactory,
         private array $objectInitializers = [],
         private ?ContainerInterface $groupProviderLocator = null,
+        private bool $propertyMetadataExistenceCheck = false,
     ) {
         $this->defaultPropertyPath = $context->getPropertyPath();
         $this->defaultGroups = [$context->getGroup() ?: Constraint::DEFAULT_GROUP];
@@ -166,6 +167,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         }
 
         $propertyMetadatas = $classMetadata->getPropertyMetadata($propertyName);
+
+        if ($this->propertyMetadataExistenceCheck && !$propertyMetadatas) {
+            throw new ValidatorException(\sprintf('The property "%s" does not exist in class "%s".', $propertyName, $classMetadata->getClassName()));
+        }
         $groups = $groups ? $this->normalizeGroups($groups) : $this->defaultGroups;
         $cacheKey = $this->generateCacheKey($object);
         $propertyPath = PropertyPath::append($this->defaultPropertyPath, $propertyName);
@@ -207,6 +212,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         }
 
         $propertyMetadatas = $classMetadata->getPropertyMetadata($propertyName);
+
+        if ($this->propertyMetadataExistenceCheck && !$propertyMetadatas) {
+            throw new ValidatorException(\sprintf('The property "%s" does not exist in class "%s".', $propertyName, $classMetadata->getClassName()));
+        }
         $groups = $groups ? $this->normalizeGroups($groups) : $this->defaultGroups;
 
         if (\is_object($objectOrClass)) {

--- a/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
@@ -40,6 +40,7 @@ class RecursiveValidator implements ValidatorInterface
         protected ConstraintValidatorFactoryInterface $validatorFactory,
         protected array $objectInitializers = [],
         protected ?ContainerInterface $groupProviderLocator = null,
+        protected bool $propertyMetadataExistenceCheck = false,
     ) {
     }
 
@@ -51,6 +52,7 @@ class RecursiveValidator implements ValidatorInterface
             $this->validatorFactory,
             $this->objectInitializers,
             $this->groupProviderLocator,
+            $this->propertyMetadataExistenceCheck,
         );
     }
 
@@ -62,6 +64,7 @@ class RecursiveValidator implements ValidatorInterface
             $this->validatorFactory,
             $this->objectInitializers,
             $this->groupProviderLocator,
+            $this->propertyMetadataExistenceCheck,
         );
     }
 

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -52,6 +52,7 @@ class ValidatorBuilder
     private ?CacheItemPoolInterface $mappingCache = null;
     private ?TranslatorInterface $translator = null;
     private string|false|null $translationDomain = null;
+    private bool $propertyMetadataExistenceCheck = false;
 
     /**
      * Adds an object initializer to the validator.
@@ -325,6 +326,22 @@ class ValidatorBuilder
     }
 
     /**
+     * Enables checking that a property has metadata when using
+     * validateProperty() or validatePropertyValue().
+     *
+     * When enabled, a ValidatorException is thrown if no metadata is found for
+     * the given property in the validated class.
+     *
+     * @return $this
+     */
+    public function enablePropertyMetadataExistenceCheck(): static
+    {
+        $this->propertyMetadataExistenceCheck = true;
+
+        return $this;
+    }
+
+    /**
      * @return $this
      */
     public function addLoader(LoaderInterface $loader): static
@@ -396,6 +413,6 @@ class ValidatorBuilder
 
         $contextFactory = new ExecutionContextFactory($translator, $this->translationDomain);
 
-        return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers, $this->groupProviderLocator);
+        return new RecursiveValidator($contextFactory, $metadataFactory, $validatorFactory, $this->initializers, $this->groupProviderLocator, $this->propertyMetadataExistenceCheck);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #62198
| License       | MIT

As suggested by @nicolas-grekas in #62198, this PR adds an opt-in `ValidatorBuilder::enablePropertyMetadataExistenceCheck()` method.

When enabled, `validateProperty()` and `validatePropertyValue()` throw a `ValidatorException` if the given property has no metadata (i.e. no constraints defined), instead of silently returning zero violations. This helps catch typos or renamed properties in tests.

The check is opt-in to avoid BC breaks, since "no metadata" currently means "no constraints" rather than "property is invalid".