### PR TITLE
[Config] Fix NodeDefinition template to be covariant

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\NodeInterface;
 /**
  * This class provides a fluent interface for defining a node.
  *
- * @template TParent of NodeParentInterface|null = null
+ * @template-covariant TParent of NodeParentInterface|null = null
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63151
| License       | MIT

`NodeDefinition`'s `@template TParent` is only used in return types (covariant positions), but is declared as invariant by default. This causes static analysis tools like Psalm to reject valid code such as passing an `ArrayNodeDefinition<null>` where `NodeDefinition<NodeParentInterface|null>` is expected.

This PR changes `@template` to `@template-covariant` to correctly express the variance of the type parameter.
