### PR TITLE
[Console] Sort suggested commands alphabetically

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -706,6 +706,8 @@ class Application implements ResetInterface
 
         $exact = \in_array($namespace, $namespaces, true);
         if (\count($namespaces) > 1 && !$exact) {
+            sort($namespaces);
+
             throw new NamespaceNotFoundException(\sprintf("The namespace \"%s\" is ambiguous.\nDid you mean one of these?\n%s.", $namespace, $this->getAbbreviationSuggestions(array_values($namespaces))), array_values($namespaces));
         }
 
@@ -801,6 +803,7 @@ class Application implements ResetInterface
         }
 
         if (\count($commands) > 1) {
+            sort($commands);
             $usableWidth = $this->terminal->getWidth() - 10;
             $abbrevs = array_values($commands);
             $maxLen = 0;

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -409,6 +409,19 @@ class ApplicationTest extends TestCase
         $application->findNamespace('f');
     }
 
+    public function testFindAmbiguousNamespaceSortedAlphabetically()
+    {
+        $application = new Application();
+        $application->addCommand(new Command('test-zzz:cmd'));
+        $application->addCommand(new Command('test-aaa:cmd'));
+        $application->addCommand(new Command('test-bbb:cmd'));
+
+        $this->expectException(NamespaceNotFoundException::class);
+        $this->expectExceptionMessage("The namespace \"test\" is ambiguous.\nDid you mean one of these?\n    test-aaa\n    test-bbb\n    test-zzz");
+
+        $application->findNamespace('test');
+    }
+
     public function testFindNonAmbiguous()
     {
         $application = new Application();
@@ -539,11 +552,34 @@ class ApplicationTest extends TestCase
             [
                 'foo:b',
                 "Command \"foo:b\" is ambiguous.\nDid you mean one of these?\n".
+                "    foo1:bar The foo1:bar command\n".
                 "    foo:bar  The foo:bar command\n".
-                "    foo:bar1 The foo:bar1 command\n".
-                '    foo1:bar The foo1:bar command',
+                '    foo:bar1 The foo:bar1 command',
             ],
         ];
+    }
+
+    public function testFindAmbiguousCommandsSortedAlphabetically()
+    {
+        putenv('COLUMNS=120');
+
+        $application = new Application();
+        // Register commands in non-alphabetical order
+        $application->addCommand(new Command('test:zzz'));
+        $application->addCommand(new Command('test:aaa'));
+        $application->addCommand(new Command('test:bbb'));
+
+        try {
+            $application->find('test:');
+            $this->fail('Expected CommandNotFoundException');
+        } catch (CommandNotFoundException $e) {
+            $this->assertMatchesRegularExpression(
+                '/test:aaa.*test:bbb.*test:zzz/s',
+                $e->getMessage()
+            );
+        } finally {
+            putenv('COLUMNS');
+        }
     }
 
     public function testFindWithAmbiguousAbbreviationsFindsCommandIfAlternativesAreHidden()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

When you type a partial command name to list all the related tests, they are listead in the registration order. I propose to list them alphabetically instead.