### PR TITLE
[Translation][Crowdin] Add automatic retry for 429 Too Many Requests responses

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Translation\Bridge\Crowdin;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
+use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
 use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
@@ -45,7 +47,8 @@ final class CrowdinProviderFactory extends AbstractProviderFactory
         $endpoint = preg_replace('/(^|\.)default$/', '\1'.self::HOST, $dsn->getHost());
         $endpoint .= $dsn->getPort() ? ':'.$dsn->getPort() : '';
 
-        $client = ScopingHttpClient::forBaseUri($this->client, \sprintf('https://%s/api/v2/projects/%d/', $endpoint, $this->getUser($dsn)), [
+        $client = new RetryableHttpClient($this->client, new GenericRetryStrategy([429]), 3, $this->logger);
+        $client = ScopingHttpClient::forBaseUri($client, \sprintf('https://%s/api/v2/projects/%d/', $endpoint, $this->getUser($dsn)), [
             'auth_bearer' => $this->getPassword($dsn),
         ], preg_quote('https://'.$endpoint.'/api/v2/'));
 

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -17,6 +17,8 @@ use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
+use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\Translation\Bridge\Crowdin\CrowdinProvider;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
 use Symfony\Component\Translation\Exception\ProviderException;
@@ -168,6 +170,100 @@ class CrowdinProviderTest extends ProviderTestCase
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
             'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+
+        $provider->write($translatorBag);
+    }
+
+    public function testWriteWithTooManyRequests()
+    {
+        $expectedMessagesFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
+        $responses = [
+            'listFiles' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+                $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
+
+                return new JsonMockResponse(['data' => []]);
+            },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+            },
+            'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+                $this->assertSame('Content-Type: application/octet-stream', $options['normalized_headers']['content-type'][0]);
+                $this->assertSame('Crowdin-API-FileName: messages.xlf', $options['normalized_headers']['crowdin-api-filename'][0]);
+                $this->assertStringMatchesFormat($expectedMessagesFileContent, $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 19]], ['http_code' => 201]);
+            },
+            'addFileWithTooManyRequests' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+                $this->assertSame(json_encode(['storageId' => 19, 'name' => 'messages.xlf']), $options['body']);
+
+                return new JsonMockResponse(
+                    ['error' => ['message' => 'Too Many Requests', 'code' => 429]],
+                    ['http_code' => 429]
+                );
+            },
+            'addFileWithSuccess' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+                $this->assertSame(json_encode(['storageId' => 19, 'name' => 'messages.xlf']), $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 199, 'name' => 'messages.xlf']], ['http_code' => 201]);
+            },
+        ];
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', [
+            'messages' => ['a' => 'trans_en_a'],
+        ]));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())
+            ->method('error');
+
+        $mockClient = new MockHttpClient($responses)->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'auth_bearer' => 'API_TOKEN',
+        ]);
+
+        $retryableClient = new RetryableHttpClient(
+            $mockClient,
+            new GenericRetryStrategy([429], 100),
+            3,
+            $logger
+        );
+
+        $provider = self::createProvider(
+            $retryableClient,
+            $this->getLoader(),
+            $logger,
+            $this->getDefaultLocale(),
+            'api.crowdin.com/api/v2/projects/1/'
+        );
 
         $provider->write($translatorBag);
     }
@@ -1048,6 +1144,93 @@ class CrowdinProviderTest extends ProviderTestCase
         ];
     }
 
