### PR TITLE
[Runtime] Add FrankenPhpWorkerResponseRunner for simple response return

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `resolveType()` for customizing how types are resolved in runtimes extending `SymfonyRuntime`
+ * Add support for apps returning a `Response` object in `FrankenPhpWorkerRunner`
 
 7.4
 ---

--- a/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Runtime\Runner;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Symfony\Component\Runtime\RunnerInterface;
@@ -24,7 +25,7 @@ use Symfony\Component\Runtime\RunnerInterface;
 class FrankenPhpWorkerRunner implements RunnerInterface
 {
     public function __construct(
-        private HttpKernelInterface $kernel,
+        private HttpKernelInterface|Response $application,
         private int $loopMax,
     ) {
     }
@@ -46,8 +47,12 @@ class FrankenPhpWorkerRunner implements RunnerInterface
             // Merge the environment variables coming from DotEnv with the ones tied to the current request
             $_SERVER += $server;
 
-            $sfRequest = Request::createFromGlobals();
-            $sfResponse = $this->kernel->handle($sfRequest);
+            if ($this->application instanceof HttpKernelInterface) {
+                $sfRequest = Request::createFromGlobals();
+                $sfResponse = $this->application->handle($sfRequest);
+            } else {
+                $sfResponse = $this->application;
+            }
 
             $sfResponse->send();
         };
@@ -56,8 +61,8 @@ class FrankenPhpWorkerRunner implements RunnerInterface
         do {
             $ret = frankenphp_handle_request($handler);
 
-            if ($this->kernel instanceof TerminableInterface && $sfRequest && $sfResponse) {
-                $this->kernel->terminate($sfRequest, $sfResponse);
+            if ($this->application instanceof TerminableInterface && $sfRequest && $sfResponse) {
+                $this->application->terminate($sfRequest, $sfResponse);
             }
 
             gc_collect_cycles();

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -177,6 +177,10 @@ class SymfonyRuntime extends GenericRuntime
         }
 
         if ($application instanceof Response) {
+            if ($_SERVER['FRANKENPHP_WORKER'] ?? false) {
+                return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max']);
+            }
+
             return new ResponseRunner($application);
         }
 

--- a/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
+++ b/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
@@ -44,4 +44,15 @@ class FrankenPhpWorkerRunnerTest extends TestCase
         $runner = new FrankenPhpWorkerRunner($application, 500);
         $this->assertSame(0, $runner->run());
     }
+
+    public function testRunWithResponse()
+    {
+        $response = $this->createMock(Response::class);
+        $response
+            ->expects($this->once())
+            ->method('send');
+
+        $runner = new FrankenPhpWorkerRunner($response, 500);
+        $this->assertSame(0, $runner->run());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This introduces `FrankenPhpWorkerResponseRunner`, a companion to the existing `FrankenPhpWorkerRunner`. While `FrankenPhpWorkerRunner` handles the full kernel lifecycle (request creation, handling,
  termination), this new runner is designed for cases where the application already provides a `Response` object — it simply sends it within the FrankenPHP worker loop.

Usage :

```php
  // public/index.php
  use App\Kernel;

  require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

  return function (array $context) {
      if($context['APP_MAINTENANCE']) {
          return new Response('....', 503);
      }

      $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();

      return $kernel->handle($request);
  };
