### PR TITLE
[Form] Fix missing resource tracking for type extensions in FormPass

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Resource;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormTypeExtensionInterface;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
@@ -211,6 +212,13 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
         if (interface_exists(ServiceSubscriberInterface::class, false) && $class->isSubclassOf(ServiceSubscriberInterface::class)) {
             yield ServiceSubscriberInterface::class;
             yield print_r($class->name::getSubscribedServices(), true);
+        }
+
+        if (interface_exists(FormTypeExtensionInterface::class, false) && $class->isSubclassOf(FormTypeExtensionInterface::class)) {
+            yield FormTypeExtensionInterface::class;
+            foreach ($class->name::getExtendedTypes() as $key => $value) {
+                yield $key.print_r($value, true);
+            }
         }
     }
 }

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -86,6 +86,7 @@ class FormPass implements CompilerPassInterface
                 $extendsTypes = false;
 
                 $typeExtensionsClasses[] = $typeExtensionClass;
+                $container->getReflectionClass($typeExtensionClass);
                 foreach ($typeExtensionClass::getExtendedTypes() as $extendedType) {
                     $typeExtensions[$extendedType][] = new Reference($serviceId);
                     $extendsTypes = true;

--- a/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
+++ b/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
@@ -260,6 +260,20 @@ class FormPassTest extends TestCase
         );
     }
 
+    public function testTypeExtensionClassIsTrackedAsResource()
+    {
+        $container = $this->createContainerBuilder();
+
+        $container->setDefinition('form.extension', $this->createExtensionDefinition());
+        $container->register('my.type_extension', Type1TypeExtension::class)
+            ->addTag('form.type_extension');
+
+        $container->compile();
+
+        $resources = array_map('strval', $container->getResources());
+        $this->assertContains('reflection.'.Type1TypeExtension::class, $resources);
+    }
+
     /**
      * @dataProvider privateTaggedServicesProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62694
| License       | MIT

When a form type extension relies on `getExtendedTypes()` (no `extended_type` tag), `FormPass` calls the static method at build time but does not track the class as a container resorce. This means the cache is not invalidated when the method is edited.

This adds a `$container->getReflectionClass()` call so the class is registered as a `ReflectionClassResource`, matching the pattern used by `RegisterListenersPass`.