### PR TITLE
[FrameworkBundle] Fix stale container after reboot in KernelTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -12,10 +12,12 @@
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -37,6 +39,8 @@ abstract class KernelTestCase extends TestCase
     protected static $kernel;
 
     protected static $booted = false;
+
+    private static bool $kernelHasBeenRebooted = false;
 
     protected function tearDown(): void
     {
@@ -88,6 +92,7 @@ abstract class KernelTestCase extends TestCase
         // reboot a fresh one.
         if ($kernel->getContainer()->initialized('cache_warmer')) {
             static::ensureKernelShutdown();
+            self::$kernelHasBeenRebooted = true;
 
             $kernel = static::createKernel($options);
             $kernel->boot();
@@ -160,6 +165,20 @@ abstract class KernelTestCase extends TestCase
 
             static::$kernel->shutdown();
             static::$booted = false;
+
+            if (self::$kernelHasBeenRebooted) {
+                self::$kernelHasBeenRebooted = false;
+                try {
+                    (new \ReflectionProperty(Kernel::class, 'freshCache'))->setValue(null, []);
+                } catch (\ReflectionException) {
+                    // ignore if the property doesn't exist
+                }
+                try {
+                    (new \ReflectionProperty(SelfCheckingResourceChecker::class, 'cache'))->setValue(null, []);
+                } catch (\ReflectionException) {
+                    // ignore if the property doesn't exist
+                }
+            }
 
             if ($container instanceof ResetInterface) {
                 $container->reset();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/KernelTestCaseFreshCacheTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/KernelTestCaseFreshCacheTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class KernelTestCaseFreshCacheTest extends AbstractWebTestCase
+{
+    private static string $trackedFile;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$trackedFile = sys_get_temp_dir().'/'.static::getVarDir().'/tracked_file.yaml';
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        @unlink(self::$trackedFile);
+    }
+
+    public function testContainerIsRebuiltWhenTrackedFileAppears()
+    {
+        @unlink(self::$trackedFile);
+
+        // First boot: container is built tracking the file as non-existing
+        static::bootKernel(['test_case' => 'TestServiceContainer', 'debug' => true]);
+
+        $this->assertFalse(static::$kernel->getContainer()->getParameter('tracked_file_existed'));
+
+        static::ensureKernelShutdown();
+
+        // Create the tracked file between boots
+        @mkdir(\dirname(self::$trackedFile), 0777, true);
+        file_put_contents(self::$trackedFile, 'placeholder');
+
+        // Reboot: should detect the resource change and rebuild the container
+        static::bootKernel(['test_case' => 'TestServiceContainer', 'debug' => true]);
+
+        $this->assertTrue(static::$kernel->getContainer()->getParameter('tracked_file_existed'));
+    }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        $kernel = parent::createKernel($options);
+
+        FileExistenceTrackingKernel::$trackedFile = self::$trackedFile;
+
+        return $kernel;
+    }
+
+    protected static function getKernelClass(): string
+    {
+        require_once __DIR__.'/app/AppKernel.php';
+
+        return FileExistenceTrackingKernel::class;
+    }
+}
+
+class FileExistenceTrackingKernel extends app\AppKernel
+{
+    public static string $trackedFile;
+
+    protected function build(\Symfony\Component\DependencyInjection\ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->setParameter('tracked_file_existed', $container->fileExists(self::$trackedFile));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63519
| License       | MIT

The reboot logic added in #63016 to get a fresh container after cache warmup populates two static freshness caches: `Kernel::$freshCache` and `SelfCheckingResourceChecker::$cache`. These caches persist across `shutdown()`/`boot()` cycles within the same PHP process, preventing subsequent boots from detecting resource changes (e.g. `FileExistenceResource`).

This causes `ensureKernelShutdown()` + `bootKernel()` to reuse a stale container even when tracked resources have changed between boots.

The fix clears both static caches via reflection in `ensureKernelShutdown()` when a cache warmer reboot has occurred. The clearing is guarded by a flag to avoid unnecessary reset on every shutdown, and wrapped in try/catch to be forward-compatible with future refactoring of these internals.
