### PR TITLE
[Console] Add customization to SymfonyStyle progressBar

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -12,6 +12,7 @@ Console
 -------
 
  * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`
+ * Add optional `$format` argument to `SymfonyStyle::createProgressBar()`, `SymfonyStyle::progressStart()`, and `SymfonyStyle::progressIterate()` to allow passing a custom `ProgressBar` format string
 
 DependencyInjection
 -------------------

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Add `TesterTrait::assertCommandFailed()` to test command
  * Add `TesterTrait::assertCommandIsInvalid()` to test command
  * Add a result-based testing API with `CommandTester::run()`, `ExecutionResult`, and `ConsoleAssertionsTrait` to assert output and error streams together
+ * Add optional `$format` argument to `SymfonyStyle::createProgressBar()`, `SymfonyStyle::progressStart()`, and `SymfonyStyle::progressIterate()` to allow passing a custom `ProgressBar` format string
 
 8.0
 ---

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -256,9 +256,13 @@ class SymfonyStyle extends OutputStyle
         return $this->askQuestion(new FileQuestion($question));
     }
 
-    public function progressStart(int $max = 0): void
+    /**
+     * @param string|null $format
+     */
+    public function progressStart(int $max = 0 /* , ?string $format = null */): void
     {
-        $this->progressBar = $this->createProgressBar($max);
+        $format = 2 <= \func_num_args() ? func_get_arg(1) : null;
+        $this->progressBar = $this->createProgressBar($max, $format);
         $this->progressBar->start();
     }
 
@@ -274,14 +278,22 @@ class SymfonyStyle extends OutputStyle
         unset($this->progressBar);
     }
 
-    public function createProgressBar(int $max = 0): ProgressBar
+    /**
+     * @param string|null $format
+     */
+    public function createProgressBar(int $max = 0 /* , ?string $format = null */): ProgressBar
     {
+        $format = 2 <= \func_num_args() ? func_get_arg(1) : null;
         $progressBar = parent::createProgressBar($max);
 
         if ('\\' !== \DIRECTORY_SEPARATOR || 'Hyper' === getenv('TERM_PROGRAM')) {
             $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
             $progressBar->setProgressCharacter('');
             $progressBar->setBarCharacter('▓'); // dark shade character \u2593
+        }
+
+        if (null !== $format) {
+            $progressBar->setFormat($format);
         }
 
         return $progressBar;
@@ -295,12 +307,14 @@ class SymfonyStyle extends OutputStyle
      *
      * @param iterable<TKey, TValue> $iterable
      * @param int|null               $max      Number of steps to complete the bar (0 if indeterminate), if null it will be inferred from $iterable
+     * @param string|null            $format   A ProgressBar format string (e.g. ' %current%/%max% [%bar%] %memory:6s%'); null uses the default format
      *
      * @return iterable<TKey, TValue>
      */
-    public function progressIterate(iterable $iterable, ?int $max = null): iterable
+    public function progressIterate(iterable $iterable, ?int $max = null /* , ?string $format = null */): iterable
     {
-        yield from $this->createProgressBar()->iterate($iterable, $max);
+        $format = 3 <= \func_num_args() ? func_get_arg(2) : null;
+        yield from $this->createProgressBar(0, $format)->iterate($iterable, $max);
 
         $this->newLine(2);
     }

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -95,6 +95,41 @@ class SymfonyStyleTest extends TestCase
         $this->assertStringEqualsFile($outputFilepath, $this->tester->getDisplay(true));
     }
 
+    public function testProgressIterateWithCustomFormat()
+    {
+        $code = static function (InputInterface $input, OutputInterface $output): int {
+            $io = new SymfonyStyle($input, $output);
+
+            foreach ($io->progressIterate(range(1, 3), null, ' %current%/%max% [%bar%] %memory:6s%') as $step) {
+                // noop
+            }
+
+            return Command::SUCCESS;
+        };
+
+        $this->command->setCode($code);
+        $this->tester->execute([], ['interactive' => false, 'decorated' => false]);
+
+        $this->assertMatchesRegularExpression('/\d+(\.\d+)? (GiB|MiB|KiB|B)/', $this->tester->getDisplay(true));
+    }
+
+    public function testProgressStartWithCustomFormat()
+    {
+        $code = static function (InputInterface $input, OutputInterface $output): int {
+            $io = new SymfonyStyle($input, $output);
+            $io->progressStart(3, ' %current%/%max% [%bar%] %memory:6s%');
+            $io->progressAdvance(3);
+            $io->progressFinish();
+
+            return Command::SUCCESS;
+        };
+
+        $this->command->setCode($code);
+        $this->tester->execute([], ['interactive' => false, 'decorated' => false]);
+
+        $this->assertMatchesRegularExpression('/\d+(\.\d+)? (GiB|MiB|KiB|B)/', $this->tester->getDisplay(true));
+    }
+
     public function testBlockWithWindowsLineEndings()
     {
         $code = static function (InputInterface $input, OutputInterface $output) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60381 
| License       | MIT

Add a parameter to SymfonyStyle::progressIterate() and SymfonyStyle::createProgressBar() to customize the format