### PR TITLE
[DependencyInjection] Fix `TypeError` when using a custom container base class with typed `$parameterBag`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1295,16 +1295,9 @@ EOF;
             }
         }
 
-        if (Container::class !== $this->baseClass) {
-            $r = $this->container->getReflectionClass($this->baseClass, false);
-            if (null !== $r
-                && (null !== $constructor = $r->getConstructor())
-                && 0 === $constructor->getNumberOfRequiredParameters()
-                && Container::class !== $constructor->getDeclaringClass()->name
-            ) {
-                $code .= "        parent::__construct();\n";
-                $code .= "        \$this->parameterBag = null;\n\n";
-            }
+        if ($this->needsUnsetParameterBag()) {
+            $code .= "        parent::__construct();\n";
+            $code .= "        unset(\$this->parameterBag);\n\n";
         }
 
         if ($this->container->getParameterBag()->all()) {
@@ -1582,9 +1575,22 @@ EOF;
         return $code ? \sprintf("\n        \$this->privates['service_container'] = static function (\$container) {%s\n        };\n", $code) : '';
     }
 
+    private function needsUnsetParameterBag(): bool
+    {
+        if (Container::class === $this->baseClass) {
+            return false;
+        }
+        $r = $this->container->getReflectionClass($this->baseClass, false);
+
+        return null !== $r
+            && (null !== $constructor = $r->getConstructor())
+            && 0 === $constructor->getNumberOfRequiredParameters()
+            && Container::class !== $constructor->getDeclaringClass()->name;
+    }
+
     private function addDefaultParametersMethod(): string
     {
-        if (!$this->container->getParameterBag()->all()) {
+        if (!$this->container->getParameterBag()->all() && !$this->needsUnsetParameterBag()) {
             return '';
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -42,6 +42,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -177,6 +178,26 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
 
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/custom_container_class_with_optional_constructor_arguments.php', $dumper->dump(['base_class' => 'ConstructorWithOptionalArgumentsContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']));
+    }
+
+    public function testDumpCustomContainerClassWithTypedParameterBagCanBeInstantiated()
+    {
+        $container = new ContainerBuilder();
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $code = $dumper->dump(['base_class' => 'ContainerWithTypedParameterBag', 'class' => 'CompiledContainerWithTypedParameterBag', 'namespace' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\Container']);
+
+        // The compiled container must not assign null to a potentially typed $parameterBag property
+        $this->assertStringNotContainsString('$this->parameterBag = null', $code);
+        $this->assertStringContainsString('unset($this->parameterBag)', $code);
+
+        // Verify the compiled container can actually be instantiated without TypeError
+        eval('?>'.$code);
+        $compiledContainer = new \Symfony\Component\DependencyInjection\Tests\Fixtures\Container\CompiledContainerWithTypedParameterBag();
+        $this->assertTrue($compiledContainer->isCompiled());
+
+        $this->assertInstanceOf(FrozenParameterBag::class, $compiledContainer->getParameterBag());
     }
 
     public function testDumpCustomContainerClassWithMandatoryArgumentLessConstructor()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Container/ContainerWithTypedParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Container/ContainerWithTypedParameterBag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Container;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ContainerWithTypedParameterBag extends \Symfony\Component\DependencyInjection\Container
+{
+    public function __construct(?ParameterBagInterface $parameterBag = null)
+    {
+        parent::__construct($parameterBag);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_constructor_without_arguments.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_constructor_without_arguments.php
@@ -21,7 +21,7 @@ class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tes
     public function __construct()
     {
         parent::__construct();
-        $this->parameterBag = null;
+        unset($this->parameterBag);
 
         $this->services = $this->privates = [];
 
@@ -36,5 +36,56 @@ class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tes
     public function isCompiled(): bool
     {
         return true;
+    }
+
+    public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
+    {
+        if (isset($this->loadedDynamicParameters[$name])) {
+            return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
+        }
+
+        return $this->parameters[$name];
+    }
+
+    public function hasParameter(string $name): bool
+    {
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
+    }
+
+    public function setParameter(string $name, $value): void
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    public function getParameterBag(): ParameterBagInterface
+    {
+        if (!isset($this->parameterBag)) {
+            $parameters = $this->parameters;
+            foreach ($this->loadedDynamicParameters as $name => $loaded) {
+                $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+            }
+            $this->parameterBag = new FrozenParameterBag($parameters);
+        }
+
+        return $this->parameterBag;
+    }
+
+    private $loadedDynamicParameters = [];
+    private $dynamicParameters = [];
+
+    private function getDynamicParameter(string $name)
+    {
+        throw new ParameterNotFoundException($name);
+    }
+
+    protected function getDefaultParameters(): array
+    {
+        return [
+
+        ];
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_optional_constructor_arguments.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_optional_constructor_arguments.php
@@ -21,7 +21,7 @@ class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tes
     public function __construct()
     {
         parent::__construct();
-        $this->parameterBag = null;
+        unset($this->parameterBag);
 
         $this->services = $this->privates = [];
 
@@ -36,5 +36,56 @@ class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tes
     public function isCompiled(): bool
     {
         return true;
+    }
+
+    public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
+    {
+        if (isset($this->loadedDynamicParameters[$name])) {
+            return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        if (!\array_key_exists($name, $this->parameters) || '.' === ($name[0] ?? '')) {
+            throw new ParameterNotFoundException($name);
+        }
+
+        return $this->parameters[$name];
+    }
+
+    public function hasParameter(string $name): bool
+    {
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
+    }
+
+    public function setParameter(string $name, $value): void
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    public function getParameterBag(): ParameterBagInterface
+    {
+        if (!isset($this->parameterBag)) {
+            $parameters = $this->parameters;
+            foreach ($this->loadedDynamicParameters as $name => $loaded) {
+                $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+            }
+            $this->parameterBag = new FrozenParameterBag($parameters);
+        }
+
+        return $this->parameterBag;
+    }
+
+    private $loadedDynamicParameters = [];
+    private $dynamicParameters = [];
+
+    private function getDynamicParameter(string $name)
+    {
+        throw new ParameterNotFoundException($name);
+    }
+
+    protected function getDefaultParameters(): array
+    {
+        return [
+
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63495
| License       | MIT

When using `getContainerBaseClass()` to provide a custom container class that declares `$parameterBag` with a type (e.g. `protected ParameterBagInterface $parameterBag`), booting the application throws TypeError: Cannot assign null to property.

`PhpDumper` generates compiled container constructors that call `parent::__construct()` followed by `$this->parameterBag = null`. The intent is to signal "not yet initialized" so that the generated `getParameterBag()` (which checks `!isset($this->parameterBag)`) lazily builds a `FrozenParameterBag`. However, assigning `null` to a non-nullable typed property is a `TypeError`.

This PR replaces the `null` assignment with `unset()`, achieving the same lazy-init behaviour without violating any type constraint.