### PR TITLE
[Dotenv] Use `APP_RUNTIME_OPTIONS` variable when dumping dotenv

### DIFF
--- a/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DotenvDumpCommand.php
@@ -66,9 +66,12 @@ final class DotenvDumpCommand extends Command
             $projectDir = \dirname($projectDir);
         }
 
-        $composerFile = $projectDir.'/composer.json';
-        $config += (is_file($composerFile) ? json_decode(file_get_contents($composerFile), true) : [])['extra']['runtime'] ?? [];
-        $dotenvPath = $projectDir.'/'.($config['dotenv_path'] ?? '.env');
+        if (null === $dotenvPath = $_SERVER['SYMFONY_DOTENV_PATH'] ?? null) {
+            $composerFile = $projectDir.'/composer.json';
+            $config += (is_file($composerFile) ? json_decode(file_get_contents($composerFile), true) : [])['extra']['runtime'] ?? [];
+            $dotenvPath = $projectDir.'/'.($config['dotenv_path'] ?? '.env');
+        }
+
         $env = $input->getArgument('env') ?? $this->defaultEnv;
         $envKey = $config['env_var_name'] ?? 'APP_ENV';
 
@@ -90,7 +93,7 @@ final class DotenvDumpCommand extends Command
             EOF;
         file_put_contents($dotenvPath.'.local.php', $vars, \LOCK_EX);
 
-        $output->writeln(\sprintf('Successfully dumped .env files in <info>.env.local.php</> for the <info>%s</> environment.', $env));
+        $output->writeln(\sprintf('Successfully dumped .env files in <info>%s.local.php</> for the <info>%s</> environment.', basename($dotenvPath), $env));
 
         return 0;
     }

--- a/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/Command/DotenvDumpCommandTest.php
@@ -20,6 +20,8 @@ class DotenvDumpCommandTest extends TestCase
 {
     protected function setUp(): void
     {
+        unset($_SERVER['SYMFONY_DOTENV_PATH']);
+
         file_put_contents(__DIR__.'/.env', <<<EOF
             APP_ENV=dev
             APP_SECRET=abc123
@@ -36,8 +38,13 @@ class DotenvDumpCommandTest extends TestCase
     {
         @unlink(__DIR__.'/.env');
         @unlink(__DIR__.'/.env.local');
+        @unlink(__DIR__.'/.env.path');
+        @unlink(__DIR__.'/.env.path.local');
         @unlink(__DIR__.'/.env.local.php');
+        @unlink(__DIR__.'/.env.path.local.php');
         @unlink(__DIR__.'/composer.json');
+
+        unset($_SERVER['SYMFONY_DOTENV_PATH']);
     }
 
     public function testExecute()
@@ -89,6 +96,35 @@ class DotenvDumpCommandTest extends TestCase
             'APP_ENV' => 'test',
             'APP_SECRET' => 'abc123',
             'APP_LOCAL' => 'yes',
+        ], $vars);
+    }
+
+    public function testExecuteSymfonyDotEnvPath()
+    {
+        file_put_contents(__DIR__.'/.env.path', <<<EOF
+            APP_ENV=test
+            APP_SECRET=newpath123
+            EOF
+        );
+        file_put_contents(__DIR__.'/.env.path.local', <<<EOF
+            LOCAL_PATH=yes
+            EOF
+        );
+
+        $_SERVER['SYMFONY_DOTENV_PATH'] = __DIR__.'/.env.path';
+
+        $command = $this->createCommand();
+        $command->execute([
+            'env' => 'dev',
+        ]);
+
+        $this->assertFileExists(__DIR__.'/.env.path.local.php');
+
+        $vars = require __DIR__.'/.env.path.local.php';
+        $this->assertSame([
+            'APP_ENV' => 'dev',
+            'APP_SECRET' => 'newpath123',
+            'LOCAL_PATH' => 'yes',
         ], $vars);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| License       | MIT

When overriding the `dotenv_path` directly in the `index.php` or `console` file like this:

```php
// public/index.php
use App\Kernel;

require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

$_SERVER['APP_RUNTIME_OPTIONS'] = [
    'dotenv_path' => '.env.path'
];

return function (array $context): Kernel {
    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
};
```

The `dotenv:dump` command was ignoring this value and used the default `.env` path, which resulted in two things:

* The file was still generated (with wrong values), but ...
* It was never used since the application itself used the `dotenv_path` from the runtime options and could not find the corresponding `*.local.php` file in the updated path

To fix this, the command itself now checks if the `SYMFONY_DOTENV_PATH` env variable is set, and if it is, its value is used instead of checking the `composer.json` file or falling back to the `.env` file.

I was thinking about only relying on this variable, as it will always be populated by the `Dotenv` class, but I'm not entirely sure about the implications here, so I went this the safest solution. 