### PR TITLE
[VarExporter] Fix serialization of objects with __serialize/__unserialize

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -100,7 +100,7 @@ class Exporter
                     throw new \TypeError($class.'::__serialize() must return an array');
                 }
 
-                if (self::$classInfo[$class][0] ??= $reflector->hasMethod('__unserialize')) {
+                if ($hasUnserialize = self::$classInfo[$class][0] ??= $reflector->hasMethod('__unserialize')) {
                     $properties = $arrayValue;
                     goto prepare_value;
                 }
@@ -188,13 +188,11 @@ class Exporter
                     trigger_error(\sprintf('serialize(): "%s" returned as member variable from __sleep() but does not exist', $n), \E_USER_NOTICE);
                 }
             }
-            $hasUnserialize = self::$classInfo[$class][0] ??= $reflector->hasMethod('__unserialize');
-            if ($hasUnserialize) {
+            if ($hasUnserialize = self::$classInfo[$class][0] ??= $reflector->hasMethod('__unserialize')) {
                 $properties = $arrayValue;
             }
 
             prepare_value:
-            $hasUnserialize ??= self::$classInfo[$class][0] ??= $reflector->hasMethod('__unserialize');
             $objectsPool[$value] = [$id = \count($objectsPool)];
             $properties = self::prepare($properties, $objectsPool, $refsPool, $objectsCount, $valueIsStatic);
             ++$objectsCount;

--- a/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
@@ -465,6 +465,27 @@ class DeepCloneTest extends TestCase
         $this->assertFalse((new DeepCloner(new \stdClass()))->isStaticValue());
         $this->assertFalse((new DeepCloner(['key' => new \stdClass()]))->isStaticValue());
     }
+
+    /**
+     * Tests that objects with __serialize/__unserialize are correctly handled
+     * when they appear after objects without these methods in the same iteration.
+     *
+     * @see https://github.com/symfony/symfony/issues/63699
+     */
+    public function testMixedSerializationClassesInSameIteration()
+    {
+        $obj = new DeepCloneWithMixedSerializationClasses(
+            new DeepCloneSimpleRecord('test-value'),
+            new \DateTimeImmutable('2024-01-15 10:30:00', new \DateTimeZone('UTC'))
+        );
+
+        $clone = DeepCloner::deepClone($obj);
+
+        $this->assertNotSame($obj, $clone);
+        $this->assertSame('test-value', $clone->record->value);
+        $this->assertNotSame($obj->storedAt, $clone->storedAt);
+        $this->assertEquals($obj->storedAt, $clone->storedAt);
+    }
 }
 
 class DeepCloneDateTimeContainer
@@ -481,6 +502,23 @@ class DeepCloneReadonlyReference
     public function __construct(
         public readonly string $class,
         public readonly array $data,
+    ) {
+    }
+}
+
+class DeepCloneWithMixedSerializationClasses
+{
+    public function __construct(
+        public readonly DeepCloneSimpleRecord $record,
+        public readonly \DateTimeImmutable $storedAt,
+    ) {
+    }
+}
+
+class DeepCloneSimpleRecord
+{
+    public function __construct(
+        public readonly string $value,
     ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63699
| License       | MIT

## Summary

When processing multiple objects in the same loop iteration of `Exporter::prepare()`, the `$hasUnserialize` variable was not reset between iterations. This caused objects with `__serialize`/`__unserialize` (like `DateTimeImmutable`) to incorrectly use `__wakeup()` when they appeared after objects without these methods in the properties list.

## The Problem

When storing an object containing both:
1. A simple object without `__serialize`/`__unserialize` (e.g., a simple DTO)
2. A `DateTimeImmutable` (which has `__serialize`/`__unserialize`)

The `DateTimeImmutable` was incorrectly flagged to use `__wakeup()` instead of `__unserialize()`, causing:
- `foreach()` warnings on non-array values
- Fatal error: "Invalid serialization data for DateTimeImmutable object"

## The Fix

Added `unset($hasUnserialize)` at the start of each object's processing to ensure the variable is properly reset for each iteration.