### PR TITLE
[Runtime] Add RuntimeTypeResolverInterface and type-resolvers option for SymfonyRuntime

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `resolveType()` for customizing how types are resolved in runtimes extending `SymfonyRuntime`
+ * Add `RuntimeTypeResolverInterface` and support for `type-resolvers` option in `SymfonyRuntime` to allow registering type resolvers in `composer.json` without needing a custom runtime
 
 7.4
 ---

--- a/src/Symfony/Component/Runtime/RuntimeTypeResolverInterface.php
+++ b/src/Symfony/Component/Runtime/RuntimeTypeResolverInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime;
+
+/**
+ * Resolves a value for a given type in the context of a SymfonyRuntime.
+ *
+ * Type resolvers can be registered in a project's composer.json under the
+ * "extra.runtime.type-resolvers" key, mapping fully-qualified class names
+ * to resolver class names implementing this interface.
+ *
+ * Arguments from the runtime can be accessed by type-hinting the constructor of
+ * the implementing class in the same way as can be done by a front-controller.
+ *
+ * @author Alexander Varwijk <git@alexandervarwijk.com>
+ */
+interface RuntimeTypeResolverInterface
+{
+    /**
+     * Resolves a value for the given fully-qualified type name.
+     *
+     * @param string $type The fully-qualified class or interface name to resolve
+     */
+    public function resolveType(string $type): mixed;
+}

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -75,6 +75,9 @@ class SymfonyRuntime extends GenericRuntime
     private readonly Command $command;
     private readonly Request $request;
 
+    /** @var array<string, RuntimeTypeResolverInterface> */
+    private array $typeResolverInstances = [];
+
     /**
      * @param array{
      *   debug?: ?bool,
@@ -93,6 +96,7 @@ class SymfonyRuntime extends GenericRuntime
      *   dotenv_overload?: ?bool,
      *   dotenv_extra_paths?: ?string[],
      *   worker_loop_max?: int, // Use 0 or a negative integer to never restart the worker. Default: 500
+     *   type-resolvers?: array<string, class-string<RuntimeTypeResolverInterface>>, // Maps type names to resolver class names
      * } $options
      */
     public function __construct(array $options = [])
@@ -222,6 +226,16 @@ class SymfonyRuntime extends GenericRuntime
 
     protected function resolveType(string $type): mixed
     {
+        if (isset($this->options['type-resolvers'][$type])) {
+            $resolverClass = $this->options['type-resolvers'][$type];
+
+            if (!isset($this->typeResolverInstances[$resolverClass])) {
+                $this->typeResolverInstances[$resolverClass] = $this->instantiateTypeResolver($resolverClass);
+            }
+
+            return $this->typeResolverInstances[$resolverClass]->resolveType($type);
+        }
+
         return match ($type) {
             Request::class => $this->request ??= Request::createFromGlobals(),
             InputInterface::class => $this->getInput(),
@@ -230,6 +244,31 @@ class SymfonyRuntime extends GenericRuntime
             Command::class => $this->command ??= new Command(),
             default => null,
         };
+    }
+
+    protected function instantiateTypeResolver(string $resolverClass): RuntimeTypeResolverInterface
+    {
+        if (!class_exists($resolverClass)) {
+            throw new \LogicException(\sprintf('Type resolver class "%s" does not exist.', $resolverClass));
+        }
+
+        if (!is_subclass_of($resolverClass, RuntimeTypeResolverInterface::class)) {
+            throw new \LogicException(\sprintf('Type resolver class "%s" must implement "%s".', $resolverClass, RuntimeTypeResolverInterface::class));
+        }
+
+        $constructor = new \ReflectionClass($resolverClass)->getConstructor();
+
+        if (null === $constructor || 0 === $constructor->getNumberOfParameters()) {
+            return new $resolverClass();
+        }
+
+        $arguments = [];
+        foreach ($constructor->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            $arguments[] = $this->getArgument($parameter, $type instanceof \ReflectionNamedType ? $type->getName() : null);
+        }
+
+        return new $resolverClass(...$arguments);
     }
 
     protected static function register(GenericRuntime $runtime): GenericRuntime

--- a/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
+++ b/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Runtime\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Runtime\Runner\FrankenPhpWorkerRunner;
+use Symfony\Component\Runtime\RuntimeTypeResolverInterface;
 use Symfony\Component\Runtime\SymfonyRuntime;
 
 class SymfonyRuntimeTest extends TestCase
@@ -49,5 +51,182 @@ class SymfonyRuntimeTest extends TestCase
         $this->expectExceptionMessage('The "worker_loop_max" runtime option must be an integer, "bool" given.');
 
         new SymfonyRuntime(['worker_loop_max' => false]);
