### PR TITLE
[DependencyInjection] Add support for using service stacks as decorators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -44,7 +44,6 @@ class UnusedTagsPass implements CompilerPassInterface
         'container.service_locator',
         'container.service_locator_context',
         'container.service_subscriber',
-        'container.stack',
         'controller.argument_value_resolver',
         'controller.service_arguments',
         'controller.targeted_value_resolver',

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add support for using service stacks as decorators, including `decorates_tag`
  * Add support for decorating all services with a specific tag using the `container.tag_decorator` resource tag or `#[AsTagDecorator]`
  * Add support for `SOURCE_DATE_EPOCH` environment variable
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
@@ -14,9 +14,11 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\VarExporter\DeepCloner;
 
@@ -29,8 +31,10 @@ class ResolveDecoratorStackPass implements CompilerPassInterface
     {
         $stacks = [];
 
-        foreach ($container->findTaggedServiceIds('container.stack') as $id => $tags) {
-            $definition = $container->getDefinition($id);
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$definition->hasTag('container.stack')) {
+                continue;
+            }
 
             if (!$definition instanceof ChildDefinition) {
                 throw new InvalidArgumentException(\sprintf('Invalid service "%s": only definitions with a "parent" can have the "container.stack" tag.', $id));
@@ -41,6 +45,44 @@ class ResolveDecoratorStackPass implements CompilerPassInterface
             }
 
             $stacks[$id] = $stack;
+            $definitionCloner = null;
+            $stackCloner = null;
+
+            foreach ($definition->getTag('container.tag_decorator') as $tag) {
+                if (!$decoratesTag = $tag['decorates_tag'] ?? null) {
+                    continue;
+                }
+
+                if ($definition->getDecoratedService()) {
+                    throw new InvalidArgumentException(\sprintf('Service stack "%s" cannot have both "decorates" and "decorates_tag".', $id));
+                }
+
+                $priority = $tag['priority'] ?? 0;
+                $invalidBehavior = $tag['on_invalid'] ?? ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+
+                if (!$taggedServices = $container->findTaggedServiceIds($decoratesTag)) {
+                    if (ContainerInterface::IGNORE_ON_INVALID_REFERENCE === $invalidBehavior) {
+                        continue;
+                    }
+
+                    if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
+                        throw new ServiceNotFoundException($decoratesTag, $id);
+                    }
+                }
+                $definitionCloner ??= new DeepCloner($definition);
+                $stackCloner ??= new DeepCloner($stack);
+
+                foreach ($taggedServices as $taggedServiceId => $_) {
+                    $cloneId = '.stack.'.$taggedServiceId.'.'.$id;
+                    $container->setDefinition($cloneId, $definitionCloner->clone())
+                        ->clearTag('container.tag_decorator')->clearTag('container.excluded')
+                        ->setDecoratedService($taggedServiceId, null, $priority, $invalidBehavior);
+                    $stacks[$cloneId] = $stackCloner->clone();
+                }
+
+                $container->removeDefinition($id);
+                unset($stacks[$id]);
+            }
         }
 
         if (!$stacks) {
@@ -55,7 +97,16 @@ class ResolveDecoratorStackPass implements CompilerPassInterface
                 continue;
             }
 
