### PR TITLE
[ErrorHandler] "@method" deprecation notices are missing when interface inheritance is used

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -443,6 +443,15 @@ class DebugClassLoader
             }
         }
 
+        // When the parent is a concrete class, we will trigger deprecation notices to make it aware that it needs
+        // to add the new methods announced with @method. The parent will have to provide all those methods.
+        // For child classes this means they will not need to deal with @method coming from any of the interfaces
+        // the parent implements.
+        // Put those interfaces that we can ignore into $parentInterfaces.
+        // The ternary makes use of the fact that abstract parent classes will accumulate the methods in self::$method,
+        // so !isset(self::$method[$parent]) indicates a concrete parent class.
+        $parentInterfaces = ($parent && !isset(self::$method[$parent])) ? class_implements($parent, false) : [];
+
         // Detect if the parent is annotated
         foreach ($parentAndOwnInterfaces + class_uses($class, false) as $use) {
             if (!isset(self::$checkedClasses[$use])) {
@@ -458,13 +467,15 @@ class DebugClassLoader
                 $deprecations[] = \sprintf('The "%s" %s is considered internal%s It may change without further notice. You should not use it from "%s".', $use, class_exists($use, false) ? 'class' : (interface_exists($use, false) ? 'interface' : 'trait'), self::$internal[$use], $className);
             }
             if (isset(self::$method[$use])) {
-                if ($refl->isAbstract()) {
+                if ($refl->isAbstract() || $refl->isInterface()) {
+                    // Abstract classes and interfaces inherit @method from interfaces they
+                    // implement directly or through inheritance.
                     if (isset(self::$method[$class])) {
                         self::$method[$class] = array_merge(self::$method[$class], self::$method[$use]);
                     } else {
                         self::$method[$class] = self::$method[$use];
                     }
-                } elseif (!$refl->isInterface()) {
+                } else {
                     if (!strncmp($vendor, str_replace('_', '\\', $use), $vendorLen)
                         && str_starts_with($className, 'Symfony\\')
                         && (!class_exists(InstalledVersions::class)
@@ -474,6 +485,11 @@ class DebugClassLoader
                         continue;
                     }
                     foreach (self::$method[$use] as [$interface, $static, $returnType, $name, $description]) {
+                        if (isset($parentInterfaces[$interface])) {
+                            // The @method annotation comes from an interface that has already been implemented by a concrete parent class,
+                            // so we can ignore it here.
+                            continue;
+                        }
                         $realName = substr($name, 0, strpos($name, '('));
                         if (!$refl->hasMethod($realName) || !($methodRefl = $refl->getMethod($realName))->isPublic() || ($static xor $methodRefl->isStatic())) {
                             $deprecations[] = \sprintf('Class "%s" should implement method "%s::%s%s"%s', $className, ($static ? 'static ' : '').$interface, $name, $returnType ? ': '.$returnType : '', null === $description ? '.' : ': '.$description);

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -342,6 +342,40 @@ class DebugClassLoaderTest extends TestCase
         ], $deprecations);
     }
 
+    public function testVirtualUseWithInheritedInterface()
+    {
+        // A concrete class implementing a child interface should also receive notices for @method
+        // annotations declared on parent interfaces, even without abstract classes in between.
+        // (ExtendsVirtualSubInterfaceDirect implements VirtualSubInterface, which extends VirtualInterface)
+
+        $deprecations = [];
+        set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
+        $e = error_reporting(E_USER_DEPRECATED);
+
+        class_exists('Test\\'.ExtendsVirtualSubInterfaceDirect::class, true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $this->assertSame([
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualSubInterface::subInterfaceMethod(): string".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::interfaceMethod(): string".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticReturningMethod(): static".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::sameLineInterfaceMethod($arg)".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::sameLineInterfaceMethodNoBraces()".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::newLineInterfaceMethod()": Some description!',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::newLineInterfaceMethodNoBraces(): \stdClass": Description.',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::invalidInterfaceMethod(): unknownType".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::invalidInterfaceMethodNoBraces(): unknownType|string".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::complexInterfaceMethod($arg, ...$args)".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::complexInterfaceMethodTyped($arg, int ...$args): array<string, int>|string[]|int": Description ...',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethod(): Foo&Bar".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethodNoBraces(): mixed".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethodTyped(int $arg): \stdClass": Description.',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualSubInterfaceDirect" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualInterface::staticMethodTypedNoBraces(): \stdClass[]".',
+        ], $deprecations);
+    }
+
     public function testVirtualUseWithMagicCall()
     {
         // This is like the preceding testVirtualUse() test, but this time the class contains
@@ -576,6 +610,9 @@ class ClassLoader
         } elseif ('Test\\'.ExtendsVirtualAbstractBase::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; abstract class ExtendsVirtualAbstractBase extends \\'.__NAMESPACE__.'\Fixtures\VirtualClass implements \\'.__NAMESPACE__.'\Fixtures\VirtualInterface {
                 public function ownAbstractBaseMethod() { }
+            }');
+        } elseif ('Test\\'.ExtendsVirtualSubInterfaceDirect::class === $class) {
+            eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsVirtualSubInterfaceDirect implements \\'.__NAMESPACE__.'\Fixtures\VirtualSubInterface {
             }');
         } elseif ('Test\\'.ExtendsVirtualMagicCall::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsVirtualMagicCall extends \\'.__NAMESPACE__.'\Fixtures\VirtualClassMagicCall implements \\'.__NAMESPACE__.'\Fixtures\VirtualInterface {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The `DebugClassLoader` supports `@method` annotations on interfaces as a way to announce that a new method will be added to the interface in a future (hopefully major) version. Implementing classes receive a deprecation notice if they have not yet added the method. See #28902.

This mechanism did not work correctly when interface inheritance is used and the `@method` annotation comes from a parent interface rather than an interface the class directly implements.

```php
  /** @method string foo() */
  interface A {}

  interface B extends A {}

  class C implements B {}
```

  No deprecation notice was triggered for C, even though it does not implement `foo()`.

The reason is that information about `@method` annotations is copied down along the inheritance chain for abstract classes, but not when interfaces inherit from other interfaces. 

This PR fixes two things:

1. Interface propagation: When an interface is analyzed, `@method` entries are copied from all interfaces it extends. Previously, this was only done for abstract classes. Since parent interfaces are processed first, the information is complete and cumulative at that point.

2. Avoiding duplicate notices: When a class extends another _concrete_ class, that parent will eventually have to deal with all `@method` annotations coming from any of the interfaces it implements (either directly or through inheritance paths). That means the child class (and any additional subclasses) need not be notified individually of those new methods. So, we can skip all `@method` announcements coming from all of the interfaces implemented by the parent class. Of course, `@method` from an interface that the class implements directly (itself) will have to be taken care of.