### PR TITLE
[Console] Fix ProgressBar `%remaining%` and `%estimated%` placeholder guards

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -578,14 +578,14 @@ final class ProgressBar
             },
             'elapsed' => fn (self $bar) => Helper::formatTime(time() - $bar->getStartTime(), 2),
             'remaining' => function (self $bar) {
-                if (null === $bar->getMaxSteps()) {
+                if (null === $bar->max) {
                     throw new LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
                 return Helper::formatTime($bar->getRemaining(), 2);
             },
             'estimated' => function (self $bar) {
-                if (null === $bar->getMaxSteps()) {
+                if (null === $bar->max) {
                     throw new LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests\Helper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -1370,5 +1371,25 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $progressBar = new ProgressBar($this->getOutputStream());
 
         $this->assertNull($progressBar->getMessage());
+    }
+
+    public function testRemainingWithoutMaxThrowsLogicException()
+    {
+        $this->expectException(LogicException::class);
+
+        $bar = new ProgressBar($this->getOutputStream());
+        $bar->setFormat('%remaining%');
+        $bar->start();
+        $bar->advance();
+    }
+
+    public function testEstimatedWithoutMaxThrowsLogicException()
+    {
+        $this->expectException(LogicException::class);
+
+        $bar = new ProgressBar($this->getOutputStream());
+        $bar->setFormat('%estimated%');
+        $bar->start();
+        $bar->advance();
     }
 }

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -100,6 +100,8 @@ class SymfonyStyleTest extends TestCase
         $code = static function (InputInterface $input, OutputInterface $output) {
             $io = new SymfonyStyle($input, $output);
             $io->block("First line.\r\nSecond line.", 'INFO', 'fg=white;bg=blue', ' ', true);
+
+            return Command::SUCCESS;
         };
 
         $this->command->setCode($code);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PR #52605 changed `getMaxSteps()` to return `$this->max ?? 0`,
which made the null checks guards for `%remaining%` and `%estimated%` placeholders ineffective.

This makes `getRemaining()` and `getEstimated()` produce negative values instead of throwing LogicException as intended.