### PR TITLE
[JsonStreamer] Add `BcMath\Number` and `GMP` value object support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
@@ -20,9 +20,11 @@ use Symfony\Component\JsonStreamer\Mapping\Read\AttributePropertyMetadataLoader 
 use Symfony\Component\JsonStreamer\Mapping\Read\DateTimeTypePropertyMetadataLoader as ReadDateTimeTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader as WriteAttributePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\Write\DateTimeTypePropertyMetadataLoader as WriteDateTimeTypePropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Transformer\BcMathNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\GmpNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\DateTimeToStringValueTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\StringToDateTimeValueTransformer;
 
@@ -113,6 +115,12 @@ return static function (ContainerConfigurator $container) {
             ->tag('json_streamer.value_object_transformer')
 
         ->set('.json_streamer.value_object_transformer.date_time_zone', DateTimeZoneValueObjectTransformer::class)
+            ->tag('json_streamer.value_object_transformer')
+
+        ->set('.json_streamer.value_object_transformer.bcmath_number', BcMathNumberValueObjectTransformer::class)
+            ->tag('json_streamer.value_object_transformer')
+
+        ->set('.json_streamer.value_object_transformer.gmp_number', GmpNumberValueObjectTransformer::class)
             ->tag('json_streamer.value_object_transformer')
 
         // cache

--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `BcMath\Number` value object support with `BcMathNumberValueObjectTransformer`
+ * Add `GMP` value object support with `GmpNumberValueObjectTransformer`
+
 8.1
 ---
 

--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -21,9 +21,11 @@ use Symfony\Component\JsonStreamer\Mapping\Read\AttributePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Read\Instantiator;
 use Symfony\Component\JsonStreamer\Read\LazyInstantiator;
 use Symfony\Component\JsonStreamer\Read\StreamReaderGenerator;
+use Symfony\Component\JsonStreamer\Transformer\BcMathNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\GmpNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 use Symfony\Component\TypeInfo\Type;
@@ -88,6 +90,8 @@ final class JsonStreamReader implements StreamReaderInterface
             \DateTimeInterface::class => new DateTimeValueObjectTransformer(),
             \DateInterval::class => new DateIntervalValueObjectTransformer(),
             \DateTimeZone::class => new DateTimeZoneValueObjectTransformer(),
+            \BcMath\Number::class => new BcMathNumberValueObjectTransformer(),
+            \GMP::class => new GmpNumberValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -18,9 +18,11 @@ use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
 use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Transformer\BcMathNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\GmpNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 use Symfony\Component\JsonStreamer\Write\StreamWriterGenerator;
@@ -110,6 +112,8 @@ final class JsonStreamWriter implements StreamWriterInterface
             \DateTimeInterface::class => new DateTimeValueObjectTransformer(),
             \DateInterval::class => new DateIntervalValueObjectTransformer(),
             \DateTimeZone::class => new DateTimeZoneValueObjectTransformer(),
+            \BcMath\Number::class => new BcMathNumberValueObjectTransformer(),
+            \GMP::class => new GmpNumberValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithBcMathNumber.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithBcMathNumber.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+use BcMath\Number;
+
+class DummyWithBcMathNumber
+{
+    public Number $number;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithGmpNumber.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithGmpNumber.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithGmpNumber
+{
+    public \GMP $gmp;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -11,16 +11,19 @@
 
 namespace Symfony\Component\JsonStreamer\Tests;
 
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\JsonStreamer\JsonStreamReader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithBcMathNumber;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateIntervals;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimeZones;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGmpNumber;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
@@ -220,6 +223,28 @@ class JsonStreamReaderTest extends TestCase
             $this->assertInstanceOf(DummyWithDateTimeZones::class, $read);
             $this->assertEquals(new \DateTimeZone('Asia/Tokyo'), $read->timezone);
         }, '{"timezone":"Asia/Tokyo"}', Type::object(DummyWithDateTimeZones::class));
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testReadObjectWithBcMathNumber()
+    {
+        $reader = JsonStreamReader::create([], $this->streamReadersDir);
+
+        $this->assertRead($reader, function (mixed $read) {
+            $this->assertInstanceOf(DummyWithBcMathNumber::class, $read);
+            $this->assertEquals(new \BcMath\Number('3.14'), $read->number);
+        }, '{"number":"3.14"}', Type::object(DummyWithBcMathNumber::class));
+    }
+
+    #[RequiresPhpExtension('gmp')]
+    public function testReadObjectWithGmpNumber()
+    {
+        $reader = JsonStreamReader::create([], $this->streamReadersDir);
+
+        $this->assertRead($reader, function (mixed $read) {
+            $this->assertInstanceOf(DummyWithGmpNumber::class, $read);
+            $this->assertEquals(new \GMP('99999999999999999999'), $read->gmp);
+        }, '{"gmp":"99999999999999999999"}', Type::object(DummyWithGmpNumber::class));
     }
 
     public function testReadUnion()

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\JsonStreamer\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\JsonStreamer\Exception\NotEncodableValueException;
@@ -20,11 +21,13 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithBcMathNumber;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateIntervals;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimeZones;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGmpNumber;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithList;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedArray;
@@ -376,6 +379,24 @@ class JsonStreamWriterTest extends TestCase
             $dummy,
             Type::object(DummyWithDateTimeZones::class),
         );
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testWriteObjectWithBcMathNumber()
+    {
+        $dummy = new DummyWithBcMathNumber();
+        $dummy->number = new \BcMath\Number('3.14');
+
+        $this->assertWritten('{"number":"3.14"}', $dummy, Type::object(DummyWithBcMathNumber::class));
+    }
+
+    #[RequiresPhpExtension('gmp')]
+    public function testWriteObjectWithGmpNumber()
+    {
+        $dummy = new DummyWithGmpNumber();
+        $dummy->gmp = new \GMP('99999999999999999999');
+
+        $this->assertWritten('{"gmp":"99999999999999999999"}', $dummy, Type::object(DummyWithGmpNumber::class));
     }
 
     public function testWriteObjectWithDollarNamedProperties()

