### PR TITLE
[Messenger] Add a `--concurrency` option to the `messenger:consume` command to process messages in parallel

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -154,6 +154,10 @@ jobs:
           7z x php_igbinary.zip -y >nul
           iwr -outf php_redis.zip https://github.com/symfony/binary-utils/releases/download/v0.1/php_redis-6.2.0-8.4-ts-vs17-x86.zip
           7z x php_redis.zip -y >nul
+          iwr -outf php_parallel.zip https://github.com/symfony/binary-utils/releases/download/v0.1/php_parallel-1.2.15-8.4-ts-vs17-x86.zip
+          7z x php_parallel.zip -y >nul
+          # dependencies of extensions are resolved next to php.exe, not in ext\
+          Move-Item -Force pthreadVC3.dll ..\pthreadVC3.dll
           cd ..
           Copy php.ini-development php.ini
           "memory_limit=-1" >> php.ini
@@ -171,6 +175,7 @@ jobs:
           "extension=php_apcu.dll" >> php.ini
           "extension=php_igbinary.dll" >> php.ini
           "extension=php_redis.dll" >> php.ini
+          "extension=php_parallel.dll" >> php.ini
           "apc.enable_cli=1" >> php.ini
           "extension=php_intl.dll" >> php.ini
           "extension=php_fileinfo.dll" >> php.ini
@@ -208,4 +213,4 @@ jobs:
         run: |
           $env:Path = 'c:\php;' + $env:Path
 
-          php phpunit src\Symfony --exclude-group tty --exclude-group benchmark --exclude-group intl-data --exclude-group transient-on-windows --requires-php-extension apcu --requires-php-extension curl --requires-php-extension fileinfo --requires-php-extension igbinary --requires-php-extension intl --requires-php-extension openssl --requires-php-extension pdo_sqlite --requires-php-extension redis --requires-php-extension sodium
+          php phpunit src\Symfony --exclude-group tty --exclude-group benchmark --exclude-group intl-data --exclude-group transient-on-windows --requires-php-extension apcu --requires-php-extension curl --requires-php-extension fileinfo --requires-php-extension igbinary --requires-php-extension intl --requires-php-extension openssl --requires-php-extension pdo_sqlite --requires-php-extension redis --requires-php-extension sodium --requires-php-extension parallel

--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,7 @@
     "require-dev": {
         "amphp/http-client": "^5.0",
         "amphp/http-tunnel": "^2.0",
+        "amphp/parallel": "^2.0",
         "async-aws/dynamo-db": "^3.0",
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0|^2.0",

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -165,6 +165,7 @@ return static function (ContainerConfigurator $container) {
                 [], // Bus names
                 service('messenger.rate_limiter_locator')->nullOnInvalid(),
                 null,
+                param('kernel.project_dir').'/bin/console',
             ])
             ->tag('console.command')
             ->tag('monolog.logger', ['channel' => 'messenger'])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -267,6 +267,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('kernel.event_subscriber')
 
         ->set('messenger.routable_message_bus', RoutableMessageBus::class)
