### PR TITLE
[FrameworkBundle] Add security expression functions to the validator expression language

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
  * Add the `session:clear` command to remove all sessions from the configured handler
  * Generate JSON schema for YAML configuration of bundles
  * Add support for rate limited transports
+ * Register the security functions `is_granted()`, `is_authenticated()`, `is_fully_authenticated()` and `is_remember_me()` in the validator expression language
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddValidatorSecurityExpressionLanguageProviderPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddValidatorSecurityExpressionLanguageProviderPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Bundle\FrameworkBundle\Validator\ValidatorSecurityExpressionLanguageProvider;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Registers security expression functions into the validator expression language
+ * when both the Validator and Security components are available.
+ */
+class AddValidatorSecurityExpressionLanguageProviderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('validator.expression_language') || !$container->has('security.authorization_checker')) {
+            return;
+        }
+
+        $container->register('validator.security_expression_language_provider', ValidatorSecurityExpressionLanguageProvider::class)
+            ->setArguments([
+                new Reference('security.authorization_checker'),
+                new Reference('security.token_storage'),
+                new Reference('request_stack'),
+            ])
+            ->setPublic(false);
+
+        $container->findDefinition('validator.expression_language')
+            ->addMethodCall('registerProvider', [new Reference('validator.security_expression_language_provider')]);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProcessorPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddValidatorSecurityExpressionLanguageProviderPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DeprecateJsonStreamerValueTransformerTagPass;
@@ -177,6 +178,7 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, ControllerAttributesListenerPass::class, PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
+        $container->addCompilerPass(new AddValidatorSecurityExpressionLanguageProviderPass());
         $this->addCompilerPassIfExists($container, AttributeMetadataPass::class);
         $container->addCompilerPass(new TranslationLintCommandPass(), PassConfig::TYPE_BEFORE_REMOVING, 10);
         // must be registered as late as possible to get access to all Twig paths registered in

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddValidatorSecurityExpressionLanguageProviderPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddValidatorSecurityExpressionLanguageProviderPassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddValidatorSecurityExpressionLanguageProviderPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddValidatorSecurityExpressionLanguageProviderPassTest extends TestCase
+{
+    public function testProviderIsRegisteredWhenBothServicesExist()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('validator.expression_language', new Definition(\stdClass::class));
+        $container->setDefinition('security.authorization_checker', new Definition(\stdClass::class));
+        $container->setDefinition('security.token_storage', new Definition(\stdClass::class));
+        $container->setDefinition('request_stack', new Definition(\stdClass::class));
+
+        (new AddValidatorSecurityExpressionLanguageProviderPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition('validator.security_expression_language_provider'));
+        $this->assertEquals([
+            new Reference('security.authorization_checker'),
+            new Reference('security.token_storage'),
+            new Reference('request_stack'),
+        ], $container->getDefinition('validator.security_expression_language_provider')->getArguments());
+
+        $calls = $container->getDefinition('validator.expression_language')->getMethodCalls();
+        $this->assertEquals([['registerProvider', [new Reference('validator.security_expression_language_provider')]]], $calls);
+    }
+
+    public function testNothingIsRegisteredWithoutSecurity()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('validator.expression_language', new Definition(\stdClass::class));
+
+        (new AddValidatorSecurityExpressionLanguageProviderPass())->process($container);
+
+        $this->assertFalse($container->hasDefinition('validator.security_expression_language_provider'));
+        $this->assertSame([], $container->getDefinition('validator.expression_language')->getMethodCalls());
+    }
+
+    public function testNothingIsRegisteredWithoutValidator()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('security.authorization_checker', new Definition(\stdClass::class));
+        $container->setDefinition('security.token_storage', new Definition(\stdClass::class));
+
+        (new AddValidatorSecurityExpressionLanguageProviderPass())->process($container);
+
+        $this->assertFalse($container->hasDefinition('validator.security_expression_language_provider'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ValidatorSecurityExpressionLanguageProviderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ValidatorSecurityExpressionLanguageProviderTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Validator;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Validator\ValidatorSecurityExpressionLanguageProvider;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Authorization\Voter\RoleVoter;
+
+class ValidatorSecurityExpressionLanguageProviderTest extends TestCase
+{
+    public function testIsGrantedReturnsTrue()
+    {
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('ROLE_ADMIN', null)
+            ->willReturn(true);
+
+        $el = $this->createExpressionLanguage($authorizationChecker);
+
+        $this->assertTrue($el->evaluate('is_granted("ROLE_ADMIN")'));
+    }
+
+    public function testIsGrantedWithSubject()
+    {
+        $subject = new \stdClass();
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('EDIT', $subject)
+            ->willReturn(true);
+
+        $el = $this->createExpressionLanguage($authorizationChecker);
+
+        $this->assertTrue($el->evaluate('is_granted("EDIT", subject)', ['subject' => $subject]));
+    }
+
+    public function testIsAuthenticated()
+    {
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED')
+            ->willReturn(true);
+
+        $el = $this->createExpressionLanguage($authorizationChecker);
+
+        $this->assertTrue($el->evaluate('is_authenticated()'));
+    }
+
+    public function testIsFullyAuthenticated()
+    {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())
+            ->method('getToken')
+            ->willReturn($this->createStub(TokenInterface::class));
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_FULLY')
+            ->willReturn(true);
+
+        $el = $this->createExpressionLanguage($authorizationChecker, $tokenStorage);
+
+        $this->assertTrue($el->evaluate('is_fully_authenticated()'));
+    }
+
+    public function testIsFullyAuthenticatedReturnsFalseWhenNoToken()
+    {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())
+            ->method('getToken')
+            ->willReturn(null);
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->never())->method('isGranted');
+
+        $el = $this->createExpressionLanguage($authorizationChecker, $tokenStorage);
+
+        $this->assertFalse($el->evaluate('is_fully_authenticated()'));
+    }
+
+    public function testIsRememberMe()
+    {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())
+            ->method('getToken')
+            ->willReturn($this->createStub(TokenInterface::class));
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_REMEMBERED')
+            ->willReturn(true);
+
+        $el = $this->createExpressionLanguage($authorizationChecker, $tokenStorage);
+
+        $this->assertTrue($el->evaluate('is_remember_me()'));
+    }
+
+    private function createExpressionLanguage(AuthorizationCheckerInterface $authorizationChecker, ?TokenStorageInterface $tokenStorage = null): ExpressionLanguage
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $expressionLanguage->registerProvider(new ValidatorSecurityExpressionLanguageProvider($authorizationChecker, $tokenStorage ?? $this->createStub(TokenStorageInterface::class), $this->createRequestStack()));
+
+        return $expressionLanguage;
+    }
+
+    private function createRequestStack(): RequestStack
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
+
+        return $requestStack;
+    }
+
+    public function testTheFunctionsReturnFalseWithoutAnyToken()
+    {
+        $tokenStorage = new TokenStorage();
+        $accessDecisionManager = new AccessDecisionManager([new AuthenticatedVoter(new AuthenticationTrustResolver()), new RoleVoter()]);
+
+        $el = new ExpressionLanguage();
+        $el->registerProvider(new ValidatorSecurityExpressionLanguageProvider(new AuthorizationChecker($tokenStorage, $accessDecisionManager), $tokenStorage, $this->createRequestStack()));
+
+        $this->assertFalse($el->evaluate('is_granted("ROLE_ADMIN")'));
+        $this->assertFalse($el->evaluate('is_authenticated()'));
+        $this->assertFalse($el->evaluate('is_fully_authenticated()'));
+        $this->assertFalse($el->evaluate('is_remember_me()'));
+    }
+
+    #[TestWith(['is_granted("ROLE_ADMIN")'])]
+    #[TestWith(['is_authenticated()'])]
+    #[TestWith(['is_fully_authenticated()'])]
+    #[TestWith(['is_remember_me()'])]
+    public function testTheFunctionsCannotBeEvaluatedOutsideOfARequest(string $expression)
+    {
+        $el = new ExpressionLanguage();
+        $el->registerProvider(new ValidatorSecurityExpressionLanguageProvider($this->createStub(AuthorizationCheckerInterface::class), new TokenStorage(), new RequestStack()));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('cannot be evaluated outside of a request');
+        $el->evaluate($expression);
+    }
+
+    #[TestWith(['is_granted("ROLE_ADMIN")'])]
+    #[TestWith(['is_authenticated()'])]
+    #[TestWith(['is_fully_authenticated()'])]
+    #[TestWith(['is_remember_me()'])]
+    public function testTheFunctionsCannotBeCompiled(string $expression)
+    {
+        $el = new ExpressionLanguage();
+        $el->registerProvider(new ValidatorSecurityExpressionLanguageProvider($this->createStub(AuthorizationCheckerInterface::class), new TokenStorage(), new RequestStack()));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('can only be evaluated');
+        $el->compile($expression);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/WhenWithSecurityTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/WhenWithSecurityTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Validator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Validator\ValidatorSecurityExpressionLanguageProvider;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\When;
+use Symfony\Component\Validator\Constraints\WhenValidator;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Integration test: When constraint with security expression functions.
+ */
+class WhenWithSecurityTest extends TestCase
+{
+    public function testConstraintIsAppliedWhenGranted()
+    {
+        $authorizationChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authorizationChecker->method('isGranted')->willReturn(true);
+
+        $violations = $this->createValidator($authorizationChecker)->validate('', new When(expression: 'is_granted("ROLE_ADMIN")', constraints: [new NotBlank()]));
+
+        $this->assertCount(1, $violations);
+    }
+
+    public function testConstraintIsSkippedWhenNotGranted()
+    {
+        $authorizationChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $authorizationChecker->method('isGranted')->willReturn(false);
+
+        $violations = $this->createValidator($authorizationChecker)->validate('', new When(expression: 'is_granted("ROLE_ADMIN")', constraints: [new NotBlank()]));
+
+        $this->assertCount(0, $violations);
+    }
+
+    private function createValidator(AuthorizationCheckerInterface $authorizationChecker): ValidatorInterface
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
+
+        $expressionLanguage = new ExpressionLanguage();
+        $expressionLanguage->registerProvider(new ValidatorSecurityExpressionLanguageProvider($authorizationChecker, $this->createStub(TokenStorageInterface::class), $requestStack));
+
+        $whenValidator = new WhenValidator($expressionLanguage);
+
+        $factory = new class($whenValidator) extends ConstraintValidatorFactory {
+            public function __construct(private WhenValidator $whenValidator)
+            {
+            }
+
+            public function getInstance(Constraint $constraint): ConstraintValidatorInterface
+            {
+                if ($constraint instanceof When) {
+                    return $this->whenValidator;
+                }
+
+                return parent::getInstance($constraint);
+            }
+        };
+
+        return Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory($factory)
+            ->getValidator();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Validator/ValidatorSecurityExpressionLanguageProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Validator/ValidatorSecurityExpressionLanguageProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Validator;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * Registers security expression functions for use in validator expressions.
+ */
+class ValidatorSecurityExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    public function __construct(
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        $authorizationChecker = $this->authorizationChecker;
+        $tokenStorage = $this->tokenStorage;
+
+        return [
+            new ExpressionFunction('is_authenticated', self::compilerThrows('is_authenticated'), $this->evaluator('is_authenticated', static fn () => $authorizationChecker->isGranted('IS_AUTHENTICATED'))),
+
+            new ExpressionFunction('is_fully_authenticated', self::compilerThrows('is_fully_authenticated'), $this->evaluator('is_fully_authenticated', static fn () => $tokenStorage->getToken() && $authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY'))),
+
+            new ExpressionFunction('is_granted', self::compilerThrows('is_granted'), $this->evaluator('is_granted', static fn ($attributes, $object = null) => $authorizationChecker->isGranted($attributes, $object))),
+
+            new ExpressionFunction('is_remember_me', self::compilerThrows('is_remember_me'), $this->evaluator('is_remember_me', static fn () => $tokenStorage->getToken() && $authorizationChecker->isGranted('IS_REMEMBERED'))),
+        ];
+    }
+
+    /**
+     * The functions read the security context of the current request. Outside a request, as in a
+     * console command or a Messenger worker, there is no context to read: returning false there
+     * would silently skip the constraints guarded by the expression, so evaluation throws instead.
+     */
+    private function evaluator(string $name, \Closure $evaluate): \Closure
+    {
+        $requestStack = $this->requestStack;
+
+        return static function (array $variables, ...$args) use ($name, $requestStack, $evaluate) {
+            if (!$requestStack->getMainRequest()) {
+                throw new \LogicException(\sprintf('The "%s()" function cannot be evaluated outside of a request.', $name));
+            }
+
+            return $evaluate(...$args);
+        };
+    }
+
+    /**
+     * The functions call the authorization checker bound at registration time, so there is
+     * nothing a compiled expression could reference: evaluation is the only supported mode.
+     */
+    private static function compilerThrows(string $name): \Closure
+    {
+        return static fn () => throw new \LogicException(\sprintf('The "%s()" function cannot be compiled, it can only be evaluated.', $name));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63587
| License       | MIT

When both the Validator and Security components are wired, the security functions `is_granted()`, `is_authenticated()`, `is_fully_authenticated()` and `is_remember_me()` are registered in the validator expression language, so `When` and `Expression` constraints can condition on the current authorization state without custom code:

```php
#[When(expression: 'is_granted("ROLE_ADMIN")', constraints: [new NotBlank()])]
public string $adminField = '';

#[Assert\Expression('is_authenticated() and value != ""')]
public string $field = '';
```

The functions are bound to the request's authorization checker, mirroring Twig's `is_granted()` and the routing condition functions. A compiler pass registers `validator.security_expression_language_provider` and adds it to `validator.expression_language`, and it runs only when both `validator.expression_language` and `security.authorization_checker` exist.

Two semantics worth knowing, both pinned by tests:

* the functions can only be **evaluated**; compiling one throws a `LogicException`, since a compiled expression could not reference the bound services;
* they can only be evaluated **inside a request**. Outside one, as in a console command or a Messenger worker, there is no security context to read and evaluation throws `LogicException: The "is_granted()" function cannot be evaluated outside of a request.`

That second point is deliberately keyed on the request rather than on the token. Inside a request a null token is normal, it only means nobody is logged in, so `is_granted()` returns `false` for an anonymous visitor as usual. Outside a request, returning `false` would silently drop the constraints guarded by a `When` expression: validation would pass and nothing would say why. Throwing makes `When` and `Expression` behave the same way instead of one skipping constraints and the other reporting a violation.

Nothing here is a BC break. `is_granted()` in a validator expression is a `SyntaxError` on every released branch, so there is no existing behaviour to preserve, and the throw-versus-false choice is still open if the security team prefers the other one.

Documentation should cover: the four functions, the two constraints they work in, that they require a request and throw outside one, and that an application adding its own functions should register a provider service and call `registerProvider` on `validator.expression_language` from a compiler pass. Note the `validator.expression_language_provider` id is already taken by the framework's own provider, the one supplying `is_valid()`, so redefining it removes that function.
