### PR TITLE
[HttpFoundation] Deprecate setting public properties of `Request` and `Response` objects directly

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -52,6 +52,11 @@ FrameworkBundle
  * Deprecate parameters `router.request_context.scheme` and `router.request_context.host`;
    use the `router.request_context.base_url` parameter or the `framework.router.default_uri` config option instead
 
+HttpFoundation
+--------------
+
+ * Deprecate setting public properties of `Request` and `Response` objects directly; use setters or constructor arguments instead
+
 HttpKernel
 ----------
 

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/RouteProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/RouteProcessorTest.php
@@ -15,7 +15,6 @@ use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\RouteProcessor;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -151,10 +150,7 @@ class RouteProcessorTest extends TestCase
 
     private function mockRequest(array $attributes): Request
     {
-        $request = new Request();
-        $request->attributes = new ParameterBag($attributes);
-
-        return $request;
+        return new Request([], [], $attributes);
     }
 
     private function createRecord(): LogRecord

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -64,8 +63,6 @@ class RedirectControllerTest extends TestCase
     #[DataProvider('provider')]
     public function testRoute($permanent, $keepRequestMethod, $keepQueryParams, $ignoreAttributes, $expectedCode, $expectedAttributes)
     {
-        $request = new Request();
-
         $route = 'new-route';
         $url = '/redirect-url';
         $attributes = [
@@ -82,7 +79,7 @@ class RedirectControllerTest extends TestCase
             ],
         ];
 
-        $request->attributes = new ParameterBag($attributes);
+        $request = new Request([], [], $attributes);
 
         $router = $this->createMock(UrlGeneratorInterface::class);
         $router
@@ -205,20 +202,18 @@ class RedirectControllerTest extends TestCase
         $httpsPort = 1443;
 
         $expectedUrl = "https://$host:$httpsPort$baseUrl$path";
-        $request = $this->createRequestObject('http', $host, $httpPort, $baseUrl);
+        $request = $this->createRequestObject('http', $host, $httpPort, $baseUrl, '', ['_route_params' => ['path' => $path, 'scheme' => 'https']]);
         $controller = $this->createRedirectController(null, $httpsPort);
         $returnValue = $controller->urlRedirectAction($request, $path, false, 'https');
         $this->assertRedirectUrl($returnValue, $expectedUrl);
-        $request->attributes = new ParameterBag(['_route_params' => ['path' => $path, 'scheme' => 'https']]);
         $returnValue = $controller($request);
         $this->assertRedirectUrl($returnValue, $expectedUrl);
 
         $expectedUrl = "http://$host:$httpPort$baseUrl$path";
-        $request = $this->createRequestObject('https', $host, $httpPort, $baseUrl);
+        $request = $this->createRequestObject('https', $host, $httpPort, $baseUrl, '', ['_route_params' => ['path' => $path, 'scheme' => 'http']]);
         $controller = $this->createRedirectController($httpPort);
         $returnValue = $controller->urlRedirectAction($request, $path, false, 'http');
         $this->assertRedirectUrl($returnValue, $expectedUrl);
-        $request->attributes = new ParameterBag(['_route_params' => ['path' => $path, 'scheme' => 'http']]);
         $returnValue = $controller($request);
         $this->assertRedirectUrl($returnValue, $expectedUrl);
     }
@@ -262,13 +257,12 @@ class RedirectControllerTest extends TestCase
         $path = '/redirect-path';
         $expectedUrl = "$scheme://$host$expectedPort$baseUrl$path";
 
-        $request = $this->createRequestObject($requestScheme, $host, $requestPort, $baseUrl);
+        $request = $this->createRequestObject($requestScheme, $host, $requestPort, $baseUrl, '', ['_route_params' => ['path' => $path, 'scheme' => $scheme, 'httpPort' => $httpPort, 'httpsPort' => $httpsPort]]);
         $controller = $this->createRedirectController();
 
         $returnValue = $controller->urlRedirectAction($request, $path, false, $scheme, $httpPort, $httpsPort);
         $this->assertRedirectUrl($returnValue, $expectedUrl);
 
