### PR TITLE
[HttpClient] Fix CachingHttpClient compatibility with decorator clients on 304 responses

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -98,6 +98,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
     private TagAwareCacheInterface|HttpCache $cache;
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
+    private bool $isInnerRequest = false;
 
     /**
      * @param bool     $sharedCache Indicates whether this cache is shared or private. When true, responses
@@ -145,6 +146,10 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
+        if ($this->isInnerRequest) {
+            return $this->client->request($method, $url, $options);
+        }
+
         if ($this->cache instanceof HttpCache) {
             return $this->legacyRequest($method, $url, $options);
         }
@@ -200,34 +205,79 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
         // consistent expiration time for all items
         $expiresAt = null === $this->maxTtl ? null : \DateTimeImmutable::createFromFormat('U', time() + $this->maxTtl);
 
-        return new AsyncResponse(
-            $this->client,
-            $method,
+        $passthru = function (ChunkInterface $chunk, AsyncContext $context) use (
+            $expiresAt,
+            $fullUrlTag,
+            $requestHash,
+            $varyKey,
+            $varyFields,
+            &$metadataKey,
+            $cachedData,
+            $freshness,
             $url,
+            $method,
             $options,
-            function (ChunkInterface $chunk, AsyncContext $context) use (
-                $expiresAt,
-                $fullUrlTag,
-                $requestHash,
-                $varyKey,
-                $varyFields,
-                &$metadataKey,
-                $cachedData,
-                $freshness,
-                $url,
-                $method,
-                $options,
-            ): \Generator {
-                static $attemptTag = null;
-                static $firstChunkKey = null;
-                static $chunkKey = null;
+        ): \Generator {
+            static $attemptTag = null;
+            static $firstChunkKey = null;
+            static $chunkKey = null;
 
-                if (null !== $chunk->getError() || $chunk->isTimeout()) {
-                    null !== $attemptTag && $this->cache->invalidateTags([$attemptTag]);
+            if (null !== $chunk->getError() || $chunk->isTimeout()) {
+                null !== $attemptTag && $this->cache->invalidateTags([$attemptTag]);
 
+                if (Freshness::StaleButUsable === $freshness) {
+                    // avoid throwing exception in ErrorChunk#__destruct()
+                    $chunk instanceof ErrorChunk && $chunk->didThrow(true);
+                    $context->passthru();
+                    $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey));
+
+                    return;
+                }
+
+                if (Freshness::MustRevalidate === $freshness) {
+                    // avoid throwing exception in ErrorChunk#__destruct()
+                    $chunk instanceof ErrorChunk && $chunk->didThrow(true);
+                    $context->passthru();
+                    $context->replaceResponse(self::createGatewayTimeoutResponse($method, $url, $options));
+
+                    return;
+                }
+
+                yield $chunk;
+
+                return;
+            }
+
+            $headers = $context->getHeaders();
+
+            if ($chunk->isFirst()) {
+                $statusCode = $context->getStatusCode();
+                $cacheControl = self::parseCacheControlHeader($headers['cache-control'] ?? []);
+
+                $attemptTag = self::generateChunkKey();
+
+                if (304 === $statusCode && null !== $freshness) {
+                    $maxAge = $this->determineMaxAge($headers, $cacheControl);
+
+                    $this->cache->get($metadataKey, static function (ItemInterface $item) use ($headers, $maxAge, $cachedData, $expiresAt, $fullUrlTag, $metadataKey): array {
+                        $item->expiresAt($expiresAt)->tag([$fullUrlTag, $metadataKey]);
+
+                        $cachedData['expires_at'] = self::calculateExpiresAt($maxAge);
+                        $cachedData['stored_at'] = time();
+                        $cachedData['initial_age'] = (int) ($headers['age'][0] ?? 0);
+                        $cachedData['headers'] = array_merge($cachedData['headers'], array_diff_key($headers, self::EXCLUDED_HEADERS));
+
+                        return $cachedData;
+                    }, \INF);
+
+                    $context->passthru();
+                    $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey, $expiresAt));
+
+                    return;
+                }
+
+                if ($statusCode >= 500 && $statusCode < 600) {
                     if (Freshness::StaleButUsable === $freshness) {
-                        // avoid throwing exception in ErrorChunk#__destruct()
-                        $chunk instanceof ErrorChunk && $chunk->didThrow(true);
                         $context->passthru();
                         $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey));
 
@@ -235,162 +285,119 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
                     }
 
                     if (Freshness::MustRevalidate === $freshness) {
-                        // avoid throwing exception in ErrorChunk#__destruct()
-                        $chunk instanceof ErrorChunk && $chunk->didThrow(true);
                         $context->passthru();
                         $context->replaceResponse(self::createGatewayTimeoutResponse($method, $url, $options));
 
                         return;
                     }
+                }
+
+                if (!$this->isServerResponseCacheable($statusCode, $options['normalized_headers'], $headers, $cacheControl)) {
+                    $context->passthru();
 
                     yield $chunk;
 
                     return;
                 }
 
-                $headers = $context->getHeaders();
-
-                if ($chunk->isFirst()) {
-                    $statusCode = $context->getStatusCode();
-                    $cacheControl = self::parseCacheControlHeader($headers['cache-control'] ?? []);
-
-                    $attemptTag = self::generateChunkKey();
-
-                    if (304 === $statusCode && null !== $freshness) {
-                        $maxAge = $this->determineMaxAge($headers, $cacheControl);
-
-                        $this->cache->get($metadataKey, static function (ItemInterface $item) use ($headers, $maxAge, $cachedData, $expiresAt, $fullUrlTag, $metadataKey): array {
-                            $item->expiresAt($expiresAt)->tag([$fullUrlTag, $metadataKey]);
-
-                            $cachedData['expires_at'] = self::calculateExpiresAt($maxAge);
-                            $cachedData['stored_at'] = time();
-                            $cachedData['initial_age'] = (int) ($headers['age'][0] ?? 0);
-                            $cachedData['headers'] = array_merge($cachedData['headers'], array_diff_key($headers, self::EXCLUDED_HEADERS));
-
-                            return $cachedData;
-                        }, \INF);
-
-                        $context->passthru();
-                        $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey, $expiresAt));
-
-                        return;
-                    }
-
-                    if ($statusCode >= 500 && $statusCode < 600) {
-                        if (Freshness::StaleButUsable === $freshness) {
-                            $context->passthru();
-                            $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey));
-
-                            return;
+                // recomputing vary fields in case it changed or for first request
+                $newVaryFields = [];
+                foreach ($headers['vary'] ?? [] as $vary) {
+                    foreach (explode(',', $vary) as $field) {
+                        $field = strtolower(trim($field));
+                        if ('cookie' === $field ? $this->sharedCache : !preg_match('/^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$/D', $field)) {
+                            $field = '*';
                         }
-
-                        if (Freshness::MustRevalidate === $freshness) {
-                            $context->passthru();
-                            $context->replaceResponse(self::createGatewayTimeoutResponse($method, $url, $options));
-
-                            return;
-                        }
+                        $newVaryFields[] = $field;
                     }
+                }
 
-                    if (!$this->isServerResponseCacheable($statusCode, $options['normalized_headers'], $headers, $cacheControl)) {
-                        $context->passthru();
-
-                        yield $chunk;
-
-                        return;
-                    }
-
-                    // recomputing vary fields in case it changed or for first request
-                    $newVaryFields = [];
-                    foreach ($headers['vary'] ?? [] as $vary) {
-                        foreach (explode(',', $vary) as $field) {
-                            $field = strtolower(trim($field));
-                            if ('cookie' === $field ? $this->sharedCache : !preg_match('/^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$/D', $field)) {
-                                $field = '*';
-                            }
-                            $newVaryFields[] = $field;
-                        }
-                    }
-
-                    if (\in_array('*', $newVaryFields, true)) {
-                        $context->passthru();
-
-                        yield $chunk;
-
-                        return;
-                    }
-
-                    sort($newVaryFields);
-
-                    if ($varyFields !== $newVaryFields) {
-                        $this->cache->invalidateTags([$fullUrlTag]);
-
-                        $metadataKey = self::getMetadataKey($requestHash, $options['normalized_headers'], $newVaryFields);
-                    }
-
-                    $this->cache->get($varyKey, static function (ItemInterface $item) use ($newVaryFields, $expiresAt, $fullUrlTag): array {
-                        $item->tag([$fullUrlTag])->expiresAt($expiresAt);
-
-                        return $newVaryFields;
-                    }, \INF);
-
-                    $firstChunkKey = $chunkKey = self::generateChunkKey();
+                if (\in_array('*', $newVaryFields, true)) {
+                    $context->passthru();
 
                     yield $chunk;
 
                     return;
                 }
 
-                if (null === $chunkKey) {
-                    // informational chunks
-                    yield $chunk;
+                sort($newVaryFields);
 
-                    return;
+                if ($varyFields !== $newVaryFields) {
+                    $this->cache->invalidateTags([$fullUrlTag]);
+
+                    $metadataKey = self::getMetadataKey($requestHash, $options['normalized_headers'], $newVaryFields);
                 }
 
-                if ($chunk->isLast()) {
-                    $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $chunk, $attemptTag): array {
-                        $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+                $this->cache->get($varyKey, static function (ItemInterface $item) use ($newVaryFields, $expiresAt, $fullUrlTag): array {
+                    $item->tag([$fullUrlTag])->expiresAt($expiresAt);
 
-                        return [
-                            'content' => $chunk->getContent(),
-                            'next_chunk' => null,
-                        ];
-                    }, \INF);
+                    return $newVaryFields;
+                }, \INF);
 
-                    $maxAge = $this->determineMaxAge($headers, self::parseCacheControlHeader($headers['cache-control'] ?? []));
-                    $this->cache->get($metadataKey, static function (ItemInterface $item) use ($context, $headers, $maxAge, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $firstChunkKey): array {
-                        $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+                $firstChunkKey = $chunkKey = self::generateChunkKey();
 
-                        return [
-                            'status_code' => $context->getStatusCode(),
-                            'headers' => array_diff_key($headers, self::EXCLUDED_HEADERS),
-                            'initial_age' => (int) ($headers['age'][0] ?? 0),
-                            'stored_at' => time(),
-                            'expires_at' => self::calculateExpiresAt($maxAge),
-                            'next_chunk' => $firstChunkKey,
-                        ];
-                    }, \INF);
+                yield $chunk;
 
-                    yield $chunk;
+                return;
+            }
 
-                    return;
-                }
+            if (null === $chunkKey) {
+                // informational chunks
+                yield $chunk;
 
-                $nextChunkKey = self::generateChunkKey();
-                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $chunk, $nextChunkKey): array {
+                return;
+            }
+
+            if ($chunk->isLast()) {
+                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $chunk, $attemptTag): array {
                     $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
 
                     return [
                         'content' => $chunk->getContent(),
-                        'next_chunk' => $nextChunkKey,
+                        'next_chunk' => null,
                     ];
                 }, \INF);
-                $chunkKey = $nextChunkKey;
+
+                $maxAge = $this->determineMaxAge($headers, self::parseCacheControlHeader($headers['cache-control'] ?? []));
+                $this->cache->get($metadataKey, static function (ItemInterface $item) use ($context, $headers, $maxAge, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $firstChunkKey): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+
+                    return [
+                        'status_code' => $context->getStatusCode(),
+                        'headers' => array_diff_key($headers, self::EXCLUDED_HEADERS),
+                        'initial_age' => (int) ($headers['age'][0] ?? 0),
+                        'stored_at' => time(),
+                        'expires_at' => self::calculateExpiresAt($maxAge),
+                        'next_chunk' => $firstChunkKey,
+                    ];
+                }, \INF);
 
                 yield $chunk;
+
+                return;
             }
-        );
+
+            $nextChunkKey = self::generateChunkKey();
+            $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $chunk, $nextChunkKey): array {
+                $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+
+                return [
+                    'content' => $chunk->getContent(),
+                    'next_chunk' => $nextChunkKey,
+                ];
+            }, \INF);
+            $chunkKey = $nextChunkKey;
+
+            yield $chunk;
+        };
+
+        $this->isInnerRequest = true;
+
+        try {
+            return new AsyncResponse($this, $method, $url, $options, $passthru);
+        } finally {
+            $this->isInnerRequest = false;
+        }
     }
 
     public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
@@ -401,26 +408,40 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
         $mockResponses = [];
         $asyncResponses = [];
+        $clientResponses = [];
 
         foreach ($responses as $response) {
             if ($response instanceof MockResponse) {
                 $mockResponses[] = $response;
-            } else {
+            } elseif ($response instanceof AsyncResponse) {
                 $asyncResponses[] = $response;
+            } else {
+                $clientResponses[] = $response;
             }
         }
 
-        if (!$mockResponses) {
+        if (!$mockResponses && !$clientResponses) {
             return $this->asyncStream($asyncResponses, $timeout);
         }
 
-        if (!$asyncResponses) {
+        if (!$asyncResponses && !$clientResponses) {
             return new ResponseStream(MockResponse::stream($mockResponses, $timeout));
         }
 
-        return new ResponseStream((function () use ($mockResponses, $asyncResponses, $timeout) {
-            yield from MockResponse::stream($mockResponses, $timeout);
-            yield from $this->asyncStream($asyncResponses, $timeout);
+        if (!$mockResponses && !$asyncResponses) {
+            return $this->client->stream($clientResponses, $timeout);
+        }
+
+        return new ResponseStream((function () use ($mockResponses, $asyncResponses, $clientResponses, $timeout) {
+            if ($mockResponses) {
+                yield from MockResponse::stream($mockResponses, $timeout);
+            }
+            if ($clientResponses) {
+                yield from $this->client->stream($clientResponses, $timeout);
+            }
+            if ($asyncResponses) {
+                yield from $this->asyncStream($asyncResponses, $timeout);
+            }
         })());
     }
 

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -20,8 +20,11 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\HttpClient\CachingHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\TraceableHttpClient;
+use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 #[CoversClass(CachingHttpClient::class)]
 #[Group('time-sensitive')]
@@ -53,7 +56,7 @@ class CachingHttpClientTest extends TestCase
         $options = ['body' => 'non-empty'];
         $client->request('GET', 'http://example.com/foo-bar', $options);
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame('non-cached response', $response->getContent(), 'Request with body should bypass cache.');
+        $this->assertSame('non-cached response', $response->getContent(), 'Request with body should bypass cache.');
     }
 
     public function testBypassCacheWhenRangeHeaderPresent()
@@ -70,7 +73,7 @@ class CachingHttpClientTest extends TestCase
         ];
         $client->request('GET', 'http://example.com/foo-bar', $options);
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame('second response', $response->getContent(), 'Presence of range header must bypass caching.');
+        $this->assertSame('second response', $response->getContent(), 'Presence of range header must bypass caching.');
     }
 
     public function testBypassCacheForNonCacheableMethod()
@@ -84,7 +87,7 @@ class CachingHttpClientTest extends TestCase
 
         $client->request('POST', 'http://example.com/foo-bar');
         $response = $client->request('POST', 'http://example.com/foo-bar');
-        self::assertSame('second response', $response->getContent(), 'Non-cacheable method must bypass caching.');
+        $this->assertSame('second response', $response->getContent(), 'Non-cacheable method must bypass caching.');
     }
 
     public function testItServesResponseFromCache()
@@ -105,15 +108,15 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(2);
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
-        self::assertSame('2', $response->getHeaders()['age'][0]);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+        $this->assertSame('2', $response->getHeaders()['age'][0]);
     }
 
     public function testItSupportsVaryHeader()
@@ -136,18 +139,18 @@ class CachingHttpClientTest extends TestCase
 
         // Request with one set of headers.
         $response = $client->request('GET', 'http://example.com/foo-bar', ['headers' => ['Foo' => 'foo', 'Bar' => 'bar']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         // Same headers: should return cached "foo".
         $response = $client->request('GET', 'http://example.com/foo-bar', ['headers' => ['Foo' => 'foo', 'Bar' => 'bar']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         // Different header values: returns a new response.
         $response = $client->request('GET', 'http://example.com/foo-bar', ['headers' => ['Foo' => 'bar', 'Bar' => 'foo']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testItDoesntServeAStaleResponse()
@@ -169,22 +172,22 @@ class CachingHttpClientTest extends TestCase
 
         // The first request returns "foo".
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(4);
 
         // After 4 seconds, the cached response is still considered valid.
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(1);
 
         // After an extra second the cache expires, so a new response is served.
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testAResponseWithoutExpirationAsStale()
@@ -206,13 +209,13 @@ class CachingHttpClientTest extends TestCase
 
         // The first request returns "foo".
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         // After an extra second the cache expires, so a new response is served.
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testItRevalidatesAResponseWithNoCacheDirective()
@@ -235,13 +238,13 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         // The next request revalidates the response and should fetch "bar".
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testItServesAStaleResponseIfError()
@@ -263,14 +266,14 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(404, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent(false));
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent(false));
 
         sleep(5);
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(404, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent(false));
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent(false));
     }
 
     public function testPrivateCacheWithSharedCacheFalse()
@@ -293,12 +296,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/test-private');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/test-private');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testItDoesntStoreAResponseWithNoStoreDirective()
@@ -319,12 +322,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testASharedCacheDoesntStoreAResponseFromRequestWithAuthorization()
@@ -347,12 +350,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testASharedCacheStoresAResponseWithPublicDirectiveFromRequestWithAuthorization()
@@ -379,12 +382,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testASharedCacheStoresAResponseWithSMaxAgeDirectiveFromRequestWithAuthorization()
@@ -411,12 +414,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testASharedCacheDoesntStoreAResponseWithPrivateDirective()
@@ -438,12 +441,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testAPrivateCacheStoresAResponseWithPrivateDirective()
@@ -465,12 +468,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testASharedCacheDoesntStoreAResponseWithAuthenticationHeader()
@@ -493,12 +496,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testAPrivateCacheStoresAResponseWithAuthenticationHeader()
@@ -521,12 +524,12 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testCacheMissAfterInvalidation()
@@ -548,14 +551,14 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $client->request('DELETE', 'http://example.com/foo-bar');
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testChunkErrorServesStaleResponse()
@@ -576,14 +579,14 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(2);
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testChunkErrorMustRevalidate()
@@ -604,13 +607,13 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(2);
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(504, $response->getStatusCode());
+        $this->assertSame(504, $response->getStatusCode());
     }
 
     public function testExceedingMaxAgeIsCappedByTtl()
@@ -632,14 +635,14 @@ class CachingHttpClientTest extends TestCase
         );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(11);
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testItCanStreamAsyncResponse()
@@ -655,14 +658,14 @@ class CachingHttpClientTest extends TestCase
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
 
-        self::assertInstanceOf(AsyncResponse::class, $response);
+        $this->assertInstanceOf(AsyncResponse::class, $response);
 
         $collected = '';
         foreach ($client->stream($response) as $chunk) {
             $collected .= $chunk->getContent();
         }
 
-        self::assertSame('foo', $collected);
+        $this->assertSame('foo', $collected);
     }
 
     public function testItCanStreamCachedResponse()
@@ -684,14 +687,14 @@ class CachingHttpClientTest extends TestCase
         $client->request('GET', 'http://example.com/foo-bar')->getContent(); // warm the cache
         $response = $client->request('GET', 'http://example.com/foo-bar');
 
-        self::assertInstanceOf(MockResponse::class, $response);
+        $this->assertInstanceOf(MockResponse::class, $response);
 
         $collected = '';
         foreach ($client->stream($response) as $chunk) {
             $collected .= $chunk->getContent();
         }
 
-        self::assertSame('foo', $collected);
+        $this->assertSame('foo', $collected);
     }
 
     public function testItCanStreamBoth()
@@ -715,15 +718,15 @@ class CachingHttpClientTest extends TestCase
         $cachedResponse = $client->request('GET', 'http://example.com/foo');
         $asyncResponse = $client->request('GET', 'http://example.com/bar');
 
-        self::assertInstanceOf(MockResponse::class, $cachedResponse);
-        self::assertInstanceOf(AsyncResponse::class, $asyncResponse);
+        $this->assertInstanceOf(MockResponse::class, $cachedResponse);
+        $this->assertInstanceOf(AsyncResponse::class, $asyncResponse);
 
         $collected = '';
         foreach ($client->stream([$asyncResponse, $cachedResponse]) as $chunk) {
             $collected .= $chunk->getContent();
         }
 
-        self::assertSame('foobar', $collected);
+        $this->assertSame('foobar', $collected);
     }
 
     public function testMultipleChunksResponse()
@@ -739,14 +742,14 @@ class CachingHttpClientTest extends TestCase
         foreach ($client->stream($response) as $chunk) {
             $content .= $chunk->getContent();
         }
-        self::assertSame('chunk1chunk2chunk3', $content);
+        $this->assertSame('chunk1chunk2chunk3', $content);
 
         $response = $client->request('GET', 'http://example.com/multi-chunk');
         $content = '';
         foreach ($client->stream($response) as $chunk) {
             $content .= $chunk->getContent();
         }
-        self::assertSame('chunk1chunk2chunk3', $content);
+        $this->assertSame('chunk1chunk2chunk3', $content);
     }
 
     public function testConditionalCacheableStatusCodeWithoutExpiration()
@@ -759,12 +762,12 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/redirect');
-        self::assertSame(302, $response->getStatusCode());
-        self::assertSame('redirected', $response->getContent(false));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('redirected', $response->getContent(false));
 
         $response = $client->request('GET', 'http://example.com/redirect');
-        self::assertSame(302, $response->getStatusCode());
-        self::assertSame('new redirect', $response->getContent(false));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('new redirect', $response->getContent(false));
     }
 
     public function testConditionalCacheableStatusCodeWithExpiration()
@@ -780,12 +783,12 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/redirect');
-        self::assertSame(302, $response->getStatusCode());
-        self::assertSame('redirected', $response->getContent(false));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('redirected', $response->getContent(false));
 
         $response = $client->request('GET', 'http://example.com/redirect');
-        self::assertSame(302, $response->getStatusCode());
-        self::assertSame('redirected', $response->getContent(false));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('redirected', $response->getContent(false));
     }
 
     public function testETagRevalidation()
@@ -801,14 +804,14 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/etag');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(6);
 
         $response = $client->request('GET', 'http://example.com/etag');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testLastModifiedRevalidation()
@@ -825,14 +828,14 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/last-modified');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(6);
 
         $response = $client->request('GET', 'http://example.com/last-modified');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testAgeCalculation()
@@ -844,15 +847,15 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/age-test');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(3);
 
         $response = $client->request('GET', 'http://example.com/age-test');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
-        self::assertSame('3', $response->getHeaders()['age'][0]);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+        $this->assertSame('3', $response->getHeaders()['age'][0]);
     }
 
     public function testGatewayTimeoutOnMustRevalidateFailure()
@@ -868,13 +871,13 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/must-revalidate');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         sleep(2);
 
         $response = $client->request('GET', 'http://example.com/must-revalidate');
-        self::assertSame(504, $response->getStatusCode());
+        $this->assertSame(504, $response->getStatusCode());
     }
 
     public function testVaryAsteriskPreventsCaching()
@@ -887,12 +890,12 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/vary-asterisk');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $response = $client->request('GET', 'http://example.com/vary-asterisk');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testExcludedHeadersAreNotCached()
@@ -916,23 +919,23 @@ class CachingHttpClientTest extends TestCase
         $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
         $response = $client->request('GET', 'http://example.com/header-test');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         $cachedResponse = $client->request('GET', 'http://example.com/header-test');
-        self::assertSame(200, $cachedResponse->getStatusCode());
-        self::assertSame('foo', $cachedResponse->getContent());
+        $this->assertSame(200, $cachedResponse->getStatusCode());
+        $this->assertSame('foo', $cachedResponse->getContent());
 
         $cachedHeaders = $cachedResponse->getHeaders();
 
-        self::assertArrayNotHasKey('connection', $cachedHeaders);
-        self::assertArrayNotHasKey('proxy-authenticate', $cachedHeaders);
-        self::assertArrayNotHasKey('proxy-authentication-info', $cachedHeaders);
-        self::assertArrayNotHasKey('proxy-authorization', $cachedHeaders);
+        $this->assertArrayNotHasKey('connection', $cachedHeaders);
+        $this->assertArrayNotHasKey('proxy-authenticate', $cachedHeaders);
+        $this->assertArrayNotHasKey('proxy-authentication-info', $cachedHeaders);
+        $this->assertArrayNotHasKey('proxy-authorization', $cachedHeaders);
 
-        self::assertArrayHasKey('cache-control', $cachedHeaders);
-        self::assertArrayHasKey('content-type', $cachedHeaders);
-        self::assertArrayHasKey('x-custom-header', $cachedHeaders);
+        $this->assertArrayHasKey('cache-control', $cachedHeaders);
+        $this->assertArrayHasKey('content-type', $cachedHeaders);
+        $this->assertArrayHasKey('x-custom-header', $cachedHeaders);
     }
 
     public function testHeuristicFreshnessWithLastModified()
@@ -950,22 +953,22 @@ class CachingHttpClientTest extends TestCase
 
         // First request caches with heuristic
         $response = $client->request('GET', 'http://example.com/heuristic');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         // Heuristic: 10% of 3600s = 360s; should be fresh within this time
         sleep(359); // 5 minutes
 
         $response = $client->request('GET', 'http://example.com/heuristic');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('foo', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
 
         // After heuristic expires
         sleep(2); // Total 361s, past 360s heuristic
 
         $response = $client->request('GET', 'http://example.com/heuristic');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('bar', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testResponseInfluencingHeadersAffectCacheKey()
@@ -984,18 +987,18 @@ class CachingHttpClientTest extends TestCase
 
         // First request with Accept-Language: en
         $response = $client->request('GET', 'http://example.com/lang-test', ['headers' => ['Accept-Language' => 'en']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('response for en', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('response for en', $response->getContent());
 
         // Same request with Accept-Language: en should return cached response
         $response = $client->request('GET', 'http://example.com/lang-test', ['headers' => ['Accept-Language' => 'en']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('response for en', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('response for en', $response->getContent());
 
         // Request with Accept-Language: fr should fetch new response
         $response = $client->request('GET', 'http://example.com/lang-test', ['headers' => ['Accept-Language' => 'fr']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('response for fr', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('response for fr', $response->getContent());
     }
 
     public function testUnsafeInvalidationInBypassFlow()
@@ -1010,16 +1013,16 @@ class CachingHttpClientTest extends TestCase
 
         // Warm cache with GET
         $response = $client->request('GET', 'http://example.com/unsafe-test');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('initial get', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('initial get', $response->getContent());
 
         // Unsafe POST with body (bypasses cache but invalidates on success)
         $client->request('POST', 'http://example.com/unsafe-test', ['body' => 'invalidate']);
 
         // Next GET should miss cache and fetch new
         $response = $client->request('GET', 'http://example.com/unsafe-test');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('after invalidate', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('after invalidate', $response->getContent());
     }
 
     public function testNoInvalidationOnErrorInBypassFlow()
@@ -1034,17 +1037,17 @@ class CachingHttpClientTest extends TestCase
 
         // Warm cache with GET
         $response = $client->request('GET', 'http://example.com/no-invalidate-test');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('initial get', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('initial get', $response->getContent());
 
         // Unsafe POST with body (bypasses cache, but 500 shouldn't invalidate)
         $response = $client->request('POST', 'http://example.com/no-invalidate-test', ['body' => 'no invalidate']);
-        self::assertSame(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
 
         // Next GET should hit cache
         $response = $client->request('GET', 'http://example.com/no-invalidate-test');
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('initial get', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('initial get', $response->getContent());
     }
 
     public function testMultipleValuesForResponseInfluencingHeadersAffectCacheKey()
@@ -1066,23 +1069,90 @@ class CachingHttpClientTest extends TestCase
 
         // First request with Accept-Language: de
         $response = $client->request('GET', 'http://example.com/lang-multi', ['headers' => ['Accept-Language' => 'de']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('response for de', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('response for de', $response->getContent());
 
         // Same request with Accept-Language: de should return cached response
         $response = $client->request('GET', 'http://example.com/lang-multi', ['headers' => ['Accept-Language' => 'de']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('response for de', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('response for de', $response->getContent());
 
         // Request with multiple Accept-Language values should fetch new response
         // because the cache key includes all header values
         $response = $client->request('GET', 'http://example.com/lang-multi', ['headers' => ['Accept-Language' => ['de', 'fr']]]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('response for de-fr', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('response for de-fr', $response->getContent());
 
         // Request with only Accept-Language: fr should fetch yet another response
         $response = $client->request('GET', 'http://example.com/lang-multi', ['headers' => ['Accept-Language' => 'fr']]);
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('response for fr', $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('response for fr', $response->getContent());
+    }
+
+    public function testETagRevalidationWithTraceableClient()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['ETag' => '"abc123"', 'Cache-Control' => 'max-age=5'],
+            ]),
+            new MockResponse('', ['http_code' => 304, 'response_headers' => ['ETag' => '"abc123"']]),
+        ]);
+
+        $cachingClient = new CachingHttpClient($mockClient, $this->cacheAdapter);
+        $client = new TraceableHttpClient($cachingClient);
+
+        $response = $client->request('GET', 'http://example.com/etag-traceable');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+
+        sleep(6);
+
+        $response = $client->request('GET', 'http://example.com/etag-traceable');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testStaleResponseWithTraceableClient()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=1, stale-if-error=60'],
+            ]),
+            new MockResponse('', ['http_code' => 500]),
+        ]);
+
+        $cachingClient = new CachingHttpClient($mockClient, $this->cacheAdapter);
+        $client = new TraceableHttpClient($cachingClient);
+
+        $response = $client->request('GET', 'http://example.com/stale-traceable');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+
+        sleep(2);
+
+        $response = $client->request('GET', 'http://example.com/stale-traceable');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testETagRevalidationWithNativeHttpClient()
+    {
+        TestHttpServer::start();
+
+        $client = new TraceableHttpClient(new CachingHttpClient(new NativeHttpClient(), $this->cacheAdapter));
+
+        $response = $client->request('GET', 'http://localhost:8057/304/etag');
+        $this->assertSame(200, $response->getStatusCode());
+        if (!$body = $response->getContent()) {
+            $this->markTestSkipped('Legacy symfony/http-client-contracts in use');
+        }
+
+        // no-cache means the cache must revalidate on every request;
+        // the server returns 304 when If-None-Match matches
+        $response = $client->request('GET', 'http://localhost:8057/304/etag');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($body, $response->getContent());
     }
 }

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -116,6 +116,15 @@ switch (parse_url($vars['REQUEST_URI'], \PHP_URL_PATH)) {
 
         return;
 
+    case '/304/etag':
+        if (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+            header('ETag: "abc123"', true, 304);
+            exit;
+        }
+        header('ETag: "abc123"');
+        header('Cache-Control: no-cache');
+        break;
+
     case '/307':
         header('Location: http://localhost:8057/post', true, 307);
         break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63553
| License       | MIT

When `CachingHttpClient` is wrapped by `TraceableHttpClient` (or any other decorator), and the upstream server returns a `304 Not Modified`, a `TypeError` is thrown because `AsyncResponse::stream()` tries to re-stream the replacement `MockResponse` through the inner HTTP client, which cannot handle it.

The root cause is that `CachingHttpClient::request()` passes `$this->client` (the inner transport) to `AsyncResponse`. When the passthru callback calls `context->replaceResponse(MockResponse)`, the `AsyncResponse` outer loop restarts and calls `$innerClient->stream([MockResponse])`, but the inner client only knows how to stream its own response type.

The fix passes `$this` (the `CachingHttpClient` itself) as the client to `AsyncResponse`, with a recursion guard to avoid infinite loops. This way, when `replaceResponse(MockResponse)` triggers re-streaming, it goes through `CachingHttpClient::stream()`, which already knows how to route `MockResponse` instances to `MockResponse::stream()`.

Best review [ignoring whitespaces](https://github.com/symfony/symfony/pull/63573/files?w=1).