### PR TITLE
[Finder] Don't use a fixed date fixture with relative-time assertions

### DIFF
--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -63,8 +63,8 @@ abstract class RealIteratorTestCase extends IteratorTestCase
         file_put_contents(self::toAbsolute('test.php'), str_repeat(' ', 800));
         file_put_contents(self::toAbsolute('test.py'), str_repeat(' ', 2000));
 
-        touch(self::toAbsolute('foo/bar.tmp'), strtotime('2005-10-15'));
-        touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
+        touch(self::toAbsolute('foo/bar.tmp'), strtotime('-19 years'));
+        touch(self::toAbsolute('test.php'), strtotime('-19 years'));
     }
 
     public static function tearDownAfterClass(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Finder tests use relative date assertions in `DateRangeFilterIteratorTest`, but the fixture timestamps in `RealIteratorTestCase` are fixed to `2005-10-15`.

As time moves forward, those fixtures fall outside the `since 20 years ago` window and make the test fail. Use a relative fixture date instead so the test stays older than `last month` while remaining within the 20-year range.
