### PR TITLE
[Cache][Messenger] Align Redis sentinel auth handling across components

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -204,4 +204,139 @@ class RedisTraitTest extends TestCase
             ],
         ];
     }
+
+    #[DataProvider('providePredisMasterAuthResolution')]
+    public function testPredisMasterAuthResolution(string $dsn, array $options, string|array|null $expectedMasterAuth)
+    {
+        $predisClass = $this->createPredisCaptureClass();
+
+        $mock = new class {
+            use RedisTrait;
+        };
+
+        $mock::createConnection($dsn, ['class' => $predisClass] + $options);
+
+        $this->assertAuthMatchesExpected($expectedMasterAuth, $predisClass::$captured['options']['parameters'] ?? []);
+    }
+
+    public static function providePredisMasterAuthResolution(): \Generator
+    {
+        yield 'userinfo user+pass' => [
+            'redis://user:pass@localhost',
+            [],
+            ['user', 'pass'],
+        ];
+
+        yield 'userinfo with @ + query auth array' => [
+            'redis://user@pass@localhost?auth[]=otheruser&auth[]=otherpass',
+            [],
+            ['otheruser', 'otherpass'],
+        ];
+
+        yield 'query auth array' => [
+            'redis://localhost?auth[]=user&auth[]=pass',
+            [],
+            ['user', 'pass'],
+        ];
+
+        yield 'options auth array' => [
+            'redis://localhost',
+            ['auth' => ['user', 'pass']],
+            ['user', 'pass'],
+        ];
+
+        yield 'query auth beats options auth' => [
+            'redis://localhost?auth[]=query-user&auth[]=query-pass',
+            ['auth' => ['opt-user', 'opt-pass']],
+            ['query-user', 'query-pass'],
+        ];
+    }
+
+    #[DataProvider('providePredisSentinelAuthResolution')]
+    public function testPredisSentinelAuthResolution(string $dsn, array $options, string|array|null $expectedMasterAuth, string|array|null $expectedSentinelAuth)
+    {
+        $predisClass = $this->createPredisCaptureClass();
+
+        $mock = new class {
+            use RedisTrait;
+        };
+
+        $mock::createConnection($dsn, ['class' => $predisClass] + $options);
+
+        $this->assertAuthMatchesExpected($expectedMasterAuth, $predisClass::$captured['options']['parameters'] ?? []);
+        $this->assertAuthMatchesExpected($expectedSentinelAuth, $predisClass::$captured['parameters'][0] ?? []);
+    }
+
+    public static function providePredisSentinelAuthResolution(): \Generator
+    {
+        yield 'sentinel query auth, master userinfo' => [
+            'redis://master-user:master-pass@localhost?redis_sentinel=mymaster&auth[]=sentinel-user&auth[]=sentinel-pass',
+            [],
+            ['master-user', 'master-pass'],
+            ['sentinel-user', 'sentinel-pass'],
+        ];
+
+        yield 'sentinel options auth when query missing' => [
+            'redis://master-pass@localhost?redis_sentinel=mymaster',
+            ['auth' => ['sentinel-user', 'sentinel-pass']],
+            'master-pass',
+            ['sentinel-user', 'sentinel-pass'],
+        ];
+
+        yield 'sentinel query auth beats options auth' => [
+            'redis://master-pass@localhost?redis_sentinel=mymaster&auth[]=query-user&auth[]=query-pass',
+            ['auth' => ['opt-user', 'opt-pass']],
+            'master-pass',
+            ['query-user', 'query-pass'],
+        ];
+    }
+
+    private function assertAuthMatchesExpected(string|array|null $expectedAuth, array $parameters): void
+    {
+        if (null === $expectedAuth) {
+            self::assertArrayNotHasKey('username', $parameters);
+            self::assertArrayNotHasKey('password', $parameters);
+
+            return;
+        }
+
+        if (\is_array($expectedAuth)) {
+            self::assertSame($expectedAuth[0], $parameters['username'] ?? null);
+            self::assertSame($expectedAuth[1], $parameters['password'] ?? null);
+
+            return;
+        }
+
+        self::assertArrayNotHasKey('username', $parameters);
+        self::assertSame($expectedAuth, $parameters['password'] ?? null);
+    }
+
+    private function createPredisCaptureClass(): string
+    {
+        $predisClass = new class extends \Predis\Client {
+            public static array $captured = [];
+            private object $connection;
+
+            public function __construct($parameters = null, $options = null)
+            {
+                self::$captured = [
+                    'parameters' => $parameters,
+                    'options' => $options,
+                ];
+                $this->connection = new class {
+                    public function setSentinelTimeout(float $timeout): void
+                    {
+                    }
+                };
+            }
+
+            public function getConnection()
+            {
+                return $this->connection;
+            }
+        };
+
+        return $predisClass::class;
+    }
+
 }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -210,10 +210,14 @@ trait RedisTrait
             };
         }
 
