### PR TITLE
[TypeInfo] Fix resolving class const type

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -86,7 +86,8 @@ class StringTypeResolverTest extends TestCase
         yield [Type::array(Type::template('TValue', Type::mixed()), Type::template('TKey', Type::union(Type::int(), Type::string()))), 'array<TKey, TValue>', $typeContextFactory->createFromClassName(DummyCollection::class)];
         yield [Type::array(Type::template('TValue', Type::mixed()), Type::arrayKey()), 'array<array-key, TValue>', $typeContextFactory->createFromClassName(DummyCollection::class)];
         yield [Type::array(Type::bool(), Type::union(Type::template('TFoo', Type::int()), Type::template('TBar', Type::string()))), 'array<TFoo|TBar, bool>', $typeContextFactory->createFromClassName($dummyTemplateKeyUnion::class)];
-        yield [Type::array(Type::bool(), Type::arrayKey()), 'array<'.DummyWithConstants::class.'::DUMMY_STRING_A|'.DummyWithConstants::class.'::DUMMY_INT_A, bool>', $typeContextFactory->createFromClassName(DummyWithConstants::class)];
+        // explicitly test both with fully qualified class name and with imported short class name
+        yield [Type::array(Type::bool(), Type::arrayKey()), 'array<\\'.DummyWithConstants::class.'::DUMMY_STRING_A|DummyWithConstants::DUMMY_INT_A, bool>', $typeContextFactory->createFromClassName(DummyWithConstants::class)];
 
         // list
         yield [Type::list(Type::bool()), 'list<bool>'];
@@ -119,6 +120,7 @@ class StringTypeResolverTest extends TestCase
         // const fetch
         yield [Type::string(), DummyWithConstants::class.'::DUMMY_STRING_*'];
         yield [Type::string(), DummyWithConstants::class.'::DUMMY_STRING_A'];
+        yield [Type::string(), 'DummyWithConstants::DUMMY_STRING_A', $typeContextFactory->createFromClassName(DummyWithConstants::class)];
         yield [Type::int(), DummyWithConstants::class.'::DUMMY_INT_*'];
         yield [Type::int(), DummyWithConstants::class.'::DUMMY_INT_A'];
         yield [Type::float(), DummyWithConstants::class.'::DUMMY_FLOAT_*'];

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -43,6 +43,7 @@ use Symfony\Component\TypeInfo\Type\BackedEnumType;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\TypeContext\TypeContext;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 
@@ -144,8 +145,17 @@ final class StringTypeResolver implements TypeResolverInterface
                     'self' => $typeContext->getDeclaringClass(),
                     'static' => $typeContext->getCalledClass(),
                     'parent' => $typeContext->getParentClass(),
-                    default => $node->constExpr->className,
+                    default => null,
                 };
+
+                if (null === $className) {
+                    $classType = $this->resolveCustomIdentifier($node->constExpr->className, $typeContext);
+                    if (!$classType instanceof ObjectType) {
+                        return Type::mixed();
+                    }
+
+                    $className = $classType->getClassName();
+                }
 
                 if (!class_exists($className)) {
                     return Type::mixed();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

I use an array type with class constants for the key type:
```php

use App\Foo;

// ...
/** @var array<Foo::BAR|Foo::BAZ, string> */
// ...
```

It doesn't fail with SF 7.4.0. However, since 7.4.1 an exception is thrown, due to https://github.com/symfony/symfony/pull/62388:
> InvalidArgumentException: "mixed" is not a valid array key type.

#62738 didn't fully solve the issue. 

Class names for class constants are not resolved via type context (namespace, imports etc.) before this pr.