### PR TITLE
[Validator] Fix required options not validated when constructor calls parent with null

### DIFF
--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Validator\Tests\Fixtures\ClassConstraint;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintC;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredOptionAndConstructor;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithStaticProperty;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithTypedProperty;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValue;
@@ -348,5 +349,14 @@ class ConstraintTest extends TestCase
         ]);
 
         $this->assertSame('bar', $constraint->foo);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testRequiredOptionsValidatedWhenConstructorCallsParentWithNull()
+    {
+        $this->expectException(MissingOptionsException::class);
+
+        new ConstraintWithRequiredOptionAndConstructor();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithRequiredOptionAndConstructor.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithRequiredOptionAndConstructor.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+
+class ConstraintWithRequiredOptionAndConstructor extends Constraint
+{
+    public $option1;
+
+    public function __construct(?array $groups = null, mixed $payload = null)
+    {
+        parent::__construct(null, $groups, $payload);
+    }
+
+    public function getRequiredOptions(): array
+    {
+        return ['option1'];
+    }
+
+    public function getTargets(): string|array
+    {
+        return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63362
| License       | MIT

When a custom constraint overrides the constructor and calls `parent::__construct(null, $groups, $payload)`, the `\func_num_args() > 0` check in `Constraint::__construct()` caused an early return **before** `normalizeOptions()` could validate required options via `getRequiredOptions()`.

This meant that constraints with required options (returned by `getRequiredOptions()`) silently accepted missing options instead of throwing `MissingOptionsException`.

**Fix**: Remove the `\func_num_args() > 0` short-circuit from the condition. The remaining `self::class === (new \ReflectionMethod(...))->getDeclaringClass()->getName()` check correctly determines whether `getRequiredOptions()` is overridden:
- Not overridden → early return (no required options to validate)
- Overridden → fall through to `normalizeOptions()` which validates required options

**Test**: Added a test with a constraint fixture that has required options and a custom constructor calling `parent::__construct(null)`, verifying that `MissingOptionsException` is thrown.