### PR TITLE
[FrameworkBundle] provide a useful message when symfony/semaphore misses lock store support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -180,6 +180,7 @@ use Symfony\Component\Semaphore\PersistingStoreInterface as SemaphoreStoreInterf
 use Symfony\Component\Semaphore\Semaphore;
 use Symfony\Component\Semaphore\SemaphoreFactory;
 use Symfony\Component\Semaphore\Serializer\SemaphoreKeyNormalizer;
+use Symfony\Component\Semaphore\Store\LockStore;
 use Symfony\Component\Semaphore\Store\StoreFactory as SemaphoreStoreFactory;
 use Symfony\Component\Serializer\Attribute as SerializerMapping;
 use Symfony\Component\Serializer\Attribute\ExtendsSerializationFor;
@@ -2341,6 +2342,11 @@ class FrameworkExtension extends Extension
 
         foreach ($config['resources'] as $resourceName => $resourceStore) {
             $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);
+
+            if (str_starts_with($storeDsn, 'lock://') && !class_exists(LockStore::class)) {
+                throw new LogicException('Cannot use a lock store as the installed version of the Semaphore component does not support it. Try running "composer require symfony/semaphore:^8.1".');
+            }
+
             $storeDefinition = new Definition(SemaphoreStoreInterface::class);
             $storeDefinition->setFactory([SemaphoreStoreFactory::class, 'createStore']);
             $storeDefinition->setArguments([match (true) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -78,6 +78,7 @@ use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Security\Core\AuthenticationEvents;
+use Symfony\Component\Semaphore\Store\LockStore;
 use Symfony\Component\Semaphore\Store\StoreFactory as SemaphoreStoreFactory;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
@@ -2906,6 +2907,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testSemaphoreWithLock()
     {
+        if (!class_exists(LockStore::class)) {
+            $this->markTestSkipped('LockStore not available');
+        }
+
         $container = $this->createContainerFromFile('semaphore_lock');
 
         $this->assertTrue($container->hasDefinition('semaphore.default.factory'));
@@ -2916,6 +2921,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testSemaphoreWithNamedLock()
     {
+        if (!class_exists(LockStore::class)) {
+            $this->markTestSkipped('LockStore not available');
+        }
+
         $container = $this->createContainerFromFile('semaphore_lock_named');
 
         $this->assertTrue($container->hasDefinition('semaphore.default.factory'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT