### PR TITLE
[Security] Add per-authenticator statelessness support

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
 7.4
 ---
 
+ * `SecurityDataCollector` no longer sets profiler cookies for stateless authentication
  * Add `debug:security:role-hierarchy` command to dump role hierarchy graphs in the Mermaid.js flowchart format
  * Add `Security::getAccessDecision()` and `getAccessDecisionForUser()` helpers
  * Add options to configure a cache pool and storage service for login throttling rate limiters

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -201,7 +201,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
         $this->data['authenticators'] = $this->firewall ? $this->firewall->getAuthenticatorsInfo() : [];
 
-        if ($this->data['listeners'] && !($this->data['firewall']['stateless'] ?? true)) {
+        if ($this->data['listeners'] && !$request->attributes->get('_security_stateless') && !($this->data['firewall']['stateless'] ?? true)) {
             $authCookieName = "{$this->data['firewall']['name']}_auth_profile_token";
             $deauthCookieName = "{$this->data['firewall']['name']}_deauth_profile_token";
             $profileToken = $response->headers->get('X-Debug-Token');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -429,6 +429,43 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertSame([], $dataCollector->getVoters());
     }
 
+    public function testProfilerCookiesNotSetForStatelessRequest()
+    {
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('user', 'pass', ['ROLE_USER']), 'provider', ['ROLE_USER']));
+
+        $request = new Request();
+        $request->attributes->set('_security_stateless', true);
+        $response = new Response();
+
+        $firewallConfig = new FirewallConfig('main', 'security.request_matcher.main', 'security.user_checker.main');
+        $firewallMap = $this->getMockBuilder(FirewallMap::class)->disableOriginalConstructor()->getMock();
+        $firewallMap->method('getFirewallConfig')->with($request)->willReturn($firewallConfig);
+
+        $firewall = new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator());
+
+        // Simulate a listener being present so the cookie condition would normally pass
+        $listener = new class extends AbstractListener {
+            public function supports(Request $request): ?bool
+            {
+                return true;
+            }
+
+            public function authenticate(RequestEvent $event): void
+            {
+            }
+        };
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $firewallMap->method('getListeners')->with($request)->willReturn([[$listener], null, null]);
+        $firewall->onKernelRequest($event);
+
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy(), null, null, $firewallMap, $firewall);
+        $collector->collect($request, $response);
+
+        // No profiler cookies should be set on the response
+        $this->assertEmpty($response->headers->getCookies());
+    }
+
     public static function provideRoles(): array
     {
         return [

--- a/src/Symfony/Component/Security/Core/Authentication/Token/StatelessTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/StatelessTokenInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * Marker interface for tokens that should not be persisted to the session.
+ *
+ * Implement this interface on tokens created by stateless authenticators
+ * (e.g. API token authenticators) to prevent session persistence and
+ * related side effects such as session cookies and profiler debug cookies.
+ *
+ * @author Jonathan Bonjour <hi@gnutix.dev>
+ */
+interface StatelessTokenInterface extends TokenInterface
+{
+}

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add `StatelessTokenInterface` to mark tokens that should not be persisted to the session
  * Add `MermaidDumper` to dump Role Hierarchy graphs in the Mermaid.js flowchart format
  * Deprecate `PersistentTokenInterface::getClass()`, the user class will be removed from the remember-me cookie in 8.0
  * Add `extraData` property to `Vote` objects

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -31,6 +31,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Authenticator\StatelessAuthenticatorInterface;
 use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
@@ -118,6 +119,10 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
         if (!$authenticators) {
             return false;
+        }
+
+        if (!array_filter($authenticators, static fn ($a) => !($a instanceof StatelessAuthenticatorInterface || ($a instanceof TraceableAuthenticator && $a->getAuthenticator() instanceof StatelessAuthenticatorInterface)))) {
+            $request->attributes->set('_security_stateless', true);
         }
 
         return $lazy ? null : true;

--- a/src/Symfony/Component/Security/Http/Authenticator/StatelessAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/StatelessAuthenticatorInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator;
+
+/**
+ * Marker interface for authenticators that do not require session persistence.
+ *
+ * When all authenticators supporting a request implement this interface,
+ * the security system will automatically treat the request as stateless:
+ * no token will be persisted to the session, and no session or profiler
+ * debug cookies will be set on the response.
+ *
+ * @author Jonathan Bonjour <hi@gnutix.dev>
+ */
+interface StatelessAuthenticatorInterface extends AuthenticatorInterface
+{
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -47,6 +47,8 @@ CHANGELOG
 7.4
 ---
 
+ * Add `StatelessAuthenticatorInterface` to mark authenticators that do not require session persistence
+ * `ContextListener` now skips session persistence for tokens implementing `StatelessTokenInterface` or requests with the `_security_stateless` attribute
  * Deprecate extending the `RememberMeDetails` class with a constructor expecting the user FQCN
 
    Before:

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\Authentication\Token\StatelessTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -169,7 +170,11 @@ class ContextListener extends AbstractListener
         $usageIndexReference = \PHP_INT_MIN;
         $token = $this->tokenStorage->getToken();
 
-        if (!$this->trustResolver->isAuthenticated($token)) {
+        $isStateless = $token instanceof StatelessTokenInterface || $request->attributes->get('_security_stateless');
+
+        if ($isStateless) {
+            $this->logger?->debug('Skipping session persistence for stateless authentication.', ['key' => $this->sessionKey]);
+        } elseif (!$this->trustResolver->isAuthenticated($token)) {
             if ($request->hasPreviousSession()) {
                 $session->remove($this->sessionKey);
             }
@@ -179,7 +184,9 @@ class ContextListener extends AbstractListener
             $this->logger?->debug('Stored the security token in the session.', ['key' => $this->sessionKey]);
         }
 
-        if ($this->sessionTrackerEnabler && $session->getId() === $sessionId) {
+        if ($isStateless) {
+            $usageIndexReference = 0;
+        } elseif ($this->sessionTrackerEnabler && $session->getId() === $sessionId) {
             $usageIndexReference = $usageIndexValue;
         } else {
             $usageIndexReference = $usageIndexReference - \PHP_INT_MIN + $usageIndexValue;

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Security\Http\Tests\Fixtures\DummyStatelessSupportsAuthenticator;
 use Symfony\Component\Security\Http\Tests\Fixtures\DummySupportsAuthenticator;
 
 class AuthenticatorManagerTest extends TestCase
@@ -385,6 +386,52 @@ class AuthenticatorManagerTest extends TestCase
         $this->assertSame($this->response, $response);
         $this->assertStringContainsString($authenticator::class, $logger->logContexts[0]['authenticator']);
         $this->assertSame($this->token, $this->tokenStorage->getToken());
+    }
+
+    public function testSupportsSetStatelessAttributeWhenAllAuthenticatorsAreStateless()
+    {
+        $manager = $this->createManager([
+            new DummyStatelessSupportsAuthenticator(true),
+            new DummyStatelessSupportsAuthenticator(null),
+        ], exposeSecurityErrors: ExposeSecurityLevel::None);
+
+        $manager->supports($this->request);
+
+        $this->assertTrue($this->request->attributes->get('_security_stateless'));
+    }
+
+    public function testSupportsDoesNotSetStatelessAttributeWhenMixedAuthenticators()
+    {
+        $manager = $this->createManager([
+            new DummyStatelessSupportsAuthenticator(true),
+            self::createDummySupportsAuthenticator(true),
+        ], exposeSecurityErrors: ExposeSecurityLevel::None);
+
+        $manager->supports($this->request);
+
+        $this->assertNull($this->request->attributes->get('_security_stateless'));
+    }
+
+    public function testSupportsDoesNotSetStatelessAttributeWhenNoAuthenticatorsSupport()
+    {
+        $manager = $this->createManager([
+            new DummyStatelessSupportsAuthenticator(false),
+        ], exposeSecurityErrors: ExposeSecurityLevel::None);
+
+        $manager->supports($this->request);
+
+        $this->assertNull($this->request->attributes->get('_security_stateless'));
+    }
+
+    public function testSupportsSetStatelessAttributeWithTraceableAuthenticator()
+    {
+        $manager = $this->createManager([
+            new TraceableAuthenticator(new DummyStatelessSupportsAuthenticator(true)),
+        ], exposeSecurityErrors: ExposeSecurityLevel::None);
+
+        $manager->supports($this->request);
+
+        $this->assertTrue($this->request->attributes->get('_security_stateless'));
     }
 
     private static function createDummySupportsAuthenticator(?bool $supports = true)

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -392,6 +392,30 @@ class ContextListenerTest extends TestCase
         $this->assertSame($user, $tokenStorage->getToken()->getUser());
     }
 
+    public function testOnKernelResponseDoesNotPersistWhenSecurityStatelessAttribute()
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('test1', 'pass1'), 'phpunit', ['ROLE_USER']));
+
+        $request = new Request();
+        $request->attributes->set('_security_firewall_run', '_security_session');
+        $request->attributes->set('_security_stateless', true);
+        $request->setSession($session);
+
+        $event = new ResponseEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response()
+        );
+
+        $listener = new ContextListener($tokenStorage, [], 'session', null, new EventDispatcher());
+        $listener->onKernelResponse($event);
+
+        $this->assertFalse($session->has('_security_session'));
+    }
+
     protected function runSessionOnKernelResponse($newToken, $original = null)
     {
         $session = new Session(new MockArraySessionStorage());

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyStatelessSupportsAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/DummyStatelessSupportsAuthenticator.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authenticator\StatelessAuthenticatorInterface;
+
+class DummyStatelessSupportsAuthenticator extends DummyAuthenticator implements StatelessAuthenticatorInterface
+{
+    private ?bool $supports;
+
+    public function __construct(?bool $supports)
+    {
+        $this->supports = $supports;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return $this->supports;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63578, relates to #45025
| License       | MIT

## Context

When a single firewall handles both stateful (session login) and stateless (API tokens) authentication, there is no way to tell Symfony "this authenticator is stateless." The `stateless: true` firewall option is all-or-nothing. Users are forced into hacky workarounds (`_security_firewall_run` manipulation, response cookie stripping) that grow more complex with each Symfony version.

See [#63578](https://github.com/symfony/symfony/issues/63578) and [discussion #45025](https://github.com/symfony/symfony/discussions/45025).

## What this PR does

Two new marker interfaces + changes to three existing classes:

### New interfaces

1. **`StatelessTokenInterface`** — marker on tokens (like `OfflineTokenInterface`). Tokens implementing this interface signal that they should not be persisted to the session.

2. **`StatelessAuthenticatorInterface`** — marker on authenticators (like `InteractiveAuthenticatorInterface`). When all authenticators supporting a request implement this interface, the request is treated as stateless.

### Modified classes

3. **`AuthenticatorManager::supports()`** — after building the list of supporting authenticators, checks if all implement `StatelessAuthenticatorInterface`. If so, sets `_security_stateless` on the request attributes. This runs before authentication, covering both success and failure paths.

4. **`ContextListener::onKernelResponse()`** — if the token implements `StatelessTokenInterface` or the request has `_security_stateless`, skips session persistence entirely. Resets the session usage index to 0 so `AbstractSessionListener` doesn't modify cache headers.

5. **`SecurityDataCollector::collect()`** — skips profiler debug cookies (`{firewallName}_auth_profile_token` / `_deauth_profile_token`) when `_security_stateless` is set.

### How it solves the problem

| Problem | Without PR (current workaround) | With PR |
|---------|-------------------------------|---------|
| Token persisted to session | `_security_firewall_run` hack at priority 1 | `ContextListener` checks `StatelessTokenInterface` |
| Session cookie on response | Strip cookies at priority -1001 | `AbstractSessionListener` already skips empty sessions; usage index reset prevents cache header side effects |
| Profiler debug cookies | Strip all cookies, re-add legitimate ones | `SecurityDataCollector` checks `_security_stateless` |
| Failed auth still sets cookies | `Authorization` header fallback | `AuthenticatorManager` sets `_security_stateless` before auth runs |

## CI note

All CI failures are **pre-existing on the 8.1 branch** and unrelated to this PR (`PropertyTypeExtractorInterface not found`, `ConsoleAssertionsTrait not found`, `AssetMapper` fixture issues, etc.). All Security component tests (`Security/Core`, `Security/Http`, `SecurityBundle`) pass, including the new tests added by this PR.

## Status: Proof of Concept — seeking feedback

This PR is a working proof of concept. We've validated it against a real-world codebase (a SaaS platform with mixed stateful/stateless authentication on a single firewall) including dedicated Behat tests for all edge cases. That said, there are rough edges and open questions I want to be transparent about:

### Known concerns

1. **`AuthenticatorManager::supports()` heuristic** — This sets `_security_stateless` before authentication, based on which authenticators claim to support the request. But `supports()` can return `null` (lazy), and the authenticator that actually runs might differ from the ones that initially matched. The "all supporting authenticators are stateless → request is stateless" heuristic works well in practice but isn't bulletproof.

2. **`usageIndexReference = 0` in ContextListener** — The existing code carefully tracks the session usage index to prevent `AbstractSessionListener` from modifying cache headers. Resetting to 0 works for our use case, but I haven't fully explored whether this could have subtle side effects when the session was started for other reasons before `onKernelResponse` runs.

3. **`_security_stateless` is a plain request attribute** — It can be set by anyone, not just our code. Not a real security concern (it can only *prevent* session persistence, not bypass authentication), but worth noting.

4. **No firewall config integration** — Symfony users expect configuration via `security.yaml`. This PR only adds interfaces with no wiring into the SecurityBundle config/compiler passes. The Symfony core team might prefer this to be integrated into the existing `stateless` config option (e.g., `stateless: per_authenticator`) or handled differently at the DI level.

5. **Mixed authenticator scenarios** — We've tested the classic case (form login + API token on the same firewall), but there may be edge cases with remember-me, switch-user, or other authenticator combinations that need more thought.

I'm happy to iterate on any of these points based on your feedback.