### PR TITLE
[Workflow] Implement missing `reset()` method in `TraceableWorkflow`

### DIFF
--- a/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
+++ b/src/Symfony/Component/Workflow/Debug/TraceableWorkflow.php
@@ -88,6 +88,11 @@ class TraceableWorkflow implements WorkflowInterface
         return $this->calls;
     }
 
+    public function reset(): void
+    {
+        $this->calls = [];
+    }
+
     private function callInner(string $method, array $args): mixed
     {
         $sMethod = $this->workflow::class.'::'.$method;

--- a/src/Symfony/Component/Workflow/DependencyInjection/WorkflowDebugPass.php
+++ b/src/Symfony/Component/Workflow/DependencyInjection/WorkflowDebugPass.php
@@ -31,7 +31,9 @@ class WorkflowDebugPass implements CompilerPassInterface
                 ->setArguments([
                     new Reference("debug.{$id}.inner"),
                     new Reference('debug.stopwatch'),
-                ]);
+                ])
+                ->addTag('kernel.reset', ['method' => 'reset'])
+            ;
         }
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/Debug/TraceableWorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Debug/TraceableWorkflowTest.php
@@ -97,4 +97,14 @@ class TraceableWorkflowTest extends TestCase
 
         yield ['getEnabledTransition', [$subject, 'foo'], null];
     }
+
+    public function testReset()
+    {
+        $this->innerWorkflow->expects($this->once())->method('can')->willReturn(true);
+        $this->traceableWorkflow->can(new \stdClass(), 'foo');
+        $this->assertCount(1, $this->traceableWorkflow->getCalls());
+
+        $this->traceableWorkflow->reset();
+        $this->assertCount(0, $this->traceableWorkflow->getCalls());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

I was testing Symfony workflow in FrankenPHP using worker mode, and I noticed that `TraceableWorkflow` is not cleaned between requests (I assume the same happens when consuming messages).