### PR TITLE
[WebProfilerBundle] Fix Symfony web debug toolbar not being displayed

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -449,7 +449,7 @@
 
                     showToolbar: function(token) {
                         var sfwdt = this.getSfwdt(token);
-                        removeClass(sfwdt, 'sf-display-none');
+                        removeClass(sfwdt.parentNode, 'sf-display-none');
 
                         if (getPreference('toolbar/displayState') == 'none') {
                             document.getElementById('sfToolbarMainContent-' + token).style.display = 'none';
@@ -464,7 +464,7 @@
 
                     hideToolbar: function(token) {
                         var sfwdt = this.getSfwdt(token);
-                        addClass(sfwdt, 'sf-display-none');
+                        addClass(sfwdt.parentNode, 'sf-display-none');
                     },
 
                     initToolbar: function(token) {
@@ -628,7 +628,7 @@
                                         An error occurred while loading the web debug toolbar. <a href="{{ url("_profiler_home")|escape('js') }}' + newToken + '">Open the web profiler.</a>\
                                     </div>\
                                 ';
-                                    sfwdt.setAttribute('class', 'sf-toolbar sf-error-toolbar');
+                                    sfwdt.parentElement.setAttribute('class', 'sf-toolbar sf-error-toolbar');
                                 }
                             },
                             options


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63504 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

### Description

Fixes #63504 by adding and removing the `sf-display-none` class on the parentNode. I did not go for the solution proposed in https://github.com/symfony/symfony/issues/63504#issuecomment-3971630667 due to the div still being present when simply moving the class.

Ignore the whitespace removals, they should not be there according to the .editorconfig:
https://github.com/symfony/symfony/blob/52bff381c87cd120834ea29d3b525aaf0babedab/.editorconfig#L9

There is no need to merge this PR upstream due to new features that have been included in Symfony 7.
A PR for Symfony 7.4 can be found here: #63530 
