### PR TITLE
[Cache] Fix `Psr16Cache::getMultiple()` returning `ValueWrapper` with `TagAwareAdapter`

### DIFF
--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -18,6 +18,7 @@ use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Traits\ProxyTrait;
+use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * Turns a PSR-6 cache into a PSR-16 one.
@@ -68,6 +69,12 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
         };
         self::$packCacheItem ??= \Closure::bind(
             static function (CacheItem $item) {
+                // Only re-pack if there's timing metadata (for Psr16Adapter compatibility)
+                // Don't re-pack if only tags metadata exists (TagAwareAdapter direct use case)
+                if (!isset($item->metadata[ItemInterface::METADATA_CTIME]) && !isset($item->metadata[ItemInterface::METADATA_EXPIRY])) {
+                    return $item->value;
+                }
+
                 $item->newMetadata = $item->metadata;
 
                 return $item->pack();

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Cache\Tests;
 
 use Cache\IntegrationTests\SimpleCacheTest;
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Psr16Cache;
 
@@ -171,6 +173,22 @@ class Psr16CacheTest extends SimpleCacheTest
         $getFileMethod = (new \ReflectionObject($pool))->getMethod('getFile');
 
         return !file_exists($getFileMethod->invoke($pool, $name));
+    }
+
+    public function testGetMultipleWithTagAwareAdapter()
+    {
+        $cache = new Psr16Cache(new TagAwareAdapter(new ArrayAdapter()));
+
+        $cache->set('foo', 'foo-val');
+        $cache->set('bar', 'bar-val');
+
+        // get() should return raw values
+        $this->assertSame('foo-val', $cache->get('foo'));
+        $this->assertSame('bar-val', $cache->get('bar'));
+
+        // getMultiple() should also return raw values, not ValueWrapper objects
+        $values = $cache->getMultiple(['foo', 'bar']);
+        $this->assertSame(['foo' => 'foo-val', 'bar' => 'bar-val'], iterator_to_array($values));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58632
| License       | MIT

`Psr16Cache::getMultiple()` was returning `ValueWrapper` objects instead of raw values when the underlying pool was a `TagAwareAdapter`.

The issue was that `$packCacheItem` re-packed all values having metadata. Since `TagAwareAdapter` adds tags metadata to items, this triggered the re-packing even for values that were stored as raw values.

The fix checks for timing metadata (`ctime` or `expiry`) before re-packing. These are only present when values were stored via `Psr16Adapter` (which needs the metadata preserved). Tags-only metadata no longer triggers re-packing.