### PR TITLE
 Use `parentElement` to set the class attribute within the Symfony toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -649,7 +649,7 @@
                                         An error occurred while loading the web debug toolbar. <a href="{{ url('_profiler_home')|escape('js') }}' + newToken + '">Open the web profiler.</a>\
                                     </div>\
                                 ';
-                                    sfwdt.parentNode.setAttribute('class', 'sf-toolbar sf-error-toolbar');
+                                    sfwdt.parentElement.setAttribute('class', 'sf-toolbar sf-error-toolbar');
                                 }
                             },
                             options


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Followup on #63530 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

As briefly mentioned here, the upstream did not include the change mentioned in https://github.com/symfony/symfony/pull/63530#issuecomment-3991203767
