### PR TITLE
[Form] Add support for grouping and nested steps in `FormFlowType`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -40,6 +40,9 @@ DoctrineBridge
 Form
 ----
 
+ * Add `createStepGroup()` method to `FormFlowBuilderInterface`; implementations not extending the default `FormFlowBuilder` must implement it
+ * Add `setGroup()`, `addStep()` and `removeStep()` methods to `StepFlowBuilderConfigInterface`; implementations not extending the default `StepFlowBuilder` must implement them
+ * Add `isGroup()`, `getSteps()`, `hasStep()` and `getStep()` methods to `StepFlowConfigInterface`; implementations not extending the default `StepFlowBuilder` must implement them
  * [BC BREAK] Children that use the `form_attr` option now carry the id the themes render on the `<form>`
    element instead of the id of the element wrapping the fields, so that the reference resolves. That id is
    the `attr.id` of the root form when the application set one, the string given to `form_attr` when the

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add support for grouping and nested steps in `FormFlowType`
  * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0
  * Add `PolymorphicCollectionType` for collections whose entries do not all share the same type
  * Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled

--- a/src/Symfony/Component/Form/Flow/FormFlow.php
+++ b/src/Symfony/Component/Form/Flow/FormFlow.php
@@ -177,7 +177,7 @@ class FormFlow extends Form implements FormFlowInterface
     {
         $steps = $this->cursor->getSteps();
 
-        if (false === $targetIndex = array_search($step, $steps)) {
+        if (false === $targetIndex = array_search($step, $steps, true)) {
             throw new InvalidArgumentException(\sprintf('Step "%s" does not exist.', $step));
         }
 
@@ -221,7 +221,7 @@ class FormFlow extends Form implements FormFlowInterface
 
             $cursor = $cursor->withCurrentStep($newStep);
 
-            if (!$this->config->getStep($newStep)->isSkipped($data)) {
+            if (!$cursor->getCurrentStepNode()->isGroupOrSkipped($data)) {
                 break;
             }
 
@@ -230,11 +230,9 @@ class FormFlow extends Form implements FormFlowInterface
 
                 if ($this->config->isAutoReset()) {
                     $this->reset();
-
-                    return true;
                 }
 
-                break;
+                return true;
             }
         }
 

--- a/src/Symfony/Component/Form/Flow/FormFlowBuilder.php
+++ b/src/Symfony/Component/Form/Flow/FormFlowBuilder.php
@@ -37,6 +37,15 @@ class FormFlowBuilder extends FormBuilder implements FormFlowBuilderInterface
     private DataStorageInterface $dataStorage;
     private StepAccessorInterface $stepAccessor;
 
+    public function createStepGroup(string $name): StepFlowBuilderConfigInterface
+    {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormFlowBuilder methods cannot be accessed anymore once the builder is turned into a FormFlowConfigInterface instance.');
+        }
+
+        return new StepFlowBuilder($name)->setGroup(true);
+    }
+
     public function createStep(string $name, string $type = FormType::class, array $options = []): StepFlowBuilderConfigInterface
     {
         if ($this->locked) {
@@ -79,12 +88,34 @@ class FormFlowBuilder extends FormBuilder implements FormFlowBuilderInterface
 
     public function hasStep(string $name): bool
     {
-        return isset($this->steps[$name]);
+        if (isset($this->steps[$name])) {
+            return true;
+        }
+
+        foreach ($this->steps as $step) {
+            if ($step->hasStep($name)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function getStep(string $name): StepFlowBuilderConfigInterface
     {
-        return $this->steps[$name] ?? throw new InvalidArgumentException(\sprintf('Step "%s" does not exist.', $name));
+        if (isset($this->steps[$name])) {
+            return $this->steps[$name];
+        }
+
+        foreach ($this->steps as $step) {
+            try {
+                return $step->getStep($name);
+            } catch (InvalidArgumentException) {
+                // Continue searching
+            }
+        }
+
+        throw new InvalidArgumentException(\sprintf('Step "%s" does not exist.', $name));
     }
 
     public function getSteps(): array
@@ -105,7 +136,7 @@ class FormFlowBuilder extends FormBuilder implements FormFlowBuilderInterface
 
     public function getInitialStep(): string
     {
-        $defaultStep = (string) key($this->steps);
+        $defaultStep = $this->resolveFirstStep();
 
         if (!isset($this->initialOptions['data'])) {
             return $defaultStep;
@@ -204,19 +235,16 @@ class FormFlowBuilder extends FormBuilder implements FormFlowBuilderInterface
 
         uasort($this->steps, static fn (StepFlowBuilderConfigInterface $a, StepFlowBuilderConfigInterface $b) => $b->getPriority() <=> $a->getPriority());
 
+        $config = $this->getFormConfig();
         $currentStep = $this->resolveCurrentStep();
 
-        if (!isset($this->steps[$currentStep])) {
-            throw new InvalidArgumentException(\sprintf('Step form "%s" is not defined.', $currentStep));
-        }
-
-        $step = $this->steps[$currentStep];
+        $step = $this->getStep($currentStep);
         $this->add($step->getName(), $step->getType(), $step->getOptions());
 
-        $cursor = new FormFlowCursor(array_keys($this->steps), $currentStep);
+        $cursor = new FormFlowCursor($config->getSteps(), $currentStep);
         $this->pruneActionButtons($this, $cursor);
 
-        return new FormFlow($this->getFormConfig(), $cursor);
+        return new FormFlow($config, $cursor);
     }
 
     private function resolveCurrentStep(): string
@@ -224,12 +252,36 @@ class FormFlowBuilder extends FormBuilder implements FormFlowBuilderInterface
         $data = $this->getData();
 
         if (!$currentStep = $this->getStepAccessor()->getStep($data)) {
-            $currentStep = key($this->steps);
+            $currentStep = $this->resolveFirstStep();
             $this->getStepAccessor()->setStep($data, $currentStep);
             $this->setData($data);
         }
 
         return $currentStep;
+    }
+
+    /**
+     * Finds the first navigable step in DFS pre-order.
+     *
+     * A step is navigable if it is neither a group nor skipped.
+     */
+    private function resolveFirstStep(?array $steps = null): string
+    {
+        foreach ($steps ?? $this->steps as $step) {
+            if (!$step->isGroup() && !$step->isSkipped($this->getData())) {
+                return $step->getName();
+            }
+
+            if ($children = $step->getSteps()) {
+                try {
+                    return $this->resolveFirstStep($children);
+                } catch (LogicException) {
+                    continue;
+                }
+            }
+        }
+
+        throw new LogicException('No navigable step found. All steps are groups or skipped.');
     }
 
     private function pruneActionButtons(FormBuilderInterface $builder, FormFlowCursor $cursor): void

--- a/src/Symfony/Component/Form/Flow/FormFlowBuilderInterface.php
+++ b/src/Symfony/Component/Form/Flow/FormFlowBuilderInterface.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Yonel Ceruto <open@yceruto.dev>
  *
+ * @method StepFlowBuilderConfigInterface createStepGroup(string $name)
+ *
  * @extends \Traversable<string, FormBuilderInterface>
  */
 interface FormFlowBuilderInterface extends FormBuilderInterface, FormFlowConfigInterface

--- a/src/Symfony/Component/Form/Flow/FormFlowCursor.php
+++ b/src/Symfony/Component/Form/Flow/FormFlowCursor.php
@@ -12,24 +12,64 @@
 namespace Symfony\Component\Form\Flow;
 
 use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Exception\LogicException;
 
 /**
  * @author Yonel Ceruto <open@yceruto.dev>
  */
 class FormFlowCursor
 {
+    /** @var list<StepFlowNode> */
+    private array $roots;
+    /** @var array<string, StepFlowNode> */
+    private array $stepMap;
+    /** @var list<string> */
+    private array $steps;
+    private StepFlowNode $currentStep;
+
     /**
-     * @param array<string> $steps
+     * @param array<string, StepFlowConfigInterface>|list<string> $steps       Step configs or a flat list of step names
+     * @param string                                              $currentStep The name of the current step
      */
     public function __construct(
-        private readonly array $steps,
-        private readonly string $currentStep,
+        array $steps,
+        string $currentStep,
     ) {
-        if (!\in_array($currentStep, $steps, true)) {
-            throw new InvalidArgumentException(\sprintf('Step "%s" does not exist. Available steps are: "%s".', $currentStep, implode('", "', $steps)));
+        $first = reset($steps);
+
+        if (\is_string($first)) {
+            $this->roots = StepFlowNode::fromArray($steps);
+        } elseif ($first instanceof StepFlowConfigInterface) {
+            $this->roots = StepFlowNode::fromConfig($steps);
+        } else {
+            throw new InvalidArgumentException('The $steps argument must be a list of step names or a list of step configs.');
         }
+
+        // Performs a DFS pre-order traversal to build flat step names and node lookup map.
+        $this->stepMap = [];
+        $this->steps = [];
+        $stack = array_reverse($this->roots);
+        while ($stack) {
+            $node = array_pop($stack);
+            $this->stepMap[$node->getName()] = $node;
+            $this->steps[] = $node->getName();
+            foreach (array_reverse($node->getChildren()) as $child) {
+                $stack[] = $child;
+            }
+        }
+
+        if (!isset($this->stepMap[$currentStep])) {
+            throw new InvalidArgumentException(\sprintf('Step "%s" does not exist. Available steps are: "%s".', $currentStep, implode('", "', $this->steps)));
+        }
+
+        $this->currentStep = $this->stepMap[$currentStep];
     }
 
+    /**
+     * Returns the flattened list of steps in DFS pre-order.
+     *
+     * @return list<string>
+     */
     public function getSteps(): array
     {
         return $this->steps;
@@ -40,64 +80,152 @@ class FormFlowCursor
         return \count($this->steps);
     }
 
+    /**
+     * Returns the global index of the current step among all flattened steps.
+     */
     public function getStepIndex(): int
     {
-        return (int) array_search($this->currentStep, $this->steps, true);
+        return $this->getStepIndexOf($this->currentStep->getName());
+    }
+
+    public function getStepIndexOf(string $name): int
+    {
+        return array_search($name, $this->steps, true);
+    }
+
+    public function getParentStep(): ?string
+    {
+        return $this->currentStep->getParent()?->getName();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getChildSteps(): array
+    {
+        return array_map(static fn (StepFlowNode $node) => $node->getName(), $this->currentStep->getChildren());
     }
 
     public function getFirstStep(): string
     {
-        return $this->steps[0];
+        foreach ($this->steps as $name) {
+            if (!$this->stepMap[$name]->isGroup()) {
+                return $name;
+            }
+        }
+
+        throw new LogicException('No visitable step found.');
     }
 
     public function getPreviousStep(): ?string
     {
-        $currentPos = array_search($this->currentStep, $this->steps, true);
-
-        return $this->steps[$currentPos - 1] ?? null;
+        return $this->currentStep->getPreviousInTraversal()?->getName();
     }
 
     public function getCurrentStep(): string
     {
-        return $this->currentStep;
+        return $this->currentStep->getName();
     }
 
     public function withCurrentStep(string $step): self
     {
-        return new self($this->steps, $step);
+        if (!isset($this->stepMap[$step])) {
+            throw new InvalidArgumentException(\sprintf('Step "%s" does not exist. Available steps are: "%s".', $step, implode('", "', $this->steps)));
+        }
+
+        $clone = clone $this;
+        $clone->currentStep = $this->stepMap[$step];
+
+        return $clone;
     }
 
     public function getNextStep(): ?string
     {
-        $currentPos = array_search($this->currentStep, $this->steps, true);
-
-        return $this->steps[$currentPos + 1] ?? null;
+        return $this->currentStep->getNextInTraversal()?->getName();
     }
 
     public function getLastStep(): string
     {
-        return $this->steps[\count($this->steps) - 1];
+        for ($i = \count($this->steps) - 1; $i >= 0; --$i) {
+            if (!$this->stepMap[$this->steps[$i]]->isGroup()) {
+                return $this->steps[$i];
+            }
+        }
+
+        throw new LogicException('No visitable step found.');
     }
 
     public function isFirstStep(): bool
     {
-        return 0 === array_search($this->currentStep, $this->steps, true);
+        $node = $this->currentStep;
+        while (null !== $prev = $node->getPreviousInTraversal()) {
+            if (!$prev->isGroup()) {
+                return false;
+            }
+            $node = $prev;
+        }
+
+        return true;
     }
 
     public function isLastStep(): bool
     {
-        $currentPos = array_search($this->currentStep, $this->steps, true);
+        $node = $this->currentStep;
+        while (null !== $next = $node->getNextInTraversal()) {
+            if (!$next->isGroup()) {
+                return false;
+            }
+            $node = $next;
+        }
 
-        return \count($this->steps) === $currentPos + 1;
+        return true;
     }
 
     public function canMoveBack(): bool
     {
-        return null !== $this->getPreviousStep();
+        $node = $this->currentStep;
+        while (null !== $prev = $node->getPreviousInTraversal()) {
+            if (!$prev->isGroup()) {
+                return true;
+            }
+            $node = $prev;
+        }
+
+        return false;
     }
 
     public function canMoveNext(): bool
     {
-        return null !== $this->getNextStep();
+        $node = $this->currentStep;
+        while (null !== $next = $node->getNextInTraversal()) {
+            if (!$next->isGroup()) {
+                return true;
+            }
+            $node = $next;
+        }
+
+        return false;
+    }
+
+    public function getCurrentStepNode(): StepFlowNode
+    {
+        return $this->currentStep;
+    }
+
+    public function getStepNode(string $name): StepFlowNode
+    {
+        if (!isset($this->stepMap[$name])) {
+            throw new InvalidArgumentException(\sprintf('Step "%s" does not exist. Available steps are: "%s".', $name, implode('", "', $this->steps)));
+        }
+
+        return $this->stepMap[$name];
+    }
+
+    /**
+     * @return list<StepFlowNode>
+     */
+    public function getRootStepNodes(): array
+    {
+        return $this->roots;
     }
 }

--- a/src/Symfony/Component/Form/Flow/StepFlowBuilder.php
+++ b/src/Symfony/Component/Form/Flow/StepFlowBuilder.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Form\Flow;
 
 use Symfony\Component\Form\Exception\BadMethodCallException;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormTypeInterface;
 
 /**
@@ -22,13 +24,16 @@ class StepFlowBuilder implements StepFlowBuilderConfigInterface
     private bool $locked = false;
     private int $priority = 0;
     private ?\Closure $skip = null;
+    /** @var array<string, StepFlowBuilderConfigInterface> */
+    private array $children = [];
+    private bool $group = false;
 
     /**
      * @param class-string<FormTypeInterface> $type
      */
     public function __construct(
         private readonly string $name,
-        private readonly string $type,
+        private readonly string $type = FormType::class,
         private readonly array $options = [],
     ) {
     }
@@ -97,6 +102,75 @@ class StepFlowBuilder implements StepFlowBuilderConfigInterface
         return $this;
     }
 
+    public function setGroup(bool $group): StepFlowBuilderConfigInterface
+    {
+        if ($this->locked) {
+            throw new BadMethodCallException('StepFlowBuilder methods cannot be accessed anymore once the builder is turned into a StepFlowConfigInterface instance.');
+        }
+
+        $this->group = $group;
+
+        return $this;
+    }
+
+    public function isGroup(): bool
+    {
+        return $this->group;
+    }
+
+    public function addStep(StepFlowBuilderConfigInterface|string $name, string $type = FormType::class, array $options = [], ?callable $skip = null, int $priority = 0): StepFlowBuilderConfigInterface
+    {
+        if ($this->locked) {
+            throw new BadMethodCallException('StepFlowBuilder methods cannot be accessed anymore once the builder is turned into a StepFlowConfigInterface instance.');
+        }
+
+        if ($name instanceof StepFlowBuilderConfigInterface) {
+            $this->children[$name->getName()] = $name;
+
+            return $this;
+        }
+
+        $this->children[$name] = new self($name, $type, $options)
+            ->setSkip($skip ? $skip(...) : null)
+            ->setPriority($priority);
+
+        return $this;
+    }
+
+    public function removeStep(string $name): StepFlowBuilderConfigInterface
+    {
+        unset($this->children[$name]);
+
+        return $this;
+    }
+
+    public function getSteps(): array
+    {
+        return $this->children;
+    }
+
+    public function hasStep(string $name): bool
+    {
+        return isset($this->children[$name]) || array_any($this->children, static fn (StepFlowBuilderConfigInterface $step) => $step->hasStep($name));
+    }
+
+    public function getStep(string $name): StepFlowConfigInterface
+    {
+        if (isset($this->children[$name])) {
+            return $this->children[$name];
+        }
+
+        foreach ($this->children as $step) {
+            try {
+                return $step->getStep($name);
+            } catch (InvalidArgumentException) {
+                // Continue searching
+            }
+        }
+
+        throw new InvalidArgumentException(\sprintf('Sub step "%s" does not exist in "%s" step.', $name, $this->name));
+    }
+
     public function getStepConfig(): StepFlowConfigInterface
     {
         if ($this->locked) {
@@ -106,6 +180,12 @@ class StepFlowBuilder implements StepFlowBuilderConfigInterface
         // This method should be idempotent, so clone the builder
         $config = clone $this;
         $config->locked = true;
+
+        uasort($config->children, static fn (StepFlowBuilderConfigInterface $a, StepFlowBuilderConfigInterface $b) => $b->getPriority() <=> $a->getPriority());
+
+        foreach ($config->children as $name => $step) {
+            $config->children[$name] = $step->getStepConfig();
+        }
 
         return $config;
     }

--- a/src/Symfony/Component/Form/Flow/StepFlowBuilderConfigInterface.php
+++ b/src/Symfony/Component/Form/Flow/StepFlowBuilderConfigInterface.php
@@ -11,8 +11,14 @@
 
 namespace Symfony\Component\Form\Flow;
 
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+
 /**
  * @author Yonel Ceruto <open@yceruto.dev>
+ *
+ * @method $this setGroup(bool $group)
+ * @method $this addStep(StepFlowBuilderConfigInterface|string $name, string $type = FormType::class, array $options = [], ?callable $skip = null, int $priority = 0)
+ * @method $this removeStep(string $name)
  */
 interface StepFlowBuilderConfigInterface extends StepFlowConfigInterface
 {

--- a/src/Symfony/Component/Form/Flow/StepFlowConfigInterface.php
+++ b/src/Symfony/Component/Form/Flow/StepFlowConfigInterface.php
@@ -13,6 +13,11 @@ namespace Symfony\Component\Form\Flow;
 
 /**
  * @author Yonel Ceruto <open@yceruto.dev>
+ *
+ * @method bool                isGroup()
+ * @method array<string, self> getSteps()
+ * @method bool                hasStep(string $name)
+ * @method self                getStep(string $name)
  */
 interface StepFlowConfigInterface
 {

--- a/src/Symfony/Component/Form/Flow/StepFlowNode.php
+++ b/src/Symfony/Component/Form/Flow/StepFlowNode.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Flow;
+
+use Symfony\Component\Form\Exception\LogicException;
+
+/**
+ * Represents a node in the step flow tree (forest graph).
+ *
+ * @author Yonel Ceruto <open@yceruto.dev>
+ */
+class StepFlowNode
+{
+    /** @var list<self> */
+    private array $children = [];
+    private ?self $previousSibling = null;
+    private ?self $nextSibling = null;
+
+    private function __construct(
+        private readonly string $name,
+        private readonly ?\Closure $skip = null,
+        private readonly bool $group = false,
+        private readonly ?self $parent = null,
+    ) {
+    }
+
+    /**
+     * @param list<string> $steps
+     *
+     * @return list<self>
+     */
+    public static function fromArray(array $steps): array
+    {
+        $nodes = [];
+        $previous = null;
+
+        foreach ($steps as $name) {
+            $node = new self($name);
+
+            if ($previous) {
+                $previous->nextSibling = $node;
+                $node->previousSibling = $previous;
+            }
+
+            $nodes[] = $node;
+            $previous = $node;
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * Builds a forest from step configurations.
+     *
+     * @param array<string, StepFlowConfigInterface> $steps Ordered step configs
+     *
+     * @return list<self>
+     */
+    public static function fromConfig(array $steps, ?self $parent = null): array
+    {
+        $nodes = [];
+        $previous = null;
+
+        foreach ($steps as $name => $step) {
+            $node = new self($name, $step->getSkip(), $step->isGroup(), $parent);
+
+            if ($previous) {
+                $previous->nextSibling = $node;
+                $node->previousSibling = $previous;
+            }
+
+            if ($children = $step->getSteps()) {
+                $node->children = self::fromConfig($children, $node);
+            } elseif ($node->group) {
+                throw new LogicException(\sprintf('Step "%s" is marked as group but has no child steps.', $name));
+            }
+
+            $nodes[] = $node;
+            $previous = $node;
+        }
+
+        return $nodes;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getParent(): ?self
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @return list<self>
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function getNextSibling(): ?self
+    {
+        return $this->nextSibling;
+    }
+
+    public function getPreviousSibling(): ?self
+    {
+        return $this->previousSibling;
+    }
+
+    public function isGroup(): bool
+    {
+        return $this->group;
+    }
+
+    public function getSkip(): ?\Closure
+    {
+        return $this->skip;
+    }
+
+    public function isGroupOrSkipped(mixed $data): bool
+    {
+        if ($this->group) {
+            return true;
+        }
+
+        if ($this->skip) {
+            return ($this->skip)($data);
+        }
+
+        // Check ancestors: if a parent is skipped via skip func, children are too
+        $ancestor = $this->parent;
+        while ($ancestor) {
+            if ($ancestor->skip && ($ancestor->skip)($data)) {
+                return true;
+            }
+            $ancestor = $ancestor->parent;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the next node in DFS pre-order traversal.
+     *
+     * If this node has children, returns the first child.
+     * Otherwise returns the next sibling, or walks up to
+     * find an ancestor with a next sibling.
+     */
+    public function getNextInTraversal(): ?self
+    {
+        if ($this->children) {
+            return $this->children[0];
+        }
+
+        if ($this->nextSibling) {
+            return $this->nextSibling;
+        }
+
+        $ancestor = $this->parent;
+        while ($ancestor) {
+            if ($ancestor->nextSibling) {
+                return $ancestor->nextSibling;
+            }
+            $ancestor = $ancestor->parent;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the previous node in DFS pre-order traversal.
+     *
+     * If this node has a previous sibling, returns that sibling's
+     * deepest last descendant. Otherwise returns the parent.
+     */
+    public function getPreviousInTraversal(): ?self
+    {
+        if ($this->previousSibling) {
+            return $this->previousSibling->getDeepestLastDescendant();
+        }
+
+        return $this->parent;
+    }
+
+    /**
+     * Returns the deepest last descendant of this node.
+     *
+     * Recursively follows the last child until a leaf node is reached.
+     * Returns self if this node has no children.
+     */
+    private function getDeepestLastDescendant(): self
+    {
+        if (!$this->children) {
+            return $this;
+        }
+
+        return $this->children[\count($this->children) - 1]->getDeepestLastDescendant();
+    }
+}

--- a/src/Symfony/Component/Form/Flow/Type/FormFlowType.php
+++ b/src/Symfony/Component/Form/Flow/Type/FormFlowType.php
@@ -17,9 +17,11 @@ use Symfony\Component\Form\Flow\ButtonFlowInterface;
 use Symfony\Component\Form\Flow\DataStorage\DataStorageInterface;
 use Symfony\Component\Form\Flow\DataStorage\NullDataStorage;
 use Symfony\Component\Form\Flow\FormFlowBuilderInterface;
+use Symfony\Component\Form\Flow\FormFlowCursor;
 use Symfony\Component\Form\Flow\FormFlowInterface;
 use Symfony\Component\Form\Flow\StepAccessor\PropertyPathStepAccessor;
 use Symfony\Component\Form\Flow\StepAccessor\StepAccessorInterface;
+use Symfony\Component\Form\Flow\StepFlowConfigInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormView;
@@ -55,27 +57,8 @@ class FormFlowType extends AbstractFlowType
     public function buildViewFlow(FormView $view, FormFlowInterface $form, array $options): void
     {
         $view->vars['cursor'] = $cursor = $form->getCursor();
-
-        $index = 0;
-        $position = 1;
-        foreach ($form->getConfig()->getSteps() as $name => $step) {
-            $isSkipped = $step->isSkipped($form->getViewData());
-
-            $stepVars = [
-                'name' => $name,
-                'index' => $index++,
-                'position' => $isSkipped ? -1 : $position++,
-                'is_current_step' => $name === $cursor->getCurrentStep(),
-                'can_be_skipped' => null !== $step->getSkip(),
-                'is_skipped' => $isSkipped,
-            ];
-
-            $view->vars['steps'][$name] = $stepVars;
-
-            if (!$isSkipped) {
-                $view->vars['visible_steps'][$name] = $stepVars;
-            }
-        }
+        $view->vars['steps'] = $this->buildStepsVars($form->getConfig()->getSteps(), $cursor, $form->getViewData());
+        $view->vars['visible_steps'] = array_filter($view->vars['steps'], static fn ($step) => !$step['is_skipped']);
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -121,5 +104,50 @@ class FormFlowType extends AbstractFlowType
         if ($button instanceof ButtonFlowInterface && $button->isClearSubmission()) {
             $event->setData([]);
         }
+    }
+
+    /**
+     * @param array<string, StepFlowConfigInterface> $steps
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildStepsVars(array $steps, FormFlowCursor $cursor, mixed $viewData, int $level = 0): array
+    {
+        $tree = [];
+        $index = 0;
+        $position = 1;
+        $currentStep = $cursor->getCurrentStep();
+
+        foreach ($steps as $name => $step) {
+            $children = [];
+            if ($childSteps = $step->getSteps()) {
+                $children = $this->buildStepsVars($childSteps, $cursor, $viewData, $level + 1);
+            }
+
+            $isSkipped = $step->isSkipped($viewData);
+
+            $tree[$name] = [
+                'name' => $name,
+                'level' => $level,
+                'index' => $index++,
+                'position' => $isSkipped ? -1 : $position++,
+                'is_before_current_step' => $cursor->getStepIndexOf($name) < $cursor->getStepIndex(),
+                'is_current_step' => $name === $currentStep,
+                'has_current_step_descendant' => $this->hasCurrentStepDescendant($children),
+                'is_after_current_step' => $cursor->getStepIndexOf($name) > $cursor->getStepIndex(),
+                'can_be_skipped' => null !== $step->getSkip(),
+                'is_skipped' => $isSkipped,
+                'is_group' => $step->isGroup(),
+                'children' => $children,
+                'visible_children' => array_filter($children, static fn (array $child): bool => !$child['is_skipped']),
+            ];
+        }
+
+        return $tree;
+    }
+
+    private function hasCurrentStepDescendant(array $children): bool
+    {
+        return array_any($children, static fn (array $child): bool => $child['is_current_step'] || $child['has_current_step_descendant']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Flow/FirstStepSkippedType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Flow/FirstStepSkippedType.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures\Flow;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Flow\AbstractFlowType;
+use Symfony\Component\Form\Flow\FormFlowBuilderInterface;
+use Symfony\Component\Form\Flow\Type\NavigatorFlowType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class FirstStepSkippedType extends AbstractFlowType
+{
+    public function buildFormFlow(FormFlowBuilderInterface $builder, array $options): void
+    {
+        $builder->addStep('step1', TextType::class, skip: static fn () => true);
+        $builder->addStep('step2', TextType::class);
+        $builder->addStep('step3', TextType::class);
+
+        $builder->add('navigator', NavigatorFlowType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => null,
+            'step_property_path' => '[currentStep]',
+        ]);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Flow/GroupingStepsFlowType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Flow/GroupingStepsFlowType.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures\Flow;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Flow\AbstractFlowType;
+use Symfony\Component\Form\Flow\DataStorage\InMemoryDataStorage;
+use Symfony\Component\Form\Flow\FormFlowBuilderInterface;
+use Symfony\Component\Form\Flow\Type\NavigatorFlowType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * a(group) => [a1, a2], b, c(group) => [c1].
+ */
+class GroupingStepsFlowType extends AbstractFlowType
+{
+    public function buildFormFlow(FormFlowBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->addStep(
+                $builder->createStepGroup('a')
+                    ->addStep('a1', TextType::class)
+                    ->addStep('a2', TextType::class)
+            )
+            ->addStep('b', TextType::class)
+            ->addStep(
+                $builder->createStepGroup('c')
+                    ->addStep('c1', TextType::class)
+            );
+
+        $builder->add('navigator', NavigatorFlowType::class, ['with_reset' => true]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => null,
+            'data_storage' => new InMemoryDataStorage('group_steps_flow'),
+            'step_property_path' => '[currentStep]',
+        ]);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Flow/NestedStepsFlowType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Flow/NestedStepsFlowType.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures\Flow;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Flow\AbstractFlowType;
+use Symfony\Component\Form\Flow\DataStorage\InMemoryDataStorage;
+use Symfony\Component\Form\Flow\FormFlowBuilderInterface;
+use Symfony\Component\Form\Flow\Type\NavigatorFlowType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class NestedStepsFlowType extends AbstractFlowType
+{
+    public function buildFormFlow(FormFlowBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->addStep(
+                $builder->createStepGroup('stepA')
+                    ->addStep('stepA1', TextType::class)
+                    ->addStep('stepA2', TextType::class)
+                    ->addStep('stepA3', TextType::class)
+            )
+            ->addStep(
+                $builder->createStep('stepB', ChoiceType::class, ['choices' => ['SkipB1' => 1, 'SkipB2' => 2]])
+                    ->addStep(
+                        $builder->createStep('stepB1')
+                            ->setSkip(static fn (array $data) => 1 == ($data['stepB'] ?? null))
+                            ->addStep('stepB11', TextType::class)
+                            ->addStep('stepB12', TextType::class)
+                    )
+                    ->addStep('stepB2', TextType::class)
+            )
+            ->addStep('stepC', TextType::class);
+
+        $builder->add('navigator', NavigatorFlowType::class, ['with_reset' => true]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => null,
+            'data_storage' => new InMemoryDataStorage('nested_steps_flow'),
+            'step_property_path' => '[currentStep]',
+        ]);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Flow/FormFlowCursorTest.php
+++ b/src/Symfony/Component/Form/Tests/Flow/FormFlowCursorTest.php
@@ -11,19 +11,50 @@
 
 namespace Symfony\Component\Form\Tests\Flow;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Flow\FormFlowCursor;
+use Symfony\Component\Form\Flow\StepFlowBuilder;
+use Symfony\Component\Form\Flow\StepFlowConfigInterface;
 
 class FormFlowCursorTest extends TestCase
 {
-    private static array $steps = ['personal', 'professional', 'account'];
+    private const array STEPS = ['personal', 'professional', 'account'];
+
+    /**
+     * @param list<string> $names
+     *
+     * @return array<string, StepFlowConfigInterface>
+     */
+    private static function createSteps(array $names = self::STEPS): array
+    {
+        $configs = [];
+        foreach ($names as $name) {
+            $configs[$name] = new StepFlowBuilder($name)->getStepConfig();
+        }
+
+        return $configs;
+    }
+
+    private static function createNestedSteps(): array
+    {
+        $personal = new StepFlowBuilder('personal')
+            ->addStep('name')
+            ->addStep('contact');
+
+        return [
+            'intro' => new StepFlowBuilder('intro')->getStepConfig(),
+            'personal' => $personal->getStepConfig(),
+            'summary' => new StepFlowBuilder('summary')->getStepConfig(),
+        ];
+    }
 
     public function testConstructorWithValidStep()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor(self::createSteps(), 'personal');
 
-        $this->assertSame(self::$steps, $cursor->getSteps());
+        $this->assertSame(self::STEPS, $cursor->getSteps());
         $this->assertSame('personal', $cursor->getCurrentStep());
     }
 
@@ -32,67 +63,78 @@ class FormFlowCursorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Step "invalid" does not exist. Available steps are: "personal", "professional", "account".');
 
-        new FormFlowCursor(self::$steps, 'invalid');
+        new FormFlowCursor(self::createSteps(), 'invalid');
+    }
+
+    public function testConstructorWithDeprecatedStringList()
+    {
+        $cursor = new FormFlowCursor(self::STEPS, 'personal');
+
+        $this->assertSame(self::STEPS, $cursor->getSteps());
     }
 
     public function testGetSteps()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor(self::createSteps(), 'personal');
 
-        $this->assertSame(self::$steps, $cursor->getSteps());
+        $this->assertSame(self::STEPS, $cursor->getSteps());
     }
 
     public function testGetTotalSteps()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor(self::createSteps(), 'personal');
 
         $this->assertSame(3, $cursor->getTotalSteps());
     }
 
     public function testGetStepIndex()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $steps = self::createSteps();
+
+        $cursor = new FormFlowCursor($steps, 'personal');
         $this->assertSame(0, $cursor->getStepIndex());
 
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor($steps, 'professional');
         $this->assertSame(1, $cursor->getStepIndex());
 
-        $cursor = new FormFlowCursor(self::$steps, 'account');
+        $cursor = new FormFlowCursor($steps, 'account');
         $this->assertSame(2, $cursor->getStepIndex());
     }
 
     public function testGetFirstStep()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor(self::createSteps(), 'professional');
 
         $this->assertSame('personal', $cursor->getFirstStep());
     }
 
     public function testGetPrevStep()
     {
+        $steps = self::createSteps();
+
         // First step has no previous step
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor($steps, 'personal');
         $this->assertNull($cursor->getPreviousStep());
 
         // Middle step has previous step
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor($steps, 'professional');
         $this->assertSame('personal', $cursor->getPreviousStep());
 
         // Last step has previous step
-        $cursor = new FormFlowCursor(self::$steps, 'account');
+        $cursor = new FormFlowCursor($steps, 'account');
         $this->assertSame('professional', $cursor->getPreviousStep());
     }
 
     public function testGetCurrentStep()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor(self::createSteps(), 'professional');
 
         $this->assertSame('professional', $cursor->getCurrentStep());
     }
 
     public function testWithCurrentStep()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor(self::createSteps(), 'personal');
 
         $newCursor = $cursor->withCurrentStep('professional');
 
@@ -103,88 +145,98 @@ class FormFlowCursorTest extends TestCase
         $this->assertSame('professional', $newCursor->getCurrentStep());
 
         // Both cursors should have the same steps
-        $this->assertSame(self::$steps, $cursor->getSteps());
-        $this->assertSame(self::$steps, $newCursor->getSteps());
+        $this->assertSame(self::STEPS, $cursor->getSteps());
+        $this->assertSame(self::STEPS, $newCursor->getSteps());
     }
 
     public function testGetNextStep()
     {
+        $steps = self::createSteps();
+
         // First step has next step
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor($steps, 'personal');
         $this->assertSame('professional', $cursor->getNextStep());
 
         // Middle step has next step
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor($steps, 'professional');
         $this->assertSame('account', $cursor->getNextStep());
 
         // Last step has no next step
-        $cursor = new FormFlowCursor(self::$steps, 'account');
+        $cursor = new FormFlowCursor($steps, 'account');
         $this->assertNull($cursor->getNextStep());
     }
 
     public function testGetLastStep()
     {
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor(self::createSteps(), 'personal');
 
         $this->assertSame('account', $cursor->getLastStep());
     }
 
     public function testIsFirstStep()
     {
+        $steps = self::createSteps();
+
         // First step
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor($steps, 'personal');
         $this->assertTrue($cursor->isFirstStep());
 
         // Not first step
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor($steps, 'professional');
         $this->assertFalse($cursor->isFirstStep());
     }
 
     public function testIsLastStep()
     {
+        $steps = self::createSteps();
+
         // Not last step
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor($steps, 'personal');
         $this->assertFalse($cursor->isLastStep());
 
         // Last step
-        $cursor = new FormFlowCursor(self::$steps, 'account');
+        $cursor = new FormFlowCursor($steps, 'account');
         $this->assertTrue($cursor->isLastStep());
     }
 
     public function testCanMovePreviousStep()
     {
+        $steps = self::createSteps();
+
         // First position cannot move a previous step
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor($steps, 'personal');
         $this->assertFalse($cursor->canMoveBack());
 
         // Middle position can move a previous step
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor($steps, 'professional');
         $this->assertTrue($cursor->canMoveBack());
 
         // Last step can move a previous step
-        $cursor = new FormFlowCursor(self::$steps, 'account');
+        $cursor = new FormFlowCursor($steps, 'account');
         $this->assertTrue($cursor->canMoveBack());
     }
 
     public function testCanMoveNext()
     {
+        $steps = self::createSteps();
+
         // First position can move next step
-        $cursor = new FormFlowCursor(self::$steps, 'personal');
+        $cursor = new FormFlowCursor($steps, 'personal');
         $this->assertTrue($cursor->canMoveNext());
 
         // Middle position can move next step
-        $cursor = new FormFlowCursor(self::$steps, 'professional');
+        $cursor = new FormFlowCursor($steps, 'professional');
         $this->assertTrue($cursor->canMoveNext());
 
         // Last position cannot move the next step
-        $cursor = new FormFlowCursor(self::$steps, 'account');
+        $cursor = new FormFlowCursor($steps, 'account');
         $this->assertFalse($cursor->canMoveNext());
     }
 
     public function testCursorWithSingleStep()
     {
         $steps = ['single'];
-        $cursor = new FormFlowCursor($steps, 'single');
+        $cursor = new FormFlowCursor(self::createSteps($steps), 'single');
 
         $this->assertSame('single', $cursor->getCurrentStep());
         $this->assertTrue($cursor->isFirstStep());
@@ -198,5 +250,239 @@ class FormFlowCursorTest extends TestCase
         $this->assertSame(1, $cursor->getTotalSteps());
         $this->assertFalse($cursor->canMoveBack());
         $this->assertFalse($cursor->canMoveNext());
+    }
+
+    public function testNestedStepsAreFlattened()
+    {
+        $cursor = new FormFlowCursor(self::createNestedSteps(), 'intro');
+
+        $this->assertSame(['intro', 'personal', 'name', 'contact', 'summary'], $cursor->getSteps());
+        $this->assertSame(5, $cursor->getTotalSteps());
+    }
+
+    public function testNavigationWithNestedSteps()
+    {
+        $nestedSteps = self::createNestedSteps();
+
+        // Forward: intro → personal → name → contact → summary
+        // Backward: summary → contact → name → personal → intro
+
+        $cursor = new FormFlowCursor($nestedSteps, 'intro');
+        $this->assertTrue($cursor->isFirstStep());
+        $this->assertNull($cursor->getPreviousStep());
+        $this->assertSame('personal', $cursor->getNextStep());
+
+        $cursor = new FormFlowCursor($nestedSteps, 'personal');
+        $this->assertSame('intro', $cursor->getPreviousStep());
+        $this->assertSame('name', $cursor->getNextStep());
+        $this->assertSame(1, $cursor->getStepIndex());
+
+        $cursor = new FormFlowCursor($nestedSteps, 'name');
+        $this->assertSame('personal', $cursor->getPreviousStep());
+        $this->assertSame('contact', $cursor->getNextStep());
+        $this->assertSame(2, $cursor->getStepIndex());
+
+        $cursor = new FormFlowCursor($nestedSteps, 'contact');
+        $this->assertSame('name', $cursor->getPreviousStep());
+        $this->assertSame('summary', $cursor->getNextStep());
+        $this->assertSame(3, $cursor->getStepIndex());
+
+        $cursor = new FormFlowCursor($nestedSteps, 'summary');
+        $this->assertTrue($cursor->isLastStep());
+        $this->assertSame('contact', $cursor->getPreviousStep());
+        $this->assertNull($cursor->getNextStep());
+        $this->assertSame(4, $cursor->getStepIndex());
+    }
+
+    public function testNestedStepsWithMultipleForests()
+    {
+        $personal = new StepFlowBuilder('personal')
+            ->addStep('name')
+            ->addStep('email');
+        $work = new StepFlowBuilder('work')
+            ->addStep('company')
+            ->addStep('role');
+
+        $cursor = new FormFlowCursor([
+            'intro' => new StepFlowBuilder('intro')->getStepConfig(),
+            'personal' => $personal->getStepConfig(),
+            'middle' => new StepFlowBuilder('middle')->getStepConfig(),
+            'work' => $work->getStepConfig(),
+            'summary' => new StepFlowBuilder('summary')->getStepConfig(),
+        ], 'intro');
+
+        $this->assertSame(['intro', 'personal', 'name', 'email', 'middle', 'work', 'company', 'role', 'summary'], $cursor->getSteps());
+        $this->assertSame(9, $cursor->getTotalSteps());
+        $this->assertSame('intro', $cursor->getFirstStep());
+        $this->assertSame('summary', $cursor->getLastStep());
+    }
+
+    public function testInvalidStepInNestedStructure()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Step "invalid" does not exist. Available steps are: "intro", "personal", "name", "contact", "summary".');
+
+        new FormFlowCursor(self::createNestedSteps(), 'invalid');
+    }
+
+    public function testStringKeyNestedStepsWithDepth()
+    {
+        $position = new StepFlowBuilder('position')
+            ->addStep('title')
+            ->addStep('department');
+        $work = new StepFlowBuilder('work')
+            ->addStep('company')
+            ->addStep($position);
+        $personal = new StepFlowBuilder('personal')
+            ->addStep('name')
+            ->addStep('contact');
+
+        $cursor = new FormFlowCursor([
+            'intro' => new StepFlowBuilder('intro')->getStepConfig(),
+            'personal' => $personal->getStepConfig(),
+            'work' => $work->getStepConfig(),
+            'summary' => new StepFlowBuilder('summary')->getStepConfig(),
+        ], 'intro');
+
+        $this->assertSame([
+            'intro',
+            'personal', 'name', 'contact',
+            'work', 'company', 'position', 'title', 'department',
+            'summary',
+        ], $cursor->getSteps());
+    }
+
+    public function testGetCurrentNode()
+    {
+        $cursor = new FormFlowCursor(self::createNestedSteps(), 'name');
+
+        $this->assertSame('name', $cursor->getCurrentStepNode()->getName());
+    }
+
+    public function testGetNode()
+    {
+        $cursor = new FormFlowCursor(self::createNestedSteps(), 'intro');
+
+        $this->assertSame('contact', $cursor->getStepNode('contact')->getName());
+    }
+
+    public function testGetNodeThrowsForInvalidName()
+    {
+        $cursor = new FormFlowCursor(self::createNestedSteps(), 'intro');
+
+        $this->expectException(InvalidArgumentException::class);
+        $cursor->getStepNode('invalid');
+    }
+
+    public function testGetRoots()
+    {
+        $cursor = new FormFlowCursor(self::createNestedSteps(), 'intro');
+
+        $this->assertCount(3, $cursor->getRootStepNodes());
+        $this->assertSame('intro', $cursor->getRootStepNodes()[0]->getName());
+    }
+
+    public function testGetParentStep()
+    {
+        $steps = self::createNestedSteps();
+
+        $this->assertNull(new FormFlowCursor($steps, 'intro')->getParentStep());
+        $this->assertNull(new FormFlowCursor($steps, 'personal')->getParentStep());
+        $this->assertSame('personal', new FormFlowCursor($steps, 'name')->getParentStep());
+        $this->assertSame('personal', new FormFlowCursor($steps, 'contact')->getParentStep());
+    }
+
+    public function testGetChildSteps()
+    {
+        $steps = self::createNestedSteps();
+
+        $this->assertSame([], new FormFlowCursor($steps, 'intro')->getChildSteps());
+        $this->assertSame(['name', 'contact'], new FormFlowCursor($steps, 'personal')->getChildSteps());
+        $this->assertSame([], new FormFlowCursor($steps, 'name')->getChildSteps());
+    }
+
+    public function testWithCurrentStepSharesForest()
+    {
+        $cursor = new FormFlowCursor(self::createNestedSteps(), 'intro');
+        $newCursor = $cursor->withCurrentStep('summary');
+
+        $this->assertSame($cursor->getRootStepNodes(), $newCursor->getRootStepNodes());
+        $this->assertSame($cursor->getStepNode('intro'), $newCursor->getStepNode('intro'));
+    }
+
+    public function testIsFirstStepWithGroupParent()
+    {
+        $steps = self::createGroupSteps();
+
+        $this->assertTrue((new FormFlowCursor($steps, 'a1'))->isFirstStep());
+        $this->assertFalse((new FormFlowCursor($steps, 'a2'))->isFirstStep());
+        $this->assertFalse((new FormFlowCursor($steps, 'b'))->isFirstStep());
+        $this->assertFalse((new FormFlowCursor($steps, 'c1'))->isFirstStep());
+    }
+
+    public function testIsLastStepWithGroupParent()
+    {
+        $steps = self::createGroupSteps();
+
+        $this->assertTrue((new FormFlowCursor($steps, 'c1'))->isLastStep());
+        $this->assertFalse((new FormFlowCursor($steps, 'b'))->isLastStep());
+        $this->assertFalse((new FormFlowCursor($steps, 'a2'))->isLastStep());
+        $this->assertFalse((new FormFlowCursor($steps, 'a1'))->isLastStep());
+    }
+
+    public function testCanMoveBackWithGroupParent()
+    {
+        $steps = self::createGroupSteps();
+
+        $this->assertFalse((new FormFlowCursor($steps, 'a1'))->canMoveBack());
+        $this->assertTrue((new FormFlowCursor($steps, 'a2'))->canMoveBack());
+        $this->assertTrue((new FormFlowCursor($steps, 'b'))->canMoveBack());
+        $this->assertTrue((new FormFlowCursor($steps, 'c1'))->canMoveBack());
+    }
+
+    public function testCanMoveNextWithGroupParent()
+    {
+        $steps = self::createGroupSteps();
+
+        $this->assertFalse((new FormFlowCursor($steps, 'c1'))->canMoveNext());
+        $this->assertTrue((new FormFlowCursor($steps, 'b'))->canMoveNext());
+        $this->assertTrue((new FormFlowCursor($steps, 'a2'))->canMoveNext());
+        $this->assertTrue((new FormFlowCursor($steps, 'a1'))->canMoveNext());
+    }
+
+    public function testGetFirstStepWithGroupRoot()
+    {
+        $steps = self::createGroupSteps();
+
+        $this->assertSame('a1', (new FormFlowCursor($steps, 'b'))->getFirstStep());
+    }
+
+    public function testGetLastStepWithGroupTail()
+    {
+        $steps = self::createGroupSteps();
+
+        $this->assertSame('c1', (new FormFlowCursor($steps, 'b'))->getLastStep());
+    }
+
+    /**
+     * Creates steps: a(group) -> [a1, a2], b, c(group) -> [c1].
+     *
+     * @return array<string, StepFlowConfigInterface>
+     */
+    private static function createGroupSteps(): array
+    {
+        $a = (new StepFlowBuilder('a'))
+            ->setGroup(true)
+            ->addStep('a1')
+            ->addStep('a2');
+        $c = (new StepFlowBuilder('c'))
+            ->setGroup(true)
+            ->addStep('c1');
+
+        return [
+            'a' => $a->getStepConfig(),
+            'b' => (new StepFlowBuilder('b'))->getStepConfig(),
+            'c' => $c->getStepConfig(),
+        ];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Flow/FormFlowTest.php
+++ b/src/Symfony/Component/Form/Tests/Flow/FormFlowTest.php
@@ -26,7 +26,10 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Tests\Fixtures\Flow\Data\UserSignUp;
 use Symfony\Component\Form\Tests\Fixtures\Flow\Extension\UserSignUpTypeExtension;
+use Symfony\Component\Form\Tests\Fixtures\Flow\FirstStepSkippedType;
+use Symfony\Component\Form\Tests\Fixtures\Flow\GroupingStepsFlowType;
 use Symfony\Component\Form\Tests\Fixtures\Flow\LastStepSkippedType;
+use Symfony\Component\Form\Tests\Fixtures\Flow\NestedStepsFlowType;
 use Symfony\Component\Form\Tests\Fixtures\Flow\UserSignUpType;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
@@ -126,27 +129,48 @@ class FormFlowTest extends TestCase
 
         $step1 = [
             'name' => 'personal',
+            'level' => 0,
             'index' => 0,
             'position' => 1,
+            'is_before_current_step' => false,
             'is_current_step' => true,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => false,
             'can_be_skipped' => false,
             'is_skipped' => false,
+            'is_group' => false,
+            'children' => [],
+            'visible_children' => [],
         ];
         $step2 = [
             'name' => 'professional',
+            'level' => 0,
             'index' => 1,
             'position' => -1,
+            'is_before_current_step' => false,
             'is_current_step' => false,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => true,
             'can_be_skipped' => true,
             'is_skipped' => true,
+            'is_group' => false,
+            'children' => [],
+            'visible_children' => [],
         ];
         $step3 = [
             'name' => 'account',
+            'level' => 0,
             'index' => 2,
             'position' => 2,
+            'is_before_current_step' => false,
             'is_current_step' => false,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => true,
             'can_be_skipped' => false,
             'is_skipped' => false,
+            'is_group' => false,
+            'children' => [],
+            'visible_children' => [],
         ];
 
         self::assertSame($step1, $view->vars['steps']['personal']);
@@ -969,5 +993,457 @@ class FormFlowTest extends TestCase
         self::assertTrue($flow->isFinished());
         self::assertNotSame($flow, $flow->getStepForm());
         self::assertSame(['currentStep' => 'step1', 'step1' => 'foo'], $flow->getData());
+    }
+
+    public function testNestedStepsFlowConfig()
+    {
+        $flow = $this->factory->create(NestedStepsFlowType::class, []);
+        $config = $flow->getConfig();
+
+        self::assertTrue($config->hasStep('stepA'));
+        self::assertTrue($config->hasStep('stepA1'));
+        self::assertTrue($config->hasStep('stepA2'));
+        self::assertTrue($config->hasStep('stepA3'));
+        self::assertTrue($config->hasStep('stepB'));
+        self::assertTrue($config->hasStep('stepB1'));
+        self::assertTrue($config->hasStep('stepB11'));
+        self::assertTrue($config->hasStep('stepB12'));
+        self::assertTrue($config->hasStep('stepB2'));
+        self::assertTrue($config->hasStep('stepC'));
+    }
+
+    public function testNestedStepsFlowNavigation()
+    {
+        $flow = $this->factory->create(NestedStepsFlowType::class, []);
+
+        // stepA is group, so the initial step is its first child
+        self::assertSame('stepA1', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepA1'));
+
+        $flow->submit([
+            'stepA1' => 'value1',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepA2', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepA2'));
+
+        $flow->submit([
+            'stepA2' => 'value2',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepA3', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepA3'));
+
+        $flow->submit([
+            'stepA3' => 'value3',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepB', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepB'));
+
+        // Submit stepB with value 2 (SkipB2) - this means stepB1 is NOT skipped
+        $flow->submit([
+            'stepB' => '2',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        // stepB1 is NOT skipped (skip condition returns false), it's a FormType container
+        self::assertSame('stepB1', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepB1'));
+
+        $flow->submit([
+            'stepB1' => [],
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepB11', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepB11'));
+
+        $flow->submit([
+            'stepB11' => 'valueB11',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepB12', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepB12'));
+
+        $flow->submit([
+            'stepB12' => 'valueB12',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepB2', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepB2'));
+
+        $flow->submit([
+            'stepB2' => 'valueB2',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepC', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepC'));
+        self::assertTrue($flow->getCursor()->isLastStep());
+
+        // Finish the flow
+        $flow->submit([
+            'stepC' => 'valueC',
+            'navigator' => ['finish' => ''],
+        ]);
+
+        self::assertTrue($flow->isSubmitted());
+        self::assertTrue($flow->isValid());
+        self::assertTrue($flow->isFinished());
+
+        // Verify all data was collected
+        $data = $flow->getData();
+        self::assertSame('value1', $data['stepA1']);
+        self::assertSame('value2', $data['stepA2']);
+        self::assertSame('value3', $data['stepA3']);
+        self::assertSame(2, $data['stepB']); // ChoiceType converts to int
+        self::assertSame('valueB11', $data['stepB11']);
+        self::assertSame('valueB12', $data['stepB12']);
+        self::assertSame('valueB2', $data['stepB2']);
+        self::assertSame('valueC', $data['stepC']);
+    }
+
+    public function testNestedStepsFlowNavigationWithSkippedParent()
+    {
+        $flow = $this->factory->create(NestedStepsFlowType::class, []);
+
+        // Navigate quickly to stepB
+        $flow->submit(['stepA' => [], 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        $flow->submit(['stepA1' => 'v1', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        $flow->submit(['stepA2' => 'v2', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        $flow->submit(['stepA3' => 'v3', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepB', $flow->getCursor()->getCurrentStep());
+
+        // Submit stepB with value 1 (SkipB1) - stepB1 parent is skipped but children are not
+        $flow->submit([
+            'stepB' => '1',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        // stepB1 is skipped via skip func, so its children (stepB11, stepB12) are also skipped
+        self::assertSame('stepB2', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('stepB2'));
+
+        $flow->submit([
+            'stepB2' => 'valueB2',
+            'navigator' => ['next' => ''],
+        ]);
+
+        $flow = $flow->getStepForm();
+
+        self::assertSame('stepC', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->getCursor()->isLastStep());
+    }
+
+    public function testNestedStepsViewVars()
+    {
+        $flow = $this->factory->create(NestedStepsFlowType::class, []);
+        $view = $flow->createView();
+
+        // Top-level steps (3 in this case)
+        self::assertArrayHasKey('steps', $view->vars);
+        self::assertCount(3, $view->vars['steps']);
+        self::assertArrayHasKey('stepA', $view->vars['steps']);
+        self::assertArrayHasKey('stepB', $view->vars['steps']);
+        self::assertArrayHasKey('stepC', $view->vars['steps']);
+
+        // Top-level index and position are level-specific
+        // stepA uses FormType (container) so it's skipped (position=-1)
+        self::assertSame(0, $view->vars['steps']['stepA']['index']);
+        self::assertSame(1, $view->vars['steps']['stepA']['position']);
+        self::assertFalse($view->vars['steps']['stepA']['is_skipped']);
+        // stepB uses ChoiceType, stepC uses TextType - both visible
+        self::assertSame(1, $view->vars['steps']['stepB']['index']);
+        self::assertSame(2, $view->vars['steps']['stepB']['position']);
+        self::assertFalse($view->vars['steps']['stepB']['is_skipped']);
+        self::assertSame(2, $view->vars['steps']['stepC']['index']);
+        self::assertSame(3, $view->vars['steps']['stepC']['position']);
+        self::assertFalse($view->vars['steps']['stepC']['is_skipped']);
+
+        // has_current_step_descendant is true for current step (stepA1 is the initial step)
+        self::assertTrue($view->vars['steps']['stepA']['has_current_step_descendant']);
+        self::assertFalse($view->vars['steps']['stepB']['has_current_step_descendant']);
+        self::assertFalse($view->vars['steps']['stepC']['has_current_step_descendant']);
+
+        // stepA children (stepA1, stepA2, stepA3) have level-specific index/position
+        $stepAChildren = $view->vars['steps']['stepA']['children'];
+        self::assertCount(3, $stepAChildren);
+        self::assertSame(0, $stepAChildren['stepA1']['index']);
+        self::assertSame(1, $stepAChildren['stepA1']['position']);
+        self::assertSame(1, $stepAChildren['stepA2']['index']);
+        self::assertSame(2, $stepAChildren['stepA2']['position']);
+        self::assertSame(2, $stepAChildren['stepA3']['index']);
+        self::assertSame(3, $stepAChildren['stepA3']['position']);
+
+        // stepB children (stepB1, stepB2)
+        $stepBChildren = $view->vars['steps']['stepB']['children'];
+        self::assertCount(2, $stepBChildren);
+        // stepB1 has explicit setSkip that checks $data['stepB'] === 1, which is false for empty data
+        self::assertSame(0, $stepBChildren['stepB1']['index']);
+        self::assertSame(1, $stepBChildren['stepB1']['position']);
+        self::assertFalse($stepBChildren['stepB1']['is_skipped']);
+        // stepB2 is a TextType, so it's visible
+        self::assertSame(1, $stepBChildren['stepB2']['index']);
+        self::assertSame(2, $stepBChildren['stepB2']['position']);
+        self::assertFalse($stepBChildren['stepB2']['is_skipped']);
+
+        // stepB1 nested children (stepB11, stepB12)
+        $stepB1Children = $stepBChildren['stepB1']['children'];
+        self::assertCount(2, $stepB1Children);
+        self::assertSame(0, $stepB1Children['stepB11']['index']);
+        self::assertSame(1, $stepB1Children['stepB11']['position']);
+        self::assertSame(1, $stepB1Children['stepB12']['index']);
+        self::assertSame(2, $stepB1Children['stepB12']['position']);
+    }
+
+    public function testNestedStepsViewVarsWithDeeplyNestedCurrentStep()
+    {
+        // Set current step to a deeply nested child (stepB11)
+        $flow = $this->factory->create(NestedStepsFlowType::class, ['currentStep' => 'stepB11']);
+        $view = $flow->createView();
+
+        // All ancestors should have has_current_step_descendant=true
+        self::assertFalse($view->vars['steps']['stepA']['has_current_step_descendant']);
+        self::assertTrue($view->vars['steps']['stepB']['has_current_step_descendant']);
+        self::assertFalse($view->vars['steps']['stepC']['has_current_step_descendant']);
+
+        // stepB1 (parent of stepB11) should have has_current_step_descendant=true
+        $stepBChildren = $view->vars['steps']['stepB']['children'];
+        self::assertTrue($stepBChildren['stepB1']['has_current_step_descendant']);
+        self::assertFalse($stepBChildren['stepB2']['has_current_step_descendant']);
+
+        // stepB11 should have is_current_step=true
+        $stepB1Children = $stepBChildren['stepB1']['children'];
+        self::assertTrue($stepB1Children['stepB11']['is_current_step']);
+        self::assertFalse($stepB1Children['stepB12']['is_current_step']);
+    }
+
+    public function testGroupViewVars()
+    {
+        $flow = $this->factory->create(GroupingStepsFlowType::class, []);
+        $view = $flow->createView();
+
+        // Current step is 'a1' (first visitable child of group 'a')
+        self::assertSame('a1', $flow->getCursor()->getCurrentStep());
+
+        // Top-level: a(group), b, c(group)
+        self::assertCount(3, $view->vars['steps']);
+        self::assertArrayHasKey('a', $view->vars['steps']);
+        self::assertArrayHasKey('b', $view->vars['steps']);
+        self::assertArrayHasKey('c', $view->vars['steps']);
+
+        $a1 = [
+            'name' => 'a1',
+            'level' => 1,
+            'index' => 0,
+            'position' => 1,
+            'is_before_current_step' => false,
+            'is_current_step' => true,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => false,
+            'can_be_skipped' => false,
+            'is_skipped' => false,
+            'is_group' => false,
+            'children' => [],
+            'visible_children' => [],
+        ];
+        $a2 = [
+            'name' => 'a2',
+            'level' => 1,
+            'index' => 1,
+            'position' => 2,
+            'is_before_current_step' => false,
+            'is_current_step' => false,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => true,
+            'can_be_skipped' => false,
+            'is_skipped' => false,
+            'is_group' => false,
+            'children' => [],
+            'visible_children' => [],
+        ];
+        $c1 = [
+            'name' => 'c1',
+            'level' => 1,
+            'index' => 0,
+            'position' => 1,
+            'is_before_current_step' => false,
+            'is_current_step' => false,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => true,
+            'can_be_skipped' => false,
+            'is_skipped' => false,
+            'is_group' => false,
+            'children' => [],
+            'visible_children' => [],
+        ];
+
+        // Group 'a': level 0, before current step, has_current_step_descendant (a1 is current)
+        self::assertSame([
+            'name' => 'a',
+            'level' => 0,
+            'index' => 0,
+            'position' => 1,
+            'is_before_current_step' => true,
+            'is_current_step' => false,
+            'has_current_step_descendant' => true,
+            'is_after_current_step' => false,
+            'can_be_skipped' => false,
+            'is_skipped' => false,
+            'is_group' => true,
+            'children' => ['a1' => $a1, 'a2' => $a2],
+            'visible_children' => ['a1' => $a1, 'a2' => $a2],
+        ], $view->vars['steps']['a']);
+
+        // Step 'b': level 0, after current step
+        self::assertSame([
+            'name' => 'b',
+            'level' => 0,
+            'index' => 1,
+            'position' => 2,
+            'is_before_current_step' => false,
+            'is_current_step' => false,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => true,
+            'can_be_skipped' => false,
+            'is_skipped' => false,
+            'is_group' => false,
+            'children' => [],
+            'visible_children' => [],
+        ], $view->vars['steps']['b']);
+
+        // Group 'c': level 0, after current step
+        self::assertSame([
+            'name' => 'c',
+            'level' => 0,
+            'index' => 2,
+            'position' => 3,
+            'is_before_current_step' => false,
+            'is_current_step' => false,
+            'has_current_step_descendant' => false,
+            'is_after_current_step' => true,
+            'can_be_skipped' => false,
+            'is_skipped' => false,
+            'is_group' => true,
+            'children' => ['c1' => $c1],
+            'visible_children' => ['c1' => $c1],
+        ], $view->vars['steps']['c']);
+    }
+
+    public function testGroupFirstRootResolvesToFirstChild()
+    {
+        $flow = $this->factory->create(GroupingStepsFlowType::class, []);
+
+        // 'a' is group, initial step is 'a1' (first child)
+        self::assertSame('a1', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('a1'));
+    }
+
+    public function testGroupForwardNavigationSkipsToChildren()
+    {
+        $flow = $this->factory->create(GroupingStepsFlowType::class, []);
+
+        // Start at a1 (skipping group 'a')
+        self::assertSame('a1', $flow->getCursor()->getCurrentStep());
+
+        $flow->submit(['a1' => 'v1', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        self::assertSame('a2', $flow->getCursor()->getCurrentStep());
+
+        $flow->submit(['a2' => 'v2', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+
+        self::assertSame('b', $flow->getCursor()->getCurrentStep());
+    }
+
+    public function testGroupForwardFromLastNonGroupStepToGroupChild()
+    {
+        $flow = $this->factory->create(GroupingStepsFlowType::class, []);
+
+        // Navigate to 'b'
+        $flow->submit(['a1' => 'v1', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        $flow->submit(['a2' => 'v2', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        self::assertSame('b', $flow->getCursor()->getCurrentStep());
+
+        // Move forward from 'b': next is 'c' (group/skipped) → 'c1' (first child)
+        $flow->submit(['b' => 'v3', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        self::assertSame('c1', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('c1'));
+    }
+
+    public function testGroupBackwardNavigationSkipsParent()
+    {
+        $flow = $this->factory->create(GroupingStepsFlowType::class, []);
+
+        // Navigate forward to a2
+        $flow->submit(['a1' => 'v1', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        self::assertSame('a2', $flow->getCursor()->getCurrentStep());
+
+        // Navigate forward to b
+        $flow->submit(['a2' => 'v2', 'navigator' => ['next' => '']]);
+        $flow = $flow->getStepForm();
+        self::assertSame('b', $flow->getCursor()->getCurrentStep());
+
+        // Move backward from 'b': previous in DFS is 'a2' (deepest last descendant of 'a')
+        // 'a' is group/skipped, so move() lands on 'a2'
+        $flow->submit(['b' => 'v3', 'navigator' => ['previous' => '']]);
+        $flow = $flow->getStepForm();
+        self::assertSame('a2', $flow->getCursor()->getCurrentStep());
+    }
+
+    public function testGroupBackwardFromFirstChildOfGroupRootThrows()
+    {
+        $flow = $this->factory->create(GroupingStepsFlowType::class, []);
+
+        self::assertSame('a1', $flow->getCursor()->getCurrentStep());
+
+        // Structurally there is a previous step ('a'), but it's group
+        // and there's nothing before it, so moving backward fails
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot determine previous step.');
+
+        $flow->movePrevious();
+    }
+
+    public function testFirstStepSkippedResolvesToSecondStep()
+    {
+        $flow = $this->factory->create(FirstStepSkippedType::class, []);
+
+        // step1 is skipped, initial step resolves to step2
+        self::assertSame('step2', $flow->getCursor()->getCurrentStep());
+        self::assertTrue($flow->has('step2'));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Flow/StepNodeTest.php
+++ b/src/Symfony/Component/Form/Tests/Flow/StepNodeTest.php
@@ -1,0 +1,375 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Flow;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Exception\LogicException;
+use Symfony\Component\Form\Flow\StepFlowBuilder;
+use Symfony\Component\Form\Flow\StepFlowNode;
+
+class StepNodeTest extends TestCase
+{
+    /**
+     * @return list<StepFlowNode>
+     */
+    private static function createNodes(array $steps): array
+    {
+        $configs = [];
+        foreach (self::buildBuilders($steps) as $name => $builder) {
+            $configs[$name] = $builder->getStepConfig();
+        }
+
+        return StepFlowNode::fromConfig($configs);
+    }
+
+    /**
+     * @return array<string, StepFlowBuilder>
+     */
+    private static function buildBuilders(array $steps): array
+    {
+        $builders = [];
+        foreach ($steps as $key => $value) {
+            if (\is_int($key)) {
+                $builders[$value] = new StepFlowBuilder($value);
+            } else {
+                $builder = new StepFlowBuilder($key);
+                foreach (self::buildBuilders($value) as $child) {
+                    $builder->addStep($child);
+                }
+                $builders[$key] = $builder;
+            }
+        }
+
+        return $builders;
+    }
+
+    public function testFlatSteps()
+    {
+        $roots = self::createNodes(['personal', 'professional', 'account']);
+
+        $this->assertCount(3, $roots);
+        $this->assertSame('personal', $roots[0]->getName());
+        $this->assertSame('professional', $roots[1]->getName());
+        $this->assertSame('account', $roots[2]->getName());
+
+        foreach ($roots as $root) {
+            $this->assertNull($root->getParent());
+            $this->assertEmpty($root->getChildren());
+        }
+    }
+
+    public function testNestedSteps()
+    {
+        $roots = self::createNodes([
+            'intro',
+            'personal' => ['name', 'contact'],
+            'summary',
+        ]);
+
+        $this->assertCount(3, $roots);
+
+        $this->assertSame('intro', $roots[0]->getName());
+        $this->assertEmpty($roots[0]->getChildren());
+
+        $this->assertSame('personal', $roots[1]->getName());
+        $this->assertCount(2, $roots[1]->getChildren());
+        $this->assertSame('name', $roots[1]->getChildren()[0]->getName());
+        $this->assertSame('contact', $roots[1]->getChildren()[1]->getName());
+
+        $this->assertSame($roots[1], $roots[1]->getChildren()[0]->getParent());
+        $this->assertSame($roots[1], $roots[1]->getChildren()[1]->getParent());
+
+        $this->assertSame('summary', $roots[2]->getName());
+        $this->assertEmpty($roots[2]->getChildren());
+    }
+
+    public function testDeepNesting()
+    {
+        $roots = self::createNodes([
+            'work' => [
+                'company',
+                'position' => ['title', 'department'],
+            ],
+        ]);
+
+        $this->assertCount(1, $roots);
+        $work = $roots[0];
+        $this->assertSame('work', $work->getName());
+        $this->assertCount(2, $work->getChildren());
+
+        $company = $work->getChildren()[0];
+        $this->assertSame('company', $company->getName());
+        $this->assertEmpty($company->getChildren());
+
+        $position = $work->getChildren()[1];
+        $this->assertSame('position', $position->getName());
+        $this->assertCount(2, $position->getChildren());
+        $this->assertSame('title', $position->getChildren()[0]->getName());
+        $this->assertSame('department', $position->getChildren()[1]->getName());
+
+        $this->assertSame($work, $company->getParent());
+        $this->assertSame($work, $position->getParent());
+        $this->assertSame($position, $position->getChildren()[0]->getParent());
+        $this->assertSame($position, $position->getChildren()[1]->getParent());
+    }
+
+    public function testParentLinksAcrossMultipleLevels()
+    {
+        $roots = self::createNodes([
+            'root' => [
+                'l1' => [
+                    'l2' => ['l3a', 'l3b'],
+                ],
+            ],
+        ]);
+
+        $root = $roots[0];
+        $l1 = $root->getChildren()[0];
+        $l2 = $l1->getChildren()[0];
+        $l3a = $l2->getChildren()[0];
+        $l3b = $l2->getChildren()[1];
+
+        $this->assertNull($root->getParent());
+        $this->assertSame($root, $l1->getParent());
+        $this->assertSame($l1, $l2->getParent());
+        $this->assertSame($l2, $l3a->getParent());
+        $this->assertSame($l2, $l3b->getParent());
+
+        $this->assertSame('l2', $l3a->getParent()->getName());
+        $this->assertSame('l1', $l3a->getParent()->getParent()->getName());
+        $this->assertSame('root', $l3a->getParent()->getParent()->getParent()->getName());
+        $this->assertNull($l3a->getParent()->getParent()->getParent()->getParent());
+    }
+
+    public function testSiblingLinks()
+    {
+        $roots = self::createNodes(['a', 'b', 'c']);
+
+        $this->assertNull($roots[0]->getPreviousSibling());
+        $this->assertSame($roots[1], $roots[0]->getNextSibling());
+
+        $this->assertSame($roots[0], $roots[1]->getPreviousSibling());
+        $this->assertSame($roots[2], $roots[1]->getNextSibling());
+
+        $this->assertSame($roots[1], $roots[2]->getPreviousSibling());
+        $this->assertNull($roots[2]->getNextSibling());
+    }
+
+    public function testSiblingLinksForChildren()
+    {
+        $roots = self::createNodes([
+            'personal' => ['name', 'email', 'phone'],
+        ]);
+        $children = $roots[0]->getChildren();
+
+        $this->assertNull($children[0]->getPreviousSibling());
+        $this->assertSame($children[1], $children[0]->getNextSibling());
+
+        $this->assertSame($children[0], $children[1]->getPreviousSibling());
+        $this->assertSame($children[2], $children[1]->getNextSibling());
+
+        $this->assertSame($children[1], $children[2]->getPreviousSibling());
+        $this->assertNull($children[2]->getNextSibling());
+    }
+
+    public function testNextInTraversalDFSOrder()
+    {
+        $roots = self::createNodes([
+            'intro',
+            'personal' => ['name', 'contact'],
+            'summary',
+        ]);
+
+        $names = [];
+        $node = $roots[0];
+        while (null !== $node) {
+            $names[] = $node->getName();
+            $node = $node->getNextInTraversal();
+        }
+
+        $this->assertSame(['intro', 'personal', 'name', 'contact', 'summary'], $names);
+    }
+
+    public function testPreviousInTraversalOrder()
+    {
+        $roots = self::createNodes([
+            'intro',
+            'personal' => ['name', 'contact'],
+            'summary',
+        ]);
+
+        $last = $roots[\count($roots) - 1];
+        $this->assertSame('summary', $last->getName());
+
+        $names = [];
+        $node = $last;
+        while (null !== $node) {
+            $names[] = $node->getName();
+            $node = $node->getPreviousInTraversal();
+        }
+
+        $this->assertSame(['summary', 'contact', 'name', 'personal', 'intro'], $names);
+    }
+
+    public function testNextInTraversalWithDeepNesting()
+    {
+        $roots = self::createNodes([
+            'intro',
+            'work' => [
+                'company',
+                'position' => ['title', 'department'],
+            ],
+            'summary',
+        ]);
+
+        $names = [];
+        $node = $roots[0];
+        while (null !== $node) {
+            $names[] = $node->getName();
+            $node = $node->getNextInTraversal();
+        }
+
+        $this->assertSame(['intro', 'work', 'company', 'position', 'title', 'department', 'summary'], $names);
+    }
+
+    public function testNextInTraversalFromLastNodeReturnsNull()
+    {
+        $roots = self::createNodes(['a', 'b']);
+
+        $this->assertNull($roots[1]->getNextInTraversal());
+    }
+
+    public function testPreviousInTraversalFromFirstNodeReturnsNull()
+    {
+        $roots = self::createNodes(['a', 'b']);
+
+        $this->assertNull($roots[0]->getPreviousInTraversal());
+    }
+
+    public function testIsSkippedWithNullSkip()
+    {
+        $roots = self::createNodes(['step']);
+
+        $this->assertNull($roots[0]->getSkip());
+        $this->assertFalse($roots[0]->isGroupOrSkipped('data'));
+    }
+
+    public function testGroupNodeIsSkipped()
+    {
+        $stepA = new StepFlowBuilder('stepA')
+            ->setGroup(true)
+            ->addStep('stepA1')
+            ->addStep('stepA2');
+        $roots = StepFlowNode::fromConfig(['stepA' => $stepA->getStepConfig()]);
+
+        $this->assertTrue($roots[0]->isGroup());
+        $this->assertTrue($roots[0]->isGroupOrSkipped(null));
+
+        $this->assertFalse($roots[0]->getChildren()[0]->isGroupOrSkipped(null));
+        $this->assertFalse($roots[0]->getChildren()[1]->isGroupOrSkipped(null));
+    }
+
+    public function testSkipPropagatesToChildren()
+    {
+        $stepB = new StepFlowBuilder('stepB')
+            ->setSkip(static fn () => true)
+            ->addStep('stepB1')
+            ->addStep('stepB2');
+        $roots = StepFlowNode::fromConfig(['stepB' => $stepB->getStepConfig()]);
+
+        $this->assertTrue($roots[0]->isGroupOrSkipped(null));
+        $this->assertTrue($roots[0]->getChildren()[0]->isGroupOrSkipped(null));
+        $this->assertTrue($roots[0]->getChildren()[1]->isGroupOrSkipped(null));
+    }
+
+    public function testSkipPropagatesAcrossMultipleLevels()
+    {
+        $stepA = new StepFlowBuilder('stepA')
+            ->setSkip(static fn () => true)
+            ->addStep(
+                new StepFlowBuilder('stepA1')
+                    ->addStep('stepA11')
+            );
+        $roots = StepFlowNode::fromConfig(['stepA' => $stepA->getStepConfig()]);
+
+        $this->assertTrue($roots[0]->isGroupOrSkipped(null));
+        $stepA1 = $roots[0]->getChildren()[0];
+        $this->assertTrue($stepA1->isGroupOrSkipped(null));
+        $this->assertTrue($stepA1->getChildren()[0]->isGroupOrSkipped(null));
+    }
+
+    public function testSkipDoesNotPropagateWhenParentNotSkipped()
+    {
+        $stepA = new StepFlowBuilder('stepA')
+            ->addStep(
+                new StepFlowBuilder('stepA1')
+                    ->setSkip(static fn () => true)
+                    ->addStep('stepA11')
+            )
+            ->addStep('stepA2');
+        $roots = StepFlowNode::fromConfig(['stepA' => $stepA->getStepConfig()]);
+
+        $this->assertFalse($roots[0]->isGroupOrSkipped(null));
+
+        $stepA1 = $roots[0]->getChildren()[0];
+        $this->assertTrue($stepA1->isGroupOrSkipped(null));
+        $this->assertTrue($stepA1->getChildren()[0]->isGroupOrSkipped(null));
+
+        $this->assertFalse($roots[0]->getChildren()[1]->isGroupOrSkipped(null));
+    }
+
+    public function testGroupWithSkipOnChildrenAreSkipped()
+    {
+        $stepA = new StepFlowBuilder('stepA')
+            ->setGroup(true)
+            ->setSkip(static fn () => true)
+            ->addStep('stepA1')
+            ->addStep('stepA2');
+
+        $roots = StepFlowNode::fromConfig(['stepA' => $stepA->getStepConfig()]);
+
+        $this->assertTrue($roots[0]->isGroupOrSkipped(null));
+        $this->assertTrue($roots[0]->getChildren()[0]->isGroupOrSkipped(null));
+        $this->assertTrue($roots[0]->getChildren()[1]->isGroupOrSkipped(null));
+    }
+
+    public function testGroupWithNoChildrenThrows()
+    {
+        $stepA = new StepFlowBuilder('stepA')
+            ->setGroup(true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Step "stepA" is marked as group but has no child steps.');
+
+        StepFlowNode::fromConfig(['stepA' => $stepA->getStepConfig()]);
+    }
+
+    public function testMultipleForests()
+    {
+        $roots = self::createNodes([
+            'intro',
+            'personal' => ['name', 'email'],
+            'middle',
+            'work' => ['company', 'role'],
+            'summary',
+        ]);
+
+        $names = [];
+        $node = $roots[0];
+        while (null !== $node) {
+            $names[] = $node->getName();
+            $node = $node->getNextInTraversal();
+        }
+
+        $this->assertSame(['intro', 'personal', 'name', 'email', 'middle', 'work', 'company', 'role', 'summary'], $names);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR introduces two new main features aimed at simplifying the creation of more complex FormFlows.

<img width="2567" height="1471" alt="image" src="https://github.com/user-attachments/assets/d622017d-a789-4e90-a013-4fbcbf4a97b0" />

## Nested Steps

Currently, FormFlow supports a single level of steps, which covers most basic use cases. However, in practice many of the flows we are implementing involve multiple levels (grouping steps, dependent steps, etc.), which the current approach does not fully accommodate.

Now you can define a full hierarchy that matches your model's composition and is easier to render:
```php
class NestedStepsFlowType extends AbstractFlowType
{
    public function buildFormFlow(FormFlowBuilderInterface $builder, array $options): void
    {
        $builder
            ->addStep(
                $builder->createStep('A', AType::class)
                    ->addStep('A1', TextType::class)
                    ->addStep('A2', TextType::class)
                    ->addStep('A3', TextType::class)
            )
            ->addStep(
                $builder->createStep('B', ChoiceType::class, ['choices' => ['Option1' => 1, 'Option2' => 2]])
                    ->addStep(
                        $builder->createStep('B1', BType::class)
                            ->setSkip(fn (array $data) => 1 == $data['B'])
                            ->addStep('B11', TextType::class)
                            ->addStep('B12', TextType::class)
                    )
                    ->addStep('B2', TextType::class)
            )
            ->addStep('C', TextType::class);

        $builder->add('navigator', NavigatorFlowType::class, ['with_reset' => true]);
    }
}
```

This means that Step A is containing form inputs. When the user clicks **Next**, the flow proceeds through steps A1, A2, and A3 before reaching Step B.

Did you notice the `->setSkip(fn (array $data) => 1 == $data['B'])` line in the example? This allows you to make decisions based on the submitted data and skip the entire branch (B1, B11, and B12) if the skip condition returns `true`.

**Important:** Having nested steps does not mean the data-mapping process is also nested across those steps. Nesting steps only affects the structural representation and navigation of the flow. Each form step data will still target the root underlying object handled by this `NestedStepsFlowType`.

## Grouping Steps 

Another very common scenario (following the example above) is that steps A and B1 are not actual form steps, but rather grouping steps used for structural meaning. For that purpose, you can use a new method `$builder->createStepGroup('Name')`. For example:

```php
class NestedStepsFlowType extends AbstractFlowType
{
    public function buildFormFlow(FormFlowBuilderInterface $builder, array $options): void
    {
        $builder
            ->addStep(
                $builder->createStepGroup('A')
                    ->addStep('A1', TextType::class)
                    ->addStep('A2', TextType::class)
                    ->addStep('A3', TextType::class)
            )
            ->addStep(
                $builder->createStepGroup('B')
                    ->addStep('B1', TextType::class)
                    ->addStep('B2', TextType::class)
            )
            ->addStep('C', CType::class);
            // ...
    }
}
```

This feature allows building multi-level form flows with a clearer and more expressive structural representation. 

A concrete visual example grouping the steps "Outbound Flight" and "Return Flight" under a root group step called "Select Flight":
<img width="822" height="484" alt="image" src="https://github.com/user-attachments/assets/54d9f154-4130-416e-8a4b-bc3e768e3847" />

There are some rules for this kind of step:
* They must define child steps (having empty group steps makes no sense).
* They are skipped by default when moving forward or backward through the flow (because they aren't actual form steps), so the cursor will be moved to their children directly.

---

To support these features, the first argument of `FormFlowCursor` now accepts the full steps configuration so it can build the flow graph and handle navigation correctly.

Cheers!