### PR TITLE
[Messenger] Improve PostgreSQL LISTEN/NOTIFY idle listener

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/EventListener/PostgreSqlNotifyOnIdleListener.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/EventListener/PostgreSqlNotifyOnIdleListener.php
@@ -11,7 +11,11 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\EventListener;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Types\Types;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
@@ -29,9 +33,14 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
     /** @var array<string, PostgreSqlConnection> */
     private array $connections = [];
     private ?PostgreSqlConnection $activeConnection = null;
+    private ?float $deadline = null;
+    private ?int $sleepCapMs = null;
+    /** @var list<string> */
+    private array $queueNames = [];
 
     public function __construct(
         private ?LoggerInterface $logger = null,
+        private ClockInterface $clock = new Clock(),
     ) {
     }
 
@@ -49,12 +58,31 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
     public function onWorkerStarted(WorkerStartedEvent $event): void
     {
         $this->activeConnection = null;
+        $this->deadline = $event->getDeadline();
 
-        foreach ($event->getWorker()->getMetadata()->getTransportNames() as $transportName) {
+        $allTransportNames = $event->getWorker()->getMetadata()->getTransportNames();
+
+        $matched = [];
+        foreach ($allTransportNames as $transportName) {
             if ($connection = $this->connections[$transportName] ?? null) {
-                $connection->listen();
-                $this->activeConnection ??= $connection;
+                $matched[$transportName] = $connection;
+                $this->queueNames[] = $connection->getConfiguration()['queue_name'];
             }
+        }
+
+        // When non-PostgreSQL transports are also consumed, cap the NOTIFY wait to
+        // the worker's sleep duration so those transports are still polled regularly.
+        $this->sleepCapMs = \count($matched) < \count($allTransportNames) ? (int) ($event->getIdleTimeout() / 1000) : null;
+
+        if (\count($matched) > 1) {
+            $this->validateConnections($matched);
+        }
+
+        foreach ($matched as $connection) {
+            // Only the first (active) connection executes LISTEN on the database; the others just mark get() as externally
+            // handled to avoid accumulating unread notifications on connections that never call waitForNotify().
+            $connection->listen(null === $this->activeConnection);
+            $this->activeConnection ??= $connection;
         }
     }
 
@@ -66,11 +94,34 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
 
         $config = $this->activeConnection->getConfiguration();
 
-        if (0 >= $timeout = $config['get_notify_timeout'] ?: $config['check_delayed_interval']) {
+        if (0 >= $timeout = $config['get_notify_timeout']) {
             return;
         }
 
-        $this->logger?->debug('Worker waiting for PostgreSQL LISTEN/NOTIFY wake-up.');
+        // Cap by worker deadline (--time-limit) — checked first to avoid a SQL query
+        // in getEarliestDelayedMessageTime() when the worker is already past its deadline.
+        if (null !== $this->deadline) {
+            $deadline = ($this->deadline - $this->clock->now()->format('U.u')) * 1000;
+            if (0 >= $timeout = min($timeout, $deadline)) {
+                return;
+            }
+        }
+
+        // Cap by earliest delayed message across all PG queues: wake up in time to process it
+        if (null !== $earliest = $this->getEarliestDelayedMessageTime()) {
+            $now = $this->clock->now();
+            $msUntilEarliest = ($earliest->format('U.u') - $now->format('U.u')) * 1000;
+            if (0 >= $timeout = min($timeout, $msUntilEarliest)) {
+                return;
+            }
+        }
+
+        // Cap by sleep duration when non-PG transports are present to ensure they are still polled regularly
+        if (0 >= $timeout = (int) min($timeout, $this->sleepCapMs ?? $timeout)) {
+            return;
+        }
+
+        $this->logger?->debug('Worker waiting for PostgreSQL LISTEN/NOTIFY wake-up.', ['timeout_ms' => $timeout]);
 
         $this->activeConnection->waitForNotify($timeout);
     }
@@ -81,5 +132,60 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
             WorkerStartedEvent::class => 'onWorkerStarted',
             WorkerRunningEvent::class => 'onWorkerRunning',
         ];
