### PR TITLE
[DependencyInjection] Handle `Stringable` for string-typed arguments in `CheckTypeDeclarationsPass`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -275,7 +275,7 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
             return;
         }
 
-        if ('string' === $type && $class instanceof \Stringable) {
+        if ('string' === $type && is_a($class, \Stringable::class, true)) {
             return;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -1032,6 +1032,18 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         (new CheckTypeDeclarationsPass(true))->process($container);
     }
+
+    public function testStringableCanBePassedToStringTypeParameter()
+    {
+        $container = new ContainerBuilder();
+        $container->register('stringable', StringableClass::class);
+        $container->register('consumer', StringConsumer::class)
+            ->setArguments([new Reference('stringable')]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
 }
 
 class CallableClass
@@ -1051,6 +1063,21 @@ class StaticCallableClass
 class ServiceWithTwoInts
 {
     public function __construct(int $a, int $b)
+    {
+    }
+}
+
+class StringableClass implements \Stringable
+{
+    public function __toString(): string
+    {
+        return 'stringable';
+    }
+}
+
+class StringConsumer
+{
+    public function __construct(string $value)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `Stringable` check used `instanceof` on a class name string, which always returns `false`. 
Services implementing `Stringable` can now be injected into `string` typed parameters.

The `6.4` branch is not affected - it uses `method_exists($class, '__toString')` which works correctly with string class names.
