### PR TITLE
[VarDumper] Wrong dumper output for Accept: aplication/json requests

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_accept_header_json_array.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dd_with_accept_header_json_array.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test dd() with "Accept: application/json" uses CliDumper with php://output
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$_SERVER['HTTP_ACCEPT'] = 'application/json';
+dd(['foo1', 'foo2']);
+--EXPECTF--
+array:2 [
+  0 => "foo1"
+  1 => "foo2"
+]

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_json_array.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_json_array.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test dump() with "Accept: application/json" uses CliDumper with php://output
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$_SERVER['HTTP_ACCEPT'] = 'application/json';
+dump(['foo1', 'foo2']);
+--EXPECTF--
+array:2 [
+  0 => "foo1"
+  1 => "foo2"
+]
+

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_json_multiple_args.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_json_multiple_args.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test dump() with "Accept: application/json" uses CliDumper with php://output
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$_SERVER['HTTP_ACCEPT'] = 'application/json';
+dump(1, 'foo', ['foo1', 'foo2']);
+--EXPECTF--
+1 1
+2 "foo"
+3 array:2 [
+  0 => "foo1"
+  1 => "foo2"
+]

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_json_string.phpt
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/functions/dump_with_accept_header_json_string.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test dump() with "Accept: application/json" uses CliDumper with php://output
+--FILE--
+<?php
+putenv('NO_COLOR=1');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$_SERVER['HTTP_ACCEPT'] = 'application/json';
+dump('Test with string');
+--EXPECTF--
+"Test with string"

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -21,6 +21,7 @@ use Symfony\Component\VarDumper\Dumper\ContextProvider\CliContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\RequestContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextualizedDumper;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Symfony\Component\VarDumper\Dumper\ServerDumper;
 
@@ -66,30 +67,21 @@ class VarDumper
         $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
 
         $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
-        switch (true) {
-            case 'html' === $format:
-                $dumper = new HtmlDumper();
-                break;
-            case 'cli' === $format:
-                $dumper = new CliDumper();
-                break;
-            case 'server' === $format:
-            case $format && 'tcp' === parse_url($format, \PHP_URL_SCHEME):
-                $host = 'server' === $format ? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912' : $format;
-                $accept = $_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html');
-                $dumper = str_contains($accept, 'html') || str_contains($accept, '*/*') ? new HtmlDumper() : new CliDumper();
-                $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders());
-                break;
-            default:
-                $accept = $_SERVER['HTTP_ACCEPT'] ?? (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? 'txt' : 'html');
-                $dumper = str_contains($accept, 'html') || str_contains($accept, '*/*') ? new HtmlDumper() : new CliDumper();
-        }
+
+        $dumper = match ($format) {
+            'html' => new HtmlDumper(),
+            'cli' => new CliDumper(),
+            'server' => self::selectDumperForAccept($_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912'),
+            default => self::selectDumperForAccept(
+                $format && 'tcp' === parse_url($format, \PHP_URL_SCHEME) ? $format : null,
+            ),
+        };
 
         if (!$dumper instanceof ServerDumper) {
             $dumper = new ContextualizedDumper($dumper, [new SourceContextProvider()]);
         }
 
-        self::$handler = function ($var, ?string $label = null) use ($cloner, $dumper) {
+        self::$handler = static function ($var, ?string $label = null) use ($cloner, $dumper) {
             $var = $cloner->cloneVar($var);
 
             if (null !== $label) {
@@ -98,6 +90,24 @@ class VarDumper
 
             $dumper->dump($var);
         };
+    }
+
+    private static function selectDumperForAccept(?string $serverHost): DataDumperInterface
+    {
+        $isCliSapi = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true);
+        $accept = $_SERVER['HTTP_ACCEPT'] ?? ($isCliSapi ? 'txt' : 'html');
+
+        $dumper = match (true) {
+            str_contains($accept, 'html'), str_contains($accept, '*/*') => new HtmlDumper(),
+            $isCliSapi => new CliDumper(),
+            default => new CliDumper('php://output'),
+        };
+
+        if (null !== $serverHost) {
+            $dumper = new ServerDumper($serverHost, $dumper, self::getDefaultContextProviders());
+        }
+
+        return $dumper;
     }
 
     private static function getDefaultContextProviders(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63601
| License       | MIT

`CliDumper::$defaultOutput` is `php://stdout`, which in PHP-FPM is redirected to the error log — not the HTTP response body. Only `php://output` goes through PHP's output buffering into the actual response.

The dumper selection fell back to `CliDumper` for any Accept header that wasn't `html` or `*/*`, so `dump()`/`dd()` output silently disappeared for JSON API requests under PHP-FPM. The same issue also affected the `server`/`tcp` format fallback dumper.

This PR fixes the issue by using `new CliDumper('php://output')` in web SAPI contexts where the Accept header is not HTML/`*/*`, and refactors the `switch(true)` into `match($format)` + an extracted `selectDumperForAccept()` method.