### PR TITLE
 Mark callbacks with @param-immediately-invoked-callable where applicable

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -66,6 +66,9 @@ class DoctrineChoiceLoader extends AbstractChoiceLoader
         return parent::doLoadValuesForChoices($choices);
     }
 
+    /**
+     * @param-immediately-invoked-callable $value
+     */
     protected function doLoadChoicesForValues(array $values, ?callable $value): array
     {
         if ($this->idReader && null === $value) {

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -28,6 +28,9 @@ abstract class AbstractSchemaListener
 {
     abstract public function postGenerateSchema(GenerateSchemaEventArgs $event): void;
 
+    /**
+     * @param-immediately-invoked-callable $configurator
+     */
     protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator): void
     {
         $filter = $connection->getConfiguration()->getSchemaAssetsFilter();

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -188,6 +188,8 @@ final class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifi
 
     /**
      * Adds the Table to the Schema if "remember me" uses this Connection.
+     *
+     * @param-immediately-invoked-callable $isSameDatabase
      */
     public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): void
     {

--- a/src/Symfony/Bridge/PsrHttpMessage/Factory/UploadedFile.php
+++ b/src/Symfony/Bridge/PsrHttpMessage/Factory/UploadedFile.php
@@ -23,6 +23,9 @@ class UploadedFile extends BaseUploadedFile
 {
     private bool $test = false;
 
+    /**
+     * @param-immediately-invoked-callable $getTemporaryPath
+     */
     public function __construct(
         private readonly UploadedFileInterface $psrUploadedFile,
         callable $getTemporaryPath,

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -644,6 +644,8 @@ class TextDescriptor extends Descriptor
     }
 
     /**
+     * @param-immediately-invoked-callable $getContainer
+     *
      * @param (callable():ContainerBuilder)|null $getContainer
      */
     private function formatControllerLink(mixed $controller, string $anchorText, ?callable $getContainer = null): string

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -244,6 +244,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addFormSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -829,6 +832,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addAssetsSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -910,6 +916,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addAssetMapperSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1031,6 +1040,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addTranslatorSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1118,6 +1130,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addValidationSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1204,6 +1219,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addSerializerSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $defaultContextNode = fn () => (new NodeBuilder())
@@ -1272,6 +1290,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $willBeAvailable
+     */
     private function addPropertyAccessSection(ArrayNodeDefinition $rootNode, callable $willBeAvailable): void
     {
         $rootNode
@@ -1292,6 +1313,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addPropertyInfoSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1310,6 +1334,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addTypeInfoSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1332,6 +1359,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $willBeAvailable
+     */
     private function addCacheSection(ArrayNodeDefinition $rootNode, callable $willBeAvailable): void
     {
         $rootNode
@@ -1514,6 +1544,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addLockSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1580,6 +1613,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addSemaphoreSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1635,6 +1671,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addWebLinkSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1647,6 +1686,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addMessengerSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1852,6 +1894,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addSchedulerSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -1877,6 +1922,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addHttpClientSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2286,6 +2334,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addMailerSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2428,6 +2479,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addNotifierSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2467,6 +2521,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addWebhookSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2500,6 +2557,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addRemoteEventSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2512,6 +2572,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addRateLimiterSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2600,6 +2663,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addUidSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2633,6 +2699,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addHtmlSanitizerSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode
@@ -2769,6 +2838,9 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+    /**
+     * @param-immediately-invoked-callable $enableIfStandalone
+     */
     private function addJsonStreamerSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
     {
         $rootNode

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1847,6 +1847,9 @@ class FrameworkExtension extends Extension
         $this->registerMappingFilesFromConfig($container, $config, $fileRecorder);
     }
 
+    /**
+     * @param-immediately-invoked-callable $fileRecorder
+     */
     private function registerMappingFilesFromDir(string $dir, callable $fileRecorder): void
     {
         foreach (Finder::create()->followLinks()->files()->in($dir)->name('/\.(xml|ya?ml)$/')->sortByName() as $file) {
@@ -1854,6 +1857,9 @@ class FrameworkExtension extends Extension
         }
     }
 
+    /**
+     * @param-immediately-invoked-callable $fileRecorder
+     */
     private function registerMappingFilesFromConfig(ContainerBuilder $container, array $config, callable $fileRecorder): void
     {
         foreach ($config['mapping']['paths'] as $path) {

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -79,6 +79,9 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
         );
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
         $item = $this->getItem($key);

--- a/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
@@ -91,6 +91,9 @@ class ChainAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
         );
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
         $doSave = true;

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -133,6 +133,9 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
         }
     }
 
+    /**
+     * @param-immediately-invoked-callable $isSameDatabase
+     */
     public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): void
     {
         if ($schema->hasTable($this->table)) {

--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -39,6 +39,9 @@ class NullAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInt
         );
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
         $save = true;

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -86,6 +86,9 @@ class ProxyAdapter implements AdapterInterface, NamespacedPoolInterface, CacheIn
         );
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
     {
         if (!$this->pool instanceof CacheInterface) {

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -39,6 +39,8 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, NamespacedPo
     }
 
     /**
+     * @param-immediately-invoked-callable $callback
+     *
      * @throws BadMethodCallException When the item pool is not a CacheInterface
      */
     public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -84,6 +84,10 @@ final class LockRegistry
         return $previousFiles;
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     * @param-immediately-invoked-callable $setMetadata
+     */
     public static function compute(callable $callback, ItemInterface $item, bool &$save, CacheInterface $pool, ?\Closure $setMetadata = null, ?LoggerInterface $logger = null, ?float $beta = null): mixed
     {
         if ('\\' === \DIRECTORY_SEPARATOR && null === self::$lockedFiles) {

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -722,6 +722,9 @@ trait RedisTrait
         return $failed;
     }
 
+    /**
+     * @param-immediately-invoked-callable $generator
+     */
     private function pipeline(\Closure $generator, ?object $redis = null): \Generator
     {
         $ids = [];

--- a/src/Symfony/Component/Config/ConfigCacheFactory.php
+++ b/src/Symfony/Component/Config/ConfigCacheFactory.php
@@ -30,6 +30,9 @@ class ConfigCacheFactory implements ConfigCacheFactoryInterface
     ) {
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     public function cache(string $file, callable $callback): ConfigCacheInterface
     {
         $cache = new ConfigCache($file, $this->debug);

--- a/src/Symfony/Component/Config/ConfigCacheFactoryInterface.php
+++ b/src/Symfony/Component/Config/ConfigCacheFactoryInterface.php
@@ -23,6 +23,8 @@ interface ConfigCacheFactoryInterface
     /**
      * Creates a cache instance and (re-)initializes it if necessary.
      *
+     * @param-immediately-invoked-callable $callable
+     *
      * @param string   $file     The absolute cache file path
      * @param callable $callable The callable to be executed when the cache needs to be filled (i. e. is not fresh). The cache will be passed as the only parameter to this callback
      */

--- a/src/Symfony/Component/Config/Definition/Loader/DefinitionFileLoader.php
+++ b/src/Symfony/Component/Config/Definition/Loader/DefinitionFileLoader.php
@@ -70,6 +70,9 @@ class DefinitionFileLoader extends FileLoader
         return 'php' === $type;
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     private function callConfigurator(callable $callback, DefinitionConfigurator $configurator, string $path): void
     {
         $callback = $callback(...);

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCacheFactory.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCacheFactory.php
@@ -27,6 +27,9 @@ class ResourceCheckerConfigCacheFactory implements ConfigCacheFactoryInterface
     ) {
     }
 
+    /**
+     * @param-immediately-invoked-callable $callable
+     */
     public function cache(string $file, callable $callable): ConfigCacheInterface
     {
         $cache = new ResourceCheckerConfigCache($file, $this->resourceCheckers);

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -257,6 +257,8 @@ class QuestionHelper extends Helper
      *
      * @param resource                  $inputStream
      * @param callable(string):string[] $autocomplete
+     *
+     * @param-immediately-invoked-callable $autocomplete
      */
     private function autocomplete(OutputInterface $output, Question $question, $inputStream, callable $autocomplete): string
     {
@@ -471,6 +473,8 @@ class QuestionHelper extends Helper
      * Validates an attempt.
      *
      * @param callable $interviewer A callable that will ask for a question and return the result
+     *
+     * @param-immediately-invoked-callable $interviewer
      *
      * @throws \Exception In case the max number of attempts has been reached and no valid response has been given
      */

--- a/src/Symfony/Component/Console/Interaction/Interaction.php
+++ b/src/Symfony/Component/Console/Interaction/Interaction.php
@@ -28,6 +28,8 @@ final class Interaction
     }
 
     /**
+     * @param-immediately-invoked-callable $parameterResolver
+     *
      * @param \Closure(\ReflectionFunction $function, InputInterface $input, OutputInterface $output): array $parameterResolver
      */
     public function interact(InputInterface $input, OutputInterface $output, \Closure $parameterResolver): void

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -64,6 +64,9 @@ class EnvVarProcessor implements EnvVarProcessorInterface, ResetInterface
         ];
     }
 
+    /**
+     * @param-immediately-invoked-callable $getEnv
+     */
     public function getEnv(string $prefix, string $name, \Closure $getEnv): mixed
     {
         $i = strpos($name, ':');

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessorInterface.php
@@ -23,6 +23,8 @@ interface EnvVarProcessorInterface
     /**
      * Returns the value of the given variable as managed by the current instance.
      *
+     * @param-immediately-invoked-callable $getEnv
+     *
      * @param string                  $prefix The namespace of the variable; when the empty string is passed, null values should be kept as is
      * @param string                  $name   The name of the variable within the namespace
      * @param \Closure(string): mixed $getEnv A closure that allows fetching more env vars

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionTrait.php
@@ -28,6 +28,9 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  */
 trait ExtensionTrait
 {
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     private function executeConfiguratorCallback(ContainerBuilder $container, \Closure $callback, ConfigurableExtensionInterface $subject, bool $prepend = false): void
     {
         $env = $container->hasParameter('kernel.environment') ? $container->getParameter('kernel.environment') : null;

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
@@ -25,6 +25,8 @@ interface InstantiatorInterface
     /**
      * Instantiates a proxy object.
      *
+     * @param-immediately-invoked-callable $realInstantiator
+     *
      * @param string                                        $id               Identifier of the requested service
      * @param (callable(): object)|(callable(object): void) $realInstantiator A callback that creates or initializes the real service instance:
      *                                                                        - For direct instantiation or value-holder proxies: Called without arguments and returns the service object.

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
@@ -21,6 +21,9 @@ use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\LazyServiceDumper;
  */
 final class LazyServiceInstantiator implements InstantiatorInterface
 {
+    /**
+     * @param-immediately-invoked-callable $realInstantiator
+     */
     public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object
     {
         $dumper = new LazyServiceDumper();

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/RealServiceInstantiator.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Definition;
 class RealServiceInstantiator implements InstantiatorInterface
 {
     /**
+     * @param-immediately-invoked-callable $realInstantiator
+     *
      * @return object The real service instance
      */
     public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -144,6 +144,8 @@ class PhpFileLoader extends FileLoader
 
     /**
      * Resolve the parameters to the $callback and execute it.
+     *
+     * @param-immediately-invoked-callable $callback
      */
     private function callConfigurator(callable $callback, ContainerConfigurator $containerConfigurator, string $path): void
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -303,6 +303,8 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @template R of mixed
      *
+     * @param-immediately-invoked-callable $closure
+     *
      * @param \Closure(static, int):R $closure
      *
      * @return list<R> An array of values returned by the anonymous function
@@ -329,6 +331,8 @@ class Crawler implements \Countable, \IteratorAggregate
      * Reduces the list of nodes by calling an anonymous function.
      *
      * To remove a node from the list, the anonymous function must return false.
+     *
+     * @param-immediately-invoked-callable $closure
      *
      * @param \Closure(static, int):bool $closure
      */

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -157,6 +157,8 @@ class ErrorHandler
     /**
      * Calls a function and turns any PHP error into \ErrorException.
      *
+     * @param-immediately-invoked-callable $function
+     *
      * @throws \ErrorException When $function(...$arguments) triggers a PHP error
      */
     public static function call(callable $function, mixed ...$arguments): mixed

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -152,6 +152,8 @@ class ArrayChoiceList implements ChoiceListInterface
      *                                     corresponding values
      * @param array|null $structuredValues The values indexed by the original keys
      *
+     * @param-immediately-invoked-callable $value
+     *
      * @internal
      */
     protected function flatten(array $choices, callable $value, ?array &$choicesByValues, ?array &$keysByValues, ?array &$structuredValues): void

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -141,6 +141,9 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         return new ChoiceListView($otherViews, $preferredViews);
     }
 
+    /**
+     * @param-immediately-invoked-callable $isPreferred
+     */
     private static function addChoiceView($choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
     {
         // $value may be an integer or a string, since it's stored in the array
@@ -247,6 +250,10 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         }
     }
 
+    /**
+     * @param-immediately-invoked-callable $groupBy
+     * @param-immediately-invoked-callable $isPreferred
+     */
     private static function addChoiceViewsGroupedByCallable(callable $groupBy, $choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
     {
         $groupLabels = $groupBy($choice, $keys[$value], $value);

--- a/src/Symfony/Component/Form/ChoiceList/Loader/AbstractChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/AbstractChoiceLoader.php
@@ -38,6 +38,9 @@ abstract class AbstractChoiceLoader implements ChoiceLoaderInterface
         return $this->doLoadChoicesForValues($values, $value);
     }
 
+    /**
+     * @param-immediately-invoked-callable $value
+     */
     public function loadValuesForChoices(array $choices, ?callable $value = null): array
     {
         if (!$choices) {

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -247,6 +247,8 @@ class FormValidator extends ConstraintValidator
      *
      * @param string|GroupSequence|array<string|GroupSequence>|callable $groups The validation groups
      *
+     * @param-immediately-invoked-callable $groups
+     *
      * @return GroupSequence|array<string|GroupSequence>
      */
     private static function resolveValidationGroups(string|GroupSequence|array|callable $groups, FormInterface $form): GroupSequence|array

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -262,6 +262,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      * Iterates over the constraints of a property, executes a constraints on
      * them and returns the best guess.
      *
+     * @param-immediately-invoked-callable $closure
+     *
      * @param \Closure $closure      The closure that returns a guess
      *                               for a given constraint
      * @param mixed    $defaultValue The default value assumed if no other value

--- a/src/Symfony/Component/Form/Flow/FormFlow.php
+++ b/src/Symfony/Component/Form/Flow/FormFlow.php
@@ -202,6 +202,9 @@ class FormFlow extends Form implements FormFlowInterface
         }
     }
 
+    /**
+     * @param-immediately-invoked-callable $direction
+     */
     private function move(\Closure $direction): bool
     {
         $data = $this->getData();

--- a/src/Symfony/Component/Form/FormTypeGuesserChain.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserChain.php
@@ -67,6 +67,8 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
      * Executes a closure for each guesser and returns the best guess from the
      * return values.
      *
+     * @param-immediately-invoked-callable $closure
+     *
      * @param \Closure $closure The closure to execute. Accepts a guesser
      *                          as argument and should return a Guess instance
      */

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -385,6 +385,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
 
     /**
      * Wraps the request's body callback to allow it to return strings longer than curl requested.
+     *
+     * @param-immediately-invoked-callable $body
      */
     private static function readRequestBody(int $length, \Closure $body, string &$buffer, bool &$eof): string
     {

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -327,6 +327,8 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
 
     /**
      * Resolves the IP of the host using the local DNS cache if possible.
+     *
+     * @param-immediately-invoked-callable $onProgress
      */
     private static function dnsResolve(string $host, NativeClientState $multi, array &$info, ?\Closure $onProgress): string
     {

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -375,6 +375,8 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
 
     /**
      * Parses header lines as curl yields them to us.
+     *
+     * @param-immediately-invoked-callable $resolveRedirect
      */
     private static function parseHeaderLine($ch, string $data, array &$info, array &$headers, ?array $options, CurlClientState $multi, int $id, ?string &$location, ?callable $resolveRedirect, ?LoggerInterface $logger): int
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -183,6 +183,8 @@ class PdoSessionHandler extends AbstractSessionHandler
 
     /**
      * Adds the Table to the Schema if it doesn't exist.
+     *
+     * @param-immediately-invoked-callable $isSameDatabase
      */
     public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null): void
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/CacheAttributeListener.php
@@ -266,6 +266,9 @@ class CacheAttributeListener implements EventSubscriberInterface
         ], $request->attributes->all(), $arguments);
     }
 
+    /**
+     * @param-immediately-invoked-callable $closureOrExpression
+     */
     private function evaluate(string|Expression|\Closure $closureOrExpression, array $variables): mixed
     {
         if ($closureOrExpression instanceof \Closure) {

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -42,6 +42,9 @@ class FileProfilerStorage implements ProfilerStorageInterface
         }
     }
 
+    /**
+     * @param-immediately-invoked-callable $filter
+     */
     public function find(?string $ip, ?string $url, ?int $limit, ?string $method, ?int $start = null, ?int $end = null, ?string $statusCode = null, ?\Closure $filter = null): array
     {
         $file = $this->getIndexFilename();

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
@@ -34,6 +34,8 @@ interface ProfilerStorageInterface
      * @param int|null      $end        The end date to search to
      * @param string|null   $statusCode The response status code
      * @param \Closure|null $filter     A filter to apply on the list of tokens
+     *
+     * @param-immediately-invoked-callable $filter
      */
     public function find(?string $ip, ?string $url, ?int $limit, ?string $method, ?int $start = null, ?int $end = null, ?string $statusCode = null, ?\Closure $filter = null): array;
 

--- a/src/Symfony/Component/JsonStreamer/StreamerDumper.php
+++ b/src/Symfony/Component/JsonStreamer/StreamerDumper.php
@@ -39,6 +39,8 @@ final class StreamerDumper
     /**
      * Dumps the generated content to the given path, optionally using config cache.
      *
+     * @param-immediately-invoked-callable $generateContent
+     *
      * @param callable(): string $generateContent
      */
     public function dump(Type $type, string $path, callable $generateContent): void

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -254,6 +254,8 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
     /**
      * Adds the Table to the Schema if it doesn't exist.
+     *
+     * @param-immediately-invoked-callable $isSameDatabase
      */
     public function configureSchema(Schema $schema, \Closure $isSameDatabase): void
     {

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -356,6 +356,8 @@ class RedisStore implements SharedLockStoreInterface
     /**
      * @template T
      *
+     * @param-immediately-invoked-callable $callback
+     *
      * @param callable(): T $callback
      *
      * @return T

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -620,6 +620,9 @@ class Connection
         return $amqpStamp?->getRoutingKey() ?? $this->getDefaultPublishRoutingKey();
     }
 
+    /**
+     * @param-immediately-invoked-callable $callable
+     */
     private function withConnectionExceptionRetry(callable $callable): void
     {
         $maxRetries = 3;

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
@@ -255,6 +255,9 @@ class Connection
         $this->watchingTube = true;
     }
 
+    /**
+     * @param-immediately-invoked-callable $command
+     */
     private function withReconnect(callable $command): mixed
     {
         try {

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -352,6 +352,8 @@ class Connection implements ResetInterface
 
     /**
      * @internal
+     *
+     * @param-immediately-invoked-callable $isSameDatabase
      */
     public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase): void
     {

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
@@ -149,6 +149,9 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
         }
     }
 
+    /**
+     * @param-immediately-invoked-callable $callable
+     */
     private function withRetryableExceptionRetry(callable $callable): void
     {
         $delay = 100;

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -137,6 +137,9 @@ class HandleMessageMiddleware implements MiddlewareInterface
         return false;
     }
 
+    /**
+     * @param-immediately-invoked-callable $handler
+     */
     private function callHandler(\Closure $handler, object $message, ?Acknowledger $ack, ?HandlerArgumentsStamp $handlerArgumentsStamp): mixed
     {
         $arguments = [$message];

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -326,6 +326,8 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     }
 
     /**
+     * @param-immediately-invoked-callable $fn
+     *
      * @param callable(): mixed $fn
      */
     private function call(callable $fn, mixed $value, object $source, ?object $target = null): mixed

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -504,6 +504,8 @@ class Process implements \IteratorAggregate
      * from the output in real-time while writing the standard input to the process.
      * It allows to have feedback from the independent process during execution.
      *
+     * @param-immediately-invoked-callable $callback
+     *
      * @param (callable('out'|'err', string):bool)|null $callback A PHP callback to run whenever there is some
      *                                                            output available on STDOUT or STDERR
      *

--- a/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
@@ -74,6 +74,9 @@ class PhpFileLoader extends FileLoader
         return \is_string($resource) && 'php' === pathinfo($resource, \PATHINFO_EXTENSION) && (!$type || 'php' === $type);
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     protected function callConfigurator(callable $callback, string $path, string $file): RouteCollection
     {
         $collection = new RouteCollection();

--- a/src/Symfony/Component/Semaphore/Store/RedisStore.php
+++ b/src/Symfony/Component/Semaphore/Store/RedisStore.php
@@ -253,6 +253,8 @@ class RedisStore implements PersistingStoreInterface
     /**
      * @template T
      *
+     * @param-immediately-invoked-callable $callback
+     *
      * @param callable(): T $callback
      *
      * @return T

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -425,6 +425,9 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
 
     abstract public function replace(string $from, string $to): static;
 
+    /**
+     * @param-immediately-invoked-callable $to
+     */
     abstract public function replaceMatches(string $fromRegexp, string|callable $to): static;
 
     abstract public function reverse(): static;

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -310,6 +310,9 @@ abstract class AbstractUnicodeString extends AbstractString
         return $this->pad($length, $pad, \STR_PAD_LEFT);
     }
 
+    /**
+     * @param-immediately-invoked-callable $to
+     */
     public function replaceMatches(string $fromRegexp, string|callable $to): static
     {
         if ($this->ignoreCase) {

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -266,6 +266,9 @@ class ByteString extends AbstractString
         return $str;
     }
 
+    /**
+     * @param-immediately-invoked-callable $to
+     */
     public function replaceMatches(string $fromRegexp, string|callable $to): static
     {
         if ($this->ignoreCase) {

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -268,6 +268,9 @@ class UnicodeString extends AbstractUnicodeString
         return $str;
     }
 
+    /**
+     * @param-immediately-invoked-callable $to
+     */
     public function replaceMatches(string $fromRegexp, string|callable $to): static
     {
         $str = parent::replaceMatches($fromRegexp, $to);

--- a/src/Symfony/Component/Translation/LocaleSwitcher.php
+++ b/src/Symfony/Component/Translation/LocaleSwitcher.php
@@ -60,6 +60,8 @@ class LocaleSwitcher implements LocaleAwareInterface
      *
      * @template T
      *
+     * @param-immediately-invoked-callable $callback
+     *
      * @param callable(string $locale):T $callback
      *
      * @return T

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -25,6 +25,8 @@ abstract class Type implements \Stringable
     /**
      * Tells if the type is satisfied by the $specification callable.
      *
+     * @param-immediately-invoked-callable $specification
+     *
      * @param callable(self): bool $specification
      */
     public function isSatisfiedBy(callable $specification): bool

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -175,6 +175,9 @@ class CollectionType extends Type implements WrappingTypeInterface
         return $defaultCollectionValueType;
     }
 
+    /**
+     * @param-immediately-invoked-callable $specification
+     */
     public function wrappedTypeIsSatisfiedBy(callable $specification): bool
     {
         return $this->getWrappedType()->isSatisfiedBy($specification);

--- a/src/Symfony/Component/TypeInfo/Type/CompositeTypeInterface.php
+++ b/src/Symfony/Component/TypeInfo/Type/CompositeTypeInterface.php
@@ -28,6 +28,8 @@ interface CompositeTypeInterface
     public function getTypes(): array;
 
     /**
+     * @param-immediately-invoked-callable $specification
+     *
      * @param callable(Type): bool $specification
      */
     public function composedTypesAreSatisfiedBy(callable $specification): bool;

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -59,6 +59,9 @@ final class GenericType extends Type implements WrappingTypeInterface
         return $this->variableTypes;
     }
 
+    /**
+     * @param-immediately-invoked-callable $specification
+     */
     public function wrappedTypeIsSatisfiedBy(callable $specification): bool
     {
         return $this->getWrappedType()->isSatisfiedBy($specification);

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -64,6 +64,9 @@ final class IntersectionType extends Type implements CompositeTypeInterface
         return $this->types;
     }
 
+    /**
+     * @param-immediately-invoked-callable $specification
+     */
     public function composedTypesAreSatisfiedBy(callable $specification): bool
     {
         foreach ($this->types as $type) {

--- a/src/Symfony/Component/TypeInfo/Type/NullableType.php
+++ b/src/Symfony/Component/TypeInfo/Type/NullableType.php
@@ -50,6 +50,9 @@ final class NullableType extends UnionType implements WrappingTypeInterface
         return $this->type;
     }
 
+    /**
+     * @param-immediately-invoked-callable $specification
+     */
     public function wrappedTypeIsSatisfiedBy(callable $specification): bool
     {
         return $this->getWrappedType()->isSatisfiedBy($specification);

--- a/src/Symfony/Component/TypeInfo/Type/TemplateType.php
+++ b/src/Symfony/Component/TypeInfo/Type/TemplateType.php
@@ -52,6 +52,9 @@ final class TemplateType extends Type implements WrappingTypeInterface
         return $this->bound;
     }
 
+    /**
+     * @param-immediately-invoked-callable $specification
+     */
     public function wrappedTypeIsSatisfiedBy(callable $specification): bool
     {
         return $this->getWrappedType()->isSatisfiedBy($specification);

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -84,6 +84,9 @@ class UnionType extends Type implements CompositeTypeInterface
         return $this->types;
     }
 
+    /**
+     * @param-immediately-invoked-callable $specification
+     */
     public function composedTypesAreSatisfiedBy(callable $specification): bool
     {
         foreach ($this->types as $type) {

--- a/src/Symfony/Component/TypeInfo/Type/WrappingTypeInterface.php
+++ b/src/Symfony/Component/TypeInfo/Type/WrappingTypeInterface.php
@@ -28,6 +28,8 @@ interface WrappingTypeInterface
     public function getWrappedType(): Type;
 
     /**
+     * @param-immediately-invoked-callable $specification
+     *
      * @param callable(Type): bool $specification
      */
     public function wrappedTypeIsSatisfiedBy(callable $specification): bool;

--- a/src/Symfony/Component/VarDumper/Server/DumpServer.php
+++ b/src/Symfony/Component/VarDumper/Server/DumpServer.php
@@ -49,6 +49,9 @@ class DumpServer
         }
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     public function listen(callable $callback): void
     {
         if (null === $this->socket) {

--- a/src/Symfony/Contracts/Cache/CacheTrait.php
+++ b/src/Symfony/Contracts/Cache/CacheTrait.php
@@ -35,6 +35,9 @@ trait CacheTrait
         return $this->deleteItem($key);
     }
 
+    /**
+     * @param-immediately-invoked-callable $callback
+     */
     private function doGet(CacheItemPoolInterface $pool, string $key, callable $callback, ?float $beta, ?array &$metadata = null, ?LoggerInterface $logger = null): mixed
     {
         if (0 > $beta ??= 1.0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This adds [`@param-immediately-invoked-callable`](https://phpstan.org/writing-php-code/phpdocs-basics#callables) PHPDoc tags across the codebase wherever a `callable`/`Closure` parameter is guaranteed to be invoked synchronously before the method returns.

The annotation lets PHPStan's flow analysis assume side effects of the callback (variables assigned by reference, exceptions thrown, etc.) have happened by the time the call returns, improving analysis precision at call sites.

Follow-up to #54654, extended to the full codebase.