### PR TITLE
[WebProfilerBundle] Misc improvements in the profiler templates

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/command.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/command.html.twig
@@ -72,7 +72,7 @@
 
                 {% if collector.arguments is empty %}
                     <div class="empty">
-                        <p>No arguments were set</p>
+                        <p>No arguments.</p>
                     </div>
                 {% else %}
                     {{ include('@WebProfiler/Profiler/table.html.twig', {data: collector.arguments, labels: ['Argument', 'Value'], maxDepth: 2}, with_context: false) }}
@@ -82,7 +82,7 @@
 
                 {% if collector.options is empty %}
                     <div class="empty">
-                        <p>No options were set</p>
+                        <p>No options.</p>
                     </div>
                 {% else %}
                     {{ include('@WebProfiler/Profiler/table.html.twig', {data: collector.options, labels: ['Option', 'Value'], maxDepth: 2}, with_context: false) }}
@@ -97,7 +97,7 @@
 
                     {% if collector.interactiveInputs is empty %}
                         <div class="empty">
-                            <p>No inputs were set</p>
+                            <p>No inputs.</p>
                         </div>
                     {% else %}
                         {{ include('@WebProfiler/Profiler/table.html.twig', {data: collector.interactiveInputs, labels: ['Input', 'Value'], maxDepth: 2}, with_context: false) }}
@@ -108,7 +108,7 @@
 
                 {% if collector.applicationInputs is empty %}
                     <div class="empty">
-                        <p>No application inputs are set</p>
+                        <p>No application inputs.</p>
                     </div>
                 {% else %}
                     {{ include('@WebProfiler/Profiler/table.html.twig', {data: collector.applicationInputs, labels: ['Input', 'Value'], maxDepth: 2}, with_context: false) }}
@@ -121,14 +121,16 @@
 
             <div class="tab-content">
                 <table>
-                    <tr>
-                        <td class="font-normal">Input</td>
-                        <td class="font-normal">{{ profiler_dump(collector.input) }}</td>
-                    </tr>
-                    <tr>
-                        <td class="font-normal">Output</td>
-                        <td class="font-normal">{{ profiler_dump(collector.output) }}</td>
-                    </tr>
+                    <tbody>
+                        <tr>
+                            <th class="font-normal" scope="row">Input</th>
+                            <td class="font-normal">{{ profiler_dump(collector.input) }}</td>
+                        </tr>
+                        <tr>
+                            <th class="font-normal" scope="row">Output</th>
+                            <td class="font-normal">{{ profiler_dump(collector.output) }}</td>
+                        </tr>
+                    </tbody>
                 </table>
             </div>
         </div>
@@ -142,7 +144,7 @@
                         <p>No helpers</p>
                     </div>
                 {% else %}
-                    <table class="{{ class|default('') }}">
+                    <table>
                         <thead>
                         <tr>
                             <th scope="col">Helpers</th>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -62,8 +62,11 @@
             text-decoration: none;
         }
 
+        .sf-profiler-form-col-property { width: 180px; }
+
+        .tree-wrapper { display: flex; gap: 0; }
+
         #tree-menu {
-            float: left;
             padding-right: 10px;
             width: 220px;
         }
@@ -84,8 +87,9 @@
         }
         #tree-details-container {
             border-left: 1px solid var(--table-border-color);
-            margin-left: 230px;
             padding-left: 20px;
