### PR TITLE
[CssSelector] Add clearCache() method to CssSelectorConverter

### DIFF
--- a/src/Symfony/Component/CssSelector/CssSelectorConverter.php
+++ b/src/Symfony/Component/CssSelector/CssSelectorConverter.php
@@ -55,6 +55,18 @@ class CssSelectorConverter
     }
 
     /**
+     * Clears the static caches of converted CSS selectors.
+     *
+     * This can be used to prevent unbounded memory growth when converting
+     * many different selectors in a long-running PHP process.
+     */
+    public static function clearCache(): void
+    {
+        self::$xmlCache = [];
+        self::$htmlCache = [];
+    }
+
+    /**
      * Translates a CSS expression to its XPath equivalent.
      *
      * Optionally, a prefix can be added to the resulting XPath

--- a/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
@@ -52,6 +52,20 @@ class CssSelectorConverterTest extends TestCase
         (new CssSelectorConverter())->toXPath('h1:');
     }
 
+    public function testClearCache()
+    {
+        $converter = new CssSelectorConverter();
+        $converter->toXPath('h1');
+
+        CssSelectorConverter::clearCache();
+
+        $cacheProperty = new \ReflectionProperty(CssSelectorConverter::class, 'htmlCache');
+        if (\PHP_VERSION_ID < 80100) {
+            $cacheProperty->setAccessible(true);
+        }
+        $this->assertSame([], $cacheProperty->getValue());
+    }
+
     #[DataProvider('getCssToXPathWithoutPrefixTestData')]
     public function testCssToXPathWithoutPrefix($css, $xpath)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`CssSelectorConverter` maintains two static caches (`$htmlCache` and `$xmlCache`) of converted CSS-to-XPath expressions. These grow unbounded when converting many different selectors in a long-running PHP process.

This PR adds a `public static clearCache()` method to allow consumers to reclaim this memory.