### PR TITLE
[Validator] Regex bypass when match is false with too big input

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -47,7 +47,9 @@ class RegexValidator extends ConstraintValidator
             $value = ($constraint->normalizer)($value);
         }
 
-        if ($constraint->match xor preg_match($constraint->pattern, $value)) {
+        $expectedResult = $constraint->match ? 1 : 0;
+
+        if (preg_match($constraint->pattern, $value) !== $expectedResult) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setParameter('{{ pattern }}', $constraint->pattern)

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -152,4 +152,19 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
             }],
         ];
     }
+
+    public function testMatchFalseWithTooManyBacktrackingShouldNotPass()
+    {
+        $value = '<'.str_repeat('a', 1000000).'<a href="javascript:alert(1)">test</a>';
+        $pattern = '/<script|([^>]*?)(on\w+\s*=\s*(["\']).*?\3|href\s*=\s*(["\'])javascript:.*?\4)[^>]*?>/is';
+        $constraint = new Regex(pattern: $pattern, message: 'myMessage', match: false);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$value.'"')
+            ->setParameter('{{ pattern }}', $pattern)
+            ->setCode(Regex::REGEX_FAILED_ERROR)
+            ->assertRaised();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When the match parameter is set to false on Regex constraint, the validator will pass if the result of preg_match is falsy.
However, when the pattern is invalid or if the backtrack/recursive/input limit is reach, false is returned, instead of `0`/`1`.
This can be use by an attacker to by pass the regex.

So with this fix, the result will be strictly compared, so a `false` result will always result to a violation of the constraint.