### PR TITLE
[Form] Add `PolymorphicCollectionType` for collections whose entries do not all share the same type

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -34,6 +34,17 @@
     {{- block('form_widget') -}}
 {%- endblock collection_widget -%}
 
+{%- block polymorphic_collection_widget -%}
+    {% if prototypes is defined %}
+        {%- for name, prototype in prototypes -%}
+            {%- if not prototype.rendered -%}
+                {%- set attr = attr|merge({('data-prototype-' ~ name): form_row(prototype)}) -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {% endif %}
+    {{- block('form_widget') -}}
+{%- endblock polymorphic_collection_widget -%}
+
 {%- block textarea_widget -%}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
 {%- endblock textarea_widget -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -14,7 +14,9 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Bridge\Twig\Test\FormLayoutTestCase;
+use Symfony\Component\Form\EntryTypeProviderInterface;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
+use Symfony\Component\Form\Extension\Core\Type\PolymorphicCollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\FormError;
@@ -2309,6 +2311,48 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
             '//div[@id="name_items"][@data-prototype]
             |
             //table[@id="name_items"][@data-prototype]'
+        );
+    }
+
+    public function testPolymorphicCollectionPrototypes()
+    {
+        if (!class_exists(PolymorphicCollectionType::class)) {
+            $this->markTestSkipped('Requires symfony/form 8.2+.');
+        }
+
+        $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType', ['items' => ['one', 'two', 'three']])
+            ->add('items', PolymorphicCollectionType::class, [
+                'entry_types' => [
+                    'text' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+                    'number' => 'Symfony\Component\Form\Extension\Core\Type\NumberType',
+                ],
+                'entry_type_provider' => new class implements EntryTypeProviderInterface {
+                    public function forModelData(mixed $data): int|string
+                    {
+                        return is_numeric($data) ? 'number' : 'text';
+                    }
+
+                    public function forSubmittedData(mixed $data): int|string
+                    {
+                        return is_numeric($data) ? 'number' : 'text';
+                    }
+                },
+                'allow_add' => true,
+            ])
+            ->getForm()
+            ->createView();
+
+        $html = $this->renderWidget($form);
+
+        $this->assertMatchesXpath($html,
+            '//div[@id="name_items"][@data-prototype-text]
+            |
+            //table[@id="name_items"][@data-prototype-text]'
+        );
+        $this->assertMatchesXpath($html,
+            '//div[@id="name_items"][@data-prototype-number]
+            |
+            //table[@id="name_items"][@data-prototype-number]'
         );
     }
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0
+ * Add `PolymorphicCollectionType` for collections whose entries do not all share the same type
  * Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled
  * Add the `choice_help` option to `ChoiceType`
  * Add `$help` parameter to `ChoiceListFactoryInterface::createView()`

--- a/src/Symfony/Component/Form/EntryTypeProviderInterface.php
+++ b/src/Symfony/Component/Form/EntryTypeProviderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+/**
+ * Tells PolymorphicCollectionType which of its "entry_types" an entry should use.
+ *
+ * Both methods return one of the keys of the "entry_types" option. They are given the same
+ * entry in two different shapes, hence the two methods: the model data before the form is
+ * populated, and the raw submitted data.
+ */
+interface EntryTypeProviderInterface
+{
+    public function forModelData(mixed $data): int|string;
+
+    public function forSubmittedData(mixed $data): int|string;
+}

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -62,6 +62,7 @@ class CoreExtension extends AbstractExtension
             new Type\NumberType(),
             new Type\PasswordType(),
             new Type\PercentType(),
+            new Type\PolymorphicCollectionType(),
             new Type\RadioType(),
             new Type\RangeType(),
             new Type\RepeatedType(),

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -12,12 +12,14 @@
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\EntryTypeProviderInterface;
 use Symfony\Component\Form\Event\PostSetDataEvent;
 use Symfony\Component\Form\Event\PreSetDataEvent;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * Resize a collection form element based on the data sent from the client.
@@ -31,14 +33,21 @@ class ResizeFormListener implements EventSubscriberInterface
     private \Closure|bool $deleteEmpty;
     private array $preSetDataChildrenStack = [];
 
