### PR TITLE
[Scheduler] Add GreedyTriggerInterface for one-by-one message processing

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `GreedyTriggerInterface` to allow triggers to process pending items one-by-one by returning the same datetime from `getNextRunDate()`
  * Add `--sort` option to `debug:command` to order recurring messages by next run date
 
 7.3

--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -16,6 +16,7 @@ use Symfony\Component\Clock\Clock;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
+use Symfony\Component\Scheduler\Trigger\GreedyTriggerInterface;
 use Symfony\Component\Scheduler\Trigger\StatefulTriggerInterface;
 
 final class MessageGenerator implements MessageGeneratorInterface
@@ -72,6 +73,37 @@ final class MessageGenerator implements MessageGeneratorInterface
                 $yield = false;
             } elseif ($time == $lastTime && $index <= $lastIndex) {
                 $yield = false;
+            }
+
+            if ($trigger instanceof GreedyTriggerInterface) {
+                if ($yield) {
+                    // Greedy burst: yield first, then ask the trigger whether there is more
+                    // work at the same time. getNextRunDate() is intentionally called *after*
+                    // each yield so the trigger can inspect the state left by the handler.
+                    do {
+                        $context = new MessageContext($this->name, $id, $trigger, $time, null);
+                        try {
+                            foreach ($recurringMessage->getMessages($context) as $message) {
+                                yield $context => $message;
+                            }
+                        } finally {
+                            $checkpoint->save($time, $index);
+                        }
+                        $nextTime = $trigger->getNextRunDate($time);
+                    } while ($nextTime == $time);
+                } else {
+                    $nextTime = $trigger->getNextRunDate($time);
+                    // Skip same-time re-entry when the item was already processed.
+                    while ($nextTime == $time) {
+                        $nextTime = $trigger->getNextRunDate($time);
+                    }
+                }
+
+                if ($nextTime) {
+                    $heap->insert([$nextTime, $index, $recurringMessage]);
+                }
+
+                continue;
             }
 
             $nextTime = $trigger->getNextRunDate($time);

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Scheduler\Generator\MessageGenerator;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
+use Symfony\Component\Scheduler\Trigger\GreedyTriggerInterface;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 class MessageGeneratorTest extends TestCase
@@ -260,6 +261,60 @@ class MessageGeneratorTest extends TestCase
         $this->assertCount(1, iterator_to_array($scheduler->getMessages(), false));
 
         $this->assertEquals(self::makeDateTime('22:23:10'), $clock->now());
+    }
+
+    public function testGreedyTriggerYieldsOneMessagePerPendingItem()
+    {
+        $clock = new MockClock(self::makeDateTime('22:12:00'));
+        $message = (object) ['id' => 'message'];
+
+        // Shared counter representing "items in queue".
+        // The trigger checks it; the foreach loop below decrements it to simulate handler work.
+        $counter = new \stdClass();
+        $counter->pending = 3;
+
+        $trigger = new class($counter) implements GreedyTriggerInterface {
+            public function __construct(private readonly \stdClass $counter)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return 'greedy-trigger';
+            }
+
+            public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
+            {
+                $scheduledTime = new \DateTimeImmutable('2020-02-20T22:13:00', new \DateTimeZone('UTC'));
+
+                if ($run < $scheduledTime) {
+                    return $scheduledTime;
+                }
+
+                // Return the same $run time when there is still work to do, null when done.
+                return $this->counter->pending > 0 ? $run : null;
+            }
+        };
+
+        $schedule = (new Schedule())->add(RecurringMessage::trigger($trigger, $message));
+        $schedule->stateful(new ArrayAdapter());
+
+        $scheduler = new MessageGenerator($schedule, 'dummy', $clock);
+
+        // Warmup – first run always returns nothing.
+        $this->assertSame([], iterator_to_array($scheduler->getMessages(), false));
+
+        $clock->modify('22:13:00');
+
+        // Collect messages while simulating handler work (decrement the counter).
+        $results = [];
+        foreach ($scheduler->getMessages() as $yielded) {
+            $results[] = $yielded;
+            --$counter->pending;
+        }
+
+        $this->assertCount(3, $results);
+        $this->assertSame(array_fill(0, 3, $message), $results);
     }
 
     public static function messagesProvider(): \Generator

--- a/src/Symfony/Component/Scheduler/Trigger/GreedyTriggerInterface.php
+++ b/src/Symfony/Component/Scheduler/Trigger/GreedyTriggerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Scheduler\Trigger;
+
+/**
+ * When implemented, MessageGenerator calls getNextRunDate() *after* each yield
+ * instead of before. This allows the trigger to check whether more work is
+ * available once the handler has finished processing the current message.
+ *
+ * Returning the same time signals "process me again immediately".
+ * Returning a future time or null ends the greedy burst.
+ */
+interface GreedyTriggerInterface extends TriggerInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59668 
| License       | MIT

When a trigger needs to process items individually (e.g. draining a queue
one item per handler invocation), MessageGenerator previously called
getNextRunDate() before yielding, so the trigger could not observe the
state left by the handler. Returning the same time to signal "more work"
caused an infinite loop or an off-by-one extra yield.

Introduce GreedyTriggerInterface as a marker interface. When implemented,
MessageGenerator reverses the call order for that trigger: it yields the
message first, then calls getNextRunDate() to decide whether to yield
again at the same time. The burst continues while the trigger returns the
same datetime and stops when it returns a different time or null.