### PR TITLE
[Mailer] Add generic key/value info store to SentMessage

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Store the SES-assigned message ID via `SentMessage::addInfo('id', ...)` instead of overwriting `SentMessage::setMessageId()`, preserving the original MIME Message-ID
+
 7.3
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 8.1
 ---
 
- * Store the SES-assigned message ID via `SentMessage::addInfo('id', ...)` instead of overwriting `SentMessage::setMessageId()`, preserving the original MIME Message-ID
+ * Store the SES-assigned message ID via `SentMessage::addMetadata('id', ...)` instead of overwriting `SentMessage::setMessageId()`, preserving the original MIME Message-ID
 
 7.3
 ---

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -121,7 +121,8 @@ class SesApiAsyncAwsTransportTest extends TestCase
 
         $message = $transport->send($mail);
 
-        $this->assertSame('foobar', $message->getMessageId());
+        $this->assertSame('foobar', $message->getInfo('id'));
+        $this->assertNotSame('foobar', $message->getMessageId());
     }
 
     public function testSendWithNonAsciiCustomHeaders()

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -121,7 +121,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
 
         $message = $transport->send($mail);
 
-        $this->assertSame('foobar', $message->getInfo('id'));
+        $this->assertSame('foobar', $message->getMetadata('id'));
         $this->assertNotSame('foobar', $message->getMessageId());
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -112,7 +112,8 @@ class SesHttpAsyncAwsTransportTest extends TestCase
 
         $message = $transport->send($mail);
 
-        $this->assertSame('foobar', $message->getMessageId());
+        $this->assertSame('foobar', $message->getInfo('id'));
+        $this->assertNotSame('foobar', $message->getMessageId());
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -112,7 +112,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
 
         $message = $transport->send($mail);
 
