### PR TITLE
[Console] Fix OUTPUT_RAW corrupting binary content on Windows

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -142,12 +142,27 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      */
     private function openOutputStream()
     {
+        static $stdout;
+
+        if ($stdout) {
+            return $stdout;
+        }
+
         if (!$this->hasStdoutSupport()) {
-            return fopen('php://output', 'w');
+            return $stdout = fopen('php://output', 'w');
         }
 
         // Use STDOUT when possible to prevent from opening too many file descriptors
-        return \defined('STDOUT') ? \STDOUT : (@fopen('php://stdout', 'w') ?: fopen('php://output', 'w'));
+        if (!\defined('STDOUT')) {
+            return $stdout = @fopen('php://stdout', 'w') ?: fopen('php://output', 'w');
+        }
+
+        // On Windows, STDOUT is opened in text mode; reopen in binary mode to prevent \n to \r\n conversion
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            return $stdout = @fopen('php://stdout', 'w') ?: \STDOUT;
+        }
+
+        return $stdout = \STDOUT;
     }
 
     /**
@@ -155,11 +170,26 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      */
     private function openErrorStream()
     {
+        static $stderr;
+
+        if ($stderr) {
+            return $stderr;
+        }
+
         if (!$this->hasStderrSupport()) {
-            return fopen('php://output', 'w');
+            return $stderr = fopen('php://output', 'w');
         }
 
         // Use STDERR when possible to prevent from opening too many file descriptors
-        return \defined('STDERR') ? \STDERR : (@fopen('php://stderr', 'w') ?: fopen('php://output', 'w'));
+        if (!\defined('STDERR')) {
+            return $stderr = @fopen('php://stderr', 'w') ?: fopen('php://output', 'w');
+        }
+
+        // On Windows, STDERR is opened in text mode; reopen in binary mode to prevent \n → \r\n conversion
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            return $stderr = @fopen('php://stderr', 'w') ?: \STDERR;
+        }
+
+        return $stderr ??= \STDERR;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/binary_output.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/binary_output.php
@@ -1,0 +1,13 @@
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+$output = new ConsoleOutput();
+$output->write("HELLO\nWORLD", false, OutputInterface::OUTPUT_RAW);

--- a/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests\Output;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Process\Process;
 
 class StreamOutputTest extends TestCase
 {
@@ -64,5 +65,13 @@ class StreamOutputTest extends TestCase
         $output = new StreamOutput($resource);
         rewind($output->getStream());
         $this->assertEquals('', stream_get_contents($output->getStream()));
+    }
+
+    public function testRawOutputPreservesNewlinesInContent()
+    {
+        $process = new Process(['php', __DIR__.'/../Fixtures/binary_output.php']);
+        $process->run();
+
+        $this->assertSame("HELLO\nWORLD", $process->getOutput(), 'Raw output must not convert LF in binary content');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61326 
| License       | MIT

On Windows, the predefined STDOUT and STDERR constants are opened by the PHP runtime in text mode, which causes \n to be silently converted to \r\n on write. This corrupts binary output.

The fix reopens php://stdout and php://stderr in binary mode ('w' means 'wb') in ConsoleOutput::openOutputStream() / openErrorStream() on Windows, instead of using the text-mode STDOUT/STDERR constants directly. The opened streams are cached in static variables to avoid opening extra file descriptors.