+    /**
+     * @param string|array<string, string>    $type              A type, or one type per entry name when $entryTypeProvider is given
+     * @param array<mixed>                    $options           Options for $type, or one set of options per entry name
+     * @param array<mixed>|null               $prototypeOptions  Same shape as $options
+     * @param EntryTypeProviderInterface|null $entryTypeProvider Picks the entry name to use for a given entry's data
+     */
     public function __construct(
-        private string $type,
+        private string|array $type,
         private array $options = [],
         private bool $allowAdd = false,
         private bool $allowDelete = false,
         bool|callable $deleteEmpty = false,
         ?array $prototypeOptions = null,
         private bool $keepAsList = false,
+        private ?EntryTypeProviderInterface $entryTypeProvider = null,
     ) {
         $this->deleteEmpty = \is_bool($deleteEmpty) ? $deleteEmpty : $deleteEmpty(...);
         $this->prototypeOptions = $prototypeOptions ?? $options;
@@ -90,9 +99,10 @@ class ResizeFormListener implements EventSubscriberInterface
                 continue;
             }
 
-            $form->add($name, $this->type, array_replace([
-                'property_path' => '['.$name.']',
-            ], $this->options));
+            $form->add($name, $this->forModelData($this->type, $value), array_replace(
+                ['property_path' => '['.$name.']'],
+                $this->forModelData($this->options, $value),
+            ));
         }
     }
 
@@ -118,9 +128,10 @@ class ResizeFormListener implements EventSubscriberInterface
         if ($this->allowAdd) {
             foreach ($data as $name => $value) {
                 if (!$form->has($name)) {
-                    $form->add($name, $this->type, array_replace([
-                        'property_path' => '['.$name.']',
-                    ], $this->prototypeOptions));
+                    $form->add($name, $this->forSubmittedData($this->type, $value), array_replace(
+                        ['property_path' => '['.$name.']'],
+                        $this->forSubmittedData($this->prototypeOptions, $value),
+                    ));
                 }
             }
         }
@@ -188,13 +199,34 @@ class ResizeFormListener implements EventSubscriberInterface
                 $form->remove($name);
             }
             foreach ($formReindex as $index => $child) {
-                $form->add($index, $this->type, array_replace([
-                    'property_path' => '['.$index.']',
-                ], $this->options, ['data' => $child->getData()]));
+                $form->add($index, $this->forModelData($this->type, $child->getData()), array_replace(
+                    ['property_path' => '['.$index.']'],
+                    $this->forModelData($this->options, $child->getData()),
+                    ['data' => $child->getData()],
+                ));
                 $data[$index] = $child->getData();
             }
         }
 
         $event->setData($data);
