### PR TITLE
[TypeInfo] Resolve tentative return types

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ObjectShapeType` to represent the exact shape of an anonymous object
+ * Resolve tentative return types
 
 8.0
 ---

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionReturnTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/ReflectionReturnTypeResolverTest.php
@@ -64,6 +64,14 @@ class ReflectionReturnTypeResolverTest extends TestCase
         $this->assertEquals(Type::int(), $this->resolver->resolve($reflectionFunction));
     }
 
+    public function testResolveTentative()
+    {
+        $reflectionClass = new \ReflectionClass(\DateTime::class);
+        $reflectionFunction = $reflectionClass->getMethod('getTimezone');
+
+        $this->assertEquals(Type::union(Type::object(\DateTimeZone::class), Type::false()), $this->resolver->resolve($reflectionFunction));
+    }
+
     public function testResolveSelfFromClassWithoutContext()
     {
         $reflectionClass = new \ReflectionClass(ReflectionExtractableDummy::class);

--- a/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/ReflectionReturnTypeResolver.php
@@ -39,7 +39,7 @@ final class ReflectionReturnTypeResolver implements TypeResolverInterface
         $typeContext ??= $this->typeContextFactory->createFromReflection($subject);
 
         try {
-            return $this->reflectionTypeResolver->resolve($subject->getReturnType(), $typeContext);
+            return $this->reflectionTypeResolver->resolve($subject->getReturnType() ?? $subject->getTentativeReturnType(), $typeContext);
         } catch (UnsupportedException $e) {
             $path = null !== $typeContext
                 ? \sprintf('%s::%s()', $typeContext->calledClassName, $subject->getName())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Resolve tentative return types. E.g. `DateTime::getTimeZone()` on PHP 8.4 has tentative return type.