### PR TITLE
[Console] Fix `ApplicationTester` ignoring `interactive` and `verbosity` options when `SHELL_VERBOSITY` is set

### DIFF
--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -49,7 +49,7 @@ class ApplicationTester
      */
     public function run(array $input, array $options = []): int
     {
-        $prevShellVerbosity = getenv('SHELL_VERBOSITY');
+        $prevShellVerbosity = [getenv('SHELL_VERBOSITY'), $_ENV['SHELL_VERBOSITY'] ?? false, $_SERVER['SHELL_VERBOSITY'] ?? false];
 
         try {
             $this->input = new ArrayInput($input);
@@ -63,22 +63,35 @@ class ApplicationTester
 
             $this->initOutput($options);
 
+            // Temporarily clear SHELL_VERBOSITY to prevent Application::configureIO
+            // from overriding the interactive and verbosity settings set above
+            if (\function_exists('putenv')) {
+                @putenv('SHELL_VERBOSITY');
+            }
+            unset($_ENV['SHELL_VERBOSITY'], $_SERVER['SHELL_VERBOSITY']);
+
             return $this->statusCode = $this->application->run($this->input, $this->output);
         } finally {
             // SHELL_VERBOSITY is set by Application::configureIO so we need to unset/reset it
             // to its previous value to avoid one test's verbosity to spread to the following tests
-            if (false === $prevShellVerbosity) {
+            if (false === $prevShellVerbosity[0]) {
                 if (\function_exists('putenv')) {
                     @putenv('SHELL_VERBOSITY');
                 }
-                unset($_ENV['SHELL_VERBOSITY']);
-                unset($_SERVER['SHELL_VERBOSITY']);
             } else {
                 if (\function_exists('putenv')) {
-                    @putenv('SHELL_VERBOSITY='.$prevShellVerbosity);
+                    @putenv('SHELL_VERBOSITY='.$prevShellVerbosity[0]);
                 }
-                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity;
-                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity;
+            }
+            if (false === $prevShellVerbosity[1]) {
+                unset($_ENV['SHELL_VERBOSITY']);
+            } else {
+                $_ENV['SHELL_VERBOSITY'] = $prevShellVerbosity[1];
+            }
+            if (false === $prevShellVerbosity[2]) {
+                unset($_SERVER['SHELL_VERBOSITY']);
+            } else {
+                $_SERVER['SHELL_VERBOSITY'] = $prevShellVerbosity[2];
             }
         }
     }

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -85,6 +85,48 @@ class ApplicationTesterTest extends TestCase
         $this->tester->assertCommandIsSuccessful('->getStatusCode() returns the status code');
     }
 
+    /**
+     * @dataProvider provideShellVerbositySources
+     */
+    public function testShellVerbosityDoesNotOverrideInteractiveAndVerbosity(callable $setShellVerbosity, callable $cleanUp)
+    {
+        $setShellVerbosity();
+
+        try {
+            $application = new Application();
+            $application->setAutoExit(false);
+            $application->register('foo')
+                ->setCode(static function ($input, $output) {
+                    $output->writeln('foo');
+                })
+            ;
+
+            $tester = new ApplicationTester($application);
+            $tester->run(['command' => 'foo'], ['interactive' => true]);
+
+            $this->assertTrue($tester->getInput()->isInteractive());
+            $this->assertSame('foo'.\PHP_EOL, $tester->getDisplay());
+        } finally {
+            $cleanUp();
+        }
+    }
+
+    public static function provideShellVerbositySources(): iterable
+    {
+        yield 'putenv' => [
+            static function () { putenv('SHELL_VERBOSITY=-1'); },
+            static function () { putenv('SHELL_VERBOSITY'); },
+        ];
+        yield '$_ENV' => [
+            static function () { $_ENV['SHELL_VERBOSITY'] = '-1'; },
+            static function () { unset($_ENV['SHELL_VERBOSITY']); },
+        ];
+        yield '$_SERVER' => [
+            static function () { $_SERVER['SHELL_VERBOSITY'] = '-1'; },
+            static function () { unset($_SERVER['SHELL_VERBOSITY']); },
+        ];
+    }
+
     public function testErrorOutput()
     {
         $application = new Application();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62260
| License       | MIT

When `SHELL_VERBOSITY=-1` is set in the environment (common in `phpunit.xml.dist` via `<server name="SHELL_VERBOSITY" value="-1" />`), `Application::configureIO()` overrides the interactive flag and output verbosity that `ApplicationTester` explicitly set from its `$options` parameter.

This causes:
- `$input->isInteractive()` to return `false` even when `['interactive' => true]` is passed
- `$tester->getDisplay()` to return an empty string because the output verbosity is set to `QUIET`

The regression was introduced #62058 when `configureIO()` was changed to read `SHELL_VERBOSITY` from `$_ENV`/`$_SERVER` in addition to `getenv()`, but the underlying issue exists on 6.4 too (via `getenv()`).

The fix temporarily clears `SHELL_VERBOSITY` from all sources (`putenv`, `$_ENV`, `$_SERVER`) before calling `Application::run()`, so that `configureIO()` defaults to normal verbosity and does not override the tester's settings. The previous values are restored in the `finally` block.
