### PR TITLE
[Runtime] Add `SymfonyRuntime::resolveType()` for customizing how types are resolved in extending runtimes

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `resolveType()` for customizing how types are resolved in runtimes extending `SymfonyRuntime`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -173,7 +173,7 @@ class SymfonyRuntime extends GenericRuntime
                 return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max']);
             }
 
-            return new HttpKernelRunner($application, $this->request ??= Request::createFromGlobals(), $this->options['debug'] ?? false);
+            return new HttpKernelRunner($application, $this->resolveType(Request::class), $this->options['debug'] ?? false);
         }
 
         if ($application instanceof Response) {
@@ -181,7 +181,7 @@ class SymfonyRuntime extends GenericRuntime
         }
 
         if ($application instanceof Command) {
-            $console = $this->console ??= new Application();
+            $console = $this->resolveType(Application::class);
             $console->setName($application->getName() ?: $console->getName());
 
             if (!$application->getName() || !$console->has($application->getName())) {
@@ -203,13 +203,13 @@ class SymfonyRuntime extends GenericRuntime
         if ($application instanceof Application) {
             set_time_limit(0);
             $defaultEnv = !isset($this->options['env']) ? ($_SERVER[$this->options['env_var_name']] ?? 'dev') : null;
-            $output = $this->output ??= new ConsoleOutput();
+            $output = $this->resolveType(OutputInterface::class);
 
-            return new ConsoleApplicationRunner($application, $defaultEnv, $this->getInput(), $output);
+            return new ConsoleApplicationRunner($application, $defaultEnv, $this->resolveType(InputInterface::class), $output);
         }
 
         if (isset($this->command)) {
-            $this->getInput()->bind($this->command->getDefinition());
+            $this->resolveType(InputInterface::class)->bind($this->command->getDefinition());
         }
 
         return parent::getRunner($application);
@@ -217,13 +217,18 @@ class SymfonyRuntime extends GenericRuntime
 
     protected function getArgument(\ReflectionParameter $parameter, ?string $type): mixed
     {
+        return $this->resolveType($type) ?? parent::getArgument($parameter, $type);
+    }
+
+    protected function resolveType(string $type): mixed
+    {
         return match ($type) {
             Request::class => $this->request ??= Request::createFromGlobals(),
             InputInterface::class => $this->getInput(),
             OutputInterface::class => $this->output ??= new ConsoleOutput(),
             Application::class => $this->console ??= new Application(),
             Command::class => $this->command ??= new Command(),
-            default => parent::getArgument($parameter, $type),
+            default => null,
         };
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63536
| License       | MIT

SymfonyRuntime needs the request object in two places and uses a private variable to ensure that only one request object is instantiated. Runtimes building on top of SymfonyRuntime may also need access to this same request, but due to the private nature of the property this is impossible.

This can be solved with two options: A) make `$request` a protected instead of private property and B) make the `Request` instance available through a dedicated method.

The downside of A is that it requires extending classes to do the right thing. Instead by implementing option B and moving the instantiation logic into a shared space downstream runtimes are guided into doing the right thing.