+            flex: 1;
+            min-width: 0;
         }
         .tree-details {
             padding-bottom: 40px;
@@ -107,6 +111,8 @@
             position: relative;
             overflow: hidden;
             text-overflow: ellipsis;
+            display: flex;
+            align-items: center;
         }
         .tree .toggle-button {
             width: 16px;
@@ -166,9 +172,8 @@
             margin-left: 6px;
         }
         .badge-error {
-            float: right;
             background: var(--background-error);
-            color: #FFF;
+            color: var(--base-0, #FFF);
             padding: 1px 4px;
             font-size: 10px;
             font-weight: bold;
@@ -182,7 +187,7 @@
         }
         .errors th {
             background: var(--background-error);
-            color: #FFF;
+            color: var(--base-0, #FFF);
         }
         .errors .toggle-icon {
             background-color: var(--background-error);
@@ -218,7 +223,7 @@
             #initTrees() {
                 const treeItems = document.querySelectorAll('.tree .tree-inner');
                 treeItems.forEach((treeItem) => {
-                    var targetId = treeItem.getAttribute('data-tab-target-id');
+                    const targetId = treeItem.getAttribute('data-tab-target-id');
                     const target = document.getElementById(targetId);
 
                     if (!target) {
@@ -379,18 +384,20 @@
     <h2>Forms</h2>
 
     {% if collector.data.forms|length %}
-        <div id="tree-menu" class="tree">
-            <ul>
-            {% for formName, formData in collector.data.forms %}
-                {{ _self.form_tree_entry(formName, formData, true) }}
-            {% endfor %}
-            </ul>
-        </div>
+        <div class="tree-wrapper">
+            <div id="tree-menu" class="tree">
+                <ul>
+                {% for formName, formData in collector.data.forms %}
+                    {{ _self.form_tree_entry(formName, formData, true) }}
+                {% endfor %}
+                </ul>
+            </div>
 
-        <div id="tree-details-container">
-            {% for formName, formData in collector.data.forms %}
-                {{ _self.form_tree_details(formName, formData, collector.data.forms_by_hash, loop.first) }}
-            {% endfor %}
+            <div id="tree-details-container">
+                {% for formName, formData in collector.data.forms %}
+                    {{ _self.form_tree_details(formName, formData, collector.data.forms_by_hash, loop.first) }}
+                {% endfor %}
+            </div>
         </div>
     {% else %}
         <div class="empty empty-panel">
@@ -548,7 +555,7 @@
         <table>
             <thead>
             <tr>
-                <th style="width: 180px">Property</th>
+                <th class="sf-profiler-form-col-property">Property</th>
                 <th>Value</th>
             </tr>
             </thead>
@@ -581,7 +588,7 @@
         </table>
     {% else %}
         <div class="empty">
-            <p>This form has default data defined.</p>
+            <p>No default data defined.</p>
         </div>
     {% endif %}
 {% endmacro %}
@@ -591,7 +598,7 @@
         <table>
             <thead>
             <tr>
-                <th style="width: 180px">Property</th>
+                <th class="sf-profiler-form-col-property">Property</th>
                 <th>Value</th>
             </tr>
             </thead>
@@ -634,7 +641,7 @@
         <table>
             <thead>
             <tr>
-                <th style="width: 180px">Option</th>
+                <th class="sf-profiler-form-col-property">Option</th>
                 <th>Passed Value</th>
                 <th>Resolved Value</th>
             </tr>
@@ -671,7 +678,7 @@
     <table>
         <thead>
         <tr>
-            <th style="width: 180px">Option</th>
+            <th class="sf-profiler-form-col-property">Option</th>
             <th>Value</th>
         </tr>
         </thead>
@@ -690,7 +697,7 @@
     <table>
         <thead>
         <tr>
-            <th style="width: 180px">Variable</th>
+            <th class="sf-profiler-form-col-property">Variable</th>
             <th>Value</th>
         </tr>
         </thead>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -7,10 +7,16 @@
         :root {
             --log-filter-active-num-color: #2563EB;
             --log-timestamp-color: #555;
+            --log-silenced-bg: #EDE9FE;
+            --log-silenced-color: #6D28D9;
+            --log-silenced-border: #a78bfa;
         }
         .theme-dark {
             --log-filter-active-num-color: #2563EB;
             --log-timestamp-color: #ccc;
+            --log-silenced-bg: #5B21B6;
+            --log-silenced-color: #EDE9FE;
+            --log-silenced-border: #a78bfa;
         }
 
         .log-filters {
@@ -181,12 +187,8 @@
             color: var(--badge-danger-color);
         }
         .log-type-badge.badge-silenced {
-            background: #EDE9FE;
-            color: #6D28D9;
-        }
-        .theme-dark .log-type-badge.badge-silenced {
-            background: #5B21B6;
-            color: #EDE9FE;
+            background: var(--log-silenced-bg);
+            color: var(--log-silenced-color);
         }
 
         tr.log-status-warning > td:first-child,
@@ -213,7 +215,11 @@
             background: var(--red-400);
         }
         tr.log-status-silenced > td:first-child:before {
-            background: #a78bfa;
+            background: var(--log-silenced-border);
+        }
+
+        .sf-profiler-log-col-time {
+            width: 140px;
         }
 
         .container-compilation-logs {
@@ -439,56 +445,58 @@
             </details>
         </div>
 
-        <table class="logs">
-            <colgroup>
-                <col style="width: 140px">
-                <col>
-            </colgroup>
+        <div aria-live="polite">
+            <table class="logs">
+                <colgroup>
+                    <col class="sf-profiler-log-col-time">
+                    <col>
+                </colgroup>
 
-            <thead>
-                <tr>
-                    <th>Time</th>
-                    <th>Message</th>
-                </tr>
-            </thead>
-
-            <tbody>
-                {% for log in collector.processedLogs %}
-                    {% set css_class = 'error' == log.type ? 'error'
-                        : (log.priorityName == 'WARNING' or 'deprecation' == log.type) ? 'warning'
-                        : 'silenced' == log.type ? 'silenced'
-                    %}
-                    <tr class="log-status-{{ css_class }}" data-type="{{ log.type }}" data-priority="{{ log.priority }}" data-channel="{{ log.channel }}" style="{{ 'event' == log.channel or 'DEBUG' == log.priorityName ? 'display: none' }}">
-                        <td class="log-timestamp">
-                            <time class="newline" title="{{ log.timestamp|date('r') }}" datetime="{{ log.timestamp|date(constant('DateTimeInterface::RFC3339_EXTENDED')) }}" data-convert-to-user-timezone data-render-as-time data-render-with-millisecond-precision>
-                                {{ log.timestamp|date('H:i:s.v') }}
-                            </time>
-
-                            {% if log.type in ['error', 'deprecation', 'silenced'] or 'WARNING' == log.priorityName %}
-                                <span class="log-type-badge badge badge-{{ css_class }}">
-                                    {% if 'error' == log.type or 'WARNING' == log.priorityName %}
-                                        {{ log.priorityName|lower }}
-                                    {% else %}
-                                        {{ log.type|lower }}
-                                    {% endif %}
-                                </span>
-                            {% else %}
-                                <span class="log-type-badge badge badge-{{ css_class }}">
-                                    {{ log.priorityName|lower }}
-                                </span>
-                            {% endif %}
-                        </td>
-
-                        <td class="font-normal">
-                            {{ _self.render_log_message('debug', loop.index, log) }}
-                        </td>
+                <thead>
+                    <tr>
+                        <th>Time</th>
+                        <th>Message</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
 
-        <div class="no-logs-message empty">
-            <p>There are no log messages.</p>
+                <tbody>
+                    {% for log in collector.processedLogs %}
+                        {% set css_class = 'error' == log.type ? 'error'
+                            : (log.priorityName == 'WARNING' or 'deprecation' == log.type) ? 'warning'
+                            : 'silenced' == log.type ? 'silenced'
+                        %}
+                        <tr class="log-status-{{ css_class }}" data-type="{{ log.type }}" data-priority="{{ log.priority }}" data-channel="{{ log.channel }}" style="{{ 'event' == log.channel or 'DEBUG' == log.priorityName ? 'display: none' }}">
+                            <td class="log-timestamp">
+                                <time class="newline" title="{{ log.timestamp|date('r') }}" datetime="{{ log.timestamp|date(constant('DateTimeInterface::RFC3339_EXTENDED')) }}" data-convert-to-user-timezone data-render-as-time data-render-with-millisecond-precision>
+                                    {{ log.timestamp|date('H:i:s.v') }}
+                                </time>
+
+                                {% if log.type in ['error', 'deprecation', 'silenced'] or 'WARNING' == log.priorityName %}
+                                    <span class="log-type-badge badge badge-{{ css_class }}">
+                                        {% if 'error' == log.type or 'WARNING' == log.priorityName %}
+                                            {{ log.priorityName|lower }}
+                                        {% else %}
+                                            {{ log.type|lower }}
+                                        {% endif %}
+                                    </span>
+                                {% else %}
+                                    <span class="log-type-badge badge badge-{{ css_class }}">
+                                        {{ log.priorityName|lower }}
+                                    </span>
+                                {% endif %}
+                            </td>
+
+                            <td class="font-normal">
+                                {{ _self.render_log_message('debug', loop.index, log) }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+            <div class="no-logs-message empty">
+                <p>There are no log messages.</p>
+            </div>
         </div>
     {% endif %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -155,6 +155,10 @@
             width: 18px;
             margin-right: 3px;
         }
+        .sf-profiler-mailer-scrollable {
+            max-height: 600px;
+            overflow-y: auto;
+        }
     </style>
 {% endblock %}
 
@@ -331,7 +335,7 @@
                 Download as EML file
             </a>
 
-            <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+            <pre class="prewrap sf-profiler-mailer-scrollable" style="margin-left: 5px">{{ message.toString() }}</pre>
         {% else %}
             <div class="sf-tabs">
                 <div class="tab">
@@ -412,7 +416,7 @@
                                     <h3 class="tab-title">Text content</h3>
                                     <div class="tab-content">
                                         {% if textBody %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            <pre class="mailer-email-body prewrap sf-profiler-mailer-scrollable">
                                                 {%- if message.textCharset() %}
                                                     {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
                                                 {%- else %}
@@ -431,7 +435,7 @@
                                     <div class="tab">
                                         <h3 class="tab-title">HTML preview</h3>
                                         <div class="tab-content">
-                                            <pre class="prewrap" style="max-height: 600px"><iframe src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}" style="height: 80vh;width: 100%;"></iframe>
+                                            <pre class="prewrap sf-profiler-mailer-scrollable"><iframe src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}" style="height: 80vh;width: 100%;"></iframe>
                                             </pre>
                                         </div>
                                     </div>
@@ -441,7 +445,7 @@
                                     <h3 class="tab-title">HTML content</h3>
                                     <div class="tab-content">
                                         {% if htmlBody %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            <pre class="mailer-email-body prewrap sf-profiler-mailer-scrollable">
                                                 {%- if message.htmlCharset() %}
                                                     {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
                                                 {%- else %}
@@ -461,7 +465,7 @@
                                     <h3 class="tab-title">Content</h3>
                                     <div class="tab-content">
                                         {% if body %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            <pre class="mailer-email-body prewrap sf-profiler-mailer-scrollable">
                                                 {{- body }}
                                             </pre>
                                         {% else %}
@@ -480,7 +484,7 @@
                 <div class="tab">
                     <h3 class="tab-title">MIME parts</h3>
                     <div class="tab-content">
-                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.body().asDebugString() }}</pre>
+                        <pre class="prewrap sf-profiler-mailer-scrollable" style="margin-left: 5px">{{ message.body().asDebugString() }}</pre>
                     </div>
                 </div>
 
@@ -492,7 +496,7 @@
                             Download as EML file
                         </a>
 
-                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+                        <pre class="prewrap sf-profiler-mailer-scrollable" style="margin-left: 5px">{{ message.toString() }}</pre>
                     </div>
                 </div>
             </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -4,6 +4,10 @@
     {{ parent() }}
 
     <style>
+        :root {
+            --messenger-error-color: #B0413E;
+        }
+
         .message-item thead th { position: relative; cursor: pointer; user-select: none; padding-right: 35px; }
         .message-item tbody tr td:first-child { width: 170px; }
 
@@ -15,7 +19,7 @@
         .message-item .sf-toggle-off .icon-close, .sf-toggle-on .icon-open { display: none; }
         .message-item .sf-toggle-off .icon-open, .sf-toggle-on .icon-close { display: block; }
 
-        .message-bus .badge.status-some-errors { line-height: 16px; border-bottom: 2px solid #B0413E; }
+        .message-bus .badge.status-some-errors { line-height: 16px; border-bottom: 2px solid var(--messenger-error-color); }
 
         .message-item tbody.sf-toggle-content.sf-toggle-visible { display: table-row-group; }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -17,7 +17,7 @@
 
             {% for transport in events.transports %}
                 <div class="sf-toolbar-info-piece">
-                    <b>{{ transport ?: '<em>Empty Transport Name</em>' }}</b>
+                    <b>{% if transport %}{{ transport }}{% else %}<em>Empty Transport Name</em>{% endif %}</b>
                     <span class="sf-toolbar-status">{{ events.messages(transport)|length }}</span>
                 </div>
             {% endfor %}
@@ -30,9 +30,10 @@
 {% block head %}
     {{ parent() }}
     <style>
-        /* utility classes */
-        .m-t-0 { margin-top: 0 !important; }
-        .m-t-10 { margin-top: 10px !important; }
+        .sf-profiler-notifier-scrollable {
+            max-height: 600px;
+            overflow-y: auto;
+        }
 
         /* basic grid */
         .row {
@@ -100,7 +101,7 @@
     </div>
 
     {% for transport in events.transports %}
-        <h3>{{ transport ?: '<em>Empty Transport Name</em>' }}</h3>
+        <h3>{% if transport %}{{ transport }}{% else %}<em>Empty Transport Name</em>{% endif %}</h3>
 
         <div class="card-block">
             <div class="sf-tabs sf-tabs-sm">
@@ -112,7 +113,7 @@
                             <div class="card">
                                 <div class="card-block">
                                     <span class="label">Subject</span>
-                                    <h2 class="m-t-10">{{ message.getSubject() ?? '(empty)' }}</h2>
+                                    <h2 style="margin-top: 10px">{{ message.getSubject() ?? '(empty)' }}</h2>
                                 </div>
                                 {% set notification = message.notification ?? null %}
                                 {% if notification %}
@@ -133,7 +134,7 @@
                                                 <div class="tab">
                                                     <h3 class="tab-title">Notification</h3>
                                                     <div class="tab-content">
-                                                        <pre class="prewrap" style="max-height: 600px">
+                                                        <pre class="prewrap sf-profiler-notifier-scrollable">
                                                             {{- 'Subject: ' ~ notification.getSubject() }}<br/>
                                                             {{- 'Content: ' ~ notification.getContent() }}<br/>
                                                             {{- 'Importance: ' ~ notification.getImportance() }}<br/>
@@ -147,7 +148,7 @@
                                                 <div class="tab">
                                                     <h3 class="tab-title">Message Options</h3>
                                                     <div class="tab-content">
-                                                        <pre class="prewrap" style="max-height: 600px">
+                                                        <pre class="prewrap sf-profiler-notifier-scrollable">
                                                             {%- if message.getOptions() is null %}
                                                                 {{- '(empty)' }}
                                                             {%- else %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -20,6 +20,10 @@
         .empty-query-post-files .empty {
             margin-bottom: 0;
         }
+        .sf-profiler-request-scrollable {
+            max-height: 500px;
+            overflow-y: auto;
+        }
     </style>
 {% endblock %}
 
@@ -83,7 +87,7 @@
             </div>
 
             <div class="sf-toolbar-info-piece">
-                <b>Stateless Check</b>
+                <b>Stateless check</b>
                 <span>{% if collector.statelesscheck %}yes{% else %}no{% endif %}</span>
             </div>
         </div>
@@ -139,7 +143,7 @@
             <div class="tab-content">
                 {% set has_no_query_post_or_files = collector.requestquery.all is empty and collector.requestrequest.all is empty and collector.requestfiles is empty %}
                 {% if has_no_query_post_or_files %}
-                    <div class="empty-query-post-files" style="display: flex; align-items: stretch">
+                    <div class="empty-query-post-files">
                         <div>
                             <h3>GET Parameters</h3>
                             <div class="empty"><p>None</p></div>
@@ -174,11 +178,11 @@
                         {{ include('@WebProfiler/Profiler/bag.html.twig', {bag: collector.requestrequest, maxDepth: 1}, with_context: false) }}
                     {% endif %}
 
-                    <h4>Uploaded Files</h4>
+                    <h3>Uploaded Files</h3>
 
                     {% if collector.requestfiles is empty %}
                         <div class="empty">
-                            <p>No files were uploaded</p>
+                            <p>No uploaded files</p>
                         </div>
                     {% else %}
                         {{ include('@WebProfiler/Profiler/bag.html.twig', {bag: collector.requestfiles, maxDepth: 1}, with_context: false) }}
@@ -189,7 +193,7 @@
 
                 {% if collector.requestattributes.all is empty %}
                     <div class="empty">
-                        <p>No attributes</p>
+                        <p>No request attributes</p>
                     </div>
                 {% else %}
                     {{ include('@WebProfiler/Profiler/bag.html.twig', {bag: collector.requestattributes}, with_context: false) }}
@@ -211,7 +215,7 @@
                         <div class="tab">
                             <h3 class="tab-title">Pretty</h3>
                             <div class="tab-content">
-                                <div class="card" style="max-height: 500px; overflow-y: auto;">
+                                <div class="card sf-profiler-request-scrollable">
                                     <pre class="break-long-words">{{ prettyJson }}</pre>
                                 </div>
                             </div>
@@ -229,12 +233,12 @@
                     </div>
                 {% else %}
                     <div class="empty">
-                        <p>No content</p>
+                        <p>No request content</p>
                     </div>
                 {% endif %}
 
                 {% if collector.curlCommand is defined and collector.curlCommand != '' %}
-                    <h3>Retry command</h3>
+                    <h3>Retry Command</h3>
                     <div class="card">
                         <button class="btn btn-sm hidden" title="Copy as cURL" data-clipboard-text="{{ collector.curlCommand }}">Copy as cURL</button>
                         <pre class="break-long-words">{{ collector.curlCommand }}</pre>
@@ -402,7 +406,7 @@
 
         {% if profile.children|length %}
         <div class="tab">
-            <h3 class="tab-title">Sub Requests <span class="badge">{{ profile.children|length }}</span></h3>
+            <h3 class="tab-title">Sub-Requests <span class="badge">{{ profile.children|length }}</span></h3>
 
             <div class="tab-content">
                 {% for child in profile.children %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -25,6 +25,10 @@
         #collector-content .sf-serializer .trace li.selected {
             background: var(--highlight-selected-line);
         }
+        #collector-content .sf-serializer .sf-serializer-compact-list {
+            line-height: 80%;
+            margin-top: 10px;
+        }
     </style>
 {% endblock %}
 
@@ -125,7 +129,7 @@
 
 {% macro render_serializer_tab(collector, serializer) %}
     <div class="tab">
-        <h3 class="tab-title">{{ serializer }} <span class="badge">{{ collector.handledCount(serializer) }}</h3>
+        <h3 class="tab-title">{{ serializer }} <span class="badge">{{ collector.handledCount(serializer) }}</span></h3>
         <div class="tab-content">
             <div class="sf-tabs">
                 {{ _self.render_serialize_tab(collector.data(serializer), true, serializer) }}
@@ -146,7 +150,7 @@
     {% set cellPrefix = serialize ? 'serialize' : 'deserialize' %}
 
     <div class="tab {{ not data ? 'disabled' }}">
-        <h3 class="tab-title">{{ serialize ? 'serialize' : 'deserialize' }} <span class="badge">{{ data|length }}</h3>
+        <h3 class="tab-title">{{ serialize ? 'serialize' : 'deserialize' }} <span class="badge">{{ data|length }}</span></h3>
         <div class="tab-content">
             {% if not data|length %}
                 <div class="empty">
@@ -219,7 +223,7 @@
     {% set cellPrefix = normalize ? 'normalize' : 'denormalize' %}
 
     <div class="tab {{ not data ? 'disabled' }}">
-        <h3 class="tab-title">{{ normalize ? 'normalize' : 'denormalize' }} <span class="badge">{{ data|length }}</h3>
+        <h3 class="tab-title">{{ normalize ? 'normalize' : 'denormalize' }} <span class="badge">{{ data|length }}</span></h3>
         <div class="tab-content">
             {% if not data|length %}
                 <div class="empty">
@@ -258,7 +262,7 @@
     {% set cellPrefix = encode ? 'encode' : 'decode' %}
 
     <div class="tab {{ not data ? 'disabled' }}">
-        <h3 class="tab-title">{{ encode ? 'encode' : 'decode' }} <span class="badge">{{ data|length }}</h3>
+        <h3 class="tab-title">{{ encode ? 'encode' : 'decode' }} <span class="badge">{{ data|length }}</span></h3>
         <div class="tab-content">
             {% if not data|length %}
                 <div class="empty">
@@ -334,7 +338,7 @@
         <div>
             <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ nested_normalizers_id }}" data-toggle-alt-content="Hide nested normalizers">Show nested normalizers</a>
             <div id="{{ nested_normalizers_id }}" class="context sf-toggle-content sf-toggle-hidden">
-                <ul class="text-small" style="line-height:80%;margin-top:10px">
+                <ul class="text-small sf-serializer-compact-list">
                     {% for normalizer in item.normalization %}
                         <li><span class="nowrap">x{{ normalizer.calls }} <a href="{{ normalizer.file|file_link(normalizer.line) }}" title="{{ normalizer.file }}">{{ normalizer.class }}</a> ({{ '%.2f'|format(normalizer.time * 1000) }} ms)</span></li>
                     {% endfor %}
@@ -355,7 +359,7 @@
         <div>
             <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ nested_encoders_id }}" data-toggle-alt-content="Hide nested encoders">Show nested encoders</a>
             <div id="{{ nested_encoders_id }}" class="context sf-toggle-content sf-toggle-hidden">
-                <ul class="text-small" style="line-height:80%;margin-top:10px">
+                <ul class="text-small sf-serializer-compact-list">
                     {% for encoder in item.encoding %}
                         <li><span class="nowrap">x{{ encoder.calls }} <a href="{{ encoder.file|file_link(encoder.line) }}" title="{{ encoder.file }}">{{ encoder.class }}</a> ({{ '%.2f'|format(encoder.time * 1000) }} ms)</span></li>
                     {% endfor %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
@@ -445,8 +445,8 @@ class Theme {
 
     // copied from https://github.com/darkskyapp/string-hash
     hash(string) {
-        var hash = 5381;
-        var i = string.length;
+        let hash = 5381;
+        let i = string.length;
 
         while(i) {
             hash = (hash * 33) ^ string.charCodeAt(--i);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -137,7 +137,7 @@
                     <p class="help">
                         These messages are not available for the given locale and cannot
                         be found in the fallback locales. Add them to the translation
-                        catalogue to avoid Symfony outputting untranslated contents.
+                        catalogue to prevent untranslated content from being displayed.
                     </p>
 
                     {% if messages_missing is empty %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
@@ -121,7 +121,9 @@
                     {% endfor %}
                 </table>
             {% else %}
-                No violations
+                <div class="empty">
+                    <p>No violations</p>
+                </div>
             {% endif %}
         </div>
     {% else %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
@@ -83,7 +83,7 @@
             font-size: .85em;
         }
 
-        dialog menu {
+        dialog .dialog-buttons {
             display: none;
         }
 
@@ -148,7 +148,7 @@
                     fontSize: 'var(--font-size-body)',
                     // the properties below don't support CSS variables
                     primaryColor: isDarkMode ? 'lightsteelblue' : 'aliceblue',
-                    primaryTextColor: isDarkMode ? '#000' : '#000',
+                    primaryTextColor: isDarkMode ? '#fff' : '#000',
                     primaryBorderColor: isDarkMode ? 'steelblue' : 'lightsteelblue',
                     lineColor: isDarkMode ? '#939393' : '#d4d4d4',
                     secondaryColor: isDarkMode ? 'lightyellow' : 'lightyellow',
@@ -243,7 +243,7 @@
                 dialog.dataset.processed = true;
             };
             // We do not load all mermaid diagrams at once, but only when the tab is opened
-            // This is because mermaid diagrams are in a tab, and cannot be renderer with a
+            // This is because mermaid diagrams are in a tab, and cannot be rendered with a
             // "good size" if they are not visible
             document.addEventListener('DOMContentLoaded', () => {
                 document.querySelectorAll('.tab').forEach((el) => {
@@ -335,8 +335,8 @@
         </div>
     {% endif %}
 
-    <dialog id="detailsDialog">
-        <h2>
+    <dialog id="detailsDialog" aria-labelledby="workflow-dialog-title">
+        <h2 id="workflow-dialog-title">
             Event listeners
             <i class="cancel">×</i>
         </h2>
@@ -351,9 +351,9 @@
             <tbody>
             </tbody>
         </table>
-        <menu>
+        <footer class="dialog-buttons">
             <small><i>⌨</i> <kbd>esc</kbd></small>
             <button class="btn btn-sm cancel">Close</button>
-        </menu>
+        </footer>
     </dialog>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_request_summary.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/_request_summary.html.twig
@@ -56,7 +56,7 @@
 
         {% set referer = request_collector ? request_collector.requestheaders.get('referer') : null %}
         {% if referer %}
-            <dt></dt>
+            <dt>Referer</dt>
             <dd>
                 <span class="icon icon-referer">{{ source('@WebProfiler/Icon/referrer.svg') }}</span>
                 <a href="{{ referer }}" class="referer">Browse referrer URL</a>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -76,7 +76,7 @@
                     }
 
                     tab.addEventListener('click', function(e) {
-                        let activeTab = e.target || e.srcElement;
+                        let activeTab = e.target;
 
                         /* needed because when the tab contains HTML contents, user can click */
                         /* on any of those elements instead of their parent '<button>' element */

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -35,6 +35,7 @@
                             </div>
 
                             {% if templates is defined %}
+                                <nav aria-label="Profiler menu">
                                 <ul id="menu-profiler">
                                     {% if 'request' is same as(profile_type) %}
                                         {% set excludes = ['command'] %}
@@ -57,6 +58,7 @@
                                         {% endif %}
                                     {% endfor %}
                                 </ul>
+                                </nav>
                             {% endif %}
                         </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

It fixes misc. minor things found in profiler templates:

* Wrong HTML code (e.g. missing `</span>` closing tag)
* Improved accessibility of certain elements
* Outdated JS code
* Updated some CSS to use variables and extracted common inline styles into classes
* Updated some texts to make everything more consistent

None of these changes fix things that prevent using the profiler, so they don't qualify as bug fixes but as improvements. Thanks.