### PR TITLE
[DependencyInjection] Update Container PHPDoc behaviors count when a service does not exist

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -35,7 +35,7 @@ class_exists(ArgumentServiceLocator::class);
  *
  * It gives access to object instances (services).
  * Services and parameters are simple key/pair stores.
- * The container can have four possible behaviors when a service
+ * The container can have five possible behaviors when a service
  * does not exist (or is not initialized for the last case):
  *
  *  * EXCEPTION_ON_INVALID_REFERENCE: Throws an exception at compilation time (the default)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Minor:

Updates the Container PHPDoc to reflect 5 invalid-reference behaviors instead of 4.

The `RUNTIME_EXCEPTION_ON_INVALID_REFERENCE` behavior was added in #26627 but the docblock still mentions four.