### PR TITLE
[JsonStreamer] Fix missing generator for shared types in self-referencing objects

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
@@ -76,7 +76,7 @@ final class StreamReaderGenerator
      * @param array<string, mixed> $options
      * @param array<string, mixed> $context
      */
-    private function createDataModel(Type $type, array $options = [], array $context = []): DataModelNodeInterface
+    private function createDataModel(Type $type, array $options = [], array &$context = []): DataModelNodeInterface
     {
         $context['original_type'] ??= $type;
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithSelfReferencingDummy.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithSelfReferencingDummy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+final class DummyWithSelfReferencingDummy
+{
+    public ClassicDummy $otherDummy;
+    public ?SelfReferencingDummyWithOtherDummy $selfReferencing = null;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/SelfReferencingDummyWithOtherDummy.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/SelfReferencingDummyWithOtherDummy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+final class SelfReferencingDummyWithOtherDummy
+{
+    public ClassicDummy $otherDummy;
+    public ?self $self = null;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -31,12 +31,14 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedList;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSelfReferencingDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyWithOtherDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\BooleanToStringValueTransformer;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DoubleIntAndCastToStringValueTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\DateTimeToStringValueTransformer;
@@ -325,6 +327,22 @@ class JsonStreamWriterTest extends TestCase
         $writer = new JsonStreamWriter(new Container(), new SyntheticPropertyMetadataLoader(), $this->streamWritersDir);
 
         $this->assertSame('{"synthetic":true}', (string) $writer->write(new DummyWithSyntheticProperties(), Type::object(DummyWithSyntheticProperties::class)));
+    }
+
+    public function testWriteSelfReferencingWithOtherDummy()
+    {
+        $dummy = new DummyWithSelfReferencingDummy();
+        $dummy->otherDummy = new ClassicDummy();
+        $dummy->selfReferencing = new SelfReferencingDummyWithOtherDummy();
+        $dummy->selfReferencing->otherDummy = new ClassicDummy();
+        $dummy->selfReferencing->self = new SelfReferencingDummyWithOtherDummy();
+        $dummy->selfReferencing->self->otherDummy = new ClassicDummy();
+
+        $this->assertWritten(
+            '{"otherDummy":{"id":1,"name":"dummy"},"selfReferencing":{"otherDummy":{"id":1,"name":"dummy"},"self":{"otherDummy":{"id":1,"name":"dummy"}}}}',
+            $dummy,
+            Type::object(DummyWithSelfReferencingDummy::class),
+        );
     }
 
     public function testWriteNestedSelfList()

--- a/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
@@ -84,6 +84,12 @@ final class PhpGenerator
      */
     private function generateObjectGenerators(DataModelNodeInterface $node, array $options, array &$context): array
     {
+        if ($node instanceof ObjectNode && $node->isMock()) {
+            $context['mocks'][$node->getIdentifier()] = true;
+
+            return [];
+        }
+
         if ($context['generated_generators'][$node->getIdentifier()] ?? false) {
             return [];
         }
@@ -105,12 +111,6 @@ final class PhpGenerator
         }
 
         if ($node instanceof ObjectNode) {
-            if ($node->isMock()) {
-                $context['mocks'][$node->getIdentifier()] = true;
-
-                return [];
-            }
-
             $context['generating_generator'] = true;
 
             ++$context['indentation_level'];

--- a/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
@@ -75,7 +75,7 @@ final class StreamWriterGenerator
      * @param array<string, mixed> $options
      * @param array<string, mixed> $context
      */
-    private function createDataModel(Type $type, string $accessor, array $options = [], array $context = []): DataModelNodeInterface
+    private function createDataModel(Type $type, string $accessor, array $options = [], array &$context = []): DataModelNodeInterface
     {
         $context['original_type'] ??= $type;
         $context['depth'] ??= 0;
@@ -152,13 +152,15 @@ final class StreamWriterGenerator
 
         if ($type instanceof CollectionType) {
             ++$context['depth'];
-
-            return new CollectionNode(
+            $node = new CollectionNode(
                 $accessor,
                 $type,
                 $this->createDataModel($type->getCollectionValueType(), '$value'.$context['depth'], $options, $context),
                 $this->createDataModel($type->getCollectionKeyType(), '$key'.$context['depth'], $options, $context),
             );
+            --$context['depth'];
+
+            return $node;
         }
 
         throw new UnsupportedException(\sprintf('"%s" type is not supported.', (string) $type));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63499
| License       | MIT

When a self-referencing type shares a property type with a sibling, the generated stream writer references an undefined generator (`Undefined array key` error at runtime).

The `$context` in `createDataModel()` is passed by value, so `generated_classes` isn't shared across sibling properties, which causing duplicate nodes instead of mocks. Additionally, `generateObjectGenerators()` skips mock registration for nodes already in `generated_generators`.

This is fixed by passing `$context` by reference and checking for mocks before the `generated_generators` early-return.