-        $request->attributes = new ParameterBag(['_route_params' => ['path' => $path, 'scheme' => $scheme, 'httpPort' => $httpPort, 'httpsPort' => $httpsPort]]);
         $returnValue = $controller($request);
         $this->assertRedirectUrl($returnValue, $expectedUrl);
     }
@@ -292,14 +286,13 @@ class RedirectControllerTest extends TestCase
         $baseUrl = '/base';
         $port = 80;
 
-        $request = $this->createRequestObject($scheme, $host, $port, $baseUrl, $queryString);
+        $request = $this->createRequestObject($scheme, $host, $port, $baseUrl, $queryString, ['_route_params' => ['path' => $path, 'scheme' => $scheme, 'httpPort' => $port]]);
 
         $controller = $this->createRedirectController();
 
         $returnValue = $controller->urlRedirectAction($request, $path, false, $scheme, $port, null);
         $this->assertRedirectUrl($returnValue, $expectedUrl);
 
-        $request->attributes = new ParameterBag(['_route_params' => ['path' => $path, 'scheme' => $scheme, 'httpPort' => $port]]);
         $returnValue = $controller($request);
         $this->assertRedirectUrl($returnValue, $expectedUrl);
     }
@@ -311,8 +304,7 @@ class RedirectControllerTest extends TestCase
         $baseUrl = '/base';
         $port = 80;
 
-        $request = $this->createRequestObject($scheme, $host, $port, $baseUrl, 'b.se=zaza&f[%2525][%26][%3D][p.c]=d');
-        $request->attributes = new ParameterBag(['_route_params' => ['base2' => 'zaza']]);
+        $request = $this->createRequestObject($scheme, $host, $port, $baseUrl, 'b.se=zaza&f[%2525][%26][%3D][p.c]=d', ['_route_params' => ['base2' => 'zaza']]);
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects($this->exactly(2))
              ->method('generate')
@@ -333,8 +325,7 @@ class RedirectControllerTest extends TestCase
         $baseUrl = '/base';
         $port = 80;
 
-        $request = $this->createRequestObject($scheme, $host, $port, $baseUrl, 'b.se=zaza');
-        $request->attributes = new ParameterBag(['_route_params' => ['b.se' => 'zouzou']]);
+        $request = $this->createRequestObject($scheme, $host, $port, $baseUrl, 'b.se=zaza', ['_route_params' => ['b.se' => 'zouzou']]);
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects($this->exactly(2))->method('generate')->willReturn('/test?b.se=zouzou')->with('/test', ['b.se' => 'zouzou'], UrlGeneratorInterface::ABSOLUTE_URL);
 
@@ -361,7 +352,7 @@ class RedirectControllerTest extends TestCase
         (new RedirectController())(new Request([], [], ['_route' => '_redirect', '_route_params' => ['path' => '/foo', 'route' => 'bar']]));
     }
 
