### PR TITLE
[Form] Fix typed property initialization in ValidatorExtension

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -39,6 +39,10 @@ class ValidatorExtension extends AbstractExtension
         /** @var ClassMetadata $metadata */
         $metadata = $validator->getMetadataFor(\Symfony\Component\Form\Form::class);
 
+        $this->validator = $validator;
+        $this->formRenderer = $formRenderer;
+        $this->translator = $translator;
+
         // Register the form constraints in the validator programmatically.
         // This functionality is required when using the Form component without
         // the DIC, where the XML file is loaded automatically. Thus the following
@@ -52,10 +56,6 @@ class ValidatorExtension extends AbstractExtension
 
         $metadata->addConstraint(new Form());
         $metadata->addConstraint(new Traverse(false));
-
-        $this->validator = $validator;
-        $this->formRenderer = $formRenderer;
-        $this->translator = $translator;
     }
 
     public function loadTypeGuesser(): ?FormTypeGuesserInterface

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -64,4 +64,23 @@ class ValidatorExtensionTest extends TestCase
         $this->assertCount(1, $metadata->getConstraints());
         $this->assertInstanceOf(FormConstraint::class, $metadata->getConstraints()[0]);
     }
+
+    public function testPropertiesInitializedWithEarlyReturn()
+    {
+        $metadata = new ClassMetadata(Form::class);
+        $metadata->addConstraint(new FormConstraint());
+
+        $metadataFactory = new FakeMetadataFactory();
+        $metadataFactory->addMetadata($metadata);
+
+        $validator = Validation::createValidatorBuilder()
+            ->setMetadataFactory($metadataFactory)
+            ->getValidator();
+
+        // create with an early return condition
+        $extension = new ValidatorExtension($validator, false);
+
+        // verify the extension is functional after an early return
+        $this->assertInstanceOf(ValidatorTypeGuesser::class, $extension->loadTypeGuesser());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| License       | MIT

The early return in the ValidatorExtension constructor added in https://github.com/symfony/form/commit/37b2f68f4cfb8c35fdd0d5a02ba216b5e119f762 prevents typed properties from being initialized when a Form constraint already existed, causing PHP errors when the extension is used:

```
Typed property Symfony\Component\Form\Extension\Validator\ValidatorExtension::$validator 
must not be accessed before initialization
```

## Changes Made

* Code Fix: Moved property initialization before the early return check in the constructor.
* Test Addition: Added `testPropertiesInitializedWithEarlyReturn()` to verify the fix.

## Solution

This fix ensures:
* All properties are initialized before any early return.
* The original duplicate constraint prevention still works.
* The extension remains fully functional in all use cases.

## Testing
Added test case that triggers the early return condition and verifies that the extension remains functional to prevent future regressions.