### PR TITLE
[Form] fix deprecation notice in `ValidatorExtensionTest::testPropertiesInitializedWithEarlyReturn` test

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -78,7 +78,7 @@ class ValidatorExtensionTest extends TestCase
             ->getValidator();
 
         // create with an early return condition
-        $extension = new ValidatorExtension($validator, false);
+        $extension = new ValidatorExtension($validator);
 
         // verify the extension is functional after an early return
         $this->assertInstanceOf(ValidatorTypeGuesser::class, $extension->loadTypeGuesser());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... 
| License       | MIT

Fix deprecation notice triggered in `ValidatorExtensionTest::testPropertiesInitializedWithEarlyReturn`.
The second parameter isn’t necessary for this test, so it can be safely removed.

However, just to be sure, could you confirm this, @SeverinGloeckle :pray:?


Deprecation notice screenshot in 8.1

<img width="843" height="400" alt="image" src="https://github.com/user-attachments/assets/e7e2c913-481c-4a94-8c95-0ab7f081ede2" />

Also the [link](https://github.com/symfony/symfony/actions/runs/23364832411/job/67976430562?pr=63712) to that error
 