### PR TITLE
 Fix default boolean values `SweegoTransportFactory`

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransportFactory.php
@@ -31,10 +31,10 @@ final class SweegoTransportFactory extends AbstractTransportFactory
         $apiKey = $this->getUser($dsn);
         $region = $dsn->getRequiredOption(SweegoOptions::REGION);
         $campaignType = $dsn->getRequiredOption(SweegoOptions::CAMPAIGN_TYPE);
-        $bat = $dsn->getOption(SweegoOptions::BAT);
+        $bat = $dsn->getBooleanOption(SweegoOptions::BAT, false);
         $campaignId = $dsn->getOption(SweegoOptions::CAMPAIGN_ID);
-        $shortenUrls = $dsn->getOption(SweegoOptions::SHORTEN_URLS);
-        $shortenWithProtocol = $dsn->getOption(SweegoOptions::SHORTEN_WITH_PROTOCOL);
+        $shortenUrls = $dsn->getBooleanOption(SweegoOptions::SHORTEN_URLS, true);
+        $shortenWithProtocol = $dsn->getBooleanOption(SweegoOptions::SHORTEN_WITH_PROTOCOL, true);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/SweegoTransportFactoryTest.php
@@ -27,8 +27,13 @@ final class SweegoTransportFactoryTest extends AbstractTransportFactoryTestCase
     public static function createProvider(): iterable
     {
         yield [
-            'sweego://host.test?region=REGION&campaign_type=CAMPAIGN_TYPE',
+            'sweego://host.test?region=REGION&campaign_type=CAMPAIGN_TYPE&bat=0&shorten_urls=1&shorten_with_protocol=1',
             'sweego://apiKey@host.test?region=REGION&campaign_type=CAMPAIGN_TYPE',
+        ];
+
+        yield [
+            'sweego://host.test?region=REGION&campaign_type=CAMPAIGN_TYPE&bat=0&shorten_urls=0&shorten_with_protocol=0',
+            'sweego://apiKey@host.test?region=REGION&campaign_type=CAMPAIGN_TYPE&bat=false&shorten_urls=false&shorten_with_protocol=false',
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? |no
| Issues        | 
| License       | MIT

**Steps to reproduce**

- Set `SWEEGO_DSN=sweego://API_KEY@default?region=FR&campaign_type=transac&shorten_urls=false`

**Actual result**

`shorten_urls` DNS config is still `true` because it is processed as string and not as boolean.

This PR set default values in `SweegoTransportFactory` according to the [documentation](https://learn.sweego.io/docs/sending/how_to_send_sms_by_api#body-parameters) 