### PR TITLE
[Console] Add Input::readStdin() to read piped stdin non-blockingly

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `Input::readStdin()` to read from stdin non-blockingly, supporting both piped input and injected test streams
  * Add `TraceableValueResolver` to help inspecting value resolvers performances
  * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`
  * Add support for pasting images with `#[Ask]` on `InputFile` types, supporting Kitty Graphics and iTerm2 protocols

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -171,4 +171,29 @@ abstract class Input implements InputInterface, StreamableInputInterface
     {
         return $this->stream;
     }
+
+    /**
+     * Reads the contents of the input stream (stdin) non-blockingly.
+     *
+     * When using a real stdin (no stream injected), stream_select() is used to
+     * avoid blocking when no data has been piped or redirected.
+     * When a custom stream is injected (e.g. in tests), it is read directly.
+     */
+    public function readStdin(): string
+    {
+        if (isset($this->stream)) {
+            return stream_get_contents($this->stream) ?: '';
+        }
+
+        $stdin = fopen('php://stdin', 'r');
+        $reads = [$stdin];
+        $writes = [];
+        $excepts = [];
+
+        if (!stream_select($reads, $writes, $excepts, 0)) {
+            return '';
+        }
+
+        return stream_get_contents($stdin) ?: '';
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -160,4 +160,24 @@ class InputTest extends TestCase
         $input->setStream($stream);
         $this->assertSame($stream, $input->getStream());
     }
+
+    public function testReadStdinReturnsContentFromInjectedStream()
+    {
+        $input = new ArrayInput([]);
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, 'hello world');
+        rewind($stream);
+        $input->setStream($stream);
+
+        $this->assertSame('hello world', $input->readStdin());
+    }
+
+    public function testReadStdinReturnsEmptyStringFromEmptyInjectedStream()
+    {
+        $input = new ArrayInput([]);
+        $stream = fopen('php://memory', 'r+');
+        $input->setStream($stream);
+
+        $this->assertSame('', $input->readStdin());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61384 
| License       | MIT

Adds a `readStdin(): string` method to the `Input` abstract class that reads from stdin without blocking. When no data has been piped or redirected, it returns an empty string immediately. When a custom stream is injected via `setStream()` (e.g. in tests), it reads from that streamdirectly, bypassing `stream_select()` since memory streams are not selectable.

Exemple:

Test Command:
```
protected function execute(InputInterface $input, OutputInterface $output): int
{
    \assert($input instanceof Input);
    $data = $input->readStdin();

    if ('' === $data) {
        $output->writeln('No data piped.');
    } else {
        $output->writeln('Received: '.$data);
    }

    return Command::SUCCESS;
}
```

Usage:
```
# No pipe: returns empty string ("No data piped.")
php bin/console app:stdin

# Pipe a string: display "Received: hello from pipe"
echo "hello from pipe" | php bin/console app:stdin

# Redirect a file: display "Received: MY-WONDERFUL-PC"
cat /etc/hostname | php bin/console app:stdin
```