### PR TITLE
[HttpKernel] Fix int-to-float coercion for JSON #[MapRequestPayload] with pre-parsed array data

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -105,7 +105,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 try {
                     $payload = $this->$payloadMapper($request, $type, $argument);
                 } catch (PartialDenormalizationException $e) {
-                    $trans = $this->translator ? $this->translator->trans(...) : fn ($m, $p) => strtr($m, $p);
+                    $trans = $this->translator ? $this->translator->trans(...) : static fn ($m, $p) => strtr($m, $p);
                     foreach ($e->getErrors() as $error) {
                         $parameters = [];
                         $template = 'This value was of an unexpected type.';
@@ -187,7 +187,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
         }
 
         if (\is_array($data)) {
-            return $this->serializer->denormalize($data, $type, 'csv', $attribute->serializationContext + self::CONTEXT_DENORMALIZE);
+            return $this->serializer->denormalize($data, $type, 'form' === $format ? 'csv' : $format, $attribute->serializationContext + self::CONTEXT_DENORMALIZE);
         }
 
         if ('form' === $format) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -845,6 +845,58 @@ class RequestPayloadValueResolverTest extends TestCase
             $this->assertSame(\sprintf('This value should be of type %s.', class_exists(InvalidTypeException::class) ? 'string' : 'unknown'), $validationFailedException->getViolations()[0]->getMessage());
         }
     }
+
+    public function testMapRequestPayloadWithPreParsedJsonIntCoercesToFloat()
+    {
+        $serializer = new Serializer(
+            [new ObjectNormalizer(null, null, null, new ReflectionExtractor())],
+            ['json' => new JsonEncoder()]
+        );
+
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('payload', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = new Request([], ['price' => 0], [], [], [], ['CONTENT_TYPE' => 'application/json']);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        /** @var RequestPayload $payload */
+        [$payload] = $event->getArguments();
+        $this->assertInstanceOf(RequestPayload::class, $payload);
+        $this->assertSame(0.0, $payload->price);
+    }
+
+    public function testMapRequestPayloadWithFormDataCoercesStringToBool()
+    {
+        $serializer = new Serializer(
+            [new ObjectNormalizer(null, null, null, new ReflectionExtractor())],
+            []
+        );
+
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('payload', FormPayloadWithBool::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = new Request([], ['active' => '0'], [], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        /** @var FormPayloadWithBool $payload */
+        [$payload] = $event->getArguments();
+        $this->assertInstanceOf(FormPayloadWithBool::class, $payload);
+        $this->assertFalse($payload->active);
+    }
 }
 
 class RequestPayload
@@ -900,4 +952,11 @@ enum RequestMethod: string
 {
     case GET = 'GET';
     case POST = 'POST';
+}
+
+class FormPayloadWithBool
+{
+    public function __construct(public readonly bool $active)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63470
| License       | MIT

`mapRequestPayload()` passes a hardcoded `'csv'` to `denormalize()` when request data is
already a PHP array. `AbstractObjectNormalizer`'s int-to-float coercion requires a JSON-based
format, so `{"price": 0}` fails to map to a `float` property.

The fix passes the request's actual format when the pre-parsed array contains a non-string
scalar (meaning it was decoded from JSON). Arrays with only string values (form-submitted data)
still use `'csv'`, keeping `'0'` to `bool` coercions working. `mapQueryString()` is unchanged.
