### PR TITLE
[Messenger] Inject ClockInterface into HandleMessageMiddleware/Acknowledger/BatchHandlerTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -106,6 +106,8 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 abstract_arg('bus handler resolver'),
+                false,
+                service('clock')->nullOnInvalid(),
             ])
             ->tag('monolog.logger', ['channel' => 'messenger'])
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])

--- a/src/Symfony/Component/Messenger/Handler/Acknowledger.php
+++ b/src/Symfony/Component/Messenger/Handler/Acknowledger.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Handler;
 
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Messenger\Exception\LogicException;
 
 /**
@@ -18,6 +20,8 @@ use Symfony\Component\Messenger\Exception\LogicException;
  */
 class Acknowledger
 {
+    public readonly ClockInterface $clock;
+
     private ?\Closure $ack;
     private \Throwable|false|null $error = null;
     private mixed $result = null;
@@ -28,7 +32,9 @@ class Acknowledger
     public function __construct(
         private string $handlerClass,
         ?\Closure $ack = null,
+        ?ClockInterface $clock = null,
     ) {
+        $this->clock = $clock ?? Clock::get();
         $this->ack = $ack ?? static function () {};
     }
 

--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Messenger\Handler;
 
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
+
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
@@ -18,6 +21,7 @@ trait BatchHandlerTrait
 {
     private array $jobs = [];
     private ?int $lastMessageAt = null;
+    private ?ClockInterface $batchClock = null;
 
     public function flush(bool $force): void
     {
@@ -40,10 +44,11 @@ trait BatchHandlerTrait
      */
     private function handle(object $message, ?Acknowledger $ack): mixed
     {
-        $this->lastMessageAt = time();
+        $this->batchClock ??= $ack?->clock ?? Clock::get();
+        $this->lastMessageAt = (int) $this->batchClock->now()->format('U');
 
         if (null === $ack) {
-            $ack = new Acknowledger(get_debug_type($this));
+            $ack = new Acknowledger(get_debug_type($this), null, $this->batchClock);
             $this->jobs[] = [$message, $ack];
             $this->flush(true);
 
@@ -68,7 +73,7 @@ trait BatchHandlerTrait
 
         $idleTimeout = $this->getIdleTimeout();
         if (null !== $idleTimeout && null !== $this->lastMessageAt) {
-            return (time() - $this->lastMessageAt) >= $idleTimeout;
+            return ((int) ($this->batchClock ?? Clock::get())->now()->format('U') - $this->lastMessageAt) >= $idleTimeout;
         }
 
         return false;

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Middleware;
 
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
@@ -35,6 +36,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
     public function __construct(
         private HandlersLocatorInterface $handlersLocator,
         private bool $allowNoHandlers = false,
+        private ?ClockInterface $clock = null,
     ) {
     }
 
@@ -71,7 +73,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                         }
 
                         $ackStamp->ack($envelope, $e);
-                    });
+                    }, $this->clock);
 
                     $result = $this->callHandler($handler, $message, $ack, $envelope->last(HandlerArgumentsStamp::class));
 

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -513,8 +513,6 @@ class WorkerTest extends TestCase
 
     public function testFlushBatchOnIdle()
     {
-        ClockMock::withClockMock(false);
-
         $expectedMessages = [
             new DummyMessage('Hey'),
         ];
@@ -526,25 +524,26 @@ class WorkerTest extends TestCase
 
         $handler = new DummyBatchHandler();
 
+        $clock = new MockClock();
         $middleware = new HandleMessageMiddleware(new HandlersLocator([
             DummyMessage::class => [new HandlerDescriptor($handler)],
-        ]));
+        ]), clock: $clock);
 
         $bus = new MessageBus([$middleware]);
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver) {
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver, $clock) {
             static $i = 0;
             if (1 < ++$i) {
                 $event->getWorker()->stop();
                 $this->assertSame(1, $receiver->getAcknowledgeCount());
             } else {
                 $this->assertSame(0, $receiver->getAcknowledgeCount());
-                sleep(1);
+                $clock->sleep(1);
             }
         });
 
-        $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
+        $worker = new Worker([$receiver], $bus, $dispatcher, clock: $clock);
         $worker->run();
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
@@ -552,8 +551,6 @@ class WorkerTest extends TestCase
 
     public function testFlushBatchWithIdleTimeout()
     {
-        ClockMock::withClockMock(false);
-
         $expectedMessages = [
             new DummyMessage('Hey'),
             new DummyMessage('Bob'),
@@ -570,25 +567,26 @@ class WorkerTest extends TestCase
 
         $handler = new DummyBatchHandler(batchSize: 5, idleTimeout: 3);
 
+        $clock = new MockClock();
         $middleware = new HandleMessageMiddleware(new HandlersLocator([
             DummyMessage::class => [new HandlerDescriptor($handler)],
-        ]));
+        ]), clock: $clock);
 
         $bus = new MessageBus([$middleware]);
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver) {
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver, $clock) {
             static $i = 0;
             if (6 < ++$i) { // 6 seconds = 4 messages + 3 idle timeout - 1 sec that overlaps (last message)
                 $this->assertSame(4, $receiver->getAcknowledgeCount());
                 $event->getWorker()->stop();
             } else {
                 $this->assertSame(0, $receiver->getAcknowledgeCount());
-                sleep(1);
+                $clock->sleep(1);
             }
         });
 
-        $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
+        $worker = new Worker([$receiver], $bus, $dispatcher, clock: $clock);
         $worker->run();
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
@@ -596,8 +594,6 @@ class WorkerTest extends TestCase
 
     public function testFlushBatchWithoutIdleTimeout()
     {
-        ClockMock::withClockMock(false);
-
         $expectedMessages = [
             new DummyMessage('Hey'),
         ];
@@ -609,23 +605,24 @@ class WorkerTest extends TestCase
 
         $handler = new DummyBatchHandler(idleTimeout: null);
 
+        $clock = new MockClock();
         $middleware = new HandleMessageMiddleware(new HandlersLocator([
             DummyMessage::class => [new HandlerDescriptor($handler)],
-        ]));
+        ]), clock: $clock);
 
         $bus = new MessageBus([$middleware]);
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver) {
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver, $clock) {
             static $i = 0;
             if (2 < ++$i) {
                 $event->getWorker()->stop();
             }
             $this->assertSame(0, $receiver->getAcknowledgeCount());
-            sleep(1);
+            $clock->sleep(1);
         });
 
-        $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
+        $worker = new Worker([$receiver], $bus, $dispatcher, clock: $clock);
         $worker->run();
 
         $this->assertSame(1, $receiver->getAcknowledgeCount());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`BatchHandlerTrait::shouldFlush()` called `time()` directly. Because that namespace was never registered with `ClockMock`, the idle-timeout logic was always driven by real wall-clock time even in tests marked `#[Group('time-sensitive')]`. This caused testFlushBatchWithIdleTimeout to flake on Windows CI when scheduler jitter pushed a sleep(1) call past the 3-second idle threshold.

Technically a new feature but a low-level one.