-    private function createRequestObject($scheme, $host, $port, $baseUrl, $queryString = '')
+    private function createRequestObject($scheme, $host, $port, $baseUrl, $queryString = '', array $attributes = [])
     {
         if ('' !== $queryString) {
             parse_str($queryString, $query);
@@ -369,7 +360,7 @@ class RedirectControllerTest extends TestCase
             $query = [];
         }
 
-        return new Request($query, [], [], [], [], [
+        return new Request($query, [], $attributes, [], [], [
             'HTTPS' => 'https' === $scheme,
             'HTTP_HOST' => $host.($port ? ':'.$port : ''),
             'SERVER_PORT' => $port,

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `BinaryFileResponse::shouldDeleteFileAfterSend()`
+ * Deprecate setting public properties of `Request` and `Response` objects directly; use setters or constructor arguments instead
 
 8.0
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -64,123 +64,6 @@ class Request
     public const METHOD_CONNECT = 'CONNECT';
     public const METHOD_QUERY = 'QUERY';
 
-    /**
-     * @var string[]
-     */
-    protected static array $trustedProxies = [];
-
-    /**
-     * @var string[]
-     */
-    protected static array $trustedHostPatterns = [];
-
-    /**
-     * @var string[]
-     */
-    protected static array $trustedHosts = [];
-
-    protected static bool $httpMethodParameterOverride = false;
-
-    /**
-     * The HTTP methods that can be overridden.
-     *
-     * @var uppercase-string[]|null
-     */
-    protected static ?array $allowedHttpMethodOverride = null;
-
-    /**
-     * Custom parameters.
-     */
-    public ParameterBag $attributes;
-
-    /**
-     * Request body parameters ($_POST).
-     *
-     * @see getPayload() for portability between content types
-     */
-    public InputBag $request;
-
-    /**
-     * Query string parameters ($_GET).
-     *
-     * @var InputBag<string>
-     */
-    public InputBag $query;
-
-    /**
-     * Server and execution environment parameters ($_SERVER).
-     */
-    public ServerBag $server;
-
-    /**
-     * Uploaded files ($_FILES).
-     */
-    public FileBag $files;
-
-    /**
-     * Cookies ($_COOKIE).
-     *
-     * @var InputBag<string>
-     */
-    public InputBag $cookies;
-
-    /**
-     * Headers (taken from the $_SERVER).
-     */
-    public HeaderBag $headers;
-
-    /**
-     * @var string|resource|false|null
-     */
-    protected $content;
-
-    /**
-     * @var string[]|null
-     */
-    protected ?array $languages = null;
-
-    /**
-     * @var string[]|null
-     */
-    protected ?array $charsets = null;
-
-    /**
-     * @var string[]|null
-     */
-    protected ?array $encodings = null;
-
-    /**
-     * @var string[]|null
-     */
-    protected ?array $acceptableContentTypes = null;
-
-    protected ?string $pathInfo = null;
-    protected ?string $requestUri = null;
-    protected ?string $baseUrl = null;
-    protected ?string $basePath = null;
-    protected ?string $method = null;
-    protected ?string $format = null;
-    protected SessionInterface|\Closure|null $session = null;
-    protected ?string $locale = null;
-    protected string $defaultLocale = 'en';
-
-    /**
-     * @var array<string, string[]>|null
-     */
-    protected static ?array $formats = null;
-
-    protected static ?\Closure $requestFactory = null;
-
-    private ?string $preferredFormat = null;
-
-    private bool $isHostValid = true;
-    private bool $isForwardedValid = true;
-    private bool $isSafeContentPreferred;
-
-    private array $trustedValuesCache = [];
-
-    private static int $trustedHeaderSet = -1;
-
     private const FORWARDED_PARAMS = [
         self::HEADER_X_FORWARDED_FOR => 'for',
         self::HEADER_X_FORWARDED_HOST => 'host',
@@ -228,6 +111,165 @@ class Request
         'yaml' => 'yaml',
     ];
 
+    /**
+     * Custom parameters.
+     */
+    public ParameterBag $attributes {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "attributes" of "%s" is deprecated; pass attributes as a constructor argument or call "initialize()" instead.', __CLASS__);
+
+            $this->attributes = $value;
+        }
+    }
+
+    /**
+     * Request body parameters ($_POST).
+     *
+     * @see getPayload() for portability between content types
+     */
+    public InputBag $request {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "request" of "%s" is deprecated; pass the POST data as a constructor argument or call "initialize()" instead.', __CLASS__);
+
+            $this->request = $value;
+        }
+    }
+
+    /**
+     * Query string parameters ($_GET).
+     *
+     * @var InputBag<string>
+     */
+    public InputBag $query {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "query" of "%s" is deprecated; pass query parameters as a constructor argument or call "initialize()" instead.', __CLASS__);
+
+            $this->query = $value;
+        }
+    }
+
+    /**
+     * Server and execution environment parameters ($_SERVER).
+     */
+    public ServerBag $server {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "server" of "%s" is deprecated; pass server parameters as a constructor argument or call "initialize()" instead.', __CLASS__);
+
+            $this->server = $value;
+        }
+    }
+
+    /**
+     * Uploaded files ($_FILES).
+     */
+    public FileBag $files {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "files" of "%s" is deprecated; pass files as a constructor argument or call "initialize()" instead.', __CLASS__);
+
+            $this->files = $value;
+        }
+    }
+
+    /**
+     * Cookies ($_COOKIE).
+     *
+     * @var InputBag<string>
+     */
+    public InputBag $cookies {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "cookies" of "%s" is deprecated; pass cookies as a constructor argument or call "initialize()" instead.', __CLASS__);
+
+            $this->cookies = $value;
+        }
+    }
+
+    /**
+     * Headers (taken from the $_SERVER).
+     */
+    public HeaderBag $headers {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "headers" of "%s" is deprecated; pass header parameters as a constructor argument or call "initialize()" instead.', __CLASS__);
+
+            $this->headers = $value;
+        }
+    }
+
+    /**
+     * @var string|resource|false|null
+     */
+    protected $content;
+
+    /**
+     * @var string[]|null
+     */
+    protected ?array $languages = null;
+
+    /**
+     * @var string[]|null
+     */
+    protected ?array $charsets = null;
+
+    /**
+     * @var string[]|null
+     */
+    protected ?array $encodings = null;
+
+    /**
+     * @var string[]|null
+     */
+    protected ?array $acceptableContentTypes = null;
+
+    protected ?string $pathInfo = null;
+    protected ?string $requestUri = null;
+    protected ?string $baseUrl = null;
+    protected ?string $basePath = null;
+    protected ?string $method = null;
+    protected ?string $format = null;
+    protected SessionInterface|\Closure|null $session = null;
+    protected ?string $locale = null;
+    protected string $defaultLocale = 'en';
+
+    /**
+     * @var array<string, string[]>|null
+     */
+    protected static ?array $formats = null;
+
+    /**
+     * @var string[]
+     */
+    protected static array $trustedProxies = [];
+
+    /**
+     * @var string[]
+     */
+    protected static array $trustedHostPatterns = [];
+
+    /**
+     * @var string[]
+     */
+    protected static array $trustedHosts = [];
+
+    protected static bool $httpMethodParameterOverride = false;
+
+    /**
+     * The HTTP methods that can be overridden.
+     *
+     * @var uppercase-string[]|null
+     */
+    protected static ?array $allowedHttpMethodOverride = null;
+
+    protected static ?\Closure $requestFactory = null;
+
+    private ?string $preferredFormat = null;
+
+    private bool $isHostValid = true;
+    private bool $isForwardedValid = true;
+    private bool $isSafeContentPreferred;
+
+    private array $trustedValuesCache = [];
+
+    private static int $trustedHeaderSet = -1;
+
     private bool $isIisRewrite = false;
 
     /**
@@ -259,13 +301,13 @@ class Request
      */
     public function initialize(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null): void
     {
-        $this->request = new InputBag($request);
-        $this->query = new InputBag($query);
-        $this->attributes = new ParameterBag($attributes);
-        $this->cookies = new InputBag($cookies);
-        $this->files = new FileBag($files);
-        $this->server = new ServerBag($server);
-        $this->headers = new HeaderBag($this->server->getHeaders());
+        self::setProperty($this, 'request', new InputBag($request));
+        self::setProperty($this, 'query', new InputBag($query));
+        self::setProperty($this, 'attributes', new ParameterBag($attributes));
+        self::setProperty($this, 'cookies', new InputBag($cookies));
+        self::setProperty($this, 'files', new FileBag($files));
+        self::setProperty($this, 'server', new ServerBag($server));
+        self::setProperty($this, 'headers', new HeaderBag($this->server->getHeaders()));
 
         $this->content = $content;
         $this->languages = null;
@@ -467,23 +509,23 @@ class Request
     {
         $dup = clone $this;
         if (null !== $query) {
-            $dup->query = new InputBag($query);
+            self::setProperty($dup, 'query', new InputBag($query));
         }
         if (null !== $request) {
-            $dup->request = new InputBag($request);
+            self::setProperty($dup, 'request', new InputBag($request));
         }
         if (null !== $attributes) {
-            $dup->attributes = new ParameterBag($attributes);
+            self::setProperty($dup, 'attributes', new ParameterBag($attributes));
         }
         if (null !== $cookies) {
-            $dup->cookies = new InputBag($cookies);
+            self::setProperty($dup, 'cookies', new InputBag($cookies));
         }
         if (null !== $files) {
-            $dup->files = new FileBag($files);
+            self::setProperty($dup, 'files', new FileBag($files));
         }
         if (null !== $server) {
-            $dup->server = new ServerBag($server);
-            $dup->headers = new HeaderBag($dup->server->getHeaders());
+            self::setProperty($dup, 'server', new ServerBag($server));
+            self::setProperty($dup, 'headers', new HeaderBag($dup->server->getHeaders()));
         }
         $dup->languages = null;
         $dup->charsets = null;
@@ -515,13 +557,13 @@ class Request
      */
     public function __clone()
     {
-        $this->query = clone $this->query;
-        $this->request = clone $this->request;
-        $this->attributes = clone $this->attributes;
-        $this->cookies = clone $this->cookies;
-        $this->files = clone $this->files;
-        $this->server = clone $this->server;
-        $this->headers = clone $this->headers;
+        self::setProperty($this, 'query', clone $this->query);
+        self::setProperty($this, 'request', clone $this->request);
+        self::setProperty($this, 'attributes', clone $this->attributes);
+        self::setProperty($this, 'cookies', clone $this->cookies);
+        self::setProperty($this, 'files', clone $this->files);
+        self::setProperty($this, 'server', clone $this->server);
+        self::setProperty($this, 'headers', clone $this->headers);
     }
 
     public function __toString(): string
@@ -2218,5 +2260,14 @@ class Request
 
         // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
         return '' === preg_replace('/[-a-zA-Z0-9_]++\.?/', '', $host);
+    }
+
+    private static function setProperty(self $response, string $name, mixed $value): void
+    {
+        static $cache;
+
+        $r = $cache[$name] ??= new \ReflectionProperty(self::class, $name);
+
+        $r->setRawValue($response, $value);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -105,13 +105,13 @@ class Response
         'etag' => true,
     ];
 
-    public ResponseHeaderBag $headers;
+    public ResponseHeaderBag $headers {
+        set {
+            trigger_deprecation('symfony/http-foundation', '8.1', 'Directly setting property "headers" of "%s" is deprecated; pass the header bag as a constructor argument instead.', __CLASS__);
 
-    protected string $content;
-    protected string $version;
-    protected int $statusCode;
-    protected string $statusText;
-    protected ?string $charset = null;
+            $this->headers = $value;
+        }
+    }
 
     /**
      * Status codes translation table.
@@ -189,6 +189,12 @@ class Response
         511 => 'Network Authentication Required',                             // RFC6585
     ];
 
+    protected string $content;
+    protected string $version;
+    protected int $statusCode;
+    protected string $statusText;
+    protected ?string $charset = null;
+
     /**
      * Tracks headers already sent in informational responses.
      */
@@ -199,9 +205,9 @@ class Response
      *
      * @throws \InvalidArgumentException When the HTTP status code is not valid
      */
-    public function __construct(?string $content = '', int $status = 200, array $headers = [])
+    public function __construct(?string $content = '', int $status = 200, array|ResponseHeaderBag $headers = [])
     {
-        $this->headers = new ResponseHeaderBag($headers);
+        self::setHeaders($this, $headers instanceof ResponseHeaderBag ? $headers : new ResponseHeaderBag($headers));
         $this->setContent($content);
         $this->setStatusCode($status);
         $this->setProtocolVersion('1.0');
@@ -229,7 +235,7 @@ class Response
      */
     public function __clone()
     {
-        $this->headers = clone $this->headers;
+        self::setHeaders($this, clone $this->headers);
     }
 
     /**
@@ -480,13 +486,7 @@ class Response
             throw new \InvalidArgumentException(\sprintf('The HTTP status code "%s" is not valid.', $code));
         }
 
-        if (null === $text) {
-            $this->statusText = self::$statusTexts[$code] ?? 'unknown status';
-
-            return $this;
-        }
-
-        $this->statusText = $text;
+        $this->statusText = $text ?? self::$statusTexts[$code] ?? 'unknown status';
 
         return $this;
     }
@@ -1318,5 +1318,14 @@ class Response
                 $this->headers->remove('Cache-Control');
             }
         }
+    }
+
+    private static function setHeaders(self $response, ResponseHeaderBag $headers): void
+    {
+        static $r;
+
+        $r ??= new \ReflectionProperty(self::class, 'headers');
+
+        $r->setRawValue($response, $headers);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4",
+        "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/polyfill-mbstring": "^1.1"
     },
     "require-dev": {

--- a/src/Symfony/Component/HttpKernel/HttpClientKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpClientKernel.php
@@ -55,20 +55,25 @@ final class HttpClientKernel implements HttpKernelInterface
             'body' => $body,
         ] + $request->attributes->get('http_client_options', []));
 
-        $response = new Response($response->getContent(!$catch), $response->getStatusCode(), $response->getHeaders(!$catch));
-
-        $response->headers->remove('X-Body-File');
-        $response->headers->remove('X-Body-Eval');
-        $response->headers->remove('X-Content-Digest');
-
-        $response->headers = new class($response->headers->all()) extends ResponseHeaderBag {
+        $headers = new class($response->getHeaders(!$catch)) extends ResponseHeaderBag {
             protected function computeCacheControlValue(): string
             {
                 return $this->getCacheControlHeader(); // preserve the original value
             }
         };
+        $headers->remove('X-Body-File');
+        $headers->remove('X-Body-Eval');
+        $headers->remove('X-Content-Digest');
 
-        return $response;
+        try {
+            return new Response($response->getContent(!$catch), $response->getStatusCode(), $headers);
+        } catch (\TypeError) {
+            // BC with Symfony < 8.1
+            $response = new Response($response->getContent(!$catch), $response->getStatusCode());
+            $response->headers = $headers;
+
+            return $response;
+        }
     }
 
     private function getBody(Request $request): ?AbstractPart

--- a/src/Symfony/Component/HttpKernel/Tests/HttpClientKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpClientKernelTest.php
@@ -24,8 +24,8 @@ class HttpClientKernelTest extends TestCase
         $request = new Request();
         $request->attributes->set('http_client_options', ['max_redirects' => 50]);
 
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->once())->method('getStatusCode')->willReturn(200);
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
 
         $client = $this->createMock(HttpClientInterface::class);
         $client

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\Tests\Authentication;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -37,7 +36,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     {
         $this->session = new Session(new MockArraySessionStorage());
         $this->request = Request::create('https://localhost/');
-        $this->request->attributes = new ParameterBag(['_stateless' => false]);
+        $this->request->attributes->replace(['_stateless' => false]);
         $this->request->setSession($this->session);
         $this->exception = new AuthenticationException();
     }
@@ -81,7 +80,7 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
 
     public function testExceptionIsNotPersistedInSessionOnStatelessRequest()
     {
-        $this->request->attributes = new ParameterBag(['_stateless' => true]);
+        $this->request->attributes->replace(['_stateless' => true]);
 
         $handler = new DefaultAuthenticationFailureHandler($this->createStub(HttpKernelInterface::class), new HttpUtils(), [], new NullLogger());
         $handler->onAuthenticationFailure($this->request, $this->exception);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\SchemeRequestMatcher;
@@ -86,7 +85,7 @@ class ChannelListenerTest extends TestCase
     public function testSupportsWithoutHeaders()
     {
         $request = Request::create('http://symfony.com');
-        $request->headers = new HeaderBag();
+        $request->headers->replace([]);
 
         $accessMap = new AccessMap();
         $accessMap->add(new SchemeRequestMatcher('http'), [], 'https');

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -82,10 +82,16 @@ class ResponseListenerTest extends TestCase
 
     private function getResponse()
     {
-        $response = new Response();
-        $response->headers = $this->createMock(ResponseHeaderBag::class);
+        $headers = $this->createMock(ResponseHeaderBag::class);
 
-        return $response;
+        try {
+            return new Response('', 200, $headers);
+        } catch (\TypeError) {
+            $response = new Response();
+            $response->headers = $headers;
+
+            return $response;
+        }
     }
 
     private function getEvent(Request $request, Response $response, int $type = HttpKernelInterface::MAIN_REQUEST): ResponseEvent


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

PHP 8.4 property hooks allow adding a set hook to existing properties without breaking the public API. This PR leverages that to deprecate external direct assignments to Request and Response properties.

The goal is to make our beloved `Request` and `Response` objects safer by using `public private(set)` in 9.0.

That's only for public properties, which are the ones that hold value objects (`ParameterBag`/`HeaderBag`) which shouldn't be reassigned at will.