### PR TITLE
[Serializer] Preserve phpdoc collection item types for nullable array…

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -1013,12 +1013,22 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         if (null !== $parameterType && $parameterTypeResolver ??= class_exists(ReflectionTypeResolver::class) ? new ReflectionTypeResolver() : false) {
             $resolvedParameterType = $parameterTypeResolver->resolve($parameterType);
-            if ($resolvedParameterType->isSatisfiedBy(static fn (Type $t) => match (true) {
-                $t instanceof BuiltinType && TypeIdentifier::NULL !== $t->getTypeIdentifier() => !$type->isIdentifiedBy($t->getTypeIdentifier()),
-                $t instanceof ObjectType => !$type->isIdentifiedBy($t->getClassName()),
+            $parameterBaseType = $resolvedParameterType instanceof NullableType ? $resolvedParameterType->getWrappedType() : $resolvedParameterType;
+            $propertyBaseType = $type instanceof NullableType ? $type->getWrappedType() : $type;
+
+            if ($parameterBaseType->isSatisfiedBy(static fn (Type $t) => match (true) {
+                $t instanceof BuiltinType && TypeIdentifier::NULL !== $t->getTypeIdentifier() => !$propertyBaseType->isIdentifiedBy($t->getTypeIdentifier()),
+                $t instanceof ObjectType => !$propertyBaseType->isIdentifiedBy($t->getClassName()),
                 default => false,
             })) {
                 $type = $resolvedParameterType;
+            } elseif (
+                $resolvedParameterType->isNullable() !== $type->isNullable()
+                && $parameterBaseType instanceof BuiltinType
+                && TypeIdentifier::ARRAY === $parameterBaseType->getTypeIdentifier()
+                && $propertyBaseType instanceof CollectionType
+            ) {
+                $type = $resolvedParameterType->isNullable() ? Type::nullable($propertyBaseType) : $propertyBaseType;
             }
         } elseif ($parameterType instanceof \ReflectionNamedType) {
             if ($parameterType->isBuiltin()) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -66,6 +66,8 @@ use Symfony\Component\Serializer\Tests\Fixtures\DummyWithObjectOrBool;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyWithObjectOrNull;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyWithStringObject;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectDummyWithContextAttribute;
+use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectInner;
+use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectOuter;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
 
@@ -985,6 +987,26 @@ class AbstractObjectNormalizerTest extends TestCase
         $serializer = new Serializer([new ObjectNormalizer(propertyTypeExtractor: $extractor)]);
 
         $this->assertEquals(new DummyWithIntOrString(1), $serializer->denormalize(['value' => 1], DummyWithIntOrString::class));
+    }
+
+    public function testDenormalizeUsesPhpDocCollectionTypeWhenConstructorArrayIsNullable()
+    {
+        $serializer = new Serializer([
+            new BackedEnumNormalizer(),
+            new ArrayDenormalizer(),
+            new ObjectNormalizer(
+                propertyTypeExtractor: new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]),
+            ),
+        ]);
+
+        $report = $serializer->denormalize([
+            'items' => [
+                ['type' => 'logon_succeeded'],
+            ],
+        ], NullableCollectionReport::class);
+
+        $this->assertContainsOnlyInstancesOf(NullableCollectionItem::class, $report->items);
+        $this->assertSame(NullableCollectionItemType::LOGON_SUCCEEDED, $report->items[0]->type);
     }
 
     public function testDenormalizeWithNumberAsSerializedNameAndNoArrayReindex()
@@ -1958,6 +1980,30 @@ class DummyWithIntOrString
 {
     public function __construct(
         public readonly int|string $value,
+    ) {
+    }
+}
+
+enum NullableCollectionItemType: string
+{
+    case LOGON_SUCCEEDED = 'logon_succeeded';
+}
+
+class NullableCollectionItem
+{
+    public function __construct(
+        public readonly ?NullableCollectionItemType $type,
+    ) {
+    }
+}
+
+class NullableCollectionReport
+{
+    /**
+     * @param list<NullableCollectionItem> $items
+     */
+    public function __construct(
+        public readonly ?array $items,
     ) {
     }
 }


### PR DESCRIPTION
# [Serializer] Preserve phpdoc collection item types for nullable array constructor args

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

When a constructor argument is declared as `?array` and PropertyInfo resolves a more precise
PHPDoc collection type such as `list<ReportItem>`, `AbstractObjectNormalizer::denormalizeParameter()`
currently treats the nullability difference as a type conflict and replaces the collection type
with the reflection type.

That drops the collection item type information and nested values stay raw arrays instead of being
denormalized to DTOs.

Before:

```php
final readonly class Report
{
    /**
     * @param list<ReportItem> $items
     */
    public function __construct(
        public ?array $items,
    ) {
    }
}
```

```php
$report = $serializer->denormalize([
    'items' => [['type' => 'logon_succeeded']],
], Report::class);

get_debug_type($report->items[0]); // "array"
```

After:

- the serializer preserves the `CollectionType<ReportItem>`
- only the nullability from the reflection type is merged
- nested items are denormalized correctly

```php
get_debug_type($report->items[0]); // "ReportItem"
$report->items[0]->type; // ReportTypeEnum::LOGON_SUCCEEDED
```

This PR updates `AbstractObjectNormalizer` to keep the PropertyInfo collection type when the
constructor parameter only differs by nullable `array`, and adds a regression test covering this case.
