### PR TITLE
[Console] Fix validator exception masked by MissingInputException on empty input

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -474,6 +474,8 @@ class QuestionHelper extends Helper
 
             try {
                 return $question->getValidator()($interviewer());
+            } catch (MissingInputException $e) {
+                throw $error ?? $e;
             } catch (RuntimeException $e) {
                 throw $e;
             } catch (\Exception $error) {

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -791,6 +791,26 @@ EOD;
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), $question);
     }
 
+    public function testValidatorExceptionPropagatesOnEmptyInput()
+    {
+        $dialog = new QuestionHelper();
+
+        $question = new Question('What\'s your name?');
+        $question->setValidator(function ($value) {
+            if ('' === $value || null === $value) {
+                throw new \InvalidArgumentException('A value is required.');
+            }
+
+            return $value;
+        });
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A value is required.');
+
+        // Simulate setInputs(['']), which writes "\n" to the stream then EOF
+        $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream("\n")), $this->createOutputInterface(), $question);
+    }
+
     public function testQuestionValidatorRepeatsThePrompt()
     {
         $tries = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #45319
| License       | MIT

When a question has a validator and the input stream contains only an empty line (e.g. `$tester->setInputs([''])`), the validator rejects the empty value and `validateAttempts()` loops for another attempt. On the next read, the stream is exhausted, so `readInput()` returns `false` and a `MissingInputException` is thrown. But because `MissingInputException` extends `RuntimeException`, it was caught and immediately re-thrown, discarding the previous validator exception.

