### PR TITLE
[JsonStreamer] Support date time timezone

### DIFF
--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add timezone support to `DateTimeValueObjectTransformer`
  * Add value object support
  * Deprecate `DateTimeTypePropertyMetadataLoader` (both Read and Write), date times are handled as value objects
  * Deprecate `DateTimeToStringValueTransformer` and `StringToDateTimeValueTransformer`, use `DateTimeValueObjectTransformer` instead

--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -32,7 +32,11 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
- * @psalm-type Options = array<string, mixed>
+ * @psalm-type Options = array{
+ *     date_time_format?: string,
+ *     date_time_timezone?: string|\DateTimeZone,
+ *     ...<string, mixed>,
+ * }
  *
  * @implements StreamReaderInterface<Options>
  */

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -31,6 +31,8 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
  * @psalm-type Options = array{
+ *     date_time_format?: string,
+ *     date_time_timezone?: string|\DateTimeZone,
  *     include_null_properties?: bool,
  *     ...<string, mixed>,
  * }

--- a/src/Symfony/Component/JsonStreamer/Tests/Transformer/DateTimeValueObjectTransformerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Transformer/DateTimeValueObjectTransformerTest.php
@@ -32,6 +32,32 @@ class DateTimeValueObjectTransformerTest extends TestCase
         );
     }
 
+    public function testTransformWithTimezone()
+    {
+        $transformer = new DateTimeValueObjectTransformer();
+
+        $this->assertSame(
+            '2016-12-01T09:00:00+09:00',
+            $transformer->transform(new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC')), [
+                DateTimeValueObjectTransformer::TIMEZONE_KEY => new \DateTimeZone('Asia/Tokyo'),
+            ]),
+        );
+
+        $this->assertSame(
+            '2016-12-01T00:00:00+09:00',
+            $transformer->transform(new \DateTimeImmutable('2016/12/01', new \DateTimeZone('Asia/Tokyo')), [
+                DateTimeValueObjectTransformer::TIMEZONE_KEY => new \DateTimeZone('Asia/Tokyo'),
+            ]),
+        );
+
+        $this->assertSame(
+            '2016-12-01T09:00:00+09:00',
+            $transformer->transform(new \DateTimeImmutable('2016/12/01', new \DateTimeZone('UTC')), [
+                DateTimeValueObjectTransformer::TIMEZONE_KEY => 'Asia/Tokyo',
+            ]),
+        );
+    }
+
     public function testTransformThrowWhenInvalidNativeValue()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -52,6 +78,34 @@ class DateTimeValueObjectTransformerTest extends TestCase
         $this->assertEquals(
             (new \DateTimeImmutable('2023-07-26'))->setTime(0, 0),
             $transformer->reverseTransform('26/07/2023 00:00:00', [DateTimeValueObjectTransformer::FORMAT_KEY => 'd/m/Y H:i:s']),
+        );
+    }
+
+    public function testReverseTransformWithTimezone()
+    {
+        $transformer = new DateTimeValueObjectTransformer();
+
+        $this->assertEquals(
+            new \DateTimeImmutable('2016/12/01 17:35:00', new \DateTimeZone('Asia/Tokyo')),
+            $transformer->reverseTransform('2016/12/01 17:35:00', [
+                DateTimeValueObjectTransformer::FORMAT_KEY => 'Y/m/d H:i:s',
+                DateTimeValueObjectTransformer::TIMEZONE_KEY => new \DateTimeZone('Asia/Tokyo'),
+            ]),
+        );
+
+        $this->assertEquals(
+            new \DateTimeImmutable('2016/12/01 17:35:00', new \DateTimeZone('Asia/Tokyo')),
+            $transformer->reverseTransform('2016/12/01 17:35:00', [
+                DateTimeValueObjectTransformer::FORMAT_KEY => 'Y/m/d H:i:s',
+                DateTimeValueObjectTransformer::TIMEZONE_KEY => 'Asia/Tokyo',
+            ]),
+        );
+
+        $this->assertEquals(
+            new \DateTimeImmutable('2016/12/01 17:35:00', new \DateTimeZone('Asia/Tokyo')),
+            $transformer->reverseTransform('2016/12/01 17:35:00', [
+                DateTimeValueObjectTransformer::TIMEZONE_KEY => new \DateTimeZone('Asia/Tokyo'),
+            ]),
         );
     }
 

--- a/src/Symfony/Component/JsonStreamer/Transformer/DateTimeValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/DateTimeValueObjectTransformer.php
@@ -21,31 +21,50 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  *
+ * @psalm-type Options = array{
+ *     date_time_format?: string,
+ *     date_time_timezone?: string|\DateTimeZone,
+ *     ...<string, mixed>,
+ * }
+ *
  * @implements ValueObjectTransformerInterface<\DateTimeInterface, string>
  */
 final class DateTimeValueObjectTransformer implements ValueObjectTransformerInterface
 {
     public const FORMAT_KEY = 'date_time_format';
+    public const TIMEZONE_KEY = 'date_time_timezone';
 
+    /**
+     * @param Options $options
+     */
     public function transform(object $object, array $options = []): int|float|string|bool|null
     {
         if (!$object instanceof \DateTimeInterface) {
             throw new InvalidArgumentException('The native value must implement the "\DateTimeInterface".');
         }
 
+        $timezone = $this->getTimezone($options);
+        if ($timezone && method_exists($object, 'setTimezone')) {
+            $object = (clone $object)->setTimezone($timezone);
+        }
+
         return $object->format($options[self::FORMAT_KEY] ?? \DateTimeInterface::RFC3339);
     }
 
-    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): object
+    /**
+     * @param Options $options
+     */
+    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): \DateTimeImmutable
     {
         if (!\is_string($scalar) || '' === trim($scalar)) {
             throw new InvalidArgumentException('The JSON value is either not an string, or an empty string; you should pass a string that can be parsed with the passed format or a valid DateTime string.');
         }
 
         $dateTimeFormat = $options[self::FORMAT_KEY] ?? null;
+        $timezone = $this->getTimezone($options);
 
         if (null !== $dateTimeFormat) {
-            if (false !== $dateTime = \DateTimeImmutable::createFromFormat($dateTimeFormat, $scalar)) {
+            if ($dateTime = \DateTimeImmutable::createFromFormat($dateTimeFormat, $scalar, $timezone)) {
                 return $dateTime;
             }
 
@@ -55,7 +74,7 @@ final class DateTimeValueObjectTransformer implements ValueObjectTransformerInte
         }
 
         try {
-            return new \DateTimeImmutable($scalar);
+            return new \DateTimeImmutable($scalar, $timezone);
         } catch (\Throwable) {
             $dateTimeErrors = \DateTimeImmutable::getLastErrors();
 
@@ -74,6 +93,18 @@ final class DateTimeValueObjectTransformer implements ValueObjectTransformerInte
     public static function getValueObjectClassName(): string
     {
         return \DateTimeInterface::class;
+    }
+
+    /**
+     * @param Options $options
+     */
+    private function getTimezone(array $options): ?\DateTimeZone
+    {
+        if (!($dateTimeZone = $options[self::TIMEZONE_KEY] ?? null)) {
+            return null;
+        }
+
+        return $dateTimeZone instanceof \DateTimeZone ? $dateTimeZone : new \DateTimeZone($dateTimeZone);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63099 
| License       | MIT

Add timezone support to `DateTimeValueObjectTransformer`, similar to what `DateTimeNormalizer` already does in the Serializer component.

A `TIMEZONE_KEY` option can be passed (as a `\DateTimeZone` or `string`) to convert the timezone when encoding/decoding datetimes.