### PR TITLE
[PropertyInfo] prioritize property type over is/has/can accessors

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -238,7 +238,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         [$accessorReflection, $prefix] = $this->getAccessorMethod($class, $property);
-        if ($accessorReflection) {
+        $allowedPrefixes = array_diff($this->accessorPrefixes, ['is', 'can', 'has']);
+        if ($accessorReflection && \in_array($prefix, $allowedPrefixes, true)) {
             try {
                 return $this->typeResolver->resolve($accessorReflection);
             } catch (UnsupportedException) {
@@ -265,6 +266,15 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         try {
             return $this->typeResolver->resolve($reflectionProperty);
         } catch (UnsupportedException) {
+        }
+
+        $allowedPrefixes = array_diff($this->accessorPrefixes, $allowedPrefixes);
+        [$accessorReflection, $prefix] = $this->getAccessorMethod($class, $property);
+        if ($accessorReflection && \in_array($prefix, $allowedPrefixes, true)) {
+            try {
+                return $this->typeResolver->resolve($accessorReflection);
+            } catch (UnsupportedException) {
+            }
         }
 
         if (null === $defaultValue = ($reflectionClass->getDefaultProperties()[$property] ?? null)) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -1046,11 +1046,25 @@ class ReflectionExtractorTest extends TestCase
 
     public function testHasserDoesNotOverridePropertyType()
     {
-        $this->assertEquals([new Type(Type::BUILTIN_TYPE_STRING, true)], $this->extractor->getTypes(DummyWithHasser::class, 'url'));
+        $this->assertEquals(Type::nullable(Type::string()), $this->extractor->getType(DummyWithHasser::class, 'url'));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testHasserDoesNotOverridePropertyTypeLegacy()
+    {
+        $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_STRING, true)], $this->extractor->getTypes(DummyWithHasser::class, 'url'));
     }
 
     public function testIsserUsedForBoolPropertyWithoutOtherTypeSource()
     {
-        $this->assertEquals([new Type(Type::BUILTIN_TYPE_BOOL)], $this->extractor->getTypes(DummyWithHasser::class, 'enabled'));
+        $this->assertEquals(Type::bool(), $this->extractor->getType(DummyWithHasser::class, 'enabled'));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testIsserUsedForBoolPropertyWithoutOtherTypeSourceLegacy()
+    {
+        $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_BOOL)], $this->extractor->getTypes(DummyWithHasser::class, 'enabled'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57719
| License       | MIT

same as #63344 for the `Type` class from the TypeInfo component