### PR TITLE
[HttpKernel] Fix variadic argument handling with #[MapUploadedFile]

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -161,6 +161,11 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 }
             }
 
+            if ($argument->metadata->isVariadic()) {
+                array_splice($arguments, $i, 1, $payload ?? []);
+                continue;
+            }
+
             if (null === $payload) {
                 $payload = match (true) {
                     $argument->metadata->hasDefaultValue() => $argument->metadata->getDefaultValue(),
@@ -233,7 +238,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
     private function mapUploadedFile(Request $request, ArgumentMetadata $argument, MapUploadedFile $attribute): UploadedFile|array|null
     {
         if ($files = $request->files->get($attribute->name ?? $argument->getName())) {
-            return $files;
+            return !\is_array($files) && $argument->isVariadic() ? [$files] : $files;
         }
 
         if ($argument->isNullable() || $argument->hasDefaultValue()) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -297,6 +297,36 @@ class UploadedFileValueResolverTest extends TestCase
     }
 
     #[DataProvider('provideContext')]
+    public function testSingleFileVariadic(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile();
+        $argument = new ArgumentMetadata(
+            'foo',
+            UploadedFile::class,
+            true,
+            false,
+            null,
+            false,
+            [$attribute::class => $attribute]
+        );
+        $event = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+        $resolver->onKernelControllerArguments($event);
+
+        /** @var UploadedFile[] $data */
+        $data = $event->getArguments();
+
+        $this->assertCount(1, $data);
+        $this->assertSame('file-small.txt', $data[0]->getFilename());
+        $this->assertSame(36, $data[0]->getSize());
+    }
+
+    #[DataProvider('provideContext')]
     public function testMultipleFilesVariadic(RequestPayloadValueResolver $resolver, Request $request)
     {
         $attribute = new MapUploadedFile();
@@ -319,7 +349,7 @@ class UploadedFileValueResolverTest extends TestCase
         $resolver->onKernelControllerArguments($event);
 
         /** @var UploadedFile[] $data */
-        $data = $event->getArguments()[0];
+        $data = $event->getArguments();
 
         $this->assertCount(2, $data);
         $this->assertSame('file-small.txt', $data[0]->getFilename());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Looks like #49978 was buggy, spotted while reviewing #54817 