### PR TITLE
[Finder] Fix path-based sorting on Windows

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -48,13 +48,13 @@ class SortableIterator implements \IteratorAggregate
         $order = $reverseOrder ? -1 : 1;
 
         if (self::SORT_BY_NAME === $sort) {
-            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strcmp($a->getRealPath() ?: $a->getPathname(), $b->getRealPath() ?: $b->getPathname());
+            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strcmp(self::getPath($a), self::getPath($b));
         } elseif (self::SORT_BY_NAME_NATURAL === $sort) {
-            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strnatcmp($a->getRealPath() ?: $a->getPathname(), $b->getRealPath() ?: $b->getPathname());
+            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strnatcmp(self::getPath($a), self::getPath($b));
         } elseif (self::SORT_BY_NAME_CASE_INSENSITIVE === $sort) {
-            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strcasecmp($a->getRealPath() ?: $a->getPathname(), $b->getRealPath() ?: $b->getPathname());
+            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strcasecmp(self::getPath($a), self::getPath($b));
         } elseif (self::SORT_BY_NAME_NATURAL_CASE_INSENSITIVE === $sort) {
-            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strnatcasecmp($a->getRealPath() ?: $a->getPathname(), $b->getRealPath() ?: $b->getPathname());
+            $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * strnatcasecmp(self::getPath($a), self::getPath($b));
         } elseif (self::SORT_BY_TYPE === $sort) {
             $this->sort = static function (\SplFileInfo $a, \SplFileInfo $b) use ($order) {
                 if ($a->isDir() && $b->isFile()) {
@@ -63,7 +63,7 @@ class SortableIterator implements \IteratorAggregate
                     return $order;
                 }
 
-                return $order * strcmp($a->getRealPath() ?: $a->getPathname(), $b->getRealPath() ?: $b->getPathname());
+                return $order * strcmp(self::getPath($a), self::getPath($b));
             };
         } elseif (self::SORT_BY_ACCESSED_TIME === $sort) {
             $this->sort = static fn (\SplFileInfo $a, \SplFileInfo $b) => $order * ($a->getATime() - $b->getATime());
@@ -82,6 +82,13 @@ class SortableIterator implements \IteratorAggregate
         } else {
             throw new \InvalidArgumentException('The SortableIterator takes a PHP callable or a valid built-in sort algorithm as an argument.');
         }
