### PR TITLE
 remove usages of the deprecated `any()` invoked count expectation

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -134,7 +134,6 @@ class ConsoleHandlerTest extends TestCase
     {
         $output = $this->createMock(OutputInterface::class);
         $output
-            ->expects($this->any())
             ->method('getVerbosity')
             ->willReturn(OutputInterface::VERBOSITY_DEBUG)
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
@@ -51,7 +51,6 @@ class CachePoolClearCommandTest extends TestCase
 
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
@@ -109,7 +109,6 @@ class CachePoolDeleteCommandTest extends TestCase
 
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePruneCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePruneCommandTest.php
@@ -92,7 +92,6 @@ class CachePruneCommandTest extends TestCase
 
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -85,7 +85,6 @@ class RouterMatchCommandTest extends TestCase
 
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container)
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -92,7 +92,6 @@ EOF;
             ->willReturn(new HelperSet());
 
         $application
-            ->expects($this->any())
             ->method('getDefinition')
             ->willReturn(new InputDefinition());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -140,7 +140,6 @@ EOF;
             ->willReturn(new HelperSet());
 
         $application
-            ->expects($this->any())
             ->method('getDefinition')
             ->willReturn(new InputDefinition());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -297,12 +297,10 @@ class ApplicationTest extends TestCase
         $kernel = $this->createMock(KernelInterface::class);
         $kernel->expects($this->once())->method('boot');
         $kernel
-            ->expects($this->any())
             ->method('getBundles')
             ->willReturn($bundles)
         ;
         $kernel
-            ->expects($this->any())
             ->method('getContainer')
             ->willReturn($container)
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/KernelBrowserTest.php
@@ -68,7 +68,7 @@ class KernelBrowserTest extends AbstractWebTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mock->expects($this->any())->method('handle')->willReturn(new Response('foo'));
+        $mock->method('handle')->willReturn(new Response('foo'));
 
         return $mock;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -194,10 +194,10 @@ class SecurityDataCollectorTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $firewallMap
-            ->expects($this->any())
             ->method('getFirewallConfig')
-            ->with($request)
-            ->willReturn(null);
+            ->willReturnMap([
+                [$request, null],
+            ]);
         $firewallMap
             ->expects($this->once())
             ->method('getListeners')

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
@@ -74,8 +74,9 @@ class TraceableFirewallListenerTest extends TestCase
         $supportingAuthenticator = $this->createMock(DummyAuthenticator::class);
         $supportingAuthenticator
             ->method('supports')
-            ->with($request)
-            ->willReturn(true);
+            ->willReturnMap([
+                [$request, true],
+            ]);
         $supportingAuthenticator
             ->expects($this->once())
             ->method('authenticate')

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -556,10 +556,11 @@ class JavaScriptImportPathCompilerTest extends TestCase
             ->method('findRootImportMapEntry')
             ->with('@popperjs/core')
             ->willReturn(ImportMapEntry::createRemote('@popperjs/core', ImportMapType::JS, './vendor/@popperjs/core.js', '1.2.3', 'could_be_anything', false));
-        $importMapConfigReader->expects($this->any())
+        $importMapConfigReader
             ->method('convertPathToFilesystemPath')
-            ->with('./vendor/@popperjs/core.js')
-            ->willReturn('/path/to/vendor/@popperjs/core.js');
+            ->willReturnMap([
+                ['./vendor/@popperjs/core.js', '/path/to/vendor/@popperjs/core.js'],
+            ]);
 
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper->expects($this->once())
@@ -583,10 +584,11 @@ class JavaScriptImportPathCompilerTest extends TestCase
             ->method('findRootImportMapEntry')
             ->with('foobar')
             ->willReturn(ImportMapEntry::createRemote('foobar', ImportMapType::JS, 'foo.js', '1.2.3', 'foobar', false));
-        $importMapConfigReader->expects($this->any())
+        $importMapConfigReader
             ->method('convertPathToFilesystemPath')
