### PR TITLE
[CssSelector] Fix memory exhaustion by adding an LRU cache to CssSelectorConverter

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/CssSelectorConverterTest.php
@@ -51,6 +51,37 @@ class CssSelectorConverterTest extends TestCase
         (new CssSelectorConverter())->toXPath('h1:');
     }
 
+    public function testLruCacheMovesRecentlyUsedToEnd()
+    {
+        CssSelectorConverter::$maxCachedItems = 5;
+        $htmlCacheProperty = new \ReflectionProperty(CssSelectorConverter::class, 'htmlCache');
+        $htmlCacheProperty->setValue(null, []);
+
+        $converter = new CssSelectorConverter(true);
+
+        // Fill cache with 5 entries (h0-h4)
+        for ($i = 0; $i < 5; ++$i) {
+            $converter->toXPath("h$i");
+        }
+
+        // Access h0 to move it to end (most recently used)
+        $converter->toXPath('h0');
+
+        // Trigger eviction
+        $converter->toXPath('h5');
+
+        $cache = $htmlCacheProperty->getValue();
+
+        // h0 was accessed recently (moved to end), so it survives eviction
+        $this->assertArrayHasKey("descendant-or-self::\0h0", $cache);
+        // h5 is the newest entry
+        $this->assertArrayHasKey("descendant-or-self::\0h5", $cache);
+        // h1 was the oldest untouched entry, should be evicted
+        $this->assertArrayNotHasKey("descendant-or-self::\0h1", $cache);
+
+        CssSelectorConverter::$maxCachedItems = 1024;
+    }
+
     /** @dataProvider getCssToXPathWithoutPrefixTestData */
     public function testCssToXPathWithoutPrefix($css, $xpath)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CssSelectorConverter` maintains two static caches (`$htmlCache` and `$xmlCache`) of converted CSS-to-XPath expressions. These grow unbounded when converting many different selectors in a long-running PHP process.

This PR adds an LRU (Least Recently Used) cache eviction strategy to automatically bound memory usage, following the same pattern used in `IpUtils`. When the cache exceeds `$maxCacheItems` (default 1024), the oldest half of entries are evicted.

The max cache size is configurable via a new optional constructor parameter:

```php
$converter = new CssSelectorConverter(html: true, maxCacheItems: 512);
```