### PR TITLE
 Improve Bulgarian translations in validators.bg.xlf

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -444,115 +444,115 @@
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target state="needs-review-translation">Тази стойност е твърде кратка. Трябва да съдържа поне една дума.|Тази стойност е твърде кратка. Трябва да съдържа поне {{ min }} думи.</target>
+                <target>Стойността е твърде кратка. Трябва да съдържа поне една дума.|Стойността е твърде кратка. Трябва да съдържа поне {{ min }} думи.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target state="needs-review-translation">Тази стойност е твърде дълга. Трябва да съдържа само една дума.|Тази стойност е твърде дълга. Трябва да съдържа {{ max }} думи или по-малко.</target>
+                <target>Стойността е твърде дълга. Трябва да съдържа само една дума.|Стойността е твърде дълга. Трябва да съдържа {{ max }} думи или по-малко.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target state="needs-review-translation">Тази стойност не представлява валидна седмица във формат ISO 8601.</target>
+                <target>Тази стойност не представлява валидна седмица във формат ISO 8601.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target state="needs-review-translation">Тази стойност не е валидна седмица.</target>
+                <target>Тази стойност не е валидна седмица.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target state="needs-review-translation">Тази стойност не трябва да бъде преди седмица "{{ min }}".</target>
+                <target>Стойността не трябва да бъде преди седмица "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target state="needs-review-translation">Тази стойност не трябва да бъде след седмица "{{ max }}".</target>
+                <target>Тази стойност не трябва да бъде след седмица "{{ max }}".</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Тази стойност не е валиден Twig шаблон.</target>
+                <target>Тази стойност не е валиден Twig шаблон.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Този файл не е валидно видео.</target>
+                <target>Този файл не е валидно видео.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Размерът на видеото не може да бъде установен.</target>
+                <target>Размерът на видеото не може да бъде установен.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Ширината на видеото е твърде голяма ({{ width }}px). Допустимата максимална ширина е {{ max_width }}px.</target>
+                <target>Ширината на видеото е твърде голяма ({{ width }}px). Допустимата максимална ширина е {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Ширината на видеото е твърде малка ({{ width }}px). Минималната изисквана ширина е {{ min_width }}px.</target>
+                <target>Ширината на видеото е твърде малка ({{ width }}px). Минималната изисквана ширина е {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Височината на видеото е твърде голяма ({{ height }}px). Максимално допустимата височина е {{ max_height }}px.</target>
+                <target>Височината на видеото е твърде голяма ({{ height }}px). Максимално допустимата височина е {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Височината на видеото е твърде малка ({{ height }}px). Очакваната минимална височина е {{ min_height }}px.</target>
+                <target>Височината на видеото е твърде малка ({{ height }}px). Очакваната минимална височина е {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Видеото има твърде малко пиксели ({{ pixels }}). Минимално изискуемото количество е {{ min_pixels }}.</target>
+                <target>Видеото има твърде малко пиксели ({{ pixels }}). Минимално изискуемото количество е {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Видеото има твърде много пиксели ({{ pixels }}). Очакваният максимум е {{ max_pixels }}.</target>
+                <target>Видеото има твърде много пиксели ({{ pixels }}). Максималният допустим брой е {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Съотношението на видеото е твърде голямо ({{ ratio }}). Позволеното максимално съотношение е {{ max_ratio }}.</target>
+                <target>Съотношението на видеото е твърде голямо ({{ ratio }}). Позволеното максимално съотношение е {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Съотношението на видеото е твърде малко ({{ ratio }}). Минималното очаквано съотношение е {{ min_ratio }}.</target>
+                <target>Съотношението на видеото е твърде малко ({{ ratio }}). Минималното очаквано съотношение е {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Видеото е квадратно ({{ width }}x{{ height }}px). Квадратни видеа не са позволени.</target>
+                <target>Видеото е квадратно ({{ width }}x{{ height }}px). Квадратни видеа не са позволени.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Видеото е в хоризонтална ориентация ({{ width }}x{{ height }} px). Хоризонтални видеа не са позволени.</target>
+                <target>Видеото е в хоризонтална ориентация ({{ width }}x{{ height }}px). Хоризонтални видеа не са позволени.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Видеото е с портретна ориентация ({{ width }}x{{ height }}px). Видеа с портретна ориентация не са позволени.</target>
+                <target>Видеото е с портретна ориентация ({{ width }}x{{ height }}px). Видеа с портретна ориентация не са позволени.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Видеофайлът е повреден.</target>
+                <target>Видеофайлът е повреден.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Видеото съдържа множество потоци. Разрешен е само един поток.</target>
+                <target>Видеото съдържа множество потоци. Разрешен е само един поток.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Неподдържан видео кодек „{{ codec }}“.</target>
+                <target>Неподдържан видео кодек „{{ codec }}“.</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Неподдържан видео контейнер "{{ container }}".</target>
+                <target>Неподдържан видео контейнер "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Файлът с изображение е повреден.</target>
+                <target>Файлът с изображение е повреден.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Изображението има твърде малко пиксели ({{ pixels }}). Очакваният минимален брой е {{ min_pixels }}.</target>
+                <target>Изображението има твърде малко пиксели ({{ pixels }}). Минималният изискуем брой е {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Изображението има твърде много пиксели ({{ pixels }}). Очакваният максимален брой е {{ max_pixels }}.</target>
+                <target>Изображението има твърде много пиксели ({{ pixels }}). Максималният допустим брой е {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Името на файла не съответства на очаквания набор от знаци.</target>
+                <target>Името на файла не съответства на очаквания набор от знаци.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #59411  <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

## Description

Improved several Bulgarian translations in `validators.bg.xlf`.

Changes include:
- Simplified wording (e.g. "Тази стойност" → "Стойността")
- Improved wording for pixel validation messages
- Fixed spacing issue with `px`
- Made translations more consistent with the existing Bulgarian style
