### PR TITLE
[Messenger] Use SignalRegistry::isSupported() in ConsumeMessagesCommand

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\SignalRegistry\SignalRegistry;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
@@ -264,7 +265,7 @@ EOF
 
     public function getSubscribedSignals(): array
     {
-        return $this->signals ?? (\extension_loaded('pcntl') ? [\SIGTERM, \SIGINT] : []);
+        return $this->signals ?? (SignalRegistry::isSupported() ? [\SIGTERM, \SIGINT] : []);
     }
 
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`ConsumeMessagesCommand::getSubscribedSignals()` uses `\extension_loaded('pcntl')` to decide whether to subscribe to `SIGTERM`/`SIGINT`. However, the `pcntl` extension can be loaded while `pcntl_signal` (and other `pcntl_*` functions) are disabled via `disable_functions` in `php.ini` (shared hoster).

This causes a `RuntimeException` in `Application::getSignalRegistry()` because signals are reported as subscribed but cannot actually be registered:

```
[Symfony\Component\Console\Exception\RuntimeException]
Signals are not supported. Make sure that the "pcntl" extension is installed
and that "pcntl_*" functions are not disabled by your php.ini's
"disable_functions" directive.
```

```
Symfony\Component\Console\Application->getSignalRegistry() at Application.php:121
Symfony\Component\Console\Application->doRunCommand() at Application.php:1032
```

This PR replaces `\extension_loaded('pcntl')` with `SignalRegistry::isSupported()`, which checks `function_exists('pcntl_signal')` — correctly handling the case where the extension is loaded but functions are disabled.