### PR TITLE
[Dotenv] Fix double-unescaping of backslashes during deferred variable resolution

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -666,7 +666,6 @@ final class Dotenv
                 }
                 $resolvedValue = $this->resolveCommands($value, $loadedVars);
                 $resolvedValue = $this->resolveVariables($resolvedValue, $loadedVars);
-                $resolvedValue = str_replace('\\\\', '\\', $resolvedValue);
                 if ($value !== $resolvedValue) {
                     $resolved[$name] = $resolvedValue;
                 }
@@ -680,11 +679,15 @@ final class Dotenv
             throw new class('Too many levels of variable indirection in env vars: '.implode(', ', array_keys($resolved)).'.') extends \LogicException implements ExceptionInterface {};
         }
 
-        // Restore literal $ signs protected from resolution
+        // Restore literal $ signs and unescape backslashes
         $restored = [];
         foreach ($loadedVars as $name => $_) {
-            if ('SYMFONY_DOTENV_VARS' !== $name && str_contains($value = $_ENV[$name] ?? '', "\x00")) {
-                $restored[$name] = str_replace("\x00", '$', $value);
+            if ('SYMFONY_DOTENV_VARS' === $name) {
+                continue;
+            }
+            $value = $_ENV[$name] ?? '';
+            if ($value !== $newValue = str_replace(["\x00", '\\\\'], ['$', '\\'], $value)) {
+                $restored[$name] = $newValue;
             }
         }
         if ($restored) {

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -366,8 +366,8 @@ class DotenvTest extends TestCase
     public function testLoadEnvResolvesVariablesFromOverriddenFiles()
     {
         $resetContext = static function (): void {
-            unset($_ENV['SYMFONY_DOTENV_VARS'], $_ENV['REDIS_HOST'], $_ENV['LOCK_DSN'], $_ENV['HOST'], $_ENV['DSN'], $_ENV['FOO'], $_ENV['BAR'], $_ENV['TEST_APP_ENV']);
-            unset($_SERVER['SYMFONY_DOTENV_VARS'], $_SERVER['REDIS_HOST'], $_SERVER['LOCK_DSN'], $_SERVER['HOST'], $_SERVER['DSN'], $_SERVER['FOO'], $_SERVER['BAR'], $_SERVER['TEST_APP_ENV']);
+            unset($_ENV['SYMFONY_DOTENV_VARS'], $_ENV['REDIS_HOST'], $_ENV['LOCK_DSN'], $_ENV['HOST'], $_ENV['DSN'], $_ENV['FOO'], $_ENV['BAR'], $_ENV['DATABASE_URL'], $_ENV['TEST_APP_ENV']);
+            unset($_SERVER['SYMFONY_DOTENV_VARS'], $_SERVER['REDIS_HOST'], $_SERVER['LOCK_DSN'], $_SERVER['HOST'], $_SERVER['DSN'], $_SERVER['FOO'], $_SERVER['BAR'], $_SERVER['DATABASE_URL'], $_SERVER['TEST_APP_ENV']);
             putenv('SYMFONY_DOTENV_VARS');
             putenv('REDIS_HOST');
             putenv('LOCK_DSN');
@@ -375,6 +375,7 @@ class DotenvTest extends TestCase
             putenv('DSN');
             putenv('FOO');
             putenv('BAR');
+            putenv('DATABASE_URL');
             putenv('TEST_APP_ENV');
         };
 
@@ -429,6 +430,24 @@ class DotenvTest extends TestCase
         (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
 
         $this->assertSame('$2y$10$AAAAAAAAAAAAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBBBB', getenv('FOO'));
+
+        // double backslash in unquoted value without $ must be unescaped during deferred resolution
+        file_put_contents($path, 'DATABASE_URL=sqlsrv://user:pass@localhost\\\\SQLEXPRESS/db');
+        file_put_contents("$path.local", 'BAR=dummy');
+
+        $resetContext();
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
+
+        $this->assertSame('sqlsrv://user:pass@localhost\\SQLEXPRESS/db', getenv('DATABASE_URL'));
+
+        // double backslash + variable in cross-file resolution must not double-unescape
+        file_put_contents($path, "HOST=localhost\nDSN=\"path\\\\\\\\:\${HOST}\"");
+        file_put_contents("$path.local", 'HOST=override');
+
+        $resetContext();
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
+
+        $this->assertSame('path\\\\:override', getenv('DSN'));
 
         $resetContext();
         unlink("$path.local");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63618
| License       | MIT

Something I missed in https://github.com/symfony/symfony/pull/63620