### PR TITLE
[DependencyInjection] Deprecate named autowiring alias that don't use `#[Target]`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -18,6 +18,13 @@ DependencyInjection
 
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
  * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
+ * Deprecate named autowiring alias that don't use `#[Target]`
+   ```diff
+    public function __construct(
+   +    #[Target]
+        private StorageInterface $imageStorage,
+    ) {
+   ```
 
 DoctrineBridge
 --------------

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Allow environment variables with `.` in them
  * Add argument `exclude` to `ContainerConfigurator::import()`
  * Add `target` parameter to `#[AsAlias]` to create target-specific autowiring aliases
+ * Deprecate named autowiring alias that don't use `#[Target]`
 
 8.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -283,6 +283,9 @@ class AutowirePass extends AbstractRecursivePass
             $currentId = $this->currentId;
 
             $getValue = function () use ($type, $parameter, $class, $method, $name, $target, $defaultArgument, $currentId) {
+                if (!$target && null !== ($namedAlias = $this->getCombinedAlias($type, $name)) && $this->canDefinitionBeAutowired($namedAlias)) {
+                    trigger_deprecation('symfony/dependency-injection', '8.1', 'Relying solely on the name of parameter "$%s" of "%s()" to match a named autowiring alias is deprecated; use the "#[Target]" attribute.', $parameter->name, $class !== $currentId ? $class.'::'.$method : $method);
+                }
                 if (!$value = $this->getAutowiredReference($ref = new TypedReference($type, $type, ContainerBuilder::EXCEPTION_ON_INVALID_REFERENCE, $name, $target), false)) {
                     $failureMessage = $this->createTypeNotFoundMessageCallback($ref, \sprintf('argument "$%s" of method "%s()"', $parameter->name, $class !== $currentId ? $class.'::'.$method : $method));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -36,6 +37,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\FooVariadic;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\OptionalParameter;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\WithoutTarget;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTargetAnonymous;
 use Symfony\Component\DependencyInjection\TypedReference;
@@ -267,7 +269,9 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testGuessableUnionType()
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testLegacyGuessableUnionType()
     {
         $container = new ContainerBuilder();
 
@@ -276,6 +280,23 @@ class AutowirePassTest extends TestCase
         $container->setAlias(CollisionB::class.' $collision', 'b');
 
         $aDefinition = $container->register('a', UnionClasses::class);
+        $aDefinition->setAutowired(true);
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertSame('b', (string) $aDefinition->getArgument(0));
+    }
+
+    public function testGuessableUnionType()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('b', \stdClass::class);
+        $container->setAlias('.'.CollisionA::class.' $collision', 'b');
+        $container->setAlias('.'.CollisionB::class.' $collision', 'b');
+
+        $aDefinition = $container->register('a', UnionClassesWithTarget::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -1077,7 +1098,9 @@ class AutowirePassTest extends TestCase
         $this->assertSame(['Cannot autowire service "some_locator": it has type "Symfony\Component\DependencyInjection\Tests\Compiler\MissingClass" but this class was not found.'], $container->getDefinition('.errored.some_locator.'.MissingClass::class)->getErrors());
     }
 
-    public function testNamedArgumentAliasResolveCollisions()
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testLegacyNamedArgumentAliasResolveCollisions()
     {
         $container = new ContainerBuilder();
 
@@ -1085,6 +1108,31 @@ class AutowirePassTest extends TestCase
         $container->register('c2', CollisionB::class);
         $container->setAlias(CollisionInterface::class.' $collision', 'c2');
         $aDefinition = $container->register('setter_injection_collision', SetterInjectionCollision::class);
+        $aDefinition->setAutowired(true);
+
+        (new AutowireRequiredMethodsPass())->process($container);
+
+        $pass = new AutowirePass();
+
+        $pass->process($container);
+
+        $expected = [
+            [
+                'setMultipleInstancesForOneArg',
+                [new TypedReference(CollisionInterface::class.' $collision', CollisionInterface::class)],
+            ],
+        ];
+        $this->assertEquals($expected, $container->getDefinition('setter_injection_collision')->getMethodCalls());
+    }
+
+    public function testNamedArgumentAliasResolveCollisions()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class);
+        $container->setAlias(CollisionInterface::class.' $collision', 'c2');
+        $aDefinition = $container->register('setter_injection_collision', SetterInjectionCollisionWithTarget::class);
         $aDefinition->setAutowired(true);
 
         (new AutowireRequiredMethodsPass())->process($container);
@@ -1160,6 +1208,22 @@ class AutowirePassTest extends TestCase
         (new AutowirePass())->process($container);
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testNamedAliasByParameterNameIsDeprecated()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('image.storage', BarInterface::class);
+        $container->registerAliasForArgument('image.storage', BarInterface::class, 'imageStorage');
+        $container->register('without_target', WithoutTarget::class)
+            ->setAutowired(true);
+
+        $this->expectUserDeprecationMessage('Since symfony/dependency-injection 8.1: Relying solely on the name of parameter "$imageStorage" of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\WithoutTarget::__construct()" to match a named autowiring alias is deprecated; use the "#[Target]" attribute.');
+
+        (new AutowirePass())->process($container);
+    }
+
     public function testArgumentWithIdTarget()
     {
         $container = new ContainerBuilder();
@@ -1208,7 +1272,9 @@ class AutowirePassTest extends TestCase
         $this->assertEquals([new TypedReference(A::class, A::class), 'abc'], $container->getDefinition('foo')->getArguments());
     }
 
