### PR TITLE
[RFC] Implement a PHPUnit `IssueTriggerResolver` to provide caller/callee contexts

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/IssueTriggerContextResolver.php
+++ b/src/Symfony/Bridge/PhpUnit/IssueTriggerContextResolver.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+use PHPUnit\Runner\IssueTriggerResolver\Resolution;
+use PHPUnit\Runner\IssueTriggerResolver\Resolver;
+use Symfony\Contracts\Deprecation\IssueTriggerContextProvider;
+
+/**
+ * PHPUnit IssueTriggerResolver that delegates to any {@see IssueTriggerContextProvider} found in
+ * the call stack.
+ *
+ * Scans the trace from the innermost frame outward for the nearest object implementing
+ * {@see IssueTriggerContextProvider}. Because trigger_error() executes synchronously, only the
+ * innermost provider can be the direct cause of the current error. Its answer is authoritative:
+ * if it returns a non-null context, that context is used to build the Resolution; if it returns
+ * null (meaning it is a bystander, not the active dispatcher), this resolver abstains immediately
+ * rather than searching further.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+final class IssueTriggerContextResolver implements Resolver
+{
+    public function resolve(array $trace, string $message): ?Resolution
+    {
+        foreach ($trace as $frame) {
+            if (!isset($frame['object']) || !$frame['object'] instanceof IssueTriggerContextProvider) {
+                continue;
+            }
+
+            // Nearest provider found — its answer is final. If it returns null it is not the
+            // active dispatcher of the current error; searching further would be unreliable.
+            $context = $frame['object']->getIssueTriggerContext();
+            if (null === $context) {
+                return null;
+            }
+
+            return new Resolution($context->getCalleeFile(), $context->getCallerFile());
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -25,6 +25,8 @@ use Psr\Log\LogLevel;
 use Symfony\Component\DependencyInjection\Argument\LazyClosure;
 use Symfony\Component\ErrorHandler\Internal\TentativeTypes;
 use Symfony\Component\VarExporter\LazyObjectInterface;
+use Symfony\Contracts\Deprecation\IssueTriggerContextInterface;
+use Symfony\Contracts\Deprecation\IssueTriggerContextProvider;
 
 /**
  * Autoloader checking if the class is really defined in the file found.
@@ -53,7 +55,7 @@ use Symfony\Component\VarExporter\LazyObjectInterface;
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Guilhem Niot <guilhem.niot@gmail.com>
  */
