### PR TITLE
[Serializer] Fix passing context option to property-info

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -152,16 +152,18 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         }
 
         if ($context['_read_attributes'] ?? true) {
-            if (!isset(self::$isReadableCache[$class.$attribute])) {
-                self::$isReadableCache[$class.$attribute] = $this->propertyInfoExtractor->isReadable($class, $attribute) || $this->hasAttributeAccessorMethod($class, $attribute) || (\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute));
-            }
+            $context = array_intersect_key($context, ['enable_getter_setter_extraction' => true, 'enable_magic_methods_extraction' => true]);
+            $cacheKey = $class.$attribute.hash('xxh128', serialize($context));
 
-            return self::$isReadableCache[$class.$attribute];
+            return self::$isReadableCache[$cacheKey] ??= $this->propertyInfoExtractor->isReadable($class, $attribute, $context) || $this->hasAttributeAccessorMethod($class, $attribute) || (\is_object($classOrObject) && $this->propertyAccessor->isReadable($classOrObject, $attribute));
         }
 
-        return self::$isWritableCache[$class.$attribute] ??= str_contains($attribute, '.')
-            || $this->propertyInfoExtractor->isWritable($class, $attribute)
-            || !\in_array($this->writeInfoExtractor->getWriteInfo($class, $attribute)?->getType(), [null, PropertyWriteInfo::TYPE_NONE, PropertyWriteInfo::TYPE_PROPERTY], true);
+        $context = array_intersect_key($context, ['enable_getter_setter_extraction' => true, 'enable_magic_methods_extraction' => true, 'enable_constructor_extraction' => true, 'enable_adder_remover_extraction' => true]);
+        $cacheKey = $class.$attribute.hash('xxh128', serialize($context));
+
+        return self::$isWritableCache[$cacheKey] ??= str_contains($attribute, '.')
+            || $this->propertyInfoExtractor->isWritable($class, $attribute, $context)
+            || !\in_array($this->writeInfoExtractor->getWriteInfo($class, $attribute, $context)?->getType(), [null, PropertyWriteInfo::TYPE_NONE, PropertyWriteInfo::TYPE_PROPERTY], true);
     }
 
     private function hasAttributeAccessorMethod(string $class, string $attribute): bool

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -14,10 +14,12 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccessorBuilder;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
@@ -182,6 +184,29 @@ class ObjectNormalizerTest extends TestCase
             ['foo' => 123, 'bar' => null],
             $this->normalizer->normalize($obj, 'any')
         );
+    }
+
+    public function testNormalizeWithDisabledMagicMethodsExtractionInContext()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $propertyInfoExtractor = $this->createMock(PropertyInfoExtractorInterface::class);
+        $propertyInfoExtractor
+            ->expects($this->once())
+            ->method('isReadable')
+            ->with(ObjectWithGroupedMagicGetPrivateProperty::class, 'foo', ['enable_magic_methods_extraction' => 0])
+            ->willReturn(false);
+        $propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
+        $propertyAccessor
+            ->expects($this->once())
+            ->method('isReadable')
+            ->with($this->isInstanceOf(ObjectWithGroupedMagicGetPrivateProperty::class), 'foo')
+            ->willReturn(false);
+        $normalizer = new ObjectNormalizer($classMetadataFactory, null, $propertyAccessor, null, null, null, [], $propertyInfoExtractor);
+
+        $this->assertSame([], $normalizer->normalize(new ObjectWithGroupedMagicGetPrivateProperty(), null, [
+            'groups' => ['read'],
+            'enable_magic_methods_extraction' => 0,
+        ]));
     }
 
     public function testNormalizeObjectWithUninitializedPrivateProperties()
@@ -1546,6 +1571,17 @@ class LazyObjectInner extends ObjectInner
     public function __isset($name): bool
     {
         return 'foo' === $name;
+    }
+}
+
+class ObjectWithGroupedMagicGetPrivateProperty
+{
+    #[Groups(['read'])]
+    private string $foo = 'foo';
+
+    public function __get($name)
+    {
+        return 'foo';
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61419
| License       | MIT
