### PR TITLE
[HttpFoundation] Handle empty session data in updateTimestamp() to fix compat with PHP 8.6

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -72,6 +72,16 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
         return $data;
     }
 
+    public function updateTimestamp(#[\SensitiveParameter] string $sessionId, string $data): bool
+    {
+        $this->igbinaryEmptyData ??= \function_exists('igbinary_serialize') ? igbinary_serialize([]) : '';
+        if ('' === $data || $this->igbinaryEmptyData === $data) {
+            return $this->destroy($sessionId);
+        }
+
+        return true;
+    }
+
     public function write(#[\SensitiveParameter] string $sessionId, string $data): bool
     {
         // see https://github.com/igbinary/igbinary/issues/146

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -48,6 +48,10 @@ class AbstractSessionHandlerTest extends TestCase
         $result = file_get_contents(\sprintf('http://localhost:8053/%s.php', $fixture), false, $context);
         $result = preg_replace_callback('/expires=[^;]++/', fn ($m) => str_replace('-', ' ', $m[0]), $result);
 
+        if (\PHP_VERSION_ID < 80600) {
+            $result = str_replace("write\ndestroy\nclose\n", "updateTimestamp\ndestroy\nclose\n", $result);
+        }
+
         $this->assertStringEqualsFile(__DIR__.\sprintf('/Fixtures/%s.expected', $fixture), $result);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
@@ -87,7 +87,7 @@ class TestSessionHandler extends AbstractSessionHandler
     {
         echo __FUNCTION__, "\n";
 
-        return true;
+        return parent::updateTimestamp($sessionId, $data);
     }
 
     public function write(string $sessionId, string $data): bool

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/storage.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/storage.expected
@@ -8,7 +8,7 @@ Array
     [0] => bar
 )
 $_SESSION is not empty
-write
+updateTimestamp
 destroy
 close
 $_SESSION is empty


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63447
| License       | MIT

PHP 8.6 changed session_encode() to return "" instead of false for empty sessions. Combined with lazy_write, this causes PHP to call updateTimestamp() instead of write() when session data is unchanged.

AbstractSessionHandler::write() has long had logic to destroy sessions when data is empty, but updateTimestamp() did not, causing empty sessions to persist instead of being properly cleaned up.

Add the same empty-data-means-destroy logic to updateTimestamp() so the behavior is consistent regardless of which method PHP calls.
