### PR TITLE
[Messenger] Fix duplicate pending messages in Redis transport with batch handlers

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -116,18 +116,38 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf(Connection::class, new Connection([], $redis));
     }
 
-    public function testKeepGettingPendingMessages()
+    public function testPendingScanAdvancesCursorWithoutDuplicates()
     {
         $redis = $this->createRedisMock();
 
-        $redis->expects($this->exactly(3))->method('xreadgroup')
-            ->with('symfony', 'consumer', ['queue' => 0], 1, 1)
-            ->willReturn(['queue' => [['message' => json_encode(['body' => 'Test', 'headers' => []])]]]);
+        $redis->expects($this->exactly(4))->method('xreadgroup')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    // pending scan from '0': returns first pending message
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], ['queue' => ['100-0' => ['message' => '{"body":"1","headers":[]}']]]],
+                    // pending scan advances cursor past '100-0': returns next pending message
+                    [['symfony', 'consumer', ['queue' => '100-0'], 1, 1], ['queue' => ['200-0' => ['message' => '{"body":"2","headers":[]}']]]],
+                    // pending scan advances cursor past '200-0': no more pending messages
+                    [['symfony', 'consumer', ['queue' => '200-0'], 1, 1], []],
+                    // fallback to new messages: none available
+                    [['symfony', 'consumer', ['queue' => '>'], 1, 1], []],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            });
 
         $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
