### PR TITLE
[WebProfilerBundle] Only decrement pendingRequests when it's more than zero

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -247,7 +247,10 @@
                         }
                     }
 
-                    pendingRequests--;
+                    if (pendingRequests > 0) {
+                        pendingRequests--;
+                    }
+
                     var row = request.DOMNode;
                     /* Unpack the children from the row */
                     var profilerCell = row.children[1];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63667 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

This PR fixes the linked issue by ensuring the `pendingRequests` variable never goes below zero.