### PR TITLE
[FrameworkBundle] Improve the output of debug:autowiring to be more visually structured

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -93,7 +93,8 @@ class DebugAutowiringCommand extends ContainerDebugCommand
         uasort($serviceIds, 'strnatcmp');
 
         $io->title('Autowirable Types');
-        $io->text('The following classes & interfaces can be used as type-hints when autowiring:');
+        $io->text('Use the following classes & interfaces as type-hints in constructor arguments to autowire services.');
+        $io->text('Add <fg=magenta>#[Target(\'</><fg=cyan>name</><fg=magenta>\')]</> to the argument to select a specific variant.');
         if ($search) {
             $io->text(\sprintf('(only showing classes/interfaces matching <comment>%s</comment>)', $search));
         }
@@ -107,21 +108,15 @@ class DebugAutowiringCommand extends ContainerDebugCommand
             }
             $text = [];
             $resolvedServiceId = $serviceId;
-            if (!str_starts_with($serviceId, $previousId.' $')) {
+            $description = '';
+
+            if ($isNewGroup = !str_starts_with($serviceId, $previousId.' $')) {
                 $text[] = '';
                 $previousId = preg_replace('/ \$.*/', '', $serviceId);
-                if ('' !== $description = Descriptor::getClassDescription($previousId, $resolvedServiceId)) {
-                    if (isset($hasAlias[$previousId])) {
-                        continue;
-                    }
-                    $text[] = $description;
+                $description = Descriptor::getClassDescription($previousId, $resolvedServiceId);
+                if ('' !== $description && isset($hasAlias[$previousId])) {
+                    continue;
                 }
-            }
-
-            $serviceLine = \sprintf('<fg=yellow>%s</>', $serviceId);
-            if ('' !== $fileLink = $this->getFileLink($previousId)) {
-                $serviceLine = substr($serviceId, \strlen($previousId));
-                $serviceLine = \sprintf('<fg=yellow;href=%s>%s</>', $fileLink, $previousId).('' !== $serviceLine ? \sprintf('<fg=yellow>%s</>', $serviceLine) : '');
             }
 
             if ($container->hasAlias($serviceId)) {
@@ -130,14 +125,13 @@ class DebugAutowiringCommand extends ContainerDebugCommand
                 $alias = (string) $serviceAlias;
 
                 $target = null;
-                foreach ($reverseAliases[(string) $serviceAlias] ?? [] as $id) {
-                    if (!str_starts_with($id, '.'.$previousId.' $')) {
+                foreach ($reverseAliases[$alias] ?? [] as $id) {
+                    if (!str_starts_with($id, '.'.$previousId.' $') || !str_contains($serviceId, ' $')) {
                         continue;
                     }
                     $target = substr($id, \strlen($previousId) + 3);
 
                     if ($container->findDefinition($id) === $container->findDefinition($serviceId)) {
-                        $serviceLine .= ' - <fg=magenta>target:</><fg=cyan>'.$target.'</>';
                         break;
                     }
                 }
@@ -146,20 +140,72 @@ class DebugAutowiringCommand extends ContainerDebugCommand
                     $alias = $decorated[0]['id'];
                 }
 
-                if ($alias !== $target) {
-                    $serviceLine .= ' - <fg=magenta>alias:</><fg=cyan>'.$alias.'</>';
-                }
+                if ($isNewGroup) {
+                    // Build the main type line with optional file link
+                    $typeLine = \sprintf('<fg=yellow>%s</>', $previousId);
+                    if ('' !== $fileLink = $this->getFileLink($previousId)) {
+                        $typeLine = \sprintf('<fg=yellow;href=%s>%s</>', $fileLink, $previousId);
+                    }
 
-                if ($serviceAlias->isDeprecated()) {
-                    $serviceLine .= ' - <fg=magenta>deprecated</>';
+                    if (null !== $target) {
+                        // Type whose first entry is already targeted (no un-targeted base)
+                        $text[] = $typeLine;
+                        if ('' !== $description) {
+                            $text[] = \sprintf('  %s', $description);
+                        }
+                        $targetLine = \sprintf('  <fg=magenta>#[Target(\'</><fg=cyan>%s</><fg=magenta>\')]</>', $target);
+                        if ($alias !== $target) {
+                            $targetLine .= \sprintf(' → <fg=cyan>%s</>', $alias);
+                        }
+                        if ($serviceAlias->isDeprecated()) {
+                            $targetLine .= ' <fg=magenta>[deprecated]</>';
+                        }
+                        $text[] = $targetLine;
+                    } else {
+                        // Regular main entry: Type → alias
+                        if ($alias !== $target) {
+                            $typeLine .= \sprintf(' → <fg=cyan>%s</>', $alias);
+                        }
+                        if ($serviceAlias->isDeprecated()) {
+                            $typeLine .= ' <fg=magenta>[deprecated]</>';
+                        }
+                        $text[] = $typeLine;
+                        if ('' !== $description) {
+                            $text[] = \sprintf('  %s', $description);
+                        }
+                    }
+                } else {
+                    // Variant entry: indented #[Target] line
+                    if (null !== $target) {
+                        $variantLine = \sprintf('  <fg=magenta>#[Target(\'</><fg=cyan>%s</><fg=magenta>\')]</>', $target);
+                    } else {
+                        $variantLine = \sprintf('  <fg=yellow>%s</>', $serviceId);
+                    }
+                    if ($alias !== $target) {
+                        $variantLine .= \sprintf(' → <fg=cyan>%s</>', $alias);
+                    }
+                    if ($serviceAlias->isDeprecated()) {
+                        $variantLine .= ' <fg=magenta>[deprecated]</>';
+                    }
+                    $text[] = $variantLine;
                 }
             } elseif (!$all) {
                 ++$serviceIdsNb;
                 continue;
-            } elseif ($container->getDefinition($serviceId)->isDeprecated()) {
-                $serviceLine .= ' - <fg=magenta>deprecated</>';
+            } else {
+                // Service without alias (shown with --all)
+                $serviceLine = \sprintf('<fg=yellow>%s</>', $previousId);
+                if ('' !== $fileLink = $this->getFileLink($previousId)) {
+                    $serviceLine = \sprintf('<fg=yellow;href=%s>%s</>', $fileLink, $previousId);
+                }
+                if ($container->getDefinition($serviceId)->isDeprecated()) {
+                    $serviceLine .= ' <fg=magenta>[deprecated]</>';
+                }
+                $text[] = $serviceLine;
+                if ($isNewGroup && '' !== $description) {
+                    $text[] = \sprintf('  %s', $description);
+                }
             }
-            $text[] = $serviceLine;
             $io->text($text);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -112,8 +112,6 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\JsonStreamer\Attribute\JsonStreamable;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadata;
-use Symfony\Component\JsonStreamer\StreamReaderInterface;
-use Symfony\Component\JsonStreamer\StreamWriterInterface;
 use Symfony\Component\JsonStreamer\ValueTransformer\ValueTransformerInterface;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
@@ -2196,9 +2194,6 @@ class FrameworkExtension extends Extension
             ->addTag('json_streamer.value_transformer');
 
         $loader->load('json_streamer.php');
-
-        $container->registerAliasForArgument('json_streamer.stream_writer', StreamWriterInterface::class, 'json.stream_writer');
-        $container->registerAliasForArgument('json_streamer.stream_reader', StreamReaderInterface::class, 'json.stream_reader');
 
         $container->setParameter('.json_streamer.default_options', $config['default_options']);
         $container->setParameter('.json_streamer.stream_writers_dir', '%kernel.cache_dir%/json_streamer/stream_writer');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -36,7 +36,7 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
         $tester->run(['command' => 'debug:autowiring'], ['decorated' => false]);
 
         $this->assertStringContainsString(HttpKernelInterface::class, $tester->getDisplay());
-        $this->assertStringContainsString('alias:http_kernel', $tester->getDisplay());
+        $this->assertStringContainsString('→ http_kernel', $tester->getDisplay());
     }
 
     public function testSearchArgument()

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -180,12 +180,9 @@ class SerializerPass implements CompilerPassInterface
             $this->bindDefaultContext($container, array_merge($normalizers, $encoders), $config['default_context'], $circularReferenceHandler, $maxDepthHandler);
 
             $container->registerChild($serializerId, 'serializer')->setArgument('$defaultContext', $config['default_context']);
-            $container->registerAliasForArgument($serializerId, SerializerInterface::class, $serializerName.'.serializer');
-            $container->registerAliasForArgument($serializerId, SerializerInterface::class, $serializerName);
-            $container->registerAliasForArgument($serializerId, NormalizerInterface::class, $serializerName.'.normalizer');
-            $container->registerAliasForArgument($serializerId, NormalizerInterface::class, $serializerName);
-            $container->registerAliasForArgument($serializerId, DenormalizerInterface::class, $serializerName.'.denormalizer');
-            $container->registerAliasForArgument($serializerId, DenormalizerInterface::class, $serializerName);
+            $container->registerAliasForArgument($serializerId, SerializerInterface::class, $serializerName.'.serializer', $serializerName);
+            $container->registerAliasForArgument($serializerId, NormalizerInterface::class, $serializerName.'.normalizer', $serializerName);
+            $container->registerAliasForArgument($serializerId, DenormalizerInterface::class, $serializerName.'.denormalizer', $serializerName);
 
             $this->configureSerializer($container, $serializerId, $normalizers, $encoders, $serializerName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I started with the goal of making this command more LLM-friendly FYI, but the result is also cleaner for us.

- Replaces the generic intro text with concrete instructions ("Use as type-hints in constructor arguments…") and a tip about `#[Target]` for selecting named variants.
- Changes the alias format to ` → service_id` for a cleaner look consistent with the new `#[Target]` variant lines.
- Named variants (autowire targets) are now shown as indented `#[Target('name')]` lines beneath their parent type, making it clear how to use them.
- Deprecated entries are now marked with `[deprecated]`

eg

Before:
<img width="1679" height="503" alt="image" src="https://github.com/user-attachments/assets/47339e4f-15b2-4c1b-a028-20bf2347838f" />

After:
<img width="1328" height="576" alt="image" src="https://github.com/user-attachments/assets/84240158-87ba-40bd-aabe-58728e06569a" />