-        $this->assertNotNull($connection->get());
-        $this->assertNotNull($connection->get());
-        $this->assertNotNull($connection->get());
+
+        $msg1 = $connection->get();
+        $this->assertSame('100-0', $msg1['id']);
+
+        $msg2 = $connection->get();
+        $this->assertSame('200-0', $msg2['id']);
+
+        $this->assertNull($connection->get());
     }
 
     /**
@@ -490,6 +510,230 @@ class ConnectionTest extends TestCase
             ], $redis),
             Connection::fromDsn('redis://user:@/var/run/redis/redis.sock', ['stream' => 'queue', 'delete_after_ack' => true], $redis)
         );
+    }
+
+    public function testSkipAlreadyInflightPendingMessage()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->exactly(5))->method('xreadgroup')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    // get #1: pending scan returns msg-A
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], ['queue' => ['msg-A' => ['message' => '{"body":"1","headers":[]}']]]],
+                    // get #2: pending scan from 'msg-A', no more pending
+                    [['symfony', 'consumer', ['queue' => 'msg-A'], 1, 1], []],
+                    // get #2: claim resets cursor to '0', rescan returns msg-A again — skipped (in-flight)
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], ['queue' => ['msg-A' => ['message' => '{"body":"1","headers":[]}']]]],
+                    // get #2: cursor advances past msg-A, no more pending
+                    [['symfony', 'consumer', ['queue' => 'msg-A'], 1, 1], []],
+                    // get #2: fallback to new messages
+                    [['symfony', 'consumer', ['queue' => '>'], 1, 1], []],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            });
+
+        $redis->expects($this->once())->method('xpending')
+            ->willReturn([[0 => 'other-msg', 1 => 'consumer-2', 2 => 3600001]]);
+        $redis->expects($this->once())->method('xclaim')->willReturn([]);
+
+        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
+
+        $this->assertSame('msg-A', $connection->get()['id']);
+
+        // msg-A is still in-flight, so when the claim resets the cursor and
+        // the rescan encounters msg-A again, it must be skipped
+        $this->assertNull($connection->get());
+    }
+
+    public function testAckRemovesInflightId()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->once())->method('xreadgroup')
+            ->with('symfony', 'consumer', ['queue' => '0'], 1, 1)
+            ->willReturn(['queue' => ['msg-A' => ['message' => '{"body":"1","headers":[]}']]]);
+
+        $redis->expects($this->once())->method('xack')
+            ->with('queue', 'symfony', ['msg-A'])
+            ->willReturn(1);
+        $redis->expects($this->once())->method('xdel')
+            ->with('queue', ['msg-A'])
+            ->willReturn(1);
+
+        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
+
+        $inflightIds = (new \ReflectionClass(Connection::class))->getProperty('inflightIds');
+
+        $msg = $connection->get();
+        $this->assertSame('msg-A', $msg['id']);
+        $this->assertArrayHasKey('msg-A', $inflightIds->getValue($connection));
+
+        $connection->ack('msg-A');
+        $this->assertEmpty($inflightIds->getValue($connection));
+    }
+
+    public function testRejectRemovesInflightId()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->once())->method('xreadgroup')
+            ->with('symfony', 'consumer', ['queue' => '0'], 1, 1)
+            ->willReturn(['queue' => ['msg-A' => ['message' => '{"body":"1","headers":[]}']]]);
+
+        $redis->expects($this->once())->method('xack')
+            ->with('queue', 'symfony', ['msg-A'])
+            ->willReturn(1);
+        $redis->expects($this->once())->method('xdel')
+            ->with('queue', ['msg-A'])
+            ->willReturn(1);
+
+        $connection = Connection::fromDsn('redis://localhost/queue?delete_after_reject=true', [], $redis);
+
+        $inflightIds = (new \ReflectionClass(Connection::class))->getProperty('inflightIds');
+
+        $msg = $connection->get();
+        $this->assertSame('msg-A', $msg['id']);
+        $this->assertArrayHasKey('msg-A', $inflightIds->getValue($connection));
+
+        $connection->reject('msg-A');
+        $this->assertEmpty($inflightIds->getValue($connection));
+    }
+
+    public function testClaimCanProcessMultipleMessagesWithinOneInterval()
+    {
+        $redis = $this->createRedisMock();
+
+        // Flow:
+        // get() #1: pending '0' → empty, claim finds claim-1, pending '0' → claim-1
+        // ack('claim-1')
+        // get() #2: pending 'claim-1' → empty, claim finds claim-2, pending '0' → claim-2
+        $redis->expects($this->exactly(4))->method('xreadgroup')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], []],
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], ['queue' => ['claim-1' => ['message' => '{"body":"1","headers":[]}']]]],
+                    [['symfony', 'consumer', ['queue' => 'claim-1'], 1, 1], []],
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], ['queue' => ['claim-2' => ['message' => '{"body":"2","headers":[]}']]]],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            });
+
+        $redis->expects($this->exactly(2))->method('xpending')
+            ->willReturnOnConsecutiveCalls(
+                [[0 => 'claim-1', 1 => 'consumer-2', 2 => 3600001]],
+                [[0 => 'claim-2', 1 => 'consumer-2', 2 => 3600001]]
+            );
+
+        $redis->expects($this->exactly(2))->method('xclaim')
+            ->willReturn([]);
+
+        $redis->expects($this->once())->method('xack')
+            ->with('queue', 'symfony', ['claim-1'])
+            ->willReturn(1);
+        $redis->expects($this->once())->method('xdel')
+            ->with('queue', ['claim-1'])
+            ->willReturn(1);
+
+        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
+
+        $msg1 = $connection->get();
+        $this->assertSame('claim-1', $msg1['id']);
+
+        $connection->ack('claim-1');
+
+        $msg2 = $connection->get();
+        $this->assertSame('claim-2', $msg2['id']);
+    }
+
+    public function testClaimIntervalAdvancedOnlyWhenNoClaimableMessages()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->exactly(4))->method('xreadgroup')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], []],
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], ['queue' => ['msg-A' => ['message' => '{"body":"1","headers":[]}']]]],
+                    [['symfony', 'consumer', ['queue' => 'msg-A'], 1, 1], []],
+                    [['symfony', 'consumer', ['queue' => '>'], 1, 1], []],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            });
+
+        $redis->expects($this->exactly(2))->method('xpending')
+            ->willReturnOnConsecutiveCalls(
+                [[0 => 'msg-A', 1 => 'consumer-2', 2 => 3600001]],
+                []
+            );
+
+        $redis->expects($this->once())->method('xclaim')->willReturn([]);
+        $redis->expects($this->once())->method('xack')->willReturn(1);
+        $redis->expects($this->once())->method('xdel')->willReturn(1);
+
+        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
+
+        $nextClaimProp = (new \ReflectionClass(Connection::class))->getProperty('nextClaim');
+
+        $this->assertSame(0.0, $nextClaimProp->getValue($connection));
+
+        $msg = $connection->get();
+        $this->assertSame('msg-A', $msg['id']);
+        $this->assertSame(0.0, $nextClaimProp->getValue($connection));
+
+        $connection->ack('msg-A');
+
+        $this->assertNull($connection->get());
+        $this->assertGreaterThan(0.0, $nextClaimProp->getValue($connection));
+    }
+
+    public function testClaimAdvancesIntervalWhenOldestPendingBelongsToOwnConsumer()
+    {
+        $redis = $this->createRedisMock();
+
+        // get #1: pending scan from '0' returns msg-A
+        // get #2: pending scan from 'msg-A' → empty (cursor exhausted)
+        //         claim: xpending returns msg-A owned by OUR consumer → should advance nextClaim, NOT rescan
+        //         fallback to new messages: none
+        $redis->expects($this->exactly(3))->method('xreadgroup')
+            ->willReturnCallback(function (...$args) {
+                static $series = [
+                    [['symfony', 'consumer', ['queue' => '0'], 1, 1], ['queue' => ['msg-A' => ['message' => '{"body":"1","headers":[]}']]]],
+                    [['symfony', 'consumer', ['queue' => 'msg-A'], 1, 1], []],
+                    [['symfony', 'consumer', ['queue' => '>'], 1, 1], []],
+                ];
+
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            });
+
+        $redis->expects($this->once())->method('xpending')
+            ->willReturn([[0 => 'msg-A', 1 => 'consumer', 2 => 100]]);
+
+        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
+
+        $nextClaimProp = (new \ReflectionClass(Connection::class))->getProperty('nextClaim');
+
+        $msg = $connection->get();
+        $this->assertSame('msg-A', $msg['id']);
+        $this->assertSame(0.0, $nextClaimProp->getValue($connection));
+
+        $this->assertNull($connection->get());
+        $this->assertGreaterThan(0.0, $nextClaimProp->getValue($connection));
     }
 
     private function createRedisMock(): \Redis

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -443,6 +443,35 @@ class RedisExtIntegrationTest extends TestCase
         $this->assertSame(1, $this->connection->getMessageCount());
     }
 
+    public function testPendingMessagesAreNotReturnedAsDuplicatesBeforeAck()
+    {
+        $this->connection->add('{"message": "1"}', ['type' => DummyMessage::class]);
+        $this->connection->add('{"message": "2"}', ['type' => DummyMessage::class]);
+        $this->connection->add('{"message": "3"}', ['type' => DummyMessage::class]);
+
+        // Fetch all 3 without acking — simulates a batch handler collecting messages.
+        // The old code would return msg-1 three times because it always read from ID '0'.
+        $msg1 = $this->connection->get();
+        $msg2 = $this->connection->get();
+        $msg3 = $this->connection->get();
+
+        $this->assertNotNull($msg1);
+        $this->assertNotNull($msg2);
+        $this->assertNotNull($msg3);
+
+        $ids = [$msg1['id'], $msg2['id'], $msg3['id']];
+        $this->assertCount(3, array_unique($ids), 'Each get() must return a distinct message, not duplicates');
+
+        // After all pending are consumed, next get() must return null (no new messages)
+        $this->assertNull($this->connection->get());
+
+        $this->connection->ack($msg1['id']);
+        $this->connection->ack($msg2['id']);
+        $this->connection->ack($msg3['id']);
+
+        $this->assertNull($this->connection->get());
+    }
+
     private function getConnectionGroup(Connection $connection): string
     {
         $property = (new \ReflectionClass(Connection::class))->getProperty('group');

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -66,7 +66,9 @@ class Connection
     private float $claimInterval;
     private bool $deleteAfterAck;
     private bool $deleteAfterReject;
-    private bool $couldHavePendingMessages = true;
+    private ?string $lastPendingMessageId = '0';
+    /** @var array<string, true> */
+    private array $inflightIds = [];
 
     public function __construct(array $options, \Redis|Relay|\RedisCluster|null $redis = null)
     {
@@ -361,45 +363,48 @@ class Connection
 
     private function claimOldPendingMessages(): void
     {
+        $redis = $this->getRedis();
+
         try {
-            // This could soon be optimized with https://github.com/antirez/redis/issues/5212 or
-            // https://github.com/antirez/redis/issues/6256
-            $pendingMessages = $this->getRedis()->xpending($this->stream, $this->group, '-', '+', 1) ?: [];
+            $pendingMessages = $redis->xpending($this->stream, $this->group, '-', '+', 1) ?: [];
         } catch (\RedisException|\Relay\Exception $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
 
-        $claimableIds = [];
-        foreach ($pendingMessages as $pendingMessage) {
-            if ($pendingMessage[1] === $this->consumer) {
-                $this->couldHavePendingMessages = true;
+        if (!$pendingMessages) {
+            $this->nextClaim = microtime(true) + $this->claimInterval;
 
-                return;
-            }
-
-            if ($pendingMessage[2] >= $this->redeliverTimeout) {
-                $claimableIds[] = $pendingMessage[0];
-            }
+            return;
         }
 
-        if (\count($claimableIds) > 0) {
-            try {
-                $this->getRedis()->xclaim(
-                    $this->stream,
-                    $this->group,
-                    $this->consumer,
-                    $this->redeliverTimeout,
-                    $claimableIds,
-                    ['JUSTID']
-                );
+        $pendingMessage = $pendingMessages[0];
 
-                $this->couldHavePendingMessages = true;
-            } catch (\RedisException|\Relay\Exception $e) {
-                throw new TransportException($e->getMessage(), 0, $e);
-            }
+        if ($pendingMessage[1] === $this->consumer) {
+            $this->nextClaim = microtime(true) + $this->claimInterval;
+
+            return;
         }
 
-        $this->nextClaim = microtime(true) + $this->claimInterval;
+        if ($pendingMessage[2] < $this->redeliverTimeout) {
+            $this->nextClaim = microtime(true) + $this->claimInterval;
+
+            return;
+        }
+
+        try {
+            $redis->xclaim(
+                $this->stream,
+                $this->group,
+                $this->consumer,
+                $this->redeliverTimeout,
+                [$pendingMessage[0]],
+                ['JUSTID']
+            );
+
+            $this->lastPendingMessageId = '0';
+        } catch (\RedisException|\Relay\Exception $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
+        }
     }
 
     public function get(): ?array
@@ -407,6 +412,26 @@ class Connection
         if ($this->autoSetup) {
             $this->setup();
         }
+
+        $this->handleDelayedMessages();
+
+        if (null !== $message = $this->getPendingMessage()) {
+            return $message;
+        }
+
+        if (null === $this->lastPendingMessageId && $this->nextClaim <= microtime(true)) {
+            $this->claimOldPendingMessages();
+
+            if (null !== $message = $this->getPendingMessage()) {
+                return $message;
+            }
+        }
+
+        return $this->getNewMessage();
+    }
+
+    private function handleDelayedMessages(): void
+    {
         $now = microtime();
         $now = substr($now, 11).substr($now, 2, 3);
 
@@ -433,16 +458,58 @@ class Connection
             $decodedQueuedMessage = json_decode($queuedMessage, true);
             $this->add(\array_key_exists('body', $decodedQueuedMessage) ? $decodedQueuedMessage['body'] : $queuedMessage, $decodedQueuedMessage['headers'] ?? [], 0);
         }
+    }
 
-        if (!$this->couldHavePendingMessages && $this->nextClaim <= microtime(true)) {
-            $this->claimOldPendingMessages();
+    private function getPendingMessage(): ?array
+    {
+        if (null === $this->lastPendingMessageId) {
+            return null;
         }
 
-        $messageId = '>'; // will receive new messages
+        while (true) {
+            $messages = $this->xReadGroup($this->lastPendingMessageId);
 
-        if ($this->couldHavePendingMessages) {
-            $messageId = '0'; // will receive consumers pending messages
+            if (empty($messages[$this->stream])) {
+                $this->lastPendingMessageId = null;
+
+                return null;
+            }
+
+            /** @var string $key */
+            $key = array_key_first($messages[$this->stream]);
+            $this->lastPendingMessageId = $key;
+
+            if (isset($this->inflightIds[$key])) {
+                continue;
+            }
+
+            $this->inflightIds[$key] = true;
+
+            return [
+                'id' => $key,
+                'data' => $messages[$this->stream][$key],
+            ];
         }
+    }
+
+    private function getNewMessage(): ?array
+    {
+        $messages = $this->xReadGroup('>');
+
+        foreach ($messages[$this->stream] ?? [] as $key => $message) {
+            $this->inflightIds[$key] = true;
+
+            return [
+                'id' => $key,
+                'data' => $message,
+            ];
+        }
+
+        return null;
+    }
+
+    private function xReadGroup(string $messageId): array
+    {
         $redis = $this->getRedis();
 
         try {
@@ -457,7 +524,7 @@ class Connection
             throw new TransportException($e->getMessage(), 0, $e);
         }
 
-        if (false === $messages) {
+        if (!\is_array($messages)) {
             if ($error = $redis->getLastError() ?: null) {
                 $redis->clearLastError();
             }
@@ -465,21 +532,7 @@ class Connection
             throw new TransportException($error ?? 'Could not read messages from the redis stream.');
         }
 
-        if ($this->couldHavePendingMessages && empty($messages[$this->stream])) {
-            $this->couldHavePendingMessages = false;
-
-            // No pending messages so get a new one
-            return $this->get();
-        }
-
-        foreach ($messages[$this->stream] ?? [] as $key => $message) {
-            return [
-                'id' => $key,
-                'data' => $message,
-            ];
-        }
-
-        return null;
+        return $messages;
     }
 
     public function ack(string $id): void
@@ -501,6 +554,8 @@ class Connection
             }
             throw new TransportException($error ?? \sprintf('Could not acknowledge redis message "%s".', $id));
         }
+
+        unset($this->inflightIds[$id]);
     }
 
     public function reject(string $id): void
@@ -522,6 +577,8 @@ class Connection
             }
             throw new TransportException($error ?? \sprintf('Could not delete message "%s" from the redis stream.', $id));
         }
