### PR TITLE
[Validator] Fix when constraint without expression language installed, when using closure expression

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/When.php
+++ b/src/Symfony/Component/Validator/Constraints/When.php
@@ -41,7 +41,7 @@ class When extends Composite
     #[HasNamedArguments]
     public function __construct(string|Expression|array|\Closure $expression, array|Constraint|null $constraints = null, ?array $values = null, ?array $groups = null, $payload = null, ?array $options = null, array|Constraint $otherwise = [])
     {
-        if (!class_exists(ExpressionLanguage::class)) {
+        if (!$expression instanceof \Closure && !class_exists(ExpressionLanguage::class)) {
             throw new LogicException(\sprintf('The "symfony/expression-language" component is required to use the "%s" constraint. Try running "composer require symfony/expression-language".', __CLASS__));
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenWithoutExpressionLanguageTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenWithoutExpressionLanguageTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClassExistsMock;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\When;
+use Symfony\Component\Validator\Exception\LogicException;
+
+#[RunTestsInSeparateProcesses]
+final class WhenWithoutExpressionLanguageTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        ClassExistsMock::register(When::class);
+        ClassExistsMock::withMockedClasses([
+            ExpressionLanguage::class => false,
+        ]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        ClassExistsMock::withMockedClasses([]);
+    }
+
+    public function testClosureDoesNotRequireExpressionLanguage()
+    {
+        $when = new When(
+            expression: static fn () => true,
+            constraints: [new NotNull()],
+        );
+
+        self::assertInstanceOf(\Closure::class, $when->expression);
+    }
+
+    public function testStringExpressionRequiresExpressionLanguage()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "symfony/expression-language" component is required');
+
+        new When(
+            expression: 'true',
+            constraints: [new NotNull()],
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The When constraint constructor unconditionally checks for the ExpressionLanguage class, even when a Closure is passed as the expression parameter. Since closures don't use the ExpressionLanguage component at all, the constructor should skip this check for closure expressions.

This allows using the When constraint with closures without requiring the symfony/expression-language package to be installed. For Example, when using PHP 8.5 with Closures in Attributes only.
