### PR TITLE
[TwigBridge] Fix image method to use DataPart content ID

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -47,9 +47,10 @@ final class WrappedTemplatedEmail
     {
         $file = $this->twig->getLoader()->getSourceContext($image);
         $body = $file->getPath() ? new File($file->getPath()) : $file->getCode();
-        $this->message->addPart((new DataPart($body, $image, $contentType))->asInline());
+        $dataPart = (new DataPart($body, $image, $contentType))->asInline();
+        $this->message->addPart($dataPart);
 
-        return 'cid:'.$image;
+        return 'cid:'.$dataPart->getContentId();
     }
 
     /**

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -141,7 +141,7 @@ class DataPart extends TextPart
         }
         $this->_headers = $this->getHeaders();
 
-        return ['_headers', '_parent', 'filename', 'mediaType'];
+        return ['_headers', '_parent', 'filename', 'mediaType', 'cid'];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63677
| License       | MIT

This fixes an issue in `WrappedTemplatedEmail::image()` when embedding inline images in twig template.
The method created a `DataPart`, added it to the message and then returned the CID obtained from the created object.

With this fix, the generated cid: reference correctly resolves to the embedded inline image. This is necessary to fix problems with not showing inline images in the Gmail and M365.