### PR TITLE
[Uid] Pass invalid UID value to `InvalidArgumentException` for better debug

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -41,7 +41,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBinary(string $uid): static
     {
         if (16 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid binary uid provided.');
+            throw new InvalidArgumentException('Invalid binary uid provided.', $uid);
         }
 
         return static::fromString($uid);
@@ -53,7 +53,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase58(string $uid): static
     {
         if (22 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-58 uid provided.');
+            throw new InvalidArgumentException('Invalid base-58 uid provided.', $uid);
         }
 
         return static::fromString($uid);
@@ -65,7 +65,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromBase32(string $uid): static
     {
         if (26 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid base-32 uid provided.');
+            throw new InvalidArgumentException('Invalid base-32 uid provided.', $uid);
         }
 
         return static::fromString($uid);
@@ -79,7 +79,7 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
     public static function fromRfc4122(string $uid): static
     {
         if (36 !== \strlen($uid)) {
-            throw new InvalidArgumentException('Invalid RFC4122 uid provided.');
+            throw new InvalidArgumentException('Invalid RFC4122 uid provided.', $uid);
         }
 
         return static::fromString($uid);

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `Uuid47Transformer` to convert between UUIDv7 and UUIDv4 using SipHash-2-4 timestamp masking
  * Add argument `$format` to `Ulid::isValid()`
+ * Add `$invalidValue` property to `InvalidArgumentException` thrown by UID classes
 
 8.0
 ---

--- a/src/Symfony/Component/Uid/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Uid/Exception/InvalidArgumentException.php
@@ -13,4 +13,10 @@ namespace Symfony\Component\Uid\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException
 {
+    public function __construct(
+        string $message,
+        public readonly mixed $invalidValue = null,
+    ) {
+        parent::__construct($message);
+    }
 }

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -49,6 +49,19 @@ class UlidTest extends TestCase
         new Ulid('this is not a ulid');
     }
 
+    public function testInvalidUlidContainsInvalidValue()
+    {
+        $invalidUlid = 'this is not a ulid';
+
+        try {
+            new Ulid($invalidUlid);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', InvalidArgumentException::class));
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame('Invalid ULID.', $e->getMessage());
+            $this->assertSame($invalidUlid, $e->invalidValue);
+        }
+    }
+
     public function testBinary()
     {
         $ulid = new Ulid('00000000000000000000000000');
@@ -203,6 +216,19 @@ class UlidTest extends TestCase
             ['1BVXue8CnY8ogucrHX3TeF'],
             ['0177058f-4dac-d0b2-a990-a49af02bc008'],
         ];
+    }
+
+    public function testInvalidBinaryUidContainsInvalidValue()
+    {
+        $invalidBinary = '01EW2RYKDCT2SAK454KBR2QG08';
+
+        try {
+            Ulid::fromBinary($invalidBinary);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', InvalidArgumentException::class));
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame('Invalid binary uid provided.', $e->getMessage());
+            $this->assertSame($invalidBinary, $e->invalidValue);
+        }
     }
 
     public function testFromBase58()

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -50,6 +50,19 @@ class UuidTest extends TestCase
         yield ['these are just thirty-six characters'];
     }
 
+    public function testInvalidUuidContainsInvalidValue()
+    {
+        $invalidUuid = 'this is not a uuid';
+
+        try {
+            Uuid::fromString($invalidUuid);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', InvalidArgumentException::class));
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame('Invalid UUID.', $e->getMessage());
+            $this->assertSame($invalidUuid, $e->invalidValue);
+        }
+    }
+
     #[DataProvider('provideInvalidVariant')]
     public function testInvalidVariant(string $uuid)
     {
@@ -386,6 +399,19 @@ class UuidTest extends TestCase
             ['1BVXue8CnY8ogucrHX3TeF'],
             ['0177058f-4dac-d0b2-a990-a49af02bc008'],
         ];
+    }
+
+    public function testInvalidBinaryUidContainsInvalidValue()
+    {
+        $invalidBinary = '01EW2RYKDCT2SAK454KBR2QG08';
+
+        try {
+            Uuid::fromBinary($invalidBinary);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', InvalidArgumentException::class));
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame('Invalid binary uid provided.', $e->getMessage());
+            $this->assertSame($invalidBinary, $e->invalidValue);
+        }
     }
 
     public function testFromBase58()

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -47,7 +47,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
             if (self::MAX === $this->uid) {
                 $this->uid = self::MAX;
             } elseif (!self::isValid($ulid)) {
-                throw new InvalidArgumentException('Invalid ULID.');
+                throw new InvalidArgumentException('Invalid ULID.', $ulid);
             }
         }
     }
@@ -55,7 +55,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
     /**
      * @param int-mask-of<Ulid::FORMAT_*> $format
      */
-    public static function isValid(string $ulid/*, int $format = self::FORMAT_BASE_32*/): bool
+    public static function isValid(string $ulid/* , int $format = self::FORMAT_BASE_32 */): bool
     {
         $format = \func_num_args() > 1 ? func_get_arg(1) : self::FORMAT_BASE_32;
 

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -41,13 +41,13 @@ class Uuid extends AbstractUid
         $type = preg_match('{^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$}Di', $uuid) ? (int) $uuid[14] : false;
 
         if (false === $type || (static::TYPE ?: $type) !== $type) {
-            throw new InvalidArgumentException(\sprintf('Invalid UUID%s.', static::TYPE ? 'v'.static::TYPE : ''));
+            throw new InvalidArgumentException(\sprintf('Invalid UUID%s.', static::TYPE ? 'v'.static::TYPE : ''), $uuid);
         }
 
         $this->uid = strtolower($uuid);
 
         if ($checkVariant && !\in_array($this->uid[19], ['8', '9', 'a', 'b'], true)) {
-            throw new InvalidArgumentException(\sprintf('Invalid UUID%s.', static::TYPE ? 'v'.static::TYPE : ''));
+            throw new InvalidArgumentException(\sprintf('Invalid UUID%s.', static::TYPE ? 'v'.static::TYPE : ''), $uuid);
         }
     }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| License       | MIT

This PR adds `$invalidValue` to `InvalidArgumentException` thrown by UID classes.