### PR TITLE
[FrameworkBundle][HttpKernel] Deprecate `Bundle::registerCommands()`

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -59,6 +59,7 @@ FrameworkBundle
    use the `router.request_context.base_url` parameter or the `framework.router.default_uri` config option instead
  * Deprecate setting `framework.http_client.default_options.caching.max_ttl` to `null`, use a positive integer instead
  * Deprecate `senders` nesting level for messenger routing config; use string or a list of strings instead
+ * Deprecate registering console commands by overriding `Bundle::registerCommands()`, use the `#[AsCommand]` attribute or the `console.command` service tag instead
 
 HttpClient
 ----------
@@ -86,6 +87,7 @@ HttpKernel
    }
    ```
  * Deprecate passing a `ControllerArgumentsEvent` to the `ViewEvent` constructor; pass a `ControllerArgumentsMetadata` instead
+ * Deprecate `Bundle::registerCommands()`, use the `#[AsCommand]` attribute or the `console.command` service tag instead of overriding this method
 
 Messenger
 ---------

--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\DebugBundle;
 
 use Symfony\Bundle\DebugBundle\DependencyInjection\Compiler\DumpDataCollectorPass;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\VarDumper\VarDumper;
@@ -54,10 +53,5 @@ class DebugBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new DumpDataCollectorPass());
-    }
-
-    public function registerCommands(Application $application): void
-    {
-        // noop
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG
  * Deprecate setting `caching.max_ttl` to `null`, use a positive integer instead
  * Deprecate `senders` nesting level for messenger routing config; use string or a list of strings instead
  * Allow configuring Webhook's header names and signing algo
+ * Deprecate registering console commands by overriding `Bundle::registerCommands()`, use the `#[AsCommand]` attribute or the `console.command` service tag instead
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -193,7 +193,12 @@ class Application extends BaseApplication implements ContainerAwareInterface
         $container = $this->kernel->getContainer();
 
         foreach ($this->kernel->getBundles() as $bundle) {
-            if ($bundle instanceof Bundle) {
+            if ($bundle instanceof Bundle
+                && \method_exists($bundle, 'registerCommands')
+                && new \ReflectionMethod($bundle, 'registerCommands')->getDeclaringClass()->getName() !== Bundle::class
+            ) {
+                trigger_deprecation('symfony/framework-bundle', '8.1', 'Overriding the "%s::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', Bundle::class, get_debug_type($bundle));
+
                 try {
                     $bundle->registerCommands($this);
                 } catch (\Throwable $e) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Console;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\EventListener\SuggestMissingPackageSubscriber;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -43,6 +46,18 @@ class ApplicationTest extends TestCase
         $application->doRun(new ArrayInput(['list']), new NullOutput());
     }
 
+    public function testNotOverridingRegisterCommandsAvoidsDeprecation()
+    {
+        $bundle = new class extends Bundle {};
+
+        $kernel = $this->getKernel([$bundle], true);
+
+        $application = new Application($kernel);
+        $application->doRun(new ArrayInput(['list']), new NullOutput());
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testBundleCommandsAreRegistered()
     {
         $bundle = $this->createBundleMock([]);
@@ -50,12 +65,17 @@ class ApplicationTest extends TestCase
         $kernel = $this->getKernel([$bundle], true);
 
         $application = new Application($kernel);
+
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/framework-bundle 8.1: Overriding the "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', get_debug_type($bundle)));
+
         $application->doRun(new ArrayInput(['list']), new NullOutput());
 
         // Calling twice: registration should only be done once.
         $application->doRun(new ArrayInput(['list']), new NullOutput());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testBundleCommandsAreRetrievable()
     {
         $bundle = $this->createBundleMock([]);
@@ -63,12 +83,17 @@ class ApplicationTest extends TestCase
         $kernel = $this->getKernel([$bundle]);
 
         $application = new Application($kernel);
+
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/framework-bundle 8.1: Overriding the "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', get_debug_type($bundle)));
+
         $application->all();
 
         // Calling twice: registration should only be done once.
         $application->all();
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testBundleSingleCommandIsRetrievable()
     {
         $command = new Command('example');
@@ -79,9 +104,13 @@ class ApplicationTest extends TestCase
 
         $application = new Application($kernel);
 
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/framework-bundle 8.1: Overriding the "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', get_debug_type($bundle)));
+
         $this->assertSame($command, $application->get('example'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testBundleCommandCanBeFound()
     {
         $command = new Command('example');
@@ -92,9 +121,13 @@ class ApplicationTest extends TestCase
 
         $application = new Application($kernel);
 
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/framework-bundle 8.1: Overriding the "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', get_debug_type($bundle)));
+
         $this->assertSame($command, $application->find('example'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testBundleCommandCanBeFoundByAlias()
     {
         $command = new Command('example');
@@ -106,9 +139,13 @@ class ApplicationTest extends TestCase
 
         $application = new Application($kernel);
 
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/framework-bundle 8.1: Overriding the "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', get_debug_type($bundle)));
+
         $this->assertSame($command, $application->find('alias'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testBundleCommandCanOverriddeAPreExistingCommandWithTheSameName()
     {
         $command = new Command('example');
@@ -121,9 +158,13 @@ class ApplicationTest extends TestCase
         $newCommand = new Command('example');
         $application->addCommand($newCommand);
 
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/framework-bundle 8.1: Overriding the "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', get_debug_type($bundle)));
+
         $this->assertSame($newCommand, $application->get('example'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testRunOnlyWarnsOnUnregistrableCommand()
     {
         $container = new ContainerBuilder();
@@ -158,6 +199,8 @@ class ApplicationTest extends TestCase
         $this->assertStringContainsString('fine', $output);
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testRegistrationErrorsAreDisplayedOnCommandNotFound()
     {
         $container = new ContainerBuilder();
@@ -189,6 +232,8 @@ class ApplicationTest extends TestCase
         $this->assertStringContainsString('Command "fine" is not defined.', $output);
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testRunOnlyWarnsOnUnregistrableCommandAtTheEnd()
     {
         $container = new ContainerBuilder();
@@ -251,7 +296,10 @@ class ApplicationTest extends TestCase
         return $event->getError()->getMessage();
     }
 
-    private function getKernel(array $bundles, $useDispatcher = false)
+    /**
+     * @param BundleInterface[] $bundles
+     */
+    private function getKernel(array $bundles, bool $useDispatcher = false): KernelInterface&MockObject
     {
         $container = new Container(new ParameterBag([
             'console.command.ids' => [],
@@ -282,7 +330,10 @@ class ApplicationTest extends TestCase
         return $kernel;
     }
 
-    private function createBundleMock(array $commands)
+    /**
+     * @param array<callable|Command> $commands
+     */
+    private function createBundleMock(array $commands): Bundle&MockObject
     {
         $bundle = $this->createMock(Bundle::class);
         $bundle

--- a/src/Symfony/Bundle/TwigBundle/TwigBundle.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigBundle.php
@@ -16,7 +16,6 @@ use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\ExtensionPass;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\RuntimeLoaderPass;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigEnvironmentPass;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigLoaderPass;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -38,10 +37,5 @@ class TwigBundle extends Bundle
         $container->addCompilerPass(new TwigEnvironmentPass());
         $container->addCompilerPass(new TwigLoaderPass());
         $container->addCompilerPass(new RuntimeLoaderPass(), PassConfig::TYPE_BEFORE_REMOVING);
-    }
-
-    public function registerCommands(Application $application): void
-    {
-        // noop
     }
 }

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -110,8 +110,12 @@ abstract class Bundle implements BundleInterface
         return $this->name;
     }
 
+    /**
+     * @deprecated since Symfony 8.1, use the #[AsCommand] attribute or the "console.command" service tag instead of overriding this method
+     */
     public function registerCommands(Application $application): void
     {
+        trigger_deprecation('symfony/http-kernel', '8.1', 'The "%s::registerCommands()" method is deprecated, use the #[AsCommand] attribute or the "console.command" service tag instead of overriding this method', self::class);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
  * Support variadic argument with `#[MapRequestPayload]`
  * Add `#[Serialize]` to serialize values returned by controllers
  * Add argument `$mapWhenEmpty` to `MapQueryString` and `MapRequestPayload` for always attempting denormalization with empty query and request payload
+ * Deprecate `Bundle::registerCommands()`, use the `#[AsCommand]` attribute or the `console.command` service tag instead of overriding this method
 
 8.0
 ---

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -11,8 +11,11 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Bundle;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Tests\Fixtures\BundleCompilerPass\BundleAsCompilerPassBundle;
@@ -68,6 +71,16 @@ class BundleTest extends TestCase
         $kernel->boot();
 
         $this->assertTrue($kernel->getContainer()->has('foo'));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testRegisterCommandsIsDeprecated()
+    {
+        $bundle = new class extends Bundle {};
+        $this->expectUserDeprecationMessage('Since symfony/http-kernel 8.1: The "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method is deprecated, use the #[AsCommand] attribute or the "console.command" service tag instead of overriding this method');
+
+        $bundle->registerCommands(self::createStub(Application::class));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

Our `Bundle` class provides an extension point to register console commands. That extension point is not covered by the `BundleInterface` contract and only consumed by FrameworkBundle.

https://github.com/symfony/symfony/blob/930b073cddb2dd8ea2fb30bd51525434c8784ba1/src/Symfony/Bundle/FrameworkBundle/Console/Application.php#L195-L203

I believe that this is a concept from the very early Symfony 2 days from when we were able to register commands through namespace conventions (removed in 4.0, #23857). Today bundles usually register their commands as services tagged with `console.command`, either explicitly or through autoconfiguration via type or the `#[AsCommand]` attribute.

Therefore, I'd like to remove this obsolete logic in Symfony 9 and save us a couple of CPU cycles.