### PR TITLE
[Mailer][Mailjet] Fix inline attachments with custom Content-ID

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 
 class MailjetApiTransportTest extends TestCase
 {
@@ -475,5 +476,46 @@ class MailjetApiTransportTest extends TestCase
             ],
             $method->invoke($transport, $email, $envelope)
         );
+    }
+
+    public function testInlineWithCustomContentId()
+    {
+        $imagePart = (new DataPart('text-contents', 'text.txt'));
+        $imagePart->asInline();
+        $imagePart->setContentId('content-identifier@symfony');
+
+        $email = new Email();
+        $email->addPart($imagePart);
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $contentId = $payload['Messages'][0]['InlinedAttachments'][0]['ContentID'] ?? null;
+
+        $this->assertSame('content-identifier@symfony', $contentId);
+        $this->assertCount(1, $payload['Messages']);
+        $this->assertCount(1, $payload['Messages'][0]['InlinedAttachments']);
+    }
+
+    public function testInlineWithoutCustomContentId()
+    {
+        $imagePart = (new DataPart('text-contents', 'text.txt'));
+        $imagePart->asInline();
+
+        $email = new Email();
+        $email->addPart($imagePart);
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $contentId = $payload['Messages'][0]['InlinedAttachments'][0]['ContentID'] ?? null;
+
+        $this->assertSame('text.txt', $contentId ?? null);
+        $this->assertCount(1, $payload['Messages']);
+        $this->assertCount(1, $payload['Messages'][0]['InlinedAttachments']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -185,7 +185,7 @@ class MailjetApiTransport extends AbstractApiTransport
                 'Base64Content' => $attachment->bodyToString(),
             ];
             if ('inline' === $headers->getHeaderBody('Content-Disposition')) {
-                $formattedAttachment['ContentID'] = $headers->getHeaderParameter('Content-Disposition', 'name');
+                $formattedAttachment['ContentID'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
                 $inlines[] = $formattedAttachment;
             } else {
                 $attachments[] = $formattedAttachment;

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
@@ -23,6 +23,9 @@
         "symfony/http-client": "^5.4|^6.0|^7.0",
         "symfony/webhook": "^6.3|^7.0"
     },
+    "conflict": {
+      "symfony/mime": "<6.2"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Mailjet\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
Fixes #63514.

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63514 
| License       | MIT

 Without this fix, custom Content-IDs are not set properly. See the issue for details.