-class DebugClassLoader
+class DebugClassLoader implements IssueTriggerContextProvider
 {
     private const SPECIAL_RETURN_TYPES = [
         'void' => 'void',
@@ -164,6 +166,8 @@ class DebugClassLoader
      */
     private static array $vendorPrefixCache = [];
 
+    private ?DebugClassLoaderDeprecationNotice $currentDeprecationNotice = null;
+
     public function __construct(callable $classLoader)
     {
         $this->classLoader = $classLoader;
@@ -206,6 +210,11 @@ class DebugClassLoader
     public function getClassLoader(): callable
     {
         return $this->classLoader;
+    }
+
+    public function getIssueTriggerContext(): ?IssueTriggerContextInterface
+    {
+        return $this->currentDeprecationNotice;
     }
 
     /**
@@ -385,9 +394,11 @@ class DebugClassLoader
 
             $deprecations = $this->checkAnnotations($refl, $name);
 
-            foreach ($deprecations as $message) {
-                @trigger_error($message, \E_USER_DEPRECATED);
+            foreach ($deprecations as $deprecation) {
+                $this->currentDeprecationNotice = $deprecation;
+                @trigger_error((string) $deprecation, \E_USER_DEPRECATED);
             }
+            $this->currentDeprecationNotice = null;
         }
 
         if (!$file) {
@@ -407,6 +418,9 @@ class DebugClassLoader
         }
     }
 
+    /**
+     * @return list<DebugClassLoaderDeprecationNotice>
+     */
     public function checkAnnotations(\ReflectionClass $refl, string $class): array
     {
         if (
@@ -464,7 +478,7 @@ class DebugClassLoader
             }
 
             if (isset(self::$final[$parent])) {
-                $deprecations[] = \sprintf('The "%s" class is considered final%s It may change without further notice as of its next major version. You should not extend it from "%s".', $parent, self::$final[$parent], $className);
+                $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('The "%s" class is considered final%s It may change without further notice as of its next major version. You should not extend it from "%s".', $parent, self::$final[$parent], $className), $class, $parent);
             }
         }
 
@@ -486,10 +500,10 @@ class DebugClassLoader
                 $type = class_exists($class, false) ? 'class' : (interface_exists($class, false) ? 'interface' : 'trait');
                 $verb = class_exists($use, false) || interface_exists($class, false) ? 'extends' : (interface_exists($use, false) ? 'implements' : 'uses');
 
-                $deprecations[] = \sprintf('The "%s" %s %s "%s" that is deprecated%s', $className, $type, $verb, $use, self::$deprecated[$use]);
+                $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('The "%s" %s %s "%s" that is deprecated%s', $className, $type, $verb, $use, self::$deprecated[$use]), $class, $use);
             }
             if (isset(self::$internal[$use]) && !$this->areFromTheSameVendor($class, $use)) {
-                $deprecations[] = \sprintf('The "%s" %s is considered internal%s It may change without further notice. You should not use it from "%s".', $use, class_exists($use, false) ? 'class' : (interface_exists($use, false) ? 'interface' : 'trait'), self::$internal[$use], $className);
+                $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('The "%s" %s is considered internal%s It may change without further notice. You should not use it from "%s".', $use, class_exists($use, false) ? 'class' : (interface_exists($use, false) ? 'interface' : 'trait'), self::$internal[$use], $className), $class, $use);
             }
             if (isset(self::$method[$use])) {
                 if ($refl->isAbstract() || $refl->isInterface()) {
@@ -517,7 +531,7 @@ class DebugClassLoader
                         }
                         $realName = substr($name, 0, strpos($name, '('));
                         if (!$refl->hasMethod($realName) || !($methodRefl = $refl->getMethod($realName))->isPublic() || ($static xor $methodRefl->isStatic())) {
-                            $deprecations[] = \sprintf('Class "%s" should implement method "%s::%s%s"%s', $className, ($static ? 'static ' : '').$interface, $name, $returnType ? ': '.$returnType : '', null === $description ? '.' : ': '.$description);
+                            $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('Class "%s" should implement method "%s::%s%s"%s', $className, ($static ? 'static ' : '').$interface, $name, $returnType ? ': '.$returnType : '', null === $description ? '.' : ': '.$description), $class, $interface);
                         }
                     }
                 }
@@ -575,13 +589,13 @@ class DebugClassLoader
 
             if ($parent && isset(self::$finalMethods[$parent][$method->name])) {
                 [$declaringClass, $message] = self::$finalMethods[$parent][$method->name];
-                $deprecations[] = \sprintf('The "%s::%s()" method is considered final%s It may change without further notice as of its next major version. You should not extend it from "%s".', $declaringClass, $method->name, $message, $className);
+                $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('The "%s::%s()" method is considered final%s It may change without further notice as of its next major version. You should not extend it from "%s".', $declaringClass, $method->name, $message, $className), $class, $declaringClass);
             }
 
             if (isset(self::$internalMethods[$class][$method->name])) {
                 [$declaringClass, $message] = self::$internalMethods[$class][$method->name];
                 if (!$this->areFromTheSameVendor($traitClass ?? $class, $declaringClass)) {
-                    $deprecations[] = \sprintf('The "%s::%s()" method is considered internal%s It may change without further notice. You should not extend it from "%s".', $declaringClass, $method->name, $message, $className);
+                    $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('The "%s::%s()" method is considered internal%s It may change without further notice. You should not extend it from "%s".', $declaringClass, $method->name, $message, $className), $class, $declaringClass);
                 }
             }
 
@@ -600,7 +614,7 @@ class DebugClassLoader
 
                 foreach (self::$annotatedParameters[$class][$method->name] as $parameterName => $deprecation) {
                     if (!isset($definedParameters[$parameterName]) && !isset($doc['param'][$parameterName])) {
-                        $deprecations[] = \sprintf($deprecation, $className);
+                        $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf($deprecation, $className), $class, null);
                     }
                 }
             }
