### PR TITLE
[DependencyInjection] Fix PriorityTaggedServiceTrait not discovering `#[AsTaggedItem]` on decorated services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -65,6 +65,12 @@ trait PriorityTaggedServiceTrait
             $class = $container->getParameterBag()->resolveValue($class) ?: null;
             $checkTaggedItem = !$definition->hasTag($definition->isAutoconfigured() ? 'container.ignore_attributes' : $tagName);
 
+            // For decorated services, fall back to the inner service's class for #[AsTaggedItem] discovery
+            if ($innerClass = $definition->getTag('container.decorator')[0]['inner'] ?? null) {
+                $innerClass = $container->has($innerClass) ? $container->findDefinition($innerClass) : null;
+                $innerClass = $container->getParameterBag()->resolveValue($innerClass?->getClass());
+            }
+
             foreach ($attributes as $attribute) {
                 $index = $priority = null;
 
@@ -72,6 +78,9 @@ trait PriorityTaggedServiceTrait
                     $priority = $attribute['priority'];
                 } elseif (null === $defaultPriority && $defaultPriorityMethod && $class) {
                     $defaultPriority = PriorityTaggedServiceUtil::getDefault($container, $serviceId, $class, $defaultPriorityMethod, $tagName, 'priority', $checkTaggedItem);
+                    if (null === $defaultPriority && $innerClass) {
+                        $defaultPriority = PriorityTaggedServiceUtil::getDefault($container, $serviceId, $innerClass, $defaultPriorityMethod, $tagName, 'priority', true);
+                    }
                 }
                 $priority ??= $defaultPriority ??= 0;
 
@@ -84,6 +93,9 @@ trait PriorityTaggedServiceTrait
                     $index = $attribute[$indexAttribute];
                 } elseif (null === $defaultIndex && $defaultPriorityMethod && $class) {
                     $defaultIndex = PriorityTaggedServiceUtil::getDefault($container, $serviceId, $class, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute, $checkTaggedItem);
+                    if (null === $defaultIndex && $innerClass) {
+                        $defaultIndex = PriorityTaggedServiceUtil::getDefault($container, $serviceId, $innerClass, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute, true);
+                    }
                 }
                 $decorated = $definition->getTag('container.decorator')[0]['id'] ?? null;
                 $index = $index ?? $defaultIndex ?? $defaultIndex = $decorated ?? $serviceId;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -233,6 +233,31 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertSame(array_keys($expected), array_keys($services));
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
+
+    public function testDecoratedServiceAsTaggedItemIndex()
+    {
+        $container = new ContainerBuilder();
+
+        // Register the inner service with AsTaggedItem
+        $container->register('inner.tagged_service', DecoratedAsTaggedItemService::class)
+            ->setAutoconfigured(true)
+            ->addTag('my_custom_tag');
+
+        // Register a decorator that wraps the inner service
+        $decorator = $container->register('decorator.tagged_service', \stdClass::class);
+        $decorator->addTag('my_custom_tag');
+        $decorator->addTag('container.decorator', ['id' => DecoratedAsTaggedItemService::class, 'inner' => 'inner.tagged_service']);
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+
+        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar');
+        $services = $priorityTaggedServiceTraitImplementation->test($tag, $container);
+
+        $this->assertArrayHasKey('custom_key', $services);
+        $this->assertSame('decorator.tagged_service', (string) $services['custom_key']);
+    }
 }
 
 class PriorityTaggedServiceTraitImplementation
@@ -258,4 +283,9 @@ class HelloNamedService2
 interface HelloInterface
 {
     public static function getFooBar(): string;
+}
+
+#[AsTaggedItem(index: 'custom_key', priority: 1)]
+class DecoratedAsTaggedItemService
+{
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -217,6 +218,37 @@ class ServiceLocatorTagPassTest extends TestCase
         static::assertSame(['service-2', 'service-1'], array_keys($factories));
     }
 
+    public function testIndexedByAsTaggedItemWithDecoration()
+    {
+        $container = new ContainerBuilder();
+
+        $locator = new Definition(Locator::class);
+        $locator->setPublic(true);
+        $locator->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('test_tag', 'key', null, true)));
+
+        $container->setDefinition(Locator::class, $locator);
+
+        $service = new Definition(AsTaggedItemService::class);
+        $service->setPublic(true);
+        $service->setAutoconfigured(true);
+        $service->addTag('test_tag');
+
+        $container->setDefinition(AsTaggedItemService::class, $service);
+
+        $decorated = new Definition(AsTaggedItemServiceDecorator::class);
+        $decorated->setPublic(true);
+        $decorated->setDecoratedService(AsTaggedItemService::class);
+
+        $container->setDefinition(AsTaggedItemServiceDecorator::class, $decorated);
+
+        $container->compile();
+
+        /** @var ServiceLocator $locator */
+        $locator = $container->get(Locator::class)->locator;
+        static::assertTrue($locator->has('custom_key'));
+        static::assertInstanceOf(AsTaggedItemServiceDecorator::class, $locator->get('custom_key'));
+    }
+
     public function testBindingsAreProcessed()
     {
         $container = new ContainerBuilder();
@@ -245,5 +277,14 @@ class Service
 }
 
 class DecoratedService
+{
+}
+
+#[AsTaggedItem(index: 'custom_key')]
+class AsTaggedItemService
+{
+}
+
+class AsTaggedItemServiceDecorator
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60242
| License       | MIT

When a service with `#[AsTaggedItem('a')]` is decorated via `#[AsDecorator]`, the `AsTaggedItem` index is lost because `PriorityTaggedServiceTrait` reads the PHP attribute from the decorator's class (which doesn't have `AsTaggedItem`), not from the original service's class.

This PR adds a fallback in `PriorityTaggedServiceTrait::findAndSortTaggedServices()`: when a decorated service's class has no `AsTaggedItem`, it looks up the inner (original) service's class via the `container.decorator` tag.