### PR TITLE
[Serializer] Fix denormalization of magic `__set` properties

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -161,9 +161,18 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $context = array_intersect_key($context, ['enable_getter_setter_extraction' => true, 'enable_magic_methods_extraction' => true, 'enable_constructor_extraction' => true, 'enable_adder_remover_extraction' => true]);
         $cacheKey = $class.$attribute.hash('xxh128', serialize($context));
 
-        return self::$isWritableCache[$cacheKey] ??= str_contains($attribute, '.')
-            || $this->propertyInfoExtractor->isWritable($class, $attribute, $context)
-            || !\in_array($this->writeInfoExtractor->getWriteInfo($class, $attribute, $context)?->getType(), [null, PropertyWriteInfo::TYPE_NONE, PropertyWriteInfo::TYPE_PROPERTY], true);
+        if (isset(self::$isWritableCache[$cacheKey])) {
+            return self::$isWritableCache[$cacheKey];
+        }
+
+        if (str_contains($attribute, '.') || $this->propertyInfoExtractor->isWritable($class, $attribute, $context)) {
+            return self::$isWritableCache[$cacheKey] = true;
+        }
+
+        $writeType = $this->writeInfoExtractor->getWriteInfo($class, $attribute, $context)?->getType();
+
+        return self::$isWritableCache[$cacheKey] = !\in_array($writeType, [null, PropertyWriteInfo::TYPE_NONE], true)
+            && (PropertyWriteInfo::TYPE_PROPERTY !== $writeType || !property_exists($class, $attribute));
     }
 
     private function hasAttributeAccessorMethod(string $class, string $attribute): bool

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/MagicSetDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/MagicSetDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class MagicSetDummy
+{
+    public array $params = [];
+
+    public function __set(string $name, mixed $value): void
+    {
+        $this->params[$name] = $value;
+    }
+
+    public function __get(string $name)
+    {
+        return $this->params[$name] ?? null;
+    }
+
+    public function __isset(string $name): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyPrivatePropertyWithoutGetter;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion;
 use Symfony\Component\Serializer\Tests\Fixtures\FormatAndContextAwareNormalizer;
+use Symfony\Component\Serializer\Tests\Fixtures\MagicSetDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74DummyPrivate;
@@ -726,6 +727,19 @@ class ObjectNormalizerTest extends TestCase
             new ObjectDummy(),
             $this->normalizer->denormalize(['non_existing' => true], ObjectDummy::class)
         );
+    }
+
+    public function testDenormalizeMagicSet()
+    {
+        $obj = $this->normalizer->denormalize(
+            ['param1' => 'test', 'param2' => 42],
+            MagicSetDummy::class,
+            'any',
+            [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true]
+        );
+
+        $this->assertSame('test', $obj->params['param1']);
+        $this->assertSame(42, $obj->params['param2']);
     }
 
     public function testNoTraversableSupport()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63270
| License       | MIT

PR #61571 fixed asymmetric visibility (`private(set)`) by adding `PropertyWriteInfo::TYPE_PROPERTY` to the exclusion list in `ObjectNormalizer::isAllowedAttribute()`. However, `ReflectionExtractor::getWriteInfo()` also returns `TYPE_PROPERTY` for magic `__set` methods, so classes relying on `__set` to handle dynamic properties could no longer denormalize them.

The fix distinguishes between the two cases: when `getWriteInfo()` returns `TYPE_PROPERTY` for a property that doesn't actually exist on the class, it means writability comes from `__set` and should be allowed. When the property does exist (e.g. with asymmetric visibility), it remains excluded.