@@ -636,7 +650,7 @@ class DebugClassLoader
                     if ('docblock' === $this->patchTypes['force']) {
                         $this->patchMethod($method, $returnType, $declaringFile, $normalizedType);
                     } elseif ('' !== $declaringClass && $this->patchTypes['deprecations']) {
-                        $deprecations[] = \sprintf('Method "%s::%s()" might add "%s" as a native return type declaration in the future. Do the same in %s "%s" now to avoid errors or add an explicit @return annotation to suppress this message.', $declaringClass, $method->name, $normalizedType, interface_exists($declaringClass) ? 'implementation' : 'child class', $className);
+                        $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('Method "%s::%s()" might add "%s" as a native return type declaration in the future. Do the same in %s "%s" now to avoid errors or add an explicit @return annotation to suppress this message.', $declaringClass, $method->name, $normalizedType, interface_exists($declaringClass) ? 'implementation' : 'child class', $className), $class, $declaringClass);
                     }
                 }
             }
@@ -705,7 +719,7 @@ class DebugClassLoader
                 foreach ($parentAndOwnInterfaces as $use) {
                     if (isset(self::${$type}[$use][$r->name]) && !isset($doc['deprecated']) && ('finalConstants' === $type || substr($use, 0, strrpos($use, '\\')) !== substr($use, 0, strrpos($class, '\\')))) {
                         $msg = 'finalConstants' === $type ? '%s" constant' : '$%s" property';
-                        $deprecations[] = \sprintf('The "%s::'.$msg.' is considered final. You should not override it in "%s".', self::${$type}[$use][$r->name], $r->name, $class);
+                        $deprecations[] = new DebugClassLoaderDeprecationNotice(\sprintf('The "%s::'.$msg.' is considered final. You should not override it in "%s".', self::${$type}[$use][$r->name], $r->name, $class), $class, self::${$type}[$use][$r->name]);
                     }
                 }
 

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoaderDeprecationNotice.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoaderDeprecationNotice.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler;
+
+use Symfony\Contracts\Deprecation\IssueTriggerContextInterface;
+
+/**
+ * Carries the context of a deprecation triggered by DebugClassLoader.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+final class DebugClassLoaderDeprecationNotice implements IssueTriggerContextInterface, \Stringable
+{
+    /**
+     * @param string      $loadingClass    The class currently being loaded (the "consumer", e.g. the child class)
+     * @param string|null $triggeringClass The class that caused the deprecation (e.g. the deprecated parent or interface),
+     *                                     or null when that information is not available
+     */
+    public function __construct(
+        private readonly string $message,
+        public readonly string $loadingClass,
+        public readonly ?string $triggeringClass,
+    ) {
+    }
+
+    public function getCalleeFile(): ?string
+    {
+        return $this->fileForClass($this->triggeringClass);
+    }
+
+    public function getCallerFile(): ?string
+    {
+        return $this->fileForClass($this->loadingClass);
+    }
+
+    public function __toString(): string
+    {
+        return $this->message;
+    }
+
+    private function fileForClass(?string $class): ?string
+    {
+        if (null === $class) {
+            return null;
+        }
+
+        return (new \ReflectionClass($class))->getFileName() ?: null;
+    }
+}

--- a/src/Symfony/Contracts/Deprecation/IssueTriggerContextInterface.php
+++ b/src/Symfony/Contracts/Deprecation/IssueTriggerContextInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Deprecation;
+
+/**
+ * Carries context regarding caller and callee for errors that are currently being dispatched via trigger_error().
+ *
+ * Instances of this interface are returned by {@see IssueTriggerContextProvider::getIssueTriggerContext()}
+ * while a trigger_error() call initiated by the provider is executing. They allow tools such as
+ * PHPUnit's IssueTriggerResolver to determine the semantic origin of the error (callee and caller
+ * file paths) without parsing message strings or making assumptions about the internal stack layout
+ * of the dispatching component.
+ *
+ * Callee and caller are defined from the perspective of the error semantics, not the call stack:
+ *   - The callee is the file that contains or defines the deprecated or restricted construct
+ *   - The caller is the file that uses, invokes or activates that construct
+ *
+ * Either can be null when the information is not available for a particular error.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+interface IssueTriggerContextInterface
+{
+    /**
+     * Returns the path of the file that defines the deprecated or restricted construct.
+     *
+     * For example, when a class extends a deprecated parent, this is the file containing the
+     * deprecated parent class definition. Returns null if this information is not available.
+     */
+    public function getCalleeFile(): ?string;
+
+    /**
+     * Returns the path of the file that uses the deprecated or restricted construct.
+     *
+     * For example, when a class extends a deprecated parent, this is the file containing the
+     * child class definition. Returns null if this information is not available.
+     */
+    public function getCallerFile(): ?string;
+}

