### PR TITLE
[Routing] Allow collection prefixes to disable trailing slash on root

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add a `$trailingSlashOnRoot` argument to `CollectionConfigurator::prefix()` to allow disabling the trailing slash on root routes
+
 8.0
 ---
 

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -21,9 +21,11 @@ class CollectionConfigurator
 {
     use Traits\AddTrait;
     use Traits\HostTrait;
+    use Traits\PrefixTrait;
     use Traits\RouteTrait;
 
     private string|array|null $host = null;
+    private bool $trailingSlashOnRoot = true;
 
     public function __construct(
         private RouteCollection $parent,
@@ -49,7 +51,7 @@ class CollectionConfigurator
     public function __destruct()
     {
         if (null === $this->prefixes) {
-            $this->collection->addPrefix($this->route->getPath());
+            $this->addPrefix($this->collection, $this->route->getPath(), $this->trailingSlashOnRoot);
         }
         if (null !== $this->host) {
             $this->addHost($this->collection, $this->host);
@@ -73,8 +75,10 @@ class CollectionConfigurator
      *
      * @return $this
      */
-    final public function prefix(string|array $prefix): static
+    final public function prefix(string|array $prefix, bool $trailingSlashOnRoot = true): static
     {
+        $this->trailingSlashOnRoot = $trailingSlashOnRoot;
+
         if (\is_array($prefix)) {
             if (null === $this->parentPrefixes) {
                 // no-op
@@ -118,6 +122,16 @@ class CollectionConfigurator
      */
     private function createRoute(string $path): Route
     {
+        if (!$this->trailingSlashOnRoot && null !== $this->prefixes) {
+            foreach ($this->prefixes as $prefix) {
+                if ($path === $prefix.'/') {
+                    $path = $prefix;
+
+                    break;
+                }
+            }
+        }
+
         return (clone $this->route)->setPath($path);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_collection_localized_prefix_no_trailing_slash.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_collection_localized_prefix_no_trailing_slash.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $sub = $routes->collection('c_')->prefix(['en' => '/categories', 'fr' => '/categorias'], false);
+
+    $sub->add('slash', '/');
+    $sub->add('show', '/{id}');
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_collection_prefix_no_trailing_slash.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_collection_prefix_no_trailing_slash.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $sub = $routes->collection('c_')->prefix('/categories', false);
+
+    $sub->add('slash', '/');
+    $sub->add('empty', '');
+    $sub->add('show', '/{id}');
+};

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -281,6 +281,37 @@ class PhpFileLoaderTest extends TestCase
         $this->assertEquals($expectedCollection, $routeCollection);
     }
 
+    public function testCollectionPrefixCanDisableTrailingSlashOnRoot()
+    {
+        $locator = new FileLocator([__DIR__.'/../Fixtures']);
+        $loader = new PhpFileLoader($locator);
+        $routeCollection = $loader->load('php_dsl_collection_prefix_no_trailing_slash.php');
+
+        $expectedCollection = new RouteCollection();
+        $expectedCollection->add('c_slash', new Route('/categories'));
+        $expectedCollection->add('c_empty', new Route('/categories'));
+        $expectedCollection->add('c_show', new Route('/categories/{id}'));
+        $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_collection_prefix_no_trailing_slash.php')));
+
+        $this->assertEquals($expectedCollection, $routeCollection);
+    }
+
+    public function testCollectionLocalizedPrefixCanDisableTrailingSlashOnRoot()
+    {
+        $locator = new FileLocator([__DIR__.'/../Fixtures']);
+        $loader = new PhpFileLoader($locator);
+        $routeCollection = $loader->load('php_dsl_collection_localized_prefix_no_trailing_slash.php');
+
+        $expectedCollection = new RouteCollection();
+        $expectedCollection->add('c_slash.en', (new Route('/categories'))->setDefaults(['_locale' => 'en', '_canonical_route' => 'c_slash'])->setRequirement('_locale', 'en'));
+        $expectedCollection->add('c_slash.fr', (new Route('/categorias'))->setDefaults(['_locale' => 'fr', '_canonical_route' => 'c_slash'])->setRequirement('_locale', 'fr'));
+        $expectedCollection->add('c_show.en', (new Route('/categories/{id}'))->setDefaults(['_locale' => 'en', '_canonical_route' => 'c_show'])->setRequirement('_locale', 'en'));
+        $expectedCollection->add('c_show.fr', (new Route('/categorias/{id}'))->setDefaults(['_locale' => 'fr', '_canonical_route' => 'c_show'])->setRequirement('_locale', 'fr'));
+        $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_collection_localized_prefix_no_trailing_slash.php')));
+
+        $this->assertEquals($expectedCollection, $routeCollection);
+    }
+
     public function testImportingRoutesWithHostsInImporter()
     {
         $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63267
| License       | MIT

Adding a prefix to a collection in the PHP DSL always appends a trailing slash to root routes (path `/` or `''`), so `/categories/` cannot be expressed as `/categories`. The XML/YAML loaders and `ImportConfigurator::prefix()` already expose a `trailing_slash_on_root` option for this; this PR extends the same option to `CollectionConfigurator::prefix()`:

```php
$routes->collection('cat.')
    ->prefix('/categories', trailingSlashOnRoot: false)
    ->add('index', '/')
    ->add('show', '/{id}');
```

produces `cat.index → /categories` and `cat.show → /categories/{id}` instead of `/categories/` and `/categories/{id}`.

Localized prefixes are supported too:

```php
$routes->collection('cat.')
    ->prefix(['en' => '/categories', 'fr' => '/categorias'], trailingSlashOnRoot: false)
    ->add('index', '/');
```

The default remains `true`, so existing behavior is preserved.