### PR TITLE
feat(http-client): add cookie store to http client

### DIFF
--- a/src/Symfony/Component/HttpClient/Cookie/Cookie.php
+++ b/src/Symfony/Component/HttpClient/Cookie/Cookie.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Cookie;
+
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Contracts\HttpClient\Cookie\CookieInterface;
+
+/**
+ * Represents a single HTTP request cookie (name=value pair).
+ *
+ * @author Edouard Courty <edouard.courty2@gmail.com>
+ */
+final class Cookie implements CookieInterface
+{
+    /**
+     * RFC 2616 separator characters illegal in a cookie-name, excluding CTLs and space
+     * which are added dynamically by getIllegalNameCharacters().
+     *
+     * Ordinal values: " ( ) , / : ; < = > ? @ [ \ ] { } DEL
+     */
+    private const array ILLEGAL_NAME_CHARS = [
+        34,           // "
+        40, 41,       // ( )
+        44,           // ,
+        47,           // /
+        58, 59,       // : ;
+        60, 61, 62,   // < = >
+        63, 64,       // ? @
+        91, 92, 93,   // [ \ ]
+        123, 125,     // { }
+        127,          // DEL
+    ];
+
+    /**
+     * Characters illegal in a cookie-value beyond CTLs and space:
+     * double-quote, comma, semicolon, backslash, DEL, and non-ASCII bytes (0x80–0xFF).
+     *
+     * Ordinal values: " , ; \ DEL
+     * (CTLs 0–32 and non-ASCII 128–255 are added dynamically by getIllegalValueCharacters().)
+     */
+    private const array ILLEGAL_VALUE_CHARS = [
+        34,  // "
+        44,  // ,
+        59,  // ;
+        92,  // \
+        127, // DEL
+    ];
+
+    private static ?string $illegalNameCharsCache = null;
+    private static ?string $illegalValueCharsCache = null;
+
+    public function __construct(
+        private readonly string $name,
+        private readonly string $value = '',
+    ) {
+        if ('' === $name) {
+            throw new InvalidArgumentException('Cookie name cannot be empty.');
+        }
+
+        if (strpbrk($name, self::getIllegalNameCharacters()) !== false) {
+            throw new InvalidArgumentException(\sprintf('Invalid cookie name "%s": it contains illegal characters.', $name));
+        }
+
+        if (strpbrk($value, self::getIllegalValueCharacters()) !== false) {
+            throw new InvalidArgumentException(\sprintf('Invalid cookie value for "%s": it must contain only printable US-ASCII characters excluding whitespace, double-quote, comma, semicolon and backslash (RFC 6265 §4.1.1). Use rawurlencode() if the value contains special characters.', $name));
+        }
+    }
+
+    /**
+     * Returns a string containing all characters illegal in a cookie name per RFC 6265.
+     *
+     * Cookie names are defined as RFC 2616 tokens: any US-ASCII character except
+     * control characters (0x00–0x1F), space (0x20), DEL (0x7F), and the separator characters above.
+     *
+     * Can be used with strpbrk() to detect illegal characters in a custom name.
+     */
+    public static function getIllegalNameCharacters(): string
+    {
+        return self::$illegalNameCharsCache ??= implode('', array_map('chr', array_merge(
+            range(0, 32), // CTLs (0x00–0x1F) and space (0x20)
+            self::ILLEGAL_NAME_CHARS,
+        )));
+    }
+
+    /**
+     * Returns a string containing all characters illegal in a cookie value per RFC 6265 §4.1.1.
+     *
+     * Valid cookie-octets are printable US-ASCII (0x21–0x7E) excluding
+     * double-quote (0x22), comma (0x2C), semicolon (0x3B), and backslash (0x5C).
+     *
+     * Can be used with strpbrk() to detect illegal characters in a custom value.
+     */
+    public static function getIllegalValueCharacters(): string
+    {
+        return self::$illegalValueCharsCache ??= implode('', array_map('chr', array_merge(
+            range(0, 32),    // CTLs (0x00–0x1F) and space (0x20)
+            self::ILLEGAL_VALUE_CHARS,
+            range(128, 255), // non-ASCII bytes
+        )));
+    }
+
+    /**
+     * Creates a Cookie from a "name=value" string.
+     */
+    public static function fromString(string $cookie): self
+    {
+        [$name, $value] = explode('=', $cookie, 2) + [1 => ''];
+
+        return new self(trim($name), trim($value));
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name . '=' . $this->value;
+    }
+}

