### PR TITLE
[HtmlSanitizer][UrlSanitizer] Add 'sms' to hostless schemes

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -112,7 +112,7 @@ final class UrlSanitizer
 
     private static function isHostlessScheme(?string $scheme): bool
     {
-        return \in_array($scheme, ['blob', 'chrome', 'data', 'file', 'geo', 'mailto', 'maps', 'tel', 'view-source'], true);
+        return \in_array($scheme, ['blob', 'chrome', 'data', 'file', 'geo', 'mailto', 'maps', 'tel', 'sms', 'view-source'], true);
     }
 
     private static function isAllowedHost(?string $host, array $allowedHosts): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Default allowed schemes are `['http', 'https', 'mailto', 'tel']`:

https://github.com/symfony/symfony/blob/39e648a8e4a29a793c3c0f68fa69a04d4bfe93b7/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php#L57

In our app, I need to allow `sms` scheme, so I do `$config->allowLinkSchemes(['http', 'https', 'mailto', 'tel', 'sms'])`, but it still strips `href` with `sms` scheme.

Turns out it happens here:

https://github.com/symfony/symfony/blob/39e648a8e4a29a793c3c0f68fa69a04d4bfe93b7/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php#L55-L66

Because `sms` is not considered hostless scheme here: 

https://github.com/symfony/symfony/blob/39e648a8e4a29a793c3c0f68fa69a04d4bfe93b7/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php#L113-L116

While it fact it's hostless.

This PR adds `sms` to this array to this the issue outlined above.