### PR TITLE
[Validator] Accept the `::class` constant of the annotated class in `GroupSequence`

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Accept the `::class` constant of the annotated class in `GroupSequence` definitions
  * Add the `cascadeCurrentGroup` option to `GroupSequence` and `GroupSequenceProvider`
  * Remove the unused `GroupSequence::$cascadedGroup` property
  * Add the `restrictGroups` option to the `Valid` constraint

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -363,6 +363,17 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             $groupSequence = new GroupSequence($groupSequence);
         }
 
+        // the ::class constant of the annotated class is an alias of its group name
+        $groups = $groupSequence->groups;
+        foreach ($groups as $i => $group) {
+            if (\is_string($group) && $this->name === ltrim($group, '\\')) {
+                $groups[$i] = $this->getDefaultGroup();
+            }
+        }
+        if ($groups !== $groupSequence->groups) {
+            $groupSequence = new GroupSequence($groups);
+        }
+
         if (\in_array(Constraint::DEFAULT_GROUP, $groupSequence->groups, true)) {
             throw new GroupDefinitionException(\sprintf('The group "%s" is not allowed in group sequences.', Constraint::DEFAULT_GROUP));
         }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -280,6 +280,20 @@ class ClassMetadataTest extends TestCase
         $this->assertInstanceOf(GroupSequence::class, $this->metadata->getGroupSequence());
     }
 
+    public function testGroupSequenceAcceptsTheClassConstantAsTheDefaultGroup()
+    {
+        $this->metadata->setGroupSequence(['Foo', Entity::class]);
+
+        $this->assertSame(['Foo', 'Entity'], $this->metadata->getGroupSequence()->groups);
+    }
+
+    public function testGroupSequenceLeavesForeignClassNamesUntouched()
+    {
+        $this->expectException(GroupDefinitionException::class);
+
+        $this->metadata->setGroupSequence(['Foo', ConstraintA::class]);
+    }
+
     public function testGroupSequencesFailIfNotContainingDefaultGroup()
     {
         $this->expectException(GroupDefinitionException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

The class name group in a `GroupSequence` had to be spelled as the short class name, a plain string no IDE relates to the class, so renaming the class silently detached its sequence:

```php
#[GroupSequence(['Foo', 'Baz', 'Bar'])]
class Baz
```

The `::class` constant of the annotated class is now accepted as an alias:

```php
#[GroupSequence(['Foo', Baz::class, 'Bar'])]
class Baz
```

`setGroupSequence()` rewrites an entry equal to the FQCN of the annotated class to its group name, so the stored sequence, serialized metadata, group matching and every existing short-name sequence are byte for byte unchanged. Only the class's own FQCN is rewritten; other class names in a sequence keep meaning whatever group string they spell.

Documentation should cover: the `::class` alias, that it only applies to the annotated class itself, and that short names keep working.
