### PR TITLE
[JsonStreamer] Fix cache invalidation for non-DTO changes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/JsonStreamerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/JsonStreamerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\app\JsonStreamer\Dto\Dummy;
+use Symfony\Component\Config\Resource\ReflectionClassResource;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\JsonStreamer\StreamerDumper;
 use Symfony\Component\JsonStreamer\StreamReaderInterface;
@@ -65,11 +66,53 @@ class JsonStreamerTest extends AbstractWebTestCase
         $this->assertFileExists($streamWritersDir);
 
         if (!class_exists(StreamerDumper::class)) {
-            $this->assertCount(2, glob($streamWritersDir.'/*'));
+            $this->assertCount(2, glob($streamWritersDir.'*'));
         } else {
-            $this->assertCount(2, glob($streamWritersDir.'/*.php'));
-            $this->assertCount(2, glob($streamWritersDir.'/*.php.meta'));
-            $this->assertCount(2, glob($streamWritersDir.'/*.php.meta.json'));
+            $this->assertCount(2, glob($streamWritersDir.'*.php'));
+            $this->assertCount(2, glob($streamWritersDir.'*.php.meta'));
+            $this->assertCount(2, glob($streamWritersDir.'*.php.meta.json'));
         }
+    }
+
+    public function testCacheInvalidationResources()
+    {
+        if (!class_exists(StreamerDumper::class)) {
+            $this->markTestSkipped('StreamerDumper is required for cache invalidation.');
+        }
+
+        /** @var Filesystem $fs */
+        $fs = static::getContainer()->get('filesystem');
+
+        $streamWritersDir = \sprintf('%s/json_streamer/stream_writer/', static::getContainer()->getParameter('kernel.cache_dir'));
+        if ($fs->exists($streamWritersDir)) {
+            $fs->remove($streamWritersDir);
+        }
+
+        $streamReadersDir = \sprintf('%s/json_streamer/stream_reader/', static::getContainer()->getParameter('kernel.cache_dir'));
+        if ($fs->exists($streamReadersDir)) {
+            $fs->remove($streamReadersDir);
+        }
+
+        static::getContainer()->get('json_streamer.cache_warmer.streamer.alias')->warmUp(static::getContainer()->getParameter('kernel.cache_dir'));
+
+        $writeMeta = array_map(static fn (string $f): mixed => json_decode(file_get_contents($f), true), glob($streamWritersDir.'*.php.meta.json'));
+
+        $dummyResources = $writeMeta[0]['resources'];
+        $this->assertSame(ReflectionClassResource::class, $dummyResources[0]['@type']);
+        $this->assertSame(Dummy::class, $dummyResources[0]['className']);
+
+        $dummyListResources = $writeMeta[1]['resources'];
+        $this->assertSame(ReflectionClassResource::class, $dummyListResources[0]['@type']);
+        $this->assertSame(Dummy::class, $dummyListResources[0]['className']);
+
+        $readMeta = array_map(static fn (string $f): mixed => json_decode(file_get_contents($f), true), glob($streamReadersDir.'*.php.meta.json'));
+
+        $dummyResources = $readMeta[0]['resources'];
+        $this->assertSame(ReflectionClassResource::class, $dummyResources[0]['@type']);
+        $this->assertSame(Dummy::class, $dummyResources[0]['className']);
+
+        $dummyListResources = $readMeta[1]['resources'];
+        $this->assertSame(ReflectionClassResource::class, $dummyListResources[0]['@type']);
+        $this->assertSame(Dummy::class, $dummyListResources[0]['className']);
     }
 }

--- a/src/Symfony/Component/JsonStreamer/CacheWarmer/StreamerCacheWarmer.php
+++ b/src/Symfony/Component/JsonStreamer/CacheWarmer/StreamerCacheWarmer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\JsonStreamer\CacheWarmer;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\JsonStreamer\Exception\ExceptionInterface;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
@@ -40,8 +41,8 @@ final class StreamerCacheWarmer implements CacheWarmerInterface
         private iterable $streamable,
         PropertyMetadataLoaderInterface $streamWriterPropertyMetadataLoader,
         PropertyMetadataLoaderInterface $streamReaderPropertyMetadataLoader,
