### PR TITLE
[JsonStreamer] Fix DateTimeValueObjectTransformer not registered for 'json_streamer.value_transformer'

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/DeprecateJsonStreamerValueTransformerTagPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/DeprecateJsonStreamerValueTransformerTagPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
@@ -30,6 +31,11 @@ class DeprecateJsonStreamerValueTransformerTagPass implements CompilerPassInterf
         foreach ($container->findTaggedServiceIds('json_streamer.value_transformer', true) as $id => $_) {
             $definition = $container->getDefinition($id);
             if ($definition->hasTag('json_streamer.property_value_transformer')) {
+                continue;
+            }
+
+            $class = $container->getParameterBag()->resolveValue($definition->getClass());
+            if (\is_string($class) && is_a($class, ValueObjectTransformerInterface::class, true)) {
                 continue;
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2235,6 +2235,7 @@ class FrameworkExtension extends Extension
             $container->getDefinition('.json_streamer.cache_warmer.streamer')->replaceArgument(7, $valueTransformers);
 
             $container->removeDefinition('.json_streamer.value_object_transformer.date_time');
+            $container->removeDefinition(\DateTimeInterface::class);
         }
 
         // FC layer for "symfony/json-streamer" >= 8.1

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
@@ -107,6 +107,9 @@ return static function (ContainerConfigurator $container) {
         ->set('.json_streamer.value_object_transformer.date_time', DateTimeValueObjectTransformer::class)
             ->tag('json_streamer.value_object_transformer')
 
+        ->set(\DateTimeInterface::class, DateTimeValueObjectTransformer::class)
+            ->tag('json_streamer.value_transformer')
+
         // cache
         ->set('.json_streamer.cache_warmer.streamer', StreamerCacheWarmer::class)
             ->args([

--- a/src/Symfony/Component/JsonStreamer/DependencyInjection/TransformerPass.php
+++ b/src/Symfony/Component/JsonStreamer/DependencyInjection/TransformerPass.php
@@ -11,11 +11,12 @@
 
 namespace Symfony\Component\JsonStreamer\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 
@@ -51,18 +52,32 @@ class TransformerPass implements CompilerPassInterface
                 throw new InvalidArgumentException(\sprintf('The service "%s" tagged "json_streamer.value_object_transformer" must implement "%s".', $id, ValueObjectTransformerInterface::class));
             }
 
-            $map[$class::getValueObjectClassName()] = new Reference($id);
+            $valueObjectClassName = $class::getValueObjectClassName();
+            $map[$valueObjectClassName] = new Reference($id);
+
+            if ($id !== $valueObjectClassName && !$container->hasDefinition($valueObjectClassName) && !$container->hasAlias($valueObjectClassName)) {
+                $container->setDefinition($valueObjectClassName, (new Definition($class))
+                    ->setPublic(false)
+                    ->setArguments($container->getDefinition($id)->getArguments())
+                    ->addTag('json_streamer.value_transformer')
+                );
+            }
         }
 
-        $transformersArgument = new ServiceLocatorArgument($map);
+        $transformersLocator = (new Definition(ServiceLocator::class, [$map]))
+            ->addTag('container.service_locator');
+
+        $container->setDefinition('json_streamer.transformers', $transformersLocator);
+
+        $transformersReference = new Reference('json_streamer.transformers');
 
         $container->getDefinition('json_streamer.stream_reader')
-            ->replaceArgument(0, $transformersArgument);
+            ->replaceArgument(0, $transformersReference);
 
         $container->getDefinition('json_streamer.stream_writer')
-            ->replaceArgument(0, $transformersArgument);
+            ->replaceArgument(0, $transformersReference);
 
         $container->getDefinition('.json_streamer.cache_warmer.streamer')
-            ->setArgument(7, $transformersArgument);
+            ->setArgument(7, $transformersReference);
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Tests/DependencyInjection/TransformerPassTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/DependencyInjection/TransformerPassTest.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\JsonStreamer\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\JsonStreamer\DependencyInjection\TransformerPass;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\BooleanToStringValueTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
@@ -48,10 +48,13 @@ class TransformerPassTest extends TestCase
 
         (new TransformerPass())->process($container);
 
-        $locator = $container->getDefinition('json_streamer.stream_reader')->getArgument(0);
-        $this->assertInstanceOf(ServiceLocatorArgument::class, $locator);
+        $locatorRef = $container->getDefinition('json_streamer.stream_reader')->getArgument(0);
+        $this->assertEquals(new Reference('json_streamer.transformers'), $locatorRef);
 
-        $map = $locator->getValues();
+        $locatorDef = $container->getDefinition('json_streamer.transformers');
+        $this->assertSame(ServiceLocator::class, $locatorDef->getClass());
+
+        $map = $locatorDef->getArgument(0);
         $this->assertArrayHasKey('my_transformer', $map);
         $this->assertEquals(new Reference('my_transformer'), $map['my_transformer']);
     }
@@ -70,12 +73,35 @@ class TransformerPassTest extends TestCase
 
         (new TransformerPass())->process($container);
 
-        $locator = $container->getDefinition('json_streamer.stream_writer')->getArgument(0);
-        $this->assertInstanceOf(ServiceLocatorArgument::class, $locator);
+        $locatorRef = $container->getDefinition('json_streamer.stream_writer')->getArgument(0);
+        $this->assertEquals(new Reference('json_streamer.transformers'), $locatorRef);
 
-        $map = $locator->getValues();
+        $locatorDef = $container->getDefinition('json_streamer.transformers');
+        $this->assertSame(ServiceLocator::class, $locatorDef->getClass());
+
+        $map = $locatorDef->getArgument(0);
         $this->assertArrayHasKey(DateTimeValueObjectTransformer::getValueObjectClassName(), $map);
         $this->assertEquals(new Reference('my_object_transformer'), $map[DateTimeValueObjectTransformer::getValueObjectClassName()]);
+    }
+
+    public function testValueObjectTransformerRegisteredUnderClassNameId()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('json_streamer.stream_reader')->setArguments([null]);
+        $container->register('json_streamer.stream_writer')->setArguments([null]);
+        $container->register('.json_streamer.cache_warmer.streamer')->setArguments([null, null]);
+
+        $container->register('my_object_transformer')
+            ->setClass(DateTimeValueObjectTransformer::class)
+            ->addTag('json_streamer.value_object_transformer');
+
+        (new TransformerPass())->process($container);
+
+        $valueObjectClassName = DateTimeValueObjectTransformer::getValueObjectClassName();
+        $this->assertTrue($container->hasDefinition($valueObjectClassName));
+        $this->assertTrue($container->getDefinition($valueObjectClassName)->hasTag('json_streamer.value_transformer'));
+        $this->assertSame(DateTimeValueObjectTransformer::class, $container->getDefinition($valueObjectClassName)->getClass());
     }
 
     public function testThrowOnInvalidPropertyTransformer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63339 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

Fix `"JSON is not valid."` error (https://github.com/api-platform/core/actions/runs/23053767922/job/66961464086?pr=7755) introduced by 8cf1714ea1cc28fe125ab96ea37e7b55d12ca2fa in #63339

https://github.com/api-platform/core/pull/7839