+    }
+
+    private function forModelData(string|array $value, mixed $data): string|array
+    {
+        return \is_string($this->type) ? $value : $this->entryOf($value, $this->entryTypeProvider->forModelData($data));
+    }
+
+    private function forSubmittedData(string|array $value, mixed $data): string|array
+    {
+        return \is_string($this->type) ? $value : $this->entryOf($value, $this->entryTypeProvider->forSubmittedData($data));
+    }
+
+    private function entryOf(array $value, int|string $name): string|array
+    {
+        if (!\array_key_exists($name, $this->type)) {
+            throw new InvalidOptionsException(\sprintf('The "%s" instance given as "entry_type_provider" must return a key of the "entry_types" option, but it returned "%s". Allowed keys are "%s".', $this->entryTypeProvider::class, $name, implode('", "', array_keys($this->type))));
+        }
+
+        return $value[$name];
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/PolymorphicCollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PolymorphicCollectionType.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\EntryTypeProviderInterface;
+use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * A collection whose entries do not all share the same type.
+ *
+ * The type of each entry is decided by the "entry_type_provider" from the entry's data,
+ * and "entry_options", "prototype_options" and "prototype_data" are keyed by the names
+ * declared in "entry_types". Use CollectionType when every entry has the same type.
+ */
+class PolymorphicCollectionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $resizePrototypeOptions = null;
+        if ($options['allow_add'] && $options['prototype']) {
+            $prototypes = $resizePrototypeOptions = [];
+            foreach ($options['entry_types'] as $name => $entryType) {
+                $resizePrototypeOptions[$name] = array_replace($options['entry_options'][$name], $options['prototype_options'][$name]);
+                $prototypeOptions = array_replace([
+                    'required' => $options['required'],
+                    'label' => $options['prototype_name'].'label__',
+                ], $resizePrototypeOptions[$name]);
+
+                if (null !== $options['prototype_data'][$name]) {
+                    $prototypeOptions['data'] = $options['prototype_data'][$name];
+                }
+
+                $prototypes[$name] = $builder->create($options['prototype_name'], $entryType, $prototypeOptions)->getForm();
+            }
+
+            $builder->setAttribute('prototypes', $prototypes);
+        }
+
+        $builder->addEventSubscriber(new ResizeFormListener(
+            $options['entry_types'],
+            $options['entry_options'],
+            $options['allow_add'],
+            $options['allow_delete'],
+            $options['delete_empty'],
+            $resizePrototypeOptions,
+            $options['keep_as_list'],
+            $options['entry_type_provider'],
+        ));
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars = array_replace($view->vars, [
+            'allow_add' => $options['allow_add'],
+            'allow_delete' => $options['allow_delete'],
+        ]);
+
+        if ($form->getConfig()->hasAttribute('prototypes')) {
+            $view->vars['prototypes'] = array_map(
+                static fn (FormInterface $prototype) => $prototype->setParent($form)->createView($view),
+                $form->getConfig()->getAttribute('prototypes'),
+            );
+        }
+    }
+
+    public function finishView(FormView $view, FormInterface $form, array $options): void
+    {
+        // entries do not share a type, so the offset is computed for each of them
+        foreach ($view as $name => $entryView) {
+            array_splice($entryView->vars['block_prefixes'], self::prefixOffset($form[$name]), 0, 'collection_entry');
+        }
+
+        if (!$prototypes = $form->getConfig()->getAttribute('prototypes')) {
+            return;
+        }
+
+        foreach ($prototypes as $name => $prototype) {
+            if ($view->vars['prototypes'][$name]->vars['multipart']) {
+                $view->vars['multipart'] = true;
+            }
+
+            array_splice($view->vars['prototypes'][$name]->vars['block_prefixes'], self::prefixOffset($prototype), 0, 'collection_entry');
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'allow_add' => false,
+            'allow_delete' => false,
+            'prototype' => true,
+            'prototype_name' => '__name__',
+            'entry_options' => [],
+            'prototype_options' => [],
+            'prototype_data' => [],
+            'delete_empty' => false,
+            'invalid_message' => 'The collection is invalid.',
+            'keep_as_list' => false,
+        ]);
+
+        $resolver->setRequired(['entry_types', 'entry_type_provider']);
+
+        $resolver->setNormalizer('entry_options', static function (Options $options, array $value) {
+            $value = self::keyByEntryType($options, $value, 'entry_options', []);
+
+            foreach ($value as $name => $entryOptions) {
+                $value[$name]['block_name'] = 'entry';
+            }
+
+            return $value;
+        });
+        $resolver->setNormalizer('prototype_options', static fn (Options $options, array $value) => self::keyByEntryType($options, $value, 'prototype_options', []));
+        $resolver->setNormalizer('prototype_data', static fn (Options $options, array $value) => self::keyByEntryType($options, $value, 'prototype_data', null));
+
+        $resolver->setAllowedTypes('entry_types', 'string[]');
+        $resolver->setAllowedTypes('entry_type_provider', EntryTypeProviderInterface::class);
+        $resolver->setAllowedTypes('entry_options', 'array');
+        $resolver->setAllowedTypes('prototype_options', 'array');
+        $resolver->setAllowedTypes('prototype_data', 'array');
+        $resolver->setAllowedTypes('delete_empty', ['bool', 'callable']);
+        $resolver->setAllowedTypes('keep_as_list', ['bool']);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'polymorphic_collection';
+    }
+
+    private static function keyByEntryType(Options $options, array $value, string $option, mixed $default): array
+    {
+        if ($unknown = array_diff_key($value, $options['entry_types'])) {
+            throw new InvalidOptionsException(\sprintf('The "%s" option can only use keys of the "entry_types" option. Allowed keys are "%s", but got "%s".', $option, implode('", "', array_keys($options['entry_types'])), implode('", "', array_keys($unknown))));
+        }
+
+        foreach ($options['entry_types'] as $name => $entryType) {
+            $value[$name] ??= $default;
+        }
+
+        return $value;
+    }
+
+    private static function prefixOffset(FormInterface $form): int
+    {
+        // the entry type may define a block prefix of its own, which sits before the type's own one
+        return $form->getConfig()->getOption('block_prefix') ? -3 : -2;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PolymorphicCollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PolymorphicCollectionTypeTest.php
@@ -1,0 +1,774 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+use Symfony\Component\Form\EntryTypeProviderInterface;
+use Symfony\Component\Form\Extension\Core\Type\PolymorphicCollectionType;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\Tests\Fixtures\Author;
+use Symfony\Component\Form\Tests\Fixtures\AuthorEntryTypeProvider;
+use Symfony\Component\Form\Tests\Fixtures\AuthorType;
+use Symfony\Component\Form\Tests\Fixtures\BlockPrefixedFooTextType;
+use Symfony\Component\Form\Tests\Fixtures\NumericEntryTypeProvider;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+
+class PolymorphicCollectionTypeTest extends BaseTypeTestCase
+{
+    public const TESTED_TYPE = PolymorphicCollectionType::class;
+
+    protected function getTestOptions(): array
+    {
+        return [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+        ];
+    }
+
+    public function testEntryTypeProviderIsRequired()
+    {
+        $this->expectException(MissingOptionsException::class);
+        $this->expectExceptionMessage('The required option "entry_type_provider" is missing.');
+        $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+        ]);
+    }
+
+    public function testEntryTypesIsRequired()
+    {
+        $this->expectException(MissingOptionsException::class);
+        $this->expectExceptionMessage('The required option "entry_types" is missing.');
+        $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+        ]);
+    }
+
+    public function testWithDifferentArrayKeysInEntriesOptions()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The "entry_options" option can only use keys of the "entry_types" option. Allowed keys are "text", "number", but got "foo", "1".');
+        $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+            'entry_options' => [
+                'foo' => ['attr' => ['maxlength' => 20]],
+                1 => ['attr' => ['maxlength' => 20]],
+            ],
+        ]);
+    }
+
+    public function testWithDifferentArrayKeysInPrototypesOptions()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The "prototype_options" option can only use keys of the "entry_types" option. Allowed keys are "text", "number", but got "0", "bar".');
+        $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+            'prototype_options' => [
+                ['help' => 'text help'],
+                'bar' => ['help' => 'author help'],
+            ],
+        ]);
+    }
+
+    public function testWithDifferentArrayKeysInPrototypesData()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The "prototype_data" option can only use keys of the "entry_types" option. Allowed keys are "text", "number", but got "foo".');
+        $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+            'prototype_data' => [
+                'foo' => 'foo',
+            ],
+        ]);
+    }
+
+    public function testSetDataAdjustsSize()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+            'entry_options' => [
+                'text' => ['attr' => ['maxlength' => 20]],
+                'number' => ['attr' => ['max' => 5]],
+            ],
+        ]);
+        $form->setData([123, 'foo']);
+
+        $this->assertInstanceOf(Form::class, $form[0]);
+        $this->assertInstanceOf(Form::class, $form[1]);
+        $this->assertCount(2, $form);
+        $this->assertEquals(123, $form[0]->getData());
+        $this->assertEquals('foo', $form[1]->getData());
+        $formAttrs0 = $form[0]->getConfig()->getOption('attr');
+        $formAttrs1 = $form[1]->getConfig()->getOption('attr');
+        $this->assertEquals(5, $formAttrs0['max']);
+        $this->assertEquals(20, $formAttrs1['maxlength']);
+
+        $form->setData([345]);
+        $this->assertInstanceOf(Form::class, $form[0]);
+        $this->assertArrayNotHasKey(1, $form);
+        $this->assertCount(1, $form);
+        $this->assertEquals(345, $form[0]->getData());
+        $formAttrs0 = $form[0]->getConfig()->getOption('attr');
+        $this->assertEquals(5, $formAttrs0['max']);
+    }
+
+    public function testNotResizedIfSubmittedWithMissingData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+        ]);
+
+        $form->setData(['foo@foo.com', 'bar@bar.com']);
+        $form->submit(['foo@bar.com']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertEquals('foo@bar.com', $form[0]->getData());
+        $this->assertEquals('', $form[1]->getData());
+    }
+
+    public function testResizedDownIfSubmittedWithMissingDataAndAllowDelete()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+            'allow_delete' => true,
+        ]);
+
+        $form->setData(['foo@foo.com', 'bar@bar.com']);
+        $form->submit(['foo@foo.com']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertEquals('foo@foo.com', $form[0]->getData());
+        $this->assertEquals(['foo@foo.com'], $form->getData());
+    }
+
+    public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+            ],
+            'entry_type_provider' => new NumericEntryTypeProvider(),
+            'allow_delete' => true,
+            'delete_empty' => true,
+        ]);
+
+        $form->setData(['foo@foo.com', 'bar@bar.com']);
+        $form->submit(['foo@foo.com', '']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertEquals('foo@foo.com', $form[0]->getData());
+        $this->assertEquals(['foo@foo.com'], $form->getData());
+    }
+
+    public function testResizedDownWithDeleteEmptyCallable()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_delete' => true,
+            'delete_empty' => static fn (string|Author|null $data): bool => !$data || ($data instanceof Author && !$data->firstName),
+        ]);
+
+        $form->setData([new Author('Bob'), new Author('Alice'), 'John', 'Jane']);
+        $form->submit([['firstName' => 'Bob'], ['firstName' => ''], 'John', '']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertTrue($form->has('2'));
+        $this->assertFalse($form->has('3'));
+        $this->assertEquals(new Author('Bob'), $form[0]->getData());
+        $this->assertEquals('John', $form[2]->getData());
+        $this->assertEquals([0 => new Author('Bob'), 2 => 'John'], $form->getData());
+    }
+
+    public function testResizedDownIfSubmittedWithCompoundEmptyDataDeleteEmptyAndNoDataClass()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new class implements EntryTypeProviderInterface {
+                public function forModelData(mixed $data): int|string
+                {
+                    if ($data instanceof Author || \is_array($data)) {
+                        return 'author';
+                    }
+
+                    return 'text';
+                }
+
+                public function forSubmittedData(mixed $data): int|string
+                {
+                    if (\is_array($data)) {
+                        return 'author';
+                    }
+
+                    return 'text';
+                }
+            },
+            'entry_options' => [
+                'author' => ['data_class' => null],
+            ],
+            'allow_add' => true,
+            'allow_delete' => true,
+            'delete_empty' => static fn (string|array|null $data): bool => \is_array($data)
+                ? empty($data['firstName'])
+                : empty($data),
+        ]);
+
+        $form->setData([
+            ['firstName' => 'first', 'lastName' => 'last'],
+            'foo',
+        ]);
+        $form->submit([
+            ['firstName' => 's_first', 'lastName' => 's_last'],
+            's_foo',
+            ['firstName' => '', 'lastName' => ''],
+            '',
+        ]);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertFalse($form->has('2'));
+        $this->assertFalse($form->has('3'));
+        $this->assertEquals(['firstName' => 's_first', 'lastName' => 's_last'], $form[0]->getData());
+        $this->assertEquals('s_foo', $form[1]->getData());
+        $this->assertEquals([['firstName' => 's_first', 'lastName' => 's_last'], 's_foo'], $form->getData());
+    }
+
+    public function testDontAddEmptyDataIfDeleteEmpty()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'delete_empty' => true,
+        ]);
+
+        $form->setData(['foo@foo.com']);
+        $form->submit(['foo@foo.com', '']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertEquals('foo@foo.com', $form[0]->getData());
+        $this->assertEquals(['foo@foo.com'], $form->getData());
+    }
+
+    public function testNoDeleteEmptyIfDeleteNotAllowed()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_delete' => false,
+            'delete_empty' => true,
+        ]);
+
+        $form->setData(['foo@foo.com', new Author('Bob')]);
+        $form->submit(['', ['firstName' => '']]);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertEquals('', $form[0]->getData());
+        $this->assertEquals(new Author(''), $form[1]->getData());
+    }
+
+    public function testNotResizedIfSubmittedWithExtraData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+        ]);
+        $form->setData(['foo@bar.com', new Author('Bob')]);
+        $form->submit(['foo@foo.com', ['firstName' => 'Alice'], 'bar@bar.com', ['firstName' => 'John']]);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertFalse($form->has('2'));
+        $this->assertFalse($form->has('3'));
+        $this->assertEquals('foo@foo.com', $form[0]->getData());
+        $this->assertEquals(new Author('Alice'), $form[1]->getData());
+    }
+
+    public function testResizedUpIfSubmittedWithExtraDataAndAllowAdd()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'keep_as_list' => true,
+        ]);
+        $form->setData(['foo@bar.com', new Author('John')]);
+        $form->submit(['foo@bar.com', ['firstName' => 'Bob'], 'bar@bar.com', ['firstName' => 'Alice']]);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertTrue($form->has('2'));
+        $this->assertTrue($form->has('3'));
+        $this->assertEquals('foo@bar.com', $form[0]->getData());
+        $this->assertEquals('bar@bar.com', $form[2]->getData());
+        $this->assertEquals(['foo@bar.com', new Author('Bob'), 'bar@bar.com', new Author('Alice')], $form->getData());
+    }
+
+    public function testPrototypeMultipartPropagation()
+    {
+        $form = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'entry_types' => [
+                    'text' => TextTypeTest::TESTED_TYPE,
+                    'file' => FileTypeTest::TESTED_TYPE,
+                ],
+                'entry_type_provider' => new class implements EntryTypeProviderInterface {
+                    public function forModelData(mixed $data): int|string
+                    {
+                        return 'text';
+                    }
+
+                    public function forSubmittedData(mixed $data): int|string
+                    {
+                        return 'text';
+                    }
+                },
+                'allow_add' => true,
+                'prototype' => true,
+            ])
+        ;
+
+        $this->assertTrue($form->createView()->vars['multipart']);
+    }
+
+    public function testPrototypeNameOption()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'prototype' => true,
+            'allow_add' => true,
+        ]);
+
+        $this->assertSame('__name__', $form->getConfig()->getAttribute('prototypes')['text']->getName());
+        $this->assertSame('__name__', $form->getConfig()->getAttribute('prototypes')['author']->getName());
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'prototype' => true,
+            'allow_add' => true,
+            'prototype_name' => '__test__',
+        ]);
+
+        $this->assertSame('__test__', $form->getConfig()->getAttribute('prototypes')['text']->getName());
+        $this->assertSame('__test__', $form->getConfig()->getAttribute('prototypes')['author']->getName());
+    }
+
+    public function testPrototypeDefaultLabel()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, [], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+        ]);
+
+        $this->assertSame('__test__label__', $form->createView()->vars['prototypes']['text']->vars['label']);
+        $this->assertSame('__test__label__', $form->createView()->vars['prototypes']['author']->vars['label']);
+    }
+
+    public function testPrototypeData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, [], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'prototype' => true,
+            'prototype_data' => [
+                'text' => 'foo',
+                'author' => new Author('Bob'),
+            ],
+            'entry_options' => [
+                'text' => [
+                    'data' => 'bar',
+                    'label' => false,
+                ],
+                'author' => [
+                    'data' => new Author('Alice'),
+                    'label' => false,
+                ],
+            ],
+            'allow_add' => true,
+        ]);
+
+        $this->assertSame('foo', $form->createView()->vars['prototypes']['text']->vars['value']);
+        $this->assertEquals(new Author('Bob'), $form->createView()->vars['prototypes']['author']->vars['value']);
+        $this->assertFalse($form->createView()->vars['prototypes']['text']->vars['label']);
+        $this->assertFalse($form->createView()->vars['prototypes']['author']->vars['label']);
+    }
+
+    public function testPrototypeDefaultRequired()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, [], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+        ]);
+
+        $this->assertTrue($form->createView()->vars['prototypes']['text']->vars['required']);
+        $this->assertTrue($form->createView()->vars['prototypes']['author']->vars['required']);
+    }
+
+    public function testPrototypeSetNotRequired()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, [], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+            'required' => false,
+        ]);
+
+        $this->assertFalse($form->createView()->vars['required'], 'collection is not required');
+        $this->assertFalse($form->createView()->vars['prototypes']['text']->vars['required'], '"prototype" should not be required');
+        $this->assertFalse($form->createView()->vars['prototypes']['author']->vars['required'], '"prototype" should not be required');
+    }
+
+    public function testPrototypeSetNotRequiredIfParentNotRequired()
+    {
+        $child = $this->factory->create(static::TESTED_TYPE, [], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+        ]);
+
+        $parent = $this->factory->create(FormTypeTest::TESTED_TYPE, [], [
+            'required' => false,
+        ]);
+
+        $child->setParent($parent);
+        $this->assertFalse($parent->createView()->vars['required'], 'Parent is not required');
+        $this->assertFalse($child->createView()->vars['required'], 'Child is not required');
+        $this->assertFalse($child->createView()->vars['prototypes']['text']->vars['required'], '"prototype" should not be required');
+        $this->assertFalse($child->createView()->vars['prototypes']['author']->vars['required'], '"prototype" should not be required');
+    }
+
+    public function testPrototypeOptionsOverrideEntryOptions()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, [], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_options' => [
+                'text' => ['help' => null],
+                'author' => ['help' => 'foo'],
+            ],
+            'prototype_options' => [
+                'text' => ['help' => 'foo'],
+                'author' => ['help' => 'bar'],
+            ],
+        ]);
+
+        $this->assertSame('foo', $form->createView()->vars['prototypes']['text']->vars['help']);
+        $this->assertSame('bar', $form->createView()->vars['prototypes']['author']->vars['help']);
+    }
+
+    public function testPrototypeOptionsAppliedToNewFields()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, ['first'], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_options' => [
+                'text' => ['disabled' => true],
+            ],
+            'prototype_options' => [
+                'text' => ['disabled' => false],
+            ],
+        ]);
+
+        $form->submit(['first_changed', 'second']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertSame('first', $form[0]->getData());
+        $this->assertSame('second', $form[1]->getData());
+        $this->assertSame(['first', 'second'], $form->getData());
+    }
+
+    public function testEntriesBlockPrefixes()
+    {
+        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, ['foo', new Author('Bob')], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+        ])
+            ->createView()
+        ;
+
+        $expectedBlockPrefixesForText = [
+            'form',
+            'collection_entry',
+            'text',
+            '_fields_entry',
+        ];
+        $expectedBlockPrefixesForAuthor = [
+            'form',
+            'collection_entry',
+            'author',
+            '_fields_entry',
+        ];
+
+        $this->assertCount(2, $collectionView);
+        $this->assertSame($expectedBlockPrefixesForText, $collectionView[0]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForAuthor, $collectionView[1]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForText, $collectionView->vars['prototypes']['text']->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForAuthor, $collectionView->vars['prototypes']['author']->vars['block_prefixes']);
+    }
+
+    public function testEntriesBlockPrefixesWithCustomBlockPrefix()
+    {
+        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, ['foo', 123.4, new Author('Bob')], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'number' => NumberTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new class implements EntryTypeProviderInterface {
+                public function forModelData(mixed $data): int|string
+                {
+                    if ($data instanceof Author) {
+                        return 'author';
+                    }
+
+                    return is_numeric($data) ? 'number' : 'text';
+                }
+
+                public function forSubmittedData(mixed $data): int|string
+                {
+                    if (\is_array($data)) {
+                        return 'author';
+                    }
+
+                    return is_numeric($data) ? 'number' : 'text';
+                }
+            },
+            'allow_add' => true,
+            'entry_options' => [
+                'text' => ['block_prefix' => 'foo'],
+                'author' => ['block_prefix' => 'bar'],
+            ],
+        ])
+            ->createView()
+        ;
+
+        $expectedBlockPrefixesForText = [
+            'form',
+            'collection_entry',
+            'text',
+            'foo',
+            '_fields_entry',
+        ];
+        $expectedBlockPrefixesForNumber = [
+            'form',
+            'collection_entry',
+            'number',
+            '_fields_entry',
+        ];
+        $expectedBlockPrefixesForAuthor = [
+            'form',
+            'collection_entry',
+            'author',
+            'bar',
+            '_fields_entry',
+        ];
+
+        $this->assertCount(3, $collectionView);
+        $this->assertSame($expectedBlockPrefixesForText, $collectionView[0]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForNumber, $collectionView[1]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForAuthor, $collectionView[2]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForText, $collectionView->vars['prototypes']['text']->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForNumber, $collectionView->vars['prototypes']['number']->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForAuthor, $collectionView->vars['prototypes']['author']->vars['block_prefixes']);
+    }
+
+    public function testEntriesBlockPrefixesWithCustomBlockPrefixedType()
+    {
+        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [
+            'entry_types' => [
+                'number' => NumberTypeTest::TESTED_TYPE,
+                'block_prefixed_foo_text' => BlockPrefixedFooTextType::class,
+            ],
+            'entry_type_provider' => new class implements EntryTypeProviderInterface {
+                public function forModelData(mixed $data): int|string
+                {
+                    return is_numeric($data) ? 'number' : 'block_prefixed_foo_text';
+                }
+
+                public function forSubmittedData(mixed $data): int|string
+                {
+                    return is_numeric($data) ? 'number' : 'block_prefixed_foo_text';
+                }
+            },
+            'allow_add' => true,
+        ])
+            ->createView()
+        ;
+
+        $expectedBlockPrefixesForNumber = [
+            'form',
+            'collection_entry',
+            'number',
+            '_fields_entry',
+        ];
+        $expectedBlockPrefixesForBlockPrefixedFooText = [
+            'form',
+            'collection_entry',
+            'block_prefixed_foo_text',
+            'foo',
+            '_fields_entry',
+        ];
+
+        $this->assertCount(1, $collectionView);
+        $this->assertSame($expectedBlockPrefixesForBlockPrefixedFooText, $collectionView[0]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForNumber, $collectionView->vars['prototypes']['number']->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForBlockPrefixedFooText, $collectionView->vars['prototypes']['block_prefixed_foo_text']->vars['block_prefixes']);
+    }
+
+    public function testPrototypeBlockPrefixesWithCustomBlockPrefix()
+    {
+        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [], [
+            'entry_types' => [
+                'text' => TextTypeTest::TESTED_TYPE,
+                'author' => AuthorType::class,
+            ],
+            'entry_type_provider' => new AuthorEntryTypeProvider(),
+            'allow_add' => true,
+            'entry_options' => [
+                'author' => ['block_prefix' => 'field'],
+            ],
+        ])
+            ->createView()
+        ;
+
+        $expectedBlockPrefixesForText = [
+            'form',
+            'collection_entry',
+            'text',
+            '_fields_entry',
+        ];
+        $expectedBlockPrefixesForAuthorText = [
+            'form',
+            'collection_entry',
+            'author',
+            'field',
+            '_fields_entry',
+        ];
+
+        $this->assertCount(0, $collectionView);
+        $this->assertSame($expectedBlockPrefixesForText, $collectionView->vars['prototypes']['text']->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixesForAuthorText, $collectionView->vars['prototypes']['author']->vars['block_prefixes']);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull([], [], []);
+    }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = [], $expectedData = [])
+    {
+        // the resize listener always sets an empty array
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/AuthorEntryTypeProvider.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AuthorEntryTypeProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\EntryTypeProviderInterface;
+
+class AuthorEntryTypeProvider implements EntryTypeProviderInterface
+{
+    public function forModelData(mixed $data): int|string
+    {
+        return $data instanceof Author ? 'author' : 'text';
+    }
+
+    public function forSubmittedData(mixed $data): int|string
+    {
+        return \is_array($data) ? 'author' : 'text';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/NumericEntryTypeProvider.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/NumericEntryTypeProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\EntryTypeProviderInterface;
+
+class NumericEntryTypeProvider implements EntryTypeProviderInterface
+{
+    public function forModelData(mixed $data): int|string
+    {
+        return is_numeric($data) ? 'number' : 'text';
+    }
+
+    public function forSubmittedData(mixed $data): int|string
+    {
+        return is_numeric($data) ? 'number' : 'text';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds `PolymorphicCollectionType`, a collection whose entries do not all share the same type. `CollectionType` is untouched.

```php
$builder->add('blocks', PolymorphicCollectionType::class, [
    'entry_types' => [
        'header' => HeaderType::class,
        'text' => TextType::class,
        'footer' => FooterType::class,
    ],
    'entry_type_provider' => new BlockEntryTypeProvider(),
]);
```

The type of each entry comes from the `entry_type_provider`, which is given the entry's data and returns one of the keys of `entry_types`. It sees the data in two shapes, hence the two methods:

```php
class BlockEntryTypeProvider implements EntryTypeProviderInterface
{
    public function forModelData(mixed $data): int|string
    {
        return match (true) {
            $data instanceof Header => 'header',
            $data instanceof Footer => 'footer',
            default => 'text',
        };
    }

    public function forSubmittedData(mixed $data): int|string
    {
        return $data['type'] ?? 'text';
    }
}
```

`entry_options`, `prototype_options` and `prototype_data` keep the names they have on `CollectionType` and are keyed by entry name:

```php
$builder->add('blocks', PolymorphicCollectionType::class, [
    'entry_types' => ['text' => TextType::class, 'number' => NumberType::class],
    'entry_type_provider' => new BlockEntryTypeProvider(),
    'entry_options' => [
        'text' => ['attr' => ['maxlength' => 20]],
        'number' => ['attr' => ['max' => 5]],
    ],
    'prototype_data' => [
        'text' => 'lorem ipsum',
    ],
]);
```

`allow_add`, `allow_delete`, `delete_empty`, `keep_as_list`, `prototype` and `prototype_name` behave as they do on `CollectionType`. With `allow_add`, one prototype is built per entry type and exposed as the `prototypes` view variable, rendered as `data-prototype-<name>` attributes so the client can pick which one to insert. Entries and prototypes still get the `collection_entry` block prefix, so existing themes apply.
