### PR TITLE
[Translation] Add support for XLIFF versions 2.1 and 2.2

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for XLIFF 2.1 and 2.2
+
 8.0
 ---
 

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -80,7 +80,7 @@ class XliffFileLoader implements LoaderInterface
             $this->extractXliff1($dom, $catalogue, $domain);
         }
 
-        if ('2.0' === $xliffVersion) {
+        if (\in_array($xliffVersion, ['2.0', '2.1', '2.2'], true)) {
             $this->extractXliff2($dom, $catalogue, $domain);
         }
     }

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.1.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.1.xlf
@@ -1,0 +1,25 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.1" srcLang="en-US" trgLang="ja-JP">
+    <file id="f1" original="Graphic Example.psd">
+        <skeleton href="Graphic Example.psd.skl"/>
+        <unit id="1">
+            <segment>
+                <source>Quetzal</source>
+                <target>Quetzal</target>
+            </segment>
+        </unit>
+        <group id="1">
+            <unit id="2">
+                <segment>
+                    <source>foo</source>
+                    <target>XLIFF 文書を編集、または処理 するアプリケーションです。</target>
+                </segment>
+            </unit>
+            <unit id="3">
+                <segment>
+                    <source>bar</source>
+                    <target order="1">XLIFF データ・マネージャ</target>
+                </segment>
+            </unit>
+        </group>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2.xlf
@@ -1,0 +1,25 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.2" srcLang="en-US" trgLang="ja-JP">
+    <file id="f1" original="Graphic Example.psd">
+        <skeleton href="Graphic Example.psd.skl"/>
+        <unit id="1">
+            <segment>
+                <source>Quetzal</source>
+                <target>Quetzal</target>
+            </segment>
+        </unit>
+        <group id="1">
+            <unit id="2">
+                <segment>
+                    <source>foo</source>
+                    <target>XLIFF 文書を編集、または処理 するアプリケーションです。</target>
+                </segment>
+            </unit>
+            <unit id="3">
+                <segment>
+                    <source>bar</source>
+                    <target order="1">XLIFF データ・マネージャ</target>
+                </segment>
+            </unit>
+        </group>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -258,6 +258,42 @@ class XliffFileLoaderTest extends TestCase
         $this->assertEquals(['target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
     }
 
+    public function testLoadVersion21()
+    {
+        $loader = new XliffFileLoader();
+        $resource = __DIR__.'/../Fixtures/resources-2.1.xlf';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals('en', $catalogue->getLocale());
+        $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
+        $this->assertSame([], libxml_get_errors());
+
+        $domains = $catalogue->all();
+        $this->assertCount(3, $domains['domain1']);
+        $this->assertContainsOnlyString($catalogue->all('domain1'));
+
+        // target attributes
+        $this->assertEquals(['target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
+    }
+
+    public function testLoadVersion22()
+    {
+        $loader = new XliffFileLoader();
+        $resource = __DIR__.'/../Fixtures/resources-2.2.xlf';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals('en', $catalogue->getLocale());
+        $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
+        $this->assertSame([], libxml_get_errors());
+
+        $domains = $catalogue->all();
+        $this->assertCount(3, $domains['domain1']);
+        $this->assertContainsOnlyString($catalogue->all('domain1'));
+
+        // target attributes
+        $this->assertEquals(['target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
+    }
+
     public function testLoadVersion2WithNoteMeta()
     {
         $loader = new XliffFileLoader();

--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -130,7 +130,7 @@ class XliffUtils
         if ('1.2' === $xliffVersion) {
             $schemaSource = file_get_contents(__DIR__.'/../Resources/schemas/xliff-core-1.2-transitional.xsd');
             $xmlUri = 'http://www.w3.org/2001/xml.xsd';
-        } elseif ('2.0' === $xliffVersion) {
+        } elseif (\in_array($xliffVersion, ['2.0', '2.1', '2.2'], true)) {
             $schemaSource = file_get_contents(__DIR__.'/../Resources/schemas/xliff-core-2.0.xsd');
             $xmlUri = 'informativeCopiesOf3rdPartySchemas/w3c/xml.xsd';
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63244 
| License       | MIT

No diff in structure or namespace between 2.0 and 2.1/2.2. They add some features that could be supported in a separate PR (plural, gender, etc.), but the core features remain the same. 

I think it worth adding these versions to the allowed ones rather than waiting for the full support of features. The full sets of feature of 1.2 and 2.0 aren't complete either, thus this rationale.