### PR TITLE
[Mailer][Mailchimp] Fix webhook rejection by switching to form-encoded request parsing

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/batch.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/batch.json
@@ -66,5 +66,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "Mjask0i0giC/nEAYZrt6sX6JF2M="
+  "X-Mandrill-Signature": "iuy630gO50dSjpvVWzsdi4mhAks="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/click.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/click.json
@@ -38,5 +38,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "5mcP4EaDf9cd1tFLAIY+E13Eqmw="
+  "X-Mandrill-Signature": "FHs+BP+LHbBXUOYmNx/zeZ6x7q4="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/deferral.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/deferral.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "VuT14QGTsui1T7B+FqjV6SqACDA="
+  "X-Mandrill-Signature": "dWwh72P2/wdEIpawfviN39XUb2k="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/delivered.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/delivered.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "Q287c9JdfPkKnVE9vRJw5jd+XcE="
+  "X-Mandrill-Signature": "6lvuLyS1YizKsBS1lRzZDmFGWPU="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/hard_bounce.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/hard_bounce.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "ip7K8yTxSFakEhIGiJz8tydjVsQ="
+  "X-Mandrill-Signature": "NR/1sMq6vu/iOHHcRz6sptTyb2c="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/opens.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/opens.json
@@ -33,5 +33,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "9dI0KIewRZJQ/ZabxPXcjhWh4J0="
+  "X-Mandrill-Signature": "47rODVxCjmwbf8ZXdhJk09rmIlY="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/reject.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/reject.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "8ExrBIUlnVaanrjQrvL8Sh/M9pg="
+  "X-Mandrill-Signature": "E8JJH/7S6ifuWYmlXqy15Ls3f38="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/send.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/send.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "mCOMq35TsmWlTHjqDzj3n2eqVg8="
+  "X-Mandrill-Signature": "XecBI/LQPX3del+xEppj7AcoIVY="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/soft_bounce.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/soft_bounce.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "0BdaIQOp5HuT+cs3769ughZdoK0="
+  "X-Mandrill-Signature": "itqKyx81VGXYLOh7A3ecouhTmp4="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/spam.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/spam.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "5mOstZe7kgzwJdBbXtlakc4W87w="
+  "X-Mandrill-Signature": "441pBD4TwDrzclO22YXK4FJ/IEg="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/unsub.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/Fixtures/unsub.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "X-Mandrill-Signature": "LIs4Mw5kGDw8VQVaX8P0Ibnejyo="
+  "X-Mandrill-Signature": "bWLg4YkS9qT+BgeomdEeAbRkxiA="
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpRequestParserTest.php
@@ -28,8 +28,11 @@ class MailchimpRequestParserTest extends AbstractRequestParserTestCase
     {
         $decodedPayload = json_decode($payload, true, 512, \JSON_THROW_ON_ERROR);
         $mandrillSignature = $decodedPayload['X-Mandrill-Signature'] ?? '';
-        unset($decodedPayload['X-Mandrill-Signature']);
-        $request = parent::createRequest(json_encode($decodedPayload, \JSON_THROW_ON_ERROR));
+        $formData = ['mandrill_events' => json_encode($decodedPayload['mandrill_events'], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)];
+
+        $request = Request::create('/', 'POST', $formData, [], [], [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ]);
         $request->headers->set('X-Mandrill-Signature', $mandrillSignature);
 
         return $request;
@@ -38,5 +41,18 @@ class MailchimpRequestParserTest extends AbstractRequestParserTestCase
     protected function getSecret(): string
     {
         return 'key-0p6mqbf74lb20gzq9f4dhpn9rg3zyk26';
+    }
+
+    public function testEmptyWebhookCheck()
+    {
+        $request = Request::create('/', 'POST', ['mandrill_events' => '[]'], [], [], [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ]);
+        // Mailchimp signs empty-check requests with the literal secret 'test-webhook'
+        $request->headers->set('X-Mandrill-Signature', 'QANhYzyeonX51wyzKImgnLZ27CE=');
+
+        $parser = $this->createRequestParser();
+
+        $this->assertNull($parser->parse($request, $this->getSecret()));
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Mailer\Bridge\Mailchimp\Webhook;
 
 use Symfony\Component\HttpFoundation\ChainRequestMatcher;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Mailer\Bridge\Mailchimp\RemoteEvent\MailchimpPayloadConverter;
@@ -33,23 +32,31 @@ final class MailchimpRequestParser extends AbstractRequestParser
     {
         return new ChainRequestMatcher([
             new MethodRequestMatcher('POST'),
-            new IsJsonRequestMatcher(),
         ]);
     }
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null
     {
-        $content = $request->toArray();
-        if (!isset($content['mandrill_events'][0]['event'])
-            || !isset($content['mandrill_events'][0]['msg'])
-        ) {
+        $content = $request->request->all();
+        if (!isset($content['mandrill_events'])) {
+            throw new RejectWebhookException(400, 'Payload malformed.');
+        }
+
+        // Mailchimp sends an empty array to verify the webhook URL is reachable.
+        if ([] === $events = json_decode($content['mandrill_events'], true)) {
+            $this->validateSignature($content, $secret, $request->getUri(), $request->headers->get('X-Mandrill-Signature'));
+
+            return null;
+        }
+
+        if (!isset($events[0]['event']) || !isset($events[0]['msg'])) {
             throw new RejectWebhookException(400, 'Payload malformed.');
         }
 
         $this->validateSignature($content, $secret, $request->getUri(), $request->headers->get('X-Mandrill-Signature'));
 
         try {
-            return array_map($this->converter->convert(...), $content['mandrill_events']);
+            return array_map($this->converter->convert(...), $events);
         } catch (ParseException $e) {
             throw new RejectWebhookException(406, $e->getMessage(), $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61489
| License       | MIT

Mailchimp Transactional (Mandrill) webhooks are sent as `application/x-www-form-urlencoded` POST requests, where `mandrill_events` is a JSON-encoded string in a form field - not a JSON body. The previous implementation used `IsJsonRequestMatcher`, which rejected every real Mailchimp webhook with a 406 "Request does not match." error.

Additionally, when a webhook URL is first registered, Mailchimp sends an empty-array check request (`mandrill_events=[]`) to verify the endpoint is reachable. Because that request carries no parseable events, the old code would reject it too, making it impossible to complete the webhook setup and obtain the signing key from the Mailchimp UI (a catch-22).

Doc at https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/