### PR TITLE
[Console] Replace executeCommand() by runCommand() when testing commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
  * Add support for `framework.secrets.decryption_env_var` to contain dots
  * Enable mocking non-shared services in tests
  * Add support for setting `mock_response_factory` per scoped HTTP client
- * Add `KernelTestCase::executeCommand()` to execute a command in functional tests
+ * Add `ConsoleCommandAssertionsTrait` to `KernelTestCase` for running a command and asserting the result
  * Add `framework.html_sanitizer.sanitizers.*.default_action` config option
  * Deprecate parameters `router.request_context.scheme` and `router.request_context.host`;
    use the `router.request_context.base_url` parameter or the `framework.router.default_uri` config option instead

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
@@ -13,29 +13,26 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tester\ConsoleAssertionsTrait;
+use Symfony\Component\Console\Tester\ExecutionResult;
 
 trait ConsoleCommandAssertionsTrait
 {
+    use ConsoleAssertionsTrait;
+
     /**
-     * Executes the command.
+     * Runs a console command and returns the execution result.
      *
-     * Available execution options:
-     *
-     *  * interactive:               Sets the input interactive flag
-     *  * decorated:                 Sets the output decorated flag
-     *  * verbosity:                 Sets the output verbosity flag
-     *  * capture_stderr_separately: Make output of stdOut and stdErr separately available
-     *
-     * @param array $input   An array of command arguments and options
-     * @param array $options An array of execution options
+     * @param array                           $input             An array of command arguments and options
+     * @param string[]                        $interactiveInputs An array of strings representing each input passed to the command input stream
+     * @param array<\Closure(string): string> $normalizers
      */
-    public static function executeCommand(string $name, array $input, array $options = []): CommandTester
+    public static function runCommand(string $name, array $input = [], array $interactiveInputs = [], ?bool $interactive = null, ?bool $decorated = null, ?int $verbosity = null, array $normalizers = []): ExecutionResult
     {
         $application = new Application(static::getContainer()->get('kernel'));
         $command = $application->find($name);
         $commandTester = new CommandTester($command);
-        $commandTester->execute($input, $options);
 
-        return $commandTester;
+        return $commandTester->run($input, $interactiveInputs, $interactive, $decorated, $verbosity, $normalizers);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\ConsoleAssertionsTrait;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\Filesystem\Filesystem;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RunCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RunCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\ExecutionResult;
+
+#[Group('functional')]
+class RunCommandTest extends AbstractWebTestCase
+{
+    protected function setUp(): void
+    {
+        static::bootKernel(['test_case' => 'RunCommand', 'root_config' => 'config.yml']);
+    }
+
+    public function testRunCommandReturnsExecutionResult()
+    {
+        $result = static::runCommand('list');
+
+        $this->assertInstanceOf(ExecutionResult::class, $result);
+        $this->assertSame(Command::SUCCESS, $result->statusCode);
+        $this->assertStringContainsString('Available commands:', $result->getOutput());
+    }
+
+    public function testRunCommandIsSuccessful()
+    {
+        $result = static::runCommand('list');
+
+        $this->assertIsSuccessful($result);
+    }
+
+    public function testRunCommandWithArguments()
+    {
+        $result = static::runCommand('list', ['namespace' => 'debug']);
+
+        $this->assertIsSuccessful($result);
+        $this->assertStringContainsString('debug', $result->getOutput());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/config.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ../config/default.yml }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Command testing suffered from two problems:

```php
self::bootKernel();
$application = new Application(self::$kernel);

$command = $application->find('app:create-user');
$commandTester = new CommandTester($command);
$commandTester->execute('email' => 'foo@bar.com');
```

Problem 1: setup is too verbose
Problem 2: it doesn't return a result object with useful utilities (`ExecutionResult`)

In 8.1 we added two methods that each solve one of these problems:

**(1)** `KernelTestCase::executeCommand()` removes the setup verbosity, but returns a `CommandTester`, forcing users back into the legacy stateful API:

```php
$tester = static::executeCommand('app:create-user', ['email' => 'foo@bar.com']);
$tester->assertCommandIsSuccessful();
$this->assertStringContainsString('User created', $tester->getDisplay());
```

**(2)** `CommandTester::run()` returns a useful object (`ExecutionResult`) but requires verbose kernel/application/command setup:

```php
$application = new Application(static::getContainer()->get('kernel'));
$command = $application->find('app:create-user');
$commandTester = new CommandTester($command);
$result = $commandTester->run(['email' => 'foo@bar.com']);
```

This PR replaces `executeCommand()` with `runCommand()` to combine both solutions: simple to call and returns `ExecutionResult`:

```php
$result = static::runCommand('app:create-user', ['email' => 'foo@bar.com']);
$this->assertIsSuccessful($result);
$this->assertStringContainsString('User created', $result->getOutput());
```

Since `executeCommand()` was added in 8.1 (unreleased), no deprecation is needed for the rename.