### PR TITLE
[FrameworkBundle][Mime] Add regex-based email body assertions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG
  * Deprecate setting `caching.max_ttl` to `null`, use a positive integer instead
  * Deprecate `senders` nesting level for messenger routing config; use string or a list of strings instead
  * Allow configuring Webhook's header names and signing algo
+ * Add `assertEmailTextBodyMatchesRegex()`, `assertEmailTextBodyNotMatchesRegex()`, `assertEmailHtmlBodyMatchesRegex()` and `assertEmailHtmlBodyNotMatchesRegex()` to the `MailerAssertionsTrait`
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
@@ -65,6 +65,38 @@ trait MailerAssertionsTrait
         self::assertThat($email, new LogicalNot(new MimeConstraint\EmailHtmlBodyContains($text)), $message);
     }
 
+    public static function assertEmailTextBodyMatchesRegex(RawMessage $email, string $regex, string $message = ''): void
+    {
+        if (!class_exists(MimeConstraint\EmailTextBodyMatchesRegex::class)) {
+            throw new \LogicException('The `assertEmailTextBodyMatchesRegex` method requires symfony/mime >= 8.1.');
+        }
+        self::assertThat($email, new MimeConstraint\EmailTextBodyMatchesRegex($regex), $message);
+    }
+
+    public static function assertEmailTextBodyNotMatchesRegex(RawMessage $email, string $regex, string $message = ''): void
+    {
+        if (!class_exists(MimeConstraint\EmailTextBodyMatchesRegex::class)) {
+            throw new \LogicException('The `assertEmailTextBodyNotMatchesRegex` method requires symfony/mime >= 8.1.');
+        }
+        self::assertThat($email, new LogicalNot(new MimeConstraint\EmailTextBodyMatchesRegex($regex)), $message);
+    }
+
+    public static function assertEmailHtmlBodyMatchesRegex(RawMessage $email, string $regex, string $message = ''): void
+    {
+        if (!class_exists(MimeConstraint\EmailHtmlBodyMatchesRegex::class)) {
+            throw new \LogicException('The `assertEmailHtmlBodyMatchesRegex` method requires symfony/mime >= 8.1.');
+        }
+        self::assertThat($email, new MimeConstraint\EmailHtmlBodyMatchesRegex($regex), $message);
+    }
+
+    public static function assertEmailHtmlBodyNotMatchesRegex(RawMessage $email, string $regex, string $message = ''): void
+    {
+        if (!class_exists(MimeConstraint\EmailHtmlBodyMatchesRegex::class)) {
+            throw new \LogicException('The `assertEmailHtmlBodyNotMatchesRegex` method requires symfony/mime >= 8.1.');
+        }
+        self::assertThat($email, new LogicalNot(new MimeConstraint\EmailHtmlBodyMatchesRegex($regex)), $message);
+    }
+
     public static function assertEmailHasHeader(RawMessage $email, string $headerName, string $message = ''): void
     {
         self::assertThat($email, new MimeConstraint\EmailHasHeader($headerName), $message);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/EmailController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/EmailController.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
+use Symfony\Bridge\Twig\Mime\BodyRenderer;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class EmailController
 {
@@ -38,5 +42,35 @@ class EmailController
         );
 
         return new Response();
+    }
+
+    public function sendEmailWithTemplateAction(MailerInterface $mailer): Response
+    {
+        $mailer->send($this->buildTemplatedEmail());
+
+        return new Response();
+    }
+
+    private function buildTemplatedEmail(): TemplatedEmail
+    {
+        $email = (new TemplatedEmail())
+            ->from('sanmartindev@gmail.com')
+            ->to(new Address('other_account@example.com'))
+            ->subject('Welcome')
+            ->textTemplate('emails/welcome.txt.twig')
+            ->htmlTemplate('emails/welcome.html.twig')
+            ->context([
+                'username' => 'santysisi',
+                'password' => 'Mock8pass9@',
+                'link' => 'https://mysuperwebapplication/activate/abcdef12-0123-abcd-5678-0123456789ab/',
+            ])
+        ;
+
+        $loader = new FilesystemLoader(\dirname(__DIR__).'/templates/');
+        $environment = new Environment($loader);
+        $renderer = new BodyRenderer($environment);
+        $renderer->render($email);
+
+        return $email;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -61,6 +61,10 @@ send_email:
     path:     /send_email
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\EmailController::indexAction }
 
