### PR TITLE
[RateLimiter] Fix `retryAfter` when consuming exactly all remaining tokens in `SlidingWindow`

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -74,7 +74,12 @@ final class SlidingWindowLimiter implements LimiterInterface
             if ($availableTokens >= $tokens) {
                 $window->add($tokens);
 
-                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
+                $retryAfter = $now;
+                if ($availableTokens === $tokens) {
+                    $retryAfter += $window->calculateTimeForTokens($this->limit, $window->getHitCount());
+                }
+
+                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->limit));
             } else {
                 $waitDuration = $window->calculateTimeForTokens($this->limit, $tokens);
 

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -70,6 +70,20 @@ class SlidingWindowLimiterTest extends TestCase
         $this->assertTrue($limiter->consume()->isAccepted());
     }
 
+    public function testConsumeLastToken()
+    {
+        $limiter = $this->createLimiter();
+        $limiter->consume(9);
+
+        $rateLimit = $limiter->consume(1);
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(
+            \DateTimeImmutable::createFromFormat('U', (string) floor(microtime(true) + 12)),
+            $rateLimit->getRetryAfter()
+        );
+    }
+
     public function testReserve()
     {
         $limiter = $this->createLimiter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This is a follow up of #54163 (I cannot push on @ERuban's fork)

When `SlidingWindowLimiter::consume()` uses all remaining tokens exactly (e.g. 10/10), the returned `RateLimit` is correctly marked as accepted, but `getRetryAfter()` returns the current time instead of the time when the next token will become available.

This matters for callers that use `retryAfter` to schedule their next request - they'd retry immediately and get rejected.

**Before:** `retryAfter = now` (wrong - 0 tokens remain, nothing is available "now")
**After:** `retryAfter = now + calculateTimeForTokens(...)` (correct - points to when the sliding window frees up a token)

The fix mirrors the logic already used in the peek path (`$tokens === 0` branch) which already handled this correctly.