### PR TITLE
[Console] Add optional PSR container parameter to `Application`

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\ArgumentResolver\ArgumentResolverInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\CompleteCommand;
@@ -52,6 +53,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SignalRegistry\SignalRegistry;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -95,6 +97,7 @@ class Application implements ResetInterface
     public function __construct(
         private string $name = 'UNKNOWN',
         private string $version = 'UNKNOWN',
+        private ?ContainerInterface $container = null,
     ) {
         $this->terminal = new Terminal();
         $this->defaultCommand = 'list';
@@ -381,6 +384,9 @@ class Application implements ResetInterface
 
     public function reset(): void
     {
+        if ($this->container?->has('services_resetter')) {
+            $this->container->get('services_resetter')->reset();
+        }
     }
 
     public function setHelperSet(HelperSet $helperSet): void
@@ -539,13 +545,19 @@ class Application implements ResetInterface
     {
         if ('UNKNOWN' !== $this->getName()) {
             if ('UNKNOWN' !== $this->getVersion()) {
-                return \sprintf('%s <info>%s</info>', $this->getName(), $this->getVersion());
+                $version = \sprintf('%s <info>%s</info>', $this->getName(), $this->getVersion());
+            } else {
+                $version = $this->getName();
             }
-
-            return $this->getName();
+        } else {
+            $version = 'Console Tool';
         }
 
-        return 'Console Tool';
+        if ($this->container instanceof SymfonyContainerInterface && $this->container->hasParameter('kernel.environment')) {
+            $version .= \sprintf(' (env: <comment>%s</>, debug: <comment>%s</>)', $this->container->getParameter('kernel.environment'), $this->container->getParameter('kernel.debug') ? 'true' : 'false');
+        }
+
+        return $version;
     }
 
     /**
@@ -1365,6 +1377,45 @@ class Application implements ResetInterface
 
         foreach ($this->getDefaultCommands() as $command) {
             $this->addCommand($command);
+        }
+
+        $this->registerContainerServices();
+    }
+
+    private function registerContainerServices(): void
+    {
+        if (!$this->container) {
+            return;
+        }
+
+        if ($this->container->has('event_dispatcher')) {
+            $this->setDispatcher($this->container->get('event_dispatcher'));
+        }
+        if ($this->container->has('console.argument_resolver')) {
+            $this->setArgumentResolver($this->container->get('console.argument_resolver'));
+        }
+        if ($this->container->has('console.command_loader')) {
+            $this->setCommandLoader($this->container->get('console.command_loader'));
+        }
+
+        if (!$commandIds = match (true) {
+            !$this->container instanceof SymfonyContainerInterface => $this->container->has('console.command.ids') ? $this->container->get('console.command.ids') : [],
+            $this->container->hasParameter('console.command.ids') => $this->container->getParameter('console.command.ids'),
+            default => [],
+        }) {
+            return;
+        }
+
+        $lazyCommandIds = match (true) {
+            !$this->container instanceof SymfonyContainerInterface => $this->container->has('console.lazy_command.ids') ? $this->container->get('console.lazy_command.ids') : [],
+            $this->container->hasParameter('console.lazy_command.ids') => $this->container->getParameter('console.lazy_command.ids'),
+            default => [],
+        };
+
+        foreach ($commandIds as $id) {
+            if (!isset($lazyCommandIds[$id])) {
+                $this->addCommand($this->container->get($id));
+            }
         }
     }
 }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add optional `$container` parameter to `Application` for automatic service wiring from a PSR container
  * Add `SymfonyStyle::outlineBlock()` and convenience methods `outlineSuccess()`, `outlineError()`, `outlineWarning()`, `outlineNote()`, `outlineInfo()`, `outlineCaution()` for border-only message blocks with the type label embedded in the top border
  * Add `TraceableValueResolver` to help inspecting value resolvers performances
  * [BC BREAK] Add `object` support to input options and arguments' default by changing the `$default` type to `mixed` in `InputArgument`, `InputOption`, `#[Argument]` and `#[Option]`

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -162,6 +163,90 @@ class ApplicationTest extends TestCase
     {
         $application = new Application('foo', 'bar');
         $this->assertEquals('foo <info>bar</info>', $application->getLongVersion(), '->getLongVersion() returns the long version of the application');
+    }
+
+    public function testGetLongVersionWithContainer()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'prod');
+        $container->setParameter('kernel.debug', false);
+        $container->compile();
+
+        $application = new Application('foo', 'bar', $container);
+        $this->assertStringContainsString('env:', $application->getLongVersion());
+        $this->assertStringContainsString('prod', $application->getLongVersion());
+    }
+
+    public function testContainerWiresEventDispatcher()
+    {
+        $container = new ContainerBuilder();
+        $container->register('event_dispatcher', EventDispatcher::class)->setPublic(true);
+        $container->compile();
+
+        $application = new Application('foo', 'bar', $container);
+        $application->all(); // triggers init
+
+        $this->assertInstanceOf(EventDispatcherInterface::class, $application->getDispatcher());
+    }
+
+    public function testContainerWiresCommandLoader()
+    {
+        $container = new ContainerBuilder();
+        $container->register('console.command_loader', FactoryCommandLoader::class)
+            ->setPublic(true)
+            ->setArguments([['test:cmd' => static fn () => new Command('test:cmd')]]);
+        $container->compile();
+
+        $application = new Application('foo', 'bar', $container);
+        $this->assertTrue($application->has('test:cmd'));
+    }
+
+    public function testContainerWiresEagerCommands()
+    {
+        $container = new ContainerBuilder();
+        $container->register('my.command', \FooCommand::class)->setPublic(true);
+        $container->setParameter('console.command.ids', ['my.command']);
+        $container->compile();
+
+        $application = new Application('foo', 'bar', $container);
+        $this->assertTrue($application->has('foo:bar'));
+    }
+
+    public function testPsrContainerWiresEagerCommands()
+    {
+        $fooCommand = new \FooCommand();
+
+        $container = $this->createStub(ContainerInterface::class);
+        $container->method('has')->willReturnCallback(static fn (string $id) => \in_array($id, ['console.command.ids', 'my.command']));
+        $container->method('get')->willReturnCallback(static fn (string $id) => match ($id) {
+            'console.command.ids' => ['my.command'],
+            'my.command' => $fooCommand,
+        });
+
+        $application = new Application('foo', 'bar', $container);
+        $this->assertTrue($application->has('foo:bar'));
+    }
+
+    public function testPsrContainerSkipsLazyCommands()
+    {
+        $fooCommand = new \FooCommand();
+
+        $container = $this->createStub(ContainerInterface::class);
+        $container->method('has')->willReturnCallback(static fn (string $id) => \in_array($id, ['console.command.ids', 'console.lazy_command.ids', 'my.command']));
+        $container->method('get')->willReturnCallback(static fn (string $id) => match ($id) {
+            'console.command.ids' => ['my.command'],
+            'console.lazy_command.ids' => ['my.command' => true],
+            'my.command' => $fooCommand,
+        });
+
+        $application = new Application('foo', 'bar', $container);
+        $this->assertFalse($application->has('foo:bar'));
+    }
+
+    public function testApplicationWithoutContainer()
+    {
+        $application = new Application('foo', 'bar');
+        $this->assertStringNotContainsString('env:', $application->getLongVersion());
     }
 
     public function testHelp()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

This PR adds an optional `$container` parameter (PSR `ContainerInterface`) to `Console\Application`.

When a container is provided, the application automatically wires:
- `event_dispatcher` → `setDispatcher()`
- `console.argument_resolver` → `setArgumentResolver()`
- `console.command_loader` → `setCommandLoader()`
- `console.command.ids` parameter → eagerly loaded commands (when using Symfony's `ContainerInterface`)
- `services_resetter` → `reset()`
- `kernel.environment` / `kernel.debug` parameters → `getLongVersion()` display

This is the first building block toward enabling pure console applications with dependency injection, without requiring HttpKernel or FrameworkBundle. The wiring logic currently duplicated in `FrameworkBundle\Console\Application` becomes available to any PSR container.

```php
$container = /* any PSR ContainerInterface */;
$app = new Application('my-cli', '1.0', $container);
$app->run();
```

All existing behavior is preserved when no container is passed.
