### PR TITLE
[DependencyInjection] Prevent false unused-env errors for abstract definitions removed at compile time

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveAbstractDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveAbstractDefinitionsPass.php
@@ -27,6 +27,7 @@ class RemoveAbstractDefinitionsPass implements CompilerPassInterface
     {
         foreach ($container->getDefinitions() as $id => $definition) {
             if ($definition->isAbstract()) {
+                $container->resolveEnvPlaceholders($definition);
                 $container->removeDefinition($id);
                 $container->log($this, \sprintf('Removed service "%s"; reason: abstract.', $id));
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -55,6 +55,7 @@ use Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable;
 use Symfony\Component\DependencyInjection\Tests\Compiler\SingleMethodInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Wither;
 use Symfony\Component\DependencyInjection\Tests\Compiler\WitherAnnotation;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\DependencyContainer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\DependencyContainerInterface;
@@ -750,6 +751,21 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
         $dumper->dump();
+    }
+
+    public function testEnvInAbstractDefinitionIsIgnoredWhenDefinitionIsRemoved()
+    {
+        $container = new ContainerBuilder();
+        $container->register('abstract_service', Bar::class)
+            ->setAbstract(true)
+            ->setArgument('$quz', '%env(FOO)%')
+        ;
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dumper->dump();
+
+        $this->assertGreaterThan(0, $container->getEnvCounters()['FOO']);
     }
 
     public function testCircularDynamicEnv()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61389
| License       | MIT

