### PR TITLE
[MonologBridge] Fix `ConsoleHandler` losing output after nested command terminates

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -95,6 +95,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
         OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG,
     ];
     private array $consoleFormatterOptions;
+    private int $nestedCommandDepth = 0;
 
     /**
      * @param OutputInterface|null $output            The console output to use (the handler remains disabled when passing null
@@ -142,6 +143,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     public function close(): void
     {
+        $this->nestedCommandDepth = 0;
         $this->output = null;
 
         parent::close();
@@ -155,6 +157,10 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     public function onCommand(ConsoleCommandEvent $event)
     {
+        if (1 !== ++$this->nestedCommandDepth) {
+            return;
+        }
+
         $output = $event->getOutput();
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
@@ -170,7 +176,9 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     public function onTerminate(ConsoleTerminateEvent $event)
     {
-        $this->close();
+        if ($this->nestedCommandDepth && !--$this->nestedCommandDepth) {
+            $this->close();
+        }
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -162,19 +162,19 @@ class ConsoleHandlerTest extends TestCase
         $logger->pushHandler($handler);
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(ConsoleEvents::COMMAND, function () use ($logger) {
+        $dispatcher->addListener(ConsoleEvents::COMMAND, static function () use ($logger) {
             $logger->info('Before command message.');
         });
-        $dispatcher->addListener(ConsoleEvents::TERMINATE, function () use ($logger) {
+        $dispatcher->addListener(ConsoleEvents::TERMINATE, static function () use ($logger) {
             $logger->info('Before terminate message.');
         });
 
         $dispatcher->addSubscriber($handler);
 
-        $dispatcher->addListener(ConsoleEvents::COMMAND, function () use ($logger) {
+        $dispatcher->addListener(ConsoleEvents::COMMAND, static function () use ($logger) {
             $logger->info('After command message.');
         });
-        $dispatcher->addListener(ConsoleEvents::TERMINATE, function () use ($logger) {
+        $dispatcher->addListener(ConsoleEvents::TERMINATE, static function () use ($logger) {
             $logger->info('After terminate message.');
         });
 
@@ -187,5 +187,37 @@ class ConsoleHandlerTest extends TestCase
         $dispatcher->dispatch($event, ConsoleEvents::TERMINATE);
         $this->assertStringContainsString('Before terminate message.', $out = $output->fetch());
         $this->assertStringContainsString('After terminate message.', $out);
+    }
+
+    public function testNestedCommandsDoNotCloseHandler()
+    {
+        $output = new BufferedOutput();
+        $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+
+        $handler = new ConsoleHandler(null, false);
+
+        $logger = new Logger('app');
+        $logger->pushHandler($handler);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($handler);
+
+        $parentInput = new ArrayInput([]);
+        $subInput = new ArrayInput([]);
+
+        $dispatcher->dispatch(new ConsoleCommandEvent(new Command('messenger:consume'), $parentInput, $output), ConsoleEvents::COMMAND);
+        $logger->info('log from parent');
+        $this->assertStringContainsString('log from parent', $output->fetch());
+
+        $subOutput = new BufferedOutput();
+        $dispatcher->dispatch(new ConsoleCommandEvent(new Command('nested:task'), $subInput, $subOutput), ConsoleEvents::COMMAND);
+        $dispatcher->dispatch(new ConsoleTerminateEvent(new Command('nested:task'), $subInput, $subOutput, Command::SUCCESS), ConsoleEvents::TERMINATE);
+
+        $logger->info('log after sub-command');
+        $this->assertStringContainsString('log after sub-command', $output->fetch(), 'Handler must still be active after nested command terminates');
+
+        // Parent command terminates: handler must be closed now
+        $dispatcher->dispatch(new ConsoleTerminateEvent(new Command('messenger:consume'), $parentInput, $output, Command::SUCCESS), ConsoleEvents::TERMINATE);
+        $this->assertFalse($handler->isHandling(RecordFactory::create(Logger::DEBUG)), 'Handler must be closed after main command terminates');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63686 
| License       | MIT

See the very good analysis from @kick-the-bucket => https://github.com/symfony/symfony/issues/63686#issuecomment-4089292023

When a command is run via `RunCommandMessageHandler` (e.g. through the Scheduler), `ConsoleHandler::onTerminate()` calls `close()` after the nested command finished, which unsets the `input` and `output` of the `ConsoleHandler`, so nothing else is logged after that.

The fix introduces a `$nestedCommandDepth` counter in `ConsoleHandler`:
- `onCommand` only activates the handler when depth goes from 0 to 1
- `onTerminate` only closes the handler when depth returns to 0