-            foreach (array_reverse($this->resolveStack($stacks, [$id]), true) as $k => $v) {
+            $resolved = $this->resolveStack($stacks, [$id]);
+
+            if ($decoratedService = $definition->getDecoratedService()) {
+                // Propagate decoration to the innermost definition in the stack,
+                // so that DecoratorServicePass can wire it to the original service.
+                end($resolved);
+                $resolved[key($resolved)]->setDecoratedService($decoratedService[0], $decoratedService[1], $decoratedService[2], $decoratedService[3] ?? ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
+            }
+
+            foreach (array_reverse($resolved, true) as $k => $v) {
                 $resolvedDefinitions[$k] = $v;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/TagDecoratorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/TagDecoratorPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\VarExporter\DeepCloner;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
@@ -24,6 +25,7 @@ final class TagDecoratorPass implements CompilerPassInterface
     {
         foreach ($container->findTaggedResourceIds('container.tag_decorator', false) as $id => $tags) {
             $definition = $container->getDefinition($id);
+            $definitionCloner = null;
 
             foreach ($tags as $tag) {
                 if (!$decoratesTag = $tag['decorates_tag'] ?? null) {
@@ -43,14 +45,12 @@ final class TagDecoratorPass implements CompilerPassInterface
                         throw new ServiceNotFoundException($decoratesTag, $id);
                     }
                 }
+                $definitionCloner ??= new DeepCloner($definition);
 
                 foreach ($taggedServices as $taggedServiceId => $_) {
-                    $clonedDefinition = clone $definition;
-                    $clonedDefinition->clearTag('container.tag_decorator');
-                    $clonedDefinition->clearTag('container.excluded');
-                    $clonedDefinition->setDecoratedService($taggedServiceId, null, $priority, $invalidBehavior);
-                    $decoratorId = \sprintf('.decorator.%s.%s', $taggedServiceId, $id);
-                    $container->setDefinition($decoratorId, $clonedDefinition);
+                    $container->setDefinition(\sprintf('.decorator.%s.%s', $taggedServiceId, $id), $definitionCloner->clone())
+                        ->clearTag('container.tag_decorator')->clearTag('container.excluded')
+                        ->setDecoratedService($taggedServiceId, null, $priority, $invalidBehavior);
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractServiceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractServiceConfigurator.php
@@ -96,7 +96,7 @@ abstract class AbstractServiceConfigurator extends AbstractConfigurator
      *
      * @param InlineServiceConfigurator[]|ReferenceConfigurator[] $services
      */
-    final public function stack(string $id, array $services): AliasConfigurator
+    final public function stack(string $id, array $services): StackConfigurator
     {
         $this->__destruct();
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
@@ -87,10 +87,10 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     tags?: TagsType,
  *     resource_tags?: TagsType,
  *     decorates?: string,
+ *     decorates_tag?: string,
  *     decoration_inner_name?: string,
  *     decoration_priority?: int,
  *     decoration_on_invalid?: 'exception'|'ignore'|null,
- *     decorates_tag?: string,
  *     autowire?: bool,
  *     autoconfigure?: bool,
  *     bind?: array<string, mixed>,
@@ -128,6 +128,11 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  *     stack: list<DefinitionType|AliasType|PrototypeType|array<class-string, ArgumentsType|null>>,
  *     public?: bool,
  *     deprecated?: DeprecationType,
+ *     decorates?: string,
+ *     decorates_tag?: string,
+ *     decoration_inner_name?: string,
+ *     decoration_priority?: int,
+ *     decoration_on_invalid?: 'exception'|'ignore'|null,
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -147,7 +147,7 @@ class ServicesConfigurator extends AbstractConfigurator
      *
      * @param InlineServiceConfigurator[]|ReferenceConfigurator[] $services
      */
-    final public function stack(string $id, array $services): AliasConfigurator
+    final public function stack(string $id, array $services): StackConfigurator
     {
         foreach ($services as $i => $service) {
             if ($service instanceof InlineServiceConfigurator) {
@@ -165,7 +165,7 @@ class ServicesConfigurator extends AbstractConfigurator
             }
         }
 
-        $alias = $this->alias($id, '');
+        $alias = new StackConfigurator($this, $this->container->setAlias($id, ''));
         $alias->definition = $this->set($id)
             ->parent('')
             ->args($services)

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/StackConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/StackConfigurator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class StackConfigurator extends AliasConfigurator
+{
+    use Traits\DecorateTrait {
+        decorate as private doDecorate;
+        decorateTag as private doDecorateTag;
+    }
+
+    public const FACTORY = 'stack';
+
+    final public function decorate(?string $id, ?string $renamedId = null, int $priority = 0, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE): static
+    {
+        if ($this->definition->hasTag('container.tag_decorator')) {
+            throw new InvalidArgumentException('A stack cannot have both "decorate" and "decorateTag".');
+        }
+
+        return $this->doDecorate($id, $renamedId, $priority, $invalidBehavior);
+    }
+
+    final public function decorateTag(string $tag, int $priority = 0, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE): static
+    {
+        if ($this->definition->getDecoratedService()) {
+            throw new InvalidArgumentException('A stack cannot have both "decorate" and "decorateTag".');
+        }
+
+        return $this->doDecorateTag($tag, $priority, $invalidBehavior);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -337,8 +337,8 @@ trait ContentLoaderTrait
                 $stack[$k] = $definition;
             }
 
-            if ($diff = array_diff(array_keys($service), ['stack', 'public', 'deprecated'])) {
-                throw new InvalidArgumentException(\sprintf('Invalid attribute "%s"; supported ones are "public" and "deprecated" for service "%s" in "%s".', implode('", "', $diff), $id, $file));
+            if ($diff = array_diff(array_keys($service), ['stack', 'public', 'deprecated', 'decorates', 'decorates_tag', 'decoration_inner_name', 'decoration_priority', 'decoration_on_invalid'])) {
+                throw new InvalidArgumentException(\sprintf('Invalid attribute "%s"; supported ones are "public", "deprecated", "decorates", "decorates_tag" and "decoration_*" for service "%s" in "%s".', implode('", "', $diff), $id, $file));
             }
 
             $service = [
@@ -347,6 +347,11 @@ trait ContentLoaderTrait
                 'tags' => ['container.stack'],
                 'public' => $service['public'] ?? null,
                 'deprecated' => $service['deprecated'] ?? null,
+                'decorates' => $service['decorates'] ?? null,
+                'decorates_tag' => $service['decorates_tag'] ?? null,
+                'decoration_inner_name' => $service['decoration_inner_name'] ?? null,
+                'decoration_priority' => $service['decoration_priority'] ?? null,
+                'decoration_on_invalid' => $service['decoration_on_invalid'] ?? null,
             ];
         }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
@@ -251,6 +251,7 @@
         "tags": { "$ref": "#/$defs/tags" },
         "resource_tags": { "$ref": "#/$defs/tags" },
         "decorates": { "type": "string" },
+        "decorates_tag": { "type": "string" },
         "decoration_inner_name": { "type": "string" },
         "decoration_priority": { "type": "integer" },
         "decoration_on_invalid": { "oneOf": [ { "enum": ["exception", "ignore"] }, { "type": "null" } ], "$comment": "Use null (without quotes) for NULL_ON_INVALID_REFERENCE." },
@@ -313,7 +314,12 @@
           }
         },
         "public": { "type": "boolean" },
-        "deprecated": { "$ref": "#/$defs/deprecation" }
+        "deprecated": { "$ref": "#/$defs/deprecation" },
+        "decorates": { "type": "string" },
+        "decorates_tag": { "type": "string" },
+        "decoration_inner_name": { "type": "string" },
+        "decoration_priority": { "type": "integer" },
+        "decoration_on_invalid": { "oneOf": [ { "enum": ["exception", "ignore"] }, { "type": "null" } ], "$comment": "Use null (without quotes) for NULL_ON_INVALID_REFERENCE." }
       },
       "required": ["stack"],
       "additionalProperties": false

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDecoratorStackPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDecoratorStackPassTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveDecoratorStackPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ResolveDecoratorStackPassTest extends TestCase
+{
+    public function testStackDecoratesExistingService()
+    {
+        $container = new ContainerBuilder();
+
+        // The existing service that should be decorated
+        $container->register('original_service', \stdClass::class)
+            ->setPublic(true)
+            ->setProperty('label', 'original');
+
+        // Define a stack that decorates the existing service
+        $stack = (new ChildDefinition(''))
+            ->addTag('container.stack')
+            ->setArguments([
+                (new Definition(\stdClass::class))
+                    ->setProperty('label', 'A')
+                    ->setProperty('inner', new Reference('.inner')),
+                (new Definition(\stdClass::class))
+                    ->setProperty('label', 'B')
+                    ->setProperty('inner', new Reference('.inner')),
+            ])
+            ->setDecoratedService('original_service')
+        ;
+
+        $container->setDefinition('my_stack', $stack);
+
+        (new ResolveDecoratorStackPass())->process($container);
+        (new DecoratorServicePass())->process($container);
+
+        // The original service should now be decorated
+        $this->assertTrue($container->hasAlias('original_service'));
+
+        // The innermost definition should wrap the original service
+        // and the outermost should be the entry point
+        $alias = $container->getAlias('my_stack');
+        $outermostId = (string) $alias;
+
+        // The outermost definition should have label 'A'
+        $outermostDef = $container->getDefinition($outermostId);
+        $this->assertSame('A', $outermostDef->getProperties()['label']);
+
+        // Follow the chain: the original service should still be accessible
+        $this->assertTrue($container->hasDefinition('original_service.inner') || $this->hasInnerService($container));
+    }
+
+    public function testStackDecoratesWithPriority()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('original_service', \stdClass::class)
+            ->setPublic(true);
+
+        $stack = (new ChildDefinition(''))
+            ->addTag('container.stack')
+            ->setArguments([
+                new Definition(\stdClass::class),
+                new Definition(\stdClass::class),
+            ])
+            ->setDecoratedService('original_service', null, 5)
+        ;
+
+        $container->setDefinition('my_stack', $stack);
+
+        (new ResolveDecoratorStackPass())->process($container);
+
+        // After resolving the stack, the innermost definition should have
+        // the decoratedService set to 'original_service' with priority 5
+        $resolved = $container->getDefinitions();
+        $innermostFound = false;
+
+        foreach ($resolved as $id => $def) {
+            if (str_starts_with($id, '.my_stack.') && null !== $def->getDecoratedService()) {
+                $decorated = $def->getDecoratedService();
+                if ('original_service' === $decorated[0]) {
+                    $innermostFound = true;
+                    $this->assertSame(5, $decorated[2]);
+                }
+            }
+        }
+
+        $this->assertTrue($innermostFound, 'The innermost stack definition should decorate "original_service"');
+    }
+
+    public function testStackDecoratesWithInvalidBehavior()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('original_service', \stdClass::class)
+            ->setPublic(true);
+
+        $stack = (new ChildDefinition(''))
+            ->addTag('container.stack')
+            ->setArguments([
+                new Definition(\stdClass::class),
+                new Definition(\stdClass::class),
+            ])
+            ->setDecoratedService('original_service', null, 0, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)
+        ;
+
+        $container->setDefinition('my_stack', $stack);
+
+        (new ResolveDecoratorStackPass())->process($container);
+
+        $resolved = $container->getDefinitions();
+        $innermostFound = false;
+
+        foreach ($resolved as $id => $def) {
+            if (str_starts_with($id, '.my_stack.') && null !== $def->getDecoratedService()) {
+                $decorated = $def->getDecoratedService();
+                if ('original_service' === $decorated[0]) {
+                    $innermostFound = true;
+                    $this->assertSame(ContainerInterface::IGNORE_ON_INVALID_REFERENCE, $decorated[3]);
+                }
+            }
+        }
+
+        $this->assertTrue($innermostFound);
+    }
+
+    public function testStackWithoutDecoratesStillWorks()
+    {
+        $container = new ContainerBuilder();
+
+        $stack = (new ChildDefinition(''))
+            ->addTag('container.stack')
+            ->setArguments([
+                (new Definition(\stdClass::class))
+                    ->setProperty('label', 'A')
+                    ->setProperty('inner', new Reference('.inner')),
+                (new Definition(\stdClass::class))
+                    ->setProperty('label', 'B'),
+            ])
+        ;
+        $stack->setPublic(true);
+        $stack->setChanges(['public' => true]);
+
+        $container->setDefinition('my_stack', $stack);
+
+        (new ResolveDecoratorStackPass())->process($container);
+
+        // The innermost definition should not decorate any external service
+        $resolved = $container->getDefinitions();
+        $stackDefs = array_filter($resolved, static fn ($v, $id) => str_starts_with($id, '.my_stack.'), \ARRAY_FILTER_USE_BOTH);
+        $this->assertCount(2, $stackDefs);
+
+        $innermost = reset($stackDefs);
+        $this->assertNull($innermost->getDecoratedService());
+    }
+
+    public function testStackDecoratesTag()
+    {
+        $container = new ContainerBuilder();
+
+        // Two services tagged with 'my_tag'
+        $container->register('foo', \stdClass::class)
+            ->setPublic(true)
+            ->addTag('my_tag')
+            ->setProperty('label', 'foo');
+
+        $container->register('bar', \stdClass::class)
+            ->setPublic(true)
+            ->addTag('my_tag')
+            ->setProperty('label', 'bar');
+
+        // A stack that decorates all services tagged 'my_tag'
+        $stack = (new ChildDefinition(''))
+            ->addTag('container.stack')
+            ->addResourceTag('container.tag_decorator', ['decorates_tag' => 'my_tag'])
+            ->setArguments([
+                (new Definition(\stdClass::class))
+                    ->setProperty('label', 'A')
+                    ->setProperty('inner', new Reference('.inner')),
+                (new Definition(\stdClass::class))
+                    ->setProperty('label', 'B')
+                    ->setProperty('inner', new Reference('.inner')),
+            ])
+        ;
+
+        $container->setDefinition('my_stack', $stack);
+
+        (new ResolveDecoratorStackPass())->process($container);
+        (new DecoratorServicePass())->process($container);
+
+        // The original stack definition should have been removed
+        $this->assertFalse($container->hasDefinition('my_stack'));
+
+        // Both foo and bar should be decorated
+        $this->assertTrue($container->hasAlias('foo'));
+        $this->assertTrue($container->hasAlias('bar'));
+    }
+
+    public function testStackCannotHaveBothDecoratesAndDecoratesTag()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', \stdClass::class)
+            ->addTag('my_tag');
+
+        $stack = (new ChildDefinition(''))
+            ->addTag('container.stack')
+            ->addResourceTag('container.tag_decorator', ['decorates_tag' => 'my_tag'])
+            ->setDecoratedService('foo')
+            ->setArguments([
+                new Definition(\stdClass::class),
+            ])
+        ;
+
+        $container->setDefinition('my_stack', $stack);
+
+        $this->expectException(\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot have both "decorates" and "decorates_tag"');
+        (new ResolveDecoratorStackPass())->process($container);
+    }
+
+    private function hasInnerService(ContainerBuilder $container): bool
+    {
+        foreach ($container->getDefinitions() as $id => $def) {
+            if (str_ends_with($id, '.inner')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack_decorates.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack_decorates.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $c) {
+    $services = $c->services();
+
+    $services->set('original_service', 'stdClass')
+        ->public()
+        ->property('label', 'original');
+
+    $services->stack('my_stack', [
+        inline_service('stdClass')
+            ->property('label', 'A')
+            ->property('inner', service('.inner')),
+        inline_service('stdClass')
+            ->property('label', 'B')
+            ->property('inner', service('.inner')),
+    ])->decorate('original_service');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack_decorates_tag.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack_decorates_tag.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $c) {
+    $services = $c->services();
+
+    $services->set('foo', 'stdClass')
+        ->public()
+        ->tag('my_tag')
+        ->property('label', 'foo');
+
+    $services->set('bar', 'stdClass')
+        ->public()
+        ->tag('my_tag')
+        ->property('label', 'bar');
+
+    $services->stack('my_stack', [
+        inline_service('stdClass')
+            ->property('label', 'A')
+            ->property('inner', service('.inner')),
+        inline_service('stdClass')
+            ->property('label', 'B')
+            ->property('inner', service('.inner')),
+    ])->decorateTag('my_tag');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/stack_decorates.yaml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/stack_decorates.yaml
@@ -1,0 +1,18 @@
+services:
+    original_service:
+        class: stdClass
+        public: true
+        properties:
+            label: original
+
+    my_stack:
+        decorates: original_service
+        stack:
+            - class: stdClass
+              properties:
+                  label: A
+                  inner: '@.inner'
+            - class: stdClass
+              properties:
+                  label: B
+                  inner: '@.inner'

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/stack_decorates_tag.yaml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/stack_decorates_tag.yaml
@@ -1,0 +1,28 @@
+services:
+    foo:
+        class: stdClass
+        public: true
+        tags:
+            - { name: my_tag }
+        properties:
+            label: foo
+
+    bar:
+        class: stdClass
+        public: true
+        tags:
+            - { name: my_tag }
+        properties:
+            label: bar
+
+    my_stack:
+        decorates_tag: my_tag
+        stack:
+            - class: stdClass
+              properties:
+                  label: A
+                  inner: '@.inner'
+            - class: stdClass
+              properties:
+                  label: B
+                  inner: '@.inner'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -219,6 +219,59 @@ class PhpFileLoaderTest extends TestCase
         $this->assertEquals($expected, $container->get('stack_d'));
     }
 
+    public function testStackDecorates()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new PhpFileLoader($container, new FileLocator(realpath(__DIR__.'/../Fixtures').'/config'));
+        $loader->load('stack_decorates.php');
+
+        $container->compile();
+
+        $expected = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'original',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $container->get('original_service'));
+    }
+
+    public function testStackDecoratesTag()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new PhpFileLoader($container, new FileLocator(realpath(__DIR__.'/../Fixtures').'/config'));
+        $loader->load('stack_decorates_tag.php');
+
+        $container->compile();
+
+        $expectedFoo = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'foo',
+                ],
+            ],
+        ];
+        $expectedBar = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'bar',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedFoo, $container->get('foo'));
+        $this->assertEquals($expectedBar, $container->get('bar'));
+    }
+
     public function testEnvConfigurator()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -1185,6 +1185,58 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals($expected, $container->get('stack_e'));
     }
 