+    }
+
+    public function testTypeResolverIsCalledForMappedType()
+    {
+        $runtime = new SymfonyRuntime([
+            'error_handler' => false,
+            'type-resolvers' => [
+                TypeResolverFixture::class => SimpleTypeResolverFixture::class,
+            ],
+        ]);
+
+        $result = $this->callResolveType($runtime, TypeResolverFixture::class);
+
+        $this->assertInstanceOf(TypeResolverFixture::class, $result);
+    }
+
+    public function testTypeResolverIsLazilyInstantiated()
+    {
+        $runtime = new SymfonyRuntime([
+            'error_handler' => false,
+            'type-resolvers' => [
+                TypeResolverFixture::class => CountsInstantiationResolverFixture::class,
+            ],
+        ]);
+
+        $this->assertEquals(0, CountsInstantiationResolverFixture::$instantiationCount, 'Type resolver should not be instantiated until the type it resolves is requested.');
+
+        $this->callResolveType($runtime, TypeResolverFixture::class);
+        $this->callResolveType($runtime, TypeResolverFixture::class);
+
+        $this->assertEquals(1, CountsInstantiationResolverFixture::$instantiationCount, 'Type resolver should only be instantiated once.');
+    }
+
+    public function testTypeResolverWithConstructorInjection()
+    {
+        $runtime = new SymfonyRuntime([
+            'error_handler' => false,
+            'type-resolvers' => [
+                TypeResolverFixture::class => TypeResolverWithRequestFixture::class,
+            ],
+        ]);
+
+        $result = $this->callResolveType($runtime, TypeResolverFixture::class);
+
+        $this->assertInstanceOf(TypeResolverFixture::class, $result);
+        $this->assertInstanceOf(Request::class, $result->injectedRequest);
+    }
+
+    public function testTypeResolverUnmappedTypeReturnsNull()
+    {
+        $runtime = new SymfonyRuntime([
+            'error_handler' => false,
+            'type-resolvers' => [],
+        ]);
+
+        $result = $this->callResolveType($runtime, TypeResolverFixture::class);
+
+        $this->assertNull($result);
+    }
+
+    public function testTypeResolverNonExistentClassThrows()
+    {
+        $runtime = new SymfonyRuntime([
+            'error_handler' => false,
+            'type-resolvers' => [
+                TypeResolverFixture::class => 'NonExistent\TypeResolver',
+            ],
+        ]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Type resolver class "NonExistent\TypeResolver" does not exist.');
+
+        $this->callResolveType($runtime, TypeResolverFixture::class);
+    }
+
+    public function testTypeResolverNotImplementingInterfaceThrows()
+    {
+        $runtime = new SymfonyRuntime([
+            'error_handler' => false,
+            'type-resolvers' => [
+                TypeResolverFixture::class => \stdClass::class,
+            ],
+        ]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Type resolver class "%s" must implement "%s".', \stdClass::class, RuntimeTypeResolverInterface::class));
+
+        $this->callResolveType($runtime, TypeResolverFixture::class);
+    }
+
+    public function testTypeResolverCanOverrideBuiltInType()
+    {
+        $runtime = new SymfonyRuntime([
+            'error_handler' => false,
+            'type-resolvers' => [
+                Request::class => OverridingRequestResolverFixture::class,
+            ],
+        ]);
+
+        $result = $this->callResolveType($runtime, Request::class);
+
+        $this->assertInstanceOf(Request::class, $result);
+        $this->assertSame('/custom', $result->getPathInfo());
+    }
+
+    private function callResolveType(SymfonyRuntime $runtime, string $type): mixed
+    {
+        $method = new \ReflectionMethod($runtime, 'resolveType');
+
+        return $method->invoke($runtime, $type);
+    }
+}
+
+/**
+ * A simple value object used as the "type" to be resolved in tests.
+ */
+class TypeResolverFixture
+{
+    public function __construct(public readonly ?Request $injectedRequest = null)
+    {
+    }
+}
+
+/**
+ * A type resolver with no constructor dependencies.
+ */
+class SimpleTypeResolverFixture implements RuntimeTypeResolverInterface
+{
+    private ?TypeResolverFixture $instance = null;
+
+    public function resolveType(string $type): mixed
+    {
+        return $this->instance ??= new TypeResolverFixture();
+    }
+}
+
+/**
+ * A type resolver that requires a Request to be injected via constructor.
+ */
+class TypeResolverWithRequestFixture implements RuntimeTypeResolverInterface
+{
+    public function __construct(private readonly Request $request)
+    {
+    }
+
+    public function resolveType(string $type): mixed
+    {
+        return new TypeResolverFixture($this->request);
+    }
+}
+
+/**
+ * A type resolver that overrides the built-in Request resolution.
+ */
+class OverridingRequestResolverFixture implements RuntimeTypeResolverInterface
+{
+    public function resolveType(string $type): mixed
+    {
+        return Request::create('/custom');
+    }
+}
+
+/**
+ * A type resolver that counts how often it was instantiated.
+ */
+class CountsInstantiationResolverFixture implements RuntimeTypeResolverInterface
+{
+    public static int $instantiationCount = 0;
+
+    public function __construct()
+    {
+        ++self::$instantiationCount;
+    }
+
+    public function resolveType(string $type): mixed
+    {
+        return new TypeResolverFixture();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63565
| License       | MIT

Adds a `RuntimeTypeResolverInterface` with a single `resolveType(string $type): mixed` method and wires it into `SymfonyRuntime::resolveType()`. Users can now register type resolvers in their project's `composer.json` without needing a custom runtime:

```json
{
    "extra": {
        "runtime": {
            "type-resolvers": {
                "Psr\\Http\\Message\\RequestInterface": "App\\SymfonyToPsr7RequestResolver"
            }
        }
    }
}
```

Type resolver classes are lazily instantiated when their mapped type is first requested. Constructor dependencies are injected by reflecting on the constructor and resolving each parameter through `getArgument()`, giving resolvers access to all types the runtime already knows how to resolve (e.g. `Request`, `InputInterface`).

User-configured type resolvers take precedence over built-in types. This allows applications to overwrite runtime behavior where desirable; without having to replace the entire runtime.