### PR TITLE
[Router] Detect indirect env var usage in routing parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Detect indirect environment variable usage in routing parameters
  * Add `marshaller` option to cache pool configuration to allow per-pool marshaller services
  * Add support for `lock://` DSN in semaphore configuration to use the Lock component as a semaphore store
  * Add support for configuring JsonStreamer's `default_options`

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -17,9 +17,11 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
@@ -38,6 +40,7 @@ final class Router extends BaseRouter implements WarmableInterface, ServiceSubsc
      * @var \Closure(string):mixed
      */
     private \Closure $paramFetcher;
+    private ?\Closure $isParamDynamic = null;
 
     /**
      * @param mixed $resource The main resource to load
@@ -58,8 +61,14 @@ final class Router extends BaseRouter implements WarmableInterface, ServiceSubsc
 
         if ($parameters) {
             $this->paramFetcher = $parameters->get(...);
+            if ($parameters instanceof ContainerBag && method_exists($parameters, 'isParameterDynamic')) {
+                $this->isParamDynamic = $parameters->isParameterDynamic(...);
+            }
         } elseif ($container instanceof SymfonyContainerInterface) {
             $this->paramFetcher = $container->getParameter(...);
+            if ($container instanceof Container && method_exists($container, 'isParameterDynamic')) {
+                $this->isParamDynamic = $container->isParameterDynamic(...);
+            }
         } else {
             throw new \LogicException(\sprintf('You should either pass a "%s" instance or provide the $parameters argument of the "%s" method.', SymfonyContainerInterface::class, __METHOD__));
         }
@@ -176,6 +185,10 @@ final class Router extends BaseRouter implements WarmableInterface, ServiceSubsc
             }
 
             $resolved = ($this->paramFetcher)($match[1]);
+
+            if ($this->isParamDynamic && ($this->isParamDynamic)($match[1])) {
+                throw new RuntimeException(\sprintf('Using "%%%s%%" is not allowed in routing configuration because the parameter "%s" depends on an environment variable.', $match[1], $match[1]));
+            }
 
             if (\is_scalar($resolved)) {
                 $this->collectedParameters[$match[1]] = $resolved;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -344,6 +344,62 @@ class RouterTest extends TestCase
         $router->getRouteCollection();
     }
 
+    public function testDynamicParameterInRouteWithSfContainer()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route('/%app.host%'));
+
+        $container = new class extends Container {
+            public function isParameterDynamic(string $name): bool
+            {
+                return 'app.host' === $name;
+            }
+        };
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+        $container->set('routing.loader', $loader);
+        $container->setParameter('app.host', 'example.com');
+
+        $router = new Router($container, 'foo');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Using "%app.host%" is not allowed in routing configuration because the parameter "app.host" depends on an environment variable.');
+
+        $router->getRouteCollection();
+    }
+
+    public function testDynamicParameterInRouteWithContainerBag()
+    {
+        if (!method_exists(ContainerBag::class, 'isParameterDynamic')) {
+            $this->markTestSkipped('ContainerBag::isParameterDynamic() is not available.');
+        }
+
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route('/%app.host%'));
+
+        $container = new class extends Container {
+            public function isParameterDynamic(string $name): bool
+            {
+                return 'app.host' === $name;
+            }
+        };
+
+        $container->setParameter('app.host', 'example.com');
+
+        $sc = $this->getPsr11ServiceContainer($routes);
+        $parameters = new ContainerBag($container);
+
+        $router = new Router($sc, 'foo', [], null, $parameters);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Using "%app.host%" is not allowed in routing configuration because the parameter "app.host" depends on an environment variable.');
+
+        $router->getRouteCollection();
+    }
+
     public function testHostPlaceholders()
     {
         $routes = new RouteCollection();

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `Container::isParameterDynamic()` to check if a parameter depends on environment variables
  * Add support for decorating all services with a specific tag using the `container.tag_decorator` resource tag or `#[AsTagDecorator]`
  * Add support for `SOURCE_DATE_EPOCH` environment variable
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -130,6 +130,16 @@ class Container implements ContainerInterface, ResetInterface
     }
 
     /**
+     * Checks whether a parameter is dynamic (i.e. its value depends on environment variables).
+     *
+     * Compiled containers override this method to report parameters that resolve env vars.
+     */
+    public function isParameterDynamic(string $name): bool
+    {
+        return false;
+    }
+
+    /**
      * Sets a service.
      *
      * Setting a synthetic service to null resets it: has() returns false and get()

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1603,6 +1603,21 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $this->getCompiler()->log($pass, $this->resolveEnvPlaceholders($message));
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        if (!$this->hasParameter($name)) {
+            return false;
+        }
+
+        $bag = $this->getParameterBag();
+        $value = $bag->resolveValue($bag->get($name));
+
+        $usedEnvs = [];
+        $this->resolveEnvPlaceholders($value, null, $usedEnvs);
+
+        return [] !== $usedEnvs;
+    }
+
     /**
      * Checks whether a class is available and will remain available in the "no-dev" mode of Composer.
      *

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1715,6 +1715,11 @@ class PhpDumper extends Dumper
             {$getDynamicParameter}
                 }
 
+                public function isParameterDynamic(string \$name): bool
+                {
+                    return isset(\$this->loadedDynamicParameters[\$name]);
+                }
+
                 protected function getDefaultParameters(): array
                 {
                     return $parameters;

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ContainerBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ContainerBag.php
@@ -37,4 +37,9 @@ class ContainerBag extends FrozenParameterBag implements ContainerBagInterface
     {
         return $this->container->hasParameter($name);
     }
+
+    public function isParameterDynamic(string $name): bool
+    {
+        return $this->container->isParameterDynamic($name);
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/inline_adapter_consumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/inline_adapter_consumer.php
@@ -170,6 +170,11 @@ class Symfony_DI_PhpDumper_Test_Inline_Adapter_Consumer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -92,6 +92,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -92,6 +92,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -116,6 +116,11 @@ class ProjectServiceContainer extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -118,6 +118,11 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -79,6 +79,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -714,6 +714,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -494,6 +494,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -556,6 +556,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -121,6 +121,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -96,6 +96,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
@@ -88,6 +88,11 @@ class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
@@ -88,6 +88,11 @@ class Symfony_DI_PhpDumper_Test_CsvParameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
@@ -92,6 +92,11 @@ class Symfony_DI_PhpDumper_Test_DefaultParameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters.php
@@ -100,6 +100,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deprecated_parameters_as_files.txt
@@ -148,6 +148,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
@@ -111,6 +111,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -494,6 +494,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
@@ -90,6 +90,11 @@ class Symfony_DI_PhpDumper_Test_JsonParameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_nonempty_parameters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_nonempty_parameters.php
@@ -98,6 +98,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_nonempty_parameters_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_nonempty_parameters_as_files.txt
@@ -146,6 +146,11 @@ class ProjectServiceContainer extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
@@ -88,6 +88,11 @@ class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -117,6 +117,11 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
@@ -114,6 +114,11 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
         throw new ParameterNotFoundException($name);
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
@@ -88,6 +88,11 @@ class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
         return $this->dynamicParameters[$name] = $value;
     }
 
+    public function isParameterDynamic(string $name): bool
+    {
+        return isset($this->loadedDynamicParameters[$name]);
+    }
+
     protected function getDefaultParameters(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62111
| License       | MIT

Add `Container::isParameterDynamic()` to check if a parameter depends on environment variables. Override in `ContainerBuilder` to support uncompiled containers using `EnvPlaceholderParameterBag`.

Use this in FrameworkBundle's `Router` to detect indirect env var usage in routing parameters and invalidate the cache accordingly.

When a routing parameter references a container parameter that itself resolves to an env var (e.g., `router.default_uri: '%my_base_url%'` where `my_base_url: '%env(BASE_URL)%'`), the router now correctly detects this as dynamic and rebuilds the cache when the env var changes.

Supersedes #63467 (retargeted from 7.4 to 8.1 per reviewer feedback: new public method qualifies as a feature).