### PR TITLE
[Uid] Add Uuid47Transformer support for UUIDv7/v4 conversion

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -205,6 +205,7 @@ use Symfony\Component\TypeInfo\TypeResolver\PhpDocAwareReflectionTypeResolver;
 use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
 use Symfony\Component\Uid\Factory\UuidFactory;
+use Symfony\Component\Uid\Uuid47Transformer;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Validator\Attribute\ExtendsValidationFor;
 use Symfony\Component\Validator\Constraint;
@@ -3481,6 +3482,11 @@ class FrameworkExtension extends Extension
         if (isset($config['name_based_uuid_namespace'])) {
             $container->getDefinition('name_based_uuid.factory')
                 ->setArguments([$config['name_based_uuid_namespace']]);
+        }
+
+        if (!class_exists(Uuid47Transformer::class)) {
+            $container->removeDefinition('uuid47_transformer');
+            $container->removeAlias(Uuid47Transformer::class);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/uid.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/uid.php
@@ -16,6 +16,7 @@ use Symfony\Component\Uid\Factory\RandomBasedUuidFactory;
 use Symfony\Component\Uid\Factory\TimeBasedUuidFactory;
 use Symfony\Component\Uid\Factory\UlidFactory;
 use Symfony\Component\Uid\Factory\UuidFactory;
+use Symfony\Component\Uid\Uuid47Transformer;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -37,5 +38,9 @@ return static function (ContainerConfigurator $container) {
         ->set('time_based_uuid.factory', TimeBasedUuidFactory::class)
             ->factory([service('uuid.factory'), 'timeBased'])
         ->alias(TimeBasedUuidFactory::class, 'time_based_uuid.factory')
+
+        ->set('uuid47_transformer', Uuid47Transformer::class)
+            ->args([param('kernel.secret')])
+        ->alias(Uuid47Transformer::class, 'uuid47_transformer')
     ;
 };

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `Uuid47Transformer` to convert between UUIDv7 and UUIDv4 using SipHash-2-4 timestamp masking
  * Add argument `$format` to `Ulid::isValid()`
 
 8.0

--- a/src/Symfony/Component/Uid/Tests/Uuid47TransformerTest.php
+++ b/src/Symfony/Component/Uid/Tests/Uuid47TransformerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Uuid47Transformer;
+use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Uid\UuidV7;
+
+#[RequiresPhpExtension('sodium')]
+class Uuid47TransformerTest extends TestCase
+{
+    private function createConverter(): Uuid47Transformer
+    {
+        // K0 = 0x0123456789abcdef, K1 = 0xfedcba9876543210 (little-endian byte representation)
+        return new Uuid47Transformer(hex2bin('efcdab89674523011032547698badcfe'));
+    }
+
+    public function testConstructorRequiresAtLeast16ByteKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Uuid47Transformer('tooshort');
+    }
+
+    public function testConstructorHashesLongKeys()
+    {
+        $v7 = new UuidV7('018f2d9f-9a2a-7def-8c3f-7b1a2c4d5e6f');
+
+        $a = new Uuid47Transformer(random_bytes(32));
+        $b = new Uuid47Transformer(random_bytes(32));
+
+        $this->assertNotSame(
+            $a->encode($v7)->toRfc4122(),
+            $b->encode($v7)->toRfc4122(),
+        );
+    }
+
+    /**
+     * Test vectors from the reference C implementation.
+     */
+    #[DataProvider('provideEncodeDecodeVectors')]
+    public function testEncode(string $inputV7, string $expectedV4)
+    {
+        $converter = $this->createConverter();
+        $encoded = $converter->encode(new UuidV7($inputV7));
+
+        $this->assertSame($expectedV4, $encoded->toRfc4122());
+    }
+
+    #[DataProvider('provideEncodeDecodeVectors')]
+    public function testDecode(string $expectedV7, string $inputV4)
+    {
+        $converter = $this->createConverter();
+        $decoded = $converter->decode(new UuidV4($inputV4));
+
+        $this->assertSame($expectedV7, $decoded->toRfc4122());
+    }
+
+    #[DataProvider('provideEncodeDecodeVectors')]
+    public function testRoundTrip(string $inputV7, string $expectedV4)
+    {
+        $converter = $this->createConverter();
+        $v7 = new UuidV7($inputV7);
+
+        $encoded = $converter->encode($v7);
+        $this->assertInstanceOf(UuidV4::class, $encoded);
+
+        $decoded = $converter->decode($encoded);
+        $this->assertInstanceOf(UuidV7::class, $decoded);
+        $this->assertSame($inputV7, $decoded->toRfc4122());
+    }
+
+    public static function provideEncodeDecodeVectors(): iterable
+    {
+        yield 'C demo.c example' => [
+            '018f2d9f-9a2a-7def-8c3f-7b1a2c4d5e6f',
+            '2463c780-7fca-4def-8c3f-7b1a2c4d5e6f',
+        ];
+
+        yield 'all zeros timestamp' => [
+            '00000000-0000-7000-8000-000000000000',
+            '22d97126-9609-4000-8000-000000000000',
+        ];
+
+        yield 'C roundtrip vector 0' => [
+            '00000000-007b-7aaa-8123-456789abcdef',
+            'b108050e-46b6-4aaa-8123-456789abcdef',
+        ];
+
+        yield 'C roundtrip vector 1' => [
+            '00000010-007b-7aad-9032-547698badcfe',
+            'bc75bd50-97ef-4aad-9032-547698badcfe',
+        ];
+
+        yield 'C roundtrip vector 2' => [
+            '00000020-007b-7aa4-a301-6745ab89efcd',
+            'a3e09c87-bf85-4aa4-a301-6745ab89efcd',
+        ];
+    }
+
+    public function testRandomBitsPreserved()
+    {
+        $converter = $this->createConverter();
+        $v7 = new UuidV7('018f2d9f-9a2a-7def-8c3f-7b1a2c4d5e6f');
+        $v4 = $converter->encode($v7);
+
+        $v7hex = str_replace('-', '', $v7->toRfc4122());
+        $v4hex = str_replace('-', '', $v4->toRfc4122());
+
+        // rand_a (lower nibble of byte 6 + byte 7) should be preserved
+        $this->assertSame($v7hex[13], $v4hex[13], 'rand_a high nibble');
+        $this->assertSame(substr($v7hex, 14, 2), substr($v4hex, 14, 2), 'rand_a low byte');
+
+        // variant bits masked, but low 6 bits of byte 8 should be preserved
+        $v7b8 = hexdec(substr($v7hex, 16, 2)) & 0x3F;
+        $v4b8 = hexdec(substr($v4hex, 16, 2)) & 0x3F;
+        $this->assertSame($v7b8, $v4b8, 'clock_seq high bits');
+
+        // bytes 9-15 should be identical
+        $this->assertSame(substr($v7hex, 18), substr($v4hex, 18), 'rand_b');
+    }
+
+    public function testEncodeReturnType()
+    {
+        $converter = $this->createConverter();
+        $result = $converter->encode(new UuidV7());
+
+        $this->assertInstanceOf(UuidV4::class, $result);
+    }
+
+    public function testDecodeReturnType()
+    {
+        $converter = $this->createConverter();
+        $v4 = $converter->encode(new UuidV7());
+        $result = $converter->decode($v4);
+
+        $this->assertInstanceOf(UuidV7::class, $result);
+    }
+
+    public function testDifferentKeysProduceDifferentResults()
+    {
+        $v7 = new UuidV7('018f2d9f-9a2a-7def-8c3f-7b1a2c4d5e6f');
+
+        $a = new Uuid47Transformer(random_bytes(16));
+        $b = new Uuid47Transformer(random_bytes(16));
+
+        $this->assertNotSame(
+            $a->encode($v7)->toRfc4122(),
+            $b->encode($v7)->toRfc4122(),
+        );
+    }
+
+    public function testDecodeWithWrongKeyProducesDifferentResult()
+    {
+        $v7 = new UuidV7('018f2d9f-9a2a-7def-8c3f-7b1a2c4d5e6f');
+
+        $correctKey = $this->createConverter();
+        $wrongKey = new Uuid47Transformer(random_bytes(16));
+
+        $encoded = $correctKey->encode($v7);
+
+        // Decoding with a wrong key does not throw, but produces a different UUIDv7
+        $decoded = $wrongKey->decode($encoded);
+        $this->assertNotSame($v7->toRfc4122(), $decoded->toRfc4122());
+    }
+}

