### PR TITLE
[Messenger][AmazonSqs] Do not override queue-level DelaySeconds when no DelayStamp is set

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
@@ -46,7 +46,7 @@ class AmazonSqsSenderTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')
-            ->with($encoded['body'], $encoded['headers'], 0, $stamp->getMessageGroupId(), $stamp->getMessageDeduplicationId());
+            ->with($encoded['body'], $encoded['headers'], null, $stamp->getMessageGroupId(), $stamp->getMessageDeduplicationId());
 
         $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
@@ -64,7 +64,7 @@ class AmazonSqsSenderTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('send')
-            ->with($encoded['body'], $encoded['headers'], 0, null, null, $stamp->getTraceId());
+            ->with($encoded['body'], $encoded['headers'], null, null, null, $stamp->getTraceId());
 
         $serializer = $this->createStub(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
@@ -39,7 +39,7 @@ class AmazonSqsSender implements SenderInterface
 
         /** @var DelayStamp|null $delayStamp */
         $delayStamp = $envelope->last(DelayStamp::class);
-        $delay = null !== $delayStamp ? (int) ceil($delayStamp->getDelay() / 1000) : 0;
+        $delay = null !== $delayStamp ? (int) ceil($delayStamp->getDelay() / 1000) : null;
 
         $messageGroupId = null;
         $messageDeduplicationId = null;

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -315,7 +315,7 @@ class Connection
         return (int) ($attributes[QueueAttributeName::APPROXIMATE_NUMBER_OF_MESSAGES] ?? 0);
     }
 
-    public function send(string $body, array $headers, int $delay = 0, ?string $messageGroupId = null, ?string $messageDeduplicationId = null, ?string $xrayTraceId = null): void
+    public function send(string $body, array $headers, ?int $delay = null, ?string $messageGroupId = null, ?string $messageDeduplicationId = null, ?string $xrayTraceId = null): void
     {
         if ($this->configuration['auto_setup']) {
             $this->setup();
@@ -324,11 +324,14 @@ class Connection
         $parameters = [
             'QueueUrl' => $this->getQueueUrl(),
             'MessageBody' => $body,
-            // Maximum delay is 15 minutes. See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html.
-            'DelaySeconds' => min(900, $delay),
             'MessageAttributes' => [],
             'MessageSystemAttributes' => [],
         ];
+
+        if (null !== $delay) {
+            // Maximum delay is 15 minutes. See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html.
+            $parameters['DelaySeconds'] = min(900, $delay);
+        }
 
         $specialHeaders = [];
         foreach ($headers as $name => $value) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

When sending a message without a `DelayStamp`, the SQS transport explicitly sets `DelaySeconds: 0` on the `SendMessage` API call. Per the [SQS API docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html), a per-message `DelaySeconds` **overrides** the queue-level default. By always sending `0`, the transport makes it impossible to rely on infrastructure-configured queue delay.

## Real-world impact

When dispatching messages from a Doctrine `postPersist` lifecycle callback, the message is sent to SQS before the database transaction commits. A queue-level `DelaySeconds` (configured via Terraform/CloudFormation) is a common way to give the transaction time to commit before the consumer processes the message. But the transport silently overrides it to `0`, causing the consumer to always fail on first attempt (entity not yet visible), then succeed on SQS retry after the visibility timeout.

## Fix

- `AmazonSqsSender`: pass `null` instead of `0` when no `DelayStamp` is present
- `Connection::send()`: only include `DelaySeconds` in the SQS API parameters when explicitly provided (`null` = use queue default)

This is fully backward-compatible:
- Messages with an explicit `DelayStamp(0)` still send `DelaySeconds: 0`
- Messages with `DelayStamp(N)` still send `DelaySeconds: N`
- Only the "no stamp" case changes: from overriding the queue default to respecting it