### PR TITLE
[Form] Use `translation_domain` for expanded `ChoiceType` placeholder

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add argument `$violationMapper` to `ValidatorExtensionTrait` and `TypeTestCase`'s `getExtensions()` methods
  * Add default `min`/`max` attributes to `BirthdayType` when `widget` is `single_text`
  * Add `labels` option to `DateType` to customize the year, month and day sub-field labels
+ * Use `translation_domain` instead of `choice_translation_domain` for the expanded `ChoiceType` placeholder
 
 8.0
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -437,7 +437,7 @@ class ChoiceType extends AbstractType
             'label_html' => $options['label_html'],
             'attr' => $choiceView->attr,
             'label_translation_parameters' => $choiceView->labelTranslationParameters,
-            'translation_domain' => $options['choice_translation_domain'],
+            'translation_domain' => 'placeholder' === $name ? $options['translation_domain'] : $options['choice_translation_domain'],
             'block_name' => 'entry',
         ];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2109,6 +2109,48 @@ class ChoiceTypeTest extends BaseTypeTestCase
         $this->assertSame('choice_translation_domain', $form->children[1]->vars['translation_domain']);
     }
 
+    public function testPlaceholderSubFormUsesTranslationDomainInsteadOfChoiceTranslationDomain()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'label' => 'label',
+            'translation_domain' => 'label_translation_domain',
+            'choices' => [
+                'choice1' => true,
+                'choice2' => false,
+            ],
+            'choice_translation_domain' => 'choice_translation_domain',
+            'placeholder' => 'placeholder_label',
+            'expanded' => true,
+            'required' => false,
+        ])->createView();
+
+        $this->assertCount(3, $form->children);
+        $this->assertSame('label_translation_domain', $form->children['placeholder']->vars['translation_domain']);
+        $this->assertSame('choice_translation_domain', $form->children[0]->vars['translation_domain']);
+        $this->assertSame('choice_translation_domain', $form->children[1]->vars['translation_domain']);
+    }
+
+    public function testPlaceholderSubFormTranslatedWhenChoiceTranslationDomainIsFalse()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'label' => 'label',
+            'translation_domain' => 'messages',
+            'choices' => [
+                'choice1' => 'a',
+                'choice2' => 'b',
+            ],
+            'choice_translation_domain' => false,
+            'placeholder' => 'Select an option',
+            'expanded' => true,
+            'required' => false,
+        ])->createView();
+
+        $this->assertCount(3, $form->children);
+        $this->assertSame('messages', $form->children['placeholder']->vars['translation_domain']);
+        $this->assertFalse($form->children[0]->vars['translation_domain']);
+        $this->assertFalse($form->children[1]->vars['translation_domain']);
+    }
+
     #[DataProvider('provideTrimCases')]
     public function testTrimIsDisabled($multiple, $expanded)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63233
| License       | MIT

When an expanded `ChoiceType` has a placeholder, `addSubForm()` sets `translation_domain` to `choice_translation_domain` for all children, including the placeholder. For `EntityType`, `choice_translation_domain` defaults to `false`, so the placeholder label is never translated even when set to a `TranslatableMessage`.

The placeholder is not a choice label. It now receives `translation_domain` instead of `choice_translation_domain`, matching how non-expanded `<select>` placeholders are translated in the Twig templates.

```php
// Before: placeholder gets choice_translation_domain (false for EntityType)
$form = $this->createForm(EntityType::class, null, [
    'class' => MyEntity::class,
    'expanded' => true,
    'placeholder' => new TranslatableMessage('select_option', [], 'messages'),
]);
// placeholder label was not translated

// After: placeholder gets translation_domain, translation works
```