--- a/src/Symfony/Component/HttpClient/Cookie/CookieStore.php
+++ b/src/Symfony/Component/HttpClient/Cookie/CookieStore.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Cookie;
+
+use Symfony\Contracts\HttpClient\Cookie\CookieInterface;
+use Symfony\Contracts\HttpClient\Cookie\CookieStoreInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * An immutable store of HTTP request cookies.
+ *
+ * @author Edouard Courty <edouard.courty2@gmail.com>
+ */
+final class CookieStore implements CookieStoreInterface
+{
+    /** @var array<string, CookieInterface> */
+    private readonly array $cookies;
+
+    /**
+     * @param iterable<CookieInterface> $cookies
+     */
+    public function __construct(iterable $cookies = [])
+    {
+        $indexed = [];
+        foreach ($cookies as $cookie) {
+            $indexed[$cookie->getName()] = $cookie;
+        }
+        $this->cookies = $indexed;
+    }
+
+    /**
+     * Creates a CookieStore by parsing a Cookie header string.
+     *
+     * Accepts the format used in the Cookie HTTP header: "name1=value1; name2=value2".
+     */
+    public static function fromString(string $cookies): self
+    {
+        if ('' === trim($cookies)) {
+            return new self();
+        }
+
+        $objects = [];
+        foreach (explode(';', $cookies) as $pair) {
+            if ('' !== trim($pair)) {
+                $objects[] = Cookie::fromString($pair);
+            }
+        }
+
+        return new self($objects);
+    }
+
+    /**
+     * Creates a CookieStore from an associative or indexed iterable.
+     *
+     * Accepted formats:
+     *   - ['name' => 'value', ...]           (associative array)
+     *   - ['name=value', ...]                (indexed strings)
+     *   - [new Cookie('name', 'value'), ...]  (Cookie objects)
+     *   - any Traversable yielding the above
+     */
+    public static function fromArray(iterable $cookies): self
+    {
+        $objects = [];
+        foreach ($cookies as $name => $value) {
+            $objects[] = match (true) {
+                $value instanceof Cookie => $value,
+                \is_int($name) => Cookie::fromString((string) $value),
+                default => new Cookie($name, (string) $value),
+            };
+        }
+
+        return new self($objects);
+    }
+
+    /**
+     * Builds a CookieStore from the Set-Cookie headers of an HTTP response.
+     *
+     * Only the name=value pair is extracted; cookie attributes (Path, Domain,
+     * Secure, HttpOnly, SameSite, Expires) are intentionally ignored since this
+     * store is meant for outgoing request cookies.
+     *
+     * @param bool $throw Whether an exception should be thrown on 3/4/5xx status codes
+     */
+    public static function extractFromResponse(ResponseInterface $response, bool $throw = true): self
+    {
+        $cookies = [];
+        foreach ($response->getHeaders($throw)['set-cookie'] ?? [] as $header) {
+            // Each Set-Cookie header is "name=value; attr1; attr2=v; ..."
+            // We pass only the first "name=value" segment to fromString().
+            // Last header for a given name wins (standard browser semantics).
+            // Non-RFC-compliant cookies from the server are silently skipped.
+            try {
+                $cookies = array_merge($cookies, self::fromString(explode(';', $header, 2)[0])->toArray());
+            } catch (\InvalidArgumentException) {
+                // skip non-RFC-compliant Set-Cookie values
+            }
+        }
+
+        return self::fromArray($cookies);
+    }
+
+    /**
+     * Returns a new instance with the given cookie added or replaced.
+     */
+    public function withCookie(string|CookieInterface $name, string $value = ''): static
+    {
+        $cookie = $name instanceof CookieInterface ? $name : new Cookie($name, $value);
+
+        $cookies = array_values($this->cookies);
+        $cookies[] = $cookie;
+
+        return new self($cookies);
+    }
+
+    public function hasCookie(string $name): bool
+    {
+        return isset($this->cookies[$name]);
+    }
+
+    public function getCookie(string $name): ?CookieInterface
+    {
+        return $this->cookies[$name] ?? null;
+    }
+
+    /**
+     * Returns a new instance without the given cookie.
+     */
+    public function withoutCookie(string $name): static
+    {
+        if (!$this->hasCookie($name)) {
+            return $this;
+        }
+
+        $cookies = array_values(array_filter(
+            $this->cookies,
+            static fn (Cookie $cookie) => $cookie->getName() !== $name,
+        ));
+
+        return new self($cookies);
+    }
+
+    /**
+     * Returns the cookies as an associative array ['name' => 'value'].
+     *
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        $result = [];
+        foreach ($this->cookies as $name => $cookie) {
+            $result[$name] = $cookie->getValue();
+        }
+
+        return $result;
+    }
+
+    public function count(): int
+    {
+        return \count($this->cookies);
+    }
+
+    /**
+     * Returns an iterator over the CookieInterface objects, keyed by cookie name.
+     *
+     * @return \ArrayIterator<string, CookieInterface>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->cookies);
+    }
+
+    /**
+     * Serializes the store as a valid Cookie header value: "name1=value1; name2=value2".
+     */
+    public function __toString(): string
+    {
+        return implode('; ', $this->cookies);
+    }
+}

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Symfony\Component\HttpClient\Cookie\CookieStore;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Response\StreamableInterface;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
+use Symfony\Component\HttpClient\Internal\Canary;
 use Symfony\Component\Mime\MimeTypes;
