### PR TITLE
[Messenger] Flush batch handlers after inactivity timeout when worker is busy

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -518,6 +518,7 @@ class WorkerTest extends TestCase
         $receiver = new DummyReceiver([
             [new Envelope($expectedMessages[0])],
             [],
+            [],
         ]);
 
         $handler = new DummyBatchHandler();
@@ -527,19 +528,21 @@ class WorkerTest extends TestCase
         ]));
 
         $bus = new MessageBus([$middleware]);
+        $clock = new MockClock();
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver) {
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($receiver, $clock) {
             static $i = 0;
-            if (1 < ++$i) {
+            if (1 === ++$i) {
+                $this->assertSame(0, $receiver->getAcknowledgeCount());
+                $clock->sleep(30);
+            } elseif (2 === $i) {
                 $event->getWorker()->stop();
                 $this->assertSame(1, $receiver->getAcknowledgeCount());
-            } else {
-                $this->assertSame(0, $receiver->getAcknowledgeCount());
             }
         });
 
-        $worker = new Worker([$receiver], $bus, $dispatcher, clock: new MockClock());
+        $worker = new Worker([$receiver], $bus, $dispatcher, clock: $clock);
         $worker->run();
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
@@ -621,6 +624,54 @@ class WorkerTest extends TestCase
         $this->assertSame($secondHandlerExpectedMessages, $secondHandler->processedMessages);
     }
 
