### PR TITLE
[Dotenv] Fix preloading warning by replacing anonymous exception class

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Dotenv;
 
-use Symfony\Component\Dotenv\Exception\ExceptionInterface;
 use Symfony\Component\Dotenv\Exception\FormatException;
 use Symfony\Component\Dotenv\Exception\FormatExceptionContext;
 use Symfony\Component\Dotenv\Exception\PathException;
+use Symfony\Component\Dotenv\Exception\VariableCircularReferenceException;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
 use Symfony\Component\Process\Process;
 
@@ -763,7 +763,7 @@ final class Dotenv
             $this->populate($resolved, true);
         }
         if (5 === $pass && $resolved) {
-            throw new class('Too many levels of variable indirection in env vars: '.implode(', ', array_keys($resolved)).'.') extends \LogicException implements ExceptionInterface {};
+            throw new VariableCircularReferenceException('Too many levels of variable indirection in env vars: '.implode(', ', array_keys($resolved)).'.');
         }
 
         // Restore literal $ signs and unescape backslashes

--- a/src/Symfony/Component/Dotenv/Exception/VariableCircularReferenceException.php
+++ b/src/Symfony/Component/Dotenv/Exception/VariableCircularReferenceException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Dotenv\Exception;
+
+/**
+ * Thrown when there are too many levels of variable indirection in env vars.
+ *
+ * @author Pascal CESCON <pascal.cescon@gmail.com>
+ */
+final class VariableCircularReferenceException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Dotenv\Exception\FormatException;
 use Symfony\Component\Dotenv\Exception\PathException;
+use Symfony\Component\Dotenv\Exception\VariableCircularReferenceException;
 
 class DotenvTest extends TestCase
 {
@@ -646,7 +647,7 @@ class DotenvTest extends TestCase
 
         $resetContext();
         try {
-            $this->expectException(\LogicException::class);
+            $this->expectException(VariableCircularReferenceException::class);
             $this->expectExceptionMessage('Too many levels of variable indirection');
             (new Dotenv())->load($path1, $path2);
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63764
| License       | MIT

## Summary

When opcache preloading is enabled, PHP emits a warning:
```
PHP Warning: Can't preload unlinked class LogicException@anonymous: Unknown interface Symfony\Component\Dotenv\Exception\ExceptionInterface
```

This happens because the anonymous exception class at line 765 implements `ExceptionInterface`, but PHP can't resolve this interface during preloading.

## Solution

Replace the anonymous exception class with a named `VariableCircularReferenceException` class, following the same pattern as other exceptions in the component (`PathException`, `FormatException`).