### PR TITLE
[ObjectMapper] fix nested mapping with class-level transform

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -262,23 +262,17 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             && ($mapTo = $this->getMapTarget($innerMetadata, $value, $source, $target, true))
             && (\is_string($mapTo->target) && class_exists($mapTo->target))
         ) {
-            $value = $this->applyTransforms($mapTo, $value, $source, $target);
+            if ($mapTo->transform) {
+                return $this->applyTransforms($mapTo, $value, $source, $target);
+            }
 
             if ($value === $source) {
                 $value = $target;
             } elseif ($objectMap->offsetExists($value)) {
                 $value = $objectMap[$value];
             } elseif (\PHP_VERSION_ID < 80400) {
-                if ($mapTo->transform) {
-                    return $value;
-                }
-
                 return ($this->objectMapper ?? $this)->map($value, $mapTo->target);
             } else {
-                if ($mapTo->transform) {
-                    return $value;
-                }
-
                 $refl = new \ReflectionClass($mapTo->target);
                 $mapper = $this->objectMapper ?? $this;
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithClassTransformSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithClassTransformSource.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ChildWithClassTransformTarget::class, transform: [ChildWithClassTransformTarget::class, 'createFromSource'])]
+class ChildWithClassTransformSource
+{
+    public string $name = 'ChildWithClassTransformSource';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithClassTransformTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithClassTransformTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer;
+
+class ChildWithClassTransformTarget
+{
+    public string $name;
+    public bool $classTransformed = false;
+
+    public static function createFromSource(ChildWithClassTransformSource $value): self
+    {
+        $target = new self();
+        $target->name = $value->name;
+        $target->classTransformed = true;
+
+        return $target;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithoutClassTransformerSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithoutClassTransformerSource.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ChildWithoutClassTransformerTarget::class)]
+class ChildWithoutClassTransformerSource
+{
+    public string $name = 'ChildWithoutClassTransformerSource';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithoutClassTransformerTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ChildWithoutClassTransformerTarget.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer;
+
+class ChildWithoutClassTransformerTarget
+{
+    public string $name;
+    public bool $propertyTransformed = false;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ParentSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ParentSource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ParentTarget::class, transform: [ParentTarget::class, 'createFromSource'])]
+class ParentSource
+{
+    public string $name = 'parent';
+
+    public ChildWithClassTransformSource $childWithClassTransformer;
+
+    #[Map(transform: [ParentTarget::class, 'childPropertyTransformer'])]
+    public ChildWithoutClassTransformerSource $childWithoutClassTransformer;
+
+    #[Map(transform: [ParentTarget::class, 'childBothTransformer'])]
+    public ChildWithClassTransformSource $childWithBothTransformers;
+
+    public function __construct()
+    {
+        $this->childWithClassTransformer = new ChildWithClassTransformSource();
+        $this->childWithoutClassTransformer = new ChildWithoutClassTransformerSource();
+        $this->childWithBothTransformers = new ChildWithClassTransformSource();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ParentTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMappingWithClassTransformer/ParentTarget.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer;
+
+class ParentTarget
+{
+    public string $name;
+    public ChildWithClassTransformTarget $childWithClassTransformer;
+    public ChildWithoutClassTransformerTarget $childWithoutClassTransformer;
+    public ChildWithClassTransformTarget $childWithBothTransformers;
+    public bool $transformed = false;
+
+    public static function createFromSource(ParentTarget $value, ParentSource $source): self
+    {
+        $value->transformed = true;
+
+        return $value;
+    }
+
+    public static function childPropertyTransformer(ChildWithoutClassTransformerSource $value, ParentSource $source): ChildWithoutClassTransformerTarget
+    {
+        $target = new ChildWithoutClassTransformerTarget();
+
+        $target->name = 'child';
+        $target->propertyTransformed = true;
+
+        return $target;
+    }
+
+    public static function childBothTransformer(ChildWithClassTransformSource $value, ParentSource $source): ChildWithClassTransformSource
+    {
+        $value->name = 'both';
+
+        return $value;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
@@ -26,8 +26,14 @@ class ServiceLoadedValueTransformer implements TransformCallableInterface
     public function __invoke(mixed $value, object $source, ?object $target): mixed
     {
         $metadata = $this->metadata->create($value);
-        \assert(count($metadata) === 1);
-        \assert($metadata[0]->target === LoadedValue::class);
+
+        if (\count($metadata) !== 1) {
+            throw new \LogicException('Exactly one metadata should be returned.');
+        }
+        if ($metadata[0]->target !== LoadedValue::class) {
+            throw new \LogicException('The target should be '.LoadedValue::class.'.');
+        }
+
         return $this->serviceLoadedValue->get();
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -69,6 +69,10 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as Mu
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ChildWithClassTransformTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ChildWithoutClassTransformerTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Source as PromotedConstructorSource;
@@ -727,5 +731,34 @@ final class ObjectMapperTest extends TestCase
         $sourceWithValue->name = 'test';
         $targetWithValue = $mapper->map($sourceWithValue);
         $this->assertSame('test', $targetWithValue->name);
+    }
+
+    public function testNestedMappingWithClassTransform()
+    {
+        $target = (new ObjectMapper())->map(new ParentSource());
+
+        $this->assertInstanceOf(ParentTarget::class, $target);
+        $this->assertTrue($target->transformed);
+        $this->assertInstanceOf(ChildWithClassTransformTarget::class, $target->childWithClassTransformer);
+        $this->assertSame('ChildWithClassTransformSource', $target->childWithClassTransformer->name);
+        $this->assertTrue($target->childWithClassTransformer->classTransformed);
+    }
+
+    public function testNestedMappingWithPropertyTransform()
+    {
+        $target = (new ObjectMapper())->map(new ParentSource());
+
+        $this->assertInstanceOf(ChildWithoutClassTransformerTarget::class, $target->childWithoutClassTransformer);
+        $this->assertSame('child', $target->childWithoutClassTransformer->name);
+        $this->assertTrue($target->childWithoutClassTransformer->propertyTransformed);
+    }
+
+    public function testNestedMappingWithBothPropertyAndClassTransforms()
+    {
+        $target = (new ObjectMapper())->map(new ParentSource());
+
+        $this->assertInstanceOf(ChildWithClassTransformTarget::class, $target->childWithBothTransformers);
+        $this->assertSame('both', $target->childWithBothTransformers->name);
+        $this->assertTrue($target->childWithBothTransformers->classTransformed);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

When a Parent class contains a Child property and the Child class has a class transformer, it is not invoked correctly during the mapping of the parent.

Not fix at this stage, just the reproducer test.