### PR TITLE
[Security] Fix lazy firewall triggering remember me authentication on POST requests to public routes

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
@@ -43,7 +43,7 @@ class LazyFirewallContext extends FirewallContext
     {
         $listeners = [];
         $request = $event->getRequest();
-        $lazy = $request->isMethodCacheable();
+        $lazy = true;
 
         foreach (parent::getListeners() as $listener) {
             if (!$lazy || !$listener instanceof FirewallListenerInterface) {
@@ -67,7 +67,7 @@ class LazyFirewallContext extends FirewallContext
             return;
         }
 
-        $this->tokenStorage->setInitializer(function () use ($event, $listeners) {
+        $this->tokenStorage->setInitializer(static function () use ($event, $listeners) {
             $event = new LazyResponseEvent($event);
             foreach ($listeners as $listener) {
                 $listener($event);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/LazyFirewallContextTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/LazyFirewallContextTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
+
+class LazyFirewallContextTest extends TestCase
+{
+    public function testPostRequestWithOnlyLazyAuthenticatorsIsHandledLazily()
+    {
+        $lazyListener = $this->createMock(FirewallListenerInterface::class);
+        $lazyListener->expects($this->once())->method('supports')->willReturn(null);
+        // authenticate() must NOT be called eagerly
+        $lazyListener->expects($this->never())->method('authenticate');
+
+        $tokenStorage = new TokenStorage();
+
+        $context = new LazyFirewallContext(
+            [$lazyListener],
+            null,
+            null,
+            null,
+            $tokenStorage,
+        );
+
+        $request = Request::create('/public-route', 'POST');
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $context($event);
+
+        $this->assertFalse($event->hasResponse(), 'No response should be set for a lazy firewall on a public route.');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | on
| Issues        | Fix #59816
| License       | MIT

In `LazyFirewallContext`, the `$lazy` flag was initialized to `$request->isMethodCacheable()`, meaning it was always `false` for non-cacheable methods like POST. This forced all firewall listeners to be called eagerly, regardless of whether their authenticators indicated they supported lazy evaluation (by returning `null` from `supports()`).

This caused a subtle bug when all of the following conditions were met:

- A lazy firewall is configured
- Remember me is enabled and the user has a remember me cookie
- The session has expired
- The user submits a POST form on a public route (one that does not require authentication)

On the POST request, `RememberMeAuthenticator::supports()` returns `null` (=lazy), but the lazy check was skipped because it was a POST. The authenticator ran eagerly, consumed the remember me cookie, and migrated the session - wiping the CSRF token storage. The subsequent CSRF validation then failed.

