### PR TITLE
[Mime] Use shell_exec() instead of passthru() in FileBinaryMimeTypeGuesser

### DIFF
--- a/src/Symfony/Component/Mime/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/Mime/FileBinaryMimeTypeGuesser.php
@@ -44,15 +44,11 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
             return $supported;
         }
 
-        if ('\\' === \DIRECTORY_SEPARATOR || !\function_exists('passthru') || !\function_exists('escapeshellarg')) {
+        if ('\\' === \DIRECTORY_SEPARATOR || !\function_exists('shell_exec') || !\function_exists('escapeshellarg')) {
             return $supported = false;
         }
 
-        ob_start();
-        passthru('command -v file', $exitStatus);
-        $binPath = trim(ob_get_clean());
-
-        return $supported = 0 === $exitStatus && '' !== $binPath;
+        return $supported = '' !== trim(shell_exec('command -v file') ?: '');
     }
 
     public function guessMimeType(string $path): ?string
@@ -65,17 +61,8 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
             throw new LogicException(\sprintf('The "%s" guesser is not supported.', __CLASS__));
         }
 
-        ob_start();
-
         // need to use --mime instead of -i. see #6641
-        passthru(\sprintf($this->cmd, escapeshellarg((str_starts_with($path, '-') ? './' : '').$path)), $return);
-        if ($return > 0) {
-            ob_end_clean();
-
-            return null;
-        }
-
-        $type = trim(ob_get_clean());
+        $type = trim(shell_exec(\sprintf($this->cmd, escapeshellarg((str_starts_with($path, '-') ? './' : '').$path))) ?: '');
 
         if (!preg_match('#^([a-z0-9\-]+/[a-z0-9\-\+\.]+)#i', $type, $match)) {
             // it's not a type, but an error message


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63459
| License       | MIT

Using `passthru()` is needlessly convoluted and creates portability issues.
The rest of the code uses shell_exec/exec/proc_open, that's the only place where we use passthru.