### PR TITLE
[Cache] Add timeout and slot eviction to LockRegistry stampede prevention

### DIFF
--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -65,12 +65,14 @@ final class LockRegistry
     /**
      * Defines a set of existing files that will be used as keys to acquire locks.
      *
-     * @return array The previously defined set of files
+     * @param list<string> $files A list of existing files
+     *
+     * @return list<string> The previously defined set of files
      */
     public static function setFiles(array $files): array
     {
         $previousFiles = self::$files;
-        self::$files = $files;
+        self::$files = array_values($files);
 
         foreach (self::$openedFiles as $file) {
             if ($file) {
@@ -97,7 +99,7 @@ final class LockRegistry
         }
 
         self::$signalingException ??= unserialize("O:9:\"Exception\":1:{s:16:\"\0Exception\0trace\";a:0:{}}");
-        self::$signalingCallback ??= fn () => throw self::$signalingException;
+        self::$signalingCallback ??= static fn () => throw self::$signalingException;
 
         while (true) {
             try {
@@ -123,14 +125,33 @@ final class LockRegistry
                 }
                 // if we failed the race, retry locking in blocking mode to wait for the winner
                 $logger?->info('Item "{key}" is locked, waiting for it to be released', ['key' => $item->getKey()]);
-                flock($lock, \LOCK_SH);
+
+                $deadline = microtime(true) + 30.0;
+                $acquired = false;
+                do {
+                    if ($acquired = flock($lock, \LOCK_SH | \LOCK_NB)) {
+                        break;
+                    }
+                    usleep(100_000);
+                } while (microtime(true) < $deadline);
+
+                if (!$acquired) {
+                    $logger?->warning('Lock on item "{key}" timed out, evicting slot', ['key' => $item->getKey()]);
+                    unset(self::$files[$key]);
+                    self::setFiles(self::$files);
+                    $lock = null;
+
+                    return self::compute($callback, $item, $save, $pool, $setMetadata, $logger, $beta);
+                }
 
                 if (\INF === $beta) {
                     $logger?->info('Force-recomputing item "{key}"', ['key' => $item->getKey()]);
                     continue;
                 }
             } finally {
-                flock($lock, \LOCK_UN);
+                if ($lock) {
+                    flock($lock, \LOCK_UN);
+                }
                 unset(self::$lockedFiles[$key]);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59191
| License       | MIT

When a process waits for [a lock held by a crashed/killed process](https://www.php.net/manual/en/function.flock.php#120874), the blocking `flock()` call would wait indefinitely, causing FPM workers to pile up and eventually exhaust the process pool.

This PR replaces the blocking `flock(LOCK_SH)` with a non-blocking poll loop that gives up after 30 seconds. On timeout, the stale lock slot is evicted and `compute()` retries with the reduced file pool. The item rehashes to a different (hopefully healthy) slot and attempts locking there.

This provides graceful degradation:
- One stale slot: the item moves to another slot, stampede protection continues with 24 slots instead of 25
- Multiple stale slots: each is evicted independently as encountered, shrinking the pool progressively
- All slots stale (worst case): self::$files becomes empty, stampede protection is fully disabled, but no process ever blocks indefinitely

The 30s timeout is chosen to be long enough to accommodate legitimately slow cache computations while being short enough to prevent worker exhaustion under typical FPM request_terminate_timeout settings.