### PR TITLE
[SecurityBundle] Update security-1.0.xsd with missing oauth2 element

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -306,6 +306,7 @@
             <xsd:choice minOccurs="0" maxOccurs="1">
                 <xsd:element name="oidc-user-info" type="oidc_user_info" />
                 <xsd:element name="oidc" type="oidc" />
+                <xsd:element name="oauth2" type="xsd:string" />
             </xsd:choice>
         </xsd:sequence>
         <xsd:attribute name="oidc-user-info" type="xsd:string" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Following https://github.com/symfony/symfony/pull/50027, the XSD schema was not updated to add `oauth2` element.

NB: I'm not very used to manipulate this kind of schema, I did it myself (no AI involved here). So, I'm not super confident in the accuracy of this change.

cc @Spomky 