### PR TITLE
[Contracts] Add `ContainerAwareInterface`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\ListCommand;
@@ -24,11 +25,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Contracts\Service\ContainerAwareInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Application extends BaseApplication
+class Application extends BaseApplication implements ContainerAwareInterface
 {
     private bool $commandsRegistered = false;
     private array $registrationErrors = [];
@@ -50,6 +52,13 @@ class Application extends BaseApplication
     public function getKernel(): KernelInterface
     {
         return $this->kernel;
+    }
+
+    public function getContainer(): ContainerInterface
+    {
+        $this->kernel->boot();
+
+        return $this->kernel->getContainer();
     }
 
     public function reset(): void

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -32,6 +32,7 @@
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php85": "^1.33",
         "symfony/routing": "^7.4|^8.0",
+        "symfony/service-contracts": "^3.7",
         "symfony/var-exporter": "^8.1"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for the `max_connect_duration` option in `HttpClientInterface`
  * Add support for hooked properties in `ServiceMethodsSubscriberTrait`
+ * Add `ContainerAwareInterface`
 
 3.6
 ---

--- a/src/Symfony/Contracts/Service/ContainerAwareInterface.php
+++ b/src/Symfony/Contracts/Service/ContainerAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Service;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Implemented by objects that expose a service container.
+ */
+interface ContainerAwareInterface
+{
+    public function getContainer(): ContainerInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Related to https://github.com/symfony/symfony/pull/63650.

This PR adds a `ContainerAwareInterface` to `symfony/service-contracts`, providing a standard way for objects to expose their service container.

The immediate use case is the Messenger component: parallel workers need to bootstrap the application and access the container to resolve the message bus. Without a contract, there's no reliable way to get the container from the console `Application` object in a decoupled manner.

The interface is intentionally minimal — a single `getContainer(): ContainerInterface` method — and `FrameworkBundle\Console\Application` implements it, booting the kernel if needed.