+
+        unset($this->inflightIds[$id]);
     }
 
     public function add(string $body, array $headers, int $delayInMs = 0): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44400, Fix #49023
| License       | MIT

The Redis transport is currently broken when used with `BatchHandlerInterface`. The root cause is in how `Connection::get()` reads pending messages.

When a batch handler calls `get()` repeatedly to accumulate messages before flushing, the transport always passes ID `0` to `XREADGROUP`, which makes Redis return pending entries from the very beginning. Since previously fetched messages haven't been acked yet (that's the whole point of batching), the first pending message is returned over and over. This fills the batch with duplicates of the same message, and when the handler tries to ack them, all but the first fail with `Could not acknowledge redis message`.

The issue has been open since 2021 and people have been working around it with custom transport decorators, message deduplication via UUIDs, and other workarounds — none of which should be necessary.

### The fix

Replace the boolean `$couldHavePendingMessages` flag with two things:

- A **cursor** (`$lastPendingMessageId`) that advances past each returned message, so successive `XREADGROUP` calls iterate through the pending list instead of restarting from the beginning every time.
- An **in-flight registry** (`$inflightIds`) that tracks which message IDs have already been delivered to the worker. When a claim resets the cursor back to `0`, any previously delivered messages are skipped. IDs are removed from the registry when `ack()` or `reject()` is called.

This also fixes #49023: the old code unconditionally advanced `$nextClaim` at the end of `claimOldPendingMessages()`, even after a successful claim. That meant the worker had to wait the full `claim_interval` (default 60s) before it could claim the next abandoned message. Now the timer only advances when there is genuinely nothing left to claim, so multiple abandoned messages can be recovered in sequence.

The `get()` method has been refactored from a single method with recursive self-calls into smaller focused methods (`getPendingMessage()`, `getNewMessage()`, `handleDelayedMessages()`, `xReadGroup()`), which makes the control flow easier to follow and test.