+    }
+
+    private static function getPath(\SplFileInfo $file): string
+    {
+        $path = $file->getRealPath() ?: $file->getPathname();
+
+        return '\\' === \DIRECTORY_SEPARATOR ? strtr($path, '\\', '/') : $path;
     }
 
     public function getIterator(): \Traversable

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -877,18 +877,10 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->sortByCaseInsensitiveName(true));
-
-        $expected = ['foo'];
-
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $expected[] = 'foo bar';
-            $expected[] = 'foo/bar.tmp';
-        } else {
-            $expected[] = 'foo/bar.tmp';
-            $expected[] = 'foo bar';
-        }
-
-        $expected = array_merge($expected, [
+        $expected = [
+            'foo',
+            'foo/bar.tmp',
+            'foo bar',
             'qux',
             'qux/baz_1_2.py',
             'qux/baz_100_1.py',
@@ -903,7 +895,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
             'toto',
             'zebulon.php',
             'Zephire.php',
-        ]);
+        ];
         $this->assertOrderedIterator($this->toAbsolute($expected), $finder->in(self::$tmpDir)->getIterator());
 
         $finder = $this->buildFinder();

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -924,7 +924,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testSort()
     {
         $finder = $this->buildFinder();
-        $this->assertSame($finder, $finder->sort(fn (\SplFileInfo $a, \SplFileInfo $b) => strcmp($a->getRealPath(), $b->getRealPath())));
+        $this->assertSame($finder, $finder->sort(static fn (\SplFileInfo $a, \SplFileInfo $b) => strcmp($a->getRealPath(), $b->getRealPath())));
         $this->assertOrderedIterator($this->toAbsolute([
             'Zephire.php',
             'foo',
@@ -980,7 +980,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testFilter()
     {
         $finder = $this->buildFinder();
-        $this->assertSame($finder, $finder->filter(fn (\SplFileInfo $f) => str_contains($f, 'test')));
+        $this->assertSame($finder, $finder->filter(static fn (\SplFileInfo $f) => str_contains($f, 'test')));
         $this->assertIterator($this->toAbsolute(['test.php', 'test.py']), $finder->in(self::$tmpDir)->getIterator());
     }
 
@@ -1007,7 +1007,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder = $this->buildFinder();
         $finder
             ->in($this->vfsScheme.'://x')
-            ->filter(fn (): bool => true, true) // does nothing
+            ->filter(static fn (): bool => true, true) // does nothing
             ->filter(function (\SplFileInfo $file): bool {
                 $path = $this->stripSchemeFromVfsPath($file->getPathname());
 
@@ -1017,7 +1017,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
                 return $res;
             }, true)
-            ->filter(fn (): bool => true, true); // does nothing
+            ->filter(static fn (): bool => true, true); // does nothing
 
         $this->assertSameVfsIterator([
             'x/a.php',
@@ -1376,10 +1376,6 @@ class FinderTest extends Iterator\RealIteratorTestCase
             ['key' => $dir.'a'.\DIRECTORY_SEPARATOR.'b'.\DIRECTORY_SEPARATOR.'c'.\DIRECTORY_SEPARATOR.'c2', 'relativePathname' => 'b'.\DIRECTORY_SEPARATOR.'c'.\DIRECTORY_SEPARATOR.'c2'],
         ];
 
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            usort($expected, static fn ($a, $b) => $a['key'] <=> $b['key']);
-        }
-
         $this->assertSame($expected, self::formatForAssert($finder));
     }
 
@@ -1415,10 +1411,6 @@ class FinderTest extends Iterator\RealIteratorTestCase
             ['key' => $dir.'a/b/c'.\DIRECTORY_SEPARATOR.'c2', 'relativePathname' => 'c2'],
         ];
 
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            usort($expected, static fn ($a, $b) => $a['key'] <=> $b['key']);
-        }
-
         $this->assertSame($expected, self::formatForAssert($finder));
     }
 
@@ -1453,10 +1445,6 @@ class FinderTest extends Iterator\RealIteratorTestCase
             ['key' => $dir.'a/b/c/c1', 'relativePathname' => $dir.'a/b/c/c1'],
             ['key' => $dir.'a/b'.\DIRECTORY_SEPARATOR.'c'.\DIRECTORY_SEPARATOR.'c2', 'relativePathname' => 'c'.\DIRECTORY_SEPARATOR.'c2'],
         ];
-
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            usort($expected, static fn ($a, $b) => $a['key'] <=> $b['key']);
-        }
 
         $this->assertSame($expected, self::formatForAssert($finder));
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1079,7 +1079,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         ]), $finder->in(self::$tmpDir)->getIterator());
     }
 
-    public function testIn()
+    public function testFindFilesInMultipleDirectories()
     {
         $finder = $this->buildFinder();
         $iterator = $finder->files()->name('*.php')->depth('< 1')->in([self::$tmpDir, __DIR__])->getIterator();

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -312,7 +312,7 @@ class SortableIteratorTest extends RealIteratorTestCase
             [SortableIterator::SORT_BY_CHANGED_TIME, self::toAbsolute($sortByChangedTime)],
             [SortableIterator::SORT_BY_MODIFIED_TIME, self::toAbsolute($sortByModifiedTime)],
             [SortableIterator::SORT_BY_NAME_NATURAL, self::toAbsolute($sortByNameNatural)],
-            [fn (\SplFileInfo $a, \SplFileInfo $b) => strcmp($a->getRealPath(), $b->getRealPath()), self::toAbsolute($customComparison)],
+            [static fn (\SplFileInfo $a, \SplFileInfo $b) => strcmp($a->getRealPath(), $b->getRealPath()), self::toAbsolute($customComparison)],
         ];
     }
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Finder\Tests\Iterator;
 
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Iterator\SortableIterator;
 
 class SortableIteratorTest extends RealIteratorTestCase
