### PR TITLE
[Validator] Fix required options check when extending a constraint with a simplified constructor

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -338,7 +338,7 @@ abstract class Constraint
             return true;
         }
 
-        $constructor = new \ReflectionMethod($this, '__construct');
+        $constructor = new \ReflectionMethod($requiredOptionsMethod->class, '__construct');
 
         if (self::class === $constructor->class) {
             return false;

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithStaticProperty;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithTypedProperty;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValue;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValueAsDefault;
+use Symfony\Component\Validator\Tests\Fixtures\CustomRegex;
 use Symfony\Component\Validator\Tests\Fixtures\LegacyConstraintA;
 
 class ConstraintTest extends TestCase
@@ -358,5 +359,12 @@ class ConstraintTest extends TestCase
         $this->expectException(MissingOptionsException::class);
 
         new ConstraintWithRequiredOptionAndConstructor();
+    }
+
+    public function testChildConstraintCanSatisfyRequiredOptionsOfParent()
+    {
+        $constraint = new CustomRegex();
+
+        $this->assertSame('/^xxxxx$/', $constraint->pattern);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63594
| License       | MIT

When a constraint extends another constraint that has required options (e.g. `CustomRegex extends Regex`) and simplifies the constructor by hardcoding those options, `areRequiredOptionsHandledByChildConstructor()` incorrectly throws a `MissingOptionsException`.

This happens because the method inspects the leaf class's constructor parameters via `new \ReflectionMethod($this, '__construct')`. When `CustomRegex::__construct` doesn't have a `$pattern` parameter (it hardcodes it and delegates to `Regex::__construct`), the check fails, even though `Regex::__construct` already validates `pattern`.

This is a regression introduced in #63463.
