### PR TITLE
[HttpClient] Fix streaming from CachingHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -160,7 +160,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
         $fullUrlTag = self::hash($fullUrl);
 
         if ('' !== $options['body'] || ($options['extra']['no_cache'] ?? false) || isset($options['normalized_headers']['range']) || !\in_array($method, self::CACHEABLE_METHODS, true)) {
-            return new AsyncResponse($this->client, $method, $url, $options, function (ChunkInterface $chunk, AsyncContext $context) use ($method, $fullUrlTag): \Generator {
+            $passthru = function (ChunkInterface $chunk, AsyncContext $context) use ($method, $fullUrlTag): \Generator {
                 if (null !== $chunk->getError() || $chunk->isTimeout() || !$chunk->isFirst()) {
                     yield $chunk;
 
@@ -175,7 +175,15 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
                 $context->passthru();
 
                 yield $chunk;
-            });
+            };
+
+            $this->isInnerRequest = true;
+
+            try {
+                return new AsyncResponse($this, $method, $url, $options, $passthru);
+            } finally {
+                $this->isInnerRequest = false;
+            }
         }
 
         $requestHash = self::hash($method.$fullUrl.serialize(array_intersect_key($options['normalized_headers'], self::RESPONSE_INFLUENCING_HEADERS)));

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -1149,7 +1149,6 @@ class CachingHttpClientTest extends TestCase
             $this->markTestSkipped('Legacy symfony/http-client-contracts in use');
         }
 
-        // no-cache means the cache must revalidate on every request;
         // the server returns 304 when If-None-Match matches
         $response = $client->request('GET', 'http://localhost:8057/304/etag');
         $this->assertSame(200, $response->getStatusCode());

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -122,7 +122,6 @@ switch (parse_url($vars['REQUEST_URI'], \PHP_URL_PATH)) {
             exit;
         }
         header('ETag: "abc123"');
-        header('Cache-Control: no-cache');
         break;
 
     case '/307':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

I missed this in #63573: all AsyncResponse instances returned by method `request()` must have the same `$client`.