### PR TITLE
[TwigBridge] Add missing form_flow_* helper functions

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -76,6 +76,10 @@ final class FormExtension extends AbstractExtension
             new TwigFunction('form_flow_previous_step', $this->getFormFlowPreviousStep(...)),
             new TwigFunction('form_flow_first_step', $this->getFormFlowFirstStep(...)),
             new TwigFunction('form_flow_last_step', $this->getFormFlowLastStep(...)),
+            new TwigFunction('form_flow_is_first_step', $this->isFormFlowFirstStep(...)),
+            new TwigFunction('form_flow_is_last_step', $this->isFormFlowLastStep(...)),
+            new TwigFunction('form_flow_can_move_next', $this->canFormFlowMoveNext(...)),
+            new TwigFunction('form_flow_can_move_back', $this->canFormFlowMoveBack(...)),
         ];
     }
 
@@ -197,6 +201,26 @@ final class FormExtension extends AbstractExtension
     public function getFormFlowLastStep(FormView $view): ?string
     {
         return ($view->vars['cursor'] ?? null)?->getLastStep();
+    }
+
+    public function isFormFlowFirstStep(FormView $view): bool
+    {
+        return ($view->vars['cursor'] ?? null)?->isFirstStep() ?? false;
+    }
+
+    public function isFormFlowLastStep(FormView $view): bool
+    {
+        return ($view->vars['cursor'] ?? null)?->isLastStep() ?? false;
+    }
+
+    public function canFormFlowMoveBack(FormView $view): bool
+    {
+        return ($view->vars['cursor'] ?? null)?->canMoveBack() ?? false;
+    }
+
+    public function canFormFlowMoveNext(FormView $view): bool
+    {
+        return ($view->vars['cursor'] ?? null)?->canMoveNext() ?? false;
     }
 
     private function createFieldChoicesList(iterable $choices, string|false|null $translationDomain): iterable

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFlowHelpersTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFlowHelpersTest.php
@@ -44,6 +44,10 @@ class FormExtensionFlowHelpersTest extends FormIntegrationTestCase
         $this->assertNull($this->rawExtension->getFormFlowPreviousStep($view));
         $this->assertSame('organization', $this->rawExtension->getFormFlowFirstStep($view));
         $this->assertSame('confirmation', $this->rawExtension->getFormFlowLastStep($view));
+        $this->assertTrue($this->rawExtension->isFormFlowFirstStep($view));
+        $this->assertFalse($this->rawExtension->isFormFlowLastStep($view));
+        $this->assertTrue($this->rawExtension->canFormFlowMoveNext($view));
+        $this->assertFalse($this->rawExtension->canFormFlowMoveBack($view));
     }
 
     public function testFlowAtMiddleStep()
@@ -63,6 +67,10 @@ class FormExtensionFlowHelpersTest extends FormIntegrationTestCase
         $this->assertSame('organization', $this->rawExtension->getFormFlowPreviousStep($view));
         $this->assertSame('organization', $this->rawExtension->getFormFlowFirstStep($view));
         $this->assertSame('confirmation', $this->rawExtension->getFormFlowLastStep($view));
+        $this->assertFalse($this->rawExtension->isFormFlowFirstStep($view));
+        $this->assertFalse($this->rawExtension->isFormFlowLastStep($view));
+        $this->assertTrue($this->rawExtension->canFormFlowMoveNext($view));
+        $this->assertTrue($this->rawExtension->canFormFlowMoveBack($view));
     }
 
     public function testFlowAtLastStep()
@@ -82,6 +90,10 @@ class FormExtensionFlowHelpersTest extends FormIntegrationTestCase
         $this->assertSame('credentials', $this->rawExtension->getFormFlowPreviousStep($view));
         $this->assertSame('organization', $this->rawExtension->getFormFlowFirstStep($view));
         $this->assertSame('confirmation', $this->rawExtension->getFormFlowLastStep($view));
+        $this->assertFalse($this->rawExtension->isFormFlowFirstStep($view));
+        $this->assertTrue($this->rawExtension->isFormFlowLastStep($view));
+        $this->assertFalse($this->rawExtension->canFormFlowMoveNext($view));
+        $this->assertTrue($this->rawExtension->canFormFlowMoveBack($view));
     }
 
     public function testFormWithoutFlow()
@@ -99,5 +111,9 @@ class FormExtensionFlowHelpersTest extends FormIntegrationTestCase
         $this->assertNull($this->rawExtension->getFormFlowPreviousStep($view));
         $this->assertNull($this->rawExtension->getFormFlowFirstStep($view));
         $this->assertNull($this->rawExtension->getFormFlowLastStep($view));
+        $this->assertFalse($this->rawExtension->isFormFlowFirstStep($view));
+        $this->assertFalse($this->rawExtension->isFormFlowLastStep($view));
+        $this->assertFalse($this->rawExtension->canFormFlowMoveNext($view));
+        $this->assertFalse($this->rawExtension->canFormFlowMoveBack($view));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63331
| License       | MIT

Add 4 new `form_flow_*` helper functions:

- `form_flow_is_first_step`
- `form_flow_is_last_step`
- `form_flow_can_move_next`
- `form_flow_can_move_back`