+    public function testStackDecorates()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('stack_decorates.yaml');
+
+        $container->compile();
+
+        $expected = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'original',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $container->get('original_service'));
+    }
+
+    public function testStackDecoratesTag()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('stack_decorates_tag.yaml');
+
+        $container->compile();
+
+        $expectedFoo = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'foo',
+                ],
+            ],
+        ];
+        $expectedBar = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'bar',
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedFoo, $container->get('foo'));
+        $this->assertEquals($expectedBar, $container->get('bar'));
+    }
+
     public function testWhenEnv()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #48418
| License       | MIT

Service stacks and service decoration are currently two distinct mechanisms. The docs present them as interchangeable, but stacks cannot be used to decorate an existing third-party service.

This PR adds support for `decorates` and `decorates_tag` on stack definitions.

For `decorates`, `ResolveDecoratorStackPass` propagates the decoration metadata to the innermost resolved definition, so that `DecoratorServicePass` can wire it to the original service:

```yaml
services:
    my_stack:
        decorates: api_platform.serializer.context_builder
        stack:
            - class: App\Decorator\AddGroupsContextBuilder
              arguments: ['@.inner']
            - class: App\Decorator\AddFiltersContextBuilder
              arguments: ['@.inner']
```

For `decorates_tag`, the stack is cloned once per tagged service, each clone getting its own decorates set automatically. This composes with the existing decorates propagation:

```yaml
services:
    my_stack:
        decorates_tag: my_tag
        stack:
            - class: App\Decorator\LoggingDecorator
              arguments: ['@.inner']
            - class: App\Decorator\CachingDecorator
              arguments: ['@.inner']
```
