### PR TITLE
[HttpClient] Add option for a custom DNS resolver

### DIFF
--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -108,6 +108,10 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
             $this->multi->dnsCache = $options['resolve'] + $this->multi->dnsCache;
         }
 
+        if (isset($options['resolver'])) {
+            $this->logger?->debug('AmpHttpClient always uses AmpResolver.');
+        }
+
         if ($options['peer_fingerprint'] && !isset($options['peer_fingerprint']['pin-sha256'])) {
             throw new TransportException(__CLASS__.' supports only "pin-sha256" fingerprints.');
         }

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `GuzzleHttpHandler` that allows using Symfony HttpClient as a Guzzle handler
  * Change `$maxTtl` argument of `CachingHttpClient` to default to `86400` (24h) instead of `null`
  * Deprecate passing `null` as `$maxTtl` to `CachingHttpClient`, pass a positive integer instead
+ * Add support for the `resolver` option (custom DNS resolver)
 
 8.0
 ---

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -170,10 +170,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         }
 
         if (isset($options['resolver'])) {
-            $ip = $options['resolver']($host);
-            if (null !== $ip) {
-                $options['resolve'] += [$host => $ip];
-            }
+            $this->logger?->debug('Option "resolver" is defined but has no effect on CurlHttpClient.');
         }
 
         // curl's resolve feature varies by host:port but ours varies by host only, let's handle this with our own DNS map

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -169,6 +169,13 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[\CURLOPT_HEADEROPT] = \CURLHEADER_SEPARATE;
         }
 
+        if (isset($options['resolver'])) {
+            $ip = $options['resolver']($host);
+            if (null !== $ip) {
+                $options['resolve'] += [$host => $ip];
+            }
+        }
+
         // curl's resolve feature varies by host:port but ours varies by host only, let's handle this with our own DNS map
         if (isset($this->multi->dnsCache->hostnames[$host])) {
             $options['resolve'] += [$host => $this->multi->dnsCache->hostnames[$host]];

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -130,6 +130,10 @@ trait HttpClientTrait
             throw new InvalidArgumentException(\sprintf('Option "on_progress" must be callable, "%s" given.', get_debug_type($onProgress)));
         }
 