+    public function testBatchFlushOnInactivityWhileWorkerIsBusy()
+    {
+        $batchHandler = new LargeBatchHandler();
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($batchHandler)],
+            SecondHandlerDummyMessage::class => [new HandlerDescriptor(function (SecondHandlerDummyMessage $message) {})],
+        ]));
+
+        $bus = new MessageBus([$middleware]);
+        $clock = new MockClock('2024-01-01 00:00:00+00:00');
+
+        // 1 batch message, then 34 non-batch messages keeping the worker busy.
+        // The batch handler requires 100 messages to flush on its own,
+        // so shouldFlush() never triggers. The worker is never idle either.
+        $envelopes = [[new Envelope(new DummyMessage('batch'))]];
+        for ($i = 0; $i < 34; ++$i) {
+            $envelopes[] = [new Envelope(new SecondHandlerDummyMessage('regular'.$i))];
+        }
+        $receiver = new DummyReceiver($envelopes);
+
+        $loopCount = 0;
+        $flushedAtLoop = null;
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, static function (WorkerRunningEvent $event) use ($clock, &$loopCount, &$flushedAtLoop, $batchHandler) {
+            ++$loopCount;
+            $clock->sleep(1);
+
+            if ($batchHandler->processedMessages) {
+                $flushedAtLoop ??= $loopCount;
+            }
+
+            if (43 <= $loopCount) {
+                $event->getWorker()->stop();
+            }
+        });
+
+        $worker = new Worker(['transport' => $receiver], $bus, $dispatcher, clock: $clock);
+        $worker->run();
+
+        // The batch message was received at t=0, then only non-batch messages arrived.
+        // After 30s of batch inactivity, the worker should force-flush.
+        $this->assertNotNull($flushedAtLoop, 'Batch should have been flushed after inactivity timeout');
+        $this->assertGreaterThanOrEqual(30, $flushedAtLoop);
+        $this->assertLessThanOrEqual(33, $flushedAtLoop);
+        $this->assertSame(['batch'], array_map(static fn ($m) => $m->getMessage(), $batchHandler->processedMessages));
+    }
+
     public function testFlushRemovesNoAutoAckStampOnException()
     {
         $envelope = new Envelope(new DummyMessage('Test'));
@@ -648,12 +699,11 @@ class WorkerTest extends TestCase
 
         $worker = new Worker(['transport' => $receiver], $bus, $dispatcher, clock: new MockClock());
 
-        $reflection = new \ReflectionClass($worker);
-        $unacksProperty = $reflection->getProperty('unacks');
-        $unacks = $unacksProperty->getValue($worker);
         $dummyHandler = new DummyBatchHandler();
         $envelopeWithNoAutoAck = $envelope->with(new NoAutoAckStamp(new HandlerDescriptor($dummyHandler)));
-        $unacks[$dummyHandler] = [$envelopeWithNoAutoAck, 'transport'];
+        $unacks = new \SplObjectStorage();
+        $unacks[$dummyHandler] = [$envelopeWithNoAutoAck, 'transport', 0];
+        (new \ReflectionProperty($worker, 'unacks'))->setValue($worker, $unacks);
 
         $worker->run();
 
@@ -718,6 +768,32 @@ class SecondDummyBatchHandler implements BatchHandlerInterface
     private function process(array $jobs): void
     {
         $this->processedMessages = array_column($jobs, 0);
+
+        foreach ($jobs as [$job, $ack]) {
+            $ack->ack($job);
+        }
+    }
+}
+
+class LargeBatchHandler implements BatchHandlerInterface
+{
+    use BatchHandlerTrait;
+
+    public array $processedMessages = [];
+
+    public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+    {
+        return $this->handle($message, $ack);
+    }
+
+    private function shouldFlush(): bool
+    {
+        return 100 <= \count($this->jobs);
+    }
+
+    private function process(array $jobs): void
+    {
+        $this->processedMessages = array_merge($this->processedMessages, array_column($jobs, 0));
 
         foreach ($jobs as [$job, $ack]) {
             $ack->ack($job);

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -45,7 +45,7 @@ class Worker
     private bool $shouldStop = false;
     private WorkerMetadata $metadata;
     private array $acks = [];
-    private \SplObjectStorage $unacks;
+    private ?\SplObjectStorage $unacks = null;
 
     /**
      * @param ReceiverInterface[] $receivers Where the key is the transport name
@@ -61,7 +61,6 @@ class Worker
         $this->metadata = new WorkerMetadata([
             'transportNames' => array_keys($receivers),
         ]);
-        $this->unacks = new \SplObjectStorage();
     }
 
     /**
@@ -125,7 +124,7 @@ class Worker
                 continue;
             }
 
-            if (!$envelopeHandled) {
+            if (!$this->flush(30.0) && !$envelopeHandled) {
                 $this->eventDispatcher?->dispatch(new WorkerRunningEvent($this, true));
 
                 if (0 < $sleep = (int) ($options['sleep'] - 1e6 * ($this->clock->now()->format('U.u') - $envelopeHandledStart->format('U.u')))) {
@@ -165,7 +164,8 @@ class Worker
         if (!$acked && !$noAutoAckStamp) {
             $this->acks[] = [$transportName, $envelope, $e];
         } elseif ($noAutoAckStamp) {
-            $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName];
+            $this->unacks ??= new \SplObjectStorage();
+            $this->unacks[$noAutoAckStamp->getHandlerDescriptor()->getBatchHandler()] = [$envelope->withoutAll(AckStamp::class), $transportName, $this->clock->now()->format('U.u')];
         }
 
         $this->ack();
@@ -243,18 +243,38 @@ class Worker
         $rateLimiter->consume();
     }
 
-    private function flush(bool $force): bool
+    private function flush(bool|float $force): bool
     {
-        $unacks = $this->unacks;
+        if (!$this->unacks) {
+            return false;
+        }
+
+        if (\is_bool($force)) {
+            $unacks = $this->unacks;
+            $this->unacks = null;
+        } else {
+            $now = $this->clock->now()->format('U.u');
+            $remaining = new \SplObjectStorage();
+            $unacks = new \SplObjectStorage();
+
+            foreach ($this->unacks as $handler) {
+                if ($force <= $now - $this->unacks[$handler][2]) {
+                    $unacks[$handler] = $this->unacks[$handler];
+                } else {
+                    $remaining[$handler] = $this->unacks[$handler];
+                }
+            }
+
+            $this->unacks = $remaining->count() ? $remaining : null;
+            $force = true;
+        }
 
         if (!$unacks->count()) {
             return false;
         }
 
-        $this->unacks = new \SplObjectStorage();
-
-        foreach ($unacks as $batchHandler) {
-            [$envelope, $transportName] = $unacks[$batchHandler];
+        foreach ($unacks as $handler) {
+            [$envelope, $transportName] = $unacks[$handler];
             try {
                 $this->bus->dispatch($envelope->with(new FlushBatchHandlersStamp($force)));
             } catch (\Throwable $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63540
| License       | MIT

Batch handlers keep messages unacknowledged until the batch is full or the worker goes idle. When the worker is continuously busy handling non-batch messages, it never goes idle, so batch messages sit unacknowledged indefinitely. With RabbitMQ 4 quorum queues, this eventually kills the consumer.

This PR adds a per-handler inactivity timeout to Worker::flush(). Each unacked batch handler now tracks the timestamp of its last received message. After 30 seconds of inactivity (no new messages for that handler), the worker force-flushes it, even if the worker itself is busy processing other messages.

Note that 30 seconds is arbitrary. Giving control over this will need a new API, thus for 8.1, instead of or on top of #63277.