### PR TITLE
[FrameworkBundle][HttpFoundation] Add command to purge session data

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
 ---
 
  * Add `framework.validation.property_metadata_existence_check` config option
+ * Add the `session:clear` command to remove all sessions from the configured handler
  * Deprecate `json_streamer.value_transformer.date_time_to_string` and `json_streamer.value_transformer.string_to_date_time` services, date times are handled as value objects
  * Deprecate `json_streamer.value_transformer` tag, use `json_streamer.property_value_transformer` instead
  * Add `marshaller` option to cache pool configuration to allow per-pool marshaller services

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SessionClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SessionClearCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\ClearableSessionHandlerInterface;
+
+/**
+ * Command to clear all session data.
+ *
+ * @author Julien Robic <nayte91@gmail.com>
+ */
+#[AsCommand(name: 'session:clear', description: 'Clear all session data')]
+final class SessionClearCommand extends Command
+{
+    public function __construct(
+        private \SessionHandlerInterface $sessionHandler,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Do not ask for confirmation')
+            ->setHelp(<<<'EOF'
+                The <info>%command.name%</info> command clears all session data from the storage.
+
+                    %command.full_name%
+
+                This will clear all active sessions. Use the <info>--force</info> option to skip confirmation:
+
+                    %command.full_name% --force
+                EOF
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->sessionHandler instanceof ClearableSessionHandlerInterface) {
+            $io->error(\sprintf('The session handler "%s" does not support clearing sessions. It must implement "%s".', get_debug_type($this->sessionHandler), ClearableSessionHandlerInterface::class));
+
+            return Command::FAILURE;
+        }
+
+        if ($input->isInteractive() && !$input->getOption('force') && !$io->confirm('This will clear all active sessions, including e.g. carts of anonymous users. Do you want to continue?', false)) {
+            return Command::SUCCESS;
+        }
+
+        try {
+            $this->sessionHandler->clear();
+        } catch (\LogicException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success('All sessions have been cleared.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\FrameworkBundle\Command\SessionClearCommand;
 use Symfony\Component\HttpFoundation\Session\SessionFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\IdentityMarshaller;
@@ -109,5 +110,11 @@ return static function (ContainerConfigurator $container) {
                 service('session.marshalling_handler.inner'),
                 service('session.marshaller'),
             ])
+
+        ->set('console.command.session_clear', SessionClearCommand::class)
+            ->args([
+                service('session.handler'),
+            ])
+            ->tag('console.command')
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SessionClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SessionClearCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\SessionClearCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\ClearableSessionHandlerInterface;
+
+abstract class ClearableSessionHandler implements \SessionHandlerInterface, ClearableSessionHandlerInterface
+{
+}
+
+class SessionClearCommandTest extends TestCase
+{
+    public function testClearSucceeds()
+    {
+        $handler = $this->createMock(ClearableSessionHandler::class);
+        $handler->expects($this->once())->method('clear');
+
+        $tester = new CommandTester(new SessionClearCommand($handler));
+        $statusCode = $tester->execute(['--force' => true]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertStringContainsString('cleared', $tester->getDisplay());
+    }
+
+    public function testUnsupportedHandler()
+    {
+        $handler = $this->createStub(\SessionHandlerInterface::class);
+
+        $tester = new CommandTester(new SessionClearCommand($handler));
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(1, $statusCode);
+        $this->assertStringContainsString('[ERROR]', $tester->getDisplay());
+    }
+
+    public function testLogicExceptionIsHandled()
+    {
+        $handler = $this->createMock(ClearableSessionHandler::class);
+        $handler->expects($this->once())
+            ->method('clear')
+            ->willThrowException(new \LogicException('Handler cannot clear sessions in this state.'));
+
+        $tester = new CommandTester(new SessionClearCommand($handler));
+        $statusCode = $tester->execute(['--force' => true]);
+
+        $this->assertSame(1, $statusCode);
+        $this->assertStringContainsString('Handler cannot clear sessions in this state.', $tester->getDisplay());
+    }
+
+    public function testForceSkipsConfirmation()
+    {
+        $handler = $this->createMock(ClearableSessionHandler::class);
+        $handler->expects($this->once())->method('clear');
+
+        $tester = new CommandTester(new SessionClearCommand($handler));
+        $tester->execute(['--force' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testInteractiveConfirmationDeclinedSkipsClearing()
+    {
+        $handler = $this->createMock(ClearableSessionHandler::class);
+        $handler->expects($this->never())->method('clear');
+
+        $tester = new CommandTester(new SessionClearCommand($handler));
+        $tester->setInputs(['no']);
+        $statusCode = $tester->execute([], ['interactive' => true]);
+
+        $this->assertSame(0, $statusCode);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `ClearableSessionHandlerInterface` for clearing all session data
  * Add `BinaryFileResponse::shouldDeleteFileAfterSend()`
  * Deprecate setting public properties of `Request` and `Response` objects directly; use setters or constructor arguments instead
  * Add `SessionHasFlashMessage` test constraint

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/ClearableSessionHandlerInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/ClearableSessionHandlerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+/** @author Julien Robic <nayte91@gmail.com> */
+interface ClearableSessionHandlerInterface
+{
+    /** Removes all sessions from the storage. */
+    public function clear(): void;
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
@@ -16,7 +16,7 @@ use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 /**
  * @author Ahmed TAILOULOUTE <ahmed.tailouloute@gmail.com>
  */
-class MarshallingSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
+class MarshallingSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface, ClearableSessionHandlerInterface
 {
     public function __construct(
         private AbstractSessionHandler $handler,
@@ -69,5 +69,16 @@ class MarshallingSessionHandler implements \SessionHandlerInterface, \SessionUpd
     public function updateTimestamp(#[\SensitiveParameter] string $sessionId, string $data): bool
     {
         return $this->handler->updateTimestamp($sessionId, $data);
+    }
+
+    public function clear(): void
+    {
+        if ($this->handler instanceof ClearableSessionHandlerInterface) {
+            $this->handler->clear();
+
+            return;
+        }
+
+        throw new \LogicException(\sprintf('The session handler "%s" does not support clearing all sessions.', get_debug_type($this->handler)));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  * @author Ross Motley <ross.motley@amara.com>
  * @author Oliver Radwell <oliver.radwell@amara.com>
  */
-class MigratingSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
+class MigratingSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface, ClearableSessionHandlerInterface
 {
     private \SessionHandlerInterface&\SessionUpdateTimestampHandlerInterface $currentHandler;
     private \SessionHandlerInterface&\SessionUpdateTimestampHandlerInterface $writeOnlyHandler;
@@ -96,5 +96,18 @@ class MigratingSessionHandler implements \SessionHandlerInterface, \SessionUpdat
         $this->writeOnlyHandler->updateTimestamp($sessionId, $sessionData);
 
         return $result;
+    }
+
+    public function clear(): void
+    {
+        if ($this->currentHandler instanceof ClearableSessionHandlerInterface) {
+            $this->currentHandler->clear();
+        } else {
+            throw new \LogicException(\sprintf('The session handler "%s" does not support clearing all sessions.', get_debug_type($this->currentHandler)));
+        }
+
+        if ($this->writeOnlyHandler instanceof ClearableSessionHandlerInterface) {
+            $this->writeOnlyHandler->clear();
+        }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -26,7 +26,7 @@ use MongoDB\Driver\Query;
  *
  * @see https://php.net/mongodb
  */
-class MongoDbSessionHandler extends AbstractSessionHandler
+class MongoDbSessionHandler extends AbstractSessionHandler implements ClearableSessionHandlerInterface
 {
     private Manager $manager;
     private string $namespace;
@@ -177,6 +177,13 @@ class MongoDbSessionHandler extends AbstractSessionHandler
 
         // Not found
         return '';
+    }
+
+    public function clear(): void
+    {
+        $write = new BulkWrite();
+        $write->delete([]);
+        $this->manager->executeBulkWrite($this->namespace, $write);
     }
 
     private function getUTCDateTime(int $additionalSeconds = 0): UTCDateTime

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -16,8 +16,11 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  *
  * @author Drak <drak@zikula.org>
  */
-class NativeFileSessionHandler extends \SessionHandler
+class NativeFileSessionHandler extends \SessionHandler implements ClearableSessionHandlerInterface
 {
+    // the prefix is hardcoded by PHP's files save handler; session.name only renames the cookie
+    private const SESSION_FILE_PREFIX = 'sess_';
+
     /**
      * @param string|null $savePath Path of directory to save session files
      *                              Default null will leave setting as defined by PHP.
@@ -50,6 +53,21 @@ class NativeFileSessionHandler extends \SessionHandler
         }
         if ('files' !== \ini_get('session.save_handler')) {
             ini_set('session.save_handler', 'files');
+        }
+    }
+
+    public function clear(): void
+    {
+        $savePath = \ini_get('session.save_path');
+        if (str_contains($savePath, ';')) {
+            $savePath = ltrim(strrchr($savePath, ';'), ';');
+        }
+
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($savePath, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::LEAVES_ONLY);
+        foreach ($files as $file) {
+            if (str_starts_with($file->getFilename(), self::SESSION_FILE_PREFIX)) {
+                unlink($file->getRealPath());
+            }
         }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NullSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NullSessionHandler.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  *
  * @author Drak <drak@zikula.org>
  */
-class NullSessionHandler extends AbstractSessionHandler
+class NullSessionHandler extends AbstractSessionHandler implements ClearableSessionHandlerInterface
 {
     public function close(): bool
     {
@@ -51,5 +51,9 @@ class NullSessionHandler extends AbstractSessionHandler
     public function gc(int $maxlifetime): int|false
     {
         return 0;
+    }
+
+    public function clear(): void
+    {
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -47,7 +47,7 @@ use Doctrine\DBAL\Types\Types;
  * @author Michael Williams <michael.williams@funsational.com>
  * @author Tobias Schultze <http://tobion.de>
  */
-class PdoSessionHandler extends AbstractSessionHandler
+class PdoSessionHandler extends AbstractSessionHandler implements ClearableSessionHandlerInterface
 {
     /**
      * No locking is done. This means sessions are prone to loss of data due to
@@ -976,6 +976,11 @@ class PdoSessionHandler extends AbstractSessionHandler
     /**
      * Return a PDO instance.
      */
+    public function clear(): void
+    {
+        $this->getConnection()->exec("DELETE FROM $this->table");
+    }
+
     protected function getConnection(): \PDO
     {
         if (!isset($this->pdo)) {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -20,7 +20,7 @@ use Relay\Relay;
  *
  * @author Dalibor Karlović <dalibor@flexolabs.io>
  */
-class RedisSessionHandler extends AbstractSessionHandler
+class RedisSessionHandler extends AbstractSessionHandler implements ClearableSessionHandlerInterface
 {
     /**
      * Key prefix for shared environments.
@@ -99,5 +99,57 @@ class RedisSessionHandler extends AbstractSessionHandler
         $ttl = ($this->ttl instanceof \Closure ? ($this->ttl)() : $this->ttl) ?? \ini_get('session.gc_maxlifetime');
 
         return $this->redis->expire($this->prefix.$sessionId, (int) $ttl);
+    }
+
+    public function clear(): void
+    {
+        if ($this->redis instanceof \Predis\ClientInterface) {
+            $cursor = 0;
+            do {
+                [$cursor, $keys] = $this->redis->scan($cursor, 'MATCH', $this->prefix.'*', 'COUNT', 1000);
+                if ($keys) {
+                    $this->redis->del($keys);
+                }
+            } while ($cursor);
+
+            return;
+        }
+
+        if ($this->redis instanceof \RedisCluster) {
+            foreach ($this->redis->_masters() as $master) {
+                $cursor = null;
+                do {
+                    $keys = $this->redis->scan($cursor, $master, $this->prefix.'*', 1000);
+                    if ($keys) {
+                        $this->redis->del(...$keys);
+                    }
+                } while ($cursor);
+            }
+
+            return;
+        }
+
+        if ($this->redis instanceof \RedisArray) {
+            foreach ($this->redis->_hosts() as $host) {
+                $instance = $this->redis->_instance($host);
+                $cursor = null;
+                do {
+                    $keys = $instance->scan($cursor, $this->prefix.'*', 1000);
+                    if ($keys) {
+                        $instance->del(...$keys);
+                    }
+                } while ($cursor);
+            }
+
+            return;
+        }
+
+        $cursor = null;
+        do {
+            $keys = $this->redis->scan($cursor, $this->prefix.'*', 1000);
+            if ($keys) {
+                $this->redis->del(...$keys);
+            }
+        } while ($cursor);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/StrictSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/StrictSessionHandler.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class StrictSessionHandler extends AbstractSessionHandler
+class StrictSessionHandler extends AbstractSessionHandler implements ClearableSessionHandlerInterface
 {
     private bool $doDestroy;
 
@@ -83,5 +83,16 @@ class StrictSessionHandler extends AbstractSessionHandler
     public function gc(int $maxlifetime): int|false
     {
         return $this->handler->gc($maxlifetime);
+    }
+
+    public function clear(): void
+    {
+        if ($this->handler instanceof ClearableSessionHandlerInterface) {
+            $this->handler->clear();
+
+            return;
+        }
+
+        throw new \LogicException(\sprintf('The session handler "%s" does not support clearing all sessions.', get_debug_type($this->handler)));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
@@ -11,11 +11,17 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\ClearableSessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MarshallingSessionHandler;
+
+abstract class ClearableAbstractSessionHandler extends AbstractSessionHandler implements ClearableSessionHandlerInterface
+{
+}
 
 /**
  * @author Ahmed TAILOULOUTE <ahmed.tailouloute@gmail.com>
@@ -117,5 +123,25 @@ class MarshallingSessionHandlerTest extends TestCase
             ->with('session_id', 'data')->willReturn(true);
 
         $marshallingSessionHandler->updateTimestamp('session_id', 'data');
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testClearForwardsToInnerHandler()
+    {
+        $clearableHandler = $this->createMock(ClearableAbstractSessionHandler::class);
+        $clearableHandler->expects($this->once())->method('clear');
+        $marshallingSessionHandler = new MarshallingSessionHandler($clearableHandler, $this->createStub(MarshallerInterface::class));
+
+        $marshallingSessionHandler->clear();
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testClearThrowsWhenInnerHandlerNotClearable()
+    {
+        $nonClearableHandler = $this->createStub(AbstractSessionHandler::class);
+        $marshallingSessionHandler = new MarshallingSessionHandler($nonClearableHandler, $this->createStub(MarshallerInterface::class));
+
+        $this->expectException(\LogicException::class);
+        $marshallingSessionHandler->clear();
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
@@ -12,7 +12,16 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\ClearableSessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MigratingSessionHandler;
+
+abstract class ClearableSessionHandlerAndTimestamp implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface, ClearableSessionHandlerInterface
+{
+}
+
+abstract class NonClearableSessionHandlerWithTimestamp implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
+{
+}
 
 class MigratingSessionHandlerTest extends TestCase
 {
@@ -195,5 +204,39 @@ class MigratingSessionHandlerTest extends TestCase
         $result = $dualHandler->updateTimestamp($sessionId, $data);
 
         $this->assertTrue($result);
+    }
+
+    public function testClearCallsBothHandlersWhenBothAreClearable()
+    {
+        $currentHandler = $this->createMock(ClearableSessionHandlerAndTimestamp::class);
+        $currentHandler->expects($this->once())->method('clear');
+
+        $writeOnlyHandler = $this->createMock(ClearableSessionHandlerAndTimestamp::class);
+        $writeOnlyHandler->expects($this->once())->method('clear');
+
+        $dualHandler = new MigratingSessionHandler($currentHandler, $writeOnlyHandler);
+        $dualHandler->clear();
+    }
+
+    public function testClearCallsOnlyCurrentHandlerWhenWriteOnlyHandlerNotClearable()
+    {
+        $currentHandler = $this->createMock(ClearableSessionHandlerAndTimestamp::class);
+        $currentHandler->expects($this->once())->method('clear');
+
+        $writeOnlyHandler = $this->createStub(NonClearableSessionHandlerWithTimestamp::class);
+
+        $dualHandler = new MigratingSessionHandler($currentHandler, $writeOnlyHandler);
+        $dualHandler->clear();
+    }
+
+    public function testClearThrowsWhenCurrentHandlerNotClearable()
+    {
+        $currentHandler = $this->createStub(NonClearableSessionHandlerWithTimestamp::class);
+        $writeOnlyHandler = $this->createStub(NonClearableSessionHandlerWithTimestamp::class);
+
+        $dualHandler = new MigratingSessionHandler($currentHandler, $writeOnlyHandler);
+
+        $this->expectException(\LogicException::class);
+        $dualHandler->clear();
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -71,4 +71,24 @@ class NativeFileSessionHandlerTest extends TestCase
 
         $this->assertEquals($path, \ini_get('session.save_path'));
     }
+
+    public function testClearDeletesSessionFiles()
+    {
+        $savePath = sys_get_temp_dir().'/sf_session_clear_test_'.uniqid('', true);
+        mkdir($savePath, 0o777, true);
+
+        touch($savePath.'/sess_abc123');
+        touch($savePath.'/sess_def456');
+        touch($savePath.'/not_a_session.txt');
+
+        $handler = new NativeFileSessionHandler($savePath);
+        $handler->clear();
+
+        $this->assertFileDoesNotExist($savePath.'/sess_abc123');
+        $this->assertFileDoesNotExist($savePath.'/sess_def456');
+        $this->assertFileExists($savePath.'/not_a_session.txt');
+
+        unlink($savePath.'/not_a_session.txt');
+        rmdir($savePath);
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -426,6 +426,25 @@ class PdoSessionHandlerTest extends TestCase
         $this->assertSame('test_data', stream_get_contents($boundData[6]['data']));
     }
 
+    public function testClear()
+    {
+        $pdo = $this->getMemorySqlitePdo();
+        $storage = new PdoSessionHandler($pdo);
+
+        $storage->open('', 'sid');
+        $storage->write('id1', 'data1');
+        $storage->write('id2', 'data2');
+        $storage->close();
+
+        $countBefore = (int) $pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn();
+        $this->assertSame(2, $countBefore);
+
+        $storage->clear();
+
+        $countAfter = (int) $pdo->query('SELECT COUNT(*) FROM sessions')->fetchColumn();
+        $this->assertSame(0, $countAfter);
+    }
+
     /**
      * @return resource
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
@@ -13,7 +13,12 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\ClearableSessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
+
+abstract class ClearableInnerSessionHandler implements \SessionHandlerInterface, ClearableSessionHandlerInterface
+{
+}
 
 class StrictSessionHandlerTest extends TestCase
 {
@@ -200,5 +205,23 @@ class StrictSessionHandlerTest extends TestCase
         $proxy = new StrictSessionHandler($handler);
 
         $this->assertSame(1, $proxy->gc(123));
+    }
+
+    public function testClearForwardsToInnerHandler()
+    {
+        $handler = $this->createMock(ClearableInnerSessionHandler::class);
+        $handler->expects($this->once())->method('clear');
+        $proxy = new StrictSessionHandler($handler);
+
+        $proxy->clear();
+    }
+
+    public function testClearThrowsWhenInnerHandlerNotClearable()
+    {
+        $handler = $this->createStub(\SessionHandlerInterface::class);
+        $proxy = new StrictSessionHandler($handler);
+
+        $this->expectException(\LogicException::class);
+        $proxy->clear();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Adds a `session:clear` command that removes every session from the configured handler, for resetting state during development and for invalidating all sessions at once in operations, e.g. after a credential leak.

```
$ php bin/console session:clear

This will clear all active sessions, including e.g. carts of anonymous users. Do you want to continue? (yes/no) [no]:
```

`--force` skips the confirmation for non-interactive use.

The capability lives in HttpFoundation as `ClearableSessionHandlerInterface::clear()`, implemented by the file, Redis (all four client flavors, `SCAN`-based), PDO, MongoDB and null handlers, and forwarded by the strict, marshalling and migrating decorators. The command reports a clear error when the configured handler does not implement the interface. The migrating decorator clears both its handlers, so a storage migration cannot resurrect cleared sessions.

Documentation should cover: the command and `--force`, that clearing also destroys anonymous-session state such as carts, the interface for custom handlers, and that the native file handler removes `sess_*` files from `session.save_path`.
