### PR TITLE
[Cache] create MemoryAwareArrayAdapter for in-memory non-serialized caching long-running processes

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/MemoryAwareArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemoryAwareArrayAdapter.php
@@ -26,7 +26,7 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
 
     private ArrayAdapter $arrayAdapter;
 
-    private MemoryUsageCalculator $memoryUsageCalculator;
+    private ?\Closure $memoryUsageCalculator;
 
     private int $softMemoryLimit;
 
@@ -45,7 +45,7 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
         string|int|null $softMemoryLimit = null,
         string|int|null $hardMemoryLimit = null,
         ?int $maxEvictionPerRun = null,
-        ?MemoryUsageCalculator $memoryUsageCalculator = null,
+        ?\Closure $memoryUsageCalculator = null,
         ?ClockInterface $clock = null,
     ) {
         if (!$softMemoryLimit && !$hardMemoryLimit) {
@@ -61,7 +61,7 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
         $this->maxEvictionPerRun = $maxEvictionPerRun ?? self::MAX_EVICTION_PER_RUN;
         $this->hardMemoryLimit = self::parseMemoryLimit($hardMemoryLimit);
         $this->softMemoryLimit = self::parseMemoryLimit($softMemoryLimit);
-        $this->memoryUsageCalculator = $memoryUsageCalculator ?? new PhpMemoryUsageCalculator();
+        $this->memoryUsageCalculator = $memoryUsageCalculator;
         $this->arrayAdapter = new ArrayAdapter(
             $defaultLifetime,
             false,
@@ -160,7 +160,7 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
 
     private function evictHardLimited(): void
     {
-        if (!$this->hardMemoryLimit || $this->hardMemoryLimit >= $this->memoryUsageCalculator->calculate()) {
+        if (!$this->hardMemoryLimit || $this->hardMemoryLimit >= $this->realMemoryUsage()) {
             return;
         }
 
@@ -170,7 +170,7 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
 
     private function evictSoftLimited(): void
     {
-        if (!$this->softMemoryLimit || $this->softMemoryLimit >= $this->memoryUsageCalculator->calculate()) {
+        if (!$this->softMemoryLimit || $this->softMemoryLimit >= $this->realMemoryUsage()) {
             return;
         }
         $target = (int) ($this->softMemoryLimit * 0.9); // hysteresis target
@@ -183,7 +183,7 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
             return;
         }
         $evicted = 0;
-        while ($target < $this->memoryUsageCalculator->calculate() && $this->maxEvictionPerRun > $evicted) {
+        while ($target < $this->realMemoryUsage() && $this->maxEvictionPerRun > $evicted) {
             if (false === $this->evictBatch($ratio)) {
                 break;
             }
@@ -220,6 +220,13 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
         return $this->delete($key);
     }
 
+    private function realMemoryUsage(): int
+    {
+        $calculator = $this->memoryUsageCalculator;
+
+        return $calculator ? $calculator() : memory_get_usage(true);
+    }
+
     private static function parseMemoryLimit(string|int|null $value): int
     {
         if (null === $value || -1 === $value || '' === $value) {
@@ -243,18 +250,5 @@ final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface,
         $value *= $multiplier;
 
         return $value;
-    }
-}
-
-interface MemoryUsageCalculator
-{
-    public function calculate(): int;
-}
-
-final class PhpMemoryUsageCalculator implements MemoryUsageCalculator
-{
-    public function calculate(): int
-    {
-        return memory_get_usage(true);
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/MemoryAwareArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemoryAwareArrayAdapter.php
@@ -1,0 +1,260 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
+
+final class MemoryAwareArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolInterface, LoggerAwareInterface, ResettableInterface
+{
+    private const int MAX_EVICTION_PER_RUN = 10;
+
+    private ArrayAdapter $arrayAdapter;
+
+    private MemoryUsageCalculator $memoryUsageCalculator;
+
+    private int $softMemoryLimit;
+
+    private int $hardMemoryLimit;
+
+    private int $maxEvictionPerRun;
+
+    /**
+     * @param string|int|null $softMemoryLimit A memory limit in bytes or a string like '128M'
+     * @param string|int|null $hardMemoryLimit A memory limit in bytes or a string like '128M'. If not set, it defaults to php memory_limit
+     */
+    public function __construct(
+        int $defaultLifetime = 0,
+        float $maxLifetime = 0,
+        int $maxItems = 0,
+        string|int|null $softMemoryLimit = null,
+        string|int|null $hardMemoryLimit = null,
+        ?int $maxEvictionPerRun = null,
+        ?MemoryUsageCalculator $memoryUsageCalculator = null,
+        ?ClockInterface $clock = null,
+    ) {
+        if (!$softMemoryLimit && !$hardMemoryLimit) {
+            $hardMemoryLimit = \ini_get('memory_limit') ? (int) \ini_get('memory_limit') : 0;
+        }
+        if (!$softMemoryLimit) {
+            $softMemoryLimit = $hardMemoryLimit;
+        }
+        if (!$hardMemoryLimit) {
+            $hardMemoryLimit = $softMemoryLimit;
+        }
+
+        $this->maxEvictionPerRun = $maxEvictionPerRun ?? self::MAX_EVICTION_PER_RUN;
+        $this->hardMemoryLimit = self::parseMemoryLimit($hardMemoryLimit);
+        $this->softMemoryLimit = self::parseMemoryLimit($softMemoryLimit);
+        $this->memoryUsageCalculator = $memoryUsageCalculator ?? new PhpMemoryUsageCalculator();
+        $this->arrayAdapter = new ArrayAdapter(
+            $defaultLifetime,
+            false,
+            $maxLifetime,
+            $maxItems,
+            $clock,
+        );
+    }
+
+    public function getItem(mixed $key): CacheItem
+    {
+        return $this->arrayAdapter->getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return $this->arrayAdapter->getItems($keys);
+    }
+
+    public function clear(string $prefix = ''): bool
+    {
+        return $this->arrayAdapter->clear($prefix);
+    }
+
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+    {
+        return $this->arrayAdapter->get($key, $callback, $beta, $metadata);
+    }
+
+    public function delete(string $key): bool
+    {
+        return $this->arrayAdapter->delete($key);
+    }
+
+    public function hasItem(mixed $key): bool
+    {
+        return $this->arrayAdapter->hasItem($key);
+    }
+
+    public function deleteItem(mixed $key): bool
+    {
+        return $this->arrayAdapter->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return $this->arrayAdapter->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        $result = $this->arrayAdapter->save($item);
+        $this->evictIfNeeded();
+
+        return $result;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->save($item);
+    }
+
+    public function commit(): bool
+    {
+        return $this->arrayAdapter->commit();
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->arrayAdapter->setLogger($logger);
+    }
+
+    public function withSubNamespace(string $namespace): static
+    {
+        $new = clone $this;
+        $new->arrayAdapter = $this->arrayAdapter->withSubNamespace($namespace);
+
+        return $new;
+    }
+
+    public function reset(): void
+    {
+        $this->arrayAdapter->reset();
+    }
+
+    public function getValues(): array
+    {
+        return $this->arrayAdapter->getValues();
+    }
+
+    private function evictIfNeeded(): void
+    {
+        $this->evictHardLimited();
+        $this->evictSoftLimited();
+    }
+
+    private function evictHardLimited(): void
+    {
+        if (!$this->hardMemoryLimit || $this->hardMemoryLimit >= $this->memoryUsageCalculator->calculate()) {
+            return;
+        }
+
+        $this->evictBatch(0.2);
+        $this->evictBatchUntilTarget(0.2, $this->softMemoryLimit);
+    }
+
+    private function evictSoftLimited(): void
+    {
+        if (!$this->softMemoryLimit || $this->softMemoryLimit >= $this->memoryUsageCalculator->calculate()) {
+            return;
+        }
+        $target = (int) ($this->softMemoryLimit * 0.9); // hysteresis target
+        $this->evictBatchUntilTarget(0.05, $target);
+    }
+
+    private function evictBatchUntilTarget(float $ratio, int $target): void
+    {
+        if (!$target) {
+            return;
+        }
+        $evicted = 0;
+        while ($target < $this->memoryUsageCalculator->calculate() && $this->maxEvictionPerRun > $evicted) {
+            if (false === $this->evictBatch($ratio)) {
+                break;
+            }
+            ++$evicted;
+        }
+    }
+
+    private function evictBatch(float $ratio): bool
+    {
+        $values = $this->arrayAdapter->getValues();
+        if ([] === $values) {
+            return false;
+        }
+        $count = max(1, (int) (\count($values) * $ratio));
+
+        for ($i = 0; $i < $count; ++$i) {
+            if (false === $this->evictOne()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function evictOne(): bool
+    {
+        $values = $this->arrayAdapter->getValues();
+        if ([] === $values) {
+            return false;
+        }
+
+        $key = array_key_first($values);
+
+        return $this->delete($key);
+    }
+
+    private static function parseMemoryLimit(string|int|null $value): int
+    {
+        if (null === $value || -1 === $value || '' === $value) {
+            return 0;
+        }
+        if (\is_int($value)) {
+            return $value;
+        }
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        $unit = strtolower(substr($value, -1));
+        $value = (int) substr($value, 0, -1);
+        $multiplier = match ($unit) {
+            'k' => 1024,
+            'm' => 1024 * 1024,
+            'g' => 1024 * 1024 * 1024,
+            default => 1,
+        };
+        $value *= $multiplier;
+
+        return $value;
+    }
+}
+
+interface MemoryUsageCalculator
+{
+    public function calculate(): int;
+}
+
+final class PhpMemoryUsageCalculator implements MemoryUsageCalculator
+{
+    public function calculate(): int
+    {
+        return memory_get_usage(true);
+    }
+}

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `MemoryAwareArrayAdapter` for in-memory non-serialized caching with memory aware LRU eviction policy 
+   for long-running processes like MQ workers, swoole, FrankenPHP etc.
+
 8.0
 ---
 

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -46,6 +46,7 @@ final class LockRegistry
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'FilesystemAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'FilesystemTagAwareAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'MemcachedAdapter.php',
+        __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'MemoryAwareArrayAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'NullAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'ParameterNormalizer.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'PdoAdapter.php',

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemoryAwareArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemoryAwareArrayAdapterTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\MemoryAwareArrayAdapter;
-use Symfony\Component\Cache\Adapter\MemoryUsageCalculator;
 use Symfony\Component\Cache\Tests\Adapter\ArrayAdapterTest;
 use Symfony\Component\Clock\MockClock;
 
@@ -71,7 +70,7 @@ class MemoryAwareArrayAdapterTest extends ArrayAdapterTest
             250,
             350,
             null,
-            $memoryUsageCalculator,
+            $memoryUsageCalculator->createCalculator(),
             new MockClock(),
         );
 
@@ -163,9 +162,9 @@ class MemoryAwareArrayAdapterTest extends ArrayAdapterTest
         );
     }
 
-    private function memoryUsageCalculator(): MemoryUsageCalculator
+    private function memoryUsageCalculator(): object
     {
-        return new class implements MemoryUsageCalculator {
+        return new class {
             private int $estimatedMemory = 0;
 
             private array $consecutiveCalculations = [];
@@ -188,6 +187,11 @@ class MemoryAwareArrayAdapterTest extends ArrayAdapterTest
                 }
 
                 return $this->estimatedMemory;
+            }
+
+            public function createCalculator(): \Closure
+            {
+                return fn () => $this->calculate();
             }
         };
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemoryAwareArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemoryAwareArrayAdapterTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Adapter;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\MemoryAwareArrayAdapter;
+use Symfony\Component\Cache\Adapter\MemoryUsageCalculator;
+use Symfony\Component\Cache\Tests\Adapter\ArrayAdapterTest;
+use Symfony\Component\Clock\MockClock;
+
+#[Group('time-sensitive')]
+class MemoryAwareArrayAdapterTest extends ArrayAdapterTest
+{
+    protected $skippedTests = [
+        'testGetMetadata' => 'ArrayAdapter does not keep metadata.',
+        'testDeferredSaveWithoutCommit' => 'Assumes a shared cache which ArrayAdapter is not.',
+        'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Assumes a shared cache which ArrayAdapter is not.',
+        'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayAdapter is not.',
+        'testNotUnserializable' => 'MemoryAwareArrayAdapter does not support serialization.',
+        'testErrorsDontInvalidate' => 'MemoryAwareArrayAdapter does not support serialization, so closure could be stored',
+    ];
+
+    public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
+    {
+        return new MemoryAwareArrayAdapter($defaultLifetime);
+    }
+
+    public function testGetValuesHitAndMiss()
+    {
+        $this->markTestSkipped('MemoryAwareArrayAdapter does not support serialization, so closure could be stored');
+    }
+
+    #[DataProvider('memoryInputs')]
+    public function testMemoryParsing($input, int $output)
+    {
+        $reflector = new \ReflectionMethod(MemoryAwareArrayAdapter::class, 'parseMemoryLimit');
+        $memory = $reflector->invoke(null, $input);
+
+        self::assertSame($output, $memory);
+    }
+
+    public static function memoryInputs()
+    {
+        yield [10, 10];
+        yield [100, 100];
+        yield ['100', 100];
+        yield ['100x', 100];
+        yield ['1k', 1024];
+        yield ['1024M', 1_073_741_824];
+        yield ['1G', 1_073_741_824];
+    }
+
+    public function testMemoryEviction()
+    {
+        $memoryUsageCalculator = $this->memoryUsageCalculator();
+        $cache = new MemoryAwareArrayAdapter(
+            0,
+            0,
+            0,
+            250,
+            350,
+            null,
+            $memoryUsageCalculator,
+            new MockClock(),
+        );
+
+        $memoryUsageCalculator->advance(30);
+        $item = $cache->getItem('a');
+        $item->set(new \stdClass());
+        $cache->save($item);
+        $this->assertTrue($cache->hasItem('a'));
+
+        $memoryUsageCalculator->advance(30);
+        $item = $cache->getItem('b');
+        $item->set(new \stdClass());
+        $cache->save($item);
+
+        $this->assertTrue($cache->hasItem('a'));
+        $this->assertTrue($cache->hasItem('b'));
+
+        $memoryUsageCalculator->advance(30);
+        $item = $cache->getItem('c');
+        $item->set(new \stdClass());
+        $cache->save($item);
+        $this->assertTrue($cache->hasItem('a'));
+        $this->assertTrue($cache->hasItem('b'));
+        $this->assertTrue($cache->hasItem('c'));
+
+        $memoryUsageCalculator->advance(30);
+        $item = $cache->getItem('d');
+        $item->set(new \stdClass());
+        $cache->save($item);
+        $this->assertTrue($cache->hasItem('a'));
+        $this->assertTrue($cache->hasItem('b'));
+        $this->assertTrue($cache->hasItem('c'));
+        $this->assertTrue($cache->hasItem('d'));
+
+        $this->assertLessThanOrEqual(
+            120,
+            $memoryUsageCalculator->calculate(),
+        );
+
+        // simulate large object creation + 131 => 120 + 131 = 251 -> soft eviction started (251-30)
+        $memoryUsageCalculator->advance(131);
+        $memoryUsageCalculator->advanceOnConsecutiveCalculationCalls(0, 0, 0, -30);
+        $item = $cache->getItem('e');
+        $item->set(new \stdClass());
+        $cache->save($item);
+        $this->assertFalse($cache->hasItem('a'));
+        $this->assertTrue($cache->hasItem('b'));
+        $this->assertTrue($cache->hasItem('c'));
+        $this->assertTrue($cache->hasItem('d'));
+        $this->assertTrue($cache->hasItem('e'));
+
+        $this->assertLessThanOrEqual(
+            250,
+            $memoryUsageCalculator->calculate(),
+        );
+
+        // +30 => 251 => soft eviction started again -> -30
+        $memoryUsageCalculator->advance(30);
+        $memoryUsageCalculator->advanceOnConsecutiveCalculationCalls(0, 0, 0, -30);
+        $item = $cache->getItem('f');
+        $item->set(new \stdClass());
+        $cache->save($item);
+        $this->assertFalse($cache->hasItem('b'));
+        $this->assertTrue($cache->hasItem('c'));
+        $this->assertTrue($cache->hasItem('d'));
+        $this->assertTrue($cache->hasItem('e'));
+        $this->assertTrue($cache->hasItem('f'));
+
+        $this->assertLessThanOrEqual(
+            250,
+            $memoryUsageCalculator->calculate(),
+        );
+
+        // large object + 230 => 221 + 230 = 451 -> hard eviction started
+        $memoryUsageCalculator->advance(230);
+        $memoryUsageCalculator->advanceOnConsecutiveCalculationCalls(0, -30, -30, -131, -30);
+        $item = $cache->getItem('g');
+        $item->set(new \stdClass());
+        $cache->save($item);
+        $this->assertFalse($cache->hasItem('c'));
+        $this->assertFalse($cache->hasItem('d'));
+        $this->assertFalse($cache->hasItem('e'));
+        $this->assertFalse($cache->hasItem('f'));
+        $this->assertTrue($cache->hasItem('g'));
+
+        $this->assertLessThanOrEqual(
+            250,
+            $memoryUsageCalculator->calculate(),
+        );
+    }
+
+    private function memoryUsageCalculator(): MemoryUsageCalculator
+    {
+        return new class implements MemoryUsageCalculator {
+            private int $estimatedMemory = 0;
+
+            private array $consecutiveCalculations = [];
+
+            public function advance(int $size): void
+            {
+                $this->estimatedMemory += $size;
+            }
+
+            public function advanceOnConsecutiveCalculationCalls(int ...$sizes): void
+            {
+                array_push($this->consecutiveCalculations, ...$sizes);
+            }
+
+            public function calculate(): int
+            {
+                $advancedSize = array_shift($this->consecutiveCalculations);
+                if (null !== $advancedSize) {
+                    $this->estimatedMemory += $advancedSize;
+                }
+
+                return $this->estimatedMemory;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This PR adds a `MemoryAwareArrayAdapter` that extends the behavior of `ArrayAdapter` with memory-based eviction.

It keeps the cache size bounded in long-lived processes by evicting least recently used items when memory usage exceeds configured limits. Both soft and hard memory limits are supported, with incremental eviction to avoid spikes.

Memory limits accept either integers (bytes) or strings (e.g. "128M") and default to the PHP memory_limit when not explicitly configured.

The implementation reuses ArrayAdapter for storage and ordering, and relies on its access-order behavior to approximate LRU.

Tests cover eviction behavior, limits handling, and integration with existing cache operations.
