### PR TITLE
[Workflow] add generics marker to Workflow event classes

### DIFF
--- a/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
+++ b/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
@@ -15,6 +15,11 @@ use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
+/**
+ * @template T of object
+ *
+ * @extends Event<T>
+ */
 final class AnnounceEvent extends Event
 {
     use EventNameTrait {
@@ -22,6 +27,9 @@ final class AnnounceEvent extends Event
     }
     use HasContextTrait;
 
+    /**
+     * @param T $subject
+     */
     public function __construct(object $subject, Marking $marking, ?Transition $transition = null, ?WorkflowInterface $workflow = null, array $context = [])
     {
         parent::__construct($subject, $marking, $transition, $workflow);

--- a/src/Symfony/Component/Workflow/Event/CompletedEvent.php
+++ b/src/Symfony/Component/Workflow/Event/CompletedEvent.php
@@ -15,6 +15,11 @@ use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
+/**
+ * @template T of object
+ *
+ * @extends Event<T>
+ */
 final class CompletedEvent extends Event
 {
     use EventNameTrait {
@@ -22,6 +27,9 @@ final class CompletedEvent extends Event
     }
     use HasContextTrait;
 
+    /**
+     * @param T $subject
+     */
     public function __construct(object $subject, Marking $marking, ?Transition $transition = null, ?WorkflowInterface $workflow = null, array $context = [])
     {
         parent::__construct($subject, $marking, $transition, $workflow);

--- a/src/Symfony/Component/Workflow/Event/EnterEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnterEvent.php
@@ -15,6 +15,11 @@ use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
+/**
+ * @template T of object
+ *
+ * @extends Event<T>
+ */
 final class EnterEvent extends Event
 {
     use EventNameTrait {
@@ -22,6 +27,9 @@ final class EnterEvent extends Event
     }
     use HasContextTrait;
 
+    /**
+     * @param T $subject
+     */
     public function __construct(object $subject, Marking $marking, ?Transition $transition = null, ?WorkflowInterface $workflow = null, array $context = [])
     {
         parent::__construct($subject, $marking, $transition, $workflow);

--- a/src/Symfony/Component/Workflow/Event/EnteredEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnteredEvent.php
@@ -15,6 +15,11 @@ use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
+/**
+ * @template T of object
+ *
+ * @extends Event<T>
+ */
 final class EnteredEvent extends Event
 {
     use EventNameTrait {
@@ -22,6 +27,9 @@ final class EnteredEvent extends Event
     }
     use HasContextTrait;
 
+    /**
+     * @param T $subject
+     */
     public function __construct(object $subject, Marking $marking, ?Transition $transition = null, ?WorkflowInterface $workflow = null, array $context = [])
     {
         parent::__construct($subject, $marking, $transition, $workflow);

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -20,9 +20,14 @@ use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Carlos Pereira De Amorim <carlos@shauri.fr>
+ *
+ * @template T of object
  */
 class Event extends BaseEvent
 {
+    /**
+     * @param T $subject
+     */
     public function __construct(
         private object $subject,
         private Marking $marking,
@@ -36,6 +41,9 @@ class Event extends BaseEvent
         return $this->marking;
     }
 
+    /**
+     * @return T
+     */
     public function getSubject(): object
     {
         return $this->subject;

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -20,6 +20,10 @@ use Symfony\Component\Workflow\WorkflowInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @template T of object
+ *
+ * @extends Event<T>
  */
 final class GuardEvent extends Event
 {
@@ -29,6 +33,9 @@ final class GuardEvent extends Event
 
     private TransitionBlockerList $transitionBlockerList;
 
+    /**
+     * @param T $subject
+     */
     public function __construct(object $subject, Marking $marking, Transition $transition, ?WorkflowInterface $workflow = null)
     {
         parent::__construct($subject, $marking, $transition, $workflow);

--- a/src/Symfony/Component/Workflow/Event/LeaveEvent.php
+++ b/src/Symfony/Component/Workflow/Event/LeaveEvent.php
@@ -15,6 +15,11 @@ use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
+/**
+ * @template T of object
+ *
+ * @extends Event<T>
+ */
 final class LeaveEvent extends Event
 {
     use EventNameTrait {
@@ -22,6 +27,9 @@ final class LeaveEvent extends Event
     }
     use HasContextTrait;
 
+    /**
+     * @param T $subject
+     */
     public function __construct(object $subject, Marking $marking, ?Transition $transition = null, ?WorkflowInterface $workflow = null, array $context = [])
     {
         parent::__construct($subject, $marking, $transition, $workflow);

--- a/src/Symfony/Component/Workflow/Event/TransitionEvent.php
+++ b/src/Symfony/Component/Workflow/Event/TransitionEvent.php
@@ -15,6 +15,11 @@ use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
+/**
+ * @template T of object
+ *
+ * @extends Event<T>
+ */
 final class TransitionEvent extends Event
 {
     use EventNameTrait {
@@ -22,6 +27,9 @@ final class TransitionEvent extends Event
     }
     use HasContextTrait;
 
+    /**
+     * @param T $subject
+     */
     public function __construct(object $subject, Marking $marking, ?Transition $transition = null, ?WorkflowInterface $workflow = null, array $context = [])
     {
         parent::__construct($subject, $marking, $transition, $workflow);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | ~
| License       | MIT

The main purpose of this MR is to document the concrete type of the workflow subject when implementing event listeners.

## Before

```php
namespace App\EventListener;

use App\Entity\Observation;
use Symfony\Component\Workflow\Attribute\AsGuardListener;
use Symfony\Component\Workflow\Event\GuardEvent;

class WorkflowListener
{
    #[AsGuardListener(workflow: 'observation', transition: 'open')]
    public function onGuardOpen(GuardEvent $event): void
    {
        /** @var Observation $observation */
        $observation = $event->getSubject();
        $observation->doSomething();
    }
}
```

## After

```php
namespace App\EventListener;

use App\Entity\Observation;
use Symfony\Component\Workflow\Attribute\AsGuardListener;
use Symfony\Component\Workflow\Event\GuardEvent;

class WorkflowListener
{
    /**
     * @param GuardEvent<Observation> $event
     */
    #[AsGuardListener(workflow: 'observation', transition: 'open')]
    public function onGuardOpen(GuardEvent $event): void
    {
        $event->getSubject()->doSomething();
    }
}
```