### PR TITLE
[VarDumper] Add CSP nonce support to HtmlDumper

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -75,6 +75,7 @@ class HtmlDumper extends CliDumper
         'fileLinkFormat' => null,
     ];
     private array $extraDisplayOptions = [];
+    private string|\Closure|null $nonce = null;
 
     public function __construct($output = null, ?string $charset = null, int $flags = 0)
     {
@@ -127,6 +128,45 @@ class HtmlDumper extends CliDumper
         $this->dumpSuffix = $suffix;
     }
 
+    /**
+     * Sets a nonce to be added to <script> and <style> tags for CSP compliance.
+     *
+     * Pass a string for a static nonce, or a {@see \Closure} returning a
+     * string (or null) to resolve the nonce lazily — useful for per-request
+     * nonces in long-running processes (the closure is invoked on every
+     * dump, so it can return a fresh value each time).
+     */
+    public function setNonce(string|\Closure|null $nonce): void
+    {
+        $this->headerIsDumped = false;
+        $this->nonce = $nonce;
+    }
+
+    private function applyNonce(string $html): string
+    {
+        if ($this->nonce instanceof \Closure) {
+            $nonce = ($this->nonce)();
+
+            if (null !== $nonce && !\is_string($nonce)) {
+                throw new \LogicException(\sprintf('The nonce closure passed to "%s::setNonce()" must return a string or null, "%s" returned.', self::class, get_debug_type($nonce)));
+            }
+        } else {
+            $nonce = $this->nonce;
+        }
+
+        if (null === $nonce) {
+            return $html;
+        }
+
+        $escaped = esc($nonce);
+
+        return str_replace(
+            ['<script>', '<style>'],
+            ['<script nonce="'.$escaped.'">', '<style nonce="'.$escaped.'">'],
+            $html,
+        );
+    }
+
     public function dump(Data $data, $output = null, array $extraDisplayOptions = []): ?string
     {
         $this->extraDisplayOptions = $extraDisplayOptions;
@@ -144,7 +184,7 @@ class HtmlDumper extends CliDumper
         $this->headerIsDumped = $this->outputStream ?? $this->lineDumper;
 
         if (null !== $this->dumpHeader) {
-            return $this->dumpHeader;
+            return $this->applyNonce($this->dumpHeader);
         }
 
         $line = str_replace('{$options}', json_encode($this->displayOptions, \JSON_FORCE_OBJECT), <<<'EOHTML'
@@ -764,7 +804,9 @@ class HtmlDumper extends CliDumper
         }
         $line .= 'pre.sf-dump .sf-dump-ellipsis-note{'.$this->styles['note'].'}';
 
-        return $this->dumpHeader = preg_replace('/\s+/', ' ', $line).'</style>'.$this->dumpHeader;
+        $this->dumpHeader = preg_replace('/\s+/', ' ', $line).'</style>'.$this->dumpHeader;
+
+        return $this->applyNonce($this->dumpHeader);
     }
 
     public function dumpString(Cursor $cursor, string $str, bool $bin, int $cut): void
@@ -948,7 +990,8 @@ class HtmlDumper extends CliDumper
                 $args[] = json_encode($this->extraDisplayOptions, \JSON_FORCE_OBJECT);
             }
             // Replace is for BC
-            $this->line .= \sprintf(str_replace('"%s"', '%s', $this->dumpSuffix), implode(', ', $args));
+            $suffix = $this->applyNonce($this->dumpSuffix);
+            $this->line .= \sprintf(str_replace('"%s"', '%s', $suffix), implode(', ', $args));
         }
         $this->lastDepth = $depth;
 

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -208,4 +208,92 @@ class HtmlDumperTest extends TestCase
             ['foo', '<span class=sf-dump-str title="3 characters">foo</span>'],
         ];
     }
+
+    public function testNonce()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $dumper->setNonce('test-nonce-123');
+        $cloner = new VarCloner();
+
+        ob_start();
+        $dumper->dump($cloner->cloneVar('foo'));
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('<script nonce="test-nonce-123">', $out);
+        $this->assertStringContainsString('<style nonce="test-nonce-123">', $out);
+        $this->assertStringNotContainsString('<script>', $out);
+        $this->assertStringNotContainsString('<style>', $out);
+    }
+
+    public function testNonceIsEscaped()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $dumper->setNonce('test"><script>alert(1)</script><x a="');
+        $cloner = new VarCloner();
+
+        ob_start();
+        $dumper->dump($cloner->cloneVar('foo'));
+        $out = ob_get_clean();
+
+        // The nonce should be HTML-escaped to prevent XSS
+        $this->assertStringContainsString('nonce="test&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;x a=&quot;"', $out);
+        // The unescaped dangerous string should not appear
+        $this->assertStringNotContainsString('nonce="test"><script>', $out);
+    }
+
+    public function testNonceCanBeAClosureResolvedPerDump()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $cloner = new VarCloner();
+        $current = 'first';
+        $dumper->setNonce(function () use (&$current): string { return $current; });
+
+        ob_start();
+        $dumper->dump($cloner->cloneVar('foo'));
+        $first = ob_get_clean();
+
+        $current = 'second';
+
+        ob_start();
+        $dumper->dump($cloner->cloneVar('bar'));
+        $second = ob_get_clean();
+
+        $this->assertStringContainsString('nonce="first"', $first);
+        $this->assertStringNotContainsString('nonce="second"', $first);
+
+        $this->assertStringContainsString('nonce="second"', $second);
+        $this->assertStringNotContainsString('nonce="first"', $second);
+    }
+
+    public function testNonceClosureMayReturnNullToSkipInjection()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $dumper->setNonce(static fn (): ?string => null);
+        $cloner = new VarCloner();
+
+        ob_start();
+        $dumper->dump($cloner->cloneVar('foo'));
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('<script>', $out);
+        $this->assertStringContainsString('<style>', $out);
+        $this->assertStringNotContainsString('nonce=', $out);
+    }
+
+    public function testNonceClosureMustReturnStringOrNull()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $dumper->setNonce(static fn (): int => 42);
+        $cloner = new VarCloner();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must return a string or null, "int" returned');
+
+        ob_start();
+        try {
+            $dumper->dump($cloner->cloneVar('foo'));
+        } finally {
+            ob_end_clean();
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49068
| License       | MIT

This PR adds a `setNonce(?string $nonce)` method to `HtmlDumper` that allows setting a Content-Security-Policy nonce. When set, the nonce is added to all `<script>` and `<style>` tags generated by the dumper.

This allows `dump()` output to work in environments with strict CSP policies that require nonces for inline scripts and styles.

### Usage

```php
$dumper = new HtmlDumper();
$dumper->setNonce($request->attributes->get('_csp_nonce'));
```

The nonce value is properly HTML-escaped to prevent XSS.