-        string $streamWritersDir,
-        string $streamReadersDir,
+        private string $streamWritersDir,
+        private string $streamReadersDir,
         private LoggerInterface $logger = new NullLogger(),
         ?ConfigCacheFactoryInterface $configCacheFactory = null,
     ) {
@@ -51,6 +52,10 @@ final class StreamerCacheWarmer implements CacheWarmerInterface
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
+        $fs = new Filesystem();
+        $fs->remove($this->streamWritersDir);
+        $fs->remove($this->streamReadersDir);
+
         foreach ($this->streamable as $className => $streamable) {
             if ($streamable['object']) {
                 $type = Type::object($className);
@@ -72,7 +77,7 @@ final class StreamerCacheWarmer implements CacheWarmerInterface
 
     public function isOptional(): bool
     {
-        return true;
+        return false;
     }
 
     private function warmUpStreamWriter(Type $type): void

--- a/src/Symfony/Component/JsonStreamer/StreamerDumper.php
+++ b/src/Symfony/Component/JsonStreamer/StreamerDumper.php
@@ -47,11 +47,12 @@ final class StreamerDumper
             $this->cacheFactory->cache(
                 $path,
                 function (ConfigCacheInterface $cache) use ($generateContent, $type) {
-                    $resourceClasses = $this->getResourceClassNames($type);
-                    $cache->write(
-                        $generateContent(),
-                        array_map(fn (string $c) => new ReflectionClassResource(new \ReflectionClass($c)), $resourceClasses),
-                    );
+                    $resources = [];
+                    foreach ($this->getResourceClassNames($type) as $className) {
+                        $resources[] = new ReflectionClassResource(new \ReflectionClass($className));
+                    }
+
+                    $cache->write($generateContent(), $resources);
                 },
             );
 

--- a/src/Symfony/Component/JsonStreamer/Tests/CacheWarmer/StreamerCacheWarmerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/CacheWarmer/StreamerCacheWarmerTest.php
@@ -29,16 +29,6 @@ class StreamerCacheWarmerTest extends TestCase
 
         $this->streamWritersDir = \sprintf('%s/symfony_json_streamer_test/stream_writer', sys_get_temp_dir());
         $this->streamReadersDir = \sprintf('%s/symfony_json_streamer_test/stream_reader', sys_get_temp_dir());
-
-        if (is_dir($this->streamWritersDir)) {
-            array_map('unlink', glob($this->streamWritersDir.'/*'));
-            rmdir($this->streamWritersDir);
-        }
-
-        if (is_dir($this->streamReadersDir)) {
-            array_map('unlink', glob($this->streamReadersDir.'/*'));
-            rmdir($this->streamReadersDir);
-        }
     }
 
     public function testWarmUp()

--- a/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
@@ -48,7 +48,7 @@ class StreamerDumperTest extends TestCase
         $path = $this->cacheDir.'/streamer.php';
 
         $dumper = new StreamerDumper($this->createStub(PropertyMetadataLoaderInterface::class), $this->cacheDir, new ConfigCacheFactory(true));
-        $dumper->dump(Type::int(), $path, fn () => 'CONTENT');
+        $dumper->dump(Type::int(), $path, static fn () => 'CONTENT');
 
         $this->assertFileExists($path);
         $this->assertFileExists($path.'.meta');
@@ -62,7 +62,7 @@ class StreamerDumperTest extends TestCase
         $path = $this->cacheDir.'/streamer.php';
 
         $dumper = new StreamerDumper($this->createStub(PropertyMetadataLoaderInterface::class), $this->cacheDir);
-        $dumper->dump(Type::int(), $path, fn () => 'CONTENT');
+        $dumper->dump(Type::int(), $path, static fn () => 'CONTENT');
 
         $this->assertFileExists($path);
         $this->assertStringEqualsFile($path, 'CONTENT');
@@ -71,16 +71,16 @@ class StreamerDumperTest extends TestCase
     /**
      * @param list<class-string> $expectedClassNames
      */
-    #[DataProvider('getCacheResourcesDataProvider')]
-    public function testGetCacheResources(Type $type, array $expectedClassNames)
+    #[DataProvider('tracksTypeClassesDataProvider')]
+    public function testTracksTypeClasses(Type $type, array $expectedClassNames)
     {
         $path = $this->cacheDir.'/streamer.php';
 
         $dumper = new StreamerDumper(new PropertyMetadataLoader(TypeResolver::create()), $this->cacheDir, new ConfigCacheFactory(true));
-        $dumper->dump($type, $path, fn () => 'CONTENT');
+        $dumper->dump($type, $path, static fn () => 'CONTENT');
 
         $resources = json_decode(file_get_contents($path.'.meta.json'), true)['resources'];
-        $classNames = array_column($resources, 'className');
+        $classNames = array_values(array_filter(array_column($resources, 'className')));
 
         $this->assertSame($expectedClassNames, $classNames);
     }
@@ -88,7 +88,7 @@ class StreamerDumperTest extends TestCase
     /**
      * @return iterable<array{0: Type, 1: list<class-string>}>
      */
-    public static function getCacheResourcesDataProvider(): iterable
+    public static function tracksTypeClassesDataProvider(): iterable
     {
         yield 'scalar' => [Type::int(), []];
         yield 'enum' => [Type::enum(DummyBackedEnum::class), [DummyBackedEnum::class]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Address https://github.com/symfony/symfony/pull/63339#discussion_r2794134149

The JsonStreamer cache (managed by `StreamerDumper`) was not tracking changes to the component's own code.
After a Symfony upgrade, stale cached streamers could be served because no resource invalidation was in place for the generator code.

This PR adds a `DirectoryResource` on the `JsonStreamer` component directory so that any change to its PHP files invalidates the cache.