@@ -22,6 +23,50 @@ class SortableIteratorTest extends RealIteratorTestCase
             $this->fail('__construct() throws an \InvalidArgumentException exception if the mode is not valid');
         } catch (\Exception $e) {
             $this->assertInstanceOf(\InvalidArgumentException::class, $e, '__construct() throws an \InvalidArgumentException exception if the mode is not valid');
+        }
+    }
+
+    /**
+     * @dataProvider getPathComparisonModes
+     */
+    public function testSortUsesPlatformPathSemantics(int $sortMode)
+    {
+        $filesystem = new Filesystem();
+        $directory = sys_get_temp_dir().'/sortable_iterator_'.strtr(uniqid('', true), '.', '_');
+
+        mkdir($directory);
+
+        try {
+            if ('\\' === \DIRECTORY_SEPARATOR) {
+                mkdir($directory.\DIRECTORY_SEPARATOR.'Folder');
+                $firstPath = $directory.\DIRECTORY_SEPARATOR.'Folder'.\DIRECTORY_SEPARATOR.'Sub.php';
+                $secondPath = $directory.\DIRECTORY_SEPARATOR.'FolderBase.php';
+            } else {
+                $firstPath = $directory.'/Folder\\Sub.php';
+                $secondPath = $directory.'/FolderBase.php';
+            }
+
+            touch($firstPath);
+            touch($secondPath);
+
+            $iterator = new SortableIterator(new \ArrayIterator([
+                new \SplFileInfo($firstPath),
+                new \SplFileInfo($secondPath),
+            ]), $sortMode);
+
+            if ('\\' === \DIRECTORY_SEPARATOR) {
+                $expected = [$firstPath, $secondPath];
+            } else {
+                $expected = SortableIterator::SORT_BY_NAME_CASE_INSENSITIVE === $sortMode
+                    ? [$firstPath, $secondPath]
+                    : [$secondPath, $firstPath];
+            }
+
+            $this->assertSame($expected, array_map(static function (\SplFileInfo $file) {
+                return $file->getPathname();
+            }, iterator_to_array($iterator, false)));
+        } finally {
+            $filesystem->remove($directory);
         }
     }
 
@@ -268,6 +313,17 @@ class SortableIteratorTest extends RealIteratorTestCase
             [SortableIterator::SORT_BY_MODIFIED_TIME, self::toAbsolute($sortByModifiedTime)],
             [SortableIterator::SORT_BY_NAME_NATURAL, self::toAbsolute($sortByNameNatural)],
             [fn (\SplFileInfo $a, \SplFileInfo $b) => strcmp($a->getRealPath(), $b->getRealPath()), self::toAbsolute($customComparison)],
+        ];
+    }
+
+    public static function getPathComparisonModes()
+    {
+        return [
+            [SortableIterator::SORT_BY_NAME],
+            [SortableIterator::SORT_BY_NAME_NATURAL],
+            [SortableIterator::SORT_BY_NAME_CASE_INSENSITIVE],
+            [SortableIterator::SORT_BY_NAME_NATURAL_CASE_INSENSITIVE],
+            [SortableIterator::SORT_BY_TYPE],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58375
| License       | MIT

Finder sorts by the raw paths returned by `SplFileInfo`. On Windows, that mixes backslashes from filesystem paths with forward slashes used elsewhere in Finder, so `sortByName()` and the related built-in path sorts can produce a different order than on Unix-like systems.

The fix normalizes directory separators only on Windows before the built-in path comparisons run. POSIX paths keep their original bytes, so filenames that legitimately contain `\` are not treated as directory separators.

Tests cover the low-level iterator behavior with real files and update the higher-level Finder expectation for the Windows-specific natural case-insensitive order.
