### PR TITLE
[RemoteEvent] Allow repeating `#[AsRemoteEventConsumer]`

### DIFF
--- a/src/Symfony/Component/RemoteEvent/Attribute/AsRemoteEventConsumer.php
+++ b/src/Symfony/Component/RemoteEvent/Attribute/AsRemoteEventConsumer.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\RemoteEvent\Attribute;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class AsRemoteEventConsumer
 {
     /**

--- a/src/Symfony/Component/RemoteEvent/CHANGELOG.md
+++ b/src/Symfony/Component/RemoteEvent/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+8.2
+---
+ * Allow repeating `AsRemoteEventConsumer` attribute
+
 6.4
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

We've got a use case where we are using same service twice with 2 different accounts. Only difference is a webhook secret. So it looks like something like this
```yaml
framework:
  webhook:
    routing:
      stripe-lt:
        secret: '%env(STRIPE_LT_WEBHOOK_SECRET)%'
      stripe-us:
        secret: '%env(STRIPE_US_WEBHOOK_SECRET)%'
```

Then, we've got a consumer defined like so
```php
#[AsRemoteEventConsumer('stripe-lt')]
final class StripeWebhookConsumer implements ConsumerInterface
```

However, because of missing `Attribute::IS_REPEATABLE`, it's not possible to add another tag for `stripe-us`. (Can be solved by specifying the tag manually, but we should be able to do it via `AsRemoteEventConsumer` attribute too..)