### PR TITLE
[Messenger] Use mutable datetime columns in Doctrine transport schema

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -32,6 +32,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Types\DateTimeType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -815,6 +816,10 @@ class ConnectionTest extends TestCase
             }
         }
         $this->assertTrue($hasCoveringIndex, 'Expected covering index on [queue_name, available_at, delivered_at, id] not found');
+
+        $this->assertInstanceOf(DateTimeType::class, $table->getColumn('created_at')->getType());
+        $this->assertInstanceOf(DateTimeType::class, $table->getColumn('available_at')->getType());
+        $this->assertInstanceOf(DateTimeType::class, $table->getColumn('delivered_at')->getType());
     }
 
     public function testConfigureSchemaDifferentDbalConnection()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -518,11 +518,12 @@ class Connection implements ResetInterface
         $table->addColumn('queue_name', Types::STRING)
             ->setLength(190) // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
             ->setNotnull(true);
-        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE)
+        // Keep schema types as mutable datetime to avoid perpetual MySQL diffs with DBAL 4+.
+        $table->addColumn('created_at', Types::DATETIME_MUTABLE)
             ->setNotnull(true);
-        $table->addColumn('available_at', Types::DATETIME_IMMUTABLE)
+        $table->addColumn('available_at', Types::DATETIME_MUTABLE)
             ->setNotnull(true);
-        $table->addColumn('delivered_at', Types::DATETIME_IMMUTABLE)
+        $table->addColumn('delivered_at', Types::DATETIME_MUTABLE)
             ->setNotnull(false);
         if (class_exists(PrimaryKeyConstraint::class)) {
             $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62298
| License       | MIT

Using immutable datetime DBAL types for messenger_messages timestamps can cause endless schema diffs/migrations after upgrading to DBAL 4.
Switching column definitions to mutable datetime types fixes it.
