### PR TITLE
[EventDispatcher] Fix memory leak in TraceableEventDispatcher for long-running processes

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -40,6 +40,9 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
     private EventDispatcherInterface $dispatcher;
     private array $wrappedListeners = [];
     private array $orphanedEvents = [];
+    private array $dispatchDepth = [];
+    private array $calledListenerInfos = [];
+    private array $calledOriginalListeners = [];
     private ?RequestStack $requestStack;
     private string $currentRequestHash = '';
 
@@ -155,20 +158,20 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
     public function getCalledListeners(?Request $request = null): array
     {
-        if (null === $this->callStack) {
+        if (!$this->calledListenerInfos) {
             return [];
         }
 
         $hash = $request ? spl_object_hash($request) : null;
         $called = [];
-        foreach ($this->callStack as $listener) {
-            [$eventName, $requestHash] = $this->callStack->getInfo();
+
+        foreach ($this->calledListenerInfos as $requestHash => $infos) {
             if (null === $hash || $hash === $requestHash) {
-                $called[] = $listener->getInfo($eventName);
+                $called[] = $infos;
             }
         }
 
-        return $called;
+        return $called ? array_merge(...$called) : [];
     }
 
     public function getNotCalledListeners(?Request $request = null): array
@@ -185,15 +188,13 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         $hash = $request ? spl_object_hash($request) : null;
         $calledListeners = [];
 
-        if (null !== $this->callStack) {
-            foreach ($this->callStack as $calledListener) {
-                [, $requestHash] = $this->callStack->getInfo();
-
-                if (null === $hash || $hash === $requestHash) {
-                    $calledListeners[] = $calledListener->getWrappedListener();
-                }
+        foreach ($this->calledOriginalListeners as $requestHash => $eventListeners) {
+            if (null === $hash || $hash === $requestHash) {
+                $calledListeners[] = array_merge(...array_values($eventListeners));
             }
         }
+
+        $calledListeners = $calledListeners ? array_merge(...$calledListeners) : [];
 
         $notCalled = [];
 
@@ -234,6 +235,9 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         $this->callStack = null;
         $this->orphanedEvents = [];
         $this->currentRequestHash = '';
+        $this->dispatchDepth = [];
+        $this->calledListenerInfos = [];
+        $this->calledOriginalListeners = [];
     }
 
     /**
@@ -267,6 +271,8 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
     private function preProcess(string $eventName): void
     {
+        $this->dispatchDepth[$eventName] = ($this->dispatchDepth[$eventName] ?? 0) + 1;
+
         if (!$this->dispatcher->hasListeners($eventName)) {
             $this->orphanedEvents[$this->currentRequestHash][] = $eventName;
 
@@ -285,6 +291,8 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
     private function postProcess(string $eventName): void
     {
+        --$this->dispatchDepth[$eventName];
+
         unset($this->wrappedListeners[$eventName]);
         $skipped = false;
         foreach ($this->dispatcher->getListeners($eventName) as $listener) {
@@ -302,9 +310,15 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
             if ($listener->wasCalled()) {
                 $this->logger?->debug('Notified event "{event}" to listener "{listener}".', $context);
-            } else {
-                unset($this->callStack[$listener]);
+
+                $original = $listener->getWrappedListener();
+                if (!\in_array($original, $this->calledOriginalListeners[$this->currentRequestHash][$eventName] ?? [], true)) {
+                    $this->calledOriginalListeners[$this->currentRequestHash][$eventName][] = $original;
+                    $this->calledListenerInfos[$this->currentRequestHash][] = $listener->getInfo($eventName);
+                }
             }
+
+            unset($this->callStack[$listener]);
 
             if (null !== $this->logger && $skipped) {
                 $this->logger->debug('Listener "{listener}" was not called for event "{event}".', $context);
@@ -315,6 +329,28 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
                 $skipped = true;
             }
+        }
+
+        if (0 < $this->dispatchDepth[$eventName]) {
+            return;
+        }
+
+        // Clean up stale callStack entries left by nested same-event dispatches
+        $stale = [];
+        foreach ($this->callStack as $listener) {
+            if ($this->callStack->getInfo()[0] === $eventName) {
+                $stale[] = $listener;
+            }
+        }
+        foreach ($stale as $listener) {
+            if ($listener->wasCalled()) {
+                $original = $listener->getWrappedListener();
+                if (!\in_array($original, $this->calledOriginalListeners[$this->currentRequestHash][$eventName] ?? [], true)) {
+                    $this->calledOriginalListeners[$this->currentRequestHash][$eventName][] = $original;
+                    $this->calledListenerInfos[$this->currentRequestHash][] = $listener->getInfo($eventName);
+                }
+            }
+            unset($this->callStack[$listener]);
         }
     }
 

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -331,6 +331,134 @@ class TraceableEventDispatcherTest extends TestCase
         $events = $tdispatcher->getOrphanedEvents();
         $this->assertCount(0, $events);
     }
+
+    public function testCallStackIsNotLeakingOnRepeatedDispatch()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', static function () {}, 5);
+
+        for ($i = 0; $i < 5; ++$i) {
+            $tdispatcher->dispatch(new Event(), 'foo');
+        }
+
+        $this->assertCount(1, $tdispatcher->getCalledListeners());
+    }
+
+    public function testCallStackIsNotLeakingWithMultipleListeners()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', static function () {}, 10);
+        $tdispatcher->addListener('foo', static function () {}, 5);
+
+        for ($i = 0; $i < 5; ++$i) {
+            $tdispatcher->dispatch(new Event(), 'foo');
+        }
+
+        $this->assertCount(2, $tdispatcher->getCalledListeners());
+    }
+
+    public function testCallStackCleanupDoesNotAffectOtherEvents()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', static function () {});
+        $tdispatcher->addListener('bar', static function () {});
+
+        $tdispatcher->dispatch(new Event(), 'foo');
+        $tdispatcher->dispatch(new Event(), 'bar');
+        $tdispatcher->dispatch(new Event(), 'foo');
+
+        $this->assertCount(2, $tdispatcher->getCalledListeners());
+    }
+
+    public function testCallStackIsNotLeakingWithStoppedPropagation()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', static function (Event $event) { $event->stopPropagation(); }, 10);
+        $tdispatcher->addListener('foo', static function () {}, 5);
+
+        for ($i = 0; $i < 5; ++$i) {
+            $tdispatcher->dispatch(new Event(), 'foo');
+        }
+
+        $this->assertCount(1, $tdispatcher->getCalledListeners());
+        $this->assertCount(1, $tdispatcher->getNotCalledListeners());
+    }
+
+    public function testPreviouslyCalledListenerStaysCalledAfterLaterStopPropagation()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', static function () {}, 5);
+
+        $tdispatcher->dispatch(new Event(), 'foo');
+        $this->assertCount(1, $tdispatcher->getCalledListeners());
+
+        $tdispatcher->addListener('foo', static function (Event $event) { $event->stopPropagation(); }, 10);
+        $tdispatcher->dispatch(new Event(), 'foo');
+
+        $this->assertCount(2, $tdispatcher->getCalledListeners());
+        $this->assertCount(0, $tdispatcher->getNotCalledListeners());
+    }
+
+    public function testCallStackCleanupWhenEventBecomesOrphaned()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $listener = static function () {};
+        $tdispatcher->addListener('foo', $listener);
+
+        $tdispatcher->dispatch(new Event(), 'foo');
+        $this->assertCount(1, $tdispatcher->getCalledListeners());
+
+        $tdispatcher->removeListener('foo', $listener);
+        $tdispatcher->dispatch(new Event(), 'foo');
+
+        $this->assertCount(1, $tdispatcher->getCalledListeners());
+        $this->assertCount(1, $tdispatcher->getOrphanedEvents());
+    }
+
+    public function testCallStackIsNotLeakingWithNestedSameEventDispatch()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $iteration = 0;
+        $tdispatcher->addListener('foo', static function () use ($tdispatcher, &$iteration) {
+            if ($iteration++ < 1) {
+                $tdispatcher->dispatch(new Event(), 'foo');
+            }
+        });
+
+        $tdispatcher->dispatch(new Event(), 'foo');
+        $this->assertCount(1, $tdispatcher->getCalledListeners());
+    }
+
+    public function testCallStackIsNotLeakingWhenListenerIsAddedBetweenDispatches()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', static function () {}, 10);
+
+        $tdispatcher->dispatch(new Event(), 'foo');
+        $this->assertCount(1, $tdispatcher->getCalledListeners());
+
+        $tdispatcher->addListener('foo', static function () {}, 5);
+        $tdispatcher->dispatch(new Event(), 'foo');
+
+        $this->assertCount(2, $tdispatcher->getCalledListeners());
+    }
+
+    public function testCallStackIsNotLeakingWhenListenerIsRemovedBetweenDispatches()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $listenerA = static function () {};
+        $listenerB = static function () {};
+        $tdispatcher->addListener('foo', $listenerA, 10);
+        $tdispatcher->addListener('foo', $listenerB, 5);
+
+        $tdispatcher->dispatch(new Event(), 'foo');
+        $this->assertCount(2, $tdispatcher->getCalledListeners());
+
+        $tdispatcher->removeListener('foo', $listenerB);
+        $tdispatcher->dispatch(new Event(), 'foo');
+
+        $this->assertCount(2, $tdispatcher->getCalledListeners());
+    }
 }
 
 class EventSubscriber implements EventSubscriberInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62996
| License       | MIT

## Problem

`TraceableEventDispatcher` leaks memory in long-running CLI processes (Messenger workers, Scheduler) running in dev mode.

`preProcess()` creates new `WrappedListener` objects on every `dispatch()` call and stores them in `$callStack`. Called listeners stay there permanently. In HTTP requests `reset()` clears them at the end. In CLI workers `reset()` is skipped during idle phases, so `$callStack` grows without limit until the process runs out of memory.

Related issues: #32422, #41709, #45386

## Solution

Two changes that work together:

**1. Dispatch-depth counter** — A per-event integer counts how deep we are in nested dispatches. We only clean up old entries at the top level (depth 1). This is safe even when listeners remove themselves during dispatch.

**2. Bounded aggregate for called listeners** — When `postProcess()` finishes, it saves "this listener was called" into a small deduplicated list, then removes the heavy wrapper object from `$callStack`. The list only stores each listener once per event, so it cannot grow. `getCalledListeners()` and `getNotCalledListeners()` read from this list.

## Result

- `$callStack` is always empty after each dispatch (no more accumulation)
- A listener that was called at any point still shows as "called" in the profiler
- No change to profiler output for normal HTTP requests
- Memory stays flat in long-running workers

## Tests

9 new tests cover: repeated dispatches, multiple listeners, cross-event isolation, stopped propagation, previously-called listener preservation, orphaned events, nested same-event dispatch, listener addition between dispatches, listener removal between dispatches.

  ## Known limitation

Memory is now bounded for stable listener graphs (the normal case in Symfony — listeners registered once at container compilation). Dynamic registration of new listener instances over time (e.g. fresh closures added and removed repeatedly) can still retain aggregate history until `reset()` is called. This does not affect the reported use case.
