### PR TITLE
[Translation] Remove dead entity loader code in XliffUtils

### DIFF
--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -60,18 +60,10 @@ class XliffUtils
     {
         $xliffVersion = static::getVersionNumber($dom);
         $internalErrors = libxml_use_internal_errors(true);
-        if ($shouldEnable = self::shouldEnableEntityLoader()) {
-            $disableEntities = libxml_disable_entity_loader(false);
-        }
-        try {
-            $isValid = @$dom->schemaValidateSource(self::getSchema($xliffVersion));
-            if (!$isValid) {
-                return self::getXmlErrors($internalErrors);
-            }
-        } finally {
-            if ($shouldEnable) {
-                libxml_disable_entity_loader($disableEntities);
-            }
+
+        $isValid = @$dom->schemaValidateSource(self::getSchema($xliffVersion));
+        if (!$isValid) {
+            return self::getXmlErrors($internalErrors);
         }
 
         $dom->normalizeDocument();
@@ -80,31 +72,6 @@ class XliffUtils
         libxml_use_internal_errors($internalErrors);
 
         return [];
-    }
-
-    private static function shouldEnableEntityLoader(): bool
-    {
-        static $dom, $schema;
-        if (null === $dom) {
-            $dom = new \DOMDocument();
-            $dom->loadXML('<?xml version="1.0"?><test/>');
-
-            $tmpfile = tempnam(sys_get_temp_dir(), 'symfony');
-            register_shutdown_function(static function () use ($tmpfile) {
-                @unlink($tmpfile);
-            });
-            $schema = '<?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:include schemaLocation="file:///'.str_replace('\\', '/', $tmpfile).'" />
-</xsd:schema>';
-            file_put_contents($tmpfile, '<?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:element name="test" type="testType" />
-  <xsd:complexType name="testType"/>
-</xsd:schema>');
-        }
-
-        return !@$dom->schemaValidateSource($schema);
     }
 
     public static function getErrorsAsString(array $xmlErrors): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| New feature?  | no <!-- please update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- please update the UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #63253
| License       | MIT

Since PHP 8.2 is the minimum required version for Symfony 7.4, `libxml_disable_entity_loader()` is deprecated and a no-op. The `shouldEnableEntityLoader()` method was testing whether entity loading needed to be toggled, but this test itself generates a `Warning: DOMDocument::schemaValidateSource(): Invalid Schema` on Windows due to `file:///` URIs in the test schema.

Even though the warning is suppressed with `@`, Symfony's ErrorHandler catches silenced errors and logs them, causing noise in logs.

This PR removes:
- The `shouldEnableEntityLoader()` private method (always returns `false` on PHP 8.2+)
- The dead `libxml_disable_entity_loader()` calls in `validateSchema()`

The actual `schemaValidateSource()` call for real XLIFF validation is unchanged.