### PR TITLE
 Fix deprecation notices for "@method" annotations and classes with `__call()`

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -127,6 +127,21 @@ class DebugClassLoader
     private static array $internalMethods = [];
     private static array $annotatedParameters = [];
     private static array $darwinCache = ['/' => ['/', []]];
+    /**
+     * @var array<string, list<array{0: string, 1: bool, 2: string, 3: string, 4: string|null}>>
+     *
+     * Maps an interface FQCN (or an abstract class accumulating entries from its interfaces) to the list of
+     * "@method" annotations declared on it. For interfaces, the entry is populated directly by parsing the
+     * annotations from the interface's docblock. For abstract classes, the information from all implemented
+     * interfaces is merged together, so that the check can later be applied to the first concrete subclass.
+     *
+     * Each entry is a tuple of:
+     *   [0] string      $interface   - FQCN of the interface that carries the "@method" annotation
+     *   [1] bool        $static      - whether the method is declared static
+     *   [2] string      $returnType  - return type from the annotation, or '' if absent
+     *   [3] string      $name        - method name plus its parameter signature, e.g. "foo($arg, int $n)"
+     *   [4] string|null $description - description text (period-normalised), or null if absent
+     */
     private static array $method = [];
     private static array $returnTypes = [];
     private static array $methodTraits = [];
