### PR TITLE
[HttpFoundation] Add `BinaryFileResponse::shouldDeleteFileAfterSend()`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -393,4 +393,9 @@ class BinaryFileResponse extends Response
 
         return $this;
     }
+
+    public function shouldDeleteFileAfterSend(): bool
+    {
+        return $this->deleteFileAfterSend;
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `BinaryFileResponse::shouldDeleteFileAfterSend()`
+
 8.0
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -332,6 +332,21 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertFileDoesNotExist($path);
     }
 
+    public function testShouldDeleteFileAfterSend()
+    {
+        $response = new BinaryFileResponse(__DIR__.'/File/Fixtures/test.gif');
+
+        $this->assertFalse($response->shouldDeleteFileAfterSend());
+
+        $response->deleteFileAfterSend(true);
+
+        $this->assertTrue($response->shouldDeleteFileAfterSend());
+
+        $response->deleteFileAfterSend(false);
+
+        $this->assertFalse($response->shouldDeleteFileAfterSend());
+    }
+
     public function testAcceptRangeOnUnsafeMethods()
     {
         $request = Request::create('/', 'POST');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61892
| License       | MIT

## Summary

Adds a public `shouldDeleteFileAfterSend()` getter to `BinaryFileResponse`.

Currently the `deleteFileAfterSend` flag is only writable (via `deleteFileAfterSend(true)`), but not readable. Custom middlewares outside Symfony (e.g. RoadRunner) need to check this flag to handle file cleanup properly, and currently have to resort to reflection.