### PR TITLE
[Console] Fix performance regression in OutputFormatter for ASCII content

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -133,6 +133,10 @@ class OutputFormatter implements WrappableOutputFormatterInterface
             return '';
         }
 
+        // For ASCII-only strings, byte positions equal character positions,
+        // so we can use native strlen/substr which is much faster than Helper::length/substr.
+        $isAscii = !preg_match('/[\x80-\xFF]/', $message);
+
         $offset = 0;
         $output = '';
         $openTagRegex = '[a-z](?:[^\\\\<>]*+ | \\\\.)*';
@@ -147,11 +151,17 @@ class OutputFormatter implements WrappableOutputFormatterInterface
                 continue;
             }
 
-            // convert byte position to character position.
-            $pos = Helper::length(substr($message, 0, $pos));
-            // add the text up to the next tag
-            $output .= $this->applyCurrentStyle(Helper::substr($message, $offset, $pos - $offset), $output, $width, $currentLineLength);
-            $offset = $pos + Helper::length($text);
+            if ($isAscii) {
+                // For ASCII, byte position = character position, no conversion needed
+                $output .= $this->applyCurrentStyle(substr($message, $offset, $pos - $offset), $output, $width, $currentLineLength);
+                $offset = $pos + \strlen($text);
+            } else {
+                // convert byte position to character position.
+                $pos = Helper::length(substr($message, 0, $pos));
+                // add the text up to the next tag
+                $output .= $this->applyCurrentStyle(Helper::substr($message, $offset, $pos - $offset), $output, $width, $currentLineLength);
+                $offset = $pos + Helper::length($text);
+            }
 
             // opening tag?
             if ($open = '/' !== $text[1]) {
@@ -172,7 +182,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
             }
         }
 
-        $output .= $this->applyCurrentStyle(Helper::substr($message, $offset), $output, $width, $currentLineLength);
+        $output .= $this->applyCurrentStyle($isAscii ? substr($message, $offset) : Helper::substr($message, $offset), $output, $width, $currentLineLength);
 
         return strtr($output, ["\0" => '\\', '\\<' => '<', '\\>' => '>']);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61845
| License       | MIT

This PR fixes the massive performance regression introduced in 6.4.24 by PR #61242.

## Problem

The change from byte positions to character positions using `Helper::length()` and `Helper::substr()` caused O(n×m) complexity where n is message length and m is number of formatting tags. For a 580KB message with 20,000 tags, formatting took **42 seconds**.

## Solution

Detect once at the start if the message is ASCII-only. For ASCII strings, byte positions equal character positions, so we can use native `strlen()`/`substr()` instead of the grapheme-aware `Helper::length()`/`Helper::substr()`.

## Benchmark results

| Version | Time per iteration |
|---------|-------------------|
| Before  | 41,965 ms |
| After   | 83 ms |

**~500x faster** for ASCII content (the common case).

UTF-8 content still uses the grapheme-aware functions to correctly handle multi-byte characters.