### PR TITLE
[Process] Throw InvalidArgumentException when env block exceeds Windows limit

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -52,6 +52,17 @@ class Process implements \IteratorAggregate
     public const ITER_SKIP_ERR = 8;     // Use this flag to skip STDERR while iterating
 
     /**
+     * Maximum number of UTF-16 code units allowed in the Windows environment block.
+     *
+     * The Win32 CreateProcess API encodes env vars as KEY=VALUE\0 in UTF-16LE,
+     * terminated by an extra \0. Exceeding this limit causes proc_open() to hang
+     * silently rather than returning false.
+     *
+     * @see https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa
+     */
+    private const WINDOWS_ENV_BLOCK_MAX_LENGTH = 32767;
+
+    /**
      * @var \Closure('out'|'err', string):bool|null
      */
     private ?\Closure $callback = null;
@@ -348,12 +359,16 @@ class Process implements \IteratorAggregate
             }
         }
 
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->validateWindowsEnvBlockSize($envPairs);
+        }
+
         if (!is_dir($this->cwd)) {
             throw new RuntimeException(\sprintf('The provided cwd "%s" does not exist.', $this->cwd));
         }
 
         $lastError = null;
-        set_error_handler(function ($type, $msg) use (&$lastError) {
+        set_error_handler(static function ($type, $msg) use (&$lastError) {
             $lastError = $msg;
 
             return true;
@@ -1313,7 +1328,7 @@ class Process implements \IteratorAggregate
     protected function buildCallback(?callable $callback = null): \Closure
     {
         if ($this->outputDisabled) {
-            return fn ($type, $data): bool => null !== $callback && $callback($type, $data);
+            return static fn ($type, $data): bool => null !== $callback && $callback($type, $data);
         }
 
         return function ($type, $data) use ($callback): bool {
@@ -1567,7 +1582,7 @@ class Process implements \IteratorAggregate
                     [^"%!^]*+
                 )++
             ) | [^"]*+ )"/x',
-            function ($m) use (&$env, $uid) {
+            static function ($m) use (&$env, $uid) {
                 static $varCount = 0;
                 static $varCache = [];
                 if (!isset($m[1])) {
@@ -1672,5 +1687,17 @@ class Process implements \IteratorAggregate
         $env = ('\\' === \DIRECTORY_SEPARATOR ? array_intersect_ukey($env, $_SERVER, 'strcasecmp') : array_intersect_key($env, $_SERVER)) ?: $env;
 
         return $_ENV + ('\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($env, $_ENV, 'strcasecmp') : $env);
+    }
+
+    private function validateWindowsEnvBlockSize(array $envPairs): void
+    {
+        $block = implode("\0", $envPairs)."\0";
+        @preg_replace('/./u', '', $block, -1, $blockLength)
+            ?? preg_replace('/./', '', $block, -1, $blockLength);
+        $blockLength += 1 + preg_match_all('/[\xF0-\xF4][\x80-\xBF]{3}/', $block);
+
+        if ($blockLength > self::WINDOWS_ENV_BLOCK_MAX_LENGTH) {
+            throw new InvalidArgumentException(\sprintf('The environment block size (%d) exceeds the Windows limit of %d UTF-16 code units.', $blockLength, self::WINDOWS_ENV_BLOCK_MAX_LENGTH));
+        }
     }
 }

--- a/src/Symfony/Component/Process/Tests/ProcessWindowsEnvBlockTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessWindowsEnvBlockTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\InvalidArgumentException;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+class ProcessWindowsEnvBlockTest extends TestCase
+{
+    private static string $phpBin;
+
+    public static function setUpBeforeClass(): void
+    {
+        $phpBin = new PhpExecutableFinder();
+        self::$phpBin = getenv('SYMFONY_PROCESS_PHP_TEST_BINARY') ?: ('phpdbg' === \PHP_SAPI ? 'php' : $phpBin->find());
+    }
+
+    public function testStartThrowsWhenSingleEnvValueExceedsWindowsLimit()
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows-only.');
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The environment block size (');
+
+        // "KEY=" (4) + 32767 + "\0" (1) + block terminator (1) = 32773 > 32767
+        $this->getProcess([self::$phpBin, '--version'], null, ['KEY' => str_repeat('x', 32767)])->start();
+    }
+
+    public function testStartThrowsWhenMultipleEntriesCollectivelyExceedWindowsLimit()
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows-only.');
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The environment block size (');
+
+        $env = [];
+        for ($i = 0; $i < 10; ++$i) {
+            $env['KEY_'.$i] = str_repeat('v', 3277);
+        }
+
+        $this->getProcess([self::$phpBin, '--version'], null, $env)->start();
+    }
+
+    public function testStartDoesNotThrowForSmallEnv()
+    {
+        $p = $this->getProcess([self::$phpBin, '--version'], null, ['SMALL' => 'value']);
+        $p->start();
+        $p->stop(0);
+
+        $this->assertTrue(true, 'start() must not throw for a small env block.');
+    }
+
+    public function testStartDoesNotThrowForEmptyEnv()
+    {
+        $p = $this->getProcess([self::$phpBin, '--version'], null, []);
+        $p->start();
+        $p->stop(0);
+
+        $this->assertTrue(true, 'start() must not throw for an empty env block.');
+    }
+
+    public function testStartDoesNotThrowForNullEnv()
+    {
+        $p = new Process([self::$phpBin, '--version']);
+        $p->start();
+        $p->stop(0);
+
+        $this->assertTrue(true, 'start() must not throw when env is null.');
+    }
+
+    public function testStartDoesNotThrowWhenEnvBlockIsExactlyAtWindowsLimit()
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows-only.');
+        }
+
+        $method = new \ReflectionMethod(Process::class, 'validateWindowsEnvBlockSize');
+
+        // "KEY=" (4) + 32761 + "\0" (1) + terminator (1) = 32767 exactly
+        $method->invoke(new Process([self::$phpBin, '--version']), ['KEY='.str_repeat('x', 32761)]);
+
+        $this->assertTrue(true, 'start() must not throw when the env block is exactly at the limit.');
+    }
+
+    public function testStartDoesNotThrowWhenFalseEnvValuesExceedLimit()
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows-only.');
+        }
+
+        // false values are stripped before the size check
+        $p = $this->getProcess([self::$phpBin, '--version'], null, ['IGNORED' => false, 'SMALL' => 'value']);
+        $p->start();
+        $p->stop(0);
+
+        $this->assertTrue(true, 'false env values must not count toward the block size.');
+    }
+
+    public function testWindowsEnvBlockValidationThrowsViaReflection()
+    {
+        $method = new \ReflectionMethod(Process::class, 'validateWindowsEnvBlockSize');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The environment block size (');
+
+        $method->invoke(new Process([self::$phpBin, '--version']), ['KEY='.str_repeat('x', 32767)]);
+    }
+
+    public function testWindowsEnvBlockValidationPassesAtExactLimitViaReflection()
+    {
+        $method = new \ReflectionMethod(Process::class, 'validateWindowsEnvBlockSize');
+
+        // "KEY=" (4) + 32761 + "\0" (1) + terminator (1) = 32767 exactly
+        $method->invoke(new Process([self::$phpBin, '--version']), ['KEY='.str_repeat('x', 32761)]);
+
+        $this->assertTrue(true, 'No exception must be thrown when the block is exactly at the limit.');
+    }
+
+    public function testWindowsEnvBlockValidationCountsMultibyteInCodeUnitsViaReflection()
+    {
+        $method = new \ReflectionMethod(Process::class, 'validateWindowsEnvBlockSize');
+
+        // "é" = 2 UTF-8 bytes but 1 UTF-16 code unit
+        // "KEY=" (4) + 32761 code units + "\0" (1) + terminator (1) = 32767 exactly → must not throw
+        $method->invoke(new Process([self::$phpBin, '--version']), ['KEY='.str_repeat('é', 32761)]);
+
+        $this->assertTrue(true, 'Multibyte chars must be counted in UTF-16 code units, not bytes.');
+    }
+
+    public function testWindowsEnvBlockValidationCountsSupplementaryCharsAsTwoCodeUnitsViaReflection()
+    {
+        $method = new \ReflectionMethod(Process::class, 'validateWindowsEnvBlockSize');
+
+        // U+1F389 "🎉" = 4 UTF-8 bytes, 1 codepoint, 2 UTF-16 code units (surrogate pair)
+        // "KK=" (3) + 16381 × 2 code units (32762) + "\0" (1) + terminator (1) = 32767 exactly → must not throw
+        $method->invoke(new Process([self::$phpBin, '--version']), ['KK='.str_repeat('🎉', 16381)]);
+
+        $this->assertTrue(true, 'Supplementary chars must be counted as 2 UTF-16 code units.');
+    }
+
+    public function testWindowsEnvBlockValidationThrowsWhenSupplementaryCharsPushOverLimitViaReflection()
+    {
+        $method = new \ReflectionMethod(Process::class, 'validateWindowsEnvBlockSize');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The environment block size (');
+
+        // "KK=" (3) + 16382 × 2 code units (32764) + "\0" (1) + terminator (1) = 32769 > 32767
+        $method->invoke(new Process([self::$phpBin, '--version']), ['KK='.str_repeat('🎉', 16382)]);
+    }
+
+    private function getProcess(array $command, ?string $cwd = null, ?array $env = null, mixed $input = null, ?int $timeout = 60): Process
+    {
+        return new Process($command, $cwd, $env, $input, $timeout);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60858 
| License       | MIT

## Summary

On Windows, PHP's `proc_open()` passes environment variables through the
Win32 `CreateProcess` `lpEnvironment` block, which has a hard limit of
32,767 UTF-16 code units. Exceeding this limit causes the child process
to hang silently with no error returned to PHP.

This fix validates the environment block size before calling `proc_open()`
and throws an `InvalidArgumentException`