### PR TITLE
[Messenger] Add SQS system attributes of received messages to AmazonSqsReceivedStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow auto-setup to create the queue when the DSN names the account the client already authenticates as
  * Add `AmazonSqsFairQueueStamp` to set a `MessageGroupId` on standard queues, enabling SQS fair queues
  * Add the `ssl` DSN option, superseding `sslmode`
+ * Add `AmazonSqsReceivedStamp::getSystemAttributes()` exposing the SQS system attributes of received messages
 
 7.4
 ---

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
@@ -97,6 +97,29 @@ class AmazonSqsReceiverTest extends TestCase
         $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
+    public function testItPassesSystemAttributesToStamp()
+    {
+        $serializer = $this->createSerializer();
+
+        $systemAttributes = [
+            'ApproximateReceiveCount' => '3',
+            'SentTimestamp' => '1638000000000',
+        ];
+
+        $sqsEnvelop = $this->createSqsEnvelope($systemAttributes);
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn([$sqsEnvelop]);
+
+        $receiver = new AmazonSqsReceiver($connection, $serializer);
+        $actualEnvelopes = iterator_to_array($receiver->get());
+        $this->assertCount(1, $actualEnvelopes);
+
+        /** @var AmazonSqsReceivedStamp $stamp */
+        $stamp = $actualEnvelopes[0]->last(AmazonSqsReceivedStamp::class);
+        $this->assertNotNull($stamp);
+        $this->assertSame($systemAttributes, $stamp->getSystemAttributes());
+    }
+
     public function testKeepalive()
     {
         $serializer = $this->createSerializer();
@@ -145,7 +168,7 @@ class AmazonSqsReceiverTest extends TestCase
         $receiver->ack(new Envelope(new DummyMessage('Hi'), [new AmazonSqsReceivedStamp('1')]));
     }
 
-    private function createSqsEnvelope()
+    private function createSqsEnvelope(array $systemAttributes = []): array
     {
         return [
             'id' => 1,
@@ -153,6 +176,7 @@ class AmazonSqsReceiverTest extends TestCase
             'headers' => [
                 'type' => DummyMessage::class,
             ],
+            'system_attributes' => $systemAttributes,
         ];
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -16,6 +16,7 @@ use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Core\Sts\Result\GetCallerIdentityResponse;
 use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use AsyncAws\Sqs\Enum\QueueAttributeName;
 use AsyncAws\Sqs\Result\GetQueueUrlResult;
 use AsyncAws\Sqs\Result\QueueExistsWaiter;
@@ -309,11 +310,13 @@ class ConnectionTest extends TestCase
                 'VisibilityTimeout' => null,
                 'MaxNumberOfMessages' => 9,
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => [MessageSystemAttributeName::ALL],
                 'WaitTimeSeconds' => 20]], $firstResult],
             [[['QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue',
                 'VisibilityTimeout' => null,
                 'MaxNumberOfMessages' => 9,
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => [MessageSystemAttributeName::ALL],
                 'WaitTimeSeconds' => 20]], $secondResult],
         ];
 
@@ -353,11 +356,13 @@ class ConnectionTest extends TestCase
                 'VisibilityTimeout' => null,
                 'MaxNumberOfMessages' => 10,
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => [MessageSystemAttributeName::ALL],
                 'WaitTimeSeconds' => 20]], $firstResult],
             [[['QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue',
                 'VisibilityTimeout' => null,
                 'MaxNumberOfMessages' => 10,
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => [MessageSystemAttributeName::ALL],
                 'WaitTimeSeconds' => 20]], $secondResult],
         ];
 
@@ -374,6 +379,46 @@ class ConnectionTest extends TestCase
         $connection = new Connection(['queue_name' => 'queue', 'account' => 123, 'auto_setup' => false, 'buffer_size' => 9], $client);
         $this->assertNotNull($connection->get(12));
         $this->assertNull($connection->get(12));
