### PR TITLE
[VarExporter] Fix readonly deep-cloning and Instantiator cache priming

### DIFF
--- a/src/Symfony/Component/VarExporter/DeepCloner.php
+++ b/src/Symfony/Component/VarExporter/DeepCloner.php
@@ -117,6 +117,10 @@ final class DeepCloner
                     $properties[$scope][$name][$id] = $propValue;
                     if ($propValue instanceof Reference || $propValue instanceof NamedClosure || \is_array($propValue) && self::hasReference($propValue)) {
                         $resolve[$scope][$name][] = $id;
+
+                        if ($canCloneAll && ((InternalHydrator::$propertyScopes[$scope] ??= InternalHydrator::getPropertyScopes($scope))[$name][4] ?? null)?->isReadOnly()) {
+                            $canCloneAll = false;
+                        }
                     }
                 }
             }

--- a/src/Symfony/Component/VarExporter/Instantiator.php
+++ b/src/Symfony/Component/VarExporter/Instantiator.php
@@ -40,7 +40,11 @@ final class Instantiator
      */
     public static function instantiate(string $class, array $properties = [], array $scopedProperties = []): object
     {
-        $reflector = Registry::$reflectors[$class] ??= Registry::getClassReflector($class);
+        if (!\array_key_exists($class, Registry::$cloneable)) {
+            Registry::getClassReflector($class);
+        }
+
+        $reflector = Registry::$reflectors[$class] ??= Registry::getClassReflector($class, Registry::$instantiableWithoutConstructor[$class], Registry::$cloneable[$class]);
 
         if (Registry::$cloneable[$class]) {
             $instance = clone Registry::$prototypes[$class];

--- a/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
@@ -183,6 +183,21 @@ class DeepCloneTest extends TestCase
         $this->assertSame('world', $clone->value);
     }
 
+    public function testReadonlyPropertyContainingReferences()
+    {
+        $child = new \stdClass();
+        $child->value = 'inner';
+
+        $obj = new DeepCloneReadonlyReference(DeepCloneReadonlyReference::class, ['child' => $child]);
+
+        $clone = DeepCloner::deepClone($obj);
+
+        $this->assertNotSame($obj, $clone);
+        $this->assertSame($obj->class, $clone->class);
+        $this->assertNotSame($child, $clone->data['child']);
+        $this->assertSame('inner', $clone->data['child']->value);
+    }
+
     public function testPrivateAndProtectedProperties()
     {
         $obj = new GoodNight();
@@ -424,5 +439,14 @@ class DeepCloneTest extends TestCase
 
         $this->assertFalse((new DeepCloner(new \stdClass()))->isStaticValue());
         $this->assertFalse((new DeepCloner(['key' => new \stdClass()]))->isStaticValue());
+    }
+}
+
+class DeepCloneReadonlyReference
+{
+    public function __construct(
+        public readonly string $class,
+        public readonly array $data,
+    ) {
     }
 }

--- a/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
@@ -38,6 +38,19 @@ class HydratorTest extends TestCase
 
         $this->assertSame(456, $object->getValue());
     }
+
+    public function testHydrateUninitializedReadonlyPropertyAfterHydratorPrimedReflector()
+    {
+        Hydrator::hydrate(new HydratorTestClass(123), [
+            'status' => 'hydrated',
+        ]);
+
+        $object = Instantiator::instantiate(HydratorTestClass::class);
+
+        Hydrator::hydrate($object, ['value' => 456]);
+
+        $this->assertSame(456, $object->getValue());
+    }
 }
 
 class HydratorTestClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Something I missed in #63612, spotted by the Doctrine CI (testing dev-deps FTW).

The first one was in `DeepCloner`: its clone-and-patch path could still be used for objects that contain initialized readonly properties holding object references. In that case, the clone needs those references to be rewritten to point to the cloned graph, but rewriting the readonly property triggers an error.

This happened in practice through `ArrayAdapter` when cloning Doctrine cache entries stored in readonly properties.

The fix is to disable the clone-and-patch optimization for these cases and fall back to full reconstruction, where readonly properties are initialized only once on the fresh instance.

The second regression was in `Instantiator`: it assumed that if `Registry::$reflectors[$class]` was already populated, then the related prototype / cloneability metadata had been populated as well. That assumption is not always true because `Hydrator` can prime only the reflector cache. This made `Instantiator::instantiate()` order-dependent and caused failures after running hydrator-related code first.

The fix is to ensure `Instantiator` initializes the missing registry metadata when needed before using it.
