### PR TITLE
[Console] Fix profiling commands that use `#[Ask]`

### DIFF
--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -178,9 +178,12 @@ final class TraceableCommand extends Command
                 'file' => $r->getFileName(),
                 'line' => $r->getStartLine(),
             ];
-        }
 
-        $this->command->setCode($code);
+            // Pass the original callable to avoid double-wrapping in Command::setCode()
+            $this->command->setCode($code->getCode());
+        } else {
+            $this->command->setCode($code);
+        }
 
         return parent::setCode(function (InputInterface $input, OutputInterface $output) use ($code): int {
             $event = $this->stopwatch->start($this->getName().'.code');

--- a/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\TraceableCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithAskCommand;
 use Symfony\Component\Console\Tests\Fixtures\LoopExampleCommand;
 use Symfony\Component\Stopwatch\Stopwatch;
 
@@ -67,6 +68,21 @@ class TraceableCommandTest extends TestCase
         $commandTester = new CommandTester($traceableCommand);
         $commandTester->execute([]);
         $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testRunOnInvokableCommandWithAskAttribute()
+    {
+        $this->application->addCommand(new InvokableWithAskCommand());
+        $command = $this->application->find('invokable:ask');
+        $traceableCommand = new TraceableCommand($command, new Stopwatch());
+
+        $commandTester = new CommandTester($traceableCommand);
+        $commandTester->setInputs(['World']);
+        $commandTester->execute([], ['interactive' => true]);
+        $commandTester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString('What is your name?', $commandTester->getDisplay());
+        self::assertStringContainsString('Hello World', $commandTester->getDisplay());
     }
 
     public function assertLoopOutputCorrectness(string $output)

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithAskCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithAskCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Ask;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('invokable:ask')]
+class InvokableWithAskCommand
+{
+    public function __invoke(
+        SymfonyStyle $io,
+
+        #[Argument]
+        #[Ask('What is your name?')]
+        string $name,
+    ): int {
+        $io->writeln('Hello '.$name);
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since #61138 `TraceableCommand::run()` delegates to `$this->command->run()` instead of `parent::run()`, which means the wrapped command's `$code` is now actually used during execution.
Problem is that `TraceableCommand::setCode()` passes the InvokableCommand directly to `$this->command->setCode()`, which wraps it again in a new InvokableCommand. This double wrapping breaks `#[Ask]` processing: when scanning for interactions, it reflects on `InvokableCommand::__invoke` instead of the original command's `__invoke`, finding no `#[Ask]` attributes.  
As a result, running a command that use `#[Ask]` with `--profile` leads to a missing arguments error, as if there were no `#[Ask]` defined on the arguments.
This PR fixes it by extracting the original callable before delegating to `Command::setCode()`.