-        if (!isset($params['redis_sentinel'])) {
+        if (!isset($params['sentinel'])) {
             $params['auth'] ??= $auth;
+            $sentinelAuth = null;
         } elseif (!class_exists(\Predis\Client::class) && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
             throw new CacheException('Redis Sentinel support requires one of: "predis/predis", "ext-redis >= 6.1", "ext-relay".');
+        } else {
+            $sentinelAuth = $params['auth'] ?? null;
+            $params['auth'] = $auth ?? $params['auth'];
         }
 
         foreach (['lazy', 'persistent', 'cluster'] as $option) {
@@ -253,14 +257,14 @@ trait RedisTrait
         if ($isRedisExt || $isRelayExt) {
             $connect = $params['persistent'] || $params['persistent_id'] ? 'pconnect' : 'connect';
 
-            $initializer = static function () use ($class, $isRedisExt, $connect, $params, $auth, $hosts, $tls) {
+            $initializer = static function () use ($class, $isRedisExt, $connect, $params, $sentinelAuth, $hosts, $tls) {
                 $sentinelClass = $isRedisExt ? \RedisSentinel::class : Sentinel::class;
                 $redis = new $class();
                 $hostIndex = 0;
                 do {
                     $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
                     $port = $hosts[$hostIndex]['port'] ?? 0;
-                    $passAuth = null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
+                    $passAuth = null !== $sentinelAuth && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     $address = false;
 
                     if (isset($hosts[$hostIndex]['host']) && $tls) {
@@ -283,7 +287,7 @@ trait RedisTrait
                             ];
 
                             if ($passAuth) {
-                                $options['auth'] = $params['auth'];
+                                $options['auth'] = $sentinelAuth;
                             }
 
                             if (null !== $params['ssl'] && version_compare(phpversion('redis'), '6.2.0', '>=')) {
@@ -292,7 +296,7 @@ trait RedisTrait
 
                             $sentinel = new \RedisSentinel($options);
                         } else {
-                            $extra = $passAuth ? [$params['auth']] : [];
+                            $extra = $passAuth ? [$sentinelAuth] : [];
 
                             $sentinel = @new $sentinelClass($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...$extra);
                         }
@@ -469,12 +473,30 @@ trait RedisTrait
             if ($params['dbindex']) {
                 $params['parameters']['database'] = $params['dbindex'];
             }
-            if (\is_array($auth)) {
+            if (\is_array($params['auth'])) {
                 // ACL
-                $params['parameters']['username'] = $auth[0];
-                $params['parameters']['password'] = $auth[1];
-            } elseif (null !== $auth) {
-                $params['parameters']['password'] = $auth;
+                $params['parameters']['username'] = $params['auth'][0];
+                $params['parameters']['password'] = $params['auth'][1];
+            } elseif (null !== $params['auth']) {
+                $params['parameters']['password'] = $params['auth'];
+            }
+
+            if (isset($params['sentinel']) && null !== $sentinelAuth) {
+                if (\is_array($sentinelAuth)) {
+                    $sentinelUsername = $sentinelAuth[0];
+                    $sentinelPassword = $sentinelAuth[1];
+                } else {
+                    $sentinelUsername = null;
+                    $sentinelPassword = $sentinelAuth;
+                }
+
+                foreach ($hosts as $i => $host) {
+                    $hosts[$i]['password'] ??= $sentinelPassword;
+
+                    if (null !== $sentinelUsername) {
+                        $hosts[$i]['username'] ??= $sentinelUsername;
+                    }
+                }
             }
 
             if (isset($params['ssl'])) {

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -77,7 +77,7 @@ class ConnectionTest extends TestCase
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
             ->willReturn(true);
-        $redis->expects($this->any())
+        $redis
             ->method('isConnected')
             ->willReturnOnConsecutiveCalls(false, true);
 
@@ -110,6 +110,35 @@ class ConnectionTest extends TestCase
             Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['consumer' => 'specific-consumer'], $this->createRedisMock()),
             Connection::fromDsn('redis://localhost/queue/group1/consumer1', [], $this->createRedisMock())
         );
+    }
+
+    public function testFromDsnWithClusterAlias()
+    {
+        $this->assertInstanceOf(Connection::class, Connection::fromDsn('redis://localhost/queue?cluster=0', [], $this->createRedisMock()));
+    }
+
+    public function testFromDsnWithRedisSentinelAlias()
+    {
+        $connection = Connection::fromDsn('redis://localhost/queue?lazy=1&redis_sentinel=mymaster', [], $this->createStub(\Redis::class));
+
+        $initializerProperty = new \ReflectionProperty(Connection::class, 'redisInitializer');
+        $initializer = $initializerProperty->getValue($connection);
+
+        $staticVariables = (new \ReflectionFunction($initializer))->getStaticVariables();
+
+        $this->assertSame('mymaster', $staticVariables['sentinelMaster']);
+    }
+
+    public function testFromDsnWithSentinelMasterAlias()
+    {
+        $connection = Connection::fromDsn('redis://localhost/queue?lazy=1&sentinel_master=mymaster', [], $this->createStub(\Redis::class));
+
+        $initializerProperty = new \ReflectionProperty(Connection::class, 'redisInitializer');
+        $initializer = $initializerProperty->getValue($connection);
+
+        $staticVariables = (new \ReflectionFunction($initializer))->getStaticVariables();
+
+        $this->assertSame('mymaster', $staticVariables['sentinelMaster']);
     }
 
     public function testRedisClusterInstanceIsSupported()
@@ -173,6 +202,86 @@ class ConnectionTest extends TestCase
             ->willReturn(true);
 
         Connection::fromDsn('redis://password1@localhost/queue', ['auth' => 'password2'], $redis);
+    }
+
+    public function testSentinelUsesAuthOptionWhileMasterPrefersUserInfoAuth()
+    {
+        $connection = Connection::fromDsn('redis://master-password@localhost/queue?auth=sentinel-password&sentinel=mymaster&lazy=1', [], $this->createStub(\Redis::class));
+
+        $staticVariables = $this->getInitializerStaticVariables($connection);
+
+        $this->assertSame('master-password', $staticVariables['auth']);
+        $this->assertSame('sentinel-password', $staticVariables['sentinelAuth']);
+    }
+
+    #[DataProvider('provideAuthResolutionMatrix')]
+    public function testFromDsnAuthResolutionMatrix(string $dsn, array $options, string|array|null $expectedMasterAuth, string|array|null $expectedSentinelAuth)
+    {
+        $connection = Connection::fromDsn($dsn, ['lazy' => true] + $options, $this->createStub(\Redis::class));
+
+        $staticVariables = $this->getInitializerStaticVariables($connection);
+
+        $this->assertSame($expectedMasterAuth, $staticVariables['auth']);
+        $this->assertSame($expectedSentinelAuth, $staticVariables['sentinelAuth']);
+    }
+
+    public static function provideAuthResolutionMatrix(): \Generator
+    {
+        yield 'userinfo user+pass' => [
+            'redis://user:pass@localhost/queue',
+            [],
+            ['user', 'pass'],
+            null,
+        ];
+
+        yield 'userinfo with @ + query auth array' => [
+            'redis://user@pass@localhost/queue?auth[]=otheruser&auth[]=otherpass',
+            [],
+            ['otheruser', 'otherpass'],
+            null,
+        ];
+
+        yield 'query auth array' => [
+            'redis://localhost/queue?auth[]=user&auth[]=pass',
+            [],
+            ['user', 'pass'],
+            null,
+        ];
+
+        yield 'options auth array' => [
+            'redis://localhost/queue',
+            ['auth' => ['user', 'pass']],
+            ['user', 'pass'],
+            null,
+        ];
+
+        yield 'query auth beats options auth' => [
+            'redis://localhost/queue?auth[]=query-user&auth[]=query-pass',
+            ['auth' => ['opt-user', 'opt-pass']],
+            ['query-user', 'query-pass'],
+            null,
+        ];
+
+        yield 'sentinel query auth, master userinfo' => [
+            'redis://master-user:master-pass@localhost/queue?sentinel=mymaster&auth[]=sentinel-user&auth[]=sentinel-pass',
+            [],
+            ['master-user', 'master-pass'],
+            ['sentinel-user', 'sentinel-pass'],
+        ];
+
+        yield 'sentinel options auth when query missing' => [
+            'redis://master-pass@localhost/queue?sentinel=mymaster',
+            ['auth' => ['sentinel-user', 'sentinel-pass']],
+            'master-pass',
+            ['sentinel-user', 'sentinel-pass'],
+        ];
+
+        yield 'sentinel query auth beats options auth' => [
+            'redis://master-pass@localhost/queue?sentinel=mymaster&auth[]=query-user&auth[]=query-pass',
+            ['auth' => ['opt-user', 'opt-pass']],
+            'master-pass',
+            ['query-user', 'query-pass'],
+        ];
     }
 
     public function testNoAuthWithEmptyPassword()
@@ -552,5 +661,13 @@ class ConnectionTest extends TestCase
 
             $this->assertEquals($property->getValue($expected), $property->getValue($actual));
         }
+    }
+
+    private function getInitializerStaticVariables(Connection $connection): array
+    {
+        $initializerProperty = new \ReflectionProperty(Connection::class, 'redisInitializer');
+        $initializer = $initializerProperty->getValue($connection);
+
+        return (new \ReflectionFunction($initializer))->getStaticVariables();
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -52,6 +52,7 @@ class Connection
         'retry_interval' => 0, //  Int, value in milliseconds (optional, default is 0)
         'persistent_id' => null, // String, persistent connection id (optional, default is NULL meaning not persistent)
         'ssl' => null, // see https://php.net/context.ssl
+        'cluster' => false, // force use of cluster
     ];
 
     private \Redis|Relay|\RedisCluster|null $redis = null;
@@ -76,6 +77,7 @@ class Connection
         $port = $options['port'];
         $auth = $options['auth'];
 
+        $sentinelAuth = $options['sentinel_auth'] ?? null;
         $sentinelMaster = $options['sentinel'] ?? $options['redis_sentinel'] ?? $options['sentinel_master'] ?? null;
 
         if (null !== $sentinelMaster && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
@@ -92,11 +94,11 @@ class Connection
             }
         }
 
-        if ((\is_array($host) && null === $sentinelMaster) || $redis instanceof \RedisCluster) {
+        if ((\is_array($host) && null === $sentinelMaster) || $redis instanceof \RedisCluster || filter_var($options['cluster'], \FILTER_VALIDATE_BOOLEAN)) {
             $hosts = \is_string($host) ? [$host.':'.$port] : $host; // Always ensure we have an array
             $this->redisInitializer = static fn () => self::initializeRedisCluster($redis, $hosts, $auth, $options);
         } else {
-            $this->redisInitializer = static function () use ($redis, $sentinelMaster, $host, $port, $options, $auth) {
+            $this->redisInitializer = static function () use ($redis, $sentinelMaster, $host, $port, $options, $auth, $sentinelAuth) {
                 if (null !== $sentinelMaster) {
                     $sentinelClass = \extension_loaded('redis') ? \RedisSentinel::class : Sentinel::class;
                     $hostIndex = 0;
@@ -105,6 +107,7 @@ class Connection
                         $host = $hosts[$hostIndex]['host'];
                         $port = $hosts[$hostIndex]['port'] ?? 0;
                         $tls = 'tls' === $hosts[$hostIndex]['scheme'];
+                        $passAuth = null !== $sentinelAuth && (!\extension_loaded('redis') || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                         $address = false;
 
                         if (isset($hosts[$hostIndex]['host']) && $tls) {
@@ -122,13 +125,18 @@ class Connection
                                     'readTimeout' => $options['read_timeout'],
                                 ];
 
+                                if ($passAuth) {
+                                    $params['auth'] = $sentinelAuth;
+                                }
+
                                 if (null !== $options['ssl'] && version_compare(phpversion('redis'), '6.2.0', '>=')) {
                                     $params['ssl'] = $options['ssl'];
                                 }
 
                                 $sentinel = @new \RedisSentinel($params);
                             } else {
-                                $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);
+                                $extra = $passAuth ? [$sentinelAuth] : [];
+                                $sentinel = @new $sentinelClass($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout'], ...$extra);
                             }
 
                             if ($address = @$sentinel->getMasterAddrByName($sentinelMaster)) {
@@ -263,7 +271,7 @@ class Connection
         }
 
         $options['sentinel'] ??= $options['redis_sentinel'] ?? $options['sentinel_master'] ?? null;
-        unset($options['redis_sentinel'], $options['sentinel_master']);
+        unset($options['redis_sentinel'], $options['sentinel_master'], $options['cluster']);
 
         if ($invalidOptions = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS), ['host', 'port'])) {
             throw new LogicException(\sprintf('Invalid option(s) "%s" passed to the Redis Messenger transport.', implode('", "', $invalidOptions)));
@@ -279,7 +287,14 @@ class Connection
 
         $pass = '' !== ($params['pass'] ?? '') ? rawurldecode($params['pass']) : null;
         $user = '' !== ($params['user'] ?? '') ? rawurldecode($params['user']) : null;
-        $options['auth'] ??= null !== $pass && null !== $user ? [$user, $pass] : ($pass ?? $user);
+        $auth = null !== $pass && null !== $user ? [$user, $pass] : ($pass ?? $user);
+        if (null === $options['sentinel']) {
+            $options['auth'] ??= $auth;
+            $options['sentinel_auth'] = null;
+        } else {
+            $options['sentinel_auth'] = $options['auth'] ?? null;
+            $options['auth'] = $auth ?? $options['auth'];
+        }
 
         if (isset($params['query'])) {
             parse_str($params['query'], $query);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58727
| License       | MIT

Instead of #62218 and #61783 /cc @FlashBlack and @WedgeSama
This is too heavy change for 6.4 IMHO but required bugfix for 7.4, thus the target.
This patch aligns the behavior of both components, esp. regarding sentinel auth handling.

A DSN like `redis://foo@localhost?sentinel=bar&auth=baz` will pass `foo` to the the master and `baz` to the sentinel.