### PR TITLE
[Translation] Add support for XLIFF PGS (Plural, Gender, and Select Module)

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for XLIFF 2.1 and 2.2
+ * Add support for XLIFF 2.2 PGS (Plural, Gender, and Select Module)
 
 8.0
 ---

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -19,6 +19,7 @@ use Symfony\Component\Translation\Exception\InvalidResourceException;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
 use Symfony\Component\Translation\Exception\RuntimeException;
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\Util\XliffUtils;
 
 /**
@@ -161,6 +162,11 @@ class XliffFileLoader implements LoaderInterface
         $xml->registerXPathNamespace('xliff', 'urn:oasis:names:tc:xliff:document:2.0');
 
         foreach ($xml->xpath('//xliff:unit') as $unit) {
+            if (null !== $pgsSwitch = $unit->attributes('urn:oasis:names:tc:xliff:pgs:1.0')['switch'] ?? null) {
+                $this->extractXliff2PgsUnit($unit, $catalogue, $domain, (string) $pgsSwitch, $encoding);
+                continue;
+            }
+
             foreach ($unit->segment as $segment) {
                 $attributes = $unit->attributes();
                 $source = $attributes['name'] ?? $segment->source;
@@ -201,6 +207,119 @@ class XliffFileLoader implements LoaderInterface
                 $catalogue->setMetadata((string) $source, $metadata, $domain);
             }
         }
+    }
+
+    private function extractXliff2PgsUnit(\SimpleXMLElement $unit, MessageCatalogue $catalogue, string $domain, string $pgsSwitch, ?string $encoding): void
+    {
+        $switches = $this->parsePgsSwitch($pgsSwitch);
+        $attributes = $unit->attributes();
+        $source = (string) ($attributes['name'] ?? $attributes['id']);
+
+        $cases = [];
+        foreach ($unit->segment as $segment) {
+            if (null === $pgsCase = $segment->attributes('urn:oasis:names:tc:xliff:pgs:1.0')['case'] ?? null) {
+                continue;
+            }
+
+            $cases[(string) $pgsCase] = $this->extractPgsSegmentText($segment->target ?? $segment->source, $switches);
+        }
+
+        $intlDomain = $domain.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+        $catalogue->set($source, $this->utf8ToCharset($this->buildIcuMessage($switches, $cases), $encoding), $intlDomain);
+
+        $metadata = ['pgs-switch' => $pgsSwitch];
+        if (isset($unit->notes)) {
+            $metadata['notes'] = [];
+            foreach ($unit->notes->note as $noteNode) {
+                $note = array_map('strval', $noteNode->attributes() ?? []);
+
+                $note['content'] = (string) $noteNode;
+                $metadata['notes'][] = $note;
+            }
+        }
+
+        $catalogue->setMetadata($source, $metadata, $intlDomain);
+    }
+
+    private function parsePgsSwitch(string $pgsSwitch): array
+    {
+        $switches = [];
+        foreach (preg_split('/\s+/', trim($pgsSwitch)) as $item) {
+            $switches[] = array_combine(['type', 'variable'], explode(':', $item, 2));
+        }
+
+        return $switches;
+    }
+
+    private function extractPgsSegmentText(\SimpleXMLElement $element, array $switches): string
+    {
+        $pluralVariables = [];
+        foreach ($switches as $switch) {
+            if ('plural' === $switch['type'] || 'ordinal' === $switch['type']) {
+                $pluralVariables[$switch['variable']] = true;
+            }
+        }
+
+        $text = '';
+        foreach (dom_import_simplexml($element)->childNodes as $child) {
+            if (\XML_TEXT_NODE === $child->nodeType) {
+                $text .= $child->textContent;
+            } elseif (\XML_ELEMENT_NODE === $child->nodeType && 'ph' === $child->localName) {
+                if (($disp = $child->getAttribute('disp')) && isset($pluralVariables[$disp])) {
+                    $text .= '#';
+                } elseif ($disp) {
+                    $text .= '{'.$disp.'}';
+                }
+            }
+        }
+
+        return $text;
+    }
+
+    private function buildIcuMessage(array $switches, array $cases): string
+    {
+        if (1 === \count($switches)) {
+            $switch = $switches[0];
+            $icuType = $this->getIcuType($switch['type']);
+
+            $icuCases = [];
+            foreach ($cases as $caseValue => $text) {
+                $icuCases[] = $this->formatIcuCase($caseValue, $switch['type']).' {'.$text.'}';
+            }
+
+            return '{'.$switch['variable'].', '.$icuType.', '.implode(' ', $icuCases).'}';
+        }
+
+        $outerSwitch = $switches[0];
+        $innerSwitches = \array_slice($switches, 1);
+        $icuType = $this->getIcuType($outerSwitch['type']);
+
+        $grouped = [];
+        foreach ($cases as $caseKey => $text) {
+            $caseParts = explode(' ', $caseKey, 2);
+            $grouped[$caseParts[0]][$caseParts[1] ?? 'other'] = $text;
+        }
+
+        $icuCases = [];
+        foreach ($grouped as $caseValue => $innerCases) {
+            $icuCases[] = $this->formatIcuCase($caseValue, $outerSwitch['type']).' {'.$this->buildIcuMessage($innerSwitches, $innerCases).'}';
+        }
+
+        return '{'.$outerSwitch['variable'].', '.$icuType.', '.implode(' ', $icuCases).'}';
+    }
+
+    private function getIcuType(string $pgsType): string
+    {
+        return match ($pgsType) {
+            'plural' => 'plural',
+            'ordinal' => 'selectordinal',
+            default => 'select',
+        };
+    }
+
+    private function formatIcuCase(int|string $caseValue, string $switchType): string
+    {
+        return (\in_array($switchType, ['plural', 'ordinal'], true) && is_numeric($caseValue) ? '=' : '').$caseValue;
     }
 
     /**

--- a/src/Symfony/Component/Translation/Resources/schemas/xliff-core-2.2.xsd
+++ b/src/Symfony/Component/Translation/Resources/schemas/xliff-core-2.2.xsd
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    XLIFF Version 2.2
+    Based on XLIFF Version 2.0 OASIS Standard with additions for 2.2 modules.
+    Adds anyAttribute on segment to support PGS module attributes.
+     -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:document:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+      schemaLocation="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+
+  <!-- Element Group -->
+
+  <xs:group name="inline">
+    <xs:choice>
+      <xs:element ref="xlf:cp"/>
+      <xs:element ref="xlf:ph"/>
+      <xs:element ref="xlf:pc"/>
+      <xs:element ref="xlf:sc"/>
+      <xs:element ref="xlf:ec"/>
+      <xs:element ref="xlf:mrk"/>
+      <xs:element ref="xlf:sm"/>
+      <xs:element ref="xlf:em"/>
+    </xs:choice>
+  </xs:group>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="yesNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="yesNoFirstNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="firstNo"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="dirValue">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ltr"/>
+      <xs:enumeration value="rtl"/>
+      <xs:enumeration value="auto"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="appliesTo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="source"/>
+      <xs:enumeration value="target"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="userDefinedValue">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\s:]+:[^\s:]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="attrType_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fmt"/>
+      <xs:enumeration value="ui"/>
+      <xs:enumeration value="quote"/>
+      <xs:enumeration value="link"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="typeForMrkValues">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="generic"/>
+      <xs:enumeration value="comment"/>
+      <xs:enumeration value="term"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="attrType_typeForMrk">
+    <xs:union memberTypes="xlf:typeForMrkValues xlf:userDefinedValue"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="priorityValue">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:minInclusive value="1"/>
+      <xs:maxInclusive value="10"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="stateType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="initial"/>
+      <xs:enumeration value="translated"/>
+      <xs:enumeration value="reviewed"/>
+      <xs:enumeration value="final"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Structural Elements -->
+
+  <xs:element name="xliff">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:file"/>
+      </xs:sequence>
+      <xs:attribute name="version" use="required"/>
+      <xs:attribute name="srcLang" use="required"/>
+      <xs:attribute name="trgLang" use="optional"/>
+      <xs:attribute ref="xml:space" use="optional" default="default"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="file">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:skeleton"/>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="xlf:unit"/>
+          <xs:element ref="xlf:group"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="original" use="optional"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="skeleton">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="href" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="group">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xlf:unit"/>
+          <xs:element ref="xlf:group"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="name" use="optional"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="unit">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:originalData"/>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="xlf:segment"/>
+          <xs:element ref="xlf:ignorable"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="name" use="optional"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:attribute name="type" use="optional" type="xlf:userDefinedValue"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="segment">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:target"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="state" use="optional" type="xlf:stateType" default="initial"/>
+      <xs:attribute name="subState" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ignorable">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:target"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="notes">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:note"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="note">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="appliesTo" use="optional" type="xlf:appliesTo"/>
+      <xs:attribute name="category" use="optional"/>
+      <xs:attribute name="priority" use="optional" type="xlf:priorityValue" default="1"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="originalData">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:data"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="data">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="xlf:cp"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute ref="xml:space" use="optional" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="source">
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="target">
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:attribute name="order" use="optional" type="xs:positiveInteger"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inline Elements -->
+
+  <xs:element name="cp">
+    <!-- Code Point -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="hex" use="required" type="xs:hexBinary"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ph">
+    <!-- Placeholder -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="pc">
+    <!-- Paired Code -->
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dispEnd" use="optional"/>
+      <xs:attribute name="dispStart" use="optional"/>
+      <xs:attribute name="equivEnd" use="optional"/>
+      <xs:attribute name="equivStart" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRefEnd" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRefStart" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlowsEnd" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subFlowsStart" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sc">
+    <!-- Start Code -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="isolated" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ec">
+    <!-- End Code -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="isolated" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="startRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="mrk">
+    <!-- Annotation Marker -->
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_typeForMrk"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="value" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sm">
+    <!-- Start Annotation Marker -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_typeForMrk"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="value" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="em">
+    <!-- End Annotation Marker -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="startRef" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2-pgs-combined.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2-pgs-combined.xlf
@@ -1,0 +1,43 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" xmlns:pgs="urn:oasis:names:tc:xliff:pgs:1.0"
+       version="2.2" srcLang="en" trgLang="fr">
+    <file id="f1">
+        <unit id="tu1" name="party_host" pgs:switch="gender:host_gender plural:guest_count">
+            <segment id="seg1" pgs:case="feminine 0">
+                <source><ph id="ph1" disp="host_name"/> did not invite anyone to her party.</source>
+                <target><ph id="ph1" disp="host_name"/> n'a invité personne à sa fête.</target>
+            </segment>
+            <segment id="seg2" pgs:case="feminine 1">
+                <source><ph id="ph2" disp="host_name"/> invited one guest to her party.</source>
+                <target><ph id="ph2" disp="host_name"/> a invité un convive à sa fête.</target>
+            </segment>
+            <segment id="seg3" pgs:case="feminine other">
+                <source><ph id="ph3" disp="host_name"/> invited <ph id="ph4" disp="guest_count"/> guests to her party.</source>
+                <target><ph id="ph3" disp="host_name"/> a invité <ph id="ph4" disp="guest_count"/> convives à sa fête.</target>
+            </segment>
+            <segment id="seg4" pgs:case="masculine 0">
+                <source><ph id="ph5" disp="host_name"/> did not invite anyone to his party.</source>
+                <target><ph id="ph5" disp="host_name"/> n'a invité personne à sa fête.</target>
+            </segment>
+            <segment id="seg5" pgs:case="masculine 1">
+                <source><ph id="ph6" disp="host_name"/> invited one guest to his party.</source>
+                <target><ph id="ph6" disp="host_name"/> a invité un convive à sa fête.</target>
+            </segment>
+            <segment id="seg6" pgs:case="masculine other">
+                <source><ph id="ph7" disp="host_name"/> invited <ph id="ph8" disp="guest_count"/> guests to his party.</source>
+                <target><ph id="ph7" disp="host_name"/> a invité <ph id="ph8" disp="guest_count"/> convives à sa fête.</target>
+            </segment>
+            <segment id="seg7" pgs:case="other 0">
+                <source><ph id="ph9" disp="host_name"/> did not invite anyone to their party.</source>
+                <target><ph id="ph9" disp="host_name"/> n'a invité personne à leur fête.</target>
+            </segment>
+            <segment id="seg8" pgs:case="other 1">
+                <source><ph id="ph10" disp="host_name"/> invited one guest to their party.</source>
+                <target><ph id="ph10" disp="host_name"/> a invité un convive à leur fête.</target>
+            </segment>
+            <segment id="seg9" pgs:case="other other">
+                <source><ph id="ph11" disp="host_name"/> invited <ph id="ph12" disp="guest_count"/> guests to their party.</source>
+                <target><ph id="ph11" disp="host_name"/> a invité <ph id="ph12" disp="guest_count"/> convives à leur fête.</target>
+            </segment>
+        </unit>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2-pgs-gender.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2-pgs-gender.xlf
@@ -1,0 +1,19 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" xmlns:pgs="urn:oasis:names:tc:xliff:pgs:1.0"
+       version="2.2" srcLang="en" trgLang="fr">
+    <file id="f1">
+        <unit id="tu1" name="party_invite" pgs:switch="gender:host_gender">
+            <segment id="seg1" pgs:case="feminine">
+                <source>You are invited to her party</source>
+                <target>Vous êtes invité à sa fête</target>
+            </segment>
+            <segment id="seg2" pgs:case="masculine">
+                <source>You are invited to his party</source>
+                <target>Vous êtes invité à sa fête</target>
+            </segment>
+            <segment id="seg3" pgs:case="other">
+                <source>You are invited to their party</source>
+                <target>Vous êtes invité à leur fête</target>
+            </segment>
+        </unit>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2-pgs-plural.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.2-pgs-plural.xlf
@@ -1,0 +1,19 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" xmlns:pgs="urn:oasis:names:tc:xliff:pgs:1.0"
+       version="2.2" srcLang="en" trgLang="fr">
+    <file id="f1">
+        <unit id="tu1" name="file_deleted" pgs:switch="plural:file_count">
+            <segment id="seg1" pgs:case="0">
+                <source>You deleted no file.</source>
+                <target>Vous n'avez supprimé aucun fichier.</target>
+            </segment>
+            <segment id="seg2" pgs:case="1">
+                <source>You deleted one file.</source>
+                <target>Vous avez supprimé un fichier.</target>
+            </segment>
+            <segment id="seg3" pgs:case="other">
+                <source>You deleted <ph id="1" disp="file_count"/> files.</source>
+                <target>Vous avez supprimé <ph id="1" disp="file_count"/> fichiers.</target>
+            </segment>
+        </unit>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\Exception\InvalidResourceException;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 
 class XliffFileLoaderTest extends TestCase
 {
@@ -422,5 +423,48 @@ class XliffFileLoaderTest extends TestCase
         $this->assertSame('translated', $metadata['segment-attributes']['state']);
         $this->assertArrayHasKey('subState', $metadata['segment-attributes']);
         $this->assertSame('My Value', $metadata['segment-attributes']['subState']);
+    }
+
+    public function testLoadVersion22WithPgsPlural()
+    {
+        $catalogue = new XliffFileLoader()->load(__DIR__.'/../Fixtures/resources-2.2-pgs-plural.xlf', 'fr', 'domain1');
+
+        $intlDomain = 'domain1'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+
+        $this->assertTrue($catalogue->defines('file_deleted', $intlDomain));
+        $this->assertSame(
+            '{file_count, plural, =0 {Vous n\'avez supprimé aucun fichier.} =1 {Vous avez supprimé un fichier.} other {Vous avez supprimé # fichiers.}}',
+            $catalogue->get('file_deleted', $intlDomain)
+        );
+
+        $this->assertSame('plural:file_count', $catalogue->getMetadata('file_deleted', $intlDomain)['pgs-switch']);
+    }
+
+    public function testLoadVersion22WithPgsGender()
+    {
+        $catalogue = new XliffFileLoader()->load(__DIR__.'/../Fixtures/resources-2.2-pgs-gender.xlf', 'fr', 'domain1');
+
+        $intlDomain = 'domain1'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+
+        $this->assertTrue($catalogue->defines('party_invite', $intlDomain));
+        $this->assertSame(
+            '{host_gender, select, feminine {Vous êtes invité à sa fête} masculine {Vous êtes invité à sa fête} other {Vous êtes invité à leur fête}}',
+            $catalogue->get('party_invite', $intlDomain)
+        );
+    }
+
+    public function testLoadVersion22WithPgsCombined()
+    {
+        $catalogue = new XliffFileLoader()->load(__DIR__.'/../Fixtures/resources-2.2-pgs-combined.xlf', 'fr', 'domain1');
+
+        $intlDomain = 'domain1'.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+
+        $this->assertTrue($catalogue->defines('party_host', $intlDomain));
+
+        $expected = <<<ICU
+            {host_gender, select, feminine {{guest_count, plural, =0 {{host_name} n'a invité personne à sa fête.} =1 {{host_name} a invité un convive à sa fête.} other {{host_name} a invité # convives à sa fête.}}} masculine {{guest_count, plural, =0 {{host_name} n'a invité personne à sa fête.} =1 {{host_name} a invité un convive à sa fête.} other {{host_name} a invité # convives à sa fête.}}} other {{guest_count, plural, =0 {{host_name} n'a invité personne à leur fête.} =1 {{host_name} a invité un convive à leur fête.} other {{host_name} a invité # convives à leur fête.}}}}
+            ICU;
+
+        $this->assertSame($expected, $catalogue->get('party_host', $intlDomain));
     }
 }

--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -130,8 +130,11 @@ class XliffUtils
         if ('1.2' === $xliffVersion) {
             $schemaSource = file_get_contents(__DIR__.'/../Resources/schemas/xliff-core-1.2-transitional.xsd');
             $xmlUri = 'http://www.w3.org/2001/xml.xsd';
-        } elseif (\in_array($xliffVersion, ['2.0', '2.1', '2.2'], true)) {
+        } elseif (\in_array($xliffVersion, ['2.0', '2.1'], true)) {
             $schemaSource = file_get_contents(__DIR__.'/../Resources/schemas/xliff-core-2.0.xsd');
+            $xmlUri = 'informativeCopiesOf3rdPartySchemas/w3c/xml.xsd';
+        } elseif ('2.2' === $xliffVersion) {
+            $schemaSource = file_get_contents(__DIR__.'/../Resources/schemas/xliff-core-2.2.xsd');
             $xmlUri = 'informativeCopiesOf3rdPartySchemas/w3c/xml.xsd';
         } else {
             throw new InvalidArgumentException(\sprintf('No support implemented for loading XLIFF version "%s".', $xliffVersion));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Now that we support XLIFF 2.2 (https://github.com/symfony/symfony/pull/63455), we can build features on top of it such as supporting plural, gender and select in XLIFF format.

Other features brought by 2.1 and 2.2 are not really relevant to Symfony that only consumes these files, but this one is useful.

We already support ICU format, so the approach here is to convert XLIFF PGS to an ICU string and register such translation directly in the `+intl-icu` domain.