### PR TITLE
[TwigBridge] Fix Bootstrap 4 form errors rendered inside `<label>`

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -235,7 +235,8 @@
         {%- endif -%}
         <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>
         {{- block('form_label_content') -}}
-        {% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
+        </{{ element|default('label') }}>
+        {% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}
     {%- else -%}
         {%- if errors|length > 0 -%}
         <div id="{{ id }}_errors" class="mb-2">
@@ -271,8 +272,8 @@
             {%- if label is not same as(false) -%}
                 {{- block('form_label_content') -}}
             {%- endif -%}
-            {{- form_errors(form) -}}
         </label>
+        {{- form_errors(form) -}}
     {%- endif -%}
 {%- endblock checkbox_radio_label %}
 
@@ -297,7 +298,7 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block">
+        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block mb-1">
             {%- for error in errors -%}
                 <span class="d-block">
                     <span class="form-error-icon badge badge-danger text-uppercase">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTestCase.php
@@ -31,14 +31,12 @@ abstract class AbstractBootstrap4HorizontalLayoutTestCase extends AbstractBootst
             '/div
     [
         ./label[@for="name"]
-        [
-            ./span[@class="alert alert-danger d-block"]
-                [./span[@class="d-block"]
-                    [./span[.="[trans]Error[/trans]"]]
-                    [./span[.="[trans]Error![/trans]"]]
-                ]
-                [count(./span)=1]
+        /following-sibling::span[@class="alert alert-danger d-block mb-1"]
+        [./span[@class="d-block"]
+            [./span[.="[trans]Error[/trans]"]]
+            [./span[.="[trans]Error![/trans]"]]
         ]
+        [count(./span)=1]
         /following-sibling::div[./input[@id="name"]]
     ]
 '

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
@@ -41,14 +41,12 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
             '/div
     [
         ./label[@for="name"]
-        [
-            ./span[@class="alert alert-danger d-block"]
-                [./span[@class="d-block"]
-                    [./span[.="[trans]Error[/trans]"]]
-                    [./span[.="[trans]Error![/trans]"]]
-                ]
-                [count(./span)=1]
+        /following-sibling::span[@class="alert alert-danger d-block mb-1"]
+        [./span[@class="d-block"]
+            [./span[.="[trans]Error[/trans]"]]
+            [./span[.="[trans]Error![/trans]"]]
         ]
+        [count(./span)=1]
         /following-sibling::input[@id="name"]
     ]
 '
@@ -324,7 +322,7 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
 
         $this->assertMatchesXpath($html,
             '/span
-    [@class="alert alert-danger d-block"]
+    [@class="alert alert-danger d-block mb-1"]
     [
         ./span[@class="d-block"]
             [./span[.="[trans]Error[/trans]"]]

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -69,10 +69,17 @@ class FormThemeTest extends TestCase
         $this->registerTwigRuntimeLoader($environment, $formRenderer);
         $compiler = new Compiler($environment);
 
+        // cope with various versions of Twig
+        $source = '[1 => "tpl1", 0 => "tpl2"]';
+        if ('["tpl1", "tpl2"]' === (new Compiler($environment))->subcompile($node->getNode('resources'))->getSource()) {
+            $source = '["tpl1", "tpl2"]';
+        }
+
         $this->assertEquals(
             \sprintf(
-                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, [1 => "tpl1", 0 => "tpl2"], true);',
-                $this->getVariableGetter('form')
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, %s, true);',
+                $this->getVariableGetter('form'),
+                $source
             ),
             trim($compiler->compile($node)->getSource())
         );
@@ -81,8 +88,9 @@ class FormThemeTest extends TestCase
 
         $this->assertEquals(
             \sprintf(
-                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, [1 => "tpl1", 0 => "tpl2"], false);',
-                $this->getVariableGetter('form')
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, %s, false);',
+                $this->getVariableGetter('form'),
+                $source
             ),
             trim($compiler->compile($node)->getSource())
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52352 
| License       | MIT

Same as #52373 with edits by maintainers possible.

This PR will fix Bootstrap 4 form layout when using a required marker.

<img width="598" height="683" alt="image" src="https://github.com/user-attachments/assets/a97c4725-43eb-4dfa-86a1-5c0cc3f78581" />