+        if (isset($options['resolver']) && !$options['resolver'] instanceof \Closure) {
+            throw new InvalidArgumentException(\sprintf('Option "resolver" must be a Closure, "%s" given.', get_debug_type($options['resolver'])));
+        }
+
         if (\is_array($options['auth_basic'] ?? null)) {
             $count = \count($options['auth_basic']);
             if ($count <= 0 || $count > 2) {

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -190,6 +190,16 @@ class HttpOptions
     /**
      * @return $this
      */
+    public function setResolver(\Closure $resolver): static
+    {
+        $this->options['resolver'] = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function setProxy(string $proxy): static
     {
         $this->options['proxy'] = $proxy;

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -262,8 +262,9 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
 
             $proxy = self::getProxy($options['proxy'], $url, $options['no_proxy']);
 
+            $resolverOptions = $options['resolver'] ?? null;
             if (!self::configureHeadersAndProxy($context, $host, $options['headers'], $proxy, 'https:' === $url['scheme'])) {
-                $ip = self::dnsResolve($host, $multi, $info, $onProgress);
+                $ip = self::dnsResolve($host, $multi, $info, $onProgress, $resolverOptions);
                 $url['authority'] = substr_replace($url['authority'], $ip, -\strlen($host) - \strlen($port), \strlen($host));
             }
 
@@ -328,7 +329,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
     /**
      * Resolves the IP of the host using the local DNS cache if possible.
      */
-    private static function dnsResolve(string $host, NativeClientState $multi, array &$info, ?\Closure $onProgress): string
+    private static function dnsResolve(string $host, NativeClientState $multi, array &$info, ?\Closure $onProgress, ?\Closure $resolver = null): string
     {
         $flag = '' !== $host && '[' === $host[0] && ']' === $host[-1] && str_contains($host, ':') ? \FILTER_FLAG_IPV6 : \FILTER_FLAG_IPV4;
         $ip = \FILTER_FLAG_IPV6 === $flag ? substr($host, 1, -1) : $host;
@@ -339,11 +340,19 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
         } elseif (null === $ip = $multi->dnsCache[$host] ?? null) {
             $info['debug'] .= "* Hostname was NOT found in DNS cache\n";
 
-            if ($ip = gethostbynamel($host)) {
-                $ip = $ip[0];
-            } elseif (!\defined('STREAM_PF_INET6')) {
-                throw new TransportException(\sprintf('Could not resolve host "%s".', $host));
-            } elseif ($ip = dns_get_record($host, \DNS_AAAA)) {
+            if (null !== $resolver) {
+                $ip = $resolver($host);
+                if (null !== $ip) {
+                    $info['debug'] .= "* Added {$host}:0:{$ip} to DNS cache via custom resolver\n";
+                }
+            }
+
+            if (null === $ip) {
+                if ($ip = gethostbynamel($host)) {
+                    $ip = $ip[0];
+                } elseif (!\defined('STREAM_PF_INET6')) {
+                    throw new TransportException(\sprintf('Could not resolve host "%s".', $host));
+                } elseif ($ip = dns_get_record($host, \DNS_AAAA)) {
                 $ip = $ip[0]['ipv6'];
             } elseif (\extension_loaded('sockets')) {
                 if (!$addrInfo = socket_addrinfo_lookup($host, 0, ['ai_socktype' => \SOCK_STREAM, 'ai_family' => \AF_INET6])) {
@@ -445,7 +454,8 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             }
 
             if ($dnsResolve) {
-                $ip = self::dnsResolve($host, $multi, $info, $onProgress);
+                $resolverOptions = $options['resolver'] ?? null;
+                $ip = self::dnsResolve($host, $multi, $info, $onProgress, $resolverOptions);
                 $url['authority'] = substr_replace($url['authority'], $ip, -\strlen($host) - \strlen($port), \strlen($host));
             }
 

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -262,9 +262,9 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
 
             $proxy = self::getProxy($options['proxy'], $url, $options['no_proxy']);
 
-            $resolverOptions = $options['resolver'] ?? null;
+            $resolverCallback = $options['resolver'] ?? null;
             if (!self::configureHeadersAndProxy($context, $host, $options['headers'], $proxy, 'https:' === $url['scheme'])) {
-                $ip = self::dnsResolve($host, $multi, $info, $onProgress, $resolverOptions);
+                $ip = self::dnsResolve($host, $multi, $info, $onProgress, $resolverCallback);
                 $url['authority'] = substr_replace($url['authority'], $ip, -\strlen($host) - \strlen($port), \strlen($host));
             }
 
@@ -353,21 +353,22 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
                 } elseif (!\defined('STREAM_PF_INET6')) {
                     throw new TransportException(\sprintf('Could not resolve host "%s".', $host));
                 } elseif ($ip = dns_get_record($host, \DNS_AAAA)) {
-                $ip = $ip[0]['ipv6'];
-            } elseif (\extension_loaded('sockets')) {
-                if (!$addrInfo = socket_addrinfo_lookup($host, 0, ['ai_socktype' => \SOCK_STREAM, 'ai_family' => \AF_INET6])) {
+                    $ip = $ip[0]['ipv6'];
+                } elseif (\extension_loaded('sockets')) {
+                    if (!$addrInfo = socket_addrinfo_lookup($host, 0, ['ai_socktype' => \SOCK_STREAM, 'ai_family' => \AF_INET6])) {
+                        throw new TransportException(\sprintf('Could not resolve host "%s".', $host));
+                    }
+
+                    $ip = socket_addrinfo_explain($addrInfo[0])['ai_addr']['sin6_addr'];
+                } elseif ('localhost' === $host || 'localhost.' === $host) {
+                    $ip = '::1';
+                } else {
                     throw new TransportException(\sprintf('Could not resolve host "%s".', $host));
                 }
-
-                $ip = socket_addrinfo_explain($addrInfo[0])['ai_addr']['sin6_addr'];
-            } elseif ('localhost' === $host || 'localhost.' === $host) {
-                $ip = '::1';
-            } else {
-                throw new TransportException(\sprintf('Could not resolve host "%s".', $host));
+                $info['debug'] .= "* Added {$host}:0:{$ip} to DNS cache\n";
             }
 
             $multi->dnsCache[$host] = $ip;
-            $info['debug'] .= "* Added {$host}:0:{$ip} to DNS cache\n";
         } else {
             $info['debug'] .= "* Hostname was found in DNS cache\n";
         }
@@ -454,8 +455,8 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             }
 
             if ($dnsResolve) {
-                $resolverOptions = $options['resolver'] ?? null;
-                $ip = self::dnsResolve($host, $multi, $info, $onProgress, $resolverOptions);
+                $resolverCallback = $options['resolver'] ?? null;
+                $ip = self::dnsResolve($host, $multi, $info, $onProgress, $resolverCallback);
                 $url['authority'] = substr_replace($url['authority'], $ip, -\strlen($host) - \strlen($port), \strlen($host));
             }
 

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -181,6 +181,13 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
             return $dnsCache[$host];
         }
 
+        if (isset($options['resolver'])) {
+            $ip = $options['resolver']($host);
+            if (null !== $ip) {
+                return $options['resolve'][$host] = $dnsCache[$host] = $ip;
+            }
+        }
+
         if ((\FILTER_FLAG_IPV4 & $ipFlags) && $ip = gethostbynamel($host)) {
             return $options['resolve'][$host] = $dnsCache[$host] = $ip[0];
         }

--- a/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
@@ -73,7 +73,7 @@ class NativeHttpClientTest extends HttpClientTestCase
 
     public function testResolverOption()
     {
-        TestHttpServer::start(-8087);
+        TestHttpServer::start(8087);
 
         $resolverCalled = false;
         $resolver = function (string $host) use (&$resolverCalled): ?string {

--- a/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NativeHttpClientTest.php
@@ -71,6 +71,25 @@ class NativeHttpClientTest extends HttpClientTestCase
         DnsMock::withMockedHosts([]);
     }
 
+    public function testResolverOption()
+    {
+        TestHttpServer::start(-8087);
+
+        $resolverCalled = false;
+        $resolver = function (string $host) use (&$resolverCalled): ?string {
+            $this->assertSame('symfony.com', $host);
+            $resolverCalled = true;
+
+            return '127.0.0.1';
+        };
+
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://symfony.com:8087/', ['resolver' => $resolver]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertTrue($resolverCalled);
+    }
+
     public function testUnixSocket()
     {
         $this->markTestSkipped('NativeHttpClient doesn\'t support binding to unix sockets.');

--- a/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
@@ -171,6 +171,29 @@ class NoPrivateNetworkHttpClientTest extends TestCase
         $client->request('GET', $url, ['on_progress' => $customCallback]);
     }
 
+    public function testResolverOption()
+    {
+        $ipAddr = '104.26.14.6';
+        $url = 'http://example.com/';
+        $content = 'foo';
+
+        $resolverCalled = false;
+        $resolver = function (string $host) use (&$resolverCalled, $ipAddr): ?string {
+            $this->assertSame('example.com', $host);
+            $resolverCalled = true;
+
+            return $ipAddr;
+        };
+
+        $previousHttpClient = $this->getMockHttpClient($ipAddr, $content);
+        $client = new NoPrivateNetworkHttpClient($previousHttpClient);
+        $response = $client->request('GET', $url, ['resolver' => $resolver]);
+
+        $this->assertTrue($resolverCalled);
+        $this->assertEquals($content, $response->getContent());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     public function testHeadersArePassedOnRedirect()
     {
         $ipAddr = '104.26.14.6';

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -63,6 +63,8 @@ interface HttpClientInterface
         'on_progress' => null,
         // string[] - a map of host to IP address that SHOULD replace DNS resolution
         'resolve' => [],
+        // \Closure(string $host): ?string - a custom DNS resolver
+        'resolver' => null,
         // string - by default, the proxy-related env vars handled by curl SHOULD be honored
         'proxy' => null,
         // string - a comma separated list of hosts that do not require a proxy to be reached


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63619 
| License       | MIT

This is what I propose to allow the use of a custom DNS resolver: a new option, `resolver` for the HttpClient expects a Closure. The HttpClient passes the hostname to resolve to that closure and expects an IP address in return.

I really need this feature and I am ready to rework this PR if needed. Regards
