### PR TITLE
[Config] Fix ArrayShapeGenerator required keys with deep merging

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -127,6 +127,14 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     }
 
     /**
+     * Whether deep merging should occur.
+     */
+    public function shouldPerformDeepMerging(): bool
+    {
+        return $this->performDeepMerging;
+    }
+
+    /**
      * Whether extra keys should just be ignored without an exception.
      *
      * @param bool $boolean To allow extra keys

--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -60,7 +60,7 @@ final class ArrayShapeGenerator
         $arrayShape = \sprintf("array{%s\n", self::generateInlinePhpDocForNode($node));
 
         foreach ($children as $child) {
-            $arrayShape .= str_repeat('    ', $nestingLevel).self::dumpNodeKey($child).': ';
+            $arrayShape .= str_repeat('    ', $nestingLevel).self::dumpNodeKey($child, $node).': ';
 
             if ($child instanceof PrototypedArrayNode) {
                 $isHashmap = (bool) $child->getKeyAttribute();
@@ -82,7 +82,7 @@ final class ArrayShapeGenerator
         return implode('|', [...self::getNormalizedTypes($node, ['array', 'any']), $arrayShape]);
     }
 
-    private static function dumpNodeKey(NodeInterface $node): string
+    private static function dumpNodeKey(NodeInterface $node, ?ArrayNode $parent = null): string
     {
         $name = $node->getName();
         $quoted = str_starts_with($name, '@')
@@ -93,7 +93,9 @@ final class ArrayShapeGenerator
             $name = "'".addslashes($name)."'";
         }
 
-        return $name.($node->isRequired() ? '' : '?');
+        $optional = !$node->isRequired() || ($parent instanceof ArrayNode && $parent->shouldPerformDeepMerging());
+
+        return $name.($optional ? '?' : '');
     }
 
     private static function handleNumericNode(NumericNode $node): string

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -105,6 +105,18 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNode('root');
         $root->addChild($child);
 
+        $this->assertStringContainsString('node?: bool', ArrayShapeGenerator::generate($root));
+    }
+
+    public function testPhpDocHandlesRequiredNodeWithNoDeepMerging()
+    {
+        $child = new BooleanNode('node');
+        $child->setRequired(true);
+
+        $root = new ArrayNode('root');
+        $root->setPerformDeepMerging(false);
+        $root->addChild($child);
+
         $expected = 'node: bool';
 
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Summary

When configuration is deep-merged across files, a required node only needs to be present after the merge, not in every individual file. The `ArrayShapeGenerator` was marking all required keys as non-optional (`node: type`) in the generated array shape, which made PHPStan complain when a required key (e.g. `resource` in `router`) was not set in every single config file.

This PR marks required keys as optional (`node?: type`) in the array shape when the parent node performs deep merging (the default behavior). Only when the parent explicitly disables deep merging (`performNoDeepMerging()`) are required keys kept non-optional.

### Changes

- Add `ArrayNode::shouldPerformDeepMerging()` getter
- Update `ArrayShapeGenerator::dumpNodeKey()` to account for the parent's deep merging setting
- Update existing test and add a new test for the `performNoDeepMerging()` case