### PR TITLE
[PropertyInfo][ReflectionExtractor] fix is/can/has type resolver on method without property

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -239,7 +239,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         [$accessorReflection, $prefix] = $this->getAccessorMethod($class, $property);
         $allowedPrefixes = array_diff($this->accessorPrefixes, ['is', 'can', 'has']);
-        if ($accessorReflection && \in_array($prefix, $allowedPrefixes, true)) {
+        if ($accessorReflection && (\in_array($prefix, $allowedPrefixes, true) || !property_exists($class, $property))) {
             try {
                 return $this->typeResolver->resolve($accessorReflection);
             } catch (UnsupportedException) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasserWithoutProperty;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
@@ -1066,5 +1067,12 @@ class ReflectionExtractorTest extends TestCase
     public function testIsserUsedForBoolPropertyWithoutOtherTypeSourceLegacy()
     {
         $this->assertEquals([new LegacyType(LegacyType::BUILTIN_TYPE_BOOL)], $this->extractor->getTypes(DummyWithHasser::class, 'enabled'));
+    }
+
+    public function testHasserWithoutProperty()
+    {
+        $this->assertEquals(Type::bool(), $this->extractor->getType(DummyWithHasserWithoutProperty::class, 'url'));
+        $this->assertEquals(Type::bool(), $this->extractor->getType(DummyWithHasserWithoutProperty::class, 'view'));
+        $this->assertEquals(Type::bool(), $this->extractor->getType(DummyWithHasserWithoutProperty::class, 'active'));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithHasserWithoutProperty.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithHasserWithoutProperty.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithHasserWithoutProperty
+{
+    public function hasUrl(): bool
+    {
+        return true;
+    }
+
+    public function canView(): bool
+    {
+        return false;
+    }
+
+    public function isActive(): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63507 
| License       | MIT

This PR restore the extraction of boolean method (without property) with API-Platform/GraphQL.

Before
``` php
#Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php#242

if ($accessorReflection && \in_array($prefix, $allowedPrefixes, true)) {
    try {
        return $this->typeResolver->resolve($accessorReflection);
    } catch (UnsupportedException) {
    }
}
```

After
``` php
#Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php#242

if ($accessorReflection && (\in_array($prefix, $allowedPrefixes, true) || !property_exists($class, $property))) {
    try {
        return $this->typeResolver->resolve($accessorReflection);
    } catch (UnsupportedException) {
    }
}
```

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