--- a/src/Symfony/Contracts/Deprecation/IssueTriggerContextProvider.php
+++ b/src/Symfony/Contracts/Deprecation/IssueTriggerContextProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Deprecation;
+
+/**
+ * Marks objects that can appear in a debug_backtrace() call stack and may expose structured
+ * context about an error they are currently dispatching via trigger_error().
+ *
+ * This interface allows tools such as PHPUnit's IssueTriggerResolver to scan the call stack for
+ * a responsible dispatcher and obtain callee/caller information from it, without parsing error
+ * message strings or making assumptions about the internal stack frame layout of any particular
+ * component.
+ *
+ * Contract for implementors
+ * -------------------------
+ * Providing context is optional: getIssueTriggerContext() may return null at any time, including
+ * during an active trigger_error() call, when no structured context is available for that error.
+ *
+ * However, if a non-null context is returned, it must be scoped strictly to the duration of the
+ * trigger_error() call that it describes: the context must not be made available before that call,
+ * must not persist after it returns, and must not "leak" into other calls or operations that happen
+ * to occur while this object is on the call stack for unrelated reasons.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+interface IssueTriggerContextProvider
+{
+    /**
+     * Returns context about the error currently being dispatched via trigger_error(), or null
+     * when this object is not the active dispatcher of an ongoing trigger_error() call.
+     *
+     * See the interface-level documentation for the precise contract.
+     */
+    public function getIssueTriggerContext(): ?IssueTriggerContextInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63700
| License       | MIT

Like Symfony's own PHPUnit bridge, PHPUnit >= 10 contains code to classify deprecations notices as self, direct or indirect, depending on the code performing a call and the called code (callee) being either "own" or "third-party" code.

One particular challenge is posed by code like the `DebugClassLoader`, which emits deprecation notices on behalf of other classes and code which may not even be on the call stack at the time of the `trigger_error()` call. To address this, a new PHPUnit extension point will be introduced in PHPUnit 13.1. See https://github.com/sebastianbergmann/phpunit/issues/6530 for details.

In a nutshell, when running PHPUnit, one can register an `IssueTriggerResolver`:

```php
  interface Resolver {
      public function resolve(array $trace, string $message): ?Resolution;
  }
```
A `Resolution` carries the semantic callee and caller file paths. PHPUnit uses these to classify the notice correctly, independently of where `trigger_error()` appeared on the call stack.

This PR here is a proposal to implement such a resolver for the purposes of Symfony; more specifically, as a first step, for the `DebugClassLoader`. 

However, this Resolver is implemented in a generic way so that also other Symfony components – for example, a YAML file loader detecting a noteworthy issue in a YAML file – can provide the relevant context in the same way. Rather than implementing the resolver in a way that parses message strings and hardcodes frame offsets, it introduces a general mechanism to expose structured context during a `trigger_error()` call.

Two new interfaces are currently added to `symfony/deprecation-contracts`, because they need to be shared between the code emitting deprecations and the resolver implementation.
  
- `IssueTriggerContextInterface`: Two methods `getCalleeFile()` and `getCallerFile()` provide the semantic origin of an error currently being dispatched.
- `IssueTriggerContextProvider` — implemented by objects that may appear in a call stack and can expose such context. A non-null context may only be returned for the duration of the `trigger_error()` call it describes; it must not leak into other operations or persist after the call returns.

In `symfony/error-handler`, the following changes are made:

- `DebugClassLoader` implements `IssueTriggerContextProvider`
- Instead of building a list of plain deprecation message strings that loses context, `DebugClassLoaderDeprecationNotice` is added as a new class and returned from `checkAnnotations()`. I hope that this is "BC enough", since that new class implements `Stringable`.

In `symfony/phpunit-bridge`, the `IssueTriggerContextResolver` implements PHPUnit's Resolver interface.

It scans the call stack (innermost frame first) for any object implementing `IssueTriggerContextProvider`, calls `getIssueTriggerContext()` on the nearest one, and builds a `Resolution' from the returned callee and caller files. If the nearest provider returns null — meaning it is present in the stack as a bystander but not the active dispatcher — the resolver abstains immediately rather than searching further, as no reliable context would
  be available from a more distant frame.

  The resolver is intentionally generic: It does not reference `DebugClassLoader` by name, and any future Symfony component that implements `IssueTriggerContextProvider` will automatically be served by the same resolver without changes.
