### PR TITLE
[HttpClient] Unset push response content when the push handler is released

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -53,6 +53,7 @@ final class CurlClientState extends ClientState
         foreach ($this->pushedResponses as $url => $response) {
             $this->logger?->debug(\sprintf('Unused pushed response: "%s"', $url));
             curl_multi_remove_handle($this->handle, $response->handle);
+            unset($this->handlesActivity[(int) $response->handle]);
         }
 
         $this->pushedResponses = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Reset method releases the handlers of push responses, though it doesn't reset the content of push responses, so the next time the curl handler is initialised(new request is being sent), it might get the same ID that was used for one of the push responses, causing the wrong/corrupted response to be returned to the client.

Reproducer:
```
$defaultOptions = ['verify_host' => false, 'verify_peer' => false];
$client = new CurlHttpClient($defaultOptions,6,50);
$max = 10;
for ($i = 0; $i < $max; $i++) {
  $request = $client->request('GET', 'https://nghttp2.org');
  $responseBody = $request->getContent();
  
  $client->reset();
}
```
Expected behavior:
Pushed response handlers are released, `CurlClientState->handlesActivity` don't contain the keys of the released handlers, so it won't conflict with any new keys we add there later.

Actual behavior:
`CurlClientState->handlesActivity` items persist, causing occasional issues with the further requests
<img width="1109" height="662" alt="image" src="https://github.com/user-attachments/assets/e4a1d1f9-80a8-402c-b8c4-7e912847ea8e" />

I've created the [reproducer](https://github.com/sakozoko/symfony-curl-push-responses-issue-reproducer) with the needed infrastructure to observe the issue. There is a simple backend that serves static content and adds a Link header, which is later pushed by nghttpx proxy to CurlHttpClient. It suits well for reproducing the case when the push response content is returned with another request body, which requires a bit of luck with the IDs of curl handlers, but it works for me 9 out of 10 cases and the json responses get mixed with the css content.

Also, I am wondering, I've seen [this commit](https://github.com/symfony/symfony/commit/ae9b88990c941b43e06853e7134bc87781e5b2ef) that states disabling HTTP2 push for curl by default, but it's not for Symfony Framework or anyone who creates it with HttpClient::create() method as [maxPendingPushes = 50 in HttpClient::create()](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpClient/HttpClient.php#L55), it raises a question - is there any way to disable curl push responses in Symfony Framework? I know I can set the HTTP version to 1.1, but it's not a very reliable option for me.