### PR TITLE
[ObjectMapper] Test mapping a nested object whose class declares no mapping

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/NestedEntity.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/NestedEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+final class NestedEntity
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/NestedEntityResource.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/NestedEntityResource.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: NestedEntity::class)]
+final class NestedEntityResource
+{
+    public function __construct(
+        public string $name = '',
+    ) {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/ParentEntity.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/ParentEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+final class ParentEntity
+{
+    public function __construct(
+        public string $name,
+        public NestedEntity $nested,
+    ) {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/ParentEntityResource.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/ParentEntityResource.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: ParentEntity::class)]
+final class ParentEntityResource
+{
+    public function __construct(
+        public string $name = '',
+        public ?NestedEntityResource $nested = null,
+    ) {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ObjectMapperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ObjectMapperTest.php
@@ -14,8 +14,12 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\CollectionSource;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\CollectionSourceItem;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\CollectionTarget;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\NestedEntity;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\NestedEntityResource;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\ObjectMapped;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\ObjectToBeMapped;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\ParentEntity;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\ParentEntityResource;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -48,5 +52,19 @@ class ObjectMapperTest extends AbstractWebTestCase
         $this->assertCount(2, $mapped->items);
         $this->assertSame('foo', $mapped->items[0]->getName());
         $this->assertSame('bar', $mapped->items[1]->getName());
+    }
+
+    public function testMapNestedObjectWhoseClassDeclaresNoMapping()
+    {
+        static::bootKernel(['test_case' => 'ObjectMapper']);
+
+        $objectMapper = static::getContainer()->get('object_mapper.alias');
+
+        /** @var ParentEntityResource $mapped */
+        $mapped = $objectMapper->map(new ParentEntity('Laptop', new NestedEntity('Electronics')), ParentEntityResource::class);
+
+        $this->assertSame('Laptop', $mapped->name);
+        $this->assertInstanceOf(NestedEntityResource::class, $mapped->nested);
+        $this->assertSame('Electronics', $mapped->nested->name);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ObjectMapper/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ObjectMapper/config.yml
@@ -9,3 +9,9 @@ services:
         autoconfigure: true
     Symfony\Component\ObjectMapper\Transform\MapCollection:
         autoconfigure: true
+    # the #[Map] attribute is collected from the classes the container scans, which in an
+    # application the default App\ loader covers
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\ParentEntityResource:
+        autoconfigure: true
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\NestedEntityResource:
+        autoconfigure: true

--- a/src/Symfony/Component/ObjectMapper/Tests/DependencyInjection/ReverseMappingPassTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/DependencyInjection/ReverseMappingPassTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\ObjectMapper\DependencyInjection\ReverseMappingPass;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Cost;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
+
+final class ReverseMappingPassTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(ContainerBuilder::class)) {
+            self::markTestSkipped('The DependencyInjection component is not available.');
+        }
+    }
+
+    public function testProcessWithoutReverseClassDefinition()
+    {
+        $this->expectNotToPerformAssertions();
+
+        (new ReverseMappingPass())->process(new ContainerBuilder());
+    }
+
+    public function testProcessCollectsTaggedResources()
+    {
+        $container = new ContainerBuilder();
+        $factory = $this->registerReverseClassFactory($container);
+
+        $this->registerMappedResource($container, QuoteRequestView::class, Quote::class);
+        $this->registerMappedResource($container, CostRequestView::class, Cost::class);
+
+        (new ReverseMappingPass())->process($container);
+
+        $this->assertSame([
+            Quote::class => [QuoteRequestView::class],
+            Cost::class => [CostRequestView::class],
+        ], $factory->getArgument(1));
+    }
+
+    public function testProcessCollectsMultipleTargetsPerSourceOnce()
+    {
+        $container = new ContainerBuilder();
+        $factory = $this->registerReverseClassFactory($container);
+
+        $this->registerMappedResource($container, QuoteRequestView::class, Quote::class);
+        $this->registerMappedResource($container, CostRequestView::class, Quote::class);
+        $this->registerMappedResource($container, QuoteRequestView::class, Quote::class, 'duplicate');
+
+        (new ReverseMappingPass())->process($container);
+
+        $this->assertSame([Quote::class => [QuoteRequestView::class, CostRequestView::class]], $factory->getArgument(1));
+    }
+
+    public function testProcessSkipsTagsWithoutSourceOrTarget()
+    {
+        $container = new ContainerBuilder();
+        $factory = $this->registerReverseClassFactory($container);
+
+        $definition = new Definition(QuoteRequestView::class);
+        $definition->addResourceTag('object_mapper.map', ['source' => Quote::class]);
+        $container->setDefinition(QuoteRequestView::class, $definition);
+
+        (new ReverseMappingPass())->process($container);
+
+        $this->assertSame([], $factory->getArgument(1));
+    }
+
+    private function registerReverseClassFactory(ContainerBuilder $container): Definition
+    {
+        $definition = new Definition();
+        $definition->setArguments([null, []]);
+        $container->setDefinition('object_mapper.metadata_factory.reverse_class', $definition);
+
+        return $definition;
+    }
+
+    private function registerMappedResource(ContainerBuilder $container, string $targetClass, string $sourceClass, string $idSuffix = ''): Definition
+    {
+        $definition = new Definition($targetClass);
+        // as added by the #[Map] attribute autoconfiguration registered in FrameworkExtension
+        $definition->addResourceTag('object_mapper.map', [
+            'source' => $sourceClass,
+            'target' => $targetClass,
+        ]);
+        $container->setDefinition($targetClass.$idSuffix, $definition);
+
+        return $definition;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/composer.json
+++ b/src/Symfony/Component/ObjectMapper/composer.json
@@ -20,6 +20,7 @@
         "psr/container": "^2.0"
     },
     "require-dev": {
+        "symfony/dependency-injection": "^7.4|^8.0",
         "symfony/property-access": "^7.4|^8.0",
         "symfony/var-exporter": "^7.4|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63678
| License       | MIT

A nested object whose class declares no mapping metadata is mapped when the class map knows its target, and the class map is built at compile time from the `#[Map]` attributes of the classes the container scans. Both halves already exist on 8.2, so this adds the coverage that was missing rather than new behaviour.

```php
#[Map(source: NestedEntity::class)]
final class NestedEntityResource
{
    public function __construct(public string $name = '') {}
}
```

`NestedEntityResource` declares where it comes from, so `ReverseMappingPass` records `NestedEntity => NestedEntityResource` and `map(new ParentEntity(...), ParentEntityResource::class)` fills the nested property. `NestedEntity` itself carries no attribute.

The catch is that the attribute is collected from the classes the container scans. An application's default `App\` loader covers `src/`, so resource classes living there are seen; a class excluded from it is not, and the nested mapping then silently does not happen. The functional test app registers its two resource classes explicitly for that reason.

Standalone, the same result comes from passing the class map:

```php
new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(
    new ReflectionObjectMapperMetadataFactory(),
    [NestedEntity::class => NestedEntityResource::class],
));
```

## What is covered

`ReverseMappingPass` had no test. Four cases now: no `object_mapper.metadata_factory.reverse_class` definition, collection of the tagged resources, several targets for one source recorded once, and tags missing `source` or `target` skipped.

The functional test exercises the whole chain, from the attribute on the resource class to the nested property of the mapped object.

`symfony/dependency-injection` moves to the component's `require-dev`, which `ReverseMappingPass` needed already.
