### PR TITLE
[ObjectMapper] Add multiple source merge mapping

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -96,6 +96,10 @@ Messenger
    they are routed through the normal retry/failure transport path instead
  * Add argument `$fetchSize` to `ReceiverInterface::get()` and `QueueReceiverInterface::getFromQueues()`
 
+Object Mapper
+-------------
+* Deprecate the `source` property in Map Attribute, use `sources` instead to allow multiple sources
+
 Security
 --------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/TransformCallable.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/TransformCallable.php
@@ -18,7 +18,7 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
  */
 final class TransformCallable implements TransformCallableInterface
 {
-    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    public function __invoke(mixed $value, object $source, ?object $target, mixed $targetValue): mixed
     {
         return 'transformed';
     }

--- a/src/Symfony/Component/ObjectMapper/Attribute/Map.php
+++ b/src/Symfony/Component/ObjectMapper/Attribute/Map.php
@@ -27,7 +27,9 @@ class Map
      */
     public function __construct(
         public readonly ?string $target = null,
+        /** @deprecated since Symfony 8.1, use "sources" instead */
         public readonly ?string $source = null,
+        public readonly array $sources = [],
         public readonly mixed $if = null,
         public readonly mixed $transform = null,
     ) {

--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
  * Add `SourceClass`, `ClassRule`, and `ClassRuleList` condition callables to match mapping rules based on source/target class
  * Allow `TargetClass` and `SourceClass` to accept arrays of class FQDNs
  * Add `IsNotNull` built-in condition to skip mapping when a source property value is null
+ * Add full source-based Map support
+ * Allow for merging mappings for standalone objects and iterable
 
 7.4
 ---

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
@@ -38,7 +38,13 @@ final class ReflectionObjectMapperMetadataFactory implements ObjectMapperMetadat
             $mappings = [];
             foreach ($attributes as $attribute) {
                 $map = $attribute->newInstance();
-                $mappings[] = new Mapping($map->target, $map->source, $map->if, $map->transform);
+
+                $sources = [];
+                if ($map->sources || $map->source) {
+                    $sources = $map->sources ?: [$map->source];
+                }
+
+                $mappings[] = new Mapping($map->target, null, $sources, $map->if, $map->transform);
             }
 
             return $this->attributesCache[$key] = $mappings;

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -62,8 +62,14 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
             foreach ($attributes as $attribute) {
                 $map = $attribute->newInstance();
                 // We're forcing the target on a reverse mapping to the property name, doesn't make sense without a source
-                if ($map->source) {
-                    $mappings[] = new Mapping($reflProperty->getName(), $map->source, $map->if, $map->transform);
+                if ($map->sources || $map->source) {
+                    $mappings[] = new Mapping(
+                        $reflProperty->getName(),
+                        null,
+                        $map->sources ?: [$map->source],
+                        $map->if,
+                        $map->transform
+                    );
                 }
             }
         }

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -47,22 +47,18 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
     public function map(object $source, object|string|null $target = null): object
     {
-        if ($this->objectMap) {
-            return $this->doMap($source, $target, $this->objectMap, false);
-        }
-
-        $this->objectMap = new \WeakMap();
+        $this->objectMap ??= new \WeakMap();
         try {
-            return $this->doMap($source, $target, $this->objectMap, true);
+            return $this->doMap($source, $target, $this->objectMap);
         } finally {
             $this->objectMap = null;
         }
     }
 
-    private function doMap(object $source, object|string|null $target, \WeakMap $objectMap, bool $rootCall): object
+    private function doMap(object $source, object|string|null $target, \WeakMap $objectMap): object
     {
         $metadata = $this->metadataFactory->create($source);
-        $map = $this->getMapTarget($metadata, null, $source, null, null === $target);
+        $map = $this->getMapping($metadata, null, $source, null, null === $target);
         $target ??= $map?->target;
         $mappingToObject = \is_object($target);
 
@@ -84,7 +80,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         if (!$metadata && $targetMetadata = $this->metadataFactory->create($mappedTarget)) {
             $metadata = $targetMetadata;
-            $map = $this->getMapTarget($metadata, null, $source, null, false);
+            $map = $this->getMapping($metadata, null, $source, null, true);
         }
 
         if ($map && $map->transform) {
@@ -101,22 +97,30 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         $objectMap[$source] = $mappedTarget;
         $ctorArguments = [];
-        $targetConstructor = $targetRefl->getConstructor();
-        foreach ($targetConstructor?->getParameters() ?? [] as $parameter) {
-            $parameterName = $parameter->getName();
+        $targetConstructor = null;
+        if (!$mappingToObject) {
+            $targetConstructor = $targetRefl->getConstructor();
 
-            if ($targetRefl->hasProperty($parameterName)) {
-                $property = $targetRefl->getProperty($parameterName);
+            foreach ($targetConstructor?->getParameters() ?? [] as $parameter) {
+                $parameterName = $parameter->getName();
 
-                if ($property->isReadOnly() && $property->isInitialized($mappedTarget)) {
-                    continue;
+                if ($targetRefl->hasProperty($parameterName)) {
+                    $property = $targetRefl->getProperty($parameterName);
+
+                    if ($property->isReadOnly() && $property->isInitialized($mappedTarget)) {
+                        continue;
+                    }
+
+                    if ($mappingToObject) {
+                        continue;
+                    }
                 }
-            }
 
-            if ($this->isReadable($source, $parameterName)) {
-                $ctorArguments[$parameterName] = $this->getRawValue($source, $parameterName);
-            } else {
-                $ctorArguments[$parameterName] = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
+                if ($this->isReadable($source, $parameterName)) {
+                    $ctorArguments[$parameterName] = $this->getRawValue($source, $parameterName);
+                } else {
+                    $ctorArguments[$parameterName] = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
+                }
             }
         }
 
@@ -136,10 +140,15 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
             $propertyName = $property->getName();
             $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName);
+            $mapSources = [$propertyName];
+
             foreach ($mappings as $mapping) {
-                $sourcePropertyName = $propertyName;
-                if ($mapping->source && (!$refl->hasProperty($propertyName) || !isset($source->$propertyName))) {
-                    $sourcePropertyName = $mapping->source;
+                if (!$refl->hasProperty($propertyName) || !isset($source->$propertyName)) {
+                    if (!empty($mapping->sources)) {
+                        $mapSources = $mapping->sources;
+                    } elseif (!empty($mapping->source)) {
+                        $mapSources = [$mapping->source];
+                    }
                 }
 
                 $targetPropertyName = $mapping->target ?? $propertyName;
@@ -158,15 +167,35 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $value = $this->getRawValue($source, $sourcePropertyName);
-                if ($if && $fn && !$this->call($fn, $value, $source, $mappedTarget)) {
-                    unset($ctorArguments[$targetPropertyName]);
+                $targetValue = null;
 
-                    continue;
+                foreach ($mapSources as $mapSource) {
+                    $value = $this->getRawValue($source, $mapSource);
+                    if ($if && $fn && !$this->call($fn, $value, $source, $mappedTarget)) {
+                        unset($ctorArguments[$targetPropertyName]);
+
+                        continue;
+                    }
+
+                    $targetValue = $ctorArguments[$targetPropertyName] ?? null;
+                    if (null !== $mappedTarget && $this->isReadable($mappedTarget, $targetPropertyName)) {
+                        $targetValue ??= $this->getRawValue($mappedTarget, $targetPropertyName);
+                    }
+
+                    $targetValue = $this->getSourceValue(
+                        $source,
+                        $mappedTarget,
+                        $value,
+                        $targetRefl->hasProperty($targetPropertyName)
+                            ? $targetRefl->getProperty($targetPropertyName)
+                            : null,
+                        $targetValue,
+                        $objectMap,
+                        $mapping,
+                    );
+
+                    $this->storeValue($targetPropertyName, $mapToProperties, $ctorArguments, $targetValue);
                 }
-
-                $value = $this->getSourceValue($source, $mappedTarget, $value, $objectMap, $mapping);
-                $this->storeValue($targetPropertyName, $mapToProperties, $ctorArguments, $value);
             }
 
             if ($mappings) {
@@ -183,7 +212,23 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $value = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap);
+                $targetValue = $ctorArguments[$propertyName] ?? null;
+                if (
+                    null !== $targetValue
+                    && null !== $mappedTarget
+                    && $this->isReadable($mappedTarget, $propertyName)
+                ) {
+                    $targetValue = $this->getRawValue($mappedTarget, $propertyName);
+                }
+
+                $value = $this->getSourceValue(
+                    $source,
+                    $mappedTarget,
+                    $this->getRawValue($source, $propertyName),
+                    $targetRefl->getProperty($propertyName),
+                    $targetValue,
+                    $objectMap
+                );
                 $this->storeValue($propertyName, $mapToProperties, $ctorArguments, $value);
                 continue;
             }
@@ -192,7 +237,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             if (
                 \is_object($rawValue)
                 && ($innerMetadata = $this->metadataFactory->create($rawValue))
-                && ($mapTo = $this->getMapTarget($innerMetadata, $rawValue, $source, $mappedTarget))
+                && ($mapTo = $this->getMapping($innerMetadata, $rawValue, $source, $mappedTarget, true))
                 && \is_string($mapTo->target)
                 && $mapTo->target === $targetRefl->getName()
             ) {
@@ -200,7 +245,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
         }
 
-        if ((!$mappingToObject || !$rootCall) && !$map?->transform && $targetConstructor
+        if (
+            !$map?->transform
+            && $targetConstructor
             && ($ctorArguments || !$targetConstructor->getNumberOfRequiredParameters())
         ) {
             try {
@@ -210,7 +257,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
         }
 
-        if ($mappingToObject && $rootCall && $ctorArguments) {
+        if ($mappingToObject && $ctorArguments) {
             foreach ($ctorArguments as $property => $value) {
                 if ($this->propertyIsMappable($refl, $property) && $this->propertyIsMappable($targetRefl, $property)) {
                     $mapToProperties[$property] = $value;
@@ -231,7 +278,11 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 continue;
             }
 
-            $mappedTarget->{$property} = $value;
+            if ($targetRefl->getProperty($property)->isReadOnly()) {
+                continue;
+            }
+
+            $targetRefl->getProperty($property)->setValue($mappedTarget, $value);
         }
 
         return $mappedTarget;
@@ -243,7 +294,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             return $this->propertyAccessor->isReadable($source, $propertyName);
         }
 
-        if (!property_exists($source, $propertyName) && !isset($source->{$propertyName})) {
+        if (!property_exists($source, $propertyName) || !isset($source->{$propertyName})) {
             return false;
         }
 
@@ -267,19 +318,39 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         return $source->{$propertyName};
     }
 
-    private function getSourceValue(object $source, object $target, mixed $value, \WeakMap $objectMap, ?Mapping $mapping = null): mixed
-    {
-        if ($mapping?->transform) {
-            $value = $this->applyTransforms($mapping, $value, $source, $target);
+    private function getSourceValue(
+        object $source,
+        object $target,
+        mixed $value,
+        ?\ReflectionProperty $reflTargetProperty,
+        mixed $targetValue,
+        \WeakMap $objectMap,
+        ?Mapping $mapping = null,
+    ): mixed {
+        // Source-based mapping
+        if (
+            \is_object($value)
+            && ($innerMetadata = $this->metadataFactory->create($target, $reflTargetProperty->getName()))
+            && ($mapFrom = $this->getMapping($innerMetadata, null, $source, $target))
+        ) {
+            $value = $this->applyTransforms($mapFrom, $value, $source, $target);
+
+            $value = ($this->objectMapper ?? $this)->map($value, $targetValue ?? $reflTargetProperty->getType()->getName());
         }
 
+        // Property-based transformation
+        if ($mapping?->transform) {
+            $value = $this->applyTransforms($mapping, $value, $source, $target, $targetValue);
+        }
+
+        // Target class-based mapping
         if (
             \is_object($value)
             && ($innerMetadata = $this->metadataFactory->create($value))
-            && ($mapTo = $this->getMapTarget($innerMetadata, $value, $source, $target, true))
+            && ($mapTo = $this->getMapping($innerMetadata, $value, $source, $target, true))
             && (\is_string($mapTo->target) && class_exists($mapTo->target))
         ) {
-            $value = $this->applyTransforms($mapTo, $value, $source, $target);
+            $value = $this->applyTransforms($mapTo, $value, $source, $target, $targetValue);
 
             if ($value === $source) {
                 $value = $target;
@@ -328,37 +399,58 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     /**
      * @param callable(): mixed $fn
      */
-    private function call(callable $fn, mixed $value, object $source, ?object $target = null): mixed
+    private function call(callable $fn, mixed $value, object $source, ?object $target = null, mixed $targetValue = null): mixed
     {
         if (\is_string($fn)) {
             return \call_user_func($fn, $value);
         }
 
-        return $fn($value, $source, $target);
+        return $fn($value, $source, $target, $targetValue);
     }
 
     /**
      * @param Mapping[] $metadata
      */
-    private function getMapTarget(array $metadata, mixed $value, object $source, ?object $target, bool $enforceUnique = false): ?Mapping
+    private function getMapping(array $metadata, mixed $value, object $source, ?object $target, bool $enforceUnique = false): ?Mapping
     {
-        $mapTo = null;
+        $mapping = null;
         foreach ($metadata as $mapAttribute) {
-            if (($if = $mapAttribute->if) && ($fn = $this->getCallable($if, $this->conditionCallableLocator, ConditionCallableInterface::class)) && !$this->call($fn, $value, $source, $target)) {
+            if (
+                $mapAttribute->if
+                && ($fn = $this->getCallable($mapAttribute->if, $this->conditionCallableLocator, ConditionCallableInterface::class))
+                && !$this->call($fn, $value, $source, $target)
+            ) {
                 continue;
             }
 
-            if ($enforceUnique && null !== $mapTo) {
-                throw new MappingException(\sprintf('Ambiguous mapping for "%s". Multiple #[Map] attributes match. Use the "if" parameter to specify conditions.', get_debug_type($value ?? $source)));
+            if (
+                $enforceUnique
+                && null !== $mapping
+                && $mapping->target === $mapAttribute->target
+                && $mapping->sources === $mapAttribute->sources
+            ) {
+                if (null !== $value) {
+                    throw new MappingException(\sprintf('Ambiguous mapping for "%s". Multiple #[Map] attributes match. Use the "if" parameter to specify conditions.', get_debug_type($value)));
+                }
+
+                throw new MappingException(\sprintf('Ambiguous mapping for "%s". Multiple #[Map] attributes match.', get_debug_type($source)));
             }
 
-            $mapTo = $mapAttribute;
+            if (!empty($mapping->sources) && !\in_array($source, $mapping->sources, true)) {
+                continue;
+            }
+
+            if (!empty($mapping->target) && $target !== $mapping->target) {
+                continue;
+            }
+
+            $mapping = $mapAttribute;
         }
 
-        return $mapTo;
+        return $mapping;
     }
 
-    private function applyTransforms(Mapping $map, mixed $value, object $source, ?object $target): mixed
+    private function applyTransforms(Mapping $map, mixed $value, object $source, ?object $target, mixed $targetValue = null): mixed
     {
         if (!$transforms = $map->transform) {
             return $value;
@@ -375,7 +467,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             if ($fn instanceof ObjectMapperAwareInterface) {
                 $fn = $fn->withObjectMapper($this->objectMapper ?? $this);
             }
-            $value = $this->call($fn, $value, $source, $target);
+            $value = $this->call($fn, $value, $source, $target, $targetValue);
         }
 
         return $value;

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InvalidConfiguration.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InvalidConfiguration.php
@@ -16,7 +16,7 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 #[Map(D::class)]
 class InvalidConfiguration
 {
-    public function __construct(#[Map('baz')] public readonly string $foo, #[Map(transform: 'wrongMethod')] public readonly string $bar)
+    public function __construct(#[Map('baz')] public readonly string $foo, #[Map(transform: 'wrongMethod')] public readonly string $bat)
     {
     }
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/D.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleSourceProperty/D.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Condition\SourceClass;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\B;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\C;
+
+#[Map(source: B::class)]
+#[Map(source: B::class)]
+#[Map(source: C::class)]
+class D
+{
+    #[Map(source: 'foo', transform: 'strtolower', if: new SourceClass(B::class))]
+    #[Map(source: 'bar', if: new SourceClass(C::class))]
+    public string $something;
+
+    #[Map(source: 'foo', transform: 'strtoupper', if: new SourceClass([B::class, C::class]))]
+    public string $somethingOther;
+
+    public string $doesNotExistInSourceB;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/D.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetProperty/D.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Condition\TargetClass;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C;
+
+#[Map(target: B::class)]
+#[Map(target: B::class)]
+#[Map(target: C::class)]
+class D
+{
+    #[Map(target: 'foo', transform: 'strtoupper', if: new TargetClass(B::class))]
+    #[Map(target: 'bar')]
+    public string $something = 'test';
+
+    #[Map(target: 'otherFoo', transform: 'strtolower', if: new TargetClass([B::class, C::class]))]
+    public string $somethingOther = 'TESTOTHER';
+
+    public string $doesNotExistInTargetB = 'foo';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLoadedValue/ServiceLoadedValueTransformer.php
@@ -23,7 +23,7 @@ class ServiceLoadedValueTransformer implements TransformCallableInterface
     {
     }
 
-    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    public function __invoke(mixed $value, object $source, ?object $target, mixed $targetValue): mixed
     {
         $metadata = $this->metadata->create($value);
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLocator/TransformCallable.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ServiceLocator/TransformCallable.php
@@ -18,7 +18,7 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
  */
 class TransformCallable implements TransformCallableInterface
 {
-    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    public function __invoke(mixed $value, object $source, ?object $target, mixed $targetValue): mixed
     {
         return "transformed$value";
     }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToStdClass.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToStdClass.php
@@ -15,7 +15,7 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
 
 class TransformToStdClass implements TransformCallableInterface
 {
-    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    public function __invoke(mixed $value, object $source, ?object $target, mixed $targetValue): mixed
     {
         return new \stdClass();
     }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToString.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Transform/TransformToString.php
@@ -15,7 +15,7 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
 
 class TransformToString implements TransformCallableInterface
 {
-    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    public function __invoke(mixed $value, object $source, ?object $target, mixed $targetValue): mixed
     {
         return 'str';
     }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/MultiplePropertiesClass.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/MultiplePropertiesClass.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Condition\ClassRule;
+
+class MultiplePropertiesClass
+{
+    public function __construct(
+        #[Map(sources: ['foo'], if: new \Symfony\Component\ObjectMapper\Condition\SourceClass(SubClassA::class))]
+        public string $foo = 'FOO',
+        #[Map(sources: ['bar'], if: new \Symfony\Component\ObjectMapper\Condition\SourceClass(SubClassB::class))]
+        public string $bar = 'BAR'
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/SourceClass.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/SourceClass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource;
+
+class SourceClass
+{
+    public function __construct(
+        public SubClassA $subClassA = new SubClassA(),
+        public SubClassB $subClassB = new SubClassB(),
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/SubClassA.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/SubClassA.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource;
+
+class SubClassA
+{
+    public function __construct(
+        public string $foo = 'foo'
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/SubClassB.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/SubClassB.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource;
+
+class SubClassB
+{
+    public function __construct(
+        public string $bar = 'bar'
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/TargetClass.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformMultiSource/TargetClass.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class TargetClass
+{
+    public function __construct(
+        #[Map(sources: ['subClassA', 'subClassB'])]
+        public MultiplePropertiesClass $multiplePropertiesClass,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -80,9 +80,11 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\B as MapTarg
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\A as MultipleSourcePropertyA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\B as MultipleSourcePropertyB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\C as MultipleSourcePropertyC;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleSourceProperty\D as MultipleSourcePropertyD;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\A as MultipleTargetPropertyA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as MultipleTargetPropertyB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\D as MultipleTargetPropertyD;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
@@ -125,6 +127,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource\MultiplePropertiesClass as MultiSourceMultiPropClass;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource\SourceClass as MultiSourceSourceClass;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformMultiSource\TargetClass as MultiSourceTargetClass;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class ObjectMapperTest extends TestCase
@@ -691,6 +696,93 @@ final class ObjectMapperTest extends TestCase
         $this->assertSame(49.99, $target->items[1]->amount);
     }
 
+    public function testMapCollectionWithMerging()
+    {
+        $source = new NestedCollectionOrderSource();
+        $source->items = [
+            new LineItemSource('Product B', 10, 49.90),
+            new LineItemSource('Product C', 2, 11.98),
+        ];
+
+        $target = new NestedCollectionOrderTarget();
+        $target->items = [
+            new LineItemTarget('Product A', 1, 5.99),
+            new LineItemTarget('Product B', 1, 4.99),
+        ];
+
+        $mapper = new ObjectMapper();
+        $mapper->map($source, $target);
+
+        $this->assertInstanceOf(NestedCollectionOrderTarget::class, $target);
+        $this->assertCount(2, $target->items);
+        $this->assertInstanceOf(LineItemTarget::class, $target->items[0]);
+        $this->assertInstanceOf(LineItemTarget::class, $target->items[1]);
+
+        $this->assertSame('Product B', $target->items[0]->productName);
+        $this->assertSame(10, $target->items[0]->quantity);
+        $this->assertSame(49.90, $target->items[0]->amount);
+
+        $this->assertSame('Product C', $target->items[1]->productName);
+        $this->assertSame(2, $target->items[1]->quantity);
+        $this->assertSame(11.98, $target->items[1]->amount);
+
+        $sourceWithKeys = new NestedCollectionOrderSource();
+        $sourceWithKeys->items = [
+            'a' => new LineItemTarget('Product A', 1, 5.99),
+            'b' => new LineItemSource('Product B', 10, 49.90),
+            'c' => new LineItemSource('Product C', 2, 11.98),
+        ];
+
+        $targetWithKeys = new NestedCollectionOrderTarget();
+        $targetWithKeys->items = [
+            'a' => new LineItemTarget('Product A', 1, 6.50),
+            'b' => new LineItemTarget('Product B', 1, 4.99),
+        ];
+
+        $mapper = new ObjectMapper();
+        $mapper->map($sourceWithKeys, $targetWithKeys);
+
+        $this->assertInstanceOf(NestedCollectionOrderTarget::class, $targetWithKeys);
+        $this->assertCount(3, $targetWithKeys->items);
+        $this->assertInstanceOf(LineItemTarget::class, $targetWithKeys->items['a']);
+        $this->assertInstanceOf(LineItemTarget::class, $targetWithKeys->items['b']);
+        $this->assertInstanceOf(LineItemTarget::class, $targetWithKeys->items['c']);
+
+        $this->assertSame('Product A', $targetWithKeys->items['a']->productName);
+        $this->assertSame(1, $targetWithKeys->items['a']->quantity);
+        $this->assertSame(5.99, $targetWithKeys->items['a']->amount);
+
+        $this->assertSame('Product B', $targetWithKeys->items['b']->productName);
+        $this->assertSame(10, $targetWithKeys->items['b']->quantity);
+        $this->assertSame(49.90, $targetWithKeys->items['b']->amount);
+
+        $this->assertSame('Product C', $targetWithKeys->items['c']->productName);
+        $this->assertSame(2, $targetWithKeys->items['c']->quantity);
+        $this->assertSame(11.98, $targetWithKeys->items['c']->amount);
+    }
+
+    public function testMultipleSourcesMapping()
+    {
+        $source = new MultiSourceSourceClass();
+
+        $mapper = new ObjectMapper();
+        $target = $mapper->map($source, MultiSourceTargetClass::class);
+        $this->assertInstanceOf(MultiSourceTargetClass::class, $target);
+        $this->assertInstanceOf(MultiSourceMultiPropClass::class, $target->multiplePropertiesClass);
+        $this->assertSame('foo', $target->multiplePropertiesClass->foo);
+        $this->assertSame('bar', $target->multiplePropertiesClass->bar);
+
+        $target = new MultiSourceTargetClass(
+            new MultiSourceMultiPropClass('baz', 'qux')
+        );
+
+        $mapper->map($source, $target);
+        $this->assertInstanceOf(MultiSourceTargetClass::class, $target);
+        $this->assertInstanceOf(MultiSourceMultiPropClass::class, $target->multiplePropertiesClass);
+        $this->assertSame('foo', $target->multiplePropertiesClass->foo);
+        $this->assertSame('bar', $target->multiplePropertiesClass->bar);
+    }
+
     public function testEmbedsAreLazyLoadedByDefault()
     {
         $mapper = new ObjectMapper();
@@ -846,14 +938,48 @@ final class ObjectMapperTest extends TestCase
         );
     }
 
-    public function testMultipleTargetsWithoutConditionThrowsExceptionWhenNoTargetProvided()
+    public function testMultipleSourcesWithoutConditionThrowsExceptionWhenDuplicateSourceTargetComboProvided()
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('Ambiguous mapping');
 
-        $source = new MultipleTargetPropertyA();
+        $source = new MultipleSourcePropertyB();
+
+        $mapper = new ObjectMapper();
+        $mapper->map($source, MultipleSourcePropertyD::class);
+    }
+
+    public function testMultipleSourcesWithoutDuplicateSourceTargetDoesNotThrowException()
+    {
+        $source = new MultipleSourcePropertyB();
+
+        $mapper = new ObjectMapper();
+        $target = $mapper->map($source, MultipleSourcePropertyA::class);
+
+        $this->assertInstanceOf(MultipleSourcePropertyA::class, $target);
+        $this->assertEquals('test', $target->something);
+        $this->assertEquals('TEST', $target->somethingOther);
+    }
+
+    public function testMultipleTargetsWithoutConditionThrowsExceptionWhenDuplicateSourceTargetComboProvided()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Ambiguous mapping');
+
+        $source = new MultipleTargetPropertyD();
         $mapper = new ObjectMapper();
         $mapper->map($source);
+    }
+
+    public function testMultipleTargetsWithoutDuplicateSourcetargetDoesNotThrowException()
+    {
+        $source = new MultipleTargetPropertyA();
+        $mapper = new ObjectMapper();
+        $target = $mapper->map($source);
+
+        $this->assertInstanceOf(MultipleTargetPropertyB::class, $target);
+        $this->assertEquals('TEST', $target->foo);
+        $this->assertEquals('testother', $target->otherFoo);
     }
 
     public function testConditionalMappingAppliedToConstructorArguments()

--- a/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
@@ -38,7 +38,7 @@ class MapCollection implements TransformCallableInterface, ObjectMapperAwareInte
         return $clone;
     }
 
-    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    public function __invoke(mixed $value, object $source, ?object $target, mixed $targetValue): mixed
     {
         if (!is_iterable($value)) {
             throw new MappingException(\sprintf('The MapCollection transform expects an iterable, "%s" given.', get_debug_type($value)));
@@ -47,7 +47,9 @@ class MapCollection implements TransformCallableInterface, ObjectMapperAwareInte
         $objectMapper = $this->objectMapper ??= new ObjectMapper();
         $values = [];
         foreach ($value as $k => $v) {
-            $values[$k] = $objectMapper->map($v, $this->targetClass);
+            $values[$k] = isset($targetValue[$k])
+                ? $objectMapper->map($v, $targetValue[$k])
+                : $objectMapper->map($v, $this->targetClass);
         }
 
         return $values;

--- a/src/Symfony/Component/ObjectMapper/TransformCallableInterface.php
+++ b/src/Symfony/Component/ObjectMapper/TransformCallableInterface.php
@@ -26,5 +26,5 @@ interface TransformCallableInterface
      * @param T       $source The object we're working on
      * @param T2|null $target The target we're mapping to
      */
-    public function __invoke(mixed $value, object $source, ?object $target): mixed;
+    public function __invoke(mixed $value, object $source, ?object $target, mixed $targetValue): mixed;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #63716
| License       | MIT

Change allows to work with a fully source based mapping system (as in an hexagonal architecture)
It also allows merging newly mapped data with existing data rather than systematically overwriting, therefore avoiding accidental data loss on map.
This in turns opens the way for multi-source mappings and merging iterables.