--- a/src/Symfony/Component/JsonStreamer/Tests/Transformer/BcMathNumberValueObjectTransformerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Transformer/BcMathNumberValueObjectTransformerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Transformer;
+
+use BcMath\Number;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\JsonStreamer\Transformer\BcMathNumberValueObjectTransformer;
+
+#[RequiresPhpExtension('bcmath')]
+class BcMathNumberValueObjectTransformerTest extends TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new BcMathNumberValueObjectTransformer();
+
+        $this->assertSame('42', $transformer->transform(new Number(42)));
+        $this->assertSame('3.14', $transformer->transform(new Number('3.14')));
+        $this->assertSame('0', $transformer->transform(new Number(0)));
+        $this->assertSame('-123', $transformer->transform(new Number(-123)));
+    }
+
+    public function testTransformThrowWhenInvalidNativeValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The native value must be an instance of "BcMath\Number".');
+
+        (new BcMathNumberValueObjectTransformer())->transform(new \stdClass());
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new BcMathNumberValueObjectTransformer();
+
+        $this->assertEquals(new Number(42), $transformer->reverseTransform(42));
+        $this->assertEquals(new Number('3.14'), $transformer->reverseTransform('3.14'));
+        $this->assertEquals(new Number('123'), $transformer->reverseTransform('123'));
+        $this->assertEquals(new Number(0), $transformer->reverseTransform(0));
+        $this->assertEquals(new Number('-123'), $transformer->reverseTransform('-123'));
+    }
+
+    public function testReverseTransformThrowWhenInvalidJsonValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value must be a string or an integer.');
+
+        (new BcMathNumberValueObjectTransformer())->reverseTransform(3.14);
+    }
+
+    public function testReverseTransformThrowWhenInvalidNumberString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new BcMathNumberValueObjectTransformer())->reverseTransform('not-a-number');
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Transformer/GmpNumberValueObjectTransformerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Transformer/GmpNumberValueObjectTransformerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Transformer;
+
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\JsonStreamer\Transformer\GmpNumberValueObjectTransformer;
+
+#[RequiresPhpExtension('gmp')]
+class GmpNumberValueObjectTransformerTest extends TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new GmpNumberValueObjectTransformer();
+
+        $this->assertSame('42', $transformer->transform(new \GMP(42)));
+        $this->assertSame('16', $transformer->transform(new \GMP('0x10')));
+        $this->assertSame('0', $transformer->transform(new \GMP(0)));
+        $this->assertSame('-123', $transformer->transform(new \GMP(-123)));
+        $this->assertSame('99999999999999999999', $transformer->transform(new \GMP('99999999999999999999')));
+    }
+
+    public function testTransformThrowWhenInvalidNativeValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The native value must be an instance of "\GMP".');
+
+        (new GmpNumberValueObjectTransformer())->transform(new \stdClass());
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new GmpNumberValueObjectTransformer();
+
+        $this->assertEquals(new \GMP(42), $transformer->reverseTransform(42));
+        $this->assertEquals(new \GMP('123'), $transformer->reverseTransform('123'));
+        $this->assertEquals(new \GMP('9223372036854775808'), $transformer->reverseTransform('9223372036854775808'));
+        $this->assertEquals(new \GMP(0), $transformer->reverseTransform(0));
+        $this->assertEquals(new \GMP('-123'), $transformer->reverseTransform('-123'));
+    }
+
+    public function testReverseTransformThrowWhenInvalidJsonValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value must be a string or an integer.');
+
+        (new GmpNumberValueObjectTransformer())->reverseTransform(3.14);
+    }
+
+    public function testReverseTransformThrowWhenInvalidGmpString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new GmpNumberValueObjectTransformer())->reverseTransform('not-a-number');
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Transformer/BcMathNumberValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/BcMathNumberValueObjectTransformer.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Transformer;
+
+use BcMath\Number;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Transforms a {@see Number} to a string and vice versa.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @implements ValueObjectTransformerInterface<Number, string>
+ */
+final class BcMathNumberValueObjectTransformer implements ValueObjectTransformerInterface
+{
+    public function transform(object $object, array $options = []): string
+    {
+        if (!$object instanceof Number) {
+            throw new InvalidArgumentException(\sprintf('The native value must be an instance of "%s".', Number::class));
+        }
+
+        return (string) $object;
+    }
+
+    /**
+     * @return Number
+     */
+    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): object
+    {
+        if (!\is_string($scalar) && !\is_int($scalar)) {
+            throw new InvalidArgumentException('The JSON value must be a string or an integer.');
+        }
+
+        try {
+            return new Number($scalar);
+        } catch (\ValueError $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::STRING>
+     */
+    public static function getStreamValueType(): BuiltinType
+    {
+        return Type::string();
+    }
+
+    public static function getValueObjectClassName(): string
+    {
+        return Number::class;
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Transformer/GmpNumberValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/GmpNumberValueObjectTransformer.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Transformer;
+
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Transforms a {@see \GMP} to a string and vice versa.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @implements ValueObjectTransformerInterface<\GMP, string>
+ */
+final class GmpNumberValueObjectTransformer implements ValueObjectTransformerInterface
+{
+    public function transform(object $object, array $options = []): string
+    {
+        if (!$object instanceof \GMP) {
+            throw new InvalidArgumentException('The native value must be an instance of "\GMP".');
+        }
+
+        return (string) $object;
+    }
+
+    /**
+     * @return \GMP
+     */
+    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): object
+    {
+        if (!\is_string($scalar) && !\is_int($scalar)) {
+            throw new InvalidArgumentException('The JSON value must be a string or an integer.');
+        }
+
+        try {
+            return new \GMP($scalar);
+        } catch (\ValueError $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::STRING>
+     */
+    public static function getStreamValueType(): BuiltinType
+    {
+        return Type::string();
+    }
+
+    public static function getValueObjectClassName(): string
+    {
+        return \GMP::class;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Add `BcMath\Number` and `GMP` value object support, similar to what `NumberNormalizer` does in the Serializer component.