### PR TITLE
[Console] Fix arguments set via `#[Ask]` wrongly considered null in profiler

### DIFF
--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -290,8 +290,8 @@ final class TraceableCommand extends Command
     {
         $this->input = $input;
         $this->output = $output;
-        $this->arguments = $input->getArguments();
-        $this->options = $input->getOptions();
+        $initialArguments = $input->getArguments();
+        $initialOptions = $input->getOptions();
         $event = $this->stopwatch->start($this->getName(), 'command');
 
         try {
@@ -306,9 +306,11 @@ final class TraceableCommand extends Command
             $this->duration = $event->getDuration().' ms';
             $this->maxMemoryUsage = ($event->getMemory() >> 20).' MiB';
 
-            if ($this->isInteractive) {
-                $this->extractInteractiveInputs($input->getArguments(), $input->getOptions());
-            }
+            $this->arguments = $input->getArguments();
+            $this->options = $input->getOptions();
+
+            $this->extractInteractiveInputs($initialArguments, $initialOptions);
+            $this->isInteractive = $this->isInteractive || $this->interactiveInputs;
         }
 
         return $this->exitCode;
@@ -347,22 +349,24 @@ final class TraceableCommand extends Command
         return $exitCode;
     }
 
-    private function extractInteractiveInputs(array $arguments, array $options): void
+    private function extractInteractiveInputs(array $initialArguments, array $initialOptions): void
     {
-        foreach ($arguments as $argName => $argValue) {
-            if (\array_key_exists($argName, $this->arguments) && $this->arguments[$argName] === $argValue) {
+        $nativeDefinition = $this->command->getNativeDefinition();
+
+        foreach ($nativeDefinition->getArguments() as $argName => $argument) {
+            if (\array_key_exists($argName, $initialArguments) && $initialArguments[$argName] === $this->arguments[$argName]) {
                 continue;
             }
 
-            $this->interactiveInputs[$argName] = $argValue;
+            $this->interactiveInputs[$argName] = $this->arguments[$argName];
         }
 
-        foreach ($options as $optName => $optValue) {
-            if (\array_key_exists($optName, $this->options) && $this->options[$optName] === $optValue) {
+        foreach ($nativeDefinition->getOptions() as $optName => $option) {
+            if (\array_key_exists($optName, $initialOptions) && $initialOptions[$optName] === $this->options[$optName]) {
                 continue;
             }
 
-            $this->interactiveInputs['--'.$optName] = $optValue;
+            $this->interactiveInputs['--'.$optName] = $this->options[$optName];
         }
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/TraceableCommandTest.php
@@ -85,6 +85,22 @@ class TraceableCommandTest extends TestCase
         self::assertStringContainsString('Hello World', $commandTester->getDisplay());
     }
 
+    public function testArgumentsCaptureValueSetDuringInteract()
+    {
+        $this->application->addCommand(new InvokableWithAskCommand());
+        $command = $this->application->find('invokable:ask');
+        $traceableCommand = new TraceableCommand($command, new Stopwatch());
+
+        $commandTester = new CommandTester($traceableCommand);
+        $commandTester->setInputs(['Robin']);
+        $commandTester->execute([], ['interactive' => true]);
+        $commandTester->assertCommandIsSuccessful();
+
+        self::assertSame('Robin', $traceableCommand->arguments['name']);
+        self::assertTrue($traceableCommand->isInteractive);
+        self::assertSame(['name' => 'Robin'], $traceableCommand->interactiveInputs);
+    }
+
     public function assertLoopOutputCorrectness(string $output)
     {
         $completeChar = '\\' !== \DIRECTORY_SEPARATOR ? '▓' : '=';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a command uses `#[Ask]` to prompt for argument values, the profiler "Arguments" section shows null instead of the entered values. This fixes it by capturing arguments and options after command execution instead of before, so values set during the interaction phase are reflected. Also such commands were not considered "interactive" despite they are, fixed as well.

Take this command: 

```php
<?php

namespace App\Command;

use Symfony\Component\Console\Attribute\Argument;
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Attribute\Ask;
use Symfony\Component\Console\Style\SymfonyStyle;

#[AsCommand(
    name: 'about:you',
)]
class AboutYouCommand
{
    public function __invoke(
        SymfonyStyle $io,
        #[Argument]
        #[Ask(question: 'What is your email address?')]
        string $email,

        #[Argument]
        #[Ask(question: 'How old are you?')]
        int $age,

        #[Argument]
        #[Ask(question: 'What is your username:')]
        string $username,
    ) {
        return 0;
    }
}
```

Before: 
<img width="1010" height="528" alt="Screenshot 2026-02-20 at 17 35 15" src="https://github.com/user-attachments/assets/541c057a-4343-4b9e-8742-d60109e3044e" />

After:
<img width="1077" height="533" alt="Screenshot 2026-02-20 at 17 33 34" src="https://github.com/user-attachments/assets/f835dc07-d9c1-4ea3-81bf-e35d249b8194" />
