### PR TITLE
[Messenger] Allow configuring the service reset interval in the `messenger:consume` command via the `--no-reset` option

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -302,7 +302,7 @@ class ConnectionTest extends TestCase
                 'WaitTimeSeconds' => 20]], $firstResult],
             [[['QueueUrl' => 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue',
                 'VisibilityTimeout' => null,
-                'MaxNumberOfMessages' => 12,
+                'MaxNumberOfMessages' => 10,
                 'MessageAttributeNames' => ['All'],
                 'WaitTimeSeconds' => 20]], $secondResult],
         ];

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add argument `$fetchSize` to `ReceiverInterface::get()` and `QueueReceiverInterface::getFromQueues()`, and to all bridges
  * Add a `--fetch-size` option to the `messenger:consume` command to control how many messages are fetched per iteration
  * Add `MessageExecutionStrategyInterface` and `SyncMessageExecutionStrategy` to decouple message execution from the `Worker`
+ * Allow configuring the service reset interval in the `messenger:consume` command via the `--no-reset` option
 
 8.0
 ---

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -74,7 +74,7 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
                 new InputOption('sleep', null, InputOption::VALUE_REQUIRED, 'Seconds to sleep before asking for new messages after no messages were found', 1),
                 new InputOption('bus', 'b', InputOption::VALUE_REQUIRED, 'Name of the bus to which received messages should be dispatched (if not passed, bus is determined automatically)'),
                 new InputOption('queues', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit receivers to only consume from the specified queues'),
-                new InputOption('no-reset', null, InputOption::VALUE_NONE, 'Do not reset container services after each message'),
+                new InputOption('no-reset', null, InputOption::VALUE_OPTIONAL, 'Do not reset container services after each message, or pass a number to reset every N messages', false),
                 new InputOption('all', null, InputOption::VALUE_NONE, 'Consume messages from all receivers'),
                 new InputOption('exclude-receivers', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude specific receivers/transports from consumption (can only be used with --all)'),
                 new InputOption('keepalive', null, InputOption::VALUE_OPTIONAL, 'Whether to use the transport\'s keepalive mechanism if implemented', self::DEFAULT_KEEPALIVE_INTERVAL),
@@ -237,7 +237,18 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             }
         }
 
-        if (null !== $this->resetServicesListener && !$input->getOption('no-reset')) {
+        $resetInterval = match ($resetInterval = $input->getOption('no-reset')) {
+            false => 1,
+            null => 0,
+            default => filter_var($resetInterval, \FILTER_VALIDATE_INT, \FILTER_NULL_ON_FAILURE),
+        };
+
+        if (0 > ($resetInterval ?? -1)) {
+            throw new InvalidOptionException(\sprintf('Option "no-reset" must be a positive integer, "%s" passed.', $input->getOption('no-reset')));
+        }
+
+        $this->resetServicesListener?->setInterval($resetInterval > 0 ? $resetInterval : 1);
+        if ($this->resetServicesListener && $resetInterval > 0) {
             $this->eventDispatcher->addSubscriber($this->resetServicesListener);
         }
 

--- a/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
@@ -21,14 +21,22 @@ use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
  */
 class ResetServicesListener implements EventSubscriberInterface
 {
+    private int $interval = 1;
+    private int $count = 0;
+
     public function __construct(
         private ServicesResetterInterface $servicesResetter,
     ) {
     }
 
+    public function setInterval(int $interval): void
+    {
+        $this->interval = $interval;
+    }
+
     public function resetServices(WorkerRunningEvent $event): void
     {
-        if (!$event->isWorkerIdle()) {
+        if (!$event->isWorkerIdle() && 0 === ++$this->count % $this->interval) {
             $this->servicesResetter->reset();
         }
     }

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -173,6 +173,7 @@ class ConsumeMessagesCommandTest extends TestCase
 
         yield 'Zero second time limit' => ['--time-limit', '0', 'Option "time-limit" must be a positive integer, "0" passed.'];
         yield 'Non-numeric time limit' => ['--time-limit', 'whatever', 'Option "time-limit" must be a positive integer, "whatever" passed.'];
+        yield 'Negative reset interval' => ['--no-reset', '-1', 'Option "no-reset" must be a positive integer, "-1" passed.'];
     }
 
     public function testRunWithTimeLimit()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR extends the `--no-reset` option of the `messenger:consume` command to optionally accept a numeric interval, allowing services to be reset every N messages instead of the current all-or-nothing behavior.

`--no-reset` now accepts an optional integer value:
- `--no-reset` (no value) — disables service resetting entirely (same as before)
- `--no-reset=100` — resets services every 100 messages
- Without the flag — resets after every message (default, unchanged)

This is useful when resetting after every message is expensive, but never resetting leads to memory leaks or stale state.
