### PR TITLE
[SecurityBundle] Fix profiler showing ERROR instead of DENIED 

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -534,7 +534,7 @@
                                     <tr class="voter_result">
                                         <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
                                         <td class="font-normal">
-                                            {% set result = decision.result|default(null) %}
+                                            {% set result = decision.result ?? null %}
                                             {% if result is same as(true) %}
                                                 <span class="label status-success same-width">GRANTED</span>
                                             {% elseif result is same as(false) %}


### PR DESCRIPTION
The `|default(null)` filter treats boolean `false` as empty and replaces it with `null`, causing the DENIED label to show as ERROR in the Access Decision log.

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63721
| License       | MIT

## Description

In `security.html.twig`, the Access Decision log Result column shows **ERROR** instead of **DENIED** when a voter denies access.

**Root cause:** Line 537 uses `decision.result|default(null)`. Twig's `default` filter treats `false` as "empty" and replaces it with `null`. The subsequent `result is same as(false)` check fails, falling through to the ERROR branch.

**Fix:** Replace `|default(null)` with `is defined ?` ternary:
```diff
- {% set result = decision.result|default(null) %}
+ {% set result = decision.result is defined ? decision.result : null %}
```

This preserves the boolean `false` value so `result is same as(false)` correctly evaluates to `true` → displays **DENIED**.