### PR TITLE
[Serializer] Fix denormalization of mixed constructor parameters with phpDoc array types

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -507,6 +507,39 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame('foo', $obj->items[0]->name);
     }
 
+    public function testCollectionPropertyTypeNotOverriddenByMixedConstructorParameterType()
+    {
+        $extractor = new class implements PropertyTypeExtractorInterface {
+            public function getTypes(string $class, string $property, array $context = []): ?array
+            {
+                return null;
+            }
+
+            public function getType(string $class, string $property, array $context = []): ?Type
+            {
+                if (MixedArrayWithObjectsDummy::class === $class && 'items' === $property) {
+                    return Type::array(Type::object(MixedArrayItemDummy::class));
+                }
+
+                return null;
+            }
+        };
+
+        $normalizer = new ObjectNormalizer(null, null, null, $extractor);
+        $serializer = new Serializer([new ArrayDenormalizer(), $normalizer]);
+        $normalizer->setSerializer($serializer);
+
+        $obj = $normalizer->denormalize(
+            ['items' => [['name' => 'foo']]],
+            MixedArrayWithObjectsDummy::class,
+        );
+
+        $this->assertInstanceOf(MixedArrayWithObjectsDummy::class, $obj);
+        $this->assertCount(1, $obj->items);
+        $this->assertInstanceOf(MixedArrayItemDummy::class, $obj->items[0]);
+        $this->assertSame('foo', $obj->items[0]->name);
+    }
+
     public function testConstructorWithObjectTypeHintDenormalize()
     {
         $data = [
@@ -2355,4 +2388,21 @@ class NullableArrayItemDummy
 class ObjectTypedDummy
 {
     public string $name;
+}
+
+class MixedArrayWithObjectsDummy
+{
+    public function __construct(
+        /** @var MixedArrayItemDummy[] */
+        public mixed $items = null,
+    ) {
+    }
+}
+
+class MixedArrayItemDummy
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63680
| License       | MIT

#63680 reported that a constructor parameter typed `mixed` with a `@var Wheel[]` phpDoc was denormalized as an array of associative arrays instead of an array of `Wheel` instances. The denormalizer was overriding the more specific phpDoc type with the native `mixed` type before passing it to the array denormalizer.

The production fix has since landed independently via #63782 (excluding `TypeIdentifier::MIXED` from the override check, mirroring the `NULL` exclusion from #63547). The tests added by that PR cover `mixed` against a single object type, but not the array-of-objects scenario from the original report.

This PR therefore narrows down to a regression test — `testCollectionPropertyTypeNotOverriddenByMixedConstructorParameterType` in `ObjectNormalizerTest` — modelled on the existing `testCollectionPropertyTypeNotOverriddenByNullableConstructorParameterType` that #63547 added for the parallel `?array` case.