### PR TITLE
[Form] Fix duplicate validation errors when ValidatorExtension is instantiated multiple times

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -44,6 +44,12 @@ class ValidatorExtension extends AbstractExtension
         // the DIC, where the XML file is loaded automatically. Thus the following
         // code must be kept synchronized with validation.xml
 
+        foreach ($metadata->getConstraints() as $constraint) {
+            if ($constraint instanceof Form) {
+                return;
+            }
+        }
+
         $metadata->addConstraint(new Form());
         $metadata->addConstraint(new Traverse(false));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -46,4 +46,22 @@ class ValidatorExtensionTest extends TestCase
         $this->assertSame(TraversalStrategy::NONE, $metadata->getTraversalStrategy());
         $this->assertCount(0, $metadata->getPropertyMetadata('children'));
     }
+
+    public function testNoDoubleConstraintWhenInstantiatedTwice()
+    {
+        $metadata = new ClassMetadata(Form::class);
+
+        $metadataFactory = new FakeMetadataFactory();
+        $metadataFactory->addMetadata($metadata);
+
+        $validator = Validation::createValidatorBuilder()
+            ->setMetadataFactory($metadataFactory)
+            ->getValidator();
+
+        new ValidatorExtension($validator, false);
+        new ValidatorExtension($validator, false);
+
+        $this->assertCount(1, $metadata->getConstraints());
+        $this->assertInstanceOf(FormConstraint::class, $metadata->getConstraints()[0]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63516
| License       | MIT

`ValidatorExtension` unconditionally adds the `Form` constraint on the shared validator class metadata. When a third party creates its own form factory alongside `FrameworkBundle`'s, both sharing the same validator instance, `ValidatorExtension` is instantiated twice, registering the Form constraint twice.

