### PR TITLE
[JsonStreamer] Add `DateInterval` value object support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
@@ -20,6 +20,7 @@ use Symfony\Component\JsonStreamer\Mapping\Read\AttributePropertyMetadataLoader 
 use Symfony\Component\JsonStreamer\Mapping\Read\DateTimeTypePropertyMetadataLoader as ReadDateTimeTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader as WriteAttributePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\Write\DateTimeTypePropertyMetadataLoader as WriteDateTimeTypePropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\DateTimeToStringValueTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\StringToDateTimeValueTransformer;
@@ -105,6 +106,9 @@ return static function (ContainerConfigurator $container) {
             ->deprecate('symfony/json-streamer', '8.1', 'The "%service_id%" is deprecated. Date times will be transformed thanks to "'.DateTimeValueObjectTransformer::class.'" instead.')
 
         ->set('.json_streamer.value_object_transformer.date_time', DateTimeValueObjectTransformer::class)
+            ->tag('json_streamer.value_object_transformer')
+
+        ->set('.json_streamer.value_object_transformer.date_interval', DateIntervalValueObjectTransformer::class)
             ->tag('json_streamer.value_object_transformer')
 
         // cache

--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `DateInterval` value object support with `DateIntervalValueObjectTransformer`
  * Add timezone support to `DateTimeValueObjectTransformer`
  * Add value object support
  * Deprecate `DateTimeTypePropertyMetadataLoader` (both Read and Write), date times are handled as value objects

--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -21,6 +21,7 @@ use Symfony\Component\JsonStreamer\Mapping\Read\AttributePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Read\Instantiator;
 use Symfony\Component\JsonStreamer\Read\LazyInstantiator;
 use Symfony\Component\JsonStreamer\Read\StreamReaderGenerator;
+use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
@@ -35,6 +36,7 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
  * @psalm-type Options = array{
  *     date_time_format?: string,
  *     date_time_timezone?: string|\DateTimeZone,
+ *     date_interval_format?: string,
  *     ...<string, mixed>,
  * }
  *
@@ -83,6 +85,7 @@ final class JsonStreamReader implements StreamReaderInterface
         $streamReadersDir ??= sys_get_temp_dir().'/json_streamer/read';
         $transformers += [
             \DateTimeInterface::class => new DateTimeValueObjectTransformer(),
+            \DateInterval::class => new DateIntervalValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -18,6 +18,7 @@ use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
 use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
@@ -33,6 +34,7 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
  * @psalm-type Options = array{
  *     date_time_format?: string,
  *     date_time_timezone?: string|\DateTimeZone,
+ *     date_interval_format?: string,
  *     include_null_properties?: bool,
  *     ...<string, mixed>,
  * }
@@ -105,6 +107,7 @@ final class JsonStreamWriter implements StreamWriterInterface
         $streamWritersDir ??= sys_get_temp_dir().'/json_streamer/write';
         $transformers += [
             \DateTimeInterface::class => new DateTimeValueObjectTransformer(),
+            \DateInterval::class => new DateIntervalValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithDateIntervals.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithDateIntervals.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithDateIntervals
+{
+    public \DateInterval $interval;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\JsonStreamer\JsonStreamReader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateIntervals;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
@@ -198,6 +199,16 @@ class JsonStreamReaderTest extends TestCase
             $this->assertEquals(new \DateTimeImmutable('2025-11-20'), $read->immutable);
             $this->assertEquals(10, $read->union);
         }, '{"interface":"2024-11-20","immutable":"2025-11-20","union":10}', Type::object(DummyWithDateTimes::class));
+    }
+
+    public function testReadObjectWithDateIntervals()
+    {
+        $reader = JsonStreamReader::create([], $this->streamReadersDir);
+
+        $this->assertRead($reader, function (mixed $read) {
+            $this->assertInstanceOf(DummyWithDateIntervals::class, $read);
+            $this->assertEquals(new \DateInterval('P2Y6M1DT12H30M5S'), $read->interval);
+        }, '{"interval":"P2Y6M1DT12H30M5S"}', Type::object(DummyWithDateIntervals::class));
     }
 
     public function testReadUnion()

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateIntervals;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
@@ -44,6 +45,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\BooleanToStringVal
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\DoubleIntAndCastToStringValueTransformer;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\HeightValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueObject\Height;
+use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
@@ -347,6 +349,19 @@ class JsonStreamWriterTest extends TestCase
             $dummy,
             Type::object(DummyWithDateTimes::class),
             options: [DateTimeValueObjectTransformer::FORMAT_KEY => 'Y-m-d'],
+        );
+    }
+
+    public function testWriteObjectWithDateIntervals()
+    {
+        $dummy = new DummyWithDateIntervals();
+        $dummy->interval = new \DateInterval('P2Y6M1DT12H30M5S');
+
+        $this->assertWritten(
+            '{"interval":"P2Y6M1DT12H30M5S"}',
+            $dummy,
+            Type::object(DummyWithDateIntervals::class),
+            options: [DateIntervalValueObjectTransformer::FORMAT_KEY => 'P%yY%mM%dDT%hH%iM%sS'],
         );
     }
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Transformer/DateIntervalValueObjectTransformerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Transformer/DateIntervalValueObjectTransformerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Transformer;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
+
+class DateIntervalValueObjectTransformerTest extends TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new DateIntervalValueObjectTransformer();
+
+        $this->assertSame(
+            'P0Y0M0DT0H0M0S',
+            $transformer->transform(new \DateInterval('P0Y')),
+        );
+
+        $this->assertSame(
+            'P2Y6M1DT12H30M5S',
+            $transformer->transform(new \DateInterval('P2Y6M1DT12H30M5S')),
+        );
+
+        $this->assertSame(
+            '2 years',
+            $transformer->transform(new \DateInterval('P2Y'), [DateIntervalValueObjectTransformer::FORMAT_KEY => '%y years']),
+        );
+    }
+
+    public function testTransformWithInvertedInterval()
+    {
+        $transformer = new DateIntervalValueObjectTransformer();
+
+        $interval = new \DateInterval('P1Y');
+        $interval->invert = 1;
+
+        $this->assertSame(
+            '-P1Y0M0DT0H0M0S',
+            $transformer->transform($interval),
+        );
+    }
+
+    public function testTransformThrowWhenInvalidNativeValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The native value must be an instance of "\DateInterval".');
+
+        (new DateIntervalValueObjectTransformer())->transform(new \stdClass());
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new DateIntervalValueObjectTransformer();
+
+        $this->assertEquals(
+            new \DateInterval('P2Y6M1DT12H30M5S'),
+            $transformer->reverseTransform('P2Y6M1DT12H30M5S'),
+        );
+    }
+
+    public function testReverseTransformWithSign()
+    {
+        $transformer = new DateIntervalValueObjectTransformer();
+
+        $expected = new \DateInterval('P1Y');
+        $expected->invert = 1;
+
+        $this->assertEquals($expected, $transformer->reverseTransform('-P1Y0M0DT0H0M0S'));
+
+        $this->assertEquals(
+            new \DateInterval('P1Y'),
+            $transformer->reverseTransform('+P1Y0M0DT0H0M0S', [DateIntervalValueObjectTransformer::FORMAT_KEY => '%RP%yY%mM%dDT%hH%iM%sS']),
+        );
+    }
+
+    #[DataProvider('formatsAndIntervalsDataProvider')]
+    public function testTransformWithFormat(string $format, string $output, string $input)
+    {
+        $transformer = new DateIntervalValueObjectTransformer();
+
+        $this->assertSame($output, $transformer->transform($this->createInterval($input), [DateIntervalValueObjectTransformer::FORMAT_KEY => $format]));
+    }
+
+    #[DataProvider('formatsAndIntervalsDataProvider')]
+    public function testReverseTransformWithFormat(string $format, string $input, string $output)
+    {
+        $transformer = new DateIntervalValueObjectTransformer();
+
+        $this->assertDateIntervalEquals($this->createInterval($output), $transformer->reverseTransform($input, [DateIntervalValueObjectTransformer::FORMAT_KEY => $format]));
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: string, 2: string}>
+     */
+    public static function formatsAndIntervalsDataProvider(): iterable
+    {
+        yield ['P%YY%MM%DDT%HH%IM%SS', 'P00Y00M00DT00H00M00S', 'PT0S'];
+        yield ['P%yY%mM%dDT%hH%iM%sS', 'P0Y0M0DT0H0M0S', 'PT0S'];
+        yield ['P%yY%mM%dDT%hH%iM%sS', 'P10Y2M3DT16H5M6S', 'P10Y2M3DT16H5M6S'];
+        yield ['P%yY%mM%dDT%hH%iM', 'P10Y2M3DT16H5M', 'P10Y2M3DT16H5M'];
+        yield ['P%yY%mM%dDT%hH', 'P10Y2M3DT16H', 'P10Y2M3DT16H'];
+        yield ['P%yY%mM%dD', 'P10Y2M3D', 'P10Y2M3DT0H'];
+        yield ['%RP%yY%mM%dD', '-P10Y2M3D', '-P10Y2M3DT0H'];
+        yield ['%RP%yY%mM%dD', '+P10Y2M3D', '+P10Y2M3DT0H'];
+        yield ['%RP%yY%mM%dD', '+P10Y2M3D', 'P10Y2M3DT0H'];
+        yield ['%rP%yY%mM%dD', '-P10Y2M3D', '-P10Y2M3DT0H'];
+        yield ['%rP%yY%mM%dD', 'P10Y2M3D', 'P10Y2M3DT0H'];
+    }
+
+    public function testReverseTransformWithOmittedPartsBeingZero()
+    {
+        $transformer = new DateIntervalValueObjectTransformer();
+
+        $this->assertDateIntervalEquals($this->createInterval('P3Y2M4DT0H0M0S'), $transformer->reverseTransform('P3Y2M4D'));
+        $this->assertDateIntervalEquals($this->createInterval('P0Y0M0DT12H34M0S'), $transformer->reverseTransform('PT12H34M'));
+    }
+
+    public function testReverseTransformThrowWhenInvalidJsonValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value is not a valid ISO 8601 interval string.');
+
+        (new DateIntervalValueObjectTransformer())->reverseTransform(42);
+    }
+
+    public function testReverseTransformThrowWhenInvalidIntervalString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value is not a valid ISO 8601 interval string.');
+
+        (new DateIntervalValueObjectTransformer())->reverseTransform('not-an-interval');
+    }
+
+    public function testReverseTransformThrowWhenFormatMismatch()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value "P1Y0M0DT0H0M0S" contains intervals not accepted by format "%dD".');
+
+        (new DateIntervalValueObjectTransformer())->reverseTransform('P1Y0M0DT0H0M0S', [DateIntervalValueObjectTransformer::FORMAT_KEY => '%dD']);
+    }
+
+    private function assertDateIntervalEquals(\DateInterval $expected, \DateInterval $actual): void
+    {
+        $this->assertSame($expected->format('%RP%yY%mM%dDT%hH%iM%sS'), $actual->format('%RP%yY%mM%dDT%hH%iM%sS'));
+    }
+
+    private function createInterval(string $data): \DateInterval
+    {
+        $interval = new \DateInterval(ltrim($data, '+-'));
+        if ('-' === $data[0]) {
+            $interval->invert = 1;
+        }
+
+        return $interval;
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Transformer/DateIntervalValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/DateIntervalValueObjectTransformer.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Transformer;
+
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Transforms a {@see \DateInterval} to a string and vice versa.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @psalm-type Options = array{
+ *     date_interval_format?: string,
+ *     ...<string, mixed>,
+ * }
+ *
+ * @implements ValueObjectTransformerInterface<\DateInterval, string>
+ */
+final class DateIntervalValueObjectTransformer implements ValueObjectTransformerInterface
+{
+    public const FORMAT_KEY = 'date_interval_format';
+
+    private const DEFAULT_FORMAT = '%rP%yY%mM%dDT%hH%iM%sS';
+
+    /**
+     * @param Options $options
+     */
+    public function transform(object $object, array $options = []): int|float|string|bool|null
+    {
+        if (!$object instanceof \DateInterval) {
+            throw new InvalidArgumentException('The native value must be an instance of "\DateInterval".');
+        }
+
+        return $object->format($options[self::FORMAT_KEY] ?? self::DEFAULT_FORMAT);
+    }
+
+    /**
+     * @param Options $options
+     */
+    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): \DateInterval
+    {
+        if (!\is_string($scalar) || !$this->isISO8601($scalar)) {
+            throw new InvalidArgumentException('The JSON value is not a valid ISO 8601 interval string.');
+        }
+
+        $dateIntervalFormat = $options[self::FORMAT_KEY] ?? self::DEFAULT_FORMAT;
+        $signPattern = match (substr($dateIntervalFormat, 0, 2)) {
+            '%R' => '[-+]',
+            '%r' => '-?',
+            default => '',
+        };
+
+        if ('' !== $signPattern) {
+            $dateIntervalFormat = substr($dateIntervalFormat, 2);
+        }
+
+        $valuePattern = '/^'.$signPattern.preg_replace('/%([yYmMdDhHiIsSwW])(\w)/', '(?:(?P<$1>\d+)$2)?', preg_replace('/(T.*)$/', '($1)?', $dateIntervalFormat)).'$/';
+        if (!preg_match($valuePattern, $scalar)) {
+            throw new InvalidArgumentException(\sprintf('The JSON value "%s" contains intervals not accepted by format "%s".', $scalar, $options[self::FORMAT_KEY] ?? self::DEFAULT_FORMAT));
+        }
+
+        try {
+            $interval = new \DateInterval(ltrim($scalar, '+-'));
+            if ('-' === $scalar[0]) {
+                $interval->invert = 1;
+            }
+
+            return $interval;
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::STRING>
+     */
+    public static function getStreamValueType(): BuiltinType
+    {
+        return Type::string();
+    }
+
+    public static function getValueObjectClassName(): string
+    {
+        return \DateInterval::class;
+    }
+
+    private function isISO8601(string $string): bool
+    {
+        return (bool) preg_match('/^[\-+]?P(?=\w*(?:\d|%\w))(?:\d+Y|%[yY]Y)?(?:\d+M|%[mM]M)?(?:\d+W|%[wW]W)?(?:\d+D|%[dD]D)?(?:T(?:\d+H|[hH]H)?(?:\d+M|[iI]M)?(?:\d+S|[sS]S)?)?$/', $string);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Add `DateInterval` value object support, similar to what `DateIntervalNormalizer` does in the Serializer component.