### PR TITLE
[TypeInfo] TypeContextFactory::collectTemplates now also works with @phpstan-template and @psalm-template

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -52,6 +52,7 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/Security/Http/Tests/Fixtures/IsGrantedAttributeWithClosureController.php'):
         case false !== strpos($file, '/src/Symfony/Component/Serializer/Tests/Fixtures/'):
         case false !== strpos($file, '/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectOuter.php'):
+        case false !== strpos($file, '/src/Symfony/Component/TypeInfo/Tests/Fixtures/'):
         case false !== strpos($file, '/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php'):
         case false !== strpos($file, '/src/Symfony/Component/VarDumper/Tests/Fixtures/NotLoadableClass.php'):

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpstanTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpstanTemplates.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @phpstan-template T of int|string
+ * @phpstan-template U
+ */
+final class DummyWithPhpstanTemplates
+{
+    private int $price;
+
+    /**
+     * @phpstan-template T of int|float
+     * @phpstan-template V
+     *
+     * @return T
+     */
+    public function getPrice(bool $inCents = false): int|float
+    {
+        return $inCents ? $this->price : $this->price / 100;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPsalmTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPsalmTemplates.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @psalm-template T of int|string
+ * @psalm-template U
+ */
+final class DummyWithPsalmTemplates
+{
+    private int $price;
+
+    /**
+     * @psalm-template T of int|float
+     * @psalm-template V
+     *
+     * @return T
+     */
+    public function getPrice(bool $inCents = false): int|float
+    {
+        return $inCents ? $this->price : $this->price / 100;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithImportedOnlyTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAliasImport;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPhpstanTemplates;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPsalmTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithRecursiveTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplateAndParent;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
@@ -120,36 +122,52 @@ class TypeContextFactoryTest extends TestCase
         $this->assertEquals($uses, $this->typeContextFactory->createFromReflection(new \ReflectionParameter([DummyWithUsesWindowsLineEndings::class, 'setCreatedAt'], 'createdAt'))->uses);
     }
 
-    public function testCollectTemplates()
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('collectTemplatesDataProvider')]
+    public function testCollectTemplates(string $className)
     {
-        $this->assertEquals([], $this->typeContextFactory->createFromClassName(Dummy::class)->templates);
         $this->assertEquals([
             'T' => Type::union(Type::int(), Type::string()),
             'U' => Type::mixed(),
-        ], $this->typeContextFactory->createFromClassName(DummyWithTemplates::class)->templates);
+        ], $this->typeContextFactory->createFromClassName($className)->templates);
 
         $this->assertEquals([
             'T' => Type::union(Type::int(), Type::string()),
             'U' => Type::mixed(),
-        ], $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithTemplates::class))->templates);
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionClass($className))->templates);
 
         $this->assertEquals([
             'T' => Type::union(Type::int(), Type::string()),
             'U' => Type::mixed(),
-        ], $this->typeContextFactory->createFromReflection(new \ReflectionProperty(DummyWithTemplates::class, 'price'))->templates);
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionProperty($className, 'price'))->templates);
 
         $this->assertEquals([
             'T' => Type::union(Type::int(), Type::float()),
             'U' => Type::mixed(),
             'V' => Type::mixed(),
-        ], $this->typeContextFactory->createFromReflection(new \ReflectionMethod(DummyWithTemplates::class, 'getPrice'))->templates);
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionMethod($className, 'getPrice'))->templates);
 
         $this->assertEquals([
             'T' => Type::union(Type::int(), Type::float()),
             'U' => Type::mixed(),
             'V' => Type::mixed(),
-        ], $this->typeContextFactory->createFromReflection(new \ReflectionParameter([DummyWithTemplates::class, 'getPrice'], 'inCents'))->templates);
+        ], $this->typeContextFactory->createFromReflection(new \ReflectionParameter([$className, 'getPrice'], 'inCents'))->templates);
+    }
 
+    /**
+     * @return iterable<array{0: class-string}>
+     */
+    public static function collectTemplatesDataProvider(): iterable
+    {
+        yield [DummyWithTemplates::class];
+        yield [DummyWithPhpstanTemplates::class];
+        yield [DummyWithPsalmTemplates::class];
+    }
+
+    public function testCollectTemplatesWithParent()
+    {
         $this->assertEquals([
             'T' => Type::object(DummyInDifferentNs::class),
         ], $this->typeContextFactory->createFromReflection(new \ReflectionClass(DummyWithTemplateAndParent::class))->templates);

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -201,7 +201,7 @@ final class TypeContextFactory
         }
 
         $templates = [];
-        foreach ($this->getPhpDocNode($rawDocNode)->getTagsByName('@template') as $tag) {
+        foreach ($this->getPhpDocNode($rawDocNode)->getTagsByName('@template') + $this->getPhpDocNode($rawDocNode)->getTagsByName('@phpstan-template') + $this->getPhpDocNode($rawDocNode)->getTagsByName('@psalm-template') as $tag) {
             if (!$tag->value instanceof TemplateTagValueNode) {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

- `TypeContextFactory` already reads `@phpstan-`/`@psalm-` prefixed tags in its other methods, but `collectTemplates()` method omitted them.