### PR TITLE
[AssetMapper] Add AssetMapperPathProviderInterface for dynamic path resolution

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -15,6 +15,7 @@ use Symfony\Component\AssetMapper\AssetMapper;
 use Symfony\Component\AssetMapper\AssetMapperCompiler;
 use Symfony\Component\AssetMapper\AssetMapperDevServerSubscriber;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\AssetMapperPathProviderInterface;
 use Symfony\Component\AssetMapper\AssetMapperRepository;
 use Symfony\Component\AssetMapper\Command\AssetMapperCompileCommand;
 use Symfony\Component\AssetMapper\Command\CompressAssetsCommand;
@@ -84,7 +85,11 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('array of excluded path patterns'),
                 abstract_arg('exclude dot files'),
                 param('kernel.debug'),
+                tagged_iterator('asset_mapper.path_provider'),
             ])
+
+        ->instanceof(AssetMapperPathProviderInterface::class)
+            ->tag('asset_mapper.path_provider')
 
         ->set('asset_mapper.public_assets_path_resolver', PublicAssetsPathResolver::class)
             ->args([

--- a/src/Symfony/Component/AssetMapper/AssetMapperPathProviderInterface.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperPathProviderInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper;
+
+/**
+ * Provides asset paths to be registered in the asset mapper.
+ *
+ * Implement this interface and tag the service with "asset_mapper.path_provider"
+ * to dynamically add asset paths (e.g. from glob patterns) to the asset mapper.
+ *
+ */
+interface AssetMapperPathProviderInterface
+{
+    /**
+     * Returns asset paths to register.
+     *
+     * @return array<string, string> Keys are directory paths (absolute or relative to project root),
+     *                               values are namespaces (empty string for no namespace)
+     */
+    public function getPaths(): array;
+}

--- a/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
+++ b/src/Symfony/Component/AssetMapper/AssetMapperRepository.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\AssetMapper;
 
+use Symfony\Component\AssetMapper\AssetMapperPathProviderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator;
 
@@ -28,6 +29,7 @@ class AssetMapperRepository
     /**
      * @param string[] $paths Array of assets paths: key is the path, value is the namespace
      *                        (empty string for no namespace)
+     * @param iterable<AssetMapperPathProviderInterface> $pathProviders
      */
     public function __construct(
         private readonly array $paths,
@@ -35,6 +37,7 @@ class AssetMapperRepository
         private readonly array $excludedPathPatterns = [],
         private readonly bool $excludeDotFiles = true,
         private readonly bool $debug = true,
+        private readonly iterable $pathProviders = [],
     ) {
     }
 
@@ -146,7 +149,12 @@ class AssetMapperRepository
         }
 
         $this->absolutePaths = [];
-        foreach ($this->paths as $path => $namespace) {
+        $allPaths = $this->paths;
+        foreach ($this->pathProviders as $provider) {
+            $allPaths += $provider->getPaths();
+        }
+
+        foreach ($allPaths as $path => $namespace) {
             if ($filesystem->isAbsolutePath($path)) {
                 if (!file_exists($path) && $this->debug) {
                     throw new \InvalidArgumentException(\sprintf('The asset mapper directory "%s" does not exist.', $path));

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `AssetMapperPathProviderInterface` to allow dynamically providing asset paths (e.g. from glob patterns); implement it and tag the service with `asset_mapper.path_provider`
+
 8.0
 ---
 

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperRepositoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperRepositoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\AssetMapperPathProviderInterface;
 use Symfony\Component\AssetMapper\AssetMapperRepository;
 use Symfony\Component\Finder\Glob;
 
@@ -181,5 +182,55 @@ class AssetMapperRepositoryTest extends TestCase
 
         $actualAssets = array_keys($repository->all());
         $this->assertEquals(['.dotfile'], $actualAssets);
+    }
+
+    public function testPathProvidersAreUsed()
+    {
+        $provider = $this->createStub(AssetMapperPathProviderInterface::class);
+        $provider->method('getPaths')->willReturn([
+            __DIR__.'/Fixtures/dir1' => '',
+            __DIR__.'/Fixtures/dir2' => 'dir2_namespace',
+        ]);
+
+        $repository = new AssetMapperRepository([], __DIR__, [], true, true, [$provider]);
+
+        $this->assertSame(realpath(__DIR__.'/Fixtures/dir1/file1.css'), $repository->find('file1.css'));
+        $this->assertSame(realpath(__DIR__.'/Fixtures/dir2/file4.js'), $repository->find('dir2_namespace/file4.js'));
+        $this->assertNull($repository->find('file4.js'));
+    }
+
+    public function testPathProvidersAreUsedInAll()
+    {
+        $provider = $this->createStub(AssetMapperPathProviderInterface::class);
+        $provider->method('getPaths')->willReturn([
+            __DIR__.'/Fixtures/dir1' => '',
+        ]);
+
+        $repository = new AssetMapperRepository([], __DIR__, [], true, true, [$provider]);
+
+        $actualAllAssets = $repository->all();
+        $this->assertCount(2, $actualAllAssets);
+        $this->assertArrayHasKey('file1.css', $actualAllAssets);
+        $this->assertArrayHasKey('file2.js', $actualAllAssets);
+    }
+
+    public function testPathProvidersAreMergedWithStaticPaths()
+    {
+        $provider = $this->createStub(AssetMapperPathProviderInterface::class);
+        $provider->method('getPaths')->willReturn([
+            __DIR__.'/Fixtures/dir2' => '',
+        ]);
+
+        $repository = new AssetMapperRepository(
+            [__DIR__.'/Fixtures/dir1' => ''],
+            __DIR__,
+            [],
+            true,
+            true,
+            [$provider]
+        );
+
+        $this->assertSame(realpath(__DIR__.'/Fixtures/dir1/file1.css'), $repository->find('file1.css'));
+        $this->assertSame(realpath(__DIR__.'/Fixtures/dir2/file4.js'), $repository->find('file4.js'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61420 
| License       | MIT

Introduce AssetMapperPathResolverInterface with a single getPaths(): array method. Implementations return the same [directory => namespace] structure as the existing paths config key.

Services implementing the interface are auto-tagged with asset_mapper.path_resolver and injected into AssetMapperRepository via a tagged_iterator. Their paths are merged with the statically configured ones at first use (lazy, cached).

Usage example

```
// src/AssetMapper/GlobPathResolver.php
class GlobPathResolver implements AssetMapperPathResolverInterface
{
    public function getPaths(): array
    {
        $dirs = glob($this->projectDir.'/src/Capability/*/Presentation/Html/Assets', GLOB_ONLYDIR);

        return array_fill_keys($dirs, '');
    }
}
```

No additional service configuration needed - the instanceof binding in asset_mapper.php auto-tags any service implementing the interface.