### PR TITLE
[Form] Add uid_format option to EntityType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add option `uid_format` to `EntityType`
  * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`. Namespace aliases are no longer supported in Doctrine.
 
 8.0

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -75,8 +75,13 @@ class DoctrineChoiceLoader extends AbstractChoiceLoader
         $idReader = null;
         if (\is_array($value) && $value[0] instanceof IdReader) {
             $idReader = $value[0];
-        } elseif ($value instanceof \Closure && ($rThis = (new \ReflectionFunction($value))->getClosureThis()) instanceof IdReader) {
-            $idReader = $rThis;
+        } elseif ($value instanceof \Closure) {
+            $ref = new \ReflectionFunction($value);
+            if (($rThis = $ref->getClosureThis()) instanceof IdReader) {
+                $idReader = $rThis;
+            } elseif (($usedVariables = $ref->getClosureUsedVariables()) && ($usedVariables['idReader'] ?? null) instanceof IdReader) {
+                $idReader = $usedVariables['idReader'];
+            }
         }
 
         // Optimize performance in case we have an object loader and
@@ -90,7 +95,7 @@ class DoctrineChoiceLoader extends AbstractChoiceLoader
             // "INDEX BY" clause to the Doctrine query in the loader,
             // but I'm not sure whether that's doable in a generic fashion.
             foreach ($this->objectLoader->getEntitiesByIds($idReader->getIdField(), $values) as $object) {
-                $objectsById[$idReader->getIdValue($object)] = $object;
+                $objectsById[$value($object) ?? ''] = $object;
             }
 
             foreach ($values as $i => $id) {

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -27,6 +27,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Service\ResetInterface;
 
 abstract class DoctrineType extends AbstractType implements ResetInterface
@@ -151,7 +152,29 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
         $choiceValue = function (Options $options) {
             // If the entity has a single-column ID, use that ID as value
             if ($options['id_reader'] instanceof IdReader && $options['id_reader']->isSingleId()) {
-                return ChoiceList::value($this, $options['id_reader']->getIdValue(...), $options['id_reader']);
+                $idReader = $options['id_reader'];
+                $uidFormat = $options['uid_format'];
+
+                if (null === $uidFormat) {
+                    return ChoiceList::value($this, $idReader->getIdValue(...), $idReader);
+                }
+
+                $formatMethod = match ($uidFormat) {
+                    'base32' => 'toBase32',
+                    'base58' => 'toBase58',
+                    'binary' => 'toBinary',
+                    'hex' => 'toHex',
+                    'rfc4122' => 'toRfc4122',
+                    default => throw new RuntimeException(sprintf('Unsupported value "%s" for "uid_format" option; valid values are "base32", "base58", "binary", "hex" and "rfc4122".', $uidFormat)),
+                };
+
+                return ChoiceList::value($this, static function (?object $object = null) use ($idReader, $formatMethod): string {
+                    if ('' === $value = $idReader->getIdValue($object)) {
+                        return '';
+                    }
+
+                    return Uuid::fromString($value)->$formatMethod();
+                }, [$idReader, $uidFormat]);
             }
 
             // Otherwise, an incrementing integer is used as value automatically
@@ -206,6 +229,7 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
             'choice_value' => $choiceValue,
             'id_reader' => null, // internal
             'choice_translation_domain' => false,
+            'uid_format' => null,
         ]);
 
         $resolver->setRequired(['class']);
@@ -215,6 +239,7 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
         $resolver->setNormalizer('id_reader', $idReaderNormalizer);
 
         $resolver->setAllowedTypes('em', ['null', 'string', ObjectManager::class]);
+        $resolver->setAllowedValues('uid_format', [null, 'base32', 'base58', 'binary', 'hex', 'rfc4122']);
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Tests\Form\Type;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -29,6 +30,10 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringCastableIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UlidIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UuidIdEntity;
+use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Form\ChoiceList\LazyChoiceList;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
@@ -40,6 +45,8 @@ use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTestCase;
 use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 class EntityTypeTest extends BaseTypeTestCase
 {
@@ -59,6 +66,15 @@ class EntityTypeTest extends BaseTypeTestCase
 
     protected function setUp(): void
     {
+        if (Type::hasType('uuid')) {
+            Type::overrideType('uuid', UuidType::class);
+        } else {
+            Type::addType('uuid', UuidType::class);
+        }
+        if (!Type::hasType('ulid')) {
+            Type::addType('ulid', UlidType::class);
+        }
+
         $this->em = DoctrineTestHelper::createTestEntityManager();
         $this->emRegistry = $this->createRegistryMock($this->em);
 
@@ -74,6 +90,8 @@ class EntityTypeTest extends BaseTypeTestCase
             $this->em->getClassMetadata(self::SINGLE_STRING_CASTABLE_IDENT_CLASS),
             $this->em->getClassMetadata(self::COMPOSITE_IDENT_CLASS),
             $this->em->getClassMetadata(self::COMPOSITE_STRING_IDENT_CLASS),
+            $this->em->getClassMetadata(UuidIdEntity::class),
+            $this->em->getClassMetadata(UlidIdEntity::class),
         ];
 
         try {
@@ -1867,5 +1885,109 @@ class EntityTypeTest extends BaseTypeTestCase
         $this->assertCount(0, $view['entity_one']->vars['choices']);
         $this->assertCount(1, $errors = $form->getErrors(true));
         $this->assertSame('The selected choice is invalid.', $errors->current()->getMessage());
+    }
+
+    public function testUidFormatBase58WithUuid()
+    {
+        $uuid = Uuid::fromString('71c5fd46-3f16-4abb-bad7-90ac1e654a2d');
+        $entity1 = new UuidIdEntity($uuid);
+        $this->persist([$entity1]);
+
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+            'em' => 'default',
+            'class' => UuidIdEntity::class,
+            'choice_label' => static fn () => 'label',
+            'uid_format' => 'base58',
+        ])->createView();
+
+        $this->assertCount(1, $view->vars['choices']);
+        $this->assertSame($uuid->toBase58(), $view->vars['choices'][0]->value);
+    }
+
+    public function testUidFormatBase32WithUuid()
+    {
+        $uuid = Uuid::fromString('71c5fd46-3f16-4abb-bad7-90ac1e654a2d');
+        $entity1 = new UuidIdEntity($uuid);
+        $this->persist([$entity1]);
+
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+            'em' => 'default',
+            'class' => UuidIdEntity::class,
+            'choice_label' => static fn () => 'label',
+            'uid_format' => 'base32',
+        ])->createView();
+
+        $this->assertCount(1, $view->vars['choices']);
+        $this->assertSame($uuid->toBase32(), $view->vars['choices'][0]->value);
+    }
+
+    public function testUidFormatBase58WithUlid()
+    {
+        $ulid = Ulid::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+        $entity1 = new UlidIdEntity($ulid);
+        $this->persist([$entity1]);
+
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+            'em' => 'default',
+            'class' => UlidIdEntity::class,
+            'choice_label' => static fn () => 'label',
+            'uid_format' => 'base58',
+        ])->createView();
+
+        $this->assertCount(1, $view->vars['choices']);
+        $this->assertSame($ulid->toBase58(), $view->vars['choices'][0]->value);
+    }
+
+    public function testUidFormatRfc4122WithUlid()
+    {
+        $ulid = Ulid::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+        $entity1 = new UlidIdEntity($ulid);
+        $this->persist([$entity1]);
+
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+            'em' => 'default',
+            'class' => UlidIdEntity::class,
+            'choice_label' => static fn () => 'label',
+            'uid_format' => 'rfc4122',
+        ])->createView();
+
+        $this->assertCount(1, $view->vars['choices']);
+        $this->assertSame($ulid->toRfc4122(), $view->vars['choices'][0]->value);
+    }
+
+    public function testSubmitWithUidFormat()
+    {
+        $uuid = Uuid::fromString('71c5fd46-3f16-4abb-bad7-90ac1e654a2d');
+        $entity1 = new UuidIdEntity($uuid);
+        $this->persist([$entity1]);
+
+        $form = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+            'em' => 'default',
+            'class' => UuidIdEntity::class,
+            'choice_label' => static fn () => 'label',
+            'uid_format' => 'base58',
+        ]);
+
+        $form->submit($uuid->toBase58());
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame($entity1, $form->getData());
+    }
+
+    public function testUidFormatDefaultBehavior()
+    {
+        $uuid = Uuid::fromString('71c5fd46-3f16-4abb-bad7-90ac1e654a2d');
+        $entity1 = new UuidIdEntity($uuid);
+        $this->persist([$entity1]);
+
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+            'em' => 'default',
+            'class' => UuidIdEntity::class,
+            'choice_label' => static fn () => 'label',
+        ])->createView();
+
+        $this->assertCount(1, $view->vars['choices']);
+        // Default behavior: UUID uses __toString() which is RFC4122 format
+        $this->assertSame($uuid->toRfc4122(), $view->vars['choices'][0]->value);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61941
| License       | MIT

## Summary

`EntityType` renders ULID choice values in Base32 and UUID values in RFC4122 format (via `__toString()`). There is currently no way to choose a different format (e.g., Base58 for shorter URLs).

This PR adds a `uid_format` option to `EntityType` that accepts `'base32'`, `'base58'`, `'rfc4122'`, or `null` (default, preserves current behavior).