### PR TITLE
[ObjectMapper] Allow class FQDN arrays as TargetClass and SourceClass param

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * Merge nested properties when targeting the same class
  * Add a `targetClass` option to `MapCollection`
  * Add a `TransformObjectMapperAwareInterface` to inject the current object mapper instance to transformers
+ * Add `SourceClass`, `ClassRule`, and `ClassRuleList` condition callables to match mapping rules based on source/target class
+ * Allow `TargetClass` and `SourceClass` to accept arrays of class FQDNs
 
 7.4
 ---

--- a/src/Symfony/Component/ObjectMapper/Condition/ClassRule.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/ClassRule.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Condition;
+
+use Symfony\Component\ObjectMapper\Exception\InvalidArgumentException;
+
+/**
+ * @template T1 of object
+ * @template T2 of object
+ *
+ * @implements ClassRuleConditionCallableInterface<T1, T2>
+ */
+final class ClassRule implements ClassRuleConditionCallableInterface
+{
+    /**
+     * @param array<class-string>|null $sources
+     * @param array<class-string>|null $targets
+     */
+    public function __construct(
+        private array $sources = [],
+        private array $targets = [],
+    ) {
+        if (!$this->sources && !$this->targets) {
+            throw new InvalidArgumentException('A ClassRule needs a sources list and/or a targets list.');
+        }
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): bool
+    {
+        $sourceMatch = !$this->sources;
+        $targetMatch = !$this->targets;
+
+        foreach ($this->sources as $sourceClass) {
+            if ($source instanceof $sourceClass) {
+                $sourceMatch = true;
+                break;
+            }
+        }
+
+        foreach ($this->targets as $targetClass) {
+            if ($target instanceof $targetClass) {
+                $targetMatch = true;
+                break;
+            }
+        }
+
+        return $sourceMatch && $targetMatch;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Condition/ClassRuleConditionCallableInterface.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/ClassRuleConditionCallableInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Condition;
+
+use Symfony\Component\ObjectMapper\ConditionCallableInterface;
+
+/**
+ * Marker interface for condition callables that validate class rules.
+ *
+ * Conditions implementing this interface are evaluated before fetching
+ * the property value, allowing early skip of mapping rules based on
+ * source/target class checks.
+ *
+ * @template T of object
+ * @template T2 of object
+ *
+ * @extends ConditionCallableInterface<T, T2>
+ */
+interface ClassRuleConditionCallableInterface extends ConditionCallableInterface
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Condition/ClassRuleList.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/ClassRuleList.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Condition;
+
+/**
+ * @implements ClassRuleConditionCallableInterface<object, object>
+ */
+final class ClassRuleList implements ClassRuleConditionCallableInterface
+{
+    /**
+     * @param non-empty-array<ClassRule|SourceClass|TargetClass> $rules
+     */
+    public function __construct(private array $rules)
+    {
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): bool
+    {
+        return array_any($this->rules, static fn ($rule) => $rule($value, $source, $target));
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Condition/SourceClass.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/SourceClass.php
@@ -14,27 +14,27 @@ namespace Symfony\Component\ObjectMapper\Condition;
 /**
  * @template T of object
  *
- * @implements ClassRuleConditionCallableInterface<object, T>
+ * @implements ClassRuleConditionCallableInterface<T, object>
  */
-final class TargetClass implements ClassRuleConditionCallableInterface
+final class SourceClass implements ClassRuleConditionCallableInterface
 {
     /**
      * @var non-empty-array<class-string>
      */
-    private readonly array $targets;
+    private readonly array $sources;
 
     /**
      * @param class-string<T>|array<class-string<T>> $className
      */
     public function __construct(string|array $className)
     {
-        $this->targets = \is_array($className) ? $className : [$className];
+        $this->sources = \is_array($className) ? $className : [$className];
     }
 
     public function __invoke(mixed $value, object $source, ?object $target): bool
     {
-        foreach ($this->targets as $validTarget) {
-            if ($target instanceof $validTarget) {
+        foreach ($this->sources as $validSource) {
+            if ($source instanceof $validSource) {
                 return true;
             }
         }

--- a/src/Symfony/Component/ObjectMapper/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/ObjectMapper/Exception/InvalidArgumentException.php
@@ -9,10 +9,8 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+namespace Symfony\Component\ObjectMapper\Exception;
 
-class B
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
-    public string $foo;
-    public string $otherFoo;
 }

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\ObjectMapper;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\ObjectMapper\Condition\TargetClass;
+use Symfony\Component\ObjectMapper\Condition\ClassRuleConditionCallableInterface;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
 use Symfony\Component\ObjectMapper\Exception\NoSuchCallableException;
@@ -152,7 +152,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 if (
                     $if
                     && ($fn = $this->getCallable($if, $this->conditionCallableLocator, ConditionCallableInterface::class))
-                    && $fn instanceof TargetClass
+                    && $fn instanceof ClassRuleConditionCallableInterface
                     && !$this->call($fn, null, $source, $mappedTarget)
                 ) {
                     continue;

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/CostRequestWithSourceView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/CostRequestWithSourceView.php
@@ -3,7 +3,6 @@
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
 
 use Symfony\Component\ObjectMapper\Attribute\Map;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Cost;
 
 #[Map(source: Cost::class)]
 final class CostRequestWithSourceView

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassRule/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassRule/A.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Condition\ClassRule;
+use Symfony\Component\ObjectMapper\Condition\ClassRuleList;
+use Symfony\Component\ObjectMapper\Condition\SourceClass;
+use Symfony\Component\ObjectMapper\Condition\TargetClass;
+
+#[Map(source: B::class)]
+#[Map(source: C::class)]
+#[Map(target: B::class)]
+#[Map(target: C::class)]
+class A
+{
+    #[Map(
+        source: 'foo',
+        transform: 'strtolower',
+        if: new ClassRuleList([
+            new SourceClass(B::class),
+        ]),
+    )]
+    #[Map(
+        source: 'bar',
+        if: new ClassRuleList([
+            new ClassRule(sources: [C::class]),
+        ]),
+    )]
+    public string $somethingSourced;
+
+    #[Map(
+        target: 'foo',
+        transform: 'strtoupper',
+        if: new ClassRuleList([
+            new TargetClass(B::class),
+        ]),
+    )]
+    #[Map(
+        target: 'bar',
+        if: new ClassRuleList([
+            new ClassRule(targets: [C::class]),
+        ]),
+    )]
+    public string $somethingTargeted = 'testTargeted';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassRule/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassRule/B.php
@@ -9,10 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule;
 
 class B
 {
-    public string $foo;
-    public string $otherFoo;
+    public string $foo = 'testSourced';
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassRule/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassRule/C.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule;
 
-class B
+class C
 {
-    public string $foo;
-    public string $otherFoo;
+    public string $foo = 'donotmap';
+    public string $bar = 'TESTSOURCED';
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/InputSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ConditionalConstructorArgument/InputSource.php
@@ -7,6 +7,6 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 #[Map(ConstructorTarget::class)]
 class InputSource
 {
-    #[Map(if: new NotNullCondition)]
+    #[Map(if: new NotNullCondition())]
     public ?string $name = null;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DefaultValueStdClass/TargetDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DefaultValueStdClass/TargetDto.php
@@ -7,7 +7,7 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 class TargetDto
 {
     public function __construct(
-        public string  $id,
+        public string $id,
         #[Map(source: 'optional', if: [self::class, 'isDefined'])]
         public ?string $optional = null,
     ) {

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/HydrateObject/SourceOnly.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/HydrateObject/SourceOnly.php
@@ -17,7 +17,7 @@ class SourceOnly
 {
     public function __construct(
         #[Map(source: 'name')] public string $mappedName,
-        #[Map(if: false)] public ?string $mappedDescription = null
+        #[Map(if: false)] public ?string $mappedDescription = null,
     ) {
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/A.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Condition\SourceClass;
+
+#[Map(source: B::class)]
+#[Map(source: C::class)]
+class A
+{
+    #[Map(source: 'foo', transform: 'strtolower', if: new SourceClass(B::class))]
+    #[Map(source: 'bar', if: new SourceClass(C::class))]
+    public string $something;
+
+    #[Map(source: 'foo', transform: 'strtoupper', if: new SourceClass([B::class, C::class]))]
+    public string $somethingOther;
+
+    public string $doesNotExistInSourceB;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/B.php
@@ -9,10 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty;
 
 class B
 {
-    public string $foo;
-    public string $otherFoo;
+    public string $foo = 'test';
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/C.php
@@ -9,10 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty;
 
-class B
+class C
 {
-    public string $foo;
-    public string $otherFoo;
+    public string $foo = 'donotmap';
+    public string $bar = 'TEST';
+    public string $doesNotExistInSourceB = 'foo';
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/A.php
@@ -22,5 +22,8 @@ class A
     #[Map(target: 'bar')]
     public string $something = 'test';
 
+    #[Map(target: 'otherFoo', transform: 'strtolower', if: new TargetClass([B::class, C::class]))]
+    public string $somethingOther = 'TESTOTHER';
+
     public string $doesNotExistInTargetB = 'foo';
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/C.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
 class C
 {
     public string $foo = 'donotmap';
+    public string $otherFoo;
     public string $bar;
     public string $doesNotExistInTargetB;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataDto.php
@@ -19,4 +19,3 @@ class NestedBankDataDto
     public string $iban;
     public NestedBankDto $bank;
 }
-

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataResource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDataResource.php
@@ -18,4 +18,3 @@ class NestedBankDataResource
     public string $bankCode;
     public string $bankName;
 }
-

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMapping/NestedBankDto.php
@@ -22,4 +22,3 @@ class NestedBankDto
     #[Map(target: 'bankName')]
     public string $name;
 }
-

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ParentTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ParentTarget.php
@@ -10,7 +10,7 @@ class ParentTarget
     public ChildWithClassTransformTarget $childWithBothTransformers;
     public bool $transformed = false;
 
-    public static function createFromSource(ParentTarget $value, ParentSource $source): self
+    public static function createFromSource(self $value, ParentSource $source): self
     {
         $value->transformed = true;
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Source.php
@@ -17,7 +17,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Map;
 class Source
 {
     public function __construct(
-        public int    $number,
+        public int $number,
         public string $name,
     ) {
     }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Target.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PromotedConstructorWithMetadata/Target.php
@@ -19,7 +19,7 @@ class Target
          * happened earlier already.
          */
         public string $notOnSourceButRequired,
-        public int    $number,
+        public int $number,
         public string $name,
     ) {
     }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ReadOnlyPromotedProperty/ReadOnlyPromotedPropertyAMapped.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ReadOnlyPromotedProperty/ReadOnlyPromotedPropertyAMapped.php
@@ -2,8 +2,6 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ReadOnlyPromotedProperty;
 
-use Symfony\Component\ObjectMapper\Attribute\Map;
-
 final class ReadOnlyPromotedPropertyAMapped
 {
     public function __construct(

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ReadOnlyPromotedProperty/ReadOnlyPromotedPropertyBMapped.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ReadOnlyPromotedProperty/ReadOnlyPromotedPropertyBMapped.php
@@ -2,8 +2,6 @@
 
 namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ReadOnlyPromotedProperty;
 
-use Symfony\Component\ObjectMapper\Attribute\Map;
-
 final class ReadOnlyPromotedPropertyBMapped
 {
     public function __construct(

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
@@ -27,10 +27,10 @@ class ServiceLoadedValueTransformer implements TransformCallableInterface
     {
         $metadata = $this->metadata->create($value);
 
-        if (\count($metadata) !== 1) {
+        if (1 !== \count($metadata)) {
             throw new \LogicException('Exactly one metadata should be returned.');
         }
-        if ($metadata[0]->target !== LoadedValue::class) {
+        if (LoadedValue::class !== $metadata[0]->target) {
             throw new \LogicException('The target should be '.LoadedValue::class.'.');
         }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -32,6 +32,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\A as ClassRuleA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\B as ClassRuleB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\C as ClassRuleC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassWithoutTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalConstructorArgument\InputSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ConditionalSourceMap\Address as ConditionalSourceMapAddress;
@@ -70,6 +73,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Target;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\A as MapTargetToSourceA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\B as MapTargetToSourceB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\A as MultipleSourcePropertyA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\B as MultipleSourcePropertyB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\C as MultipleSourcePropertyC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\A as MultipleTargetPropertyA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as MultipleTargetPropertyB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
@@ -419,11 +425,61 @@ final class ObjectMapperTest extends TestCase
         $b = $mapper->map($u, MultipleTargetPropertyB::class);
         $this->assertInstanceOf(MultipleTargetPropertyB::class, $b);
         $this->assertEquals('TEST', $b->foo);
+        $this->assertEquals('testother', $b->otherFoo);
+
         $c = $mapper->map($u, MultipleTargetPropertyC::class);
         $this->assertInstanceOf(MultipleTargetPropertyC::class, $c);
         $this->assertEquals('test', $c->bar);
         $this->assertEquals('donotmap', $c->foo);
+        $this->assertEquals('testother', $c->otherFoo);
         $this->assertEquals('foo', $c->doesNotExistInTargetB);
+    }
+
+    public function testMultipleSourceMapProperty()
+    {
+        $b = new MultipleSourcePropertyB();
+        $c = new MultipleSourcePropertyC();
+        $mapper = new ObjectMapper();
+
+        $a1 = $mapper->map($b, MultipleSourcePropertyA::class);
+        $this->assertInstanceOf(MultipleSourcePropertyA::class, $a1);
+        $this->assertEquals('test', $a1->something);
+        $this->assertEquals('TEST', $a1->somethingOther);
+
+        $a2 = $mapper->map($c, MultipleSourcePropertyA::class);
+        $this->assertInstanceOf(MultipleSourcePropertyA::class, $a2);
+        $this->assertEquals('TEST', $a2->something);
+        $this->assertEquals('DONOTMAP', $a2->somethingOther);
+        $this->assertEquals('foo', $a2->doesNotExistInSourceB);
+    }
+
+    public function testMultipleClassRuleMapProperty()
+    {
+        $a = new ClassRuleA();
+
+        $mapper = new ObjectMapper();
+        $b = $mapper->map($a, ClassRuleB::class);
+        $this->assertInstanceOf(ClassRuleB::class, $b);
+        $this->assertEquals('TESTTARGETED', $b->foo);
+
+        $c = $mapper->map($a, ClassRuleC::class);
+        $this->assertInstanceOf(ClassRuleC::class, $c);
+        $this->assertEquals('testTargeted', $c->bar);
+        $this->assertEquals('donotmap', $c->foo);
+
+        $b = new ClassRuleB();
+        $c = new ClassRuleC();
+        $mapper = new ObjectMapper();
+
+        $a1 = $mapper->map($b, ClassRuleA::class);
+        $this->assertInstanceOf(ClassRuleA::class, $a1);
+        $this->assertEquals('testsourced', $a1->somethingSourced);
+        $this->assertEquals('testTargeted', $a1->somethingTargeted);
+
+        $a2 = $mapper->map($c, ClassRuleA::class);
+        $this->assertInstanceOf(ClassRuleA::class, $a2);
+        $this->assertEquals('TESTSOURCED', $a2->somethingSourced);
+        $this->assertEquals('testTargeted', $a2->somethingTargeted);
     }
 
     public function testDefaultValueStdClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63370
| License       | MIT

This PR adds class-based condition callables to the ObjectMapper component, reducing the number of `Map` attributes needed for multi-class bidirectional mappings. It supersedes #63316.

**New classes:**

- `SourceClass` — conditions a mapping rule based on the source object's class (mirrors the existing `TargetClass`)
- `ClassRule` — combines source and target class checks in a single condition
- `ClassRuleList` — matches when any of its child rules (`SourceClass`, `TargetClass`, or `ClassRule`) matches

**Array FQDN support:**

`TargetClass` and `SourceClass` now accept an array of class names, matching when the object is an instance of any of them.

### Examples

**Before** — one `Map` attribute per source class, repeated conditions:

```php
#[Map(source: B::class)]
#[Map(source: C::class)]
class A
{
    #[Map(source: 'foo', if: new SourceClass(B::class))]
    #[Map(source: 'foo', if: new SourceClass(C::class))]
    public string $something;
}
```

After — single attribute with an array:

```php
#[Map(source: B::class)]
#[Map(source: C::class)]
class A
{
    #[Map(source: 'foo', if: new SourceClass([B::class, C::class]))]
    public string $something;
}
```

Combined source + target check with ClassRule:

```php
#[Map(
    target: 'bar',
    if: new ClassRuleList([
        new ClassRule(sources: [A::class], targets: [C::class]),
    ]),
)]
public string $value = 'test';
```

Bidirectional mapping with ClassRuleList:

```php
#[Map(source: B::class)]
#[Map(source: C::class)]
#[Map(target: B::class)]
#[Map(target: C::class)]
class A
{
    #[Map(source: 'foo', transform: 'strtolower', if: new ClassRuleList([new SourceClass(B::class)]))]
    #[Map(source: 'bar', if: new ClassRuleList([new ClassRule(sources: [C::class])]))]
    public string $somethingSourced;

    #[Map(target: 'foo', transform: 'strtoupper', if: new ClassRuleList([new TargetClass(B::class)]))]
    #[Map(target: 'bar', if: new ClassRuleList([new ClassRule(targets: [C::class])]))]
    public string $somethingTargeted = 'testTargeted';
}
```
