### PR TITLE
[Validator] Remove constant existence check in `ExpressionSyntaxValidator`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
@@ -46,7 +46,7 @@ class ExpressionSyntaxValidator extends ConstraintValidator
         $this->expressionLanguage ??= new ExpressionLanguage();
 
         try {
-            if (null === $constraint->allowedVariables && \defined(Parser::class.'::IGNORE_UNKNOWN_VARIABLES')) {
+            if (null === $constraint->allowedVariables) {
                 $this->expressionLanguage->lint($expression, [], Parser::IGNORE_UNKNOWN_VARIABLES);
             } else {
                 $this->expressionLanguage->lint($expression, $constraint->allowedVariables);

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -44,7 +44,8 @@
     },
     "conflict": {
         "doctrine/lexer": "<1.1",
-        "symfony/doctrine-bridge": "<7.4"
+        "symfony/doctrine-bridge": "<7.4",
+        "symfony/expression-language": "<7.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Validator\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In 8.0, Validator requires `symfony/expression-language:^7.4|^8.0`, so the constant is always defined (introduced in 7.1).