### PR TITLE
[Serializer] Fix nullable array constructor parameter overriding collection value type

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -1014,7 +1014,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         if (null !== $parameterType && $parameterTypeResolver ??= class_exists(ReflectionTypeResolver::class) ? new ReflectionTypeResolver() : false) {
             $resolvedParameterType = $parameterTypeResolver->resolve($parameterType);
             if ($resolvedParameterType->isSatisfiedBy(static fn (Type $t) => match (true) {
-                $t instanceof BuiltinType => !$type->isIdentifiedBy($t->getTypeIdentifier()),
+                $t instanceof BuiltinType && TypeIdentifier::NULL !== $t->getTypeIdentifier() => !$type->isIdentifiedBy($t->getTypeIdentifier()),
                 $t instanceof ObjectType => !$type->isIdentifiedBy($t->getClassName()),
                 default => false,
             })) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -471,6 +471,39 @@ class ObjectNormalizerTest extends TestCase
         $this->assertFalse($obj->isAttributeAllowed('userName'));
     }
 
+    public function testCollectionPropertyTypeNotOverriddenByNullableConstructorParameterType()
+    {
+        $extractor = new class implements PropertyTypeExtractorInterface {
+            public function getTypes(string $class, string $property, array $context = []): ?array
+            {
+                return null;
+            }
+
+            public function getType(string $class, string $property, array $context = []): ?Type
+            {
+                if (NullableArrayWithObjectsDummy::class === $class && 'items' === $property) {
+                    return Type::array(Type::object(NullableArrayItemDummy::class));
+                }
+
+                return null;
+            }
+        };
+
+        $normalizer = new ObjectNormalizer(null, null, null, $extractor);
+        $serializer = new Serializer([new ArrayDenormalizer(), $normalizer]);
+        $normalizer->setSerializer($serializer);
+
+        $obj = $normalizer->denormalize(
+            ['items' => [['name' => 'foo']]],
+            NullableArrayWithObjectsDummy::class,
+        );
+
+        $this->assertInstanceOf(NullableArrayWithObjectsDummy::class, $obj);
+        $this->assertCount(1, $obj->items);
+        $this->assertInstanceOf(NullableArrayItemDummy::class, $obj->items[0]);
+        $this->assertSame('foo', $obj->items[0]->name);
+    }
+
     public function testConstructorWithObjectTypeHintDenormalize()
     {
         $data = [
@@ -2255,5 +2288,22 @@ class ObjectWithMetadata
     public function getHello(): string
     {
         return 'Hello i am '.$this->getName();
+    }
+}
+
+class NullableArrayWithObjectsDummy
+{
+    public function __construct(
+        /** @var NullableArrayItemDummy[] */
+        public ?array $items = null,
+    ) {
+    }
+}
+
+class NullableArrayItemDummy
+{
+    public function __construct(
+        public string $name,
+    ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63513
| License       | MIT

When a constructor parameter has a native type of `?array` but a property type extractor returns a more specific collection type (e.g. `array<SomeClass>`), the type override check introduced in #63401 incorrectly treated the `null` component as a mismatch against the extractor's type. This caused the extractor's collection element type information to be discarded, resulting in array items being left as raw arrays instead of being denormalized into objects.
