### PR TITLE
[Messenger][SQS] Receive SQS `MessageSystemAttributeNames` to allow access to SQS message metadata

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+* Receive SQS `MessageSystemAttributeNames` to allow access to SQS message metadata and attach those to envelopes through `AmazonSqsMessageSystemAttributeNamesStamp`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
+use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsMessageSystemAttributeNamesStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceivedStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceiver;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
@@ -38,6 +40,9 @@ class AmazonSqsReceiverTest extends TestCase
         $actualEnvelopes = iterator_to_array($receiver->get());
         $this->assertCount(1, $actualEnvelopes);
         $this->assertEquals(new DummyMessage('Hi'), $actualEnvelopes[0]->getMessage());
+
+        $messageSystemAttributeNamesStamp = $actualEnvelopes[0]->last(AmazonSqsMessageSystemAttributeNamesStamp::class);
+        $this->assertSame(['ApproximateReceiveCount' => '1'], $messageSystemAttributeNamesStamp->getMessageSystemAttributeNames());
     }
 
     public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException()
@@ -85,6 +90,9 @@ class AmazonSqsReceiverTest extends TestCase
             'body' => '{"message": "Hi"}',
             'headers' => [
                 'type' => DummyMessage::class,
+            ],
+            'attributes' => [
+                MessageSystemAttributeName::APPROXIMATE_RECEIVE_COUNT => '1',
             ],
         ];
     }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
@@ -13,8 +13,10 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\Http\ServerException;
+use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsMessageSystemAttributeNamesStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceivedStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceiver;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransport;
@@ -51,6 +53,7 @@ class AmazonSqsTransportTest extends TestCase
             'id' => '5',
             'body' => 'body',
             'headers' => ['my' => 'header'],
+            'attributes' => [MessageSystemAttributeName::APPROXIMATE_RECEIVE_COUNT => '1'],
         ];
 
         $serializer->expects($this->once())->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
@@ -58,6 +61,9 @@ class AmazonSqsTransportTest extends TestCase
 
         $envelopes = iterator_to_array($transport->get());
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());
+
+        $messageSystemAttributeNamesStamp = $envelopes[0]->last(AmazonSqsMessageSystemAttributeNamesStamp::class);
+        $this->assertSame(['ApproximateReceiveCount' => '1'], $messageSystemAttributeNamesStamp->getMessageSystemAttributeNames());
     }
 
     public function testTransportIsAMessageCountAware()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -246,11 +246,13 @@ class ConnectionTest extends TestCase
                 'VisibilityTimeout' => null,
                 'MaxNumberOfMessages' => 9,
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => ['All'],
                 'WaitTimeSeconds' => 20]], $firstResult],
             [[['QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue',
                 'VisibilityTimeout' => null,
                 'MaxNumberOfMessages' => 9,
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => ['All'],
                 'WaitTimeSeconds' => 20]], $secondResult],
         ];
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsMessageSystemAttributeNamesStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsMessageSystemAttributeNamesStamp.php
@@ -11,18 +11,19 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
+use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
 /**
  * @author Ilaria Cangini <ilaria.cangini@kanbanbox.com>
  */
-readonly class AmazonSqsMessageSystemAttributeNamesStamp implements NonSendableStampInterface
+class AmazonSqsMessageSystemAttributeNamesStamp implements NonSendableStampInterface
 {
     /**
      * @param array<MessageSystemAttributeName::*, string> $messageSystemAttributeNames
      */
     public function __construct(
-        private array $messageSystemAttributeNames,
+        private readonly array $messageSystemAttributeNames,
     ) {
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsMessageSystemAttributeNamesStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsMessageSystemAttributeNamesStamp.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * @author Ilaria Cangini <ilaria.cangini@kanbanbox.com>
+ */
+readonly class AmazonSqsMessageSystemAttributeNamesStamp implements NonSendableStampInterface
+{
+    /**
+     * @param array<MessageSystemAttributeName::*, string> $messageSystemAttributeNames
+     */
+    public function __construct(
+        private array $messageSystemAttributeNames,
+    ) {
+    }
+
+    /**
+     * @return array<MessageSystemAttributeName::*, string>
+     */
+    public function getMessageSystemAttributeNames(): array
+    {
+        return $this->messageSystemAttributeNames;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
@@ -57,7 +57,7 @@ class AmazonSqsReceiver implements KeepaliveReceiverInterface, MessageCountAware
             throw $exception;
         }
 
-        yield $envelope->with(new AmazonSqsReceivedStamp($sqsEnvelope['id']));
+        yield $envelope->with(new AmazonSqsReceivedStamp($sqsEnvelope['id']), new AmazonSqsMessageSystemAttributeNamesStamp($sqsEnvelope['attributes']));
     }
 
     public function ack(Envelope $envelope): void

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -231,6 +231,7 @@ class Connection
                 'VisibilityTimeout' => $this->configuration['visibility_timeout'],
                 'MaxNumberOfMessages' => $this->configuration['buffer_size'],
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => ['All'],
                 'WaitTimeSeconds' => $this->configuration['wait_time'],
             ]);
         }
@@ -267,6 +268,7 @@ class Connection
                 'id' => $message->getReceiptHandle(),
                 'body' => $message->getBody(),
                 'headers' => $headers,
+                'attributes' => $message->getAttributes(),
             ];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| Issues        | 
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

This PR adds support for receiving SQS `MessageSystemAttributeNames` to access SQS message metadata. 

This allows to retrieve system-level information about SQS messages (like approximate receive count, sent timestamp, sender ID, etc.) and attach them to Symfony Messenger envelopes through the new `AmazonSqsMessageSystemAttributeNamesStamp`.

This is needed because SQS provides valuable metadata about messages that applications might need for logging, debugging, or business logic (e.g. tracking how many times a message has been received, when it was sent, etc.).