+            ->public()
             ->args([
                 abstract_arg('message bus locator'),
                 service('messenger.default_bus'),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -25,9 +25,9 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\JsonPath\UppercaseFunction;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\DummyMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FullStack;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
-use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
@@ -83,6 +83,7 @@ use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Transport\TransportFactory;
@@ -864,7 +865,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testRouterRequestContextUsesHostAndSchemeParameters()
     {
-        $container = $this->createContainerFromClosure(function ($container) {
+        $container = $this->createContainerFromClosure(static function ($container) {
             $container->setParameter('router.request_context.host', 'example.com');
             $container->setParameter('router.request_context.scheme', 'https');
             $container->loadFromExtension('framework', [
@@ -1093,12 +1094,15 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($container->hasDefinition('console.command.messenger_consume_messages'));
         $this->assertTrue($container->hasAlias('messenger.default_bus'));
         $this->assertTrue($container->getAlias('messenger.default_bus')->isPublic());
+        $this->assertTrue($container->hasAlias(MessageBusInterface::class));
+        $this->assertFalse($container->getAlias(MessageBusInterface::class)->isPublic());
         $this->assertTrue($container->hasDefinition('messenger.transport_factory'));
         $this->assertSame(TransportFactory::class, $container->getDefinition('messenger.transport_factory')->getClass());
         $this->assertInstanceOf(TaggedIteratorArgument::class, $container->getDefinition('messenger.transport_factory')->getArgument(0));
         $this->assertEquals($expectedFactories, $container->getDefinition('messenger.transport_factory')->getArgument(0)->getValues());
         $this->assertTrue($container->hasDefinition('messenger.listener.reset_services'));
         $this->assertSame('messenger.listener.reset_services', (string) $container->getDefinition('console.command.messenger_consume_messages')->getArgument(5));
+        $this->assertSame('%kernel.project_dir%/bin/console', $container->getDefinition('console.command.messenger_consume_messages')->getArgument(9));
     }
 
     public function testMessengerAsMessageAttributeIsForwardedToTheTag()

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
  * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`
  * `RedispatchMessage` now dispatches to the senders configured for the message (routing config or `#[AsMessage]`) when `$transportNames` is empty, instead of sending to no sender at all
+ * Add a `--concurrency` option to the `messenger:consume` command to process messages in parallel
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Messenger\Command;
 
+use Amp\Parallel\Worker\ContextWorkerFactory;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
@@ -32,6 +34,7 @@ use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnFailureLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMemoryLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Execution\ParallelExecutionStrategy;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransport;
 use Symfony\Component\Messenger\Worker;
@@ -56,6 +59,7 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
         private array $busIds = [],
         private ?ContainerInterface $rateLimiterLocator = null,
         private ?array $signals = null,
+        private string $console = '',
     ) {
         parent::__construct();
     }
@@ -78,7 +82,8 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
                 new InputOption('all', null, InputOption::VALUE_NONE, 'Consume messages from all receivers'),
                 new InputOption('exclude-receivers', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude specific receivers/transports from consumption (can only be used with --all)'),
                 new InputOption('keepalive', null, InputOption::VALUE_OPTIONAL, 'Whether to use the transport\'s keepalive mechanism if implemented', self::DEFAULT_KEEPALIVE_INTERVAL),
-                new InputOption('fetch-size', null, InputOption::VALUE_REQUIRED, 'The number of messages to fetch per call to the transport', 1),
+                new InputOption('concurrency', null, InputOption::VALUE_REQUIRED, 'The number of concurrent messages to process', 1),
+                new InputOption('fetch-size', null, InputOption::VALUE_REQUIRED, 'The number of messages to fetch per call to the transport (defaults to --concurrency)'),
             ])
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> command consumes messages and dispatches them to the message bus.
@@ -134,9 +139,13 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
                     <info>php %command.full_name% --all --exclude-receivers=<receiver-name></info>
 
-                Use the <info>--fetch-size</info> option to control how many messages are fetched per call to the transport:
+                Use the <info>--concurrency</info> option to process several messages at the same time:
 
-                    <info>php %command.full_name% <receiver-name> --fetch-size=8</info>
+                    <info>php %command.full_name% <receiver-name> --concurrency=4</info>
+
+                Use the <info>--fetch-size</info> option to control how many messages are fetched per call to the transport (defaults to the value of <info>--concurrency</info>):
+
+                    <info>php %command.full_name% <receiver-name> --concurrency=4 --fetch-size=8</info>
                 EOF
             )
         ;
@@ -150,6 +159,16 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
         if ($input->getOption('exclude-receivers') && !$input->getOption('all')) {
             throw new InvalidOptionException('The "--exclude-receivers" option can only be used with the "--all" option.');
+        }
+
+        $concurrency = $input->getOption('concurrency');
+        if (!is_numeric($concurrency) || 0 >= (int) $concurrency) {
+            throw new InvalidOptionException(\sprintf('Option "concurrency" must be a positive integer, "%s" passed.', $concurrency));
+        }
+
+        $fetchSize = $input->getOption('fetch-size');
+        if (null !== $fetchSize && (!is_numeric($fetchSize) || 0 >= (int) $fetchSize)) {
+            throw new InvalidOptionException(\sprintf('Option "fetch-size" must be a positive integer, "%s" passed.', $fetchSize));
         }
     }
 
@@ -300,7 +319,26 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
         $bus = $input->getOption('bus') ? $this->routableBus->getMessageBus($input->getOption('bus')) : $this->routableBus;
 
-        $this->worker = new Worker($receivers, $bus, $this->eventDispatcher, $this->logger, $rateLimiters);
+        $messageExecutionStrategy = null;
+
+        if (1 < $concurrency = (int) $input->getOption('concurrency')) {
+            if (!class_exists(ContextWorkerFactory::class)) {
+                throw new RuntimeException('Parallel message execution requires the "amphp/parallel" package. Try running "composer require amphp/parallel".');
+            }
+
+            if (!$this->console) {
+                throw new RuntimeException('Parallel message execution requires the console entry point to be configured.');
+            }
+
+            $messageExecutionStrategy = new ParallelExecutionStrategy(
+                $this->console,
+                $concurrency,
+                $resetInterval,
+                $memoryLimit ? $this->convertToBytes($memoryLimit) : null,
+            );
+        }
+
+        $this->worker = new Worker($receivers, $bus, $this->eventDispatcher, $this->logger, $rateLimiters, new Clock(), $messageExecutionStrategy);
         $options = [
             'sleep' => $input->getOption('sleep') * 1000000,
             'time_limit' => null !== $timeLimit ? (int) $timeLimit : null,
@@ -309,16 +347,16 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             $options['queues'] = $queues;
         }
 
-        if (1 > $fetchSize = (int) $input->getOption('fetch-size')) {
-            throw new \InvalidArgumentException(\sprintf('The "--fetch-size" option must be a positive integer, "%s" given.', $input->getOption('fetch-size')));
+        $options['fetch_size'] = (int) ($input->getOption('fetch-size') ?? $concurrency);
+        if ($busName = $input->getOption('bus')) {
+            $options['bus_name'] = $busName;
         }
-
-        $options['fetch_size'] = $fetchSize;
 
         try {
             $this->worker->run($options);
         } finally {
             $this->worker = null;
+            $messageExecutionStrategy?->shutdown();
         }
 
         return 0;

--- a/src/Symfony/Component/Messenger/Execution/DeferredBatchMessageQueue.php
+++ b/src/Symfony/Component/Messenger/Execution/DeferredBatchMessageQueue.php
@@ -27,10 +27,11 @@ final class DeferredBatchMessageQueue
         return null !== $this->messages;
     }
 
-    public function add(object $batchHandler, string $transportName, Envelope $envelope, bool &$acked, float $queuedAt): void
+    public function add(object $batchHandler, mixed $context, Envelope $envelope, bool &$acked, float $queuedAt): void
     {
-        $this->messages ??= new \SplObjectStorage();
-        $this->messages[$batchHandler] = new DeferredBatchMessage($transportName, $envelope, $acked, $queuedAt);
+        /** @var \SplObjectStorage<object, DeferredBatchMessage> $messages */
+        $messages = $this->messages ??= new \SplObjectStorage();
+        $messages[$batchHandler] = new DeferredBatchMessage($context, $envelope, $acked, $queuedAt);
     }
 
     /**
@@ -49,7 +50,9 @@ final class DeferredBatchMessageQueue
             return $messages;
         }
 
+        /** @var \SplObjectStorage<object, DeferredBatchMessage> $remaining */
         $remaining = new \SplObjectStorage();
+        /** @var \SplObjectStorage<object, DeferredBatchMessage> $flushable */
         $flushable = new \SplObjectStorage();
 
         foreach ($this->messages as $handler) {

--- a/src/Symfony/Component/Messenger/Execution/DispatchTask.php
+++ b/src/Symfony/Component/Messenger/Execution/DispatchTask.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Execution;
+
+use Amp\Cancellation;
+use Amp\Parallel\Worker\Task;
+use Amp\Sync\Channel;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Execution\Message\DeferredEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\Message\DispatchEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\Message\FlushBatchHandlersMessage;
+use Symfony\Component\Messenger\Execution\Message\HandledEnvelopeMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\AckStamp;
+use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
+use Symfony\Component\Runtime\RuntimeInterface;
+use Symfony\Component\Runtime\SymfonyRuntime;
+use Symfony\Contracts\Service\ContainerProviderInterface;
+
+/**
+ * @internal
+ *
+ * @implements Task<null, DispatchEnvelopeMessage|FlushBatchHandlersMessage, DeferredEnvelopeMessage|HandledEnvelopeMessage>
+ */
+final class DispatchTask implements Task
+{
+    public function __construct(
+        private readonly string $console,
+        private readonly int $resetInterval = 1,
+        private readonly ?int $memoryLimit = null,
+    ) {
+    }
+
+    public function run(Channel $channel, Cancellation $cancellation): mixed
+    {
+        ini_set('zend.exception_ignore_args', '1');
+
+        [$bus, $container] = $this->bootstrap();
+        $count = 0;
+        $unacks = new DeferredBatchMessageQueue();
+
+        while ($message = $channel->receive($cancellation)) {
+            if ($message instanceof FlushBatchHandlersMessage) {
+                $this->flush($bus, $channel, $message->force, $unacks);
+
+                continue;
+            }
+
+            // the channel carries whatever the parent serialised, so this stays a runtime check
+            // @phpstan-ignore instanceof.alwaysTrue
+            if (!$message instanceof DispatchEnvelopeMessage) {
+                continue;
+            }
+
+            $requestId = $message->requestId;
+            $acked = false;
+            $ack = static function (Envelope $handledEnvelope, ?\Throwable $handledError = null) use (&$acked, $requestId, $channel): void {
+                $acked = true;
+
+                if (null !== $handledError) {
+                    $handledEnvelope = ParallelExecutionFailureSanitizer::decorateFailedEnvelope($handledEnvelope);
+                    $handledError = ParallelExecutionFailureSanitizer::sanitizeError($handledError, $handledEnvelope);
+                }
+
+                self::sendHandled($channel, $requestId, $handledEnvelope->withoutAll(AckStamp::class), $handledError);
+            };
+
+            try {
+                $envelope = $bus->dispatch($message->envelope->with(new AckStamp($ack)));
+                $envelope = $envelope->withoutAll(AckStamp::class);
+            } catch (\Throwable $e) {
+                $envelope = ParallelExecutionFailureSanitizer::decorateFailedEnvelope($message->envelope);
+                self::sendHandled($channel, $requestId, $envelope, ParallelExecutionFailureSanitizer::sanitizeError($e, $envelope));
+
+                unset($ack, $acked);
+
+                continue;
+            }
+
+            $noAutoAckStamp = $envelope->last(NoAutoAckStamp::class);
+
+            if (!$acked && !$noAutoAckStamp) {
+                self::sendHandled($channel, $requestId, $envelope, null);
+            } elseif ($noAutoAckStamp) {
+                $channel->send(new DeferredEnvelopeMessage($requestId));
+                $unacks->add($noAutoAckStamp->getHandlerDescriptor()->getBatchHandler(), $requestId, $envelope, $acked, microtime(true));
+            }
+
+            // break the shared reference set so that each message tracks its own ack flag
+            unset($ack, $acked);
+
+            if ($this->resetInterval > 0 && 0 === ++$count % $this->resetInterval && $container->has('services_resetter')) {
+                $container->get('services_resetter')->reset();
+            }
+
+            if (null !== $this->memoryLimit && memory_get_usage(true) >= $this->memoryLimit) {
+                $this->flush($bus, $channel, true, $unacks);
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    private function flush(MessageBusInterface $bus, Channel $channel, bool|float $force, DeferredBatchMessageQueue $unacks): void
+    {
+        if (!$unacks->hasPending()) {
+            return;
+        }
+
+        $toFlush = $unacks->popFlushable($force, microtime(true));
+
+        foreach ($toFlush as $handler) {
+            $deferredMessage = $toFlush[$handler];
+            $requestId = $deferredMessage->context;
+            $envelope = $deferredMessage->envelope;
+
+            try {
+                $envelope = $bus->dispatch($envelope->with(new FlushBatchHandlersStamp(false !== $force)))->withoutAll(AckStamp::class);
+            } catch (\Throwable $e) {
+                $envelope = ParallelExecutionFailureSanitizer::decorateFailedEnvelope($envelope);
+                self::sendHandled($channel, $requestId, $envelope, ParallelExecutionFailureSanitizer::sanitizeError($e, $envelope));
+
+                continue;
+            }
+
+            $noAutoAckStamp = $envelope->last(NoAutoAckStamp::class);
+
+            if (!$deferredMessage->acked && !$noAutoAckStamp) {
+                self::sendHandled($channel, $requestId, $envelope, null);
+            } elseif ($noAutoAckStamp) {
+                $unacks->add($noAutoAckStamp->getHandlerDescriptor()->getBatchHandler(), $requestId, $envelope, $deferredMessage->acked, microtime(true));
+            }
+        }
+    }
+
+    private static function sendHandled(Channel $channel, int $requestId, Envelope $envelope, ?\Throwable $error): void
+    {
+        try {
+            $channel->send(new HandledEnvelopeMessage($requestId, $envelope, $error));
+        } catch (\Throwable) {
+            // handler results may not be serializable; retry without them but keep the
+            // handler names so that retries don't run already-successful handlers again
+            $handledStamps = $envelope->all(HandledStamp::class);
+            $envelope = $envelope->withoutAll(HandledStamp::class);
+
+            foreach ($handledStamps as $stamp) {
+                $envelope = $envelope->with(new HandledStamp(null, $stamp->getHandlerName()));
+            }
+
+            $channel->send(new HandledEnvelopeMessage($requestId, $envelope, $error));
+        }
+    }
+
+    private function bootstrap(): array
+    {
+        if (!is_file($console = $this->console)) {
+            throw new \LogicException(\sprintf('Unable to bootstrap the Messenger worker: the entry point "%s" was not found.', $console));
+        }
+
+        ob_start(static function ($chunk, $flag) {
+            if (($flag & \PHP_OUTPUT_HANDLER_START) && str_starts_with($chunk, '#') && false !== $i = strpos($chunk, "\n")) {
+                $chunk = substr($chunk, 1 + $i);
+            }
+
+            return $chunk;
+        }, 1);
+        try {
+            // the argument is read with func_get_arg() so that the required file does not
+            // inherit a variable from this scope
+            // @phpstan-ignore arguments.count
+            $app = (static fn () => require func_get_arg(0))->bindTo(null, null)($console);
+        } finally {
+            ob_end_flush();
+        }
+
+        if ($app instanceof \Closure) {
+            $app = $this->resolveRuntimeApplication($app);
+        }
+
+        if (!$app instanceof ContainerProviderInterface) {
+            throw new \LogicException(\sprintf('The "%s" entry point must return an instance of "%s", got "%s".', $console, ContainerProviderInterface::class, get_debug_type($app)));
+        }
+
+        $container = $app->getContainer();
+
+        return [$container->get('messenger.routable_message_bus'), $container];
+    }
+
+    private function resolveRuntimeApplication(\Closure $app): object
+    {
+        if (!interface_exists(RuntimeInterface::class)) {
+            throw new \LogicException('Package "symfony/runtime" is required to bootstrap the Messenger worker from "bin/console". Try running "composer require symfony/runtime".');
+        }
+
+        $runtimeClass = $_SERVER['APP_RUNTIME'] ?? $_ENV['APP_RUNTIME'] ?? SymfonyRuntime::class;
+
+        if (!class_exists($runtimeClass)) {
+            throw new \LogicException(\sprintf('Runtime class "%s" not found while bootstrapping the Messenger worker.', $runtimeClass));
+        }
+
+        $options = $_SERVER['APP_RUNTIME_OPTIONS'] ?? $_ENV['APP_RUNTIME_OPTIONS'] ?? [];
+
+        if (\is_string($options)) {
+            $options = json_decode($options, true, 512, \JSON_THROW_ON_ERROR);
+        }
+
+        $runtime = new $runtimeClass(array_replace($options, [
+            'project_dir' => \dirname($this->console, 2),
+            'error_handler' => false,
+        ]));
+
+        [$app, $args] = $runtime->getResolver($app)->resolve();
+        $app = $app(...$args);
+
+        if (!\is_object($app)) {
+            throw new \LogicException(\sprintf('Invalid return value while bootstrapping the Messenger worker: object expected, "%s" returned.', get_debug_type($app)));
+        }
+
+        return $app;
+    }
+}

--- a/src/Symfony/Component/Messenger/Execution/Message/DeferredEnvelopeMessage.php
+++ b/src/Symfony/Component/Messenger/Execution/Message/DeferredEnvelopeMessage.php
@@ -11,21 +11,13 @@
 
 namespace Symfony\Component\Messenger\Execution\Message;
 
-use Symfony\Component\Messenger\Envelope;
-
 /**
  * @internal
  */
-final class DeferredBatchMessage
+final class DeferredEnvelopeMessage
 {
-    public bool $acked;
-
     public function __construct(
-        public readonly mixed $context,
-        public readonly Envelope $envelope,
-        bool &$acked,
-        public readonly float $queuedAt,
+        public readonly int $requestId,
     ) {
-        $this->acked = &$acked;
     }
 }

--- a/src/Symfony/Component/Messenger/Execution/Message/DispatchEnvelopeMessage.php
+++ b/src/Symfony/Component/Messenger/Execution/Message/DispatchEnvelopeMessage.php
@@ -16,16 +16,11 @@ use Symfony\Component\Messenger\Envelope;
 /**
  * @internal
  */
-final class DeferredBatchMessage
+final class DispatchEnvelopeMessage
 {
-    public bool $acked;
-
     public function __construct(
-        public readonly mixed $context,
+        public readonly int $requestId,
         public readonly Envelope $envelope,
-        bool &$acked,
-        public readonly float $queuedAt,
     ) {
-        $this->acked = &$acked;
     }
 }

--- a/src/Symfony/Component/Messenger/Execution/Message/FlushBatchHandlersMessage.php
+++ b/src/Symfony/Component/Messenger/Execution/Message/FlushBatchHandlersMessage.php
@@ -11,21 +11,13 @@
 
 namespace Symfony\Component\Messenger\Execution\Message;
 
-use Symfony\Component\Messenger\Envelope;
-
 /**
  * @internal
  */
-final class DeferredBatchMessage
+final class FlushBatchHandlersMessage
 {
-    public bool $acked;
-
     public function __construct(
-        public readonly mixed $context,
-        public readonly Envelope $envelope,
-        bool &$acked,
-        public readonly float $queuedAt,
+        public readonly bool|float $force,
     ) {
-        $this->acked = &$acked;
     }
 }

--- a/src/Symfony/Component/Messenger/Execution/Message/HandledEnvelopeMessage.php
+++ b/src/Symfony/Component/Messenger/Execution/Message/HandledEnvelopeMessage.php
@@ -16,16 +16,12 @@ use Symfony\Component\Messenger\Envelope;
 /**
  * @internal
  */
-final class DeferredBatchMessage
+final class HandledEnvelopeMessage
 {
-    public bool $acked;
-
     public function __construct(
-        public readonly mixed $context,
+        public readonly int $requestId,
         public readonly Envelope $envelope,
-        bool &$acked,
-        public readonly float $queuedAt,
+        public readonly ?\Throwable $error,
     ) {
-        $this->acked = &$acked;
     }
 }

--- a/src/Symfony/Component/Messenger/Execution/MessageExecutionStrategyInterface.php
+++ b/src/Symfony/Component/Messenger/Execution/MessageExecutionStrategyInterface.php
@@ -13,22 +13,27 @@ namespace Symfony\Component\Messenger\Execution;
 
 use Symfony\Component\Messenger\Envelope;
 
+/**
+ * The bool argument of the $onHandled callable MUST be passed as a by-reference
+ * variable: batch handlers flip it through the reference to signal a late ack,
+ * so passing a literal or an unwired local silently breaks batch acking.
+ */
 interface MessageExecutionStrategyInterface
 {
     /**
-     * @param callable(Envelope, string, bool, ?\Throwable): void $onHandled
+     * @param callable(Envelope, string, bool &$acked, ?\Throwable): void $onHandled
      */
     public function execute(Envelope $envelope, string $transportName, callable $onHandled): void;
 
     public function shouldPauseConsumption(): bool;
 
     /**
-     * @param callable(Envelope, string, bool, ?\Throwable): void $onHandled
+     * @param callable(Envelope, string, bool &$acked, ?\Throwable): void $onHandled
      */
     public function wait(callable $onHandled): bool;
 
     /**
-     * @param callable(Envelope, string, bool, ?\Throwable): void $onHandled
+     * @param callable(Envelope, string, bool &$acked, ?\Throwable): void $onHandled
      */
     public function flush(callable $onHandled, bool|float $force = false): bool;
 

--- a/src/Symfony/Component/Messenger/Execution/ParallelExecutionFailureSanitizer.php
+++ b/src/Symfony/Component/Messenger/Execution/ParallelExecutionFailureSanitizer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Execution;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\ValidationFailedException;
+use Symfony\Component\Messenger\Stamp\AckStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
+
+/**
+ * @internal
+ */
+final class ParallelExecutionFailureSanitizer
+{
+    public static function decorateFailedEnvelope(Envelope $envelope): Envelope
+    {
+        return $envelope
+            ->withoutStampsOfType(AckStamp::class)
+            ->withoutStampsOfType(NoAutoAckStamp::class);
+    }
+
+    public static function sanitizeError(\Throwable $error, Envelope $envelope): \Throwable
+    {
+        if ($error instanceof HandlerFailedException) {
+            return new HandlerFailedException($envelope, self::sanitizeWrappedExceptions($error->getWrappedExceptions(), $envelope));
+        }
+
+        if ($error instanceof DelayedMessageHandlingException) {
+            return new DelayedMessageHandlingException(self::sanitizeWrappedExceptions($error->getWrappedExceptions(), $envelope), $envelope);
+        }
+
+        if ($error instanceof ValidationFailedException) {
+            return new ValidationFailedException($error->getViolatingMessage(), $error->getViolations(), $envelope);
+        }
+
+        return $error;
+    }
+
+    private static function sanitizeWrappedExceptions(array $exceptions, Envelope $envelope): array
+    {
+        foreach ($exceptions as $key => $exception) {
+            $exceptions[$key] = self::sanitizeError($exception, $envelope);
+        }
+
+        return $exceptions;
+    }
+}

--- a/src/Symfony/Component/Messenger/Execution/ParallelExecutionStrategy.php
+++ b/src/Symfony/Component/Messenger/Execution/ParallelExecutionStrategy.php
@@ -1,0 +1,423 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Execution;
+
+use Amp\CancelledException;
+use Amp\Future;
+use Amp\Parallel\Worker\ContextWorkerFactory;
+use Amp\Parallel\Worker\Worker;
+use Amp\Sync\Channel;
+use Amp\TimeoutCancellation;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Execution\Message\DeferredEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\Message\DispatchEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\Message\FlushBatchHandlersMessage;
+use Symfony\Component\Messenger\Execution\Message\HandledEnvelopeMessage;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+
+use function Amp\async;
+use function Amp\Future\await;
+use function Amp\Future\awaitFirst;
+
+/**
+ * Runs messages on a pool of workers, one message at a time per worker.
+ *
+ * Batch handlers accumulate state in the worker that holds them, so all messages sharing
+ * an affinity key (bus + transport + message class) must reach that same worker. Such keys
+ * are therefore pinned to one channel and process serially: their throughput scales with
+ * the number of distinct batching keys in flight, not with the concurrency limit.
+ * Non-batching keys are free to use any available worker.
+ */
+final class ParallelExecutionStrategy implements MessageExecutionStrategyInterface
+{
+    private const KEY_MODE_NON_BATCHING = 1;
+    private const KEY_MODE_BATCHING = 2;
+
+    private int $nextRequestId = 0;
+
+    /** @var array<int, array<int, PendingParallelExecutionRequest>> */
+    private array $pendingRequests = [];
+
+    /** @var array<int, Channel> */
+    private array $channels = [];
+
+    /** @var array<string, self::KEY_MODE_*> */
+    private array $keyModes = [];
+
+    /** @var array<string, int> Batching keys, each pinned to the channel that owns its batch */
+    private array $batchingKeyAffinities = [];
+
+    /** @var array<int, true> */
+    private array $busyChannels = [];
+
+    /** @var array<int, Worker> */
+    private array $workers = [];
+
+    /** @var array<int, Future<array{int, mixed, ?\Throwable}>> */
+    private array $receiveFutures = [];
+
+    // whether a key batches is only known once a handler defers, so the first message of an
+    // unknown key runs alone: spreading its siblings across channels first would strand a
+    // batch on a worker that can never complete it
+    private ?int $pendingProbeRequestId = null;
+
+    public function __construct(
+        private readonly string $console,
+        private readonly int $concurrencyLimit = 1,
+        private readonly int $resetInterval = 1,
+        private readonly ?int $memoryLimit = null,
+    ) {
+    }
+
+    public function execute(Envelope $envelope, string $transportName, callable $onHandled): void
+    {
+        try {
+            $affinityKey = $this->getAffinityKey($envelope);
+            $keyMode = $this->keyModes[$affinityKey] ?? null;
+            $isProbe = null === $keyMode;
+            $channel = $this->getChannel($affinityKey, $keyMode);
+            $channelId = spl_object_id($channel);
+            $requestId = ++$this->nextRequestId;
+            $message = new DispatchEnvelopeMessage($requestId, $envelope);
+
+            try {
+                $channel->send($message);
+            } catch (\Throwable $e) {
+                $this->removeChannel($channelId, $onHandled, $e);
+                $channel = $this->getChannel($affinityKey, $keyMode);
+                $channelId = spl_object_id($channel);
+                $channel->send($message);
+            }
+
+            $this->pendingRequests[$channelId][$requestId] = new PendingParallelExecutionRequest($transportName, $envelope, $channelId, $affinityKey, $isProbe);
+            $this->busyChannels[$channelId] = true;
+
+            if ($isProbe) {
+                $this->pendingProbeRequestId = $requestId;
+            }
+
+            $this->armChannel($channelId);
+            $this->drainReadyResponses($onHandled);
+        } catch (\Throwable $e) {
+            $acked = false;
+            $onHandled($envelope, $transportName, $acked, $e);
+        }
+    }
+
+    public function shouldPauseConsumption(): bool
+    {
+        return null !== $this->pendingProbeRequestId || \count($this->busyChannels) >= $this->concurrencyLimit;
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function wait(callable $onHandled): bool
+    {
+        while ($this->pendingRequests && $this->receiveFutures) {
+            try {
+                // the timeout is a heartbeat only: the event loop wakes us as soon as any
+                // channel produces a response, there is no per-channel polling involved
+                [$channelId, $response, $error] = awaitFirst($this->receiveFutures, new TimeoutCancellation(0.1));
+            } catch (CancelledException) {
+                continue;
+            }
+
+            unset($this->receiveFutures[$channelId]);
+
+            if (null !== $error) {
+                return $this->removeChannel($channelId, $onHandled, $error);
+            }
+
+            $handled = $this->handleResponse($channelId, $response, $onHandled);
+            $this->armChannel($channelId);
+
+            if ($handled) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function flush(callable $onHandled, bool|float $force = false): bool
+    {
+        $handled = $this->drainReadyResponses($onHandled);
+
+        if (!$this->pendingRequests) {
+            return $handled;
+        }
+
+        foreach ($this->channels as $channelId => $channel) {
+            if (!isset($this->pendingRequests[$channelId])) {
+                continue;
+            }
+
+            try {
+                $channel->send(new FlushBatchHandlersMessage($force));
+            } catch (\Throwable $e) {
+                $handled = $this->removeChannel($channelId, $onHandled, $e) || $handled;
+            }
+        }
+
+        $handled = $this->drainReadyResponses($onHandled) || $handled;
+
+        if (true === $force) {
+            while ($this->pendingRequests) {
+                $handled = $this->wait($onHandled) || $handled;
+            }
+        }
+
+        return $handled;
+    }
+
+    public function shutdown(): void
+    {
+        foreach ($this->channels as $channel) {
+            try {
+                $channel->send(null);
+            } catch (\Throwable) {
+            }
+        }
+
+        $shutdowns = [];
+        foreach ($this->workers as $worker) {
+            $shutdowns[] = async(static function () use ($worker): void {
+                try {
+                    $worker->shutdown();
+                } catch (\Throwable) {
+                    $worker->kill();
+                }
+            });
+        }
+        await($shutdowns);
+
+        $this->workers = [];
+        $this->channels = [];
+        $this->receiveFutures = [];
+    }
+
+    private function getChannel(string $affinityKey, ?int $keyMode): Channel
+    {
+        $channelId = $this->batchingKeyAffinities[$affinityKey] ?? null;
+
+        // a pinned key goes back to its channel even when that channel is busy, which is what
+        // serializes batching keys; the pin is dropped only when the channel dies
+        if (isset($channelId, $this->channels[$channelId])) {
+            return $this->channels[$channelId];
+        }
+
+        if (\count($this->channels) < max(1, $this->concurrencyLimit)) {
+            $channel = $this->createChannel();
+
+            if (self::KEY_MODE_BATCHING === $keyMode) {
+                $this->batchingKeyAffinities[$affinityKey] = spl_object_id($channel);
+            }
+
+            return $channel;
+        }
+
+        /** @var int $channelId At least one channel exists at this point */
+        $channelId = array_key_first($this->channels);
+
+        foreach ($this->channels as $id => $channel) {
+            if (!isset($this->busyChannels[$id])) {
+                $channelId = $id;
+                break;
+            }
+        }
+
+        if (self::KEY_MODE_BATCHING === $keyMode) {
+            $this->batchingKeyAffinities[$affinityKey] = $channelId;
+        }
+
+        return $this->channels[$channelId];
+    }
+
+    private function createChannel(): Channel
+    {
+        $factory = new ContextWorkerFactory();
+        $worker = $factory->create();
+
+        $execution = $worker->submit(new DispatchTask($this->console, $this->resetInterval, $this->memoryLimit));
+        $channel = $execution->getChannel();
+        $channelId = spl_object_id($channel);
+        $this->workers[$channelId] = $worker;
+        $this->channels[$channelId] = $channel;
+
+        return $channel;
+    }
+
+    private function armChannel(int $channelId): void
+    {
+        if (isset($this->receiveFutures[$channelId]) || !isset($this->pendingRequests[$channelId], $this->channels[$channelId])) {
+            return;
+        }
+
+        $channel = $this->channels[$channelId];
+
+        // the future must stay armed until it resolves: an abandoned receive would
+        // consume a response that nobody reads; catching inside the coroutine also
+        // guarantees the future always completes with a value and never goes unhandled
+        $this->receiveFutures[$channelId] = async(static function () use ($channelId, $channel): array {
+            try {
+                return [$channelId, $channel->receive(), null];
+            } catch (\Throwable $e) {
+                return [$channelId, null, $e];
+            }
+        });
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    private function drainReadyResponses(callable $onHandled): bool
+    {
+        $handled = false;
+
+        while ($this->receiveFutures) {
+            try {
+                // a zero timeout lets the event loop process buffered channel data
+                // once without waiting for responses that are not there yet
+                [$channelId, $response, $error] = awaitFirst($this->receiveFutures, new TimeoutCancellation(0));
+            } catch (CancelledException) {
+                return $handled;
+            }
+
+            unset($this->receiveFutures[$channelId]);
+
+            if (null !== $error) {
+                $handled = $this->removeChannel($channelId, $onHandled, $error) || $handled;
+
+                continue;
+            }
+
+            $handled = $this->handleResponse($channelId, $response, $onHandled) || $handled;
+            $this->armChannel($channelId);
+        }
+
+        return $handled;
+    }
+
+    private function handleResponse(int $channelId, mixed $response, callable $onHandled): bool
+    {
+        if (!$response instanceof DeferredEnvelopeMessage && !$response instanceof HandledEnvelopeMessage) {
+            return false;
+        }
+
+        $requestId = $response->requestId;
+
+        if (!isset($this->pendingRequests[$channelId][$requestId])) {
+            return false;
+        }
+
+        $pendingRequest = $this->pendingRequests[$channelId][$requestId];
+
+        if ($response instanceof DeferredEnvelopeMessage) {
+            if ($pendingRequest->deferred) {
+                return false;
+            }
+
+            // a deferred ack means a batch handler took the message: pin the key here for good
+            $pendingRequest->deferred = true;
+            $this->keyModes[$pendingRequest->affinityKey] = self::KEY_MODE_BATCHING;
+            $this->batchingKeyAffinities[$pendingRequest->affinityKey] = $channelId;
+
+            if ($pendingRequest->isProbe && $requestId === $this->pendingProbeRequestId) {
+                $this->pendingProbeRequestId = null;
+            }
+
+            $this->recomputeBusyChannel($channelId);
+
+            return true;
+        }
+
+        unset($this->pendingRequests[$channelId][$requestId]);
+
+        if (!$this->pendingRequests[$channelId]) {
+            unset($this->pendingRequests[$channelId], $this->busyChannels[$channelId]);
+        } else {
+            $this->recomputeBusyChannel($channelId);
+        }
+
+        if ($pendingRequest->isProbe && $requestId === $this->pendingProbeRequestId) {
+            $this->pendingProbeRequestId = null;
+        }
+
+        $this->keyModes[$pendingRequest->affinityKey] ??= self::KEY_MODE_NON_BATCHING;
+
+        // rebuild the envelope around the original message object so that identity-keyed
+        // bookkeeping in the parent (e.g. Worker::$keepalives) keeps matching
+        $handledEnvelope = Envelope::wrap($pendingRequest->envelope->getMessage(), array_merge(...array_values($response->envelope->all())));
+
+        if (null !== $error = $response->error) {
+            $handledEnvelope = ParallelExecutionFailureSanitizer::decorateFailedEnvelope($handledEnvelope);
+            $error = ParallelExecutionFailureSanitizer::sanitizeError($error, $handledEnvelope);
+        }
+
+        $acked = false;
+        $onHandled($handledEnvelope, $pendingRequest->transportName, $acked, $error);
+
+        return true;
+    }
+
+    private function recomputeBusyChannel(int $channelId): void
+    {
+        unset($this->busyChannels[$channelId]);
+
+        // a deferred request sits in a batch instead of occupying the worker, so it leaves the
+        // channel free to accept the next message of its key and let the batch fill up
+        foreach ($this->pendingRequests[$channelId] ?? [] as $request) {
+            if (!$request->deferred) {
+                $this->busyChannels[$channelId] = true;
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    private function removeChannel(int $channelId, callable $onHandled, ?\Throwable $previous = null): bool
+    {
+        $handled = false;
+
+        unset($this->workers[$channelId], $this->channels[$channelId], $this->busyChannels[$channelId], $this->receiveFutures[$channelId]);
+        $channelPendingRequests = $this->pendingRequests[$channelId] ?? [];
+        unset($this->pendingRequests[$channelId]);
+
+        foreach ($this->batchingKeyAffinities as $key => $affinityChannelId) {
+            if ($channelId === $affinityChannelId) {
+                unset($this->batchingKeyAffinities[$key]);
+            }
+        }
+
+        foreach ($channelPendingRequests as $requestId => $pendingRequest) {
+            if ($pendingRequest->isProbe && $requestId === $this->pendingProbeRequestId) {
+                $this->pendingProbeRequestId = null;
+            }
+
+            $acked = false;
+            $onHandled($pendingRequest->envelope, $pendingRequest->transportName, $acked, new \RuntimeException('The parallel worker stopped before returning a result.', 0, $previous));
+            $handled = true;
+        }
+
+        return $handled;
+    }
+
+    private function getAffinityKey(Envelope $envelope): string
+    {
+        return ($envelope->last(BusNameStamp::class)?->getBusName() ?? 'message.bus').'|'.($envelope->last(ReceivedStamp::class)?->getTransportName() ?? '').'|'.$envelope->getMessage()::class;
+    }
+}

--- a/src/Symfony/Component/Messenger/Execution/PendingParallelExecutionRequest.php
+++ b/src/Symfony/Component/Messenger/Execution/PendingParallelExecutionRequest.php
@@ -9,23 +9,23 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Execution\Message;
+namespace Symfony\Component\Messenger\Execution;
 
 use Symfony\Component\Messenger\Envelope;
 
 /**
  * @internal
  */
-final class DeferredBatchMessage
+final class PendingParallelExecutionRequest
 {
-    public bool $acked;
+    public bool $deferred = false;
 
     public function __construct(
-        public readonly mixed $context,
+        public readonly string $transportName,
         public readonly Envelope $envelope,
-        bool &$acked,
-        public readonly float $queuedAt,
+        public readonly int $channelId,
+        public readonly string $affinityKey,
+        public readonly bool $isProbe,
     ) {
-        $this->acked = &$acked;
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -66,7 +66,7 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
         try {
             // Execute the whole middleware stack & message handling for main dispatch:
             $returnedEnvelope = $stack->next()->handle($envelope, $stack);
-        } catch (\Throwable $exception) {
+        } catch (\Throwable $e) {
             /*
              * Whenever an exception occurs while handling a message that has
              * queued other messages, we drop the queued ones.
@@ -76,7 +76,7 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
             $this->queue = [];
             $this->isRootDispatchCallRunning = false;
 
-            throw $exception;
+            throw $e;
         }
 
         // "Root dispatch" call is finished, dispatch stored messages.

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\Messenger\Tests\Command;
 
+use Amp\Parallel\Worker\ContextWorkerFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
@@ -42,6 +44,8 @@ class ConsumeMessagesCommandTest extends TestCase
         $inputArgument = $command->getDefinition()->getArgument('receivers');
         $this->assertFalse($inputArgument->isRequired());
         $this->assertSame(['amqp'], $inputArgument->getDefault());
+        $this->assertTrue($command->getDefinition()->hasOption('concurrency'));
+        $this->assertFalse($command->getDefinition()->hasOption('parallel-limit'));
     }
 
     public function testBasicRun()
@@ -175,6 +179,35 @@ class ConsumeMessagesCommandTest extends TestCase
         yield 'Zero second time limit' => ['--time-limit', '0', 'Option "time-limit" must be a positive integer, "0" passed.'];
         yield 'Non-numeric time limit' => ['--time-limit', 'whatever', 'Option "time-limit" must be a positive integer, "whatever" passed.'];
         yield 'Negative reset interval' => ['--no-reset', '-1', 'Option "no-reset" must be a positive integer, "-1" passed.'];
+        yield 'Zero concurrency' => ['--concurrency', '0', 'Option "concurrency" must be a positive integer, "0" passed.'];
+        yield 'Negative concurrency' => ['--concurrency', '-1', 'Option "concurrency" must be a positive integer, "-1" passed.'];
+        yield 'Non-numeric concurrency' => ['--concurrency', 'abc', 'Option "concurrency" must be a positive integer, "abc" passed.'];
+        yield 'Zero fetch size' => ['--fetch-size', '0', 'Option "fetch-size" must be a positive integer, "0" passed.'];
+        yield 'Negative fetch size' => ['--fetch-size', '-1', 'Option "fetch-size" must be a positive integer, "-1" passed.'];
+        yield 'Non-numeric fetch size' => ['--fetch-size', 'abc', 'Option "fetch-size" must be a positive integer, "abc" passed.'];
+    }
+
+    public function testParallelExecutionRequiresConfiguredConsoleEntryPoint()
+    {
+        if (!class_exists(ContextWorkerFactory::class)) {
+            $this->markTestSkipped(ContextWorkerFactory::class.' is not available.');
+        }
+
+        $receiverLocator = new Container();
+        $receiverLocator->set('dummy-receiver', $this->createStub(ReceiverInterface::class));
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus(new Container()), $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        $application->addCommand($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Parallel message execution requires the console entry point to be configured.');
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--concurrency' => 2,
+        ]);
     }
 
     public function testRunWithFetchSizeOption()
@@ -202,25 +235,6 @@ class ConsumeMessagesCommandTest extends TestCase
 
         $tester->assertCommandIsSuccessful();
         $this->assertSame([8], $receiver->getFetchSizes());
-    }
-
-    public function testRunWithInvalidFetchSizeOption()
-    {
-        $receiverLocator = new Container();
-        $receiverLocator->set('dummy-receiver', new \stdClass());
-
-        $command = new ConsumeMessagesCommand(new RoutableMessageBus(new Container()), $receiverLocator, new EventDispatcher());
-
-        $application = new Application();
-        $application->addCommand($command);
-        $tester = new CommandTester($application->get('messenger:consume'));
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "--fetch-size" option must be a positive integer, "0" given.');
-        $tester->execute([
-            'receivers' => ['dummy-receiver'],
-            '--fetch-size' => '0',
-        ]);
     }
 
     public function testRunWithTimeLimit()
@@ -565,7 +579,7 @@ class ConsumeMessagesCommandTest extends TestCase
         }
         $tester = new CommandTester($application->get('messenger:consume'));
 
-        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('All transports/receivers have been excluded, please specify at least one to consume from.');
         $tester->execute([
             '--all' => true,

--- a/src/Symfony/Component/Messenger/Tests/Execution/DispatchTaskTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Execution/DispatchTaskTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Execution;
+
+use Amp\Cancellation;
+use Amp\Parallel\Worker\ContextWorkerFactory;
+use Amp\Sync\Channel;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Execution\DispatchTask;
+use Symfony\Component\Messenger\Execution\Message\DispatchEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\Message\FlushBatchHandlersMessage;
+use Symfony\Component\Messenger\Execution\Message\HandledEnvelopeMessage;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\App\HandledByBusStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Contracts\Service\ContainerProviderInterface;
+
+class DispatchTaskTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(ContextWorkerFactory::class)) {
+            $this->markTestSkipped(ContextWorkerFactory::class.' is not available.');
+        }
+    }
+
+    public function testItBootstrapsTheApplicationUsingConsoleEntryPoint()
+    {
+        $envelope = $this->runTask(new Envelope(new DummyMessage('Hello')));
+
+        $this->assertInstanceOf(Envelope::class, $envelope);
+        $this->assertSame('Hello', $envelope->getMessage()->getMessage());
+    }
+
+    public function testItPreservesStampedBusRoutingWhenBootstrappingTheApplication()
+    {
+        $envelope = $this->runTask((new Envelope(new DummyMessage('Hello')))->with(new BusNameStamp('other.bus')));
+
+        $this->assertSame('other.bus', $envelope->last(HandledByBusStamp::class)?->getBusName());
+    }
+
+    public function testFixtureConsoleReturnsAContainerAwareApplicationDirectly()
+    {
+        $app = (static fn () => require __DIR__.'/../Fixtures/App/bin/console')->bindTo(null, null)();
+
+        $this->assertInstanceOf(ContainerProviderInterface::class, $app);
+    }
+
+    private function runTask(Envelope $envelope): Envelope
+    {
+        $result = null;
+
+        $channel = new class($envelope, $result) implements Channel {
+            private int $received = 0;
+
+            public function __construct(
+                private readonly Envelope $envelope,
+                private mixed &$result,
+            ) {
+            }
+
+            public function send(mixed $data): void
+            {
+                $this->result = $data;
+            }
+
+            public function receive(?Cancellation $cancellation = null): mixed
+            {
+                return match ($this->received++) {
+                    0 => new DispatchEnvelopeMessage(1, $this->envelope),
+                    1 => new FlushBatchHandlersMessage(true),
+                    default => null,
+                };
+            }
+
+            public function close(): void
+            {
+            }
+
+            public function isClosed(): bool
+            {
+                return false;
+            }
+
+            public function onClose(\Closure $onClose): void
+            {
+            }
+        };
+
+        $task = new DispatchTask(__DIR__.'/../Fixtures/App/bin/console');
+
+        $cancellation = new class implements Cancellation {
+            public function subscribe(\Closure $callback): string
+            {
+                return 'subscription';
+            }
+
+            public function unsubscribe(string $id): void
+            {
+            }
+
+            public function throwIfRequested(): void
+            {
+            }
+
+            public function isRequested(): bool
+            {
+                return false;
+            }
+        };
+
+        $task->run($channel, $cancellation);
+
+        self::assertInstanceOf(HandledEnvelopeMessage::class, $result);
+
+        return $result->envelope;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Execution/ExtDispatchTaskTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Execution/ExtDispatchTaskTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Execution;
+
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresPhpExtension('parallel')]
+class ExtDispatchTaskTest extends DispatchTaskTest
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Execution/ExtParallelExecutionStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Execution/ExtParallelExecutionStrategyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Execution;
+
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresPhpExtension('parallel')]
+class ExtParallelExecutionStrategyTest extends ParallelExecutionStrategyTest
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Execution/ParallelExecutionStrategyTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Execution/ParallelExecutionStrategyTest.php
@@ -1,0 +1,370 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Execution;
+
+use Amp\Cancellation;
+use Amp\DeferredFuture;
+use Amp\Parallel\Worker\ContextWorkerFactory;
+use Amp\Sync\Channel;
+use PHPUnit\Framework\TestCase;
+use Revolt\EventLoop;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Execution\Message\DeferredEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\Message\DispatchEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\Message\FlushBatchHandlersMessage;
+use Symfony\Component\Messenger\Execution\Message\HandledEnvelopeMessage;
+use Symfony\Component\Messenger\Execution\ParallelExecutionStrategy;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+
+class ParallelExecutionStrategyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(ContextWorkerFactory::class)) {
+            $this->markTestSkipped(ContextWorkerFactory::class.' is not available.');
+        }
+    }
+
+    public function testShouldPauseConsumptionWhileAProbeIsPending()
+    {
+        $strategy = new ParallelExecutionStrategy(__DIR__.'/../Fixtures/App/bin/console');
+
+        $this->setPrivateProperty($strategy, 'pendingProbeRequestId', 1);
+
+        $this->assertTrue($strategy->shouldPauseConsumption());
+    }
+
+    public function testShouldPauseConsumptionWhenAllWorkersAreBusy()
+    {
+        $strategy = new ParallelExecutionStrategy(__DIR__.'/../Fixtures/App/bin/console', 2);
+
+        $this->setPrivateProperty($strategy, 'busyChannels', [1 => true, 2 => true]);
+
+        $this->assertTrue($strategy->shouldPauseConsumption());
+    }
+
+    public function testShouldNotPauseConsumptionWhileMoreWorkersCanBeCreated()
+    {
+        $strategy = new ParallelExecutionStrategy(__DIR__.'/../Fixtures/App/bin/console', 2);
+
+        $this->setPrivateProperty($strategy, 'busyChannels', [1 => true]);
+
+        $this->assertFalse($strategy->shouldPauseConsumption());
+    }
+
+    public function testExecuteDispatchesTheEnvelopeToAWorkerAndProbesTheMessageKey()
+    {
+        $channel = $this->createFakeChannel();
+        $strategy = $this->createStrategy($channel);
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+
+        $this->assertCount(1, $channel->sent);
+        $this->assertInstanceOf(DispatchEnvelopeMessage::class, $channel->sent[0]);
+        $this->assertSame($envelope, $channel->sent[0]->envelope);
+        $this->assertSame([], $calls);
+        $this->assertTrue($strategy->shouldPauseConsumption());
+    }
+
+    public function testHandledResponseCompletesTheRequestAndReleasesTheWorker()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $channel = $this->createFakeChannel([new HandledEnvelopeMessage(1, $envelope, null)]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+
+        $this->assertCount(1, $calls);
+        $this->assertSame([$envelope->getMessage(), 'async', null], [$calls[0][0]->getMessage(), $calls[0][1], $calls[0][2]]);
+        $this->assertFalse($strategy->shouldPauseConsumption());
+    }
+
+    public function testDeferredResponseReleasesTheWorkerWhileKeepingTheRequestPending()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $channel = $this->createFakeChannel([new DeferredEnvelopeMessage(1)]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+
+        $this->assertSame([], $calls);
+        $this->assertFalse($strategy->shouldPauseConsumption());
+    }
+
+    public function testDuplicateDeferredResponsesAreIgnored()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $channel = $this->createFakeChannel([new DeferredEnvelopeMessage(1), new DeferredEnvelopeMessage(1)]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+        $strategy->flush($this->createOnHandled($calls));
+
+        $this->assertSame([], $calls);
+        $this->assertFalse($strategy->shouldPauseConsumption());
+    }
+
+    public function testForcedFlushDeliversDeferredEnvelopes()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $channel = $this->createFakeChannel([new DeferredEnvelopeMessage(1)], [new HandledEnvelopeMessage(1, $envelope, null)]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+        $this->assertSame([], $calls);
+
+        $this->assertTrue($strategy->flush($this->createOnHandled($calls), true));
+
+        $this->assertInstanceOf(FlushBatchHandlersMessage::class, $channel->sent[1]);
+        $this->assertTrue($channel->sent[1]->force);
+        $this->assertCount(1, $calls);
+        $this->assertSame([$envelope->getMessage(), 'async', null], [$calls[0][0]->getMessage(), $calls[0][1], $calls[0][2]]);
+        $this->assertFalse($strategy->shouldPauseConsumption());
+    }
+
+    public function testHandlerErrorsAreRebuiltAroundTheLocalEnvelope()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $remoteError = new HandlerFailedException($envelope, ['handler' => new \RuntimeException('boom')]);
+        $channel = $this->createFakeChannel([new HandledEnvelopeMessage(1, $envelope, $remoteError)]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+
+        $this->assertCount(1, $calls);
+        [$handledEnvelope, $transportName, $error] = $calls[0];
+        $this->assertSame('async', $transportName);
+        $this->assertSame($envelope->getMessage(), $handledEnvelope->getMessage());
+        $this->assertInstanceOf(HandlerFailedException::class, $error);
+        $this->assertNotSame($remoteError, $error);
+        $this->assertSame('boom', $error->getWrappedExceptions()['handler']->getMessage());
+    }
+
+    public function testAFailedWorkerFailsItsPendingRequests()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $channel = $this->createFakeChannel([new \RuntimeException('worker crashed')]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+
+        $this->assertCount(1, $calls);
+        [$failedEnvelope, $transportName, $error] = $calls[0];
+        $this->assertSame($envelope, $failedEnvelope);
+        $this->assertSame('async', $transportName);
+        $this->assertInstanceOf(\RuntimeException::class, $error);
+        $this->assertSame('The parallel worker stopped before returning a result.', $error->getMessage());
+        $this->assertSame('worker crashed', $error->getPrevious()->getMessage());
+        $this->assertFalse($strategy->shouldPauseConsumption());
+    }
+
+    public function testHandledResponseReportsTheRequestsOwnTransport()
+    {
+        $channel = $this->createFakeChannel([new DeferredEnvelopeMessage(1)]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute(new Envelope(new DummyMessage('A')), 'transport_a', $this->createOnHandled($calls));
+        $this->assertSame([], $calls);
+
+        $envelopeB = new Envelope(new SecondMessage());
+        $channel->push(new HandledEnvelopeMessage(2, $envelopeB, null));
+        $strategy->execute($envelopeB, 'transport_b', $this->createOnHandled($calls));
+
+        $this->assertCount(1, $calls);
+        $this->assertSame('transport_b', $calls[0][1]);
+    }
+
+    public function testDeferredResponseKeepsTheChannelBusyWhileAnotherDispatchIsInFlight()
+    {
+        $channel = $this->createFakeChannel([new DeferredEnvelopeMessage(1)]);
+        $strategy = $this->createStrategy($channel);
+        $this->setPrivateProperty($strategy, 'keyModes', ['message.bus||'.SecondMessage::class => 1]);
+        $calls = [];
+
+        $strategy->execute(new Envelope(new DummyMessage('A')), 'async', $this->createOnHandled($calls));
+        $this->assertFalse($strategy->shouldPauseConsumption());
+
+        $strategy->execute(new Envelope(new SecondMessage()), 'async', $this->createOnHandled($calls));
+        $this->assertTrue($strategy->shouldPauseConsumption());
+
+        $channel->push(new DeferredEnvelopeMessage(3));
+        $strategy->execute(new Envelope(new DummyMessage('C')), 'async', $this->createOnHandled($calls));
+
+        $this->assertSame([], $calls);
+        $this->assertTrue($strategy->shouldPauseConsumption());
+    }
+
+    public function testHandledEnvelopeKeepsTheOriginalMessageIdentity()
+    {
+        $message = new DummyMessage('Hello');
+        $remoteEnvelope = new Envelope(new DummyMessage('Hello'), [new BusNameStamp('the-bus')]);
+        $channel = $this->createFakeChannel([new HandledEnvelopeMessage(1, $remoteEnvelope, null)]);
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute(new Envelope($message), 'async', $this->createOnHandled($calls));
+
+        $this->assertCount(1, $calls);
+        $this->assertSame($message, $calls[0][0]->getMessage());
+        $this->assertSame('the-bus', $calls[0][0]->last(BusNameStamp::class)->getBusName());
+    }
+
+    public function testWaitSkipsStaleResponses()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'));
+        $channel = $this->createFakeChannel();
+        $strategy = $this->createStrategy($channel);
+        $calls = [];
+
+        $strategy->execute($envelope, 'async', $this->createOnHandled($calls));
+
+        $channel->push(new HandledEnvelopeMessage(999, $envelope, null));
+        $channel->push(new HandledEnvelopeMessage(1, $envelope, null));
+
+        $this->assertTrue($strategy->wait($this->createOnHandled($calls)));
+        $this->assertCount(1, $calls);
+        $this->assertFalse($strategy->shouldPauseConsumption());
+    }
+
+    public function testBatchingMessagesKeepTheirWorkerAffinity()
+    {
+        $channelA = $this->createFakeChannel([new DeferredEnvelopeMessage(1)]);
+        $channelB = $this->createFakeChannel();
+        $strategy = $this->createStrategy([$channelA, $channelB], 2);
+        $calls = [];
+
+        $strategy->execute(new Envelope(new DummyMessage('First')), 'async', $this->createOnHandled($calls));
+        $strategy->execute(new Envelope(new DummyMessage('Second')), 'async', $this->createOnHandled($calls));
+
+        $this->assertCount(2, $channelA->sent);
+        $this->assertSame([], $channelB->sent);
+    }
+
+    private function createStrategy(object|array $channels, int $concurrencyLimit = 1): ParallelExecutionStrategy
+    {
+        $strategy = new ParallelExecutionStrategy(__DIR__.'/../Fixtures/App/bin/console', $concurrencyLimit);
+
+        $indexedChannels = [];
+        foreach (\is_array($channels) ? $channels : [$channels] as $channel) {
+            $indexedChannels[spl_object_id($channel)] = $channel;
+        }
+        $this->setPrivateProperty($strategy, 'channels', $indexedChannels);
+
+        return $strategy;
+    }
+
+    private function createOnHandled(array &$calls): \Closure
+    {
+        return static function (Envelope $envelope, string $transportName, bool &$acked, ?\Throwable $error = null) use (&$calls) {
+            $calls[] = [$envelope, $transportName, $error];
+        };
+    }
+
+    private function createFakeChannel(array $responses = [], array $flushResponses = []): Channel
+    {
+        return new class($responses, $flushResponses) implements Channel {
+            public array $sent = [];
+            private array $queue;
+            private ?DeferredFuture $waiter = null;
+            private int $receiveCalls = 0;
+
+            public function __construct(
+                array $responses,
+                private array $flushResponses,
+            ) {
+                $this->queue = $responses;
+            }
+
+            public function push(mixed $response): void
+            {
+                if ($waiter = $this->waiter) {
+                    $this->waiter = null;
+                    $waiter->complete($response);
+                } else {
+                    $this->queue[] = $response;
+                }
+            }
+
+            public function send(mixed $data): void
+            {
+                $this->sent[] = $data;
+
+                if ($data instanceof FlushBatchHandlersMessage) {
+                    foreach ($this->flushResponses as $response) {
+                        $this->push($response);
+                    }
+                    $this->flushResponses = [];
+                }
+            }
+
+            public function receive(?Cancellation $cancellation = null): mixed
+            {
+                if (100 < ++$this->receiveCalls) {
+                    throw new \LogicException('Too many receive() calls, the strategy is likely stuck in a wait loop.');
+                }
+
+                if ($this->queue) {
+                    $response = array_shift($this->queue);
+                } else {
+                    // a real channel is stream-backed and keeps the event loop referenced
+                    // while waiting; emulate this so that Revolt's deadlock detection
+                    // does not kill the parked receive when the loop goes idle
+                    $keepAlive = EventLoop::repeat(60, static fn () => null);
+                    $this->waiter = new DeferredFuture();
+
+                    try {
+                        $response = $this->waiter->getFuture()->await($cancellation);
+                    } finally {
+                        EventLoop::cancel($keepAlive);
+                    }
+                }
+
+                if ($response instanceof \Throwable) {
+                    throw $response;
+                }
+
+                return $response;
+            }
+
+            public function close(): void
+            {
+            }
+
+            public function isClosed(): bool
+            {
+                return false;
+            }
+
+            public function onClose(\Closure $onClose): void
+            {
+            }
+        };
+    }
+
+    private function setPrivateProperty(object $object, string $property, mixed $value)
+    {
+        $reflectionProperty = new \ReflectionProperty($object, $property);
+        $reflectionProperty->setValue($object, $value);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/App/HandledByBusStamp.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/App/HandledByBusStamp.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures\App;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+final class HandledByBusStamp implements StampInterface
+{
+    public function __construct(private readonly string $busName)
+    {
+    }
+
+    public function getBusName(): string
+    {
+        return $this->busName;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/App/Kernel.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/App/Kernel.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures\App;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Contracts\Service\ContainerProviderInterface;
+
+final class App implements ContainerProviderInterface
+{
+    private readonly ContainerInterface $container;
+
+    public function __construct()
+    {
+        $defaultBus = new MessageBus([new StampingMiddleware('default.bus'), new BatchHandlingMiddleware()]);
+        $otherBus = new MessageBus([new StampingMiddleware('other.bus'), new BatchHandlingMiddleware()]);
+
+        $this->container = new TestContainer([
+            'messenger.routable_message_bus' => new RoutableMessageBus(new BusLocator($defaultBus, $otherBus), $defaultBus),
+        ]);
+    }
+
+    public function getContainer(): ContainerInterface
+    {
+        return $this->container;
+    }
+}
+
+final class TestContainer implements ContainerInterface
+{
+    public function __construct(private readonly array $services)
+    {
+    }
+
+    public function get(string $id): mixed
+    {
+        return $this->services[$id] ?? throw new \InvalidArgumentException(\sprintf('Unknown service "%s".', $id));
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->services[$id]);
+    }
+}
+
+final class BusLocator implements ContainerInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $defaultBus,
+        private readonly MessageBusInterface $otherBus,
+    ) {
+    }
+
+    public function get(string $id): mixed
+    {
+        return match ($id) {
+            'message.bus' => $this->defaultBus,
+            'other.bus' => $this->otherBus,
+            default => throw new \InvalidArgumentException(\sprintf('Unknown bus "%s".', $id)),
+        };
+    }
+
+    public function has(string $id): bool
+    {
+        return \in_array($id, ['message.bus', 'other.bus'], true);
+    }
+}
+
+final class StampingMiddleware implements MiddlewareInterface
+{
+    public function __construct(private readonly string $busName)
+    {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        return $stack->next()->handle($envelope->with(new HandledByBusStamp($this->busName)), $stack);
+    }
+}
+
+final class BatchHandlingMiddleware implements MiddlewareInterface
+{
+    private readonly HandleMessageMiddleware $middleware;
+
+    public function __construct()
+    {
+        $this->middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor(new BatchSizeReportingHandler())],
+        ]));
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        return $this->middleware->handle($envelope, $stack);
+    }
+}
+
+final class BatchSizeReportingHandler implements BatchHandlerInterface
+{
+    use BatchHandlerTrait;
+
+    public function __invoke(DummyMessage $message, ?Acknowledger $ack = null): mixed
+    {
+        return $this->handle($message, $ack);
+    }
+
+    private function getBatchSize(): int
+    {
+        return 2;
+    }
+
+    private function process(array $jobs): void
+    {
+        foreach ($jobs as [$job]) {
+            if ('fail' === $job->getMessage()) {
+                throw new \RuntimeException('Parallel handler failed.');
+            }
+        }
+
+        $batchSize = \count($jobs);
+
+        foreach ($jobs as [, $ack]) {
+            $ack->ack($batchSize);
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/App/bin/console
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/App/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Messenger\Tests\Fixtures\App\App;
+
+require_once __DIR__.'/../Kernel.php';
+
+$vendor = __DIR__;
+while (!is_dir($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require_once $vendor.'/vendor/autoload.php';
+
+return new App();

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -285,6 +285,43 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $middleware->handle(new Envelope(new DummyMessage('Hey'), [new AckStamp($ack)]), new StackMiddleware());
     }
 
+    public function testBatchHandlerCanBeUsedWithAckStamp()
+    {
+        $handler = new class implements BatchHandlerInterface {
+            use BatchHandlerTrait;
+
+            public array $processedMessages = [];
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function shouldFlush()
+            {
+                return true;
+            }
+
+            private function process(array $jobs): void
+            {
+                $this->processedMessages = array_column($jobs, 0);
+
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $envelope = $middleware->handle(new Envelope(new DummyMessage('Hey'), [new AckStamp(static function () {})]), new StackMiddleware());
+
+        $this->assertNull($envelope->last(NoAutoAckStamp::class));
+        $this->assertCount(1, $handler->processedMessages);
+    }
+
     public function testBatchHandlerNoBatch()
     {
         $handler = new class implements BatchHandlerInterface {

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -31,8 +31,10 @@ use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
 use Symfony\Component\Messenger\EventListener\ResetMemoryUsageListener;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Execution\DeferredBatchMessageQueue;
+use Symfony\Component\Messenger\Execution\ParallelExecutionStrategy;
 use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
@@ -43,12 +45,15 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\App\HandledByBusStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyReceiver;
@@ -65,6 +70,8 @@ use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 #[Group('time-sensitive')]
 class WorkerTest extends TestCase
 {
+    private string $console = __DIR__.'/Fixtures/App/bin/console';
+
     public function testWorkerDispatchTheReceivedMessage()
     {
         $apiMessage = new DummyMessage('API');
@@ -111,6 +118,292 @@ class WorkerTest extends TestCase
         $this->assertSame('transport', $envelopes[0]->last(ReceivedStamp::class)->getTransportName());
 
         $this->assertSame(2, $receiver->getAcknowledgeCount());
+    }
+
+    public function testBusNameOptionOverridesTheStampedBusName()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'), [new BusNameStamp('origin.bus')]);
+        $receiver = new DummyReceiver([[$envelope]]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(
+                static fn (Envelope $e) => 1 === \count($e->all(BusNameStamp::class))
+                    && 'forced.bus' === $e->last(BusNameStamp::class)->getBusName()
+            ))
+            ->willReturnArgument(0);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+
+        $worker = new Worker(['transport' => $receiver], $bus, $dispatcher, clock: new MockClock());
+        $worker->run(['bus_name' => 'forced.bus']);
+    }
+
+    public function testFuturesAreAcknowledgedOnTheirOriginatingTransport()
+    {
+        $receiverWithoutMessages = new DummyReceiver([
+            [],
+            [],
+        ]);
+        $receiverWithFuture = new DummyReceiver([
+            [
+                new Envelope(new DummyMessage('API')),
+            ],
+            [],
+        ]);
+
+        $bus = new MessageBus();
+
+        $dispatcher = new class implements EventDispatcherInterface {
+            public function dispatch(object $event): object
+            {
+                if ($event instanceof WorkerRunningEvent && $event->isWorkerIdle()) {
+                    $event->getWorker()->stop();
+                }
+
+                return $event;
+            }
+        };
+
+        $worker = new Worker([
+            'secondary' => $receiverWithoutMessages,
+            'primary' => $receiverWithFuture,
+        ], $bus, $dispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy = new ParallelExecutionStrategy($this->console));
+        $worker->run();
+        $messageExecutionStrategy->shutdown();
+
+        $this->assertSame(0, $receiverWithoutMessages->getAcknowledgeCount());
+        $this->assertSame(1, $receiverWithFuture->getAcknowledgeCount());
+    }
+
+    public function testParallelExecutionPreservesWorkerStamps()
+    {
+        $apiMessage = new DummyMessage('API');
+        $ipaMessage = new DummyMessage('IPA');
+
+        $receiver = new DummyReceiver([
+            [new Envelope($apiMessage), new Envelope($ipaMessage)],
+        ]);
+
+        $dispatcher = new class implements EventDispatcherInterface {
+            private StopWorkerOnMessageLimitListener $listener;
+            public array $handledEnvelopes = [];
+
+            public function __construct()
+            {
+                $this->listener = new StopWorkerOnMessageLimitListener(2);
+            }
+
+            public function dispatch(object $event): object
+            {
+                if ($event instanceof WorkerMessageHandledEvent) {
+                    $this->handledEnvelopes[] = $event->getEnvelope();
+                }
+
+                if ($event instanceof WorkerRunningEvent) {
+                    $this->listener->onWorkerRunning($event);
+                }
+
+                return $event;
+            }
+        };
+
+        $messageExecutionStrategy = new ParallelExecutionStrategy($this->console);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $worker->run();
+        $messageExecutionStrategy->shutdown();
+
+        $envelope = $dispatcher->handledEnvelopes[0];
+        $envelopeOther = $dispatcher->handledEnvelopes[1];
+
+        $this->assertSame($apiMessage->getMessage(), $envelope->getMessage()->getMessage());
+        $this->assertSame($ipaMessage->getMessage(), $envelopeOther->getMessage()->getMessage());
+        $this->assertCount(1, $envelope->all(ReceivedStamp::class));
+        $this->assertCount(1, $envelope->all(ConsumedByWorkerStamp::class));
+        $this->assertSame('transport', $envelope->last(ReceivedStamp::class)->getTransportName());
+    }
+
+    public function testParallelExecutionUsesExplicitBusName()
+    {
+        $receiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('API'))],
+        ]);
+
+        $dispatcher = new class implements EventDispatcherInterface {
+            private StopWorkerOnMessageLimitListener $listener;
+
+            public function __construct()
+            {
+                $this->listener = new StopWorkerOnMessageLimitListener(1);
+            }
+
+            public function dispatch(object $event): object
+            {
+                if ($event instanceof WorkerRunningEvent) {
+                    $this->listener->onWorkerRunning($event);
+                }
+
+                return $event;
+            }
+        };
+
+        $messageExecutionStrategy = new ParallelExecutionStrategy($this->console);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $worker->run([
+            'bus_name' => 'other.bus',
+        ]);
+        $messageExecutionStrategy->shutdown();
+
+        $this->assertSame('other.bus', $receiver->getAcknowledgedEnvelopes()[0]->last(HandledByBusStamp::class)?->getBusName());
+    }
+
+    public function testParallelExecutionFlushesBatchOnMessageLimit()
+    {
+        $receiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('API'))],
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+
+        $messageExecutionStrategy = new ParallelExecutionStrategy($this->console);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $worker->run();
+        $messageExecutionStrategy->shutdown();
+
+        $this->assertSame(1, $receiver->getAcknowledgeCount());
+        $this->assertSame(1, $receiver->getAcknowledgedEnvelopes()[0]->last(HandledStamp::class)?->getResult());
+    }
+
+    public function testParallelExecutionFlushesBatchWhenChildMemoryLimitIsReached()
+    {
+        $receiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('API'))],
+            [],
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, static function (WorkerRunningEvent $event) {
+            if ($event->isWorkerIdle()) {
+                $event->getWorker()->stop();
+            }
+        });
+
+        $messageExecutionStrategy = new ParallelExecutionStrategy($this->console, memoryLimit: 1);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $worker->run();
+        $messageExecutionStrategy->shutdown();
+
+        $this->assertSame(1, $receiver->getAcknowledgeCount());
+        $this->assertSame(1, $receiver->getAcknowledgedEnvelopes()[0]->last(HandledStamp::class)?->getResult());
+    }
+
+    public function testParallelExecutionBatchesMessagesOnTheSameTask()
+    {
+        $receiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('Hey'))],
+            [new Envelope(new DummyMessage('Bob'))],
+            [],
+        ]);
+
+        $dispatcher = new class implements EventDispatcherInterface {
+            public function dispatch(object $event): object
+            {
+                static $calls = 0;
+
+                if ($event instanceof WorkerRunningEvent && 3 <= ++$calls) {
+                    $event->getWorker()->stop();
+                }
+
+                return $event;
+            }
+        };
+
+        $messageExecutionStrategy = new ParallelExecutionStrategy($this->console);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $worker->run();
+        $messageExecutionStrategy->shutdown();
+
+        $this->assertSame([2, 2], array_map(static fn (Envelope $envelope) => $envelope->last(HandledStamp::class)?->getResult(), $receiver->getAcknowledgedEnvelopes()));
+    }
+
+    public function testParallelExecutionRemembersBatchingKeysAfterThePreviousBatchWasFlushed()
+    {
+        $messageExecutionStrategy = new ParallelExecutionStrategy($this->console);
+
+        $firstReceiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('first'))],
+        ]);
+
+        $firstDispatcher = new EventDispatcher();
+        $firstDispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+
+        $firstWorker = new Worker(['transport' => $firstReceiver], new MessageBus(), $firstDispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $firstWorker->run();
+
+        $this->assertSame(1, $firstReceiver->getAcknowledgedEnvelopes()[0]->last(HandledStamp::class)?->getResult());
+
+        $secondReceiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('second')), new Envelope(new DummyMessage('third'))],
+            [],
+        ]);
+
+        $secondDispatcher = new EventDispatcher();
+        $secondDispatcher->addListener(WorkerRunningEvent::class, static function (WorkerRunningEvent $event) use ($secondReceiver) {
+            if ($event->isWorkerIdle() && 0 < $secondReceiver->getAcknowledgeCount()) {
+                $event->getWorker()->stop();
+            }
+        });
+
+        $secondWorker = new Worker(['transport' => $secondReceiver], new MessageBus(), $secondDispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $secondWorker->run();
+        $messageExecutionStrategy->shutdown();
+
+        $handledBatches = [];
+
+        foreach ($secondReceiver->getAcknowledgedEnvelopes() as $envelope) {
+            $handledBatches[$envelope->getMessage()->getMessage()] = $envelope->last(HandledStamp::class)?->getResult();
+        }
+
+        $this->assertSame(['second' => 2, 'third' => 2], $handledBatches);
+    }
+
+    public function testParallelExecutionFailureKeepsDebugInfoWithoutLeakingControlStamp()
+    {
+        $receiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('fail'))],
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+
+        $failedEvent = null;
+        $dispatcher->addListener(WorkerMessageFailedEvent::class, static function (WorkerMessageFailedEvent $event) use (&$failedEvent) {
+            $failedEvent = $event;
+        });
+
+        $messageExecutionStrategy = new ParallelExecutionStrategy($this->console);
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher, clock: new MockClock(), messageExecutionStrategy: $messageExecutionStrategy);
+
+        $worker->run();
+        $messageExecutionStrategy->shutdown();
+
+        $this->assertInstanceOf(WorkerMessageFailedEvent::class, $failedEvent);
+        $this->assertSame(1, $receiver->getRejectCount());
+        $this->assertNull($failedEvent->getEnvelope()->last(NoAutoAckStamp::class));
+
+        $throwable = $failedEvent->getThrowable();
+        $this->assertInstanceOf(HandlerFailedException::class, $throwable);
+        $this->assertNull($throwable->getEnvelope()?->last(NoAutoAckStamp::class));
     }
 
     public function testHandlingErrorCausesReject()
@@ -963,8 +1256,8 @@ class WorkerTest extends TestCase
 
         $dummyHandler = new DummyBatchHandler();
         $envelopeWithNoAutoAck = $envelope->with(new NoAutoAckStamp(new HandlerDescriptor($dummyHandler)));
-        $unacks = new DeferredBatchMessageQueue();
         $acked = false;
+        $unacks = new DeferredBatchMessageQueue();
         $unacks->add($dummyHandler, 'transport', $envelopeWithNoAutoAck, $acked, 0.0);
         (new \ReflectionProperty($worker, 'unacks'))->setValue($worker, $unacks);
 

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -29,6 +29,7 @@ use Symfony\Component\Messenger\Execution\DeferredBatchMessageQueue;
 use Symfony\Component\Messenger\Execution\MessageExecutionStrategyInterface;
 use Symfony\Component\Messenger\Execution\SyncMessageExecutionStrategy;
 use Symfony\Component\Messenger\Stamp\AckStamp;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
 use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
@@ -93,6 +94,7 @@ class Worker
         ], $options);
         $queueNames = $options['queues'] ?? null;
         $endTime = null !== $options['time_limit'] ? $this->clock->now()->format('U.u') + $options['time_limit'] : null;
+        $bufferedEnvelopes = [];
 
         $this->metadata->set(['queueNames' => $queueNames]);
 
@@ -117,15 +119,40 @@ class Worker
             $envelopeHandledStart = $this->clock->now();
             $fetchSize = max(1, $options['fetch_size'] ?? 1);
 
-            foreach ($this->receivers as $transportName => $receiver) {
-                if ($queueNames) {
-                    /** @var QueueReceiverInterface $receiver */
-                    $envelopes = $receiver->getFromQueues($queueNames, $fetchSize);
-                } else {
-                    $envelopes = $receiver->get($fetchSize);
+            if ($this->messageExecutionStrategy->shouldPauseConsumption()
+                && $this->messageExecutionStrategy->wait($this->preAck(...))
+            ) {
+                if ($this->shouldStop) {
+                    break;
                 }
 
-                foreach ($envelopes as $envelope) {
+                continue;
+            }
+
+            // drain buffered envelopes first: they are already off the broker and must not
+            // be starved by fetching new messages from higher-priority receivers
+            $receivers = $bufferedEnvelopes ? array_intersect_key($this->receivers, $bufferedEnvelopes) + $this->receivers : $this->receivers;
+
+            foreach ($receivers as $transportName => $receiver) {
+                if ($envelopes = $bufferedEnvelopes[$transportName] ?? null) {
+                    unset($bufferedEnvelopes[$transportName]);
+                    // advance past the last handled envelope now that the worker is ready
+                    // again; lazy receivers fetch from the broker only at this point
+                    $envelopes->next();
+                } else {
+                    if ($queueNames) {
+                        /** @var QueueReceiverInterface $receiver */
+                        $envelopes = $receiver->getFromQueues($queueNames, $fetchSize);
+                    } else {
+                        $envelopes = $receiver->get($fetchSize);
+                    }
+
+                    $envelopes = (static fn () => yield from $envelopes)();
+                    $envelopes->rewind();
+                }
+
+                for (; $envelopes->valid(); $envelopes->next()) {
+                    $envelope = $envelopes->current();
                     $envelopeHandled = true;
 
                     if ($receiver instanceof KeepaliveReceiverInterface) {
@@ -133,8 +160,14 @@ class Worker
                     }
 
                     $this->rateLimit($transportName);
-                    $this->handleMessage($envelope, $transportName);
+                    $this->handleMessage($envelope, $transportName, $options['bus_name'] ?? null);
                     $this->eventDispatcher?->dispatch(new WorkerRunningEvent($this, false));
+
+                    if ($this->messageExecutionStrategy->shouldPauseConsumption()) {
+                        $bufferedEnvelopes[$transportName] = $envelopes;
+
+                        break 2;
+                    }
 
                     if ($this->shouldStop) {
                         break 2;
@@ -176,7 +209,7 @@ class Worker
         $this->eventDispatcher?->dispatch(new WorkerStoppedEvent($this));
     }
 
-    private function handleMessage(Envelope $envelope, string $transportName): void
+    private function handleMessage(Envelope $envelope, string $transportName, ?string $busName = null): void
     {
         $event = new WorkerMessageReceivedEvent($envelope, $transportName);
         $this->eventDispatcher?->dispatch($event);
@@ -184,6 +217,10 @@ class Worker
 
         if (!$event->shouldHandle()) {
             return;
+        }
+
+        if (null !== $busName && $busName !== $envelope->last(BusNameStamp::class)?->getBusName()) {
+            $envelope = $envelope->withoutAll(BusNameStamp::class)->with(new BusNameStamp($busName));
         }
 
         $this->messageExecutionStrategy->execute(
@@ -308,7 +345,7 @@ class Worker
             if ($deferredMessage->acked) {
                 continue;
             }
-            $transportName = $deferredMessage->transportName;
+            $transportName = $deferredMessage->context;
             $envelope = $deferredMessage->envelope;
             try {
                 $e = null;

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -22,6 +22,7 @@
         "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
+        "amphp/parallel": "^2.0",
         "psr/cache": "^1.0|^2.0|^3.0",
         "symfony/console": "^7.4|^8.0",
         "symfony/dependency-injection": "^8.1",
@@ -33,7 +34,7 @@
         "symfony/rate-limiter": "^7.4|^8.0",
         "symfony/routing": "^8.2",
         "symfony/serializer": "^7.4.4|^8.0.4",
-        "symfony/service-contracts": "^2.5|^3",
+        "symfony/service-contracts": "^3.7.1",
         "symfony/stopwatch": "^7.4|^8.0",
         "symfony/validator": "^7.4|^8.0",
         "symfony/var-dumper": "^7.4|^8.0"
@@ -44,7 +45,8 @@
         "symfony/event-dispatcher-contracts": "<2.5",
         "symfony/lock": "<7.4",
         "symfony/routing": "<8.2",
-        "symfony/serializer": "<7.4.4|>=8.0,<8.0.4"
+        "symfony/serializer": "<7.4.4|>=8.0,<8.0.4",
+        "symfony/service-contracts": "<3.7.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Messenger\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53964
| License       | MIT

This PR adds parallel message processing to the Messenger component via a new `--concurrency` option on `messenger:consume`.

```
php bin/console messenger:consume async --concurrency=4
```

When `--concurrency` is greater than 1, messages are dispatched to child processes using `amphp/parallel` (or to threads when `ext-parallel` is available). Each child bootstraps the app from `bin/console`, receives envelopes over a channel, dispatches them through the bus, and sends results back:

- `ParallelExecutionStrategy` manages a pool of amphp workers, dispatching messages to any available worker by default
- A probe mechanism detects batch handlers on first encounter; once detected, subsequent messages of the same type (keyed by bus + transport + message class) are pinned to the same worker for correct batching
- The `Worker` loop pauses consumption when all workers are busy and resumes when a slot frees up, buffering any already-fetched envelopes
- `DispatchTask` runs in the child process: bootstraps the kernel, dispatches envelopes, handles batch flushing, and respects per-child memory limits and service reset intervals

### Batch handlers do not parallelize within a message type

Pinning is required for correctness, since a batch handler accumulates state in the worker that holds it. The consequence is that messages sharing an affinity key are processed serially: parallelism for batch handlers is bounded by the number of distinct keys in flight, not by `--concurrency`. Raising `--concurrency` above that number gains nothing.

Measured on 192 messages of 20ms each, 24 cores, warm workers:

| handler | sync | `--concurrency=2` | `=4` | `=8` |
| --- | --- | --- | --- | --- |
| batch, 1 message class | 4.22s | 0.98x | 0.97x | 0.98x |
| batch, 2 message classes | 4.28s | 1.88x | 1.98x | 2.00x |
| plain | 4.28s | 1.89x | 3.73x | 7.52x |

Applications that consume a single batching message type should keep using several `messenger:consume` processes.

FTR, compared to running several consume commands in parallel, this requires only one connection to the queue backend - which also means the fetch+unserialize steps are not parallelized when `--concurrency` is used. This is unfavorable for very short tasks, and favorable to reduce the number of connections to the backend for larger ones.
