### PR TITLE
[HttpFoundation] Fix session cookie_lifetime not applied in mock session storage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1265,6 +1265,7 @@ class FrameworkExtension extends Extension
         }
 
         $container->setParameter('session.storage.options', $options);
+        $container->setParameter('session.metadata.cookie_lifetime', $options['cookie_lifetime'] ?? null);
 
         // session handler (the internal callback registered with PHP session management)
         if (null === $config['handler_id']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -43,6 +43,7 @@ return static function (ContainerConfigurator $container) {
                     ->args([
                         param('session.metadata.storage_key'),
                         param('session.metadata.update_threshold'),
+                        param('session.metadata.cookie_lifetime'),
                     ]),
                 false,
             ])
@@ -53,6 +54,7 @@ return static function (ContainerConfigurator $container) {
                     ->args([
                         param('session.metadata.storage_key'),
                         param('session.metadata.update_threshold'),
+                        param('session.metadata.cookie_lifetime'),
                     ]),
                 false,
             ])
@@ -64,6 +66,7 @@ return static function (ContainerConfigurator $container) {
                     ->args([
                         param('session.metadata.storage_key'),
                         param('session.metadata.update_threshold'),
+                        param('session.metadata.cookie_lifetime'),
                     ]),
             ])
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
@@ -41,14 +41,18 @@ class MetadataBag implements SessionBagInterface
 
     private int $updateThreshold;
 
+    private ?int $cookieLifetime;
+
     /**
-     * @param string $storageKey      The key used to store bag in the session
-     * @param int    $updateThreshold The time to wait between two UPDATED updates
+     * @param string   $storageKey      The key used to store bag in the session
+     * @param int      $updateThreshold The time to wait between two UPDATED updates
+     * @param int|null $cookieLifetime  The configured cookie lifetime; null to read from php.ini
      */
-    public function __construct(string $storageKey = '_sf2_meta', int $updateThreshold = 0)
+    public function __construct(string $storageKey = '_sf2_meta', int $updateThreshold = 0, ?int $cookieLifetime = null)
     {
         $this->storageKey = $storageKey;
         $this->updateThreshold = $updateThreshold;
+        $this->cookieLifetime = $cookieLifetime;
     }
 
     /**
@@ -143,6 +147,6 @@ class MetadataBag implements SessionBagInterface
     {
         $timeStamp = time();
         $this->meta[self::CREATED] = $this->meta[self::UPDATED] = $this->lastUsed = $timeStamp;
-        $this->meta[self::LIFETIME] = $lifetime ?? (int) \ini_get('session.cookie_lifetime');
+        $this->meta[self::LIFETIME] = $lifetime ?? $this->cookieLifetime ?? (int) \ini_get('session.cookie_lifetime');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MetadataBagTest.php
@@ -135,4 +135,13 @@ class MetadataBagTest extends TestCase
 
         $this->assertIsInt($bag->getLifetime());
     }
+
+    public function testCookieLifetimeFromConstructor()
+    {
+        $bag = new MetadataBag('_sf2_meta', 0, 60);
+        $sessionMetadata = [];
+        $bag->initialize($sessionMetadata);
+
+        $this->assertSame(60, $bag->getLifetime());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63030
| License       | MIT

When using `session.storage.factory.mock_file` (the default in tests), the configured `framework.session.cookie_lifetime` is never applied to the `MetadataBag`. This causes `$session->getMetadataBag()->getLifetime()` to always return `0`.

The root cause is that `NativeSessionStorage` calls `ini_set('session.cookie_lifetime', ...)` before the `MetadataBag` reads it back via `ini_get()`, but mock storages never touch PHP ini settings, so `MetadataBag::stampCreated()` always reads PHP's default value (`0`).

The fix adds an optional `$cookieLifetime` parameter to `MetadataBag`'s constructor. When provided, it takes precedence over `ini_get()` in `stampCreated()`. The configured value is passed from the framework config through a new `session.metadata.cookie_lifetime` container parameter to all inline `MetadataBag` service definitions.