--- a/src/Symfony/Component/Uid/Uuid47Transformer.php
+++ b/src/Symfony/Component/Uid/Uuid47Transformer.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+use Symfony\Component\Uid\Exception\InvalidArgumentException;
+use Symfony\Component\Uid\Exception\LogicException;
+
+/**
+ * Converts between UUIDv7 and UUIDv4 using SipHash-2-4 timestamp masking.
+ *
+ * This allows storing time-ordered UUIDv7 in databases while emitting
+ * UUIDv4-looking identifiers at API boundaries, hiding timing information.
+ *
+ * The 48-bit timestamp of a UUIDv7 is XOR-masked with a keyed SipHash-2-4
+ * digest derived from the UUID's own random bits, producing a valid UUIDv4.
+ * The transformation is reversible with the same key.
+ *
+ * @see https://github.com/n2p5/uuid47
+ */
+class Uuid47Transformer
+{
+    private string $secret;
+
+    /**
+     * @param string $secret A binary secret of at least 16 bytes
+     */
+    public function __construct(
+        #[\SensitiveParameter]
+        string $secret,
+    ) {
+        if (!\extension_loaded('sodium')) {
+            throw new LogicException('The "sodium" PHP extension is required to use Uuid47.');
+        }
+        if (16 > \strlen($secret)) {
+            throw new InvalidArgumentException('The secret must be at least 16 bytes.');
+        }
+
+        $this->secret = 16 === \strlen($secret) ? $secret : substr(hash('sha256', $secret, true), 0, 16);
+    }
+
+    /**
+     * Encodes a UUIDv7 into a UUIDv4-looking UUID.
+     */
+    public function encode(UuidV7 $uuid): UuidV4
+    {
+        return new UuidV4(self::transform($uuid->toRfc4122(), $this->secret, '4'));
+    }
+
+    /**
+     * Decodes a UUIDv4-looking UUID back into the original UUIDv7.
+     */
+    public function decode(UuidV4 $uuid): UuidV7
+    {
+        return new UuidV7(self::transform($uuid->toRfc4122(), $this->secret, '7'));
+    }
+
+    private static function transform(string $rfc4122, string $secret, string $targetVersion): string
+    {
+        $bytes = hex2bin(str_replace('-', '', $rfc4122));
+
+        // Build 10-byte SipHash input from the 74 random bits (version and variant masked out).
+        // These bits are identical in both the UUIDv7 and UUIDv4 representations,
+        // ensuring the same digest is produced in both directions.
+        $sipInput = ($bytes[6] & "\x0F").$bytes[7].($bytes[8] & "\x3F").substr($bytes, 9, 7);
+
+        // sodium_crypto_shorthash is SipHash-2-4, returns 8 bytes in little-endian order.
+        // XOR the 48-bit timestamp (first 6 big-endian bytes) with the low 48 bits of the hash.
+        // The hash is little-endian (LSB first) while the timestamp is big-endian (MSB first),
+        // so we XOR in reverse byte order.
+        $hash = sodium_crypto_shorthash($sipInput, $secret);
+
+        $bytes[0] = $bytes[0] ^ $hash[5];
+        $bytes[1] = $bytes[1] ^ $hash[4];
+        $bytes[2] = $bytes[2] ^ $hash[3];
+        $bytes[3] = $bytes[3] ^ $hash[2];
+        $bytes[4] = $bytes[4] ^ $hash[1];
+        $bytes[5] = $bytes[5] ^ $hash[0];
+        $hex = bin2hex($bytes);
+
+        return substr($hex, 0, 8).'-'.substr($hex, 8, 4).'-'.$targetVersion.substr($rfc4122, 15);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

This PR adds `Uuid47Transformer` to the Uid component, a converter between UUIDv7 and UUIDv4 inspired by the [uuid47 Go implementation](https://github.com/n2p5/uuid47), itself derived from the [reference C implementation](https://github.com/stateless-me/uuidv47).

It allows storing time-ordered UUIDv7 in databases while emitting UUIDv4-looking identifiers at API boundaries, hiding timing information from external consumers. The 48-bit timestamp of a UUIDv7 is XOR-masked with a keyed SipHash-2-4 digest (via `sodium_crypto_shorthash`) derived from the UUID's own random bits, producing a valid UUIDv4. The transformation is reversible with the same secret.

The implementation is 32-bit safe; the XOR masking operates at the byte level without any 64-bit integer arithmetic.

When the Uid component is used with FrameworkBundle, `Uuid47Transformer` is registered as a service using `kernel.secret` for the key.

(fabbot failure is a false-positive)