+    public function testReadWithTooManyRequests()
+    {
+        $responses = [
+            'listFiles' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+
+                return new JsonMockResponse([
+                    'data' => [
+                        [
+                            'data' => [
+                                'id' => 12,
+                                'name' => 'messages.xlf',
+                            ]
+                        ],
+                    ],
+                ]);
+            },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new JsonMockResponse([
+                    'data' => [
+                        'languageMapping' => [
+                            'pt-PT' => [
+                                'locale' => 'pt',
+                            ],
+                        ],
+                    ],
+                ]);
+            },
+            'exportProjectTranslationsWithTooManyRequests' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/translations/exports', $url);
+
+                return new JsonMockResponse(
+                    ['error' => ['message' => 'Too Many Requests', 'code' => 429]],
+                    ['http_code' => 429]
+                );
+            },
+            'exportProjectTranslationsWithSuccess' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/translations/exports', $url);
+
+                return new JsonMockResponse(['data' => ['url' => 'https://file.url']]);
+            },
+            'downloadFile' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://file.url/', $url);
+
+                return new MockResponse('');
+            },
+        ];
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())
+            ->method('error');
+
+        $mockLoader = $this->createMock(LoaderInterface::class);
+        $mockLoader->expects(self::once())
+            ->method('load')
+            ->willReturn(new MessageCatalogue('fr', ['messages' => []]));
+
+        $mockClient = new MockHttpClient($responses)->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'auth_bearer' => 'API_TOKEN',
+        ]);
+
+        $retryableClient = new RetryableHttpClient(
+            $mockClient,
+            new GenericRetryStrategy([429], 100),
+            3,
+            $logger
+        );
+
+        $crowdinProvider = self::createProvider(
+            $retryableClient,
+            $mockLoader,
+            $logger,
+            $this->getDefaultLocale(),
+            'api.crowdin.com/api/v2'
+        );
+
+        $crowdinProvider->read(['messages'], ['fr']);
+    }
+
     public function testReadServerException()
     {
         $responses = [
@@ -1521,6 +1704,122 @@ class CrowdinProviderTest extends ProviderTestCase
         $this->expectExceptionMessage(
             'Unable to update file "12" and domain "messages": '.
             '"Unable to update file in Crowdin for file ID "12" and domain "messages"."'
+        );
+
+        $provider->delete($deletedStrings);
+    }
+
+    public function testDeleteWithTooManyRequests()
+    {
+        $sourceFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%1$s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                  <trans-unit id="%2$s" resname="b">
+                    <source>b</source>
+                    <target>trans_en_b</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+
+        $responses = [
+            'listFiles' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+
+                return new JsonMockResponse([
+                    'data' => [
+                        [
+                            'data' => [
+                                'id' => 12,
+                                'name' => 'messages.xlf',
+                            ],
+                        ],
+                    ],
+                ]);
+            },
+            'downloadSource' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12/download', $url);
+
+                return new JsonMockResponse(['data' => ['url' => 'https://file.url']]);
+            },
+            'downloadFile' => function (string $method, string $url) use ($sourceFileContent): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://file.url/', $url);
+
+                return new MockResponse($sourceFileContent);
+            },
+            'addStorage' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+
+                return new JsonMockResponse(['data' => ['id' => 19]], ['http_code' => 201]);
+            },
+            'updateFileWithTooManyRequests' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('PUT', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12', $url);
+                $this->assertSame(json_encode(['storageId' => 19]), $options['body']);
+
+                return new JsonMockResponse(
+                    ['error' => ['message' => 'Too Many Requests', 'code' => 429]],
+                    ['http_code' => 429]
+                );
+            },
+            'updateFileWithSuccess' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('PUT', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12', $url);
+                $this->assertSame(json_encode(['storageId' => 19]), $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 12, 'name' => 'messages.xlf']]);
+            },
+        ];
+
+        $deletedStrings = new TranslatorBag();
+        $deletedStrings->addCatalogue(
+            new MessageCatalogue(
+                'en',
+                [
+                    'messages' => [
+                        'b' => 'trans_en_b',
+                    ],
+                ]
+            )
+        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())
+            ->method('error');
+
+        $mockClient = new MockHttpClient($responses)->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'auth_bearer' => 'API_TOKEN',
+        ]);
+
+        $retryableClient = new RetryableHttpClient(
+            $mockClient,
+            new GenericRetryStrategy([429], 100),
+            3,
+            $logger
+        );
+
+        $provider = self::createProvider(
+            $retryableClient,
+            $this->getLoader(),
+            $logger,
+            $this->getDefaultLocale(),
+            'api.crowdin.com/api/v2/projects/1/'
         );
 
         $provider->delete($deletedStrings);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | --
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
### Description

Adds automatic retry for 429 rate limit responses in Crowdin translation provider.

Wraps the HTTP client in a RetryableHttpClient to automatically retry requests when the Crowdin API returns 429 Too Many Requests. Tests included.