### PR TITLE
[Contracts] Fix SubscribedService $type phpdoc to allow non-class strings

### DIFF
--- a/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
+++ b/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
@@ -31,10 +31,10 @@ final class SubscribedService
     public array $attributes;
 
     /**
-     * @param string|null       $key        The key to use for the service
-     * @param class-string|null $type       The service class
-     * @param bool              $nullable   Whether the service is optional
-     * @param object|object[]   $attributes One or more dependency injection attributes to use
+     * @param string|null     $key        The key to use for the service
+     * @param string|null     $type       The service type (a class name, "string", "iterable", etc.)
+     * @param bool            $nullable   Whether the service is optional
+     * @param object|object[] $attributes One or more dependency injection attributes to use
      */
     public function __construct(
         public ?string $key = null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63493
| License       | MIT