+use Symfony\Contracts\HttpClient\Cookie\CookieStoreInterface;
 
 /**
  * Provides the common logic from writing HttpClientInterface implementations.
@@ -165,8 +168,22 @@ trait HttpClientTrait
             if (($options['auth_bearer'] ?? false) && !($options['normalized_headers']['authorization'] ?? false)) {
                 $options['normalized_headers']['authorization'] = ['Authorization: Bearer '.$options['auth_bearer']];
             }
+            // Merge cookies with headers; "cookies" option takes precedence over any Cookie header
+            if (isset($options['cookies'])) {
+                $cookies = $options['cookies'];
+                if (\is_array($cookies)) {
+                    $cookies = CookieStore::fromArray($cookies);
+                } elseif (\is_string($cookies)) {
+                    $cookies = CookieStore::fromString($cookies);
+                } elseif (!$cookies instanceof CookieStoreInterface) {
+                    throw new InvalidArgumentException(\sprintf('Option "cookies" must be a string, an array, or a "%s", "%s" given.', CookieStoreInterface::class, get_debug_type($cookies)));
+                }
+                if ('' !== (string) $cookies) {
+                    $options['normalized_headers']['cookie'] = ['Cookie: '.$cookies];
+                }
+            }
 
-            unset($options['auth_basic'], $options['auth_bearer']);
+            unset($options['auth_basic'], $options['auth_bearer'], $options['cookies']);
 
             // Parse base URI
             if (\is_string($baseUri = $options['base_uri'] ?? null)) {

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Symfony\Component\HttpClient\Cookie\Cookie;
+use Symfony\Component\HttpClient\Cookie\CookieStore;
+use Symfony\Contracts\HttpClient\Cookie\CookieStoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -59,6 +62,18 @@ class HttpOptions
     public function setQuery(array $query): static
     {
         $this->options['query'] = $query;
+
+        return $this;
+    }
+
+    /**
+     * @param CookieStoreInterface|array<string, string|Cookie>|list<string|Cookie>|string $cookies
+     *
+     * @return $this
+     */
+    public function setCookies(CookieStoreInterface|array|string $cookies): static
+    {
+        $this->options['cookies'] = $cookies;
 
         return $this;
     }

--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\HttpClient\Response;
 
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\LastChunk;
+use Symfony\Component\HttpClient\Cookie\CookieStore;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\Cookie\CookieStoreInterface;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
@@ -114,6 +116,14 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
         }
 
         return $headers;
+    }
+
+    /**
+     * @see TransportResponseTrait::getCookies() for full documentation and BC note
+     */
+    public function getCookies(bool $throw = true): CookieStoreInterface
+    {
+        return CookieStore::extractFromResponse($this, $throw);
     }
 
     public function getInfo(?string $type = null): mixed

