### PR TITLE
[Validator] Add clock-awareness to comparison and range validators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Validator\Constraints\EmailValidator;
@@ -77,6 +78,7 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->tag('container.excluded')
             ->tag('validator.constraint_validator')
+            ->bind(ClockInterface::class, service('clock')->nullOnInvalid())
 
         ->set('validator.expression', ExpressionValidator::class)
             ->args([service('validator.expression_language')->nullOnInvalid()])

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add clock-awareness to comparison and range validators for testable date comparisons
  * Add the `Xml` constraint for validating XML content
 
 8.0

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -28,8 +30,10 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 abstract class AbstractComparisonValidator extends ConstraintValidator
 {
-    public function __construct(private ?PropertyAccessorInterface $propertyAccessor = null)
-    {
+    public function __construct(
+        private ?PropertyAccessorInterface $propertyAccessor = null,
+        private ?ClockInterface $clock = null,
+    ) {
     }
 
     public function validate(mixed $value, Constraint $constraint): void
@@ -63,7 +67,7 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
         // https://php.net/datetime.formats
         if (\is_string($comparedValue) && $value instanceof \DateTimeInterface) {
             try {
-                $comparedValue = new $value($comparedValue);
+                $comparedValue = $this->clock ? $value::createFromInterface(new DatePoint($comparedValue, null, $this->clock->now())) : new $value($comparedValue);
             } catch (\Exception) {
                 throw new ConstraintDefinitionException(\sprintf('The compared value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $comparedValue, get_debug_type($value), get_debug_type($constraint)));
             }

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -25,8 +27,10 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class RangeValidator extends ConstraintValidator
 {
-    public function __construct(private ?PropertyAccessorInterface $propertyAccessor = null)
-    {
+    public function __construct(
+        private ?PropertyAccessorInterface $propertyAccessor = null,
+        private ?ClockInterface $clock = null,
+    ) {
     }
 
     public function validate(mixed $value, Constraint $constraint): void
@@ -65,7 +69,7 @@ class RangeValidator extends ConstraintValidator
         if ($value instanceof \DateTimeInterface) {
             if (\is_string($min)) {
                 try {
-                    $min = new $value($min);
+                    $min = $this->clock ? $value::createFromInterface(new DatePoint($min, null, $this->clock->now())) : new $value($min);
                 } catch (\Exception) {
                     throw new ConstraintDefinitionException(\sprintf('The min value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $min, get_debug_type($value), get_debug_type($constraint)));
                 }
@@ -73,7 +77,7 @@ class RangeValidator extends ConstraintValidator
 
             if (\is_string($max)) {
                 try {
-                    $max = new $value($max);
+                    $max = $this->clock ? $value::createFromInterface(new DatePoint($max, null, $this->clock->now())) : new $value($max);
                 } catch (\Exception) {
                     throw new ConstraintDefinitionException(\sprintf('The max value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $max, get_debug_type($value), get_debug_type($constraint)));
                 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanValidator;
@@ -82,5 +83,81 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             ['22', '"22"', '333', '"333"', 'string'],
             ['22', '"22"', '22', '"22"', 'string'],
         ];
+    }
+
+    public function testValidRelativeDateWithMockClock()
+    {
+        $clock = new MockClock('2025-01-15 00:00:00 UTC');
+        $this->validator = new GreaterThanValidator(null, $clock);
+        $this->validator->initialize($this->context);
+
+        // Value is 20 days after the frozen "now", compared to "-10 days" (Jan 5)
+        $value = new \DateTimeImmutable('2025-01-20 00:00:00 UTC');
+        $constraint = new GreaterThan('-10 days');
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidRelativeDateWithMockClock()
+    {
+        $clock = new MockClock('2025-01-15 00:00:00 UTC');
+        $this->validator = new GreaterThanValidator(null, $clock);
+        $this->validator->initialize($this->context);
+
+        // Value (Jan 1) is before the frozen "now" (Jan 15) minus 10 days (Jan 5)
+        $value = new \DateTimeImmutable('2025-01-01 00:00:00 UTC');
+        $constraint = new GreaterThan(value: '-10 days', message: 'myMessage');
+
+        $this->validator->validate($value, $constraint);
+
+        $comparedValue = $clock->now()->modify('-10 days');
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', self::formatDateTime($value))
+            ->setParameter('{{ compared_value }}', self::formatDateTime($comparedValue))
+            ->setParameter('{{ compared_value_type }}', \DateTimeImmutable::class)
+            ->setCode(GreaterThan::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    public function testAbsoluteDateWithMockClock()
+    {
+        $clock = new MockClock('2025-01-15 00:00:00 UTC');
+        $this->validator = new GreaterThanValidator(null, $clock);
+
+        // Absolute dates should still work with a mock clock
+        $value = new \DateTimeImmutable('2025-06-01 00:00:00 UTC');
+        $constraint = new GreaterThan('2025-01-01');
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testBackwardCompatWithoutClock()
+    {
+        // Without setClock(), the validator should still work (falls back to system clock)
+        $value = new \DateTimeImmutable('2000-01-01 UTC');
+        $constraint = new GreaterThan('1999-01-01');
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    private static function formatDateTime(\DateTimeInterface $value): string
+    {
+        if (class_exists(\IntlDateFormatter::class)) {
+            $formatter = new \IntlDateFormatter(\Locale::getDefault(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT, 'UTC');
+
+            return $formatter->format(new \DateTimeImmutable(
+                $value->format('Y-m-d H:i:s.u'),
+                new \DateTimeZone('UTC')
+            ));
+        }
+
+        return $value->format('Y-m-d H:i:s');
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\RangeValidator;
@@ -834,6 +835,82 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             ->setParameters(['{{ min }}' => '1', '{{ max }}' => '10', '{{ value }}' => (string) $value])
             ->setCode($expectedCode)
             ->assertRaised();
+    }
+
+    public function testValidRelativeRangeWithMockClock()
+    {
+        $clock = new MockClock('2025-01-15 00:00:00 UTC');
+        $this->validator = new RangeValidator(null, $clock);
+        $this->validator->initialize($this->context);
+
+        // Value is Jan 10, within range [-10 days (Jan 5) .. +10 days (Jan 25)]
+        $value = new \DateTimeImmutable('2025-01-10 00:00:00 UTC');
+        $constraint = new Range(min: '-10 days', max: '+10 days');
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidRelativeRangeWithMockClock()
+    {
+        $clock = new MockClock('2025-01-15 00:00:00 UTC');
+        $this->validator = new RangeValidator(null, $clock);
+        $this->validator->initialize($this->context);
+
+        // Value is Feb 1, outside range [-10 days (Jan 5) .. +10 days (Jan 25)]
+        $value = new \DateTimeImmutable('2025-02-01 00:00:00 UTC');
+        $constraint = new Range(min: '-10 days', max: '+10 days', notInRangeMessage: 'myMessage');
+
+        $this->validator->validate($value, $constraint);
+
+        $now = $clock->now();
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', self::formatDateTime($value))
+            ->setParameter('{{ min }}', self::formatDateTime($now->modify('-10 days')))
+            ->setParameter('{{ max }}', self::formatDateTime($now->modify('+10 days')))
+            ->setCode(Range::NOT_IN_RANGE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testAbsoluteRangeWithMockClock()
+    {
+        $clock = new MockClock('2025-01-15 00:00:00 UTC');
+        $this->validator = new RangeValidator(null, $clock);
+        $this->validator->initialize($this->context);
+
+        // Absolute dates should still work with a mock clock
+        $value = new \DateTimeImmutable('2025-03-15 00:00:00 UTC');
+        $constraint = new Range(min: '2025-01-01', max: '2025-12-31');
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testBackwardCompatWithoutClock()
+    {
+        // Without setClock(), the validator should still work (falls back to system clock)
+        $value = new \DateTimeImmutable('2025-03-15 00:00:00 UTC');
+        $constraint = new Range(min: '2025-01-01', max: '2025-12-31');
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    private static function formatDateTime(\DateTimeInterface $value): string
+    {
+        if (class_exists(\IntlDateFormatter::class)) {
+            $formatter = new \IntlDateFormatter(\Locale::getDefault(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT, 'UTC');
+
+            return $formatter->format(new \DateTimeImmutable(
+                $value->format('Y-m-d H:i:s.u'),
+                new \DateTimeZone('UTC')
+            ));
+        }
+
+        return $value->format('Y-m-d H:i:s');
     }
 }
 

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -24,6 +24,7 @@
     "require-dev": {
         "egulias/email-validator": "^2.1.10|^3|^4",
         "symfony/cache": "^7.4|^8.0",
+        "symfony/clock": "^7.4|^8.0",
         "symfony/config": "^7.4|^8.0",
         "symfony/console": "^7.4|^8.0",
         "symfony/dependency-injection": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60747
| License       | MIT

This PR adds clock-aware handling for relative date strings in comparison and range validators to make date comparisons testable with MockClock.

It also wires ClockInterface into FrameworkBundle’s constraint validator service prototype so validators can receive the container clock when available.