@@ -398,6 +413,14 @@ class DebugClassLoader
 
             if ($refl->isInterface() && isset($doc['method'])) {
                 foreach ($doc['method'] as $name => [$static, $returnType, $signature, $description]) {
+                    if ($refl->hasMethod($static ? '__callStatic' : '__call')) {
+                        // When the interface has "virtual" @method declarations but at the same time contains a __call/__callStatic magic method,
+                        // do not trigger a deprecation notice. This is to address special use cases like in Predis' ClientInterface where the
+                        // "@method" annotations never intend to actually add the method to the interface, but are used to document the "virtual"
+                        // API provided by the interface through the technical implementation of magic calls. This might cause false negatives
+                        // (missing notices) in the case that such interfaces are later amended with actual (real) methods.
+                        continue;
+                    }
                     self::$method[$class][] = [$class, $static, $returnType, $name.$signature, $description];
 
                     if ('' !== $returnType) {
@@ -450,14 +473,9 @@ class DebugClassLoader
                         // skip "same vendor" @method deprecations for Symfony\* classes unless symfony/symfony is being tested
                         continue;
                     }
-                    $hasCall = $refl->hasMethod('__call');
-                    $hasStaticCall = $refl->hasMethod('__callStatic');
                     foreach (self::$method[$use] as [$interface, $static, $returnType, $name, $description]) {
-                        if ($static ? $hasStaticCall : $hasCall) {
-                            continue;
-                        }
                         $realName = substr($name, 0, strpos($name, '('));
-                        if (!$refl->hasMethod($realName) || !($methodRefl = $refl->getMethod($realName))->isPublic() || ($static && !$methodRefl->isStatic()) || (!$static && $methodRefl->isStatic())) {
+                        if (!$refl->hasMethod($realName) || !($methodRefl = $refl->getMethod($realName))->isPublic() || ($static xor $methodRefl->isStatic())) {
                             $deprecations[] = \sprintf('Class "%s" should implement method "%s::%s%s"%s', $className, ($static ? 'static ' : '').$interface, $name, $returnType ? ': '.$returnType : '', null === $description ? '.' : ': '.$description);
                         }
                     }

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -344,11 +344,51 @@ class DebugClassLoaderTest extends TestCase
 
     public function testVirtualUseWithMagicCall()
     {
+        // This is like the preceding testVirtualUse() test, but this time the class contains
+        // __call/__callStatic magic methods. We want the notices to be triggered in this case:
+        // If the interface changes the "@method" to a real declaration in the future, the class
+        // will need to contain that method.
+
         $deprecations = [];
         set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
         $e = error_reporting(E_USER_DEPRECATED);
 
         class_exists('Test\\'.ExtendsVirtualMagicCall::class, true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $this->assertSame([
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::interfaceMethod(): string".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticReturningMethod(): static".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::sameLineInterfaceMethod($arg)".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::sameLineInterfaceMethodNoBraces()".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::newLineInterfaceMethod()": Some description!',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::newLineInterfaceMethodNoBraces(): \stdClass": Description.',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::invalidInterfaceMethod(): unknownType".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::invalidInterfaceMethodNoBraces(): unknownType|string".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::complexInterfaceMethod($arg, ...$args)".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::complexInterfaceMethodTyped($arg, int ...$args): array<string, int>|string[]|int": Description ...',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethod(): Foo&Bar".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethodNoBraces(): mixed".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethodTyped(int $arg): \stdClass": Description.',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualMagicCall" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethodTypedNoBraces(): \stdClass[]".',
+        ], $deprecations);
+    }
+
+    public function testVirtualUseWithMagicCallInterface()
+    {
+        // When an interface uses "@method" annotations and, at the same time, requires the __call method to be
+        // implemented, do not trigger notices. The assumption is that this interface documents an API contract
+        // using a pattern of magic calls, for example like https://github.com/predis/predis/blob/deee2b6d605eb6401446f6f6354414ab7571a5a0/src/ClientInterface.php.
+        // This has the risk of false negatives, i. e. missing notices in case the interface intends to add real
+        // methods in the future.
+
+        $deprecations = [];
+        set_error_handler(static function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
+        $e = error_reporting(\E_USER_DEPRECATED);
+
+        class_exists('Test\\'.ExtendsVirtualMagicCallInterface::class, true);
 
         error_reporting($e);
         restore_error_handler();
@@ -539,6 +579,10 @@ class ClassLoader
             }');
         } elseif ('Test\\'.ExtendsVirtualMagicCall::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsVirtualMagicCall extends \\'.__NAMESPACE__.'\Fixtures\VirtualClassMagicCall implements \\'.__NAMESPACE__.'\Fixtures\VirtualInterface {
+            }');
+        } elseif ('Test\\'.ExtendsVirtualMagicCallInterface::class === $class) {
+            eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsVirtualMagicCallInterface implements \\'.__NAMESPACE__.'\Fixtures\VirtualInterfaceWithCall {
+                public function __call(string $name, array $arguments): mixed { return null; }
             }');
         } elseif ('Test\\'.ReturnType::class === $class) {
             return $fixtureDir.\DIRECTORY_SEPARATOR.'ReturnType.php';

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/VirtualInterfaceWithCall.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/VirtualInterfaceWithCall.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+/**
+ * @method string magicInterfaceMethod()
+ */
+interface VirtualInterfaceWithCall
+{
+    public function __call(string $name, array $arguments): mixed;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In #28902, the `@method` annotation on interfaces was introduced as a deprecation mechanism. It allows interface authors to announce that a new method will be added to the interface in a future major version, giving implementing classes time to add the method before it becomes a hard requirement.

As part of that PR, an exception was added: If the implementing class has a `__call` magic method, no deprecation notice is triggered. The rationale was that such a class already handles arbitrary method calls dynamically, so the absence of a concrete implementation is intentional.

However, this check is too broad. It suppresses notices based on the implementing class, regardless of why `__call` is there. In particular, it incorrectly silences notices for the migration use case. If an interface announces `@method foo()` as a future method, a class that happens to have `__call` (for unrelated reasons) will never be warned to add `foo()`. Even if `__call` is present, adding the method to the interface requires the class to have an implementation as well.

A practical example is a `SomeRepositoryInterface` that you'd like to add a method to, and the class implementing it extending Doctrine's `EntityRepository`, which contains `__call`.

The use case that motivated the suppression is this interface: https://github.com/predis/predis/blob/deee2b6d605eb6401446f6f6354414ab7571a5a0/src/ClientInterface.php. Here, the interface uses `@method` to describe a virtual (or "magic"?) API, and `__call` is explicitly part of the interface definition. In that case, there is no intention to actually add the methods to the interface at a later time, so a deprecation notice would be misleading.

This PR tightens the check. It ignores `@method` on interfaces only when the interface itself declares `__call`. This should prevent the deprecation notices for that particular example. Of course, it still leaves a slight risk of false negatives (missing notices) in case the `__call` is in the interface for other reasons, and the interface author actually intends to add a real method to the interface, instead of only documenting "magic"/virtual methods.