--- a/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
@@ -12,11 +12,13 @@
 namespace Symfony\Component\HttpClient\Response;
 
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
+use Symfony\Component\HttpClient\Cookie\CookieStore;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\TraceableHttpClient;
 use Symfony\Component\Stopwatch\StopwatchEvent;
+use Symfony\Contracts\HttpClient\Cookie\CookieStoreInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
@@ -82,6 +84,14 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
                 $this->event->lap();
             }
         }
+    }
+
+    /**
+     * @see TransportResponseTrait::getCookies() for full documentation and BC note
+     */
+    public function getCookies(bool $throw = true): CookieStoreInterface
+    {
+        return CookieStore::extractFromResponse($this->response, $throw);
     }
 
     public function getContent(bool $throw = true): string

--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -16,9 +16,11 @@ use Symfony\Component\HttpClient\Chunk\DataChunk;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Chunk\LastChunk;
+use Symfony\Component\HttpClient\Cookie\CookieStore;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\Canary;
 use Symfony\Component\HttpClient\Internal\ClientState;
+use Symfony\Contracts\HttpClient\Cookie\CookieStoreInterface;
 
 /**
  * Implements common logic for transport-level response classes.
@@ -68,6 +70,28 @@ trait TransportResponseTrait
         }
 
         return $this->headers;
+    }
+
+    /**
+     * Gets the cookies set by the response (extracted from Set-Cookie headers).
+     *
+     * Only name=value pairs are extracted; cookie attributes (Path, Domain, Secure,
+     * HttpOnly, SameSite, Expires) are intentionally ignored — this store is meant
+     * for use as outgoing request cookies on a subsequent request.
+     *
+     * Non-RFC-compliant cookies from the server are silently skipped.
+     *
+     * Note: this method is not part of ResponseInterface because adding it would be
+     * a backwards-compatibility break for existing implementations. Type-hint against
+     * the concrete response class (e.g. CurlResponse, NativeResponse, MockResponse)
+     * or against ResponseInterface and call getCookies() without a type-check if you
+     * control all response implementations in your project.
+     *
+     * @param bool $throw Whether an exception should be thrown on 3/4/5xx status codes
+     */
+    public function getCookies(bool $throw = true): CookieStoreInterface
+    {
+        return CookieStore::extractFromResponse($this, $throw);
     }
 
     public function cancel(): void

