### PR TITLE
[Cache] Fix undefined array key when tag save fails in AbstractTagAwareAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -192,6 +192,11 @@ abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagA
             if (\is_array($e) || 1 === \count($values)) {
                 foreach (\is_array($e) ? $e : array_keys($values) as $id) {
                     $ok = false;
+                    if (!isset($values[$id])) {
+                        $message = 'Failed to save tag "{key}"'.($e instanceof \Exception ? ': '.$e->getMessage() : '.');
+                        CacheItem::log($this->logger, $message, ['key' => substr($id, \strlen($this->rootNamespace)), 'exception' => $e instanceof \Exception ? $e : null, 'cache-adapter' => get_debug_type($this)]);
+                        continue;
+                    }
                     $v = $values[$id];
                     $type = get_debug_type($v);
                     $message = \sprintf('Failed to save key "{key}" of type %s%s', $type, $e instanceof \Exception ? ': '.$e->getMessage() : '.');

--- a/src/Symfony/Component/Cache/Tests/Adapter/FilesystemTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/FilesystemTagAwareAdapterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemTagAwareAdapter;
+use Symfony\Component\Cache\Tests\Fixtures\FailingTagFilesystemAdapter;
 
 /**
  * @group time-sensitive
@@ -24,5 +25,20 @@ class FilesystemTagAwareAdapterTest extends FilesystemAdapterTest
     public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new FilesystemTagAwareAdapter('', $defaultLifetime);
+    }
+
+    public function testCommitDoesNotFailWhenTagSaveFails()
+    {
+        $adapter = new FailingTagFilesystemAdapter();
+
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $item->tag(['tag1']);
+        $adapter->saveDeferred($item);
+
+        // Should not throw "Undefined array key" when tag save fails
+        $result = $adapter->commit();
+
+        $this->assertFalse($result, 'Commit should return false when tag save fails');
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Fixtures/FailingTagFilesystemAdapter.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/FailingTagFilesystemAdapter.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Fixtures;
+
+use Symfony\Component\Cache\Adapter\FilesystemTagAwareAdapter;
+
+/**
+ * Adapter that simulates a failure when saving tags.
+ */
+class FailingTagFilesystemAdapter extends FilesystemTagAwareAdapter
+{
+    protected function doSave(array $values, int $lifetime, array $addTagData = [], array $removeTagData = []): array
+    {
+        $failed = parent::doSave($values, $lifetime, $addTagData, $removeTagData);
+
+        // Simulate tag save failure by returning tag IDs as failed
+        foreach ($addTagData as $tagId => $ids) {
+            $failed[] = $tagId;
+        }
+
+        return $failed;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63729
| License       | MIT

When `doSave()` returns failed IDs, the code in `commit()` assumes all IDs are cache value keys. However, `doSave()` can also return tag IDs (prefixed with `\1tags\1`) when tag persistence fails (e.g., Redis timeout).

Since tags are passed separately via `$addTagData`/`$removeTagData` and not stored in `$values`, accessing `$values[$id]` throws an "Undefined array key" warning.

**The fix:** Check if the ID exists in `$values` before accessing it. If it doesn't exist, it's a failed tag save, which we now log appropriately and skip.
