### PR TITLE
 Remove `7.3` branch from `PULL_REQUEST_TEMPLATE.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | 8.1 for features / 6.4, 7.3, 7.4, 8.0 for bug fixes
+| Branch?       | 8.1 for features / 6.4, 7.4, 8.0 for bug fixes
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
 | Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

According to the [Symfony Releases](https://symfony.com/releases) page, the 7.3 branch is no longer maintained.