### PR TITLE
[Form] Add `labels` option to DateType to customize year/month/day sub-field labels

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecate passing boolean as the second argument of `ValidatorExtension` and `FormTypeValidatorExtension`'s constructors; pass a `ViolationMapperInterface` instead
  * Add argument `$violationMapper` to `ValidatorExtensionTrait` and `TypeTestCase`'s `getExtensions()` methods
  * Add default `min`/`max` attributes to `BirthdayType` when `widget` is `single_text`
+ * Add `labels` option to `DateType` to customize the year, month and day sub-field labels
 
 8.0
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -147,6 +147,10 @@ class DateType extends AbstractType
                 $yearOptions[$passOpt] = $monthOptions[$passOpt] = $dayOptions[$passOpt] = $options[$passOpt];
             }
 
+            $yearOptions['label'] = $options['labels']['year'];
+            $monthOptions['label'] = $options['labels']['month'];
+            $dayOptions['label'] = $options['labels']['day'];
+
             $builder
                 ->add('year', self::WIDGETS[$options['widget']], $yearOptions)
                 ->add('month', self::WIDGETS[$options['widget']], $monthOptions)
@@ -269,6 +273,11 @@ class DateType extends AbstractType
             ];
         };
 
+        $labelsNormalizer = static fn (Options $options, array $labels) => array_replace(
+            ['year' => null, 'month' => null, 'day' => null],
+            array_filter($labels, static fn ($label) => null !== $label)
+        );
+
         $format = static fn (Options $options) => 'single_text' === $options['widget'] ? self::HTML5_FORMAT : self::DEFAULT_FORMAT;
 
         $resolver->setDefaults([
@@ -282,6 +291,7 @@ class DateType extends AbstractType
             'view_timezone' => null,
             'calendar' => null,
             'placeholder' => $placeholderDefault,
+            'labels' => [],
             'html5' => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
@@ -301,6 +311,8 @@ class DateType extends AbstractType
 
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);
         $resolver->setNormalizer('choice_translation_domain', $choiceTranslationDomainNormalizer);
+        $resolver->setNormalizer('labels', $labelsNormalizer);
+        $resolver->setAllowedTypes('labels', 'array');
 
         $resolver->setAllowedValues('input', [
             'datetime',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -1204,6 +1204,39 @@ class DateTypeTest extends BaseTypeTestCase
         $this->assertSame('113-03-31', $form->getViewData());
     }
 
+    public function testPassLabelsAsArray()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
+            'labels' => [
+                'year' => 'Year label',
+                'month' => 'Month label',
+                'day' => 'Day label',
+            ],
+        ])
+            ->createView();
+
+        $this->assertSame('Year label', $view['year']->vars['label']);
+        $this->assertSame('Month label', $view['month']->vars['label']);
+        $this->assertSame('Day label', $view['day']->vars['label']);
+    }
+
+    public function testPassLabelsAsPartialArray()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'widget' => 'choice',
+            'labels' => [
+                'year' => 'Year label',
+                'day' => 'Day label',
+            ],
+        ])
+            ->createView();
+
+        $this->assertSame('Year label', $view['year']->vars['label']);
+        $this->assertNull($view['month']->vars['label']);
+        $this->assertSame('Day label', $view['day']->vars['label']);
+    }
+
     protected function getTestOptions(): array
     {
         return ['widget' => 'choice'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59825 
| License       | MIT

**Problem**
When using `DateType` (or `BirthdayType`) with `widget: choice` or `widget: text`, the year/month/day sub-field labels are auto-generated from the field names ("Year", "Month", "Day") with no way to customize or disable them.

**Solution**
Add a `labels` option to `DateType`, following the same pattern as the existing `labels` option in `DateIntervalType`.

Accepted values:

- `[]` (default) - auto-generates labels from field names
- `array` - per-field control, unspecified fields fall back to null

Usage:

```
$builder->add('dueDate', DateType::class, [
    'widget' => 'choice',
    'labels' => [
        'year'  => 'Birth year',
        'month' => 'Birth month',
        'day'   => 'Birth day',
    ],
]);

// partial array — only override what you need
$builder->add('dueDate', DateType::class, [
    'widget' => 'choice',
    'labels' => [
        'year' => 'Birth year',
    ],
]);
```

Since BirthdayType extends DateType, it inherits this option automatically.