-        $this->assertSame('foobar', $message->getInfo('id'));
+        $this->assertSame('foobar', $message->getMetadata('id'));
         $this->assertNotSame('foobar', $message->getMessageId());
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -55,7 +55,7 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
         $response = $result->info()['response'];
 
         try {
-            $message->setMessageId($result->getMessageId());
+            $message->addInfo('id', $result->getMessageId());
             $message->appendDebug($response->getInfo('debug') ?? '');
         } catch (HttpException $e) {
             $exception = new HttpTransportException(\sprintf('Unable to send an email: %s (code %s).', $e->getAwsMessage() ?: $e->getMessage(), $e->getAwsCode() ?: $e->getCode()), $e->getResponse(), $e->getCode(), $e);

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -55,7 +55,7 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
         $response = $result->info()['response'];
 
         try {
-            $message->addInfo('id', $result->getMessageId());
+            $message->addMetadata('id', $result->getMessageId());
             $message->appendDebug($response->getInfo('debug') ?? '');
         } catch (HttpException $e) {
             $exception = new HttpTransportException(\sprintf('Unable to send an email: %s (code %s).', $e->getAwsMessage() ?: $e->getMessage(), $e->getAwsCode() ?: $e->getCode()), $e->getResponse(), $e->getCode(), $e);

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 8.1
 ---
 
- * Add `SentMessage::addInfo()`, `SentMessage::getInfo()`, and `SentMessage::getAllInfo()` to allow transports to store transport-specific metadata on a sent message
+ * Add `SentMessage::addMetadata()`, `SentMessage::getMetadata()`, and `SentMessage::getAllMetadata()` to allow transports to store transport-specific metadata on a sent message
 
 8.0
 ---

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `SentMessage::addInfo()`, `SentMessage::getInfo()`, and `SentMessage::getAllInfo()` to allow transports to store transport-specific metadata on a sent message
+
 8.0
 ---
 

--- a/src/Symfony/Component/Mailer/SentMessage.php
+++ b/src/Symfony/Component/Mailer/SentMessage.php
@@ -23,6 +23,7 @@ class SentMessage
     private RawMessage $raw;
     private string $messageId;
     private string $debug = '';
+    private array $info = [];
 
     /**
      * @internal
@@ -81,6 +82,21 @@ class SentMessage
     public function appendDebug(string $debug): void
     {
         $this->debug .= $debug;
+    }
+
+    public function addInfo(string $key, mixed $value): void
+    {
+        $this->info[$key] = $value;
+    }
+
+    public function getInfo(string $key, mixed $default = null): mixed
+    {
+        return $this->info[$key] ?? $default;
+    }
+
+    public function getAllInfo(): array
+    {
+        return $this->info;
     }
 
     public function toString(): string

--- a/src/Symfony/Component/Mailer/SentMessage.php
+++ b/src/Symfony/Component/Mailer/SentMessage.php
@@ -23,7 +23,7 @@ class SentMessage
     private RawMessage $raw;
     private string $messageId;
     private string $debug = '';
-    private array $info = [];
+    private array $metadata = [];
 
     /**
      * @internal
@@ -84,19 +84,19 @@ class SentMessage
         $this->debug .= $debug;
     }
 
-    public function addInfo(string $key, mixed $value): void
+    public function addMetadata(string $key, mixed $value): void
     {
-        $this->info[$key] = $value;
+        $this->metadata[$key] = $value;
     }
 
-    public function getInfo(string $key, mixed $default = null): mixed
+    public function getMetadata(string $key, mixed $default = null): mixed
     {
-        return $this->info[$key] ?? $default;
+        return $this->metadata[$key] ?? $default;
     }
 
-    public function getAllInfo(): array
+    public function getAllMetadata(): array
     {
-        return $this->info;
+        return $this->metadata;
     }
 
     public function toString(): string

--- a/src/Symfony/Component/Mailer/Tests/SentMessageTest.php
+++ b/src/Symfony/Component/Mailer/Tests/SentMessageTest.php
@@ -34,35 +34,35 @@ class SentMessageTest extends TestCase
         $this->assertNotSame($r, $m->getMessage());
     }
 
-    public function testInfo()
+    public function testMetadata()
     {
         $m = new SentMessage(
             new RawMessage('Email'),
             new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')])
         );
 
-        $this->assertNull($m->getInfo('ses_message_id'));
-        $this->assertSame('default', $m->getInfo('ses_message_id', 'default'));
-        $this->assertSame([], $m->getAllInfo());
+        $this->assertNull($m->getMetadata('ses_message_id'));
+        $this->assertSame('default', $m->getMetadata('ses_message_id', 'default'));
+        $this->assertSame([], $m->getAllMetadata());
 
-        $m->addInfo('ses_message_id', 'ses-abc-123');
-        $m->addInfo('request_id', 'req-xyz-456');
+        $m->addMetadata('ses_message_id', 'ses-abc-123');
+        $m->addMetadata('request_id', 'req-xyz-456');
 
-        $this->assertSame('ses-abc-123', $m->getInfo('ses_message_id'));
-        $this->assertSame('req-xyz-456', $m->getInfo('request_id'));
-        $this->assertSame(['ses_message_id' => 'ses-abc-123', 'request_id' => 'req-xyz-456'], $m->getAllInfo());
+        $this->assertSame('ses-abc-123', $m->getMetadata('ses_message_id'));
+        $this->assertSame('req-xyz-456', $m->getMetadata('request_id'));
+        $this->assertSame(['ses_message_id' => 'ses-abc-123', 'request_id' => 'req-xyz-456'], $m->getAllMetadata());
     }
 
-    public function testInfoOverwrite()
+    public function testMetadataOverwrite()
     {
         $m = new SentMessage(
             new RawMessage('Email'),
             new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')])
         );
 
-        $m->addInfo('key', 'first');
-        $m->addInfo('key', 'second');
+        $m->addMetadata('key', 'first');
+        $m->addMetadata('key', 'second');
 
-        $this->assertSame('second', $m->getInfo('key'));
+        $this->assertSame('second', $m->getMetadata('key'));
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/SentMessageTest.php
+++ b/src/Symfony/Component/Mailer/Tests/SentMessageTest.php
@@ -33,4 +33,36 @@ class SentMessageTest extends TestCase
         $this->assertSame($r, $m->getOriginalMessage());
         $this->assertNotSame($r, $m->getMessage());
     }
+
+    public function testInfo()
+    {
+        $m = new SentMessage(
+            new RawMessage('Email'),
+            new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')])
+        );
+
+        $this->assertNull($m->getInfo('ses_message_id'));
+        $this->assertSame('default', $m->getInfo('ses_message_id', 'default'));
+        $this->assertSame([], $m->getAllInfo());
+
+        $m->addInfo('ses_message_id', 'ses-abc-123');
+        $m->addInfo('request_id', 'req-xyz-456');
+
+        $this->assertSame('ses-abc-123', $m->getInfo('ses_message_id'));
+        $this->assertSame('req-xyz-456', $m->getInfo('request_id'));
+        $this->assertSame(['ses_message_id' => 'ses-abc-123', 'request_id' => 'req-xyz-456'], $m->getAllInfo());
+    }
+
+    public function testInfoOverwrite()
+    {
+        $m = new SentMessage(
+            new RawMessage('Email'),
+            new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')])
+        );
+
+        $m->addInfo('key', 'first');
+        $m->addInfo('key', 'second');
+
+        $this->assertSame('second', $m->getInfo('key'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #45871 
| License       | MIT

Add generic info store to SentMessage for transport-specific metadata

Add `addInfo()`, `getInfo()`, and `getAllInfo()` methods to `SentMessage`
to allow transports to attach arbitrary key/value metadata without
overwriting the original MIME Message-ID.

Update `SesHttpAsyncAwsTransport` to store the SES-assigned message ID
via `addInfo('id', ...)` instead of `setMessageId()`, so both the
original MIME Message-ID (accessible via `getMessageId()`) and the
SES-assigned ID (accessible via `getInfo('id')`) are preserved.