### PR TITLE
[FrameworkBundle] Add `MicroKernelTrait::$allowedEnvs` to enforce allowed values for `APP_ENV`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -31,6 +31,11 @@ use Symfony\Component\Routing\RouteCollection;
 trait MicroKernelTrait
 {
     /**
+     * @var list<string> The list of allowed environments - typically prod, dev, test - empty allows any environments
+     */
+    private array $allowedEnvs = [];
+
+    /**
      * Configures the container.
      *
      * You can register extensions:
@@ -255,12 +260,18 @@ trait MicroKernelTrait
         $parameters = parent::getKernelParameters();
         $bundlesPath = $this->getBundlesPath();
         $bundlesDefinition = !is_file($bundlesPath) ? [FrameworkBundle::class => ['all' => true]] : require $bundlesPath;
-        $knownEnvs = [$this->environment => true];
 
-        foreach ($bundlesDefinition as $envs) {
-            $knownEnvs += $envs;
+        if (!$knownEnvs = array_flip($this->allowedEnvs)) {
+            $knownEnvs = [$this->environment => true];
+
+            foreach ($bundlesDefinition as $envs) {
+                $knownEnvs += $envs;
+            }
+            unset($knownEnvs['all']);
+        } elseif (!isset($knownEnvs[$this->environment])) {
+            throw new \InvalidArgumentException(\sprintf('The environment "%s" is not registered as allowed in "%s::$allowedEnvs".', $this->environment, static::class));
         }
-        unset($knownEnvs['all']);
+
         $parameters['.container.known_envs'] = array_keys($knownEnvs);
         $parameters['.kernel.config_dir'] = $this->getConfigDir();
         $parameters['.kernel.bundles_definition'] = $bundlesDefinition;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -241,6 +241,25 @@ class MicroKernelTraitTest extends TestCase
         ], $parameters['.kernel.bundles_definition']);
     }
 
+    public function testAllowedEnvsRestrictsKnownEnvs()
+    {
+        $kernel = $this->kernel = new AllowedEnvsKernel('prod', ['dev', 'test', 'prod']);
+
+        $parameters = $kernel->getKernelParameters();
+
+        $this->assertSame(['dev', 'test', 'prod'], $parameters['.container.known_envs']);
+    }
+
+    public function testAllowedEnvsThrowsWhenCurrentEnvNotAllowed()
+    {
+        $kernel = $this->kernel = new AllowedEnvsKernel('staging', ['dev', 'test', 'prod']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The environment "staging" is not registered as allowed in "'.AllowedEnvsKernel::class.'::$allowedEnvs".');
+
+        $kernel->getKernelParameters();
+    }
+
     public function testRelativeEnvDirsAreResolvedFromProjectDir()
     {
         $_SERVER['APP_CACHE_DIR'] = 'var/custom-cache';
@@ -268,5 +287,23 @@ class EnvDirKernel extends Kernel
     public function getProjectDir(): string
     {
         return $this->projectDir;
+    }
+}
+
+class AllowedEnvsKernel extends Kernel
+{
+    use MicroKernelTrait {
+        getKernelParameters as public;
+    }
+
+    public function __construct(string $environment, array $allowedEnvs)
+    {
+        parent::__construct($environment, false);
+        $this->allowedEnvs = $allowedEnvs;
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/sf_allowed_envs_kernel/'.$this->environment;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | no
| License       | MIT

## Description
This PR introduces a strict validation for the APP_ENV environment variable within the Kernel constructor to enforce "Secure by Default" behavior.

## The Problem
Currently, if APP_ENV is set to an undefined value (e.g., APP_ENV=main commonly caused by CI/CD pipelines using branch names, or typos like prodution), Symfony boots using default settings. In many standard configurations (e.g. symfony/skeleton), this results in a dangerous "Zombie State":

1. Debug Mode is often ON (fallback default), leaking stack traces on error pages.
2. WebProfiler is OFF (because config/bundles.php only enables it for dev and test), leading developers to falsely believe they are in a "production-like" environment because the toolbar is missing.
3. Production Hardening is OFF: Specific prod configurations (secure session cookies, caching) are not loaded because config/packages/main/ does not exist.

This violates security best practices regarding Secure Configuration and Information Disclosure (as defined in standards like OWASP or BSI APP.3.1.A12).

## The Solution
The Kernel now throws an InvalidArgumentException immediately if the environment is not explicitly allowed. This implements a "Fail Fast" strategy.
Example (How it works)
```php
// src/Kernel.php
    private array $allowedEnvs = ['dev', 'prod', 'test'];
```

## Before / After Comparison

• Before:
    ◦ APP_ENV=main -> App boots. Error pages show stack traces. Performance is degraded (no cache). No visual warning (no toolbar).
• After:
    ◦ APP_ENV=main -> App crashes immediately with InvalidArgumentException, forcing the operator to fix the configuration to a valid state (prod).
