### PR TITLE
[Console] Silence shell_exec warning in hasSttyAvailable

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -128,7 +128,7 @@ class Terminal
             return false;
         }
 
-        return self::$stty = (bool) shell_exec('stty 2> '.('\\' === \DIRECTORY_SEPARATOR ? 'NUL' : '/dev/null'));
+        return self::$stty = (bool) @shell_exec('stty 2> '.('\\' === \DIRECTORY_SEPARATOR ? 'NUL' : '/dev/null'));
     }
 
     private static function initDimensions(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61225
| License       | MIT

## Summary

When `exec`/`fork` is disallowed (e.g. via sudo with `NOEXEC` tag), `shell_exec()` generates a PHP warning even though `function_exists('shell_exec')` returns `true`.

```
Warning: shell_exec(): Unable to execute 'stty 2> /dev/null'
```

This adds the `@` error suppression operator to the `shell_exec()` call in `hasSttyAvailable()`, consistent with how `proc_open` is already called with `@` in `readFromProcess()` within the same component.

The functional behavior is unchanged: `shell_exec()` returns `null` on failure regardless of `@`, so `hasSttyAvailable()` correctly returns `false`.