+    }
+
+    public function testGetReturnsSystemAttributes()
+    {
+        $client = $this->createMock(SqsClient::class);
+        $client
+            ->method('getQueueUrl')
+            ->willReturnMap([
+                [['QueueName' => 'queue', 'QueueOwnerAWSAccountId' => 123], ResultMockFactory::create(GetQueueUrlResult::class, ['QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue'])],
+            ]);
+
+        $result = ResultMockFactory::create(ReceiveMessageResult::class, ['Messages' => [
+            new Message([
+                'MessageId' => 1,
+                'Body' => 'this is a test',
+                'Attributes' => [
+                    MessageSystemAttributeName::APPROXIMATE_RECEIVE_COUNT => '3',
+                    MessageSystemAttributeName::SENT_TIMESTAMP => '1638000000000',
+                ],
+            ]),
+        ]]);
+
+        $client->expects($this->once())
+            ->method('receiveMessage')
+            ->with([
+                'QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue',
+                'VisibilityTimeout' => null,
+                'MaxNumberOfMessages' => 9,
+                'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => [MessageSystemAttributeName::ALL],
+                'WaitTimeSeconds' => 20,
+            ])
+            ->willReturn($result)
+        ;
+
+        $connection = new Connection(['queue_name' => 'queue', 'account' => 123, 'auto_setup' => false], $client);
+
+        $message = $connection->get();
+        $this->assertNotNull($message);
+        $this->assertSame(['ApproximateReceiveCount' => '3', 'SentTimestamp' => '1638000000000'], $message[0]['system_attributes']);
     }
 
     public function testUnexpectedSqsError()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceivedStamp.php
@@ -20,11 +20,20 @@ class AmazonSqsReceivedStamp implements NonSendableStampInterface
 {
     public function __construct(
         private string $id,
+        private array $systemAttributes = [],
     ) {
     }
 
     public function getId(): string
     {
         return $this->id;
+    }
+
+    /**
+     * @return array<string, string> SQS system attributes (e.g. ApproximateReceiveCount, SentTimestamp)
+     */
+    public function getSystemAttributes(): array
+    {
+        return $this->systemAttributes;
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
@@ -53,7 +53,7 @@ class AmazonSqsReceiver implements KeepaliveReceiverInterface, MessageCountAware
 
         foreach ($sqsEnvelopes as $sqsEnvelope) {
             $stamps = [
-                new AmazonSqsReceivedStamp($sqsEnvelope['id']),
+                new AmazonSqsReceivedStamp($sqsEnvelope['id'], $sqsEnvelope['system_attributes'] ?? []),
                 new TransportMessageIdStamp($sqsEnvelope['id']),
             ];
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -238,6 +238,7 @@ class Connection
                 'VisibilityTimeout' => $this->configuration['visibility_timeout'],
                 'MaxNumberOfMessages' => min($fetchSize, 10), // SQS limitation
                 'MessageAttributeNames' => ['All'],
+                'MessageSystemAttributeNames' => [MessageSystemAttributeName::ALL],
                 'WaitTimeSeconds' => $this->configuration['wait_time'],
             ]);
         }
@@ -274,6 +275,7 @@ class Connection
                 'id' => $message->getReceiptHandle(),
                 'body' => $message->getBody(),
                 'headers' => $headers,
+                'system_attributes' => $message->getAttributes(),
             ];
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "async-aws/core": "^1.7",
-        "async-aws/sqs": "^1.0|^2.0",
+        "async-aws/sqs": "^2.1",
         "psr/log": "^1|^2|^3",
         "symfony/messenger": "^8.1",
         "symfony/service-contracts": "^2.5|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

The SQS transport now requests all system attributes when receiving messages and exposes them through `AmazonSqsReceivedStamp::getSystemAttributes()`:

```php
$stamp = $envelope->last(AmazonSqsReceivedStamp::class);
$sentAt = $stamp->getSystemAttributes()['SentTimestamp'] ?? null; // epoch milliseconds, as a string
```

The attributes keep their raw AWS names and string values: `ApproximateReceiveCount`, `ApproximateFirstReceiveTimestamp`, `SentTimestamp`, `SenderId`, `AWSTraceHeader`, `DeadLetterQueueSourceArn`, and on FIFO queues also `MessageGroupId`, `MessageDeduplicationId` and `SequenceNumber`. See the [ReceiveMessage documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html) for their meaning.

There is no option to trim the list: requesting system attributes is the same API call with a marginally larger response, so they are always requested. This relies on the `MessageSystemAttributeNames` request parameter, added in async-aws/sqs 2.1; the constraint is bumped accordingly. SQS-compatible test servers that predate this parameter ignore it, in which case `getSystemAttributes()` returns an empty array.

Points for the documentation:
- `AmazonSqsReceivedStamp::getSystemAttributes()` returns `array<string, string>`, keyed by the AWS attribute names
- typical uses: latency tracking via `SentTimestamp`, redelivery detection via `ApproximateReceiveCount`
