### PR TITLE
[DoctrineBridge] Rename `_schema_subscriber_check` table to `schema_subscriber_check_` for Oracle compatibility

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
- * Use a single table named `_schema_subscriber_check` in schema listeners to detect same database connections
+ * Use a single table named `schema_subscriber_check_` in schema listeners to detect same database connections
  * Add support for `Symfony\Component\Clock\DatePoint` as `DayPointType` and `TimePointType` Doctrine type
  * Deprecate the `AbstractDoctrineExtension` class; its code is incorporated into the extension classes of Doctrine bundles
 

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -65,7 +65,7 @@ abstract class AbstractSchemaListener
         return static function (\Closure $exec) use ($connection): bool {
             $schemaManager = method_exists($connection, 'createSchemaManager') ? $connection->createSchemaManager() : $connection->getSchemaManager();
             $key = bin2hex(random_bytes(7));
-            $table = new Table('_schema_subscriber_check');
+            $table = new Table('schema_subscriber_check_');
             $table->addColumn('id', Types::INTEGER)
                 ->setAutoincrement(true)
                 ->setNotnull(true);
@@ -85,19 +85,19 @@ abstract class AbstractSchemaListener
             } catch (DatabaseObjectExistsException) {
             }
 
-            $connection->executeStatement('INSERT INTO _schema_subscriber_check (random_key) VALUES (:key)', ['key' => $key], ['key' => Types::STRING]);
+            $connection->executeStatement('INSERT INTO schema_subscriber_check_ (random_key) VALUES (:key)', ['key' => $key], ['key' => Types::STRING]);
 
             try {
-                $exec(\sprintf('DELETE FROM _schema_subscriber_check WHERE random_key = %s', $connection->getDatabasePlatform()->quoteStringLiteral($key)));
+                $exec(\sprintf('DELETE FROM schema_subscriber_check_ WHERE random_key = %s', $connection->getDatabasePlatform()->quoteStringLiteral($key)));
             } catch (DatabaseObjectNotFoundException|ConnectionException|\PDOException) {
             }
 
             try {
-                return !$connection->executeStatement('DELETE FROM _schema_subscriber_check WHERE random_key = :key', ['key' => $key], ['key' => Types::STRING]);
+                return !$connection->executeStatement('DELETE FROM schema_subscriber_check_ WHERE random_key = :key', ['key' => $key], ['key' => Types::STRING]);
             } finally {
-                if (!$connection->executeQuery('SELECT count(id) FROM _schema_subscriber_check')->fetchOne()) {
+                if (!$connection->executeQuery('SELECT count(id) FROM schema_subscriber_check_')->fetchOne()) {
                     try {
-                        $schemaManager->dropTable('_schema_subscriber_check');
+                        $schemaManager->dropTable('schema_subscriber_check_');
                     } catch (DatabaseObjectNotFoundException) {
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63406
| License       | MIT

Oracle Database does not allow unquoted identifiers that start with `_`. Therefore, to fix the compatibility of the `doctrine:migrations:diff` command with Oracle, the table `_schema_subscriber_check` must either be quoted or renamed.

After digging into the code a bit, it seems there are several deprecations related to quoting in `Doctrine\DBAL\Schema\Table`. Because of that, I decided to just move `_` to the end of the table name. I also didn’t want to remove it entirely, since I’m a bit concerned that the new name might collide with an existing database object. It’s not very common, but still, I think adding the underscore as a postfix is safer.
