### PR TITLE
[Validator] Fix missing null type in ValidatorInterface::validate() phpdoc

### DIFF
--- a/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
+++ b/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
@@ -30,7 +30,7 @@ interface ValidatorInterface extends MetadataFactoryInterface
      * If no constraint is passed, the constraint
      * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
      *
-     * @param Constraint|Constraint[]                               $constraints The constraint(s) to validate against
+     * @param Constraint|Constraint[]|null                          $constraints The constraint(s) to validate against
      * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return ConstraintViolationListInterface A list of constraint violations


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

The `@param` phpdoc for `$constraints` on `ValidatorInterface::validate()` is missing null, even though the native type is Constraint|array|null and the default value is null.

This was picked up by https://github.com/carthage-software/mago
