### PR TITLE
[DoctrineBridge] add IterableToArrayCollection transformer for Object Mapper

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add IterableToArrayCollectionTransformer for ObjectMapper
+
 8.1
 ---
 

--- a/src/Symfony/Bridge/Doctrine/ObjectMapper/Transform/IterableToArrayCollection.php
+++ b/src/Symfony/Bridge/Doctrine/ObjectMapper/Transform/IterableToArrayCollection.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\ObjectMapper\Transform;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+/**
+ * @template T of object
+ *
+ * @implements TransformCallableInterface<object, T>
+ */
+class IterableToArrayCollection implements TransformCallableInterface
+{
+    public function __construct(private MapCollection $mapCollection)
+    {
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        return new ArrayCollection(($this->mapCollection)($value, $source, $target));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ObjectMapper/IterableToArrayCollection/ClassA.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ObjectMapper/IterableToArrayCollection/ClassA.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\ObjectMapper\IterableToArrayCollection;
+
+class ClassA
+{
+    public function __construct(
+        public string $value,
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ObjectMapper/IterableToArrayCollection/ClassB.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ObjectMapper/IterableToArrayCollection/ClassB.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\ObjectMapper\IterableToArrayCollection;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Symfony\Bridge\Doctrine\ObjectMapper\Transform\IterableToArrayCollection;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
+
+class ClassB
+{
+    /** @param Collection<int, ClassA> $collection */
+    public function __construct(
+        #[Map(transform: new IterableToArrayCollection(new MapCollection(targetClass: ClassA::class)))]
+        public Collection $collection = new ArrayCollection()
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ObjectMapper/IterableToArrayCollection/ClassC.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ObjectMapper/IterableToArrayCollection/ClassC.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\ObjectMapper\IterableToArrayCollection;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+class ClassC
+{
+    /** @param Collection<int, ClassA> $collection */
+    public function __construct(
+        public Collection $collection = new ArrayCollection()
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/ObjectMapper/Transform/IterableToArrayCollectionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ObjectMapper/Transform/IterableToArrayCollectionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ObjectMapper\Transform;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\ObjectMapper\IterableToArrayCollection\ClassA;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\ObjectMapper\IterableToArrayCollection\ClassB;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\ObjectMapper\IterableToArrayCollection\ClassC;
+use Symfony\Component\ObjectMapper\ObjectMapper;
+
+class IterableToArrayCollectionTest extends TestCase
+{
+    public function testMapCollectionWithTargetClass()
+    {
+        if (!class_exists(ObjectMapper::class)) {
+            self::markTestSkipped('The ObjectMapper class is not available.');
+        }
+
+        $source = new ClassB(
+            collection: new ArrayCollection([new ClassA('a'), new ClassA('b')]),
+        );
+
+        $mapper = new ObjectMapper();
+        $target = $mapper->map($source, ClassC::class);
+
+        $this->assertInstanceOf(ClassC::class, $target);
+        $this->assertInstanceOf(ArrayCollection::class, $target->collection);
+        $this->assertCount(2, $target->collection);
+        $this->assertEquals('a', $target->collection[0]->value);
+        $this->assertEquals('b', $target->collection[1]->value);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63366
| License       | MIT

The default ObjectMapper MapCollection transformer actually transforms any iterable into an array of mapped objects
When using Doctrine Collections in entities or any DTO classes, the default mapping is not sufficient with manual post-processing.
This change allows to wrap the MapCollection transformer into another Transformer to automate the conversion into an ArrayCollection object
