### PR TITLE
[RateLimiter] Prevent negative token from causing integer underflow

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -70,7 +70,7 @@ final class SlidingWindow implements LimiterStateInterface
 
     public function add(int $hits = 1): void
     {
-        $this->hitCount += $hits;
+        $this->hitCount = max(0, $this->hitCount + $hits);
     }
 
     /**

--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -53,7 +53,7 @@ final class Window implements LimiterStateInterface
             $this->hitCount = 0;
         }
 
-        $this->hitCount += $hits;
+        $this->hitCount = max(0, $this->hitCount + $hits);
     }
 
     public function getHitCount(): int

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -201,6 +201,10 @@ class FixedWindowLimiterTest extends TestCase
     {
         $limiter = $this->createLimiter();
 
+        // negative consume without previous hits should have no effect
+        $rateLimit = $limiter->consume(-1);
+        $this->assertEquals(10, $rateLimit->getRemainingTokens());
+
         $limiter->consume(10);
 
         for ($i = 1; $i <= 3; ++$i) {

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -128,6 +128,10 @@ class SlidingWindowLimiterTest extends TestCase
     {
         $limiter = $this->createLimiter();
 
+        // negative consume without previous hits should have no effect
+        $rateLimit = $limiter->consume(-1);
+        $this->assertEquals(10, $rateLimit->getRemainingTokens());
+
         $limiter->consume(10);
 
         for ($i = 1; $i <= 3; ++$i) {

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -201,6 +201,10 @@ class TokenBucketLimiterTest extends TestCase
     {
         $limiter = $this->createLimiter();
 
+        // negative consume without previous hits should have no effect
+        $rateLimit = $limiter->consume(-1);
+        $this->assertEquals(10, $rateLimit->getRemainingTokens());
+
         $limiter->consume(10);
 
         for ($i = 1; $i <= 3; ++$i) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63548
| License       | MIT

This PR fixes an issue where consuming negative tokens could cause `hitCount` to become negative. Because it gets serialized with `pack('N')`, an integer underflow would occur.

### Example
```php
$factory = new RateLimiterFactory([
    'id' => 'test',
    'policy' => 'fixed_window',
    'limit' => 10,
    'interval' => '1 hour',
], new InMemoryStorage());

$limiter = $factory->create();
```

#### Before
```php
var_dump($limiter->consume(-1)->getRemainingTokens()); // int(11)          ❌
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(-4294967285) ❌
```

#### After
```php
var_dump($limiter->consume(-1)->getRemainingTokens()); // int(10) ✅ (no increase above limit)
var_dump($limiter->consume( 1)->getRemainingTokens()); // int(9)  ✅ (no integer underflow)
```