### PR TITLE
[Validator] Correctly handle null `allowedVariables` in `ExpressionSyntaxValidator`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\Parser;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -45,7 +46,11 @@ class ExpressionSyntaxValidator extends ConstraintValidator
         $this->expressionLanguage ??= new ExpressionLanguage();
 
         try {
-            $this->expressionLanguage->lint($expression, $constraint->allowedVariables);
+            if (null === $constraint->allowedVariables) {
+                $this->expressionLanguage->lint($expression, [], Parser::IGNORE_UNKNOWN_VARIABLES);
+            } else {
+                $this->expressionLanguage->lint($expression, $constraint->allowedVariables);
+            }
         } catch (SyntaxError $exception) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ syntax_error }}', $this->formatValue($exception->getMessage()))

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
@@ -75,6 +75,13 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testExpressionWithNullAllowedVariables()
+    {
+        $this->validator->validate('a + 1', new ExpressionSyntax());
+
+        $this->assertNoViolation();
+    }
+
     public function testExpressionIsNotValid()
     {
         $this->validator->validate('a + 1', new ExpressionSyntax(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63475
| License       | MIT