+    }
+
+    /**
+     * @param array<string, PostgreSqlConnection> $connections
+     */
+    private function validateConnections(array $connections): void
+    {
+        $referenceConfig = null;
+        $referenceDriver = null;
+        $referenceName = null;
+
+        foreach ($connections as $transportName => $connection) {
+            $config = $connection->getConfiguration();
+            $driver = $connection->getDriverConnection();
+
+            if (null === $referenceConfig) {
+                $referenceConfig = $config;
+                $referenceDriver = $driver;
+                $referenceName = $transportName;
+                continue;
+            }
+
+            if ($driver !== $referenceDriver) {
+                throw new \LogicException(\sprintf('PostgreSQL transports "%s" and "%s" use different DBAL connections. When consuming from multiple PostgreSQL queues in one worker, all transports must share the same DBAL connection.', $referenceName, $transportName));
+            }
+
+            if ($config['table_name'] !== $referenceConfig['table_name']) {
+                throw new \LogicException(\sprintf('PostgreSQL transports "%s" and "%s" use different table_name values ("%s" vs "%s"). When consuming from multiple PostgreSQL queues in one worker, all transports must use the same table.', $referenceName, $transportName, $referenceConfig['table_name'], $config['table_name']));
+            }
+        }
+    }
+
+    /**
+     * Returns the earliest available_at for delayed messages across all tracked PG queues, or null if there are none.
+     */
+    private function getEarliestDelayedMessageTime(): ?\DateTimeImmutable
+    {
+        $config = $this->activeConnection->getConfiguration();
+        $dbal = $this->activeConnection->getDriverConnection();
+        $now = $this->clock->now();
+
+        $sql = \sprintf('SELECT MIN(available_at) FROM %s WHERE queue_name IN (?) AND available_at > ? AND delivered_at IS NULL', $config['table_name']);
+        $result = $dbal->executeQuery($sql, [
+            $this->queueNames,
+            $now,
+        ], [
+            ArrayParameterType::STRING,
+            Types::DATETIME_IMMUTABLE,
+        ])->fetchOne();
+
+        if (!$result) {
+            return null;
+        }
+
+        return new \DateTimeImmutable($result, new \DateTimeZone('UTC'));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/EventListener/PostgreSqlNotifyOnIdleListenerTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/EventListener/PostgreSqlNotifyOnIdleListenerTest.php
@@ -12,6 +12,10 @@
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\EventListener;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Result as DriverResult;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\EventListener\PostgreSqlNotifyOnIdleListener;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
@@ -110,10 +114,13 @@ class PostgreSqlNotifyOnIdleListenerTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testMultipleTransportsListenOnAllConnections()
+    public function testMultipleTransportsOnlyFirstGetsDbListen()
     {
-        $conn1 = $this->createPostgreSqlConnection();
-        $conn2 = $this->createPostgreSqlConnection();
+        $driverConnection = $this->createStub(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $conn1 = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+        $conn2 = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 
         $listener = new PostgreSqlNotifyOnIdleListener();
         $listener->addConnection('high', $conn1);
@@ -121,8 +128,60 @@ class PostgreSqlNotifyOnIdleListenerTest extends TestCase
 
         $listener->onWorkerStarted(new WorkerStartedEvent($this->createWorkerWithTransports(['high', 'low'])));
 
+        // Only the active (first) connection should have LISTEN registered on DB
         $this->assertTrue($conn1->isListening());
-        $this->assertTrue($conn2->isListening());
+        // The second connection should NOT have LISTEN registered on DB
+        $this->assertFalse($conn2->isListening());
+    }
+
+    public function testMismatchedTableNamesThrows()
+    {
+        $driverConnection = $this->createStub(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $conn1 = new PostgreSqlConnection(['table_name' => 'table_a'], $driverConnection);
+        $conn2 = new PostgreSqlConnection(['table_name' => 'table_b'], $driverConnection);
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('high', $conn1);
+        $listener->addConnection('low', $conn2);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('table_name');
+
+        $listener->onWorkerStarted(new WorkerStartedEvent($this->createWorkerWithTransports(['high', 'low'])));
+    }
+
+    public function testMismatchedDriverConnectionsThrows()
+    {
+        $driverConnection1 = $this->createStub(Connection::class);
+        $driverConnection1->method('executeStatement')->willReturn(1);
+        $driverConnection2 = $this->createStub(Connection::class);
+        $driverConnection2->method('executeStatement')->willReturn(1);
+
+        $conn1 = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection1);
+        $conn2 = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection2);
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('high', $conn1);
+        $listener->addConnection('low', $conn2);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('DBAL connection');
+
+        $listener->onWorkerStarted(new WorkerStartedEvent($this->createWorkerWithTransports(['high', 'low'])));
+    }
+
+    public function testSingleTransportDoesNotThrowValidation()
+    {
+        $connection = $this->createPostgreSqlConnection();
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $listener->onWorkerStarted(new WorkerStartedEvent($this->createWorkerWithTransports(['async'])));
+
+        $this->assertTrue($connection->isListening());
     }
 
     public function testGetSubscribedEvents()
@@ -131,5 +190,186 @@ class PostgreSqlNotifyOnIdleListenerTest extends TestCase
             WorkerStartedEvent::class => 'onWorkerStarted',
             WorkerRunningEvent::class => 'onWorkerRunning',
         ], PostgreSqlNotifyOnIdleListener::getSubscribedEvents());