+send_email_with_template:
+    path:     /send_email_with_template
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\EmailController::sendEmailWithTemplateAction }
+
 http_client_call:
     path:     /http_client_call
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\HttpClientController::index }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/templates/emails/welcome.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/templates/emails/welcome.html.twig
@@ -1,0 +1,7 @@
+<h1>Welcome!</h1>
+
+<p>Your user is {{ username }}</p>
+<p>Your password is {{ password }}</p>
+<p>
+    <a href="{{ link }}">Activate your account</a>
+</p>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/templates/emails/welcome.txt.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/templates/emails/welcome.txt.twig
@@ -1,0 +1,6 @@
+Welcome!
+
+Your user is {{ username }}
+Your password is {{ password }}
+
+Link for Activate your account: {{ link }}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MailerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -19,6 +20,8 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Test\Constraint\EmailHtmlBodyMatchesRegex;
+use Symfony\Component\Mime\Test\Constraint\EmailTextBodyMatchesRegex;
 
 class MailerTest extends AbstractWebTestCase
 {
@@ -109,5 +112,39 @@ class MailerTest extends AbstractWebTestCase
         $this->assertEmailAddressContains($email, 'Reply-To', 'me@symfony.com');
         $this->assertEmailAddressNotContains($email, 'To', 'helene@symfony.com');
         $this->assertEmailAddressNotContains($email, 'Reply-To', 'helene@symfony.com');
+    }
+
+    #[RequiresMethod(EmailHtmlBodyMatchesRegex::class, '__construct')]
+    #[RequiresMethod(EmailTextBodyMatchesRegex::class, '__construct')]
+    public function testMailerAssertionsWithRegex()
+    {
+        $client = $this->createClient(['test_case' => 'Mailer', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->request('GET', '/send_email_with_template');
+
+        $this->assertEmailCount(1);
+        $first = 0;
+        if (!class_exists(FullStack::class)) {
+            $this->assertQueuedEmailCount(1);
+            $first = 1;
+            $this->assertEmailIsQueued($this->getMailerEvent(0));
+        }
+        $this->assertEmailIsNotQueued($this->getMailerEvent($first));
+
+        $email = $this->getMailerMessage($first);
+        $this->assertEmailAddressContains($email, 'From', 'sanmartindev@gmail.com');
+        $this->assertEmailAddressContains($email, 'To', 'other_account@example.com');
+        $this->assertEmailSubjectContains($email, 'Welcome');
+        $this->assertEmailHtmlBodyContains($email, '<h1>Welcome!</h1>');
+        $this->assertEmailHtmlBodyContains($email, '<p>Your user is santysisi</p>');
+        $this->assertEmailHtmlBodyMatchesRegex($email, '<p>Your password is [A-Za-z0-9]{7,10}[0-9][!@#$%^&*]</p>');
+        $this->assertEmailHtmlBodyMatchesRegex($email, '<a href="https://mysuperwebapplication/activate/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/">Activate your account</a>');
+        $this->assertEmailHtmlBodyNotMatchesRegex($email, '<p>Your password is [A-Za-z0-9]{7,10}[0-9][!@#$%^&*]{100}</p>');
+        $this->assertEmailHtmlBodyNotMatchesRegex($email, '<a href="https://mysuperwebapplication/activate/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}/">Activate your account</a>');
+        $this->assertEmailTextBodyContains($email, 'Welcome!');
+        $this->assertEmailTextBodyContains($email, 'Your user is santysisi');
+        $this->assertEmailTextBodyMatchesRegex($email, 'Your password is [A-Za-z0-9]{7,10}[0-9][!@#$%^&*]');
+        $this->assertEmailTextBodyMatchesRegex($email, 'Link for Activate your account: https://mysuperwebapplication/activate/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/');
+        $this->assertEmailTextBodyNotMatchesRegex($email, 'Your password is [A-Za-z0-9]{7,10}[0-9][!@#$%^&*]{100}');
+        $this->assertEmailTextBodyNotMatchesRegex($email, 'Link for Activate your account: https://mysuperwebapplication/activate/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}/');
     }
 }

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `EmailTextBodyMatchesRegex` and `EmailHtmlBodyMatchesRegex` constraints
+
 8.0
 ---
 

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailHtmlBodyMatchesRegex.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailHtmlBodyMatchesRegex.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Mime\Email;
+
+/**
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+final class EmailHtmlBodyMatchesRegex extends Constraint
+{
+    public function __construct(
+        private string $expectedRegex,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('matches HTML body against regex "%s"', $this->expectedRegex);
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Email) {
+            throw new \LogicException('Can only test a message html body on an Email instance.');
+        }
+
+        return (bool) preg_match(\sprintf('{%s}', $this->expectedRegex), $other->getHtmlBody());
+    }
+
+    protected function failureDescription($other): string
+    {
+        $message = 'The Email HTML body '.$this->toString();
+
+        if ($other instanceof Email) {
+            $message .= \sprintf('. The HTML body was: "%s"', $other->getHtmlBody());
+        }
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailTextBodyMatchesRegex.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailTextBodyMatchesRegex.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Mime\Email;
+
+/**
+ * @author Santiago San Martin <sanmartindev@gmail.com>
+ */
+final class EmailTextBodyMatchesRegex extends Constraint
+{
+    public function __construct(
+        private string $expectedRegex,
+    ) {
+    }
+
+    public function toString(): string
+    {
+        return \sprintf('matches text body against regex "%s"', $this->expectedRegex);
+    }
+
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Email) {
+            throw new \LogicException('Can only test a message text body on an Email instance.');
+        }
+
+        return (bool) preg_match(\sprintf('{%s}', $this->expectedRegex), $other->getTextBody());
+    }
+
+    protected function failureDescription($other): string
+    {
+        $message = 'The Email text body '.$this->toString();
+
+        if ($other instanceof Email) {
+            $message .= \sprintf('. The text body was: "%s"', $other->getTextBody());
+        }
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/Test/Constraint/EmailHtmlBodyMatchesRegexTest.php
+++ b/src/Symfony/Component/Mime/Tests/Test/Constraint/EmailHtmlBodyMatchesRegexTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Tests\Test\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Test\Constraint\EmailHtmlBodyMatchesRegex;
+
+class EmailHtmlBodyMatchesRegexTest extends TestCase
+{
+    public function testToString()
+    {
+        $constraint = new EmailHtmlBodyMatchesRegex('expectedRegex');
+
+        $this->assertSame('matches HTML body against regex "expectedRegex"', $constraint->toString());
+    }
+
+    public function testFailureDescription()
+    {
+        $expectedRegex = 'expectedRegex';
+        $email = new Email();
+        $email->html('actualValue');
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that The Email HTML body matches HTML body against regex "expectedRegex". The HTML body was: "actualValue".');
+
+        (new EmailHtmlBodyMatchesRegex($expectedRegex))->evaluate($email);
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/Test/Constraint/EmailTextBodyMatchesRegexTest.php
+++ b/src/Symfony/Component/Mime/Tests/Test/Constraint/EmailTextBodyMatchesRegexTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Tests\Test\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Test\Constraint\EmailTextBodyMatchesRegex;
+
+class EmailTextBodyMatchesRegexTest extends TestCase
+{
+    public function testToString()
+    {
+        $constraint = new EmailTextBodyMatchesRegex('expectedRegex');
+
+        $this->assertSame('matches text body against regex "expectedRegex"', $constraint->toString());
+    }
+
+    public function testFailureDescription()
+    {
+        $expectedRegex = 'expectedRegex';
+        $email = new Email();
+        $email->text('actualValue');
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that The Email text body matches text body against regex "expectedRegex". The text body was: "actualValue".');
+
+        (new EmailTextBodyMatchesRegex($expectedRegex))->evaluate($email);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

### Description
This PR introduces **new constraints and assertion methods** for testing email bodies with **regular expressions**, providing more flexible and robust test capabilities.

### What’s included
1. **New Constraints:**
* `EmailTextBodyMatchesRegex`
* `EmailHtmlBodyMatchesRegex`
2. **New Assertion Methods:**
* `assertEmailTextBodyMatchesRegex` / `assertEmailTextBodyDoesNotMatchRegex`
* `assertEmailHtmlBodyMatchesRegex` / `assertEmailHtmlBodyDoesNotMatchRegex`

### Why this is useful
Before this feature, testing email bodies was limited to **literal contains checks**. This makes it difficult to test dynamic or structured content, such as:

1. **Randomly generated passwords:**
* Example: `8 characters + 1 number + 1 special character`
* Literal `contains` assertions cannot reliably verify the format without mocking the password generation service.
2. **Generated links with dynamic parts (e.g., UUIDs):** 
* Example: `/reset-password/<uuid>`
* Cannot assert correctness with literal string checks because the UUID changes every time.

With regex assertions, you can now **directly validate the structure of dynamic content** in emails without mocks, improving test coverage and keeping tests simple and meaningful.

### Example Usage
```php
// Check a generated password pattern
self::assertEmailTextBodyMatchesRegex($email, 'Your password is [A-Za-z0-9]{7,8}[0-9][!@#$%^&*]');

// Check a password reset link ending with UUID
self::assertEmailHtmlBodyMatchesRegex($email, '<a href="https://mysuperwebapplication/reset-pasword/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}/">Reset your password</a>');
```


**Note**: This PR description was generated with the help of **ChatGPT**