### PR TITLE
[DependencyInjection] Fix env placeholder validation for numeric nodes with min constraint

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ValidateEnvPlaceholdersPass implements CompilerPassInterface
 {
-    private const TYPE_FIXTURES = ['array' => [], 'bool' => false, 'float' => 0.0, 'int' => 0, 'string' => ''];
+    private const TYPE_FIXTURES = ['array' => [], 'bool' => false, 'float' => 1.0, 'int' => 1, 'string' => ''];
 
     private array $extensionConfig = [];
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -314,6 +314,32 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame('1', $container->getParameter('boolish'));
     }
 
+    public function testFloatEnvWithMinConstraint()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', $expected = [
+            'float_node_with_min' => '%env(float:MESSENGER_MULTIPLIER)%',
+        ]);
+
+        $this->doProcess($container);
+
+        $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
+    public function testIntEnvWithMinConstraint()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', $expected = [
+            'int_node_with_min' => '%env(int:MESSENGER_MAX_RETRIES)%',
+        ]);
+
+        $this->doProcess($container);
+
+        $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
     private function doProcess(ContainerBuilder $container): void
     {
         (new MergeExtensionConfigurationPass())->process($container);
@@ -339,6 +365,8 @@ class EnvConfiguration implements ConfigurationInterface
                 ->end()
                 ->integerNode('int_node')->end()
                 ->floatNode('float_node')->end()
+                ->floatNode('float_node_with_min')->min(1)->end()
+                ->integerNode('int_node_with_min')->min(1)->end()
                 ->booleanNode('bool_node')->end()
                 ->arrayNode('array_node')
                     ->beforeNormalization()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62370
| License       | MIT

## Summary

This PR fixes the inability to use environment variables for numeric configuration options that have a `min(1)` constraint.

### The Problem

When using `%env(float:MESSENGER_MULTIPLIER)%` for the Messenger retry_strategy `multiplier` option, the configuration validation fails with:

```
The value 0 is too small for path "framework.messenger.transports.async.retry_strategy.multiplier". Should be greater than or equal to 1
```

This happens because `ValidateEnvPlaceholdersPass` uses fixture values to test configuration during compilation. The fixture for `float` was `0.0` and for `int` was `0`, which fail any `min(1)` constraint.

### The Fix

Change the `TYPE_FIXTURES` constant to use `1` instead of `0` for both `int` and `float` types:

```php
// Before
private const TYPE_FIXTURES = ['array' => [], 'bool' => false, 'float' => 0.0, 'int' => 0, 'string' => ''];

// After
private const TYPE_FIXTURES = ['array' => [], 'bool' => false, 'float' => 1.0, 'int' => 1, 'string' => ''];
```

This allows env variables to work with common constraints like `min(0)` and `min(1)`.

### Example (now works)

```yaml
framework:
    messenger:
        transports:
            async:
                retry_strategy:
                    multiplier: '%env(float:MESSENGER_MULTIPLIER)%'
```