+    }
+
+    private function createConnectionWithGetNotifyCapture(array $config, ?string $delayedAvailableAt = null): array
+    {
+        $driverConnection = $this->createStub(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
+        $driverConnection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+        $driverConnection->method('createQueryBuilder')->willReturn(new QueryBuilder($driverConnection));
+
+        // For getEarliestDelayedMessageTime query
+        $delayedResult = $this->createStub(DriverResult::class);
+        $delayedResult->method('fetchOne')->willReturn($delayedAvailableAt ?? false);
+
+        $driverConnection->method('executeQuery')
+            ->willReturn(new Result($delayedResult, $driverConnection));
+
+        // Use ArrayObject so object identity survives array destructuring
+        // (plain array references are lost when using [$a, $b] = ...)
+        $capturedTimeouts = new \ArrayObject();
+        $wrappedConnection = new class($capturedTimeouts) {
+            public function __construct(private \ArrayObject $captured)
+            {
+            }
+
+            public function getNotify(int $fetchMode, int $timeout): false
+            {
+                $this->captured[] = $timeout;
+
+                return false;
+            }
+        };
+
+        $driverConnection->method('getNativeConnection')->willReturn($wrappedConnection);
+
+        $connection = new PostgreSqlConnection($config + ['table_name' => 'queue_table', 'queue_name' => 'default'], $driverConnection);
+
+        return [$connection, $capturedTimeouts, $driverConnection];
+    }
+
+    public function testTimeoutCappedByDeadline()
+    {
+        [$connection, $capturedTimeouts] = $this->createConnectionWithGetNotifyCapture([
+            'get_notify_timeout' => 60000,
+        ]);
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $worker = $this->createWorkerWithTransports(['async']);
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker, microtime(true) + 2));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        $this->assertCount(1, $capturedTimeouts);
+        $this->assertGreaterThan(0, $capturedTimeouts[0]);
+        $this->assertLessThanOrEqual(2500, $capturedTimeouts[0]);
+    }
+
+    public function testTimeoutCappedByDelayedMessage()
+    {
+        $future = new \DateTimeImmutable('+3 seconds', new \DateTimeZone('UTC'));
+
+        [$connection, $capturedTimeouts] = $this->createConnectionWithGetNotifyCapture(
+            ['get_notify_timeout' => 60000],
+            $future->format('Y-m-d H:i:s.u'),
+        );
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $worker = $this->createWorkerWithTransports(['async']);
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        $this->assertCount(1, $capturedTimeouts);
+        $this->assertGreaterThan(0, $capturedTimeouts[0]);
+        $this->assertLessThanOrEqual(4000, $capturedTimeouts[0]);
+    }
+
+    public function testTimeoutUsesMinOfAllConstraints()
+    {
+        // Delayed message in 10 seconds, deadline in 5 seconds, config 60s
+        $future = new \DateTimeImmutable('+10 seconds', new \DateTimeZone('UTC'));
+
+        [$connection, $capturedTimeouts] = $this->createConnectionWithGetNotifyCapture(
+            ['get_notify_timeout' => 60000],
+            $future->format('Y-m-d H:i:s.u'),
+        );
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $worker = $this->createWorkerWithTransports(['async']);
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker, microtime(true) + 5));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        // Should pick deadline (5s) as minimum over delayed (10s) and config (60s)
+        $this->assertCount(1, $capturedTimeouts);
+        $this->assertGreaterThan(0, $capturedTimeouts[0]);
+        $this->assertLessThanOrEqual(5500, $capturedTimeouts[0]);
+    }
+
+    public function testNoWaitWhenDeadlineAlreadyPassed()
+    {
+        [$connection, $capturedTimeouts] = $this->createConnectionWithGetNotifyCapture([
+            'get_notify_timeout' => 60000,
+        ]);
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('async', $connection);
+
+        $worker = $this->createWorkerWithTransports(['async']);
+        // Use a deadline already in the past
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker, microtime(true) - 1));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        // Should not call waitForNotify when deadline has passed
+        $this->assertCount(0, $capturedTimeouts);
+    }
+
+    public function testTimeoutCappedBySleepWhenNonPgTransportsPresent()
+    {
+        [$connection, $capturedTimeouts] = $this->createConnectionWithGetNotifyCapture([
+            'get_notify_timeout' => 60000,
+        ]);
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('pg_transport', $connection);
+
+        // Worker consumes from both a PG and a non-PG transport
+        $worker = $this->createWorkerWithTransports(['pg_transport', 'redis_transport']);
+        // sleep = 2_000_000 microseconds = 2s → cap should be 2000ms
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker, null, 2000000));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        $this->assertCount(1, $capturedTimeouts);
+        $this->assertLessThanOrEqual(2000, $capturedTimeouts[0]);
+        $this->assertGreaterThan(0, $capturedTimeouts[0]);
+    }
+
+    public function testTimeoutNotCappedBySleepWhenAllTransportsArePg()
+    {
+        $driverConnection = $this->createStub(Connection::class);
+        $driverConnection->method('executeStatement')->willReturn(1);
+        $driverConnection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+        $driverConnection->method('createQueryBuilder')->willReturn(new QueryBuilder($driverConnection));
+
+        $delayedResult = $this->createStub(DriverResult::class);
+        $delayedResult->method('fetchOne')->willReturn(false);
+        $driverConnection->method('executeQuery')
+            ->willReturn(new Result($delayedResult, $driverConnection));
+
+        $capturedTimeouts = new \ArrayObject();
+        $wrappedConnection = new class($capturedTimeouts) {
+            public function __construct(private \ArrayObject $captured)
+            {
+            }
+
+            public function getNotify(int $fetchMode, int $timeout): false
+            {
+                $this->captured[] = $timeout;
+
+                return false;
+            }
+        };
+        $driverConnection->method('getNativeConnection')->willReturn($wrappedConnection);
+
+        $conn1 = new PostgreSqlConnection(['table_name' => 'queue_table', 'queue_name' => 'default', 'get_notify_timeout' => 60000], $driverConnection);
+        $conn2 = new PostgreSqlConnection(['table_name' => 'queue_table', 'queue_name' => 'other', 'get_notify_timeout' => 60000], $driverConnection);
+
+        $listener = new PostgreSqlNotifyOnIdleListener();
+        $listener->addConnection('high', $conn1);
+        $listener->addConnection('low', $conn2);
+
+        // All transports are PG, idleTimeout = 1s → should NOT cap to 1000ms
+        $worker = $this->createWorkerWithTransports(['high', 'low']);
+        $listener->onWorkerStarted(new WorkerStartedEvent($worker, null, 1000000));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+
+        $this->assertCount(1, $capturedTimeouts);
+        // Without sleep cap, the full 60000ms config timeout should be used
+        $this->assertSame(60000, $capturedTimeouts[0]);
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -102,12 +102,10 @@ class PostgreSqlConnectionTest extends TestCase
         $driverConnection->method('executeStatement')->willReturn(1);
 
         $driverConnection
-            ->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn(new PostgreSQLPlatform());
 
         $driverConnection
-            ->expects(self::any())
             ->method('createQueryBuilder')
             ->willReturn(new QueryBuilder($driverConnection));
 
@@ -131,7 +129,6 @@ class PostgreSqlConnectionTest extends TestCase
         $driverResult->method('fetchAssociative')
             ->willReturn(false);
         $driverConnection
-            ->expects(self::any())
             ->method('executeQuery')
             ->willReturn(new Result($driverResult, $driverConnection));
 
@@ -153,12 +150,10 @@ class PostgreSqlConnectionTest extends TestCase
         $driverConnection->method('executeStatement')->willReturn(1);
 
         $driverConnection
-            ->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn(new PostgreSQLPlatform());
 
         $driverConnection
-            ->expects(self::any())
             ->method('createQueryBuilder')
             ->willReturn(new QueryBuilder($driverConnection));
 
@@ -171,7 +166,6 @@ class PostgreSqlConnectionTest extends TestCase
         $driverResult->method('fetchAssociative')
             ->willReturn(false);
         $driverConnection
-            ->expects(self::any())
             ->method('executeQuery')
             ->willReturn(new Result($driverResult, $driverConnection));
 
@@ -192,5 +186,70 @@ class PostgreSqlConnectionTest extends TestCase
         $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 
         $this->assertFalse($connection->isListening());
+    }
+
+    public function testListenWithoutDatabaseRegistration()
+    {
+        $driverConnection = $this->createMock(Connection::class);
+        // executeStatement should NOT be called when registerOnDatabase is false
+        $driverConnection->expects(self::never())->method('executeStatement');
+
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+
+        $connection->listen(registerOnDatabase: false);
+
+        // notifyHandledExternally should still be set (get() skips blocking)
+        $this->assertFalse($connection->isListening());
+    }
+
+    public function testListenWithDatabaseRegistrationIsDefault()
+    {
+        $driverConnection = $this->createMock(Connection::class);
+        // executeStatement will be called for LISTEN and then UNLISTEN in __destruct
+        $driverConnection->expects(self::exactly(2))->method('executeStatement')
+            ->willReturn(1);
+
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+
+        $connection->listen();
+
+        $this->assertTrue($connection->isListening());
+    }
+
+    public function testGetSkipsBlockingWhenListenCalledWithoutDatabaseRegistration()
+    {
+        $driverConnection = $this->createMock(Connection::class);
+
+        $driverConnection
+            ->method('getDatabasePlatform')
+            ->willReturn(new PostgreSQLPlatform());
+
+        $driverConnection
+            ->method('createQueryBuilder')
+            ->willReturn(new QueryBuilder($driverConnection));
+
+        // getNativeConnection should never be called since blocking is skipped
+        $driverConnection
+            ->expects(self::never())
+            ->method('getNativeConnection');
+
+        // Allow executeStatement for the base get() flow, but not for LISTEN
+        $driverConnection->method('executeStatement')->willReturn(1);
+
+        $driverResult = $this->createStub(DriverResult::class);
+        $driverResult->method('fetchAssociative')
+            ->willReturn(false);
+        $driverConnection
+            ->method('executeQuery')
+            ->willReturn(new Result($driverResult, $driverConnection));
+
+        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
+
+        // External listener calls listen() without database registration
+        $connection->listen(registerOnDatabase: false);
+
+        // get() should always delegate to parent without blocking
+        $connection->get();
+        $connection->get();
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
+use Doctrine\DBAL\Connection as DBALConnection;
+
 /**
  * Uses PostgreSQL LISTEN/NOTIFY to push messages to workers.
  *
@@ -27,11 +29,11 @@ final class PostgreSqlConnection extends Connection
 
     /**
      * * check_delayed_interval: The interval to check for delayed messages, in milliseconds. Set to 0 to disable checks. Default: 60000 (1 minute)
-     * * get_notify_timeout: The time to wait for a message, in milliseconds. Default: 0, which means until check_delayed_interval is reached.
+     * * get_notify_timeout: The maximum time to wait for a NOTIFY, in milliseconds. Default: 60000 (1 minute).
      */
     protected const DEFAULT_OPTIONS = parent::DEFAULT_OPTIONS + [
         'check_delayed_interval' => 60000,
-        'get_notify_timeout' => 0,
+        'get_notify_timeout' => 60000,
     ];
 
     public function __serialize(): array
@@ -100,14 +102,27 @@ final class PostgreSqlConnection extends Connection
      * assuming an external listener (e.g. PostgreSqlNotifyOnIdleListener) handles it.
      *
      * Safe to call multiple times; PostgreSQL ignores duplicate LISTEN for the same channel.
+     *
+     * @param bool $registerOnDatabase Whether to execute the SQL LISTEN command.
+     *                                 When false, only marks get() as externally handled
+     *                                 without registering on the database. This avoids
+     *                                 accumulating unread notifications on connections
+     *                                 that will never call waitForNotify().
      */
-    public function listen(): void
+    public function listen(bool $registerOnDatabase = true): void
     {
-        // This is secure because the table name must be a valid identifier:
-        // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
-        $this->executeStatement(\sprintf('LISTEN "%s"', $this->configuration['table_name']));
-        $this->listening = true;
+        if ($registerOnDatabase) {
+            // This is secure because the table name must be a valid identifier:
+            // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+            $this->executeStatement(\sprintf('LISTEN "%s"', $this->configuration['table_name']));
+            $this->listening = true;
+        }
         $this->notifyHandledExternally = true;
+    }
+
+    public function getDriverConnection(): DBALConnection
+    {
+        return $this->driverConnection;
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -18,9 +18,10 @@
     "require": {
         "php": ">=8.4",
         "doctrine/dbal": "^4.3",
+        "symfony/clock": "^7.4|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^7.4|^8.0",
-        "symfony/messenger": "^7.4|^8.0",
+        "symfony/messenger": "^8.1",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -289,6 +289,9 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
         $options = [
             'sleep' => $input->getOption('sleep') * 1000000,
         ];
+        if (null !== $timeLimit) {
+            $options['time_limit'] = (int) $timeLimit;
+        }
         if ($queues = $input->getOption('queues')) {
             $options['queues'] = $queues;
         }

--- a/src/Symfony/Component/Messenger/Event/WorkerStartedEvent.php
+++ b/src/Symfony/Component/Messenger/Event/WorkerStartedEvent.php
@@ -22,11 +22,34 @@ final class WorkerStartedEvent
 {
     public function __construct(
         private Worker $worker,
+        private ?float $deadline = null,
+        private int $idleTimeout = 1000000,
     ) {
     }
 
     public function getWorker(): Worker
     {
         return $this->worker;
+    }
+
+    /**
+     * Returns the absolute time (as a microtime(true) float) at which the
+     * worker must stop, or null if no --time-limit was set.
+     */
+    public function getDeadline(): ?float
+    {
+        return $this->deadline;
+    }
+
+    /**
+     * Returns the duration in microseconds the worker sleeps between two
+     * idle polling cycles (i.e. when no messages are found).
+     *
+     * Defaults to 1 000 000 µs (1 second).  Corresponds to the
+     * --sleep option of messenger:consume.
+     */
+    public function getIdleTimeout(): int
+    {
+        return $this->idleTimeout;
     }
 }

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -87,7 +87,7 @@ class Worker
 
         $this->metadata->set(['queueNames' => $queueNames]);
 
-        $this->eventDispatcher?->dispatch(new WorkerStartedEvent($this));
+        $this->eventDispatcher?->dispatch(new WorkerStartedEvent($this, isset($options['time_limit']) ? $this->clock->now()->format('U.u') + (int) $options['time_limit'] : null, $options['sleep']));
 
         if ($queueNames) {
             // if queue names are specified, all receivers must implement the QueueReceiverInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR is meant to address https://github.com/symfony/symfony/pull/47666#issuecomment-3905383759 by @d-ph

This reworks `PostgreSqlNotifyOnIdleListener` to compute a smarter NOTIFY wait timeout, avoid LISTEN on non-active connections, and validate configuration when multiple PostgreSQL transports are consumed.

LISTEN fix:
- Ensure only the active connection executes SQL LISTEN; the others just mark `get()` as externally handled, avoiding unread notification buildup.

Smart timeout computation:
- Cap the NOTIFY timeout by the earliest delayed message so the worker wakes up in time to dispatch it.
- Cap by the worker deadline (`--time-limit`) exposed via a new WorkerStartedEvent::getDeadline() property.
- Cap by the worker sleep duration when non-PostgreSQL transports are also consumed, so they keep being polled regularly. The sleep value is exposed via `WorkerStartedEvent::getIdleTimeout()`.
- Give `get_notify_timeout` its own default of 60000 ms instead of falling back to `check_delayed_interval`.

Configuration validation:
- Throw `LogicException` when multiple PG transports use different DBAL connections or table names.
- Add `PostgreSqlConnection::getDriverConnection()` getter for validation.