### PR TITLE
[Console] ProgressIndicator console helper display with multiple processes

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Helper;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -140,7 +141,9 @@ class ProgressIndicator
 
         $this->message = $message;
         $this->display();
-        $this->output->writeln('');
+        if (!$this->output instanceof ConsoleSectionOutput) {
+            $this->output->writeln('');
+        }
         $this->started = false;
     }
 
@@ -207,7 +210,9 @@ class ProgressIndicator
      */
     private function overwrite(string $message): void
     {
-        if ($this->output->isDecorated()) {
+        if ($this->output instanceof ConsoleSectionOutput) {
+            $this->output->overwrite($message);
+        } elseif ($this->output->isDecorated()) {
             $this->output->write("\x0D\x1B[2K");
             $this->output->write($message);
         } else {

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\ProgressIndicator;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
@@ -168,6 +170,58 @@ class ProgressIndicatorTest extends TestCase
             ['very_verbose'],
             ['debug'],
         ];
+    }
+
+    public function testWithConsoleSectionOutput()
+    {
+        $sections = [];
+        $stream = fopen('php://memory', 'r+', false);
+        $output = new ConsoleSectionOutput($stream, $sections, StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $bar = new ProgressIndicator($output, null, 100, ['-', '\\', '|', '/']);
+        $bar->start('Starting...');
+        usleep(101000);
+        $bar->advance();
+        $bar->finish('Done...');
+
+        rewind($stream);
+        $content = stream_get_contents($stream);
+
+        // Must not use raw ANSI line-clear sequences — those corrupt ConsoleSectionOutput's internal line tracking
+        $this->assertStringNotContainsString("\x0D\x1B[2K", $content);
+
+        // finish() must not add an extra trailing newline — ConsoleSectionOutput::overwrite() already ends with writeln()
+        $this->assertStringEndsWith(' \\ Done...'.\PHP_EOL, $content);
+    }
+
+    public function testMultipleSectionsWithProgressIndicators()
+    {
+        $sections = [];
+        $stream = fopen('php://memory', 'r+', false);
+        $formatter = new OutputFormatter();
+        $section1 = new ConsoleSectionOutput($stream, $sections, StreamOutput::VERBOSITY_NORMAL, true, $formatter);
+        $section2 = new ConsoleSectionOutput($stream, $sections, StreamOutput::VERBOSITY_NORMAL, true, $formatter);
+
+        $bar1 = new ProgressIndicator($section1, null, 100, ['-', '\\', '|', '/']);
+        $bar2 = new ProgressIndicator($section2, null, 100, ['-', '\\', '|', '/']);
+
+        $bar1->start('Project 1...');
+        $bar2->start('Project 2...');
+        usleep(101000);
+        $bar1->advance();
+        $bar2->advance();
+        $bar1->finish('Project 1 Done.');
+        $bar2->finish('Project 2 Done.');
+
+        rewind($stream);
+        $content = stream_get_contents($stream);
+
+        // Must not use raw ANSI line-clear sequences
+        $this->assertStringNotContainsString("\x0D\x1B[2K", $content);
+
+        // Both finished messages must appear in the output
+        $this->assertStringContainsString('Project 1 Done.', $content);
+        $this->assertStringContainsString('Project 2 Done.', $content);
     }
 
     protected function getOutputStream($decorated = true, $verbosity = StreamOutput::VERBOSITY_NORMAL)


### PR DESCRIPTION
Fixes incorrect display when ProgressIndicator is used by multiple processes.

| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62306 
| License       | MIT

When the output is a ConsoleSectionOutput, the overwrite() method was writing raw ANSI escape sequences (\x0D\x1B[2K) directly via write(), which ConsoleSectionOutput's doWrite() recorded as content — corrupting its internal line counter and causing indicators to creep upward on each redraw cycle.

Also, finish() called writeln('') after display() to terminate the line, but ConsoleSectionOutput::overwrite() already ends with writeln(), so the extra call registered a phantom blank line in the section's content.

Fix by delegating to ConsoleSectionOutput::overwrite() when the output is an instance of ConsoleSectionOutput, and skipping the trailing writeln('') in finish() for the same case.

The original issue:
![progress_indicator_KO_override](https://github.com/user-attachments/assets/02918b8a-c0f6-47b3-8a1a-14864ddd71f5)

The blank line issue:
![progress_indicator_KO_blank_line](https://github.com/user-attachments/assets/39b0692c-c82e-401d-a3ae-50b41853ec1d)

The fix:
![progress_indicator_OK](https://github.com/user-attachments/assets/d9d7a44e-7f00-4fbd-8be4-8172546c7944)
