### PR TITLE
[FrameworkBundle] Remove hard-dep of KernelTestCase on ConsoleAssertionsTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
@@ -13,13 +13,13 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Console\Tester\ConsoleAssertionsTrait;
+use Symfony\Component\Console\Tester\Constraint\CommandFailed;
+use Symfony\Component\Console\Tester\Constraint\CommandIsInvalid;
+use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 use Symfony\Component\Console\Tester\ExecutionResult;
 
 trait ConsoleCommandAssertionsTrait
 {
-    use ConsoleAssertionsTrait;
-
     /**
      * Runs a console command and returns the execution result.
      *
@@ -34,5 +34,45 @@ trait ConsoleCommandAssertionsTrait
         $commandTester = new CommandTester($command);
 
         return $commandTester->run($input, $interactiveInputs, $interactive, $decorated, $verbosity, $normalizers);
+    }
+
+    public function assertCommandIsSuccessful(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandIsSuccessful(), $message);
+    }
+
+    public function assertCommandFailed(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandFailed(), $message);
+    }
+
+    public function assertCommandIsInvalid(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandIsInvalid(), $message);
+    }
+
+    public function assertCommandResultEquals(ExecutionResult $result, ?int $expectedStatusCode = null, ?string $expectedOutput = null, ?string $expectedErrorOutput = null, ?string $expectedDisplay = null, string $message = ''): void
+    {
+        $expected = [];
+        $actual = [];
+
+        if (null !== $expectedStatusCode) {
+            $expected['statusCode'] = $expectedStatusCode;
+            $actual['statusCode'] = $result->statusCode;
+        }
+        if (null !== $expectedOutput) {
+            $expected['output'] = $expectedOutput;
+            $actual['output'] = $result->getOutput();
+        }
+        if (null !== $expectedErrorOutput) {
+            $expected['errorOutput'] = $expectedErrorOutput;
+            $actual['errorOutput'] = $result->getErrorOutput();
+        }
+        if (null !== $expectedDisplay) {
+            $expected['display'] = $expectedDisplay;
+            $actual['display'] = $result->getDisplay();
+        }
+
+        $this->assertEquals($expected, $actual, $message);
     }
 }

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -89,7 +89,7 @@ class CommandTester
         $testOutput = new TestOutput($decorated ?? $this->decorated, $verbosity ?? $this->verbosity, $this->outputFormatter);
         $statusCode = $this->command->run($input, $testOutput);
 
-        return ExecutionResult::fromExecution($input, $statusCode, $testOutput, $normalizers);
+        return new ExecutionResult($input, $statusCode, $testOutput, $normalizers);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tester/ConsoleAssertionsTrait.php
+++ b/src/Symfony/Component/Console/Tester/ConsoleAssertionsTrait.php
@@ -22,22 +22,22 @@ use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
  */
 trait ConsoleAssertionsTrait
 {
-    public function assertIsSuccessful(ExecutionResult $result, string $message = ''): void
+    public function assertCommandIsSuccessful(ExecutionResult $result, string $message = ''): void
     {
         $this->assertThat($result->statusCode, new CommandIsSuccessful(), $message);
     }
 
-    public function assertFailed(ExecutionResult $result, string $message = ''): void
+    public function assertCommandFailed(ExecutionResult $result, string $message = ''): void
     {
         $this->assertThat($result->statusCode, new CommandFailed(), $message);
     }
 
-    public function assertIsInvalid(ExecutionResult $result, string $message = ''): void
+    public function assertCommandIsInvalid(ExecutionResult $result, string $message = ''): void
     {
         $this->assertThat($result->statusCode, new CommandIsInvalid(), $message);
     }
 
-    public function assertResultEquals(ExecutionResult $result, ?int $expectedStatusCode = null, ?string $expectedOutput = null, ?string $expectedErrorOutput = null, ?string $expectedDisplay = null, string $message = ''): void
+    public function assertCommandResultEquals(ExecutionResult $result, ?int $expectedStatusCode = null, ?string $expectedOutput = null, ?string $expectedErrorOutput = null, ?string $expectedDisplay = null, string $message = ''): void
     {
         $expected = [];
         $actual = [];

--- a/src/Symfony/Component/Console/Tester/ExecutionResult.php
+++ b/src/Symfony/Component/Console/Tester/ExecutionResult.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Console\Tester;
 
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\TestOutput;
 
 /**
@@ -25,19 +24,11 @@ final class ExecutionResult
     /**
      * @param array<\Closure(string): string> $normalizers
      */
-    public static function fromExecution(InputInterface $input, int $statusCode, TestOutput $output, array $normalizers = []): self
-    {
-        return new self($input->__toString(), $statusCode, $output, $normalizers);
-    }
-
-    /**
-     * @param array<\Closure(string): string> $normalizers
-     */
     public function __construct(
         public readonly string $input,
         public readonly int $statusCode,
         private readonly TestOutput $output,
-        private readonly array $normalizers,
+        private readonly array $normalizers = [],
     ) {
     }
 

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -695,7 +695,7 @@ class CommandTesterTest extends TestCase
 
         $result = (new CommandTester($command))->run();
 
-        $this->assertIsSuccessful($result);
+        $this->assertCommandIsSuccessful($result);
         $this->assertSame(0, $result->statusCode);
         $this->assertSame("bar\n", $result->getDisplay());
     }
@@ -722,7 +722,7 @@ class CommandTesterTest extends TestCase
         $tester = new CommandTester($command);
         $result = $tester->run(interactiveInputs: ['Bobby', 'Fine', 'France']);
 
-        $this->assertResultEquals(
+        $this->assertCommandResultEquals(
             $result,
             0,
             '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Preventing this when using KernelTestCase without Console installed, as seen on our 7.4 build:

> PHP Fatal error:  Trait "Symfony\Component\Console\Tester\ConsoleAssertionsTrait" not found in src/Symfony/Bridge/PsrHttpMessage/vendor/symfony/framework-bundle/Test/ConsoleCommandAssertionsTrait.php on line 19

Also renaming so that the method play better when mixed with other traits.