### PR TITLE
[FrameworkBundle] Fix lint:container skipping tagged services in debug mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -21,8 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
-use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveFactoryClassPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveTaggedIteratorArgumentPass;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -101,12 +101,8 @@ final class ContainerLintCommand extends Command
             $refl->setValue($parameterBag, true);
 
             $container->getCompilerPassConfig()->setBeforeOptimizationPasses([]);
-            $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveFactoryClassPass()]);
+            $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveFactoryClassPass(), new ResolveTaggedIteratorArgumentPass()]);
             $container->getCompilerPassConfig()->setBeforeRemovingPasses([]);
-            $container->getCompilerPassConfig()->setRemovingPasses(array_filter(
-                $container->getCompilerPassConfig()->getRemovingPasses(),
-                fn ($pass) => !$pass instanceof RemoveUnusedDefinitionsPass,
-            ));
         }
 
         $container->setParameter('container.build_hash', 'lint_container');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveFactoryClassPass;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -102,6 +103,10 @@ final class ContainerLintCommand extends Command
             $container->getCompilerPassConfig()->setBeforeOptimizationPasses([]);
             $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveFactoryClassPass()]);
             $container->getCompilerPassConfig()->setBeforeRemovingPasses([]);
+            $container->getCompilerPassConfig()->setRemovingPasses(array_filter(
+                $container->getCompilerPassConfig()->getRemovingPasses(),
+                fn ($pass) => !$pass instanceof RemoveUnusedDefinitionsPass,
+            ));
         }
 
         $container->setParameter('container.build_hash', 'lint_container');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedConsumer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedConsumer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class TaggedConsumer
+{
+    public function __construct(iterable $services)
+    {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedServiceWithTypeMismatch.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedServiceWithTypeMismatch.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class TaggedServiceWithTypeMismatch
+{
+    public function __construct(\DateTimeInterface $date)
+    {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
@@ -40,6 +40,21 @@ class ContainerLintCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString($expectedOutput, $tester->getDisplay());
     }
 
+    public function testLintContainerDetectsTypeErrorOnTaggedServices()
+    {
+        $kernel = static::createKernel([
+            'test_case' => 'ContainerLint',
+            'root_config' => 'config.yml',
+            'debug' => true,
+        ]);
+        $this->application = new Application($kernel);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(1, $exitCode, 'lint:container should detect type errors on services referenced only via tagged iterators in debug mode');
+    }
+
     public static function containerLintProvider(): array
     {
         return [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/config.yml
@@ -1,0 +1,15 @@
+imports:
+    - { resource: ../config/default.yml }
+
+services:
+    tagged_consumer:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedConsumer
+        arguments:
+            - !tagged_iterator 'app.handler'
+        public: true
+    tagged_with_wrong_type:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedServiceWithTypeMismatch
+        arguments:
+            - '@tagged_consumer'
+        tags:
+            - { name: 'app.handler' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53839 
| License       | MIT

## Summary

In debug mode with a fresh container cache, `lint:container` loads definitions from the XML
dump and skips most compiler passes for performance. Because `ResolveTaggedIteratorArgumentPass`
is skipped, tagged iterator arguments are left unresolved, causing `RemoveUnusedDefinitionsPass`
to treat services tagged for discovery (e.g. via `!tagged_iterator`) as unreferenced and remove
them so `CheckTypeDeclarationsPass` never validates them, silently missing type errors.

## Fix

Exclude `RemoveUnusedDefinitionsPass` from the removing passes when loading from the cached dump.
Since the container was already fully compiled at boot time, there is nothing to remove all
definitions should remain available for type checking.

## Test

Added a functional test with a service that has a deliberate type mismatch
(`TaggedServiceWithTypeMismatch`) only referenced via a `!tagged_iterator`. The test asserts
that `lint:container` returns exit code `1` in debug mode failing before the fix, passing after.

## Note

Exclude the `RemoveUnusedDefinitionsPass` from the compiler pass config feels odd to me. We might have some real unused definitions that we want to remove.
I ask a LLM about that, here is the answer:

*The XML dump is a snapshot of the "before-removing" state — all definitions in it were deemed necessary during the real build. Removing unused definitions from a re-loaded dump where tags aren't re-resolved would incorrectly remove services.*
*The only real concern: is there a scenario where the dump contains a genuinely broken definition that RemoveUnusedDefinitionsPass would have cleaned up, preventing a false positive from CheckTypeDeclarationsPass? I'd say no — the dump is the real container state, and lint:container should validate everything in it.*

That is why I went that way. But for now, this is a little bit over my current skills on that Symfony part. I might go deeper to understand it more, but feel free to help me, comment, give hints on that PR. Thank you very much !