### PR TITLE
[Cache] Wrap `DoctrineDbalAdapter::doSave()` in savepoint to prevent transaction poisoning

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
 use Psr\Cache\CacheItemPoolInterface;
@@ -85,7 +86,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         $schema = new Schema();
 
         $adapter = new DoctrineDbalAdapter($connection);
-        $adapter->configureSchema($schema, $connection, fn () => true);
+        $adapter->configureSchema($schema, $connection, static fn () => true);
         $this->assertTrue($schema->hasTable('cache_items'));
     }
 
@@ -99,7 +100,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         $schema = new Schema();
 
         $adapter = $this->createCachePool();
-        $adapter->configureSchema($schema, $otherConnection, fn () => false);
+        $adapter->configureSchema($schema, $otherConnection, static fn () => false);
         $this->assertFalse($schema->hasTable('cache_items'));
     }
 
@@ -114,7 +115,7 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         $schema->createTable('cache_items');
 
         $adapter = new DoctrineDbalAdapter($connection);
-        $adapter->configureSchema($schema, $connection, fn () => true);
+        $adapter->configureSchema($schema, $connection, static fn () => true);
         $table = $schema->getTable('cache_items');
         $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
     }
@@ -166,6 +167,49 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
             $pdo = new \PDO('pgsql:host='.$host.';user=postgres;password=password');
             $pdo->exec('DROP TABLE IF EXISTS cache_items');
         }
+    }
+
+    public function testSaveWithinActiveTransactionUsesSavepoint()
+    {
+        $dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_savepoint');
+        try {
+            $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $dbFile], $this->getDbalConfig());
+            $adapter = new DoctrineDbalAdapter($connection);
+            $adapter->createTable();
+
+            $connection->beginTransaction();
+            $item = $adapter->getItem('savepoint_key');
+            $item->set('savepoint_value');
+            $adapter->save($item);
+
+            $this->assertTrue($connection->isTransactionActive(), 'Outer transaction must still be active after cache save');
+            $connection->commit();
+
+            $this->assertSame('savepoint_value', $adapter->getItem('savepoint_key')->get());
+        } finally {
+            @unlink($dbFile);
+        }
+    }
+
+    public function testSavepointIsRolledBackOnFailure()
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->method('supportsSavepoints')->willReturn(true);
+
+        $conn = $this->createMock(Connection::class);
+        $conn->method('isTransactionActive')->willReturn(true);
+        $conn->method('getDatabasePlatform')->willReturn($platform);
+        $conn->expects($this->once())->method('createSavepoint')->with($this->stringStartsWith('cache_save_'));
+        $conn->expects($this->once())->method('rollbackSavepoint')->with($this->stringStartsWith('cache_save_'));
+        $conn->expects($this->never())->method('releaseSavepoint');
+        $conn->method('prepare')->willThrowException(new \RuntimeException('DB error'));
+
+        $adapter = new DoctrineDbalAdapter($conn);
+
+        $doSave = new \ReflectionMethod($adapter, 'doSave');
+
+        $this->expectException(\RuntimeException::class);
+        $doSave->invoke($adapter, ['key' => 'value'], 0);
     }
 
     protected function isPruned(DoctrineDbalAdapter $cache, string $name): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63417
| License       | MIT

## Summary

When `DoctrineDbalAdapter` is used within an active PostgreSQL transaction (e.g. inside a Symfony Messenger transactional middleware), a cache save failure silently corrupts the transaction. `AbstractAdapter::commit()` catches the exception, but PostgreSQL marks the transaction as aborted (`SQLSTATE 25P02`) — all subsequent queries fail with a misleading error.

## Fix

When a transaction is active, wrap the `doSave()` operation in a `SAVEPOINT`. If the save fails, `ROLLBACK TO SAVEPOINT` restores the transaction to a healthy state before the exception propagates.

The original `doSave()` logic is extracted into a private `doSaveInner()` method, called either directly (no transaction) or within the savepoint wrapper.

The DBAL `createSavepoint()` / `releaseSavepoint()` / `rollbackSavepoint()` methods are available in all supported DBAL versions (2.13+, 3.x, 4.x).

## Reproduction scenario

```php
$connection->beginTransaction();
// Cache miss → doSave() INSERT fails (deadlock, constraint, etc.)
$value = $cache->get('key', fn () => 'computed');
// $value is returned fine, but...
$connection->executeQuery('SELECT 1'); // 💥 SQLSTATE 25P02
```

With this fix, the savepoint absorbs the failed INSERT and the transaction remains usable.