### PR TITLE
[DoctrineBridge] Add the `EntityExists` constraint

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `DoctrineDbalTransactionMiddleware` to wrap all handlers in a single DBAL transaction without requiring the ORM
  * Map the `DatePoint`, `DayPoint` and `TimePoint` property types to their Doctrine types, so schema tools detect them without an explicit `type`
  * Load a list of entities into `array`-typed controller and command arguments with `#[MapEntity]`, using `findBy()`
+ * Add the `EntityExists` constraint for validating that a value references an existing entity
 
 8.1
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/EntityExistsTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/EntityExistsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Validator\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExists;
+use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExistsValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
+
+class EntityExistsTest extends TestCase
+{
+    public function testAttributeWithDefaultOptions()
+    {
+        $metadata = new ClassMetadata(EntityExistsDummyOne::class);
+        $loader = new AttributeLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        [$constraint] = $metadata->getPropertyMetadata('entityId')[0]->getConstraints();
+        self::assertInstanceOf(EntityExists::class, $constraint);
+        self::assertSame('Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\SingleIntIdEntity', $constraint->entityClass);
+        self::assertSame(EntityExistsValidator::class, $constraint->validatedBy());
+        self::assertNull($constraint->em);
+        self::assertNull($constraint->identifierField);
+        self::assertNull($constraint->repositoryMethod);
+        self::assertSame(['Default', 'EntityExistsDummyOne'], $constraint->groups);
+        self::assertSame('This value is not valid.', $constraint->invalidMessage);
+    }
+
+    public function testAttributeWithIdentifierField()
+    {
+        $metadata = new ClassMetadata(EntityExistsDummyTwo::class);
+        $loader = new AttributeLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        [$constraint] = $metadata->getPropertyMetadata('identifier')[0]->getConstraints();
+        self::assertInstanceOf(EntityExists::class, $constraint);
+        self::assertSame('App\\Entity\\MyEntity', $constraint->entityClass);
+        self::assertSame('myMessage', $constraint->message);
+        self::assertSame('my_own_entity_manager', $constraint->em);
+        self::assertSame('uuid', $constraint->identifierField);
+        self::assertNull($constraint->repositoryMethod);
+        self::assertSame(['custom_group'], $constraint->groups);
+        self::assertSame('payload', $constraint->payload);
+    }
+
+    public function testAttributeWithRepositoryMethod()
+    {
+        $metadata = new ClassMetadata(EntityExistsDummyThree::class);
+        $loader = new AttributeLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        [$constraint] = $metadata->getPropertyMetadata('identifier')[0]->getConstraints();
+        self::assertInstanceOf(EntityExists::class, $constraint);
+        self::assertSame('App\\Entity\\MyEntity', $constraint->entityClass);
+        self::assertSame('findByCustom', $constraint->repositoryMethod);
+        self::assertNull($constraint->identifierField);
+    }
+
+    public function testAttributeWithInvalidMessage()
+    {
+        $metadata = new ClassMetadata(EntityExistsDummyFour::class);
+        $loader = new AttributeLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        [$constraint] = $metadata->getPropertyMetadata('entityId')[0]->getConstraints();
+        self::assertInstanceOf(EntityExists::class, $constraint);
+        self::assertSame('myInvalidMessage', $constraint->invalidMessage);
+    }
+
+    public function testThrowsWhenIdentifierFieldAndRepositoryMethodAreSetTogether()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "identifierField" and "repositoryMethod" options cannot be used together.');
+
+        new EntityExists(
+            entityClass: 'App\\Entity\\MyEntity',
+            identifierField: 'id',
+            repositoryMethod: 'findByCustom',
+        );
+    }
+}
+
+class EntityExistsDummyOne
+{
+    #[EntityExists(entityClass: 'Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\SingleIntIdEntity')]
+    public int $entityId;
+}
+
+class EntityExistsDummyTwo
+{
+    #[EntityExists(entityClass: 'App\\Entity\\MyEntity', message: 'myMessage', em: 'my_own_entity_manager', identifierField: 'uuid', groups: ['custom_group'], payload: 'payload')]
+    public string $identifier;
+}
+
+class EntityExistsDummyThree
+{
+    #[EntityExists(entityClass: 'App\\Entity\\MyEntity', repositoryMethod: 'findByCustom')]
+    public string $identifier;
+}
+
+class EntityExistsDummyFour
+{
+    #[EntityExists(entityClass: 'Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\SingleIntIdEntity', invalidMessage: 'myInvalidMessage')]
+    public int $entityId;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/EntityExistsValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/EntityExistsValidatorTest.php
@@ -1,0 +1,329 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Validator\Constraints;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UserUuidNameEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UuidIdEntity;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExists;
+use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExistsValidator;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class EntityExistsValidatorTest extends ConstraintValidatorTestCase
+{
+    protected ?ObjectManager $em;
+    protected ManagerRegistry $registry;
+
+    protected function setUp(): void
+    {
+        if (!Type::hasType('uuid')) {
+            Type::addType('uuid', UuidType::class);
+        }
+
+        $this->em = DoctrineTestHelper::createTestEntityManager();
+        $this->createSchema($this->em);
+        $this->registry = $this->createRegistryMock($this->em);
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->em?->close();
+        $this->em = null;
+
+        parent::tearDown();
+    }
+
+    protected function createValidator(): EntityExistsValidator
+    {
+        return new EntityExistsValidator($this->registry);
+    }
+
+    public function testValidateSkipsNull()
+    {
+        $constraint = new EntityExists(entityClass: SingleIntIdEntity::class);
+
+        $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidateSkipsEmptyString()
+    {
+        $this->validator->validate('', new EntityExists(entityClass: SingleIntIdEntity::class));
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidateExistingEntityBySingleIdentifier()
+    {
+        $this->em->persist(new SingleIntIdEntity(1, 'Foo'));
+        $this->em->flush();
+
+        $this->validator->validate(1, new EntityExists(entityClass: SingleIntIdEntity::class, message: 'myMessage'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidateExistingEntityByUuidIdentifier()
+    {
+        $id = Uuid::fromString('ec562e21-1fc8-4e55-8de7-a42389ac75c5');
+        $this->em->persist(new UserUuidNameEntity($id, 'Foo Bar'));
+        $this->em->flush();
+
+        $this->validator->validate((string) $id, new EntityExists(entityClass: UserUuidNameEntity::class, message: 'myMessage'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testRaiseViolationWhenEntityDoesNotExist()
+    {
+        $this->validator->validate(999, new EntityExists(entityClass: SingleIntIdEntity::class, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '999')
+            ->setInvalidValue(999)
+            ->setCode(EntityExists::ENTITY_NOT_FOUND_ERROR)
+            ->assertRaised();
+    }
+
+    #[DataProvider('provideInvalidUuidValues')]
+    public function testRaiseInvalidValueViolationWhenValueCannotBeConvertedToTheFieldType(string $value)
+    {
+        $this->validator->validate($value, new EntityExists(entityClass: UuidIdEntity::class, invalidMessage: 'myInvalidMessage'));
+
+        $this->buildViolation('myInvalidMessage')
+            ->setParameter('{{ value }}', \sprintf('"%s"', $value))
+            ->setInvalidValue($value)
+            ->setCode(EntityExists::INVALID_VALUE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testASixteenByteStringIsAValidBinaryUuid()
+    {
+        // 16 byte strings are valid binary uuid input, so this is a not-found, not an invalid value
+        $this->validator->validate('not-a-valid-uuid', new EntityExists(entityClass: UuidIdEntity::class, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"not-a-valid-uuid"')
+            ->setInvalidValue('not-a-valid-uuid')
+            ->setCode(EntityExists::ENTITY_NOT_FOUND_ERROR)
+            ->assertRaised();
+    }
+
+    public function testValidateExistingEntityByRealUuidType()
+    {
+        $id = Uuid::fromString('ec562e21-1fc8-4e55-8de7-a42389ac75c5');
+        $this->em->persist(new UuidIdEntity($id));
+        $this->em->flush();
+
+        $this->validator->validate((string) $id, new EntityExists(entityClass: UuidIdEntity::class));
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidateExistingEntityByAssociation()
+    {
+        $single = new SingleIntIdEntity(1, 'Foo');
+        $association = new AssociationEntity();
+        $association->single = $single;
+        $this->em->persist($single);
+        $this->em->persist($association);
+        $this->em->flush();
+
+        $this->validator->validate(1, new EntityExists(entityClass: AssociationEntity::class, identifierField: 'single'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testRaiseViolationWhenNoEntityReferencesTheAssociation()
+    {
+        $this->validator->validate(999, new EntityExists(entityClass: AssociationEntity::class, identifierField: 'single', message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '999')
+            ->setInvalidValue(999)
+            ->setCode(EntityExists::ENTITY_NOT_FOUND_ERROR)
+            ->assertRaised();
+    }
+
+    #[DataProvider('provideNegativeIntegerValues')]
+    public function testRaiseViolationWhenIntegerIdentifierIsNegative(mixed $value, string $formatted)
+    {
+        $this->validator->validate($value, new EntityExists(entityClass: SingleIntIdEntity::class, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $formatted)
+            ->setInvalidValue($value)
+            ->setCode(EntityExists::ENTITY_NOT_FOUND_ERROR)
+            ->assertRaised();
+    }
+
+    public function testValidateUsingRepositoryMethodReturningObject()
+    {
+        /** @var EntityRepository $repository */
+        $repository = $this->em->getRepository(SingleIntIdEntity::class);
+        $repository->result = new \stdClass();
+
+        $this->validator->validate('ignored', new EntityExists(
+            entityClass: SingleIntIdEntity::class,
+            repositoryMethod: 'findByCustom',
+        ));
+
+        $this->assertNoViolation();
+    }
+
+    public function testRaiseViolationWhenRepositoryMethodReturnsNull()
+    {
+        /** @var EntityRepository $repository */
+        $repository = $this->em->getRepository(SingleIntIdEntity::class);
+        $repository->result = null;
+
+        $this->validator->validate('unknown', new EntityExists(
+            entityClass: SingleIntIdEntity::class,
+            message: 'myMessage',
+            repositoryMethod: 'findByCustom',
+        ));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"unknown"')
+            ->setInvalidValue('unknown')
+            ->setCode(EntityExists::ENTITY_NOT_FOUND_ERROR)
+            ->assertRaised();
+    }
+
+    public function testThrowsWhenEntityHasMultipleIdentifiersAndIdentifierFieldIsNotConfigured()
+    {
+        $constraint = new EntityExists(entityClass: CompositeIntIdEntity::class);
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Entity "Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\CompositeIntIdEntity" has multiple identifier fields. Use the "identifierField" option to specify which one to use.');
+
+        $this->validator->validate(1, $constraint);
+    }
+
+    public function testThrowsWhenIdentifierFieldDoesNotExist()
+    {
+        $constraint = new EntityExists(entityClass: SingleIntIdEntity::class, identifierField: 'nonExistentField');
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Entity "Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\SingleIntIdEntity" does not have a field named "nonExistentField".');
+
+        $this->validator->validate('Foo', $constraint);
+    }
+
+    public function testValidateExistingEntityByRegularIdentifierField()
+    {
+        $this->em->persist(new SingleIntIdEntity(1, 'Foo'));
+        $this->em->flush();
+
+        $this->validator->validate('Foo', new EntityExists(entityClass: SingleIntIdEntity::class, identifierField: 'name'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testThrowsWhenRepositoryMethodDoesNotExist()
+    {
+        $constraint = new EntityExists(entityClass: SingleIntIdEntity::class, repositoryMethod: 'nonExistentMethod');
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Repository for class "Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\SingleIntIdEntity" does not have method "nonExistentMethod".');
+
+        $this->validator->validate('ignored', $constraint);
+    }
+
+    public function testThrowsWhenObjectManagerDoesNotExist()
+    {
+        $this->registry = $this->createRegistryMock($this->em, true, true);
+        $this->validator = $this->createValidator();
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Object manager "missing" does not exist.');
+
+        $this->validate(1, new EntityExists(entityClass: SingleIntIdEntity::class, em: 'missing'));
+    }
+
+    public function testThrowsWhenManagerForClassCannotBeResolved()
+    {
+        $this->registry = $this->createRegistryMock($this->em, false);
+        $this->validator = $this->createValidator();
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Unable to find the object manager associated with an entity of class "Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\SingleIntIdEntity".');
+
+        $this->validate(1, new EntityExists(entityClass: SingleIntIdEntity::class));
+    }
+
+    private function createRegistryMock(?ObjectManager $em, bool $managerForClassExists = true, bool $throwOnGetManager = false): ManagerRegistry
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        if ($throwOnGetManager) {
+            $registry->method('getManager')
+                ->willThrowException(new \InvalidArgumentException());
+        } else {
+            $registry->method('getManager')
+                ->willReturn($em);
+        }
+
+        $registry->method('getManagerForClass')
+            ->willReturn($managerForClassExists ? $em : null);
+
+        $registry->method('getConnection')
+            ->willReturn($em?->getConnection());
+
+        return $registry;
+    }
+
+    public static function provideInvalidUuidValues(): iterable
+    {
+        yield ['abc'];
+        yield ['random-string'];
+        yield ['123'];
+    }
+
+    public static function provideNegativeIntegerValues(): iterable
+    {
+        yield 'negative int' => [-1, '-1'];
+        yield 'another negative int' => [-42, '-42'];
+        yield 'negative numeric string' => ['-10', '"-10"'];
+    }
+
+    /**
+     * @param EntityManagerInterface $em
+     */
+    private function createSchema(ObjectManager $em): void
+    {
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->createSchema([
+            $em->getClassMetadata(SingleIntIdEntity::class),
+            $em->getClassMetadata(CompositeIntIdEntity::class),
+            $em->getClassMetadata(UserUuidNameEntity::class),
+            $em->getClassMetadata(UuidIdEntity::class),
+            $em->getClassMetadata(AssociationEntity::class),
+        ]);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/EntityExists.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/EntityExists.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Validator\Constraints;
+
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * Constraint for validating that a value references an existing entity.
+ *
+ * @author Evgen Yurchenko <evgenijvy@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class EntityExists extends Constraint
+{
+    public const ENTITY_NOT_FOUND_ERROR = 'f7ef7fa8-4ef7-48d2-a264-b57447e1f2ad';
+    public const INVALID_VALUE_ERROR = '24f19c7f-eff5-4a5a-9d4c-163c4ce7ba6b';
+
+    protected const ERROR_NAMES = [
+        self::ENTITY_NOT_FOUND_ERROR => 'ENTITY_NOT_FOUND_ERROR',
+        self::INVALID_VALUE_ERROR => 'INVALID_VALUE_ERROR',
+    ];
+
+    public string $message = 'The referenced entity does not exist.';
+    public string $invalidMessage = 'This value is not valid.';
+
+    /**
+     * @param string      $entityClass      The entity class to look the value up in
+     * @param string|null $em               The object manager to use, or null to resolve it from the entity class
+     * @param string|null $identifierField  Look the value up by this field instead of the identifier
+     * @param string|null $repositoryMethod Call this repository method with the value instead of findOneBy(); a truthy return means the entity exists
+     * @param string|null $invalidMessage   The message when the value cannot be converted to the field's type
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        public string $entityClass,
+        ?string $message = null,
+        public ?string $em = null,
+        public ?string $identifierField = null,
+        public ?string $repositoryMethod = null,
+        ?array $groups = null,
+        mixed $payload = null,
+        ?string $invalidMessage = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        if ($this->identifierField && $this->repositoryMethod) {
+            throw new ConstraintDefinitionException('The "identifierField" and "repositoryMethod" options cannot be used together.');
+        }
+
+        $this->message = $message ?? $this->message;
+        $this->invalidMessage = $invalidMessage ?? $this->invalidMessage;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/EntityExistsValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/EntityExistsValidator.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Validator\Constraints;
+
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\MappingException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validates that a value references an existing entity.
+ *
+ * @author Evgen Yurchenko <evgenijvy@gmail.com>
+ */
+class EntityExistsValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof EntityExists) {
+            throw new UnexpectedTypeException($constraint, EntityExists::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if ($constraint->em) {
+            try {
+                $em = $this->registry->getManager($constraint->em);
+            } catch (\InvalidArgumentException $e) {
+                throw new ConstraintDefinitionException(\sprintf('Object manager "%s" does not exist.', $constraint->em), 0, $e);
+            }
+        } else {
+            $em = $this->registry->getManagerForClass($constraint->entityClass);
+
+            if (!$em) {
+                throw new ConstraintDefinitionException(\sprintf('Unable to find the object manager associated with an entity of class "%s".', $constraint->entityClass));
+            }
+        }
+
+        try {
+            $classMetadata = $em->getClassMetadata($constraint->entityClass);
+        } catch (MappingException $e) {
+            throw new ConstraintDefinitionException(\sprintf('Unable to load class "%s".', $constraint->entityClass), 0, $e);
+        }
+
+        $repository = $em->getRepository($constraint->entityClass);
+
+        if ($constraint->repositoryMethod) {
+            if (!method_exists($repository, $constraint->repositoryMethod)) {
+                throw new ConstraintDefinitionException(\sprintf('Repository for class "%s" does not have method "%s".', $constraint->entityClass, $constraint->repositoryMethod));
+            }
+
+            $data = $repository->{$constraint->repositoryMethod}($value);
+        } else {
+            try {
+                // the manager converts the value to the field's type itself, against its
+                // own connection; a value it cannot convert can reference no entity, which
+                // is a problem with the value rather than with the constraint
+                $data = $repository->findOneBy([$this->resolveField($constraint, $classMetadata) => $value]);
+            } catch (ConversionException) {
+                $this->context->buildViolation($constraint->invalidMessage)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setInvalidValue($value)
+                    ->setCode(EntityExists::INVALID_VALUE_ERROR)
+                    ->addViolation();
+
+                return;
+            }
+        }
+
+        if (!$data) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setInvalidValue($value)
+                ->setCode(EntityExists::ENTITY_NOT_FOUND_ERROR)
+                ->addViolation();
+        }
+    }
+
+    private function resolveField(EntityExists $constraint, ClassMetadata $classMetadata): string
+    {
+        if (!$field = $constraint->identifierField) {
+            $identifierFieldNames = $classMetadata->getIdentifierFieldNames();
+
+            if (1 !== \count($identifierFieldNames)) {
+                throw new ConstraintDefinitionException(\sprintf('Entity "%s" has multiple identifier fields. Use the "identifierField" option to specify which one to use.', $constraint->entityClass));
+            }
+
+            return $identifierFieldNames[0];
+        }
+
+        if (!$classMetadata->hasField($field) && !$classMetadata->hasAssociation($field)) {
+            throw new ConstraintDefinitionException(\sprintf('Entity "%s" does not have a field named "%s".', $constraint->entityClass, $field));
+        }
+
+        return $field;
+    }
+}

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>This value is not a valid cron expression.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target>The referenced entity does not exist.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds an `EntityExists` constraint to the Doctrine bridge, validating that a value references an existing entity. It removes the repetitive find-check-throw logic for identifiers arriving in DTOs, and reports a missing row as a regular violation on the property, aggregated and translated like any other.

```php
use Symfony\Bridge\Doctrine\Validator\Constraints\EntityExists;

final class AssignUserCommand
{
    #[EntityExists(entityClass: User::class)]
    public string $userId;
}
```

By default the value is looked up by the entity's single identifier field, through `findOneBy()`, so the loaded entity stays in the identity map and a later `find()` for the same id is free. Options:

- `identifierField`: look the value up by another field or by an association instead of the identifier;
- `repositoryMethod`: call this repository method with the value; a truthy return means the entity exists, so a custom method can return an entity, a count or a boolean;
- `em`: the object manager name, when it cannot be resolved from the entity class;
- `message` / `invalidMessage`: the violation messages, see below.

Two violation codes:

- `ENTITY_NOT_FOUND_ERROR` with `message` ("The referenced entity does not exist.") when no row matches;
- `INVALID_VALUE_ERROR` with `invalidMessage` ("This value is not valid.") when the value cannot be converted to the field's type, for example a malformed uuid for a `uuid` column. The conversion happens inside the manager, against the manager's own connection, so multiple entity managers on different platforms behave correctly.

`null` and `''` are considered valid, as for most constraints; combine with `NotBlank` when the value is required. Configuration mistakes (unknown field, unknown repository method, ambiguous manager, composite identifier without `identifierField`) throw `ConstraintDefinitionException`.

**Registration**: the validator needs the `ManagerRegistry`, so full-stack usage requires DoctrineBundle to register it as a `validator.constraint_validator` service, like `doctrine.orm.validator.unique`. A companion DoctrineBundle PR is needed before this is usable out of the box; standalone users pass a factory able to instantiate the validator to `ValidatorBuilder::setConstraintValidatorFactory()`.

Points for the documentation:
- the default lookup and the identity-map warm-up;
- `repositoryMethod`'s truthiness contract, including using it for count-style checks that avoid hydration;
- the two violation codes and when each fires;
- the `NotBlank` pairing for required values.
