### PR TITLE
[RateLimiter] Fix retryAfter when consuming exactly all remaining tokens in FixedWindow and TokenBucket

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -65,7 +65,12 @@ final class FixedWindowLimiter implements LimiterInterface
             } elseif ($availableTokens >= $tokens) {
                 $window->add($tokens, $now);
 
-                $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
+                $retryAfter = $now;
+                if ($availableTokens === $tokens) {
+                    $retryAfter += $window->calculateTimeForTokens(1, $now);
+                }
+
+                $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->limit));
             } else {
                 $waitDuration = $window->calculateTimeForTokens($tokens, $now);
 

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -75,16 +75,12 @@ final class TokenBucketLimiter implements LimiterInterface
                 // tokens are now available, update bucket
                 $bucket->setTokens($availableTokens - $tokens);
 
-                if (0 === $availableTokens) {
-                    // This means 0 tokens where consumed (discouraged in most cases).
-                    // Return the first time a new token is available
-                    $waitDuration = $this->rate->calculateTimeForTokens(1);
-                    $waitTime = \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration));
-                } else {
-                    $waitTime = \DateTimeImmutable::createFromFormat('U', floor($now));
+                $retryAfter = $now;
+                if ($availableTokens === $tokens) {
+                    $retryAfter += $this->rate->calculateTimeForTokens(1);
                 }
 
-                $reservation = new Reservation($now, new RateLimit($bucket->getAvailableTokens($now), $waitTime, true, $this->maxBurst));
+                $reservation = new Reservation($now, new RateLimit($bucket->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->maxBurst));
             } else {
                 $remainingTokens = $tokens - $availableTokens;
                 $waitDuration = $this->rate->calculateTimeForTokens($remainingTokens);

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -57,6 +57,21 @@ class FixedWindowLimiterTest extends TestCase
         $this->assertEquals($retryAfter, $rateLimit->getRetryAfter());
     }
 
+    public function testConsumeLastToken()
+    {
+        $now = time();
+        $limiter = $this->createLimiter();
+        $limiter->consume(9);
+
+        $rateLimit = $limiter->consume(1);
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(
+            \DateTimeImmutable::createFromFormat('U', $now + 60),
+            $rateLimit->getRetryAfter()
+        );
+    }
+
     /**
      * @dataProvider provideConsumeOutsideInterval
      */
@@ -107,6 +122,15 @@ class FixedWindowLimiterTest extends TestCase
         $this->assertEquals(60, ceil($second->getWaitDuration()));
         // these 5 tokens overflow into the third window (8 + 5 = 13 > 10)
         $this->assertEquals(120, ceil($third->getWaitDuration()));
+    }
+
+    public function testReserveExactlyAvailable()
+    {
+        $limiter = $this->createLimiter('PT1S');
+
+        $this->assertEquals(0, $limiter->reserve(5)->getWaitDuration());
+        $this->assertEquals(0, $limiter->reserve(5)->getWaitDuration());
+        $this->assertEquals(1, $limiter->reserve(5)->getWaitDuration());
     }
 
     public function testWaitIntervalOnConsumeOverLimit()

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -103,6 +103,35 @@ class TokenBucketLimiterTest extends TestCase
         $this->assertSame(10, $rateLimit->getLimit());
     }
 
+    public function testConsumeLastToken()
+    {
+        $rate = Rate::perSecond(1);
+        $limiter = $this->createLimiter(10, $rate);
+
+        $rateLimit = $limiter->consume(10);
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEqualsWithDelta(time(), $rateLimit->getRetryAfter()->getTimestamp(), 10);
+    }
+
+    public function testConsumeZeroTokens()
+    {
+        $rate = Rate::perSecond(1);
+        $limiter = $this->createLimiter(10, $rate);
+
+        $rateLimit = $limiter->consume(0);
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(time(), $rateLimit->getRetryAfter()->getTimestamp());
+
+        $limiter->reset();
+        $limiter->consume(10);
+
+        $rateLimit = $limiter->consume(0);
+        $this->assertTrue($rateLimit->isAccepted());
+        // no tokens available, retryAfter should point to when the next token regenerates
+        $this->assertEqualsWithDelta(time() + 1, $rateLimit->getRetryAfter()->getTimestamp(), 1);
+    }
+
     public function testWaitIntervalOnConsumeOverLimit()
     {
         $limiter = $this->createLimiter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Same bug as #54163 on `SlidingWindow`, now fixed for `FixedWindowLimiter` and `TokenBucketLimiter`.

When `consume()` uses exactly all remaining tokens, the `RateLimit` is correctly accepted, but `getRetryAfter()` returns "now" - even though 0 tokens remain and nothing is actually available. Callers relying on `retryAfter` to schedule their next request would retry immediately and get rejected.
