### PR TITLE
[JsonStreamer] Fix lazy instantiation for internal PHP classes

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Read/LazyInstantiator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/LazyInstantiator.php
@@ -68,6 +68,13 @@ final class LazyInstantiator
             throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
 
+        if ($classReflection->isInternal()) {
+            $instance = $classReflection->newInstanceWithoutConstructor();
+            $initializer($instance);
+
+            return $instance;
+        }
+
         // use native lazy ghosts if available
         if (\PHP_VERSION_ID >= 80400) {
             return $classReflection->newLazyGhost($initializer);

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
@@ -62,11 +62,19 @@ class LazyInstantiatorTest extends TestCase
     #[RequiresPhp('>=8.4')]
     public function testCreateLazyGhostUsingPhp()
     {
-        $ghost = (new LazyInstantiator())->instantiate(ClassicDummy::class, function (ClassicDummy $object): void {
+        $ghost = (new LazyInstantiator())->instantiate(ClassicDummy::class, static function (ClassicDummy $object): void {
             $object->id = 123;
         });
 
         $this->assertSame(123, $ghost->id);
+    }
+
+    public function testInstantiateInternalClassEagerly()
+    {
+        $object = (new LazyInstantiator())->instantiate(\DateTimeImmutable::class, static function (\DateTimeImmutable $object): void {
+        });
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $object);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63625
| License       | MIT

Fix the following error: 

```
Cannot make instance of internal class lazy: DateTimeImmutable is internal
```

