### PR TITLE
[Form] hide the placeholder in ChoiceType/select when not required

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -348,6 +348,8 @@ class ChoiceType extends AbstractType
             return new LazyChoiceLoader($choiceLoader);
         };
 
+        $placeholderAttr = static fn (Options $options) => $options['required'] ? ['hidden' => true] : [];
+
         $resolver->setDefaults([
             'multiple' => false,
             'expanded' => false,
@@ -367,7 +369,7 @@ class ChoiceType extends AbstractType
             'group_by' => null,
             'empty_data' => $emptyData,
             'placeholder' => $placeholderDefault,
-            'placeholder_attr' => [],
+            'placeholder_attr' => $placeholderAttr,
             'error_bubbling' => false,
             'compound' => $compound,
             // The view data is always a string or an array of strings,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1672,6 +1672,31 @@ class ChoiceTypeTest extends BaseTypeTestCase
         $this->assertSame('', $view->vars['placeholder']);
     }
 
+    public function testPlaceholderAttrIsEmptyByDefaultIfNotRequired()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'multiple' => false,
+            'required' => false,
+            'choices' => $this->choices,
+        ])
+            ->createView();
+
+        $this->assertSame([], $view->vars['placeholder_attr']);
+    }
+
+    public function testPlaceholderAttrIsHiddenByDefaultIfRequired()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'multiple' => false,
+            'required' => true,
+            'placeholder' => 'Select an option',
+            'choices' => $this->choices,
+        ])
+            ->createView();
+
+        $this->assertSame(['hidden' => true], $view->vars['placeholder_attr']);
+    }
+
     #[DataProvider('getOptionsWithPlaceholder')]
     public function testPassPlaceholderToView($multiple, $expanded, $required, $placeholder, $placeholderViewValue, $placeholderAttr, $placeholderAttrViewValue)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix
| License       | MIT

I discoverd a new HTML attribution on `<option>` tag: `hidden`.
When set, the user could not select it.

Since a placeholder is not meant to be selected, let's use it.

However, I dicided to use it only when the field is required.
This condition could be removed, but if the user selectect something, 
and then change its mind to "unselect" it, the placeholder must be selectable

---

### Demo 

#### required

```php
<?php

namespace App\Form\Type\Pottery\Calcul;

use App\Pottery\Calcul\CalculType as CalculTypeEnum;
use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\Extension\Core\Type\EnumType;
use Symfony\Component\Form\FormBuilderInterface;

class CalculType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('type', EnumType::class, [
                'class' => CalculTypeEnum::class,
                'choice_label' => 'toHuman',
                'placeholder' => 'Sélectionnez un type de calcul',
                'label' => false,
            ])
        ;
    }

}
```

<img width="241" height="147" alt="image" src="https://github.com/user-attachments/assets/fe2e0f6a-293a-4d6d-bbbe-99a1126bdd42" />



#### Not required


<img width="241" height="171" alt="image" src="https://github.com/user-attachments/assets/74574162-96a6-4bd1-96f1-3ac06dd3cb76" />