-    public function testAutowireUnderscoreNamedArgument()
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testLegacyAutowireUnderscoreNamedArgument()
     {
         $container = new ContainerBuilder();
 
@@ -1218,6 +1284,18 @@ class AutowirePassTest extends TestCase
         (new AutowirePass())->process($container);
 
         $this->assertInstanceOf(\DateTimeImmutable::class, $container->get('foo')->now_datetime);
+    }
+
+    public function testAutowireUnderscoreNamedArgument()
+    {
+        $container = new ContainerBuilder();
+
+        $container->autowire(\DateTimeImmutable::class.' $now_datetime', \DateTimeImmutable::class);
+        $container->autowire('foo', UnderscoreNamedArgumentWithTarget::class)->setPublic(true);
+
+        (new AutowirePass())->process($container);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $container->get('foo')->dt);
     }
 
     public function testAutowireDefaultValueParametersLike()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithoutTarget.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithoutTarget.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class WithoutTarget
+{
+    public function __construct(BarInterface $imageStorage)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -6,6 +6,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Contracts\Service\Attribute\Required;
 
 require __DIR__.'/uniontype_classes.php';
@@ -140,6 +141,15 @@ class CollisionB implements CollisionInterface
 {
 }
 
+class UnionClassesWithTarget
+{
+    public function __construct(
+        #[Target('collision')]
+        CollisionA|CollisionB $any,
+    ) {
+    }
+}
+
 class CannotBeAutowired
 {
     public function __construct(CollisionInterface $collision)
@@ -217,6 +227,15 @@ class UnderscoreNamedArgument
     }
 }
 
+class UnderscoreNamedArgumentWithTarget
+{
+    public function __construct(
+        #[Target('now_datetime')]
+        public \DateTimeImmutable $dt,
+    ) {
+    }
+}
+
 /*
  * Classes used for testing createResourceForClass
  */
@@ -249,6 +268,14 @@ class SetterInjectionCollision
         // The CollisionInterface cannot be autowired - there are multiple
 
         // should throw an exception
+    }
+}
+
+class SetterInjectionCollisionWithTarget
+{
+    #[Required]
+    public function setMultipleInstancesForOneArg(#[Target('collision')] CollisionInterface $col)
+    {
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

I think it's time to deprecate named autowiring aliases that don't use `#[Target]`.

Named autowiring aliases can be matched in two ways:

1. **Implicitly**, by naming a constructor/method parameter to match the alias (e.g. `BarInterface $imageStorage` resolves `BarInterface $imageStorage` alias).
2. **Explicitly**, by using the `#[Target('image')]` attribute, which is independent of the parameter name.

This PR deprecates approach (1) in favor of (2).

Relying on parameter names to resolve named autowiring aliases has two significant drawbacks:

- **Typos and renames are silent**: renaming a parameter (e.g. during a refactor) may silently break the injection without any error at compile time - the container just falls back to the default unnamed autowiring alias. `#[Target]` makes the intent explicit and keeps it intact across renames.
- **Lack of clarity**: reading a constructor signature gives no indication that the parameter name is load-bearing for service resolution. `#[Target]` makes this immediately visible.

Before:
```php
public function __construct(
    private StorageInterface $imageStorage,
) {}
```

After:
```php
public function __construct(
    #[Target('image')]
    private StorageInterface $storage,
) {}
```

/cc @lyrixx @tgalopin FYI