### PR TITLE
[DependencyInjection] Fix `#[AsTaggedItem]` discovery through multi-level decoration chains

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -65,10 +65,15 @@ trait PriorityTaggedServiceTrait
             $class = $container->getParameterBag()->resolveValue($class) ?: null;
             $checkTaggedItem = !$definition->hasTag($definition->isAutoconfigured() ? 'container.ignore_attributes' : $tagName);
 
-            // For decorated services, fall back to the inner service's class for #[AsTaggedItem] discovery
-            if ($innerClass = $definition->getTag('container.decorator')[0]['inner'] ?? null) {
-                $innerClass = $container->has($innerClass) ? $container->findDefinition($innerClass) : null;
-                $innerClass = $container->getParameterBag()->resolveValue($innerClass?->getClass());
+            // For decorated services, walk the decoration chain to find #[AsTaggedItem] on the original service
+            $innerClass = null;
+            $innerDef = $definition;
+            while ($innerId = $innerDef->getTag('container.decorator')[0]['inner'] ?? null) {
+                if (!$container->has($innerId)) {
+                    break;
+                }
+                $innerDef = $container->findDefinition($innerId);
+                $innerClass = $container->getParameterBag()->resolveValue($innerDef->getClass()) ?: null;
             }
 
             foreach ($attributes as $attribute) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -258,6 +258,36 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertArrayHasKey('custom_key', $services);
         $this->assertSame('decorator.tagged_service', (string) $services['custom_key']);
     }
+
+    public function testMultiLevelDecoratedServiceAsTaggedItemIndex()
+    {
+        $container = new ContainerBuilder();
+
+        // Register the innermost service with AsTaggedItem
+        $container->register('inner.tagged_service', DecoratedAsTaggedItemService::class)
+            ->setAutoconfigured(true)
+            ->addTag('my_custom_tag');
+
+        // First decorator wraps the inner service
+        $decorator1 = $container->register('decorator1.tagged_service', \stdClass::class);
+        $decorator1->addTag('my_custom_tag');
+        $decorator1->addTag('container.decorator', ['id' => DecoratedAsTaggedItemService::class, 'inner' => 'inner.tagged_service']);
+
+        // Second decorator wraps the first decorator
+        $decorator2 = $container->register('decorator2.tagged_service', \stdClass::class);
+        $decorator2->addTag('my_custom_tag');
+        $decorator2->addTag('container.decorator', ['id' => DecoratedAsTaggedItemService::class, 'inner' => 'decorator1.tagged_service']);
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+
+        $tag = new TaggedIteratorArgument('my_custom_tag', 'foo', 'getFooBar');
+        $services = $priorityTaggedServiceTraitImplementation->test($tag, $container);
+
+        $this->assertArrayHasKey('custom_key', $services);
+        $this->assertSame('decorator2.tagged_service', (string) $services['custom_key']);
+    }
 }
 
 class PriorityTaggedServiceTraitImplementation


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As spotted by @stof in https://github.com/symfony/symfony/pull/63473#issuecomment-3950671841