### PR TITLE
[Messenger] Make $clock nullable in PostgreSqlNotifyOnIdleListener

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -147,9 +147,9 @@ class AmqpReceiverTest extends TestCase
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
         $amqpEnvelope = $this->createAMQPEnvelope();
-        $connection = $this->createMock(Connection::class);
+        $connection = $this->createStub(Connection::class);
         $connection->method('getQueueNames')->willReturn(['queueName']);
-        $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
+        $connection->method('get')->willReturn($amqpEnvelope);
 
         $receiver = new AmqpReceiver($connection, $serializer);
         $envelopes = iterator_to_array($receiver->get());

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/EventListener/PostgreSqlNotifyOnIdleListener.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/EventListener/PostgreSqlNotifyOnIdleListener.php
@@ -13,9 +13,8 @@ namespace Symfony\Component\Messenger\Bridge\Doctrine\EventListener;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Types\Types;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Clock\Clock;
-use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
@@ -40,7 +39,7 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
 
     public function __construct(
         private ?LoggerInterface $logger = null,
-        private ClockInterface $clock = new Clock(),
+        private ?ClockInterface $clock = null,
     ) {
     }
 
@@ -98,10 +97,12 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
             return;
         }
 
+        $now = $this->clock?->now()->format('U.u') ?? microtime(true);
+
         // Cap by worker deadline (--time-limit) — checked first to avoid a SQL query
         // in getEarliestDelayedMessageTime() when the worker is already past its deadline.
         if (null !== $this->deadline) {
-            $deadline = ($this->deadline - $this->clock->now()->format('U.u')) * 1000;
+            $deadline = ($this->deadline - $now) * 1000;
             if (0 >= $timeout = min($timeout, $deadline)) {
                 return;
             }
@@ -109,8 +110,7 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
 
         // Cap by earliest delayed message across all PG queues: wake up in time to process it
         if (null !== $earliest = $this->getEarliestDelayedMessageTime()) {
-            $now = $this->clock->now();
-            $msUntilEarliest = ($earliest->format('U.u') - $now->format('U.u')) * 1000;
+            $msUntilEarliest = ($earliest->format('U.u') - $now) * 1000;
             if (0 >= $timeout = min($timeout, $msUntilEarliest)) {
                 return;
             }
@@ -171,12 +171,11 @@ class PostgreSqlNotifyOnIdleListener implements EventSubscriberInterface
     {
         $config = $this->activeConnection->getConfiguration();
         $dbal = $this->activeConnection->getDriverConnection();
-        $now = $this->clock->now();
 
         $sql = \sprintf('SELECT MIN(available_at) FROM %s WHERE queue_name IN (?) AND available_at > ? AND delivered_at IS NULL', $config['table_name']);
         $result = $dbal->executeQuery($sql, [
             $this->queueNames,
-            $now,
+            $this->clock?->now() ?? new \DateTimeImmutable(),
         ], [
             ArrayParameterType::STRING,
             Types::DATETIME_IMMUTABLE,

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": ">=8.4",
         "doctrine/dbal": "^4.3",
-        "symfony/clock": "^7.4|^8.0",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^7.4|^8.0",
         "symfony/messenger": "^8.1",

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
@@ -270,8 +270,8 @@ class RedisReceiverTest extends TestCase
             ],
         ];
 
-        $connection = $this->createMock(Connection::class);
-        $connection->method('find')->with('123')->willReturn($message);
+        $connection = $this->createStub(Connection::class);
+        $connection->method('find')->willReturn($message);
 
         $receiver = new RedisReceiver($connection, new Serializer(
             new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
@@ -286,8 +286,8 @@ class RedisReceiverTest extends TestCase
 
     public function testFindReturnsNullForNonExistentMessage()
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->method('find')->with('999')->willReturn(null);
+        $connection = $this->createStub(Connection::class);
+        $connection->method('find')->willReturn(null);
 
         $receiver = new RedisReceiver($connection, new Serializer(
             new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
@@ -306,8 +306,8 @@ class RedisReceiverTest extends TestCase
             ],
         ];
 
-        $connection = $this->createMock(Connection::class);
-        $connection->method('find')->with('123')->willReturn($message);
+        $connection = $this->createStub(Connection::class);
+        $connection->method('find')->willReturn($message);
 
         $receiver = new RedisReceiver($connection, new Serializer(
             new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])

--- a/src/Symfony/Component/Messenger/Handler/Acknowledger.php
+++ b/src/Symfony/Component/Messenger/Handler/Acknowledger.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Messenger\Handler;
 
-use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Messenger\Exception\LogicException;
 
 /**

--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Messenger\Handler;
 
-use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This makes conditional wiring easier, as spotted in https://github.com/doctrine/DoctrineBundle/pull/2204