### PR TITLE
[Notifier] Fix `SweegoTransport` by allowing bool values

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
@@ -91,7 +91,7 @@ final class SweegoTransport extends AbstractTransport
             'headers' => [
                 'Api-Key' => $this->apiKey,
             ],
-            'json' => array_filter($body),
+            'json' => array_filter($body, static fn ($value) => null !== $value),
         ]);
 
         try {
@@ -114,7 +114,7 @@ final class SweegoTransport extends AbstractTransport
 
     private function setBat(array $body, array $options): array
     {
-        $body['bat'] = (bool) ($options[SweegoOptions::BAT] ?? $this->bat);
+        $body['bat'] = $options[SweegoOptions::BAT] ?? $this->bat;
 
         return $body;
     }
@@ -143,14 +143,14 @@ final class SweegoTransport extends AbstractTransport
 
     private function setShortenUrls(array $body, array $options): array
     {
-        $body['shorten_urls'] = (bool) ($options[SweegoOptions::SHORTEN_URLS] ?? $this->shortenUrls);
+        $body['shorten_urls'] = $options[SweegoOptions::SHORTEN_URLS] ?? $this->shortenUrls;
 
         return $body;
     }
 
     private function setShortenWithProtocol(array $body, array $options): array
     {
-        $body['shorten_with_protocol'] = (bool) ($options[SweegoOptions::SHORTEN_WITH_PROTOCOL] ?? $this->shortenWithProtocol);
+        $body['shorten_with_protocol'] = $options[SweegoOptions::SHORTEN_WITH_PROTOCOL] ?? $this->shortenWithProtocol;
 
         return $body;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Sweego\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\Notifier\Bridge\Sweego\SweegoOptions;
 use Symfony\Component\Notifier\Bridge\Sweego\SweegoTransport;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -84,6 +85,44 @@ final class SweegoTransportTest extends TransportTestCase
 
         $transport = self::createTransport($client);
         $sentMessage = $transport->send(new SmsMessage('0611223344', 'Hello!'));
+
+        $this->assertSame('123', $sentMessage->getMessageId());
+    }
+
+    public function testSendSmsMessageWithOptions()
+    {
+        $client = new MockHttpClient(function ($method, $url, $options) {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.sweego.io/send', $url);
+
+            $body = json_decode($options['body'], true);
+            $this->assertSame('sms', $body['channel']);
+            $this->assertFalse(isset($body['bat']));
+            $this->assertTrue($body['shorten_urls']);
+            $this->assertFalse($body['shorten_with_protocol']);
+
+            return new JsonMockResponse(['swg_uids' => ['123']]);
+        });
+
+        $transport = new SweegoTransport(
+            'apiKey',
+            'REGION',
+            'CAMPAIGN_TYPE',
+            null,
+            'CAMPAIGN_ID',
+            null,
+            null,
+            $client,
+        );
+
+        $options = new SweegoOptions([
+            'bat' => null,
+            'shorten_urls' => true,
+            'shorten_with_protocol' => false,
+        ]);
+
+        $smsMessage = new SmsMessage('0611223344', 'Hello!', '', $options);
+        $sentMessage = $transport->send($smsMessage);
 
         $this->assertSame('123', $sentMessage->getMessageId());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? |no
| Issues        | Fix #63521
| License       | MIT

Allow boolean values in body payload, remove null values.