--- a/src/Symfony/Component/HttpClient/Tests/Cookie/CookieStoreTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Cookie/CookieStoreTest.php
@@ -1,0 +1,292 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Cookie;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Cookie\Cookie;
+use Symfony\Component\HttpClient\Cookie\CookieStore;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class CookieStoreTest extends TestCase
+{
+    public function testFromString(): void
+    {
+        $store = CookieStore::fromString('flavor=chocolate; size=medium');
+
+        $this->assertCount(2, $store);
+        $this->assertSame('chocolate', $store->getCookie('flavor')->getValue());
+        $this->assertSame('medium', $store->getCookie('size')->getValue());
+        $this->assertSame('flavor=chocolate; size=medium', (string) $store);
+    }
+
+    public function testFromStringWithSingleCookie(): void
+    {
+        $store = CookieStore::fromString('flavor=chocolate');
+
+        $this->assertCount(1, $store);
+        $this->assertSame('chocolate', $store->getCookie('flavor')->getValue());
+    }
+
+    public function testFromStringWithEmptyString(): void
+    {
+        $store = CookieStore::fromString('');
+
+        $this->assertCount(0, $store);
+    }
+
+    public function testFromStringWithWhitespace(): void
+    {
+        $store = CookieStore::fromString('  flavor=chocolate ;  size=medium  ');
+
+        $this->assertCount(2, $store);
+        $this->assertSame('chocolate', $store->getCookie('flavor')->getValue());
+        $this->assertSame('medium', $store->getCookie('size')->getValue());
+    }
+
+    public function testHasCookie(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate']);
+
+        $this->assertTrue($store->hasCookie('flavor'));
+        $this->assertFalse($store->hasCookie('missing'));
+    }
+
+    public function testWithoutCookieRemoves(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate', 'size' => 'medium']);
+        $newStore = $store->withoutCookie('flavor');
+
+        $this->assertCount(2, $store, 'Original store is unchanged');
+        $this->assertCount(1, $newStore);
+        $this->assertNull($newStore->getCookie('flavor'));
+        $this->assertSame('medium', $newStore->getCookie('size')->getValue());
+    }
+
+    public function testWithoutCookieReturnsSameInstanceIfNotFound(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate']);
+        $newStore = $store->withoutCookie('missing');
+
+        $this->assertSame($store, $newStore);
+    }
+
+    public function testEmptyStore(): void
+    {
+        $store = new CookieStore();
+
+        $this->assertCount(0, $store);
+        $this->assertSame('', (string) $store);
+        $this->assertSame([], $store->toArray());
+    }
+
+    public function testFromArrayAssociative(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate', 'size' => 'medium']);
+
+        $this->assertCount(2, $store);
+        $this->assertSame('flavor=chocolate; size=medium', (string) $store);
+    }
+
+    public function testFromArrayIndexedStrings(): void
+    {
+        $store = CookieStore::fromArray(['flavor=chocolate', 'size=medium']);
+
+        $this->assertSame('flavor=chocolate; size=medium', (string) $store);
+    }
+
+    public function testFromArrayCookieObjects(): void
+    {
+        $store = CookieStore::fromArray([
+            new Cookie('flavor', 'chocolate'),
+            new Cookie('size', 'medium'),
+        ]);
+
+        $this->assertSame('flavor=chocolate; size=medium', (string) $store);
+    }
+
+    public function testFromArrayMixed(): void
+    {
+        $store = CookieStore::fromArray([
+            'flavor' => 'chocolate',
+            new Cookie('size', 'medium'),
+        ]);
+
+        $this->assertCount(2, $store);
+    }
+
+    public function testGetCookie(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate']);
+
+        $cookie = $store->getCookie('flavor');
+
+        $this->assertNotNull($cookie);
+        $this->assertSame('flavor', $cookie->getName());
+        $this->assertSame('chocolate', $cookie->getValue());
+    }
+
+    public function testGetCookieReturnsNullForMissing(): void
+    {
+        $store = new CookieStore();
+
+        $this->assertNull($store->getCookie('missing'));
+    }
+
+    public function testToArray(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate', 'size' => 'medium']);
+
+        $this->assertSame(['flavor' => 'chocolate', 'size' => 'medium'], $store->toArray());
+    }
+
+    public function testWithCookieAddsNew(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate']);
+        $newStore = $store->withCookie('size', 'medium');
+
+        $this->assertCount(1, $store, 'Original store is unchanged');
+        $this->assertCount(2, $newStore);
+        $this->assertSame('flavor=chocolate; size=medium', (string) $newStore);
+    }
+
+    public function testWithCookieReplaces(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate']);
+        $newStore = $store->withCookie('flavor', 'vanilla');
+
+        $this->assertSame('chocolate', $store->getCookie('flavor')->getValue(), 'Original unchanged');
+        $this->assertSame('vanilla', $newStore->getCookie('flavor')->getValue());
+        $this->assertCount(1, $newStore);
+    }
+
+    public function testWithCookieObject(): void
+    {
+        $store = new CookieStore();
+        $newStore = $store->withCookie(new Cookie('flavor', 'chocolate'));
+
+        $this->assertCount(1, $newStore);
+        $this->assertSame('flavor=chocolate', (string) $newStore);
+    }
+
+    public function testExtractFromResponseWithThrowFalse(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('getHeaders')->with(false)->willReturn([
+            'set-cookie' => ['session=abc123; Path=/'],
+        ]);
+
+        $store = CookieStore::extractFromResponse($response, false);
+
+        $this->assertCount(1, $store);
+    }
+
+    public function testExtractFromResponse(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('getHeaders')->with(true)->willReturn([
+            'set-cookie' => [
+                'session=abc123; Path=/; HttpOnly',
+                'token=xyz; Secure; SameSite=Lax',
+            ],
+        ]);
+
+        $store = CookieStore::extractFromResponse($response);
+
+        $this->assertCount(2, $store);
+        $this->assertSame('abc123', $store->getCookie('session')->getValue());
+        $this->assertSame('xyz', $store->getCookie('token')->getValue());
+        $this->assertSame('session=abc123; token=xyz', (string) $store);
+    }
+
+    public function testExtractFromResponseWithNoSetCookies(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('getHeaders')->with(true)->willReturn([]);
+
+        $store = CookieStore::extractFromResponse($response);
+
+        $this->assertCount(0, $store);
+    }
+
+    public function testExtractFromResponseLastHeaderWinsForDuplicateNames(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('getHeaders')->with(true)->willReturn([
+            'set-cookie' => [
+                'session=old; Path=/',
+                'session=new; Path=/',
+            ],
+        ]);
+
+        $store = CookieStore::extractFromResponse($response);
+
+        $this->assertCount(1, $store);
+        $this->assertSame('new', $store->getCookie('session')->getValue(), 'Last Set-Cookie header must win');
+    }
+
+    public function testImplementsStringableAndCountable(): void
+    {
+        $store = new CookieStore();
+
+        $this->assertInstanceOf(\Stringable::class, $store);
+        $this->assertInstanceOf(\Countable::class, $store);
+        $this->assertInstanceOf(\IteratorAggregate::class, $store);
+    }
+
+    public function testGetIteratorYieldsCookiesKeyedByName(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate', 'size' => 'medium']);
+
+        $result = [];
+        foreach ($store as $name => $cookie) {
+            $result[$name] = $cookie->getValue();
+        }
+
+        $this->assertSame(['flavor' => 'chocolate', 'size' => 'medium'], $result);
+    }
+
+    public function testFromArrayAcceptsTraversable(): void
+    {
+        $generator = (static function () {
+            yield 'flavor' => 'chocolate';
+            yield 'size' => 'medium';
+        })();
+
+        $store = CookieStore::fromArray($generator);
+
+        $this->assertCount(2, $store);
+        $this->assertSame('chocolate', $store->getCookie('flavor')->getValue());
+    }
+
+    public function testConstructorAcceptsTraversable(): void
+    {
+        $generator = (static function () {
+            yield new Cookie('flavor', 'chocolate');
+            yield new Cookie('size', 'medium');
+        })();
+
+        $store = new CookieStore($generator);
+
+        $this->assertCount(2, $store);
+        $this->assertSame('medium', $store->getCookie('size')->getValue());
+    }
+
+    public function testToStringUsableAsHeaderValue(): void
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate', 'size' => 'medium']);
+
+        // Simulate what HttpClientTrait::normalizeHeaders does with a Stringable
+        $headerValue = (string) $store;
+
+        $this->assertSame('flavor=chocolate; size=medium', $headerValue);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/Cookie/CookieTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Cookie/CookieTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Cookie;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Cookie\Cookie;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+
+class CookieTest extends TestCase
+{
+    public function testConstructorAndGetters(): void
+    {
+        $cookie = new Cookie('flavor', 'chocolate');
+
+        $this->assertSame('flavor', $cookie->getName());
+        $this->assertSame('chocolate', $cookie->getValue());
+    }
+
+    public function testDefaultValueIsEmpty(): void
+    {
+        $cookie = new Cookie('session');
+
+        $this->assertSame('', $cookie->getValue());
+    }
+
+    public function testToString(): void
+    {
+        $cookie = new Cookie('flavor', 'chocolate');
+
+        $this->assertSame('flavor=chocolate', (string) $cookie);
+    }
+
+    public function testToStringWithEmptyValue(): void
+    {
+        $this->assertSame('session=', (string) new Cookie('session'));
+    }
+
+    public function testFromString(): void
+    {
+        $cookie = Cookie::fromString('flavor=chocolate');
+
+        $this->assertSame('flavor', $cookie->getName());
+        $this->assertSame('chocolate', $cookie->getValue());
+    }
+
+    public function testFromStringWithSpaces(): void
+    {
+        $cookie = Cookie::fromString('  flavor = chocolate  ');
+
+        $this->assertSame('flavor', $cookie->getName());
+        $this->assertSame('chocolate', $cookie->getValue());
+    }
+
+    public function testFromStringWithEqualsInValue(): void
+    {
+        $cookie = Cookie::fromString('token=abc=def==');
+
+        $this->assertSame('token', $cookie->getName());
+        $this->assertSame('abc=def==', $cookie->getValue());
+    }
+
+    public function testEmptyNameThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cookie name cannot be empty');
+
+        new Cookie('');
+    }
+
+    public function testInvalidNameCharactersThrow(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('illegal characters');
+
+        new Cookie('bad name');
+    }
+
+    public function testInvalidNameWithSemicolon(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Cookie('bad;name');
+    }
+
+    /**
+     * @dataProvider provideInvalidCookieNames
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvalidCookieNames')]
+    public function testInvalidCookieNameThrows(string $name): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Cookie($name);
+    }
+
+    public static function provideInvalidCookieNames(): iterable
+    {
+        yield 'space' => ['bad name'];
+        yield 'semicolon' => ['bad;name'];
+        yield 'double-quote' => ['bad"name'];
+        yield 'slash' => ['bad/name'];
+        yield 'colon' => ['bad:name'];
+        yield 'equals' => ['bad=name'];
+        yield 'at-sign' => ['bad@name'];
+        yield 'backslash' => ['bad\\name'];
+        yield 'open-bracket' => ['bad[name'];
+        yield 'open-paren' => ['bad(name'];
+        yield 'DEL (0x7F)' => ["bad\x7fname"];
+        // CTLs that were previously not caught (0x01–0x08, 0x0B, 0x0C, 0x0E–0x1F)
+        yield 'CTL 0x01' => ["\x01name"];
+        yield 'CTL 0x08 (BS)' => ["\x08name"];
+        yield 'CTL 0x0B (VT)' => ["\x0Bname"];
+        yield 'CTL 0x0C (FF)' => ["\x0Cname"];
+        yield 'CTL 0x0E (SO)' => ["\x0Ename"];
+        yield 'CTL 0x1F (US)' => ["\x1Fname"];
+    }
+
+    public function testGetIllegalNameCharactersReturnsSameInstance(): void
+    {
+        $this->assertSame(Cookie::getIllegalNameCharacters(), Cookie::getIllegalNameCharacters());
+    }
+
+    public function testGetIllegalNameCharactersCoversFullCTLRange(): void
+    {
+        $illegal = Cookie::getIllegalNameCharacters();
+
+        // All CTLs 0–31 must be present
+        for ($i = 0; $i <= 31; ++$i) {
+            $this->assertStringContainsString(chr($i), $illegal, \sprintf('CTL 0x%02X must be illegal', $i));
+        }
+
+        // Space and DEL
+        $this->assertStringContainsString(' ', $illegal);
+        $this->assertStringContainsString("\x7F", $illegal);
+
+        // Key separators
+        foreach (['"', '(', ')', ',', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '{', '}'] as $sep) {
+            $this->assertStringContainsString($sep, $illegal, \sprintf('Separator "%s" must be illegal', $sep));
+        }
+    }
+
+    public function testInvalidValueWithCrLfThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Cookie('name', "value\r\n");
+    }
+
+    /**
+     * @dataProvider provideValidCookieValues
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideValidCookieValues')]
+    public function testValidCookieValue(string $value): void
+    {
+        $cookie = new Cookie('name', $value);
+        $this->assertSame($value, $cookie->getValue());
+    }
+
+    public static function provideValidCookieValues(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'simple word' => ['chocolate'];
+        yield 'digits' => ['12345'];
+        yield 'base64 chars' => ['abc+def/ghi='];
+        yield 'url-encoded' => ['hello%20world'];
+        yield 'equals sign in value' => ['abc=def=='];
+        yield 'printable specials' => ['!#$%&\'()*+-./:'];
+        yield 'angle brackets and query' => ['<=>?@'];
+        yield 'brackets and tilde' => ['[]^_`{|}~'];
+        yield 'long value' => [str_repeat('a', 4096)];
+    }
+
+    /**
+     * @dataProvider provideInvalidCookieValues
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvalidCookieValues')]
+    public function testInvalidCookieValueThrows(string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Cookie('name', $value);
+    }
+
+    public static function provideInvalidCookieValues(): iterable
+    {
+        yield 'semicolon' => ['foo;bar'];
+        yield 'space' => ['foo bar'];
+        yield 'comma' => ['foo,bar'];
+        yield 'backslash' => ['foo\\bar'];
+        yield 'double-quote' => ['foo"bar'];
+        yield 'CR' => ["foo\rbar"];
+        yield 'LF' => ["foo\nbar"];
+        yield 'NUL' => ["foo\0bar"];
+        yield 'tab' => ["foo\tbar"];
+        yield 'DEL (0x7F)' => ["foo\x7Fbar"];
+        yield 'non-ASCII byte' => ["\xC3\xA9"]; // UTF-8 "é"
+        yield 'control char 0x01' => ["\x01"];
+        yield 'control char 0x1F' => ["\x1F"];
+    }
+
+    public function testGetIllegalValueCharactersReturnsSameInstance(): void
+    {
+        $this->assertSame(Cookie::getIllegalValueCharacters(), Cookie::getIllegalValueCharacters());
+    }
+
+    public function testGetIllegalValueCharactersCoversAllInvalidChars(): void
+    {
+        $illegal = Cookie::getIllegalValueCharacters();
+
+        // All CTLs 0–31 and space must be present
+        for ($i = 0; $i <= 32; ++$i) {
+            $this->assertStringContainsString(chr($i), $illegal, \sprintf('CTL 0x%02X must be illegal in values', $i));
+        }
+
+        // Specific separators illegal in values
+        foreach (['"', ',', ';', '\\'] as $sep) {
+            $this->assertStringContainsString($sep, $illegal, \sprintf('"%s" must be illegal in values', $sep));
+        }
+
+        // DEL
+        $this->assertStringContainsString("\x7F", $illegal);
+
+        // Non-ASCII spot checks
+        $this->assertStringContainsString("\x80", $illegal);
+        $this->assertStringContainsString("\xFF", $illegal);
+    }
+
+    public function testImplementsStringable(): void
+    {
+        $this->assertInstanceOf(\Stringable::class, new Cookie('name', 'value'));
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Cookie\CookieStore;
 use Symfony\Component\HttpClient\HttpOptions;
 
 /**
@@ -53,5 +54,24 @@ class HttpOptionsTest extends TestCase
     public function testSetMaxConnectDuration()
     {
         $this->assertSame(5.0, (new HttpOptions())->setMaxConnectDuration(5.0)->toArray()['max_connect_duration']);
+    }
+
+    public function testSetCookiesWithString()
+    {
+        $options = (new HttpOptions())->setCookies('flavor=chocolate; size=medium');
+        $this->assertSame('flavor=chocolate; size=medium', $options->toArray()['cookies']);
+    }
+
+    public function testSetCookiesWithArray()
+    {
+        $options = (new HttpOptions())->setCookies(['flavor' => 'chocolate', 'size' => 'medium']);
+        $this->assertSame(['flavor' => 'chocolate', 'size' => 'medium'], $options->toArray()['cookies']);
+    }
+
+    public function testSetCookiesWithCookieStore()
+    {
+        $store = CookieStore::fromArray(['flavor' => 'chocolate']);
+        $options = (new HttpOptions())->setCookies($store);
+        $this->assertSame($store, $options->toArray()['cookies']);
     }
 }

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -30,6 +30,12 @@ interface HttpClientInterface
         'auth_basic' => null,
         // string - a token enabling HTTP Bearer authorization (RFC 6750)
         'auth_bearer' => null,
+        // CookieStoreInterface|array|string - cookies to send with the request; if a
+        //   CookieStoreInterface or array is provided, it is serialized as "name=value" pairs;
+        //   alternatively, cookies can still be passed via the "headers" option using the "Cookie" key.
+        // If both "cookies" and "headers" options provide Cookie data, the "cookies" option takes
+        // precedence and overrides any Cookie header set via the "headers" option
+        'cookies' => null,
         // string[] - associative array of query string values to merge with the request's URL
         'query' => [],
         // iterable|string[]|string[][] - headers names provided as keys or as part of values


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63637 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Add `CookieStore` and `Cookie` classes for proper cookie management in HttpClient

This is a work in progress