### PR TITLE
[HttpKernel] Set propertyPath on MapUploadedFile validation violations

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -151,7 +151,11 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                     if (\is_array($payload) && !empty($constraints) && !$constraints instanceof Assert\All) {
                         $constraints = new Assert\All($constraints);
                     }
-                    $violations->addAll($this->validator->validate($payload, $constraints, $argument->validationGroups ?? null));
+                    if ($argument instanceof MapUploadedFile) {
+                        $violations->addAll($this->validator->startContext()->atPath($argument->metadata->getName())->validate($payload, $constraints, $argument->validationGroups ?? null)->getViolations());
+                    } else {
+                        $violations->addAll($this->validator->validate($payload, $constraints, $argument->validationGroups ?? null));
+                    }
                 }
 
                 if (\count($violations)) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\ValidatorBuilder;
 
 class UploadedFileValueResolverTest extends TestCase
@@ -235,6 +236,37 @@ class UploadedFileValueResolverTest extends TestCase
         $this->expectExceptionMessageMatches('/^The file is too large/');
 
         $resolver->onKernelControllerArguments($event);
+    }
+
+    #[DataProvider('provideContext')]
+    public function testConstraintsViolationHasArgumentNameAsPropertyPath(RequestPayloadValueResolver $resolver, Request $request)
+    {
+        $attribute = new MapUploadedFile(constraints: new Assert\File(maxSize: 50));
+        $argument = new ArgumentMetadata(
+            'bar',
+            UploadedFile::class,
+            false,
+            false,
+            null,
+            false,
+            [$attribute::class => $attribute]
+        );
+        $event = new ControllerArgumentsEvent(
+            $this->createStub(HttpKernelInterface::class),
+            static function () {},
+            $resolver->resolve($request, $argument),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        try {
+            $resolver->onKernelControllerArguments($event);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
+        } catch (HttpException $e) {
+            $validationFailedException = $e->getPrevious();
+            $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
+            $this->assertSame('bar', $validationFailedException->getViolations()[0]->getPropertyPath());
+        }
     }
 
     #[DataProvider('provideContext')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61370
| License       | MIT

`MapUploadedFile` validation errors produce a `ConstraintViolation` with an empty `propertyPath`, which makes it impossible to map errors back to the correct form field.

The fix uses `startContext()->atPath()` to set the argument name as the `propertyPath` before calling `validate()`. Other attribute types (`MapRequestPayload`, `MapQueryString`) are not affected because their payloads are objects where Symfony's validator already sets nested property paths.

Added a test that uploads a file exceeding `maxSize`, catches the `HttpException`, unwraps the `ValidationFailedException`, and asserts that the first violation's `propertyPath` equals the argument name.