-            ->with('foo.js')
-            ->willReturn('foo.js');
+            ->willReturnMap([
+                ['foo.js', 'foo.js'],
+            ]);
 
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper->expects($this->once())

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -71,7 +71,7 @@ class ImportMapManagerTest extends TestCase
             })
         ;
 
-        $this->configReader->expects($this->any())
+        $this->configReader
             ->method('convertPathToFilesystemPath')
             ->willReturnCallback(function ($path) {
                 if (str_ends_with($path, 'some_file.js')) {
@@ -80,7 +80,7 @@ class ImportMapManagerTest extends TestCase
 
                 throw new \Exception(\sprintf('Unexpected path "%s"', $path));
             });
-        $this->configReader->expects($this->any())
+        $this->configReader
             ->method('convertFilesystemPathToPath')
             ->willReturnCallback(function ($path) {
                 return match ($path) {
@@ -407,7 +407,7 @@ class ImportMapManagerTest extends TestCase
         $this->remotePackageDownloader ??= $this->createStub(RemotePackageDownloader::class);
 
         // mock this to behave like normal
-        $this->configReader->expects($this->any())
+        $this->configReader
             ->method('createRemoteEntry')
             ->willReturnCallback(function (string $importName, ImportMapType $type, string $version, string $packageModuleSpecifier, bool $isEntrypoint) {
                 $path = '/path/to/vendor/'.$packageModuleSpecifier.'.js';
@@ -434,7 +434,7 @@ class ImportMapManagerTest extends TestCase
 
     private function mockImportMap(array $importMapEntries): void
     {
-        $this->configReader->expects($this->any())
+        $this->configReader
             ->method('getEntries')
             ->willReturn(new ImportMapEntries($importMapEntries))
         ;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -31,13 +31,13 @@ class MergeExtensionConfigurationPassTest extends TestCase
         $tmpProviders = [];
 
         $extension = $this->createMock(ExtensionInterface::class);
-        $extension->expects($this->any())
+        $extension
             ->method('getXsdValidationBasePath')
             ->willReturn(false);
-        $extension->expects($this->any())
+        $extension
             ->method('getNamespace')
             ->willReturn('http://example.org/schema/dic/foo');
-        $extension->expects($this->any())
+        $extension
             ->method('getAlias')
             ->willReturn('foo');
         $extension->expects($this->once())

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -892,7 +892,6 @@ class FormTest extends TestCase
         ;
 
         $field
-            ->expects($this->any())
             ->method('getValue')
             ->willReturn($value)
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
@@ -25,7 +25,7 @@ class LazyLoadingFragmentHandlerTest extends TestCase
     {
         $renderer = $this->createMock(FragmentRendererInterface::class);
         $renderer->expects($this->once())->method('getName')->willReturn('foo');
-        $renderer->expects($this->any())->method('render')->willReturn(new Response());
+        $renderer->method('render')->willReturn(new Response());
 
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -243,12 +243,12 @@ class EsiTest extends TestCase
               ->willReturn($request)
         ;
         if (\is_array($response)) {
-            $cache->expects($this->any())
+            $cache
                   ->method('handle')
                   ->willReturn(...$response)
             ;
         } else {
-            $cache->expects($this->any())
+            $cache
                   ->method('handle')
                   ->willReturn($response)
             ;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -199,12 +199,12 @@ class SsiTest extends TestCase
               ->willReturn($request)
         ;
         if (\is_array($response)) {
-            $cache->expects($this->any())
+            $cache
                   ->method('handle')
                   ->willReturn(...$response)
             ;
         } else {
-            $cache->expects($this->any())
+            $cache
                   ->method('handle')
                   ->willReturn($response)
             ;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -162,7 +162,7 @@ class HttpKernelBrowserTest extends TestCase
             ->method('getSize')
             ->willReturn(\PHP_INT_MAX)
         ;
-        $file->expects($this->any())
+        $file
             ->method('getClientSize')
             ->willReturn(\PHP_INT_MAX)
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -752,7 +752,7 @@ EOF
         ;
 
         $kernel = $kernelMockBuilder->getMock();
-        $kernel->expects($this->any())
+        $kernel
             ->method('registerBundles')
             ->willReturn($bundles)
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -47,7 +47,7 @@ class ProfilerTest extends TestCase
         $collector = $this->getMockBuilder(DataCollectorInterface::class)
             ->onlyMethods(['collect', 'getName', 'reset'])
             ->getMock();
-        $collector->expects($this->any())->method('getName')->willReturn('mock');
+        $collector->method('getName')->willReturn('mock');
         $collector->expects($this->once())->method('reset');
 
         $profiler = new Profiler($this->storage);

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -190,7 +190,9 @@ class CheckLdapCredentialsListenerTest extends TestCase
                 $this->assertSame(array_shift($series), $args);
             })
         ;
-        $ldap->expects($this->any())->method('escape')->with('Wouter', '', LdapInterface::ESCAPE_FILTER)->willReturn('wouter');
+        $ldap->method('escape')->willReturnMap([
+            ['Wouter', '', LdapInterface::ESCAPE_FILTER, 'wouter'],
+        ]);
         $ldap->expects($this->once())->method('query')->with('{user_identifier}', 'wouter_test')->willReturn($query);
 
         $listener = $this->createListener($ldap);

--- a/src/Symfony/Component/Lock/Tests/LockFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockFactoryTest.php
@@ -25,7 +25,7 @@ class LockFactoryTest extends TestCase
     public function testCreateLock()
     {
         $store = $this->createMock(PersistingStoreInterface::class);
-        $store->expects($this->any())->method('exists')->willReturn(false);
+        $store->method('exists')->willReturn(false);
 
         $keys = [];
         $store
@@ -53,7 +53,7 @@ class LockFactoryTest extends TestCase
     public function testCreateLockFromKey()
     {
         $store = $this->createMock(PersistingStoreInterface::class);
-        $store->expects($this->any())->method('exists')->willReturn(false);
+        $store->method('exists')->willReturn(false);
 
         $keys = [];
         $store

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -138,7 +138,6 @@ class CombinedStoreTest extends AbstractStoreTestCase
             ->method('canBeMet')
             ->willReturn(false);
         $strategy
-            ->expects($this->any())
             ->method('isMet')
             ->willReturn(false);
 
@@ -241,7 +240,6 @@ class CombinedStoreTest extends AbstractStoreTestCase
             ->method('canBeMet')
             ->willReturn(false);
         $strategy
-            ->expects($this->any())
             ->method('isMet')
             ->willReturn(false);
 
@@ -264,7 +262,6 @@ class CombinedStoreTest extends AbstractStoreTestCase
         $ttl = random_int(1, 10);
 
         $strategy
-            ->expects($this->any())
             ->method('canBeMet')
             ->willReturn(true);
         $strategy
@@ -292,7 +289,6 @@ class CombinedStoreTest extends AbstractStoreTestCase
 
         $strategy = $this->createMock(StrategyInterface::class);
         $strategy
-            ->expects($this->any())
             ->method('canBeMet')
             ->willReturn(true);
         $strategy

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -224,10 +224,11 @@ class ConnectionTest extends TestCase
     public function testKeepGettingPendingMessages()
     {
         $client = $this->createMock(SqsClient::class);
-        $client->expects($this->any())
+        $client
             ->method('getQueueUrl')
-            ->with(['QueueName' => 'queue', 'QueueOwnerAWSAccountId' => 123])
-            ->willReturn(ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue']));
+            ->willReturnMap([
+                [['QueueName' => 'queue', 'QueueOwnerAWSAccountId' => 123], ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue'])],
+            ]);
 
         $firstResult = ResultMockFactory::create(ReceiveMessageResult::class, ['Messages' => [
             new Message(['MessageId' => 1, 'Body' => 'this is a test']),

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -55,12 +55,10 @@ class PostgreSqlConnectionTest extends TestCase
         $driverConnection->method('executeStatement')->willReturn(1);
 
         $driverConnection
-            ->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn(new PostgreSQLPlatform());
 
         $driverConnection
-            ->expects(self::any())
             ->method('createQueryBuilder')
             ->willReturn(new QueryBuilder($driverConnection));
 
@@ -95,7 +93,6 @@ class PostgreSqlConnectionTest extends TestCase
                 ->willReturn($wrappedConnection);
 
             $driverConnection
-                ->expects(self::any())
                 ->method('executeQuery')
                 ->willReturn(new ArrayStatement([]));
         } else {
@@ -109,7 +106,6 @@ class PostgreSqlConnectionTest extends TestCase
             $driverResult->method('fetchAssociative')
                 ->willReturn(false);
             $driverConnection
-                ->expects(self::any())
                 ->method('executeQuery')
                 ->willReturn(new Result($driverResult, $driverConnection));
         }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -75,7 +75,7 @@ class ConnectionTest extends TestCase
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
             ->willReturn(true);
-        $redis->expects($this->any())
+        $redis
             ->method('isConnected')
             ->willReturnOnConsecutiveCalls(false, true);
 

--- a/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/FailoverTransportTest.php
@@ -61,7 +61,9 @@ class FailoverTransportTest extends TestCase
         $message = new DummyMessage();
 
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->method('supports')->with($message)->willReturn(true);
+        $t1->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
         $t1->expects($this->exactly(3))->method('send')->with($message)->willReturn(new SentMessage($message, 'test'));
 
         $t2 = $this->createMock(TransportInterface::class);
@@ -79,11 +81,15 @@ class FailoverTransportTest extends TestCase
         $message = new DummyMessage();
 
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->method('supports')->with($message)->willReturn(true);
+        $t1->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
         $t1->expects($this->once())->method('send')->with($message)->willThrowException($this->createStub(TransportExceptionInterface::class));
 
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->method('supports')->with($message)->willReturn(true);
+        $t2->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
         $t2->expects($this->once())->method('send')->with($message)->willThrowException($this->createStub(TransportExceptionInterface::class));
 
         $t = new FailoverTransport([$t1, $t2]);
@@ -99,11 +105,15 @@ class FailoverTransportTest extends TestCase
         $message = new DummyMessage();
 
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->method('supports')->with($message)->willReturn(true);
+        $t1->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
         $t1->expects($this->once())->method('send')->willThrowException($this->createStub(TransportExceptionInterface::class));
 
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->method('supports')->with($message)->willReturn(true);
+        $t2->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
         $t2->expects($this->exactly(1))->method('send')->with($message)->willReturn(new SentMessage($message, 'test'));
 
         $t = new FailoverTransport([$t1, $t2]);
@@ -116,11 +126,15 @@ class FailoverTransportTest extends TestCase
         $message = new DummyMessage();
 
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->method('supports')->with($message)->willReturn(true);
+        $t1->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
         $t1->method('send')->willThrowException($this->createStub(TransportExceptionInterface::class));
         $t1->expects($this->once())->method('send');
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->method('supports')->with($message)->willReturn(true);
+        $t2->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
 
         $matcher = $this->exactly(3);
         $t2->expects($matcher)
@@ -149,7 +163,9 @@ class FailoverTransportTest extends TestCase
         $message = new DummyMessage();
 
         $t1 = $this->createMock(TransportInterface::class);
-        $t1->method('supports')->with($message)->willReturn(true);
+        $t1->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
 
         $t1Matcher = $this->exactly(2);
         $t1->expects($t1Matcher)->method('send')
@@ -161,7 +177,9 @@ class FailoverTransportTest extends TestCase
                 return new SentMessage($message, 't1');
             });
         $t2 = $this->createMock(TransportInterface::class);
-        $t2->method('supports')->with($message)->willReturn(true);
+        $t2->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
 
         $t2Matcher = $this->exactly(2);
         $t2->expects($t2Matcher)->method('send')->willReturnCallback(function () use ($t2Matcher, $message) {

--- a/src/Symfony/Component/Notifier/Tests/Transport/TransportsTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/TransportsTest.php
@@ -29,7 +29,9 @@ class TransportsTest extends TestCase
 
         $message = new ChatMessage('subject');
 
-        $one->method('supports')->with($message)->willReturn(true);
+        $one->method('supports')->willReturnMap([
+            [$message, true],
+        ]);
 
         $one->expects($this->once())->method('send')->willReturn(new SentMessage($message, 'one'));
 

--- a/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
@@ -27,7 +27,9 @@ class CacheStorageTest extends TestCase
         $cacheItem = $this->createMock(CacheItemInterface::class);
         $cacheItem->expects($this->exactly(2))->method('expiresAfter')->with(10);
 
-        $pool->expects($this->any())->method('getItem')->with(sha1('test'))->willReturn($cacheItem);
+        $pool->method('getItem')->willReturnMap([
+            [sha1('test'), $cacheItem],
+        ]);
         $pool->expects($this->exactly(2))->method('save')->with($cacheItem);
 
         $window = new Window('test', 10, 20);

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -169,7 +169,7 @@ class AuthenticatorManagerTest extends TestCase
         $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
         $this->request->attributes->set('_security_authenticators', [$authenticator]);
 
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter')));
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter')));
 
         $authenticator->expects($this->once())->method('onAuthenticationFailure')->with($this->anything(), $this->callback(fn ($exception) => 'Authentication failed; Some badges marked as required by the firewall config are not available on the passport: "'.CsrfTokenBadge::class.'".' === $exception->getMessage()));
 
@@ -184,8 +184,8 @@ class AuthenticatorManagerTest extends TestCase
 
         $csrfBadge = new CsrfTokenBadge('csrfid', 'csrftoken');
         $csrfBadge->markResolved();
-        $authenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter'), [$csrfBadge]));
-        $authenticator->expects($this->any())->method('createToken')->willReturn(new UsernamePasswordToken($this->user, 'main'));
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter'), [$csrfBadge]));
+        $authenticator->method('createToken')->willReturn(new UsernamePasswordToken($this->user, 'main'));
 
         $authenticator->expects($this->once())->method('onAuthenticationSuccess');
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -83,7 +83,7 @@ class PasswordMigratingListenerTest extends TestCase
     public function testUpgradeWithoutUpgrader()
     {
         $userLoader = $this->createMock(TestMigratingUserProvider::class);
-        $userLoader->expects($this->any())->method('loadUserByIdentifier')->willReturn($this->user);
+        $userLoader->method('loadUserByIdentifier')->willReturn($this->user);
 
         $userLoader->expects($this->exactly(2))
             ->method('upgradePassword')

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -183,7 +183,6 @@ class HttpUtilsTest extends TestCase
             ->willReturn('/foo/bar')
         ;
         $urlGenerator
-            ->expects($this->any())
             ->method('getContext')
             ->willReturn(new RequestContext())
         ;

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -94,10 +94,11 @@ class PersistentRememberMeHandlerTest extends TestCase
     public function testConsumeRememberMeCookieValid()
     {
         $tokenProvider = $this->createMock(TokenProviderInterface::class);
-        $tokenProvider->expects($this->any())
+        $tokenProvider
             ->method('loadTokenBySeries')
-            ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', $lastUsed = new \DateTimeImmutable('-10 min')))
+            ->willReturnMap([
+                ['series1', new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', $lastUsed = new \DateTimeImmutable('-10 min'))],
+            ])
         ;
 
         $tokenProvider->expects($this->once())->method('updateToken')->with('series1');
@@ -173,10 +174,11 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->expectException(CookieTheftException::class);
 
         $tokenProvider = $this->createMock(TokenProviderInterface::class);
-        $tokenProvider->expects($this->any())
+        $tokenProvider
             ->method('loadTokenBySeries')
-            ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue1', new \DateTimeImmutable('-10 min')));
+            ->willReturnMap([
+                ['series1', new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue1', new \DateTimeImmutable('-10 min'))],
+            ]);
 
         $tokenProvider->expects($this->never())->method('updateToken')->with('series1');
 
@@ -189,10 +191,11 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->expectExceptionMessage('The cookie has expired.');
 
         $tokenProvider = $this->createMock(TokenProviderInterface::class);
-        $tokenProvider->expects($this->any())
+        $tokenProvider
             ->method('loadTokenBySeries')
-            ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('@'.(time() - (31536000 + 1)))));
+            ->willReturnMap([
+                ['series1', new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('@'.(time() - (31536000 + 1))))],
+            ]);
 
         $tokenProvider->expects($this->never())->method('updateToken')->with('series1');
 
@@ -202,10 +205,11 @@ class PersistentRememberMeHandlerTest extends TestCase
     public function testBase64EncodedTokens()
     {
         $tokenProvider = $this->createMock(TokenProviderInterface::class);
-        $tokenProvider->expects($this->any())
+        $tokenProvider
             ->method('loadTokenBySeries')
-            ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')))
+            ->willReturnMap([
+                ['series1', new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min'))],
+            ])
         ;
 
         $tokenProvider->expects($this->once())->method('updateToken')->with('series1');

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -199,10 +199,11 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         ], 'fr'));
 
         $provider = $this->createMock(ProviderInterface::class);
-        $provider->expects($this->any())
+        $provider
             ->method('read')
-            ->with($domains, $locales)
-            ->willReturn($providerReadTranslatorBag);
+            ->willReturnMap([
+                [$domains, $locales, $providerReadTranslatorBag],
+            ]);
 
         // Create local bag, with a missing message.
         $localTranslatorBag = new TranslatorBag();
@@ -221,10 +222,11 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         $providerReadTranslatorBag->addCatalogue($arrayLoader->load(['note' => 'NOTE'], 'en'));
         $providerReadTranslatorBag->addCatalogue($arrayLoader->load(['note' => 'NOTE'], 'fr'));
 
-        $provider->expects($this->any())
+        $provider
             ->method('read')
-            ->with($domains, $locales)
-            ->willReturn($providerReadTranslatorBag);
+            ->willReturnMap([
+                [$domains, $locales, $providerReadTranslatorBag],
+            ]);
 
         $provider->expects($this->once())
             ->method('write')
@@ -261,10 +263,11 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         ], 'fr'));
 
         $provider = $this->createMock(ProviderInterface::class);
-        $provider->expects($this->any())
+        $provider
             ->method('read')
-            ->with($domains, $locales)
-            ->willReturn($providerReadTranslatorBag);
+            ->willReturnMap([
+                [$domains, $locales, $providerReadTranslatorBag],
+            ]);
 
         // Create local bag, with a missing message, an updated one and a new one.
         $localTranslatorBag = new TranslatorBag();
@@ -283,10 +286,11 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         $providerReadTranslatorBag->addCatalogue($arrayLoader->load(['note' => 'NOTE'], 'en'));
         $providerReadTranslatorBag->addCatalogue($arrayLoader->load(['note' => 'NOTE'], 'fr'));
 
-        $provider->expects($this->any())
+        $provider
             ->method('read')
-            ->with($domains, $locales)
-            ->willReturn($providerReadTranslatorBag);
+            ->willReturnMap([
+                [$domains, $locales, $providerReadTranslatorBag],
+            ]);
 
         $translationBagToWrite = $localTranslatorBag->diff($providerReadTranslatorBag);
         $translationBagToWrite->addBag($localTranslatorBag->intersect($providerReadTranslatorBag));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
