### PR TITLE
[Validator] Fix Compound constraint with nested Composite and validation groups

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Compound.php
+++ b/src/Symfony/Component/Validator/Constraints/Compound.php
@@ -34,7 +34,16 @@ abstract class Compound extends Composite
 
         $this->constraints = $this->getConstraints($this->normalizeOptions($options));
 
+        if (null !== $groups) {
+            // reset nested groups so that Composite::__construct() does not run its subset check
+            self::resetNestedConstraintsGroups($this->constraints);
+        }
+
         parent::__construct($options, $groups, $payload);
+
+        if (null !== $groups) {
+            self::propagateGroupsToNestedConstraints($this->constraints, $this->groups);
+        }
     }
 
     final protected function getCompositeOption(): string
@@ -53,4 +62,37 @@ abstract class Compound extends Composite
      * @return Constraint[]
      */
     abstract protected function getConstraints(array $options): array;
+
+    private static function resetNestedConstraintsGroups(array $constraints): void
+    {
+        foreach ($constraints as $constraint) {
+            if (!$constraint instanceof Constraint) {
+                continue;
+            }
+            if ($constraint instanceof Composite) {
+                // skip Composites with explicit groups: their subset check is the user's contract
+                if ([Constraint::DEFAULT_GROUP] !== $constraint->groups) {
+                    continue;
+                }
+                self::resetNestedConstraintsGroups($constraint->getNestedConstraints());
+            }
+            unset($constraint->groups);
+        }
+    }
+
+    private static function propagateGroupsToNestedConstraints(array $constraints, array $groups): void
+    {
+        foreach ($constraints as $constraint) {
+            if (!$constraint instanceof Constraint) {
+                continue;
+            }
+            if ($constraint instanceof Composite && $groups !== $constraint->groups) {
+                continue;
+            }
+            $constraint->groups = $groups;
+            if ($constraint instanceof Composite) {
+                self::propagateGroupsToNestedConstraints($constraint->getNestedConstraints(), $groups);
+            }
+        }
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompoundTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompoundTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Compound;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Sequentially;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 class CompoundTest extends TestCase
@@ -58,6 +59,36 @@ class CompoundTest extends TestCase
 
         $this->assertSame($min, $constraint->constraints[0]->min);
     }
+
+    public function testGroupsArePropagatedToNestedCompositeConstraints()
+    {
+        $compound = new CompoundWithSequentially(groups: ['my-group']);
+
+        $this->assertSame(['my-group'], $compound->groups);
+
+        $sequentially = $compound->constraints[0];
+        $this->assertInstanceOf(Sequentially::class, $sequentially);
+        $this->assertSame(['my-group'], $sequentially->groups);
+
+        foreach ($sequentially->constraints as $nestedConstraint) {
+            $this->assertSame(['my-group'], $nestedConstraint->groups);
+        }
+    }
+
+    public function testExplicitGroupsOnNestedCompositeArePreserved()
+    {
+        $compound = new CompoundWithExplicitlyGroupedSequentially(groups: ['outer', 'inner']);
+
+        $this->assertSame(['outer', 'inner'], $compound->groups);
+
+        $sequentially = $compound->constraints[0];
+        $this->assertInstanceOf(Sequentially::class, $sequentially);
+        $this->assertSame(['inner'], $sequentially->groups);
+
+        foreach ($sequentially->constraints as $nestedConstraint) {
+            $this->assertSame(['inner'], $nestedConstraint->groups);
+        }
+    }
 }
 
 class EmptyCompound extends Compound
@@ -81,6 +112,32 @@ class ForwardingOptionCompound extends Compound
     {
         return [
             new Length(min: $options['min'] ?? null),
+        ];
+    }
+}
+
+class CompoundWithSequentially extends Compound
+{
+    protected function getConstraints(array $options): array
+    {
+        return [
+            new Sequentially([
+                new NotBlank(),
+                new Length(min: 3),
+            ]),
+        ];
+    }
+}
+
+class CompoundWithExplicitlyGroupedSequentially extends Compound
+{
+    protected function getConstraints(array $options): array
+    {
+        return [
+            new Sequentially(constraints: [
+                new NotBlank(),
+                new Length(min: 3),
+            ], groups: ['inner']),
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62035
| License       | MIT

When a `Compound` constraint's `getConstraints()` returns a nested `Composite` (e.g. `Sequentially`), constructing the outer `Compound` with explicit groups currently throws:

> The group(s) "Default" passed to the constraint "Sequentially" should also be passed to its containing constraint "PasswordRequirement".

The nested `Composite`'s constructor auto-merges its children's groups (which default to `[Default]`), then the outer `Composite::__construct()` subset check rejects `[Default]` against the user's explicit groups.

This PR resets the nested groups before `parent::__construct()` so the subset check does not fire on auto-derived groups, then propagates the outer groups recursively into the subtree.

To preserve the documented contract of `Composite` (case 3: nested groups must be a subset of the outer groups), the reset is gated on `[Constraint::DEFAULT_GROUP]` — the unambiguous "nobody set anything" marker. A nested `Composite` with explicit groups is left untouched, and the existing subset check validates it as before.