### PR TITLE
[HttpClient][EventSourceHttpClient] Fix broken streams when first event is delayed

### DIFF
--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -115,9 +115,7 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
                     $context->passthru();
                 }
 
-                if (null === $lastError) {
-                    yield $chunk;
-                }
+                yield $chunk;
 
                 return;
             }

--- a/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
@@ -191,6 +191,34 @@ TXT
         }
     }
 
+    public function testFirstChunkIsYieldedAfterTimeout()
+    {
+        $es = new EventSourceHttpClient(new MockHttpClient([
+            // Throws TransportException before any chunks are sent, emulating a stream timeout
+            new MockResponse('', [
+                'response_headers' => ['content-type: text/event-stream'],
+                'error' => 'timeout',
+            ]),
+            new MockResponse("data: hello\n\n", [
+                'response_headers' => ['content-type: text/event-stream'],
+            ]),
+        ]), reconnectionTime: 0.0);
+
+        $res = $es->connect('http://localhost:8080/events');
+
+        $expected = [
+            new FirstChunk(),
+            new ServerSentEvent("data: hello\n\n"),
+            new LastChunk(13),
+        ];
+
+        foreach ($es->stream($res) as $chunk) {
+            $this->assertEquals(array_shift($expected), $chunk);
+        }
+
+        $this->assertSame([], $expected);
+    }
+
     public static function contentTypeProvider()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

If an SSE endpoint is delayed in sending the first event, the `EventSourceHttpClient` will fail to read that first event - as long as that inital delay is longer than the timeout passed to `EventSourceHttpClient->stream()`.

The timeout chunks that are created before the first event is received set an internal error flag that prevents the first chunk from being yielded. This breaks the stream when the first event is received.

This fix removes the condition around yielding the first chunk.

### Reproducer

https://github.com/LachlanArthur/symfony-sse-timeout-bug

I could not get the sub-requests working via the `symfony serve` command, but running it in Docker works:

```sh
docker run --rm -it -v $PWD:/app -e SERVER_NAME=:80 -p 80 dunglas/frankenphp
```

Load the page in a browser at `localhost:[random port]` and monitor both the Docker logs and the page output.

The page will display this exception after a couple of seconds:

> LogicException: A chunk passthru must yield an "isFirst()" chunk before any content chunk. in /app/vendor/symfony/http-client/Response/AsyncResponse.php:416

Now set `BugController::SERVER_START_DELAY` to zero and try again - the stream works.

Currently, if `SERVER_START_DELAY` is lower than `CLIENT_CHUNK_TIMEOUT` then the events will stream ok. If it is equal or larger, then the first timeout chunk will break the stream. Removing the condition on yielding the first chunk fixes this.