### PR TITLE
[Process] Widen the type of `Process::$commandline`

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -66,7 +66,7 @@ class Process implements \IteratorAggregate
 
     /** @var \Closure('out'|'err', string):bool|null */
     private ?\Closure $callback = null;
-    /** @var list<string>|string */
+    /** @var string[]|string */
     private array|string $commandline;
     private ?string $cwd;
     /** @var EnvArray */
@@ -151,7 +151,7 @@ class Process implements \IteratorAggregate
     ];
 
     /**
-     * @param list<string>   $command The command to run and its arguments listed as separate entries
+     * @param string[]       $command The command to run and its arguments listed as separate entries
      * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
      * @param EnvArray|null  $env     The environment variables or null to use the same environment as the current PHP process
      * @param mixed          $input   The input as stream resource, scalar or \Traversable, or null for no input


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follows #62343
| License       | MIT

In #62343, we've narrowed the type of of the `$command` array that needs to be passed to the constructor of `Process` to `list<string>`. However, when processing that array, we pipe it through `array_values()` anyway.

This change created some unnecessary busywork in a codebase I'm working on because that codebase didn't fully ensure that the arrays passed to `Process` is actually a list. I'd like to widen the type to `string[]`.