### PR TITLE
[FrameworkBundle] Fix misleading error message for non-existent parameters in `debug:container`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
@@ -182,6 +183,12 @@ class ContainerDebugCommand extends Command
             if (isset($options['id']) && isset($kernel->getContainer()->getRemovedIds()[$options['id']])) {
                 $errorIo->note(\sprintf('The "%s" service or alias has been removed or inlined when the container was compiled.', $options['id']));
             }
+        } catch (ParameterNotFoundException $e) {
+            if (isset($options['parameter']) && $options['parameter'] === $e->getKey()) {
+                throw new InvalidArgumentException(\sprintf('You have requested a non-existent parameter "%s".', $options['parameter']));
+            }
+
+            throw $e;
         } catch (ServiceNotFoundException $e) {
             if ('' !== $e->getId() && '@' === $e->getId()[0]) {
                 throw new ServiceNotFoundException($e->getId(), $e->getSourceId(), null, [substr($e->getId(), 1)]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -426,6 +426,34 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
         ];
     }
 
+    public function testNonExistentParameterDisplaysClearErrorMessage()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true]);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:container', '--parameter' => '.non_existent_build_parameter']);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertStringContainsString('You have requested a non-existent parameter ".non_existent_build_parameter".', $tester->getDisplay());
+    }
+
+    public function testNonExistentRegularParameterDisplaysClearErrorMessage()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => true]);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:container', '--parameter' => 'non_existent_parameter']);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertStringContainsString('You have requested a non-existent parameter "non_existent_parameter".', $tester->getDisplay());
+    }
+
     private function runDecorationStackWithFormat(string $format): string
     {
         static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml']);


### PR DESCRIPTION
  | Q             | A                                                                                                                                                                         
  | ------------- | ---                                                                                                                                                                       
  | Branch?       | 8.1                                                                                                                                                                       
  | Bug fix?      | no                                                                                                                                                                        
  | New feature?  | no                                                                                                                                                                        
  | Deprecations? | no                                                                                                                                                                        
  | Issues        | Fix #63378                                                                                                                                                                
  | License       | MIT                                                                                                                                                                       
                                                                                                                                                                                              
  The `debug:container --parameter` command was showing a misleading error message when a parameter did not exist, suggesting it was "deleted during the compilation of the container" when it
   never existed in the first place.                                                                                                                                                          
                                                                                                                                                                                              
  The debug container has access to all parameters (including build parameters prefixed with `.`) because the dump is created before `RemoveBuildParametersPass` runs. If a parameter is not  
  found there, it simply never existed. 