### PR TITLE
[Scheduler] Fix checkpoint state expiring when cache has default TTL

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/Checkpoint.php
+++ b/src/Symfony/Component/Scheduler/Generator/Checkpoint.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Component\Scheduler\Generator;
 
+use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 
 final class Checkpoint implements CheckpointInterface
 {
+    private const CACHE_EXPIRY = 5 * 365 * 86400; // 5 years
+
     private \DateTimeImmutable $from;
     private \DateTimeImmutable $time;
     private int $index = -1;
@@ -38,7 +41,11 @@ final class Checkpoint implements CheckpointInterface
         }
 
         if ($this->cache) {
-            [$this->time, $this->index, $this->from] = $this->cache->get($this->name, static fn () => [$now, -1, $now]) + [2 => $now];
+            [$this->time, $this->index, $this->from] = $this->cache->get($this->name, static function (CacheItemInterface $item) use ($now) {
+                $item->expiresAfter(self::CACHE_EXPIRY);
+
+                return [$now, -1, $now];
+            }) + [2 => $now];
             $this->save($this->time, $this->index);
         } elseif ($this->reset) {
             $this->reset = false;
@@ -71,7 +78,12 @@ final class Checkpoint implements CheckpointInterface
         $this->time = $time;
         $this->index = $index;
         $this->from ??= $time;
-        $this->cache?->get($this->name, fn () => [$time, $index, $this->from], \INF);
+        $from = $this->from;
+        $this->cache?->get($this->name, static function (CacheItemInterface $item) use ($time, $index, $from) {
+            $item->expiresAfter(self::CACHE_EXPIRY);
+
+            return [$time, $index, $from];
+        }, \INF);
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Tests/Generator/CheckpointTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/CheckpointTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Scheduler\Generator\Checkpoint;
+use Symfony\Contracts\Cache\ItemInterface;
 
 class CheckpointTest extends TestCase
 {
@@ -149,17 +150,14 @@ class CheckpointTest extends TestCase
         $checkpoint = new Checkpoint('cache', new NoLock(), $cache = new ArrayAdapter());
         $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
 
-        // init
         $cache->get('cache', static fn () => [$now->modify('-1 min'), 3], \INF);
 
-        // action
         $acquired = $checkpoint->acquire($now);
         $lastTime = $checkpoint->time();
         $lastIndex = $checkpoint->index();
         $checkpoint->save($now, 0);
         $checkpoint->release($now, null);
 
-        // asserting
         $this->assertTrue($acquired);
         $this->assertEquals($now->modify('-1 min'), $lastTime);
         $this->assertSame(3, $lastIndex);
@@ -259,22 +257,32 @@ class CheckpointTest extends TestCase
         $checkpoint = new Checkpoint('dummy', $lock);
         $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
 
-        // init
         $checkpoint->save($now->modify('-1 min'), 3);
 
-        // action
         $acquired = $checkpoint->acquire($now);
         $lastTime = $checkpoint->time();
         $lastIndex = $checkpoint->index();
         $checkpoint->save($now, 0);
         $checkpoint->release($now, null);
 
-        // asserting
         $this->assertTrue($acquired);
         $this->assertEquals($now->modify('-1 min'), $lastTime);
         $this->assertSame(3, $lastIndex);
         $this->assertEquals($now, $checkpoint->time());
         $this->assertSame(0, $checkpoint->index());
         $this->assertFalse($lock->isAcquired());
+    }
+
+    public function testCheckpointOverridesPoolDefaultLifetime()
+    {
+        $cache = new ArrayAdapter(1);
+        $checkpoint = new Checkpoint('cache', new NoLock(), $cache);
+        $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
+
+        $checkpoint->acquire($now);
+        $checkpoint->save($now, 5);
+
+        $expiry = $cache->getItem('cache')->getMetadata()[ItemInterface::METADATA_EXPIRY] ?? null;
+        $this->assertGreaterThan(time() + 365 * 86400, $expiry);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52911
| License       | MIT

When the cache pool used by the Scheduler has a default TTL configured, the checkpoint state would expire and reset, causing recurring messages to stop being dispatched entirely.

This fix explicitly sets a very long expiration (~100 years) on the cache items to override any default TTL the pool might have.