### PR TITLE
[Validator] Add a guard when `Parser::IGNORE_UNKNOWN_VARIABLES` is not defined

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
@@ -46,7 +46,7 @@ class ExpressionSyntaxValidator extends ConstraintValidator
         $this->expressionLanguage ??= new ExpressionLanguage();
 
         try {
-            if (null === $constraint->allowedVariables) {
+            if (null === $constraint->allowedVariables && \defined(Parser::class.'::IGNORE_UNKNOWN_VARIABLES')) {
                 $this->expressionLanguage->lint($expression, [], Parser::IGNORE_UNKNOWN_VARIABLES);
             } else {
                 $this->expressionLanguage->lint($expression, $constraint->allowedVariables);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixing low-deps after https://github.com/symfony/symfony/pull/63476

If the constant is not defined, flags on `lint()` aren't either and it only takes 2 parameters. This guard should be enough.