### PR TITLE
[DoctrineBridge][VarExporter] Fix "Cannot modify readonly property" error during cache:clear

### DIFF
--- a/src/Symfony/Bridge/Doctrine/IdGenerator/UuidGenerator.php
+++ b/src/Symfony/Bridge/Doctrine/IdGenerator/UuidGenerator.php
@@ -22,7 +22,7 @@ use Symfony\Component\Uid\Uuid;
 
 final class UuidGenerator extends AbstractIdGenerator
 {
-    private readonly UuidFactory $protoFactory;
+    private UuidFactory $protoFactory;
     private UuidFactory|NameBasedUuidFactory|RandomBasedUuidFactory|TimeBasedUuidFactory $factory;
     private ?string $entityGetter = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | #63634 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

Fix the following error: 
```
In Hydrator.php line 60:

  Cannot modify readonly property Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator::$protoFactory
```
