### PR TITLE
[HttpClient] Add custom DNS resolution using a decorator

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add option `extra.use_persistent_connections` to `CurlHttpClient` to control the use of persistent connections introduced in PHP 8.5
  * Add `GuzzleHttpHandler` that allows using Symfony HttpClient as a Guzzle handler
  * Add `$allowList` argument to `NoPrivateNetworkHttpClient` to allow specific hosts (e.g. a local proxy) to bypass the private-network filter
+ * Add `DnsResolvingHttpClient` decorator to resolve host names using a custom resolver, including on redirects
  * Change `$maxTtl` argument of `CachingHttpClient` to default to `86400` (24h) instead of `null`
  * Deprecate passing `null` as `$maxTtl` to `CachingHttpClient`, pass a positive integer instead
  * Make `CachingHttpClient` implement `Psr\Log\LoggerAwareInterface` to log when a stale cached response is served because the upstream call failed (`stale-if-error` fallback)

--- a/src/Symfony/Component/HttpClient/DnsResolvingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/DnsResolvingHttpClient.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Symfony\Component\HttpClient\Internal\FollowRedirectsTrait;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Decorator that resolves host names using a custom resolver before delegating to the transport.
+ *
+ * The resolver is called for the requested host and for the host of every followed redirect. When it
+ * returns an IP address, the result is injected into the "resolve" option so that the transport connects
+ * to that IP without performing its own DNS resolution. When it returns null, the transport's default
+ * DNS resolution is used. Hosts that are already in the "resolve" option or that are IP addresses are
+ * not passed to it.
+ *
+ * Note that using this decorator opts out of the asynchronous and cached DNS resolution that the curl
+ * and amphp transports provide; the resolver is responsible for any caching it needs.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class DnsResolvingHttpClient implements HttpClientInterface, ResetInterface
+{
+    use AsyncDecoratorTrait;
+    use FollowRedirectsTrait;
+    use HttpClientTrait;
+
+    private array $defaultOptions = self::OPTIONS_DEFAULTS;
+
+    /** @var callable(string): ?string */
+    private $resolver;
+
+    /**
+     * @param callable(string $host): ?string $resolver Returns the IP address the given host name should resolve to,
+     *                                                  or null to let the transport perform its default DNS resolution
+     */
+    public function __construct(
+        private HttpClientInterface $client,
+        callable $resolver,
+    ) {
+        $this->resolver = $resolver;
+    }
+
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        [$url, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions, true);
+
+        $host = parse_url($url['authority'], \PHP_URL_HOST);
+        $url = implode('', $url);
+
+        $resolver = $this->resolver;
+        $resolve = static function (string $host, string $url, array &$options) use ($resolver): void {
+            if (isset($options['resolve'][$host]) || false !== filter_var(trim($host, '[]'), \FILTER_VALIDATE_IP)) {
+                return;
+            }
+
+            if (null !== $ip = $resolver($host)) {
+                $options['resolve'][$host] = $ip;
+            }
+        };
+
+        $resolve($host, $url, $options);
+
+        return $this->followRedirects($method, $url, $host, $options, $resolve);
+    }
+
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $this->client->withOptions($options);
+        $clone->defaultOptions = self::mergeDefaultOptions($options, $this->defaultOptions);
+
+        return $clone;
+    }
+
+    public function reset(): void
+    {
+        if ($this->resolver instanceof ResetInterface) {
+            $this->resolver->reset();
+        }
+
+        if ($this->client instanceof ResetInterface) {
+            $this->client->reset();
+        }
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/FollowRedirectsTrait.php
+++ b/src/Symfony/Component/HttpClient/Internal/FollowRedirectsTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Symfony\Component\HttpClient\Response\AsyncContext;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+
+/**
+ * Follows redirections in userland so that decorators can inspect each hop.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+trait FollowRedirectsTrait
+{
+    /**
+     * @param string                                                     $url        An already prepared, absolute URL
+     * @param string                                                     $host       The host name found in $url
+     * @param \Closure(string $host, string $url, array &$options): void $onRedirect Called before each followed redirect
+     */
+    private function followRedirects(string $method, string $url, string $host, array $options, \Closure $onRedirect): AsyncResponse
+    {
+        if (0 >= $maxRedirects = $options['max_redirects']) {
+            return new AsyncResponse($this->client, $method, $url, $options);
+        }
+
+        $options['max_redirects'] = 0;
+        $redirectHeaders = [
+            'host' => $host,
+            'port' => parse_url($url, \PHP_URL_PORT),
+            'with_auth' => $options['headers'],
+            'no_auth' => $options['headers'],
+        ];
+
+        if (isset($options['normalized_headers']['host']) || isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {
+            $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
+        }
+
+        return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use (&$method, &$options, $maxRedirects, &$redirectHeaders, $onRedirect): \Generator {
+            if (null !== $chunk->getError() || $chunk->isTimeout() || !$chunk->isFirst()) {
+                yield $chunk;
+
+                return;
+            }
+
+            $statusCode = $context->getStatusCode();
+
+            if ($statusCode < 300 || 400 <= $statusCode || null === $url = $context->getInfo('redirect_url')) {
+                $context->passthru();
+
+                yield $chunk;
+
+                return;
+            }
+
+            $host = parse_url($url, \PHP_URL_HOST);
+            $onRedirect($host, $url, $options);
+
+            // Do like curl and browsers: turn POST to GET on 301, 302 and 303
+            if (303 === $statusCode || 'POST' === $method && \in_array($statusCode, [301, 302], true)) {
+                $method = 'HEAD' === $method ? 'HEAD' : 'GET';
+                unset($options['body'], $options['json']);
+
+                if (isset($options['normalized_headers']['content-length']) || isset($options['normalized_headers']['content-type']) || isset($options['normalized_headers']['transfer-encoding'])) {
+                    $filterContentHeaders = static fn ($h) => 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:') && 0 !== stripos($h, 'Transfer-Encoding:');
+                    $options['headers'] = array_filter($options['headers'], $filterContentHeaders);
+                    $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], $filterContentHeaders);
+                    $redirectHeaders['with_auth'] = array_filter($redirectHeaders['with_auth'], $filterContentHeaders);
+                }
+            }
+
+            // Authorization and Cookie headers MUST NOT follow except for the initial host name
+            $port = parse_url($url, \PHP_URL_PORT);
+            $options['headers'] = $redirectHeaders['host'] === $host && ($redirectHeaders['port'] ?? null) === $port ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
+
+            static $redirectCount = 0;
+            $context->setInfo('redirect_count', ++$redirectCount);
+
+            $context->replaceRequest($method, $url, $options);
+
+            if ($redirectCount >= $maxRedirects) {
+                $context->passthru();
+            }
+        });
+    }
+}

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -12,10 +12,8 @@
 namespace Symfony\Component\HttpClient;
 
 use Symfony\Component\HttpClient\Exception\TransportException;
-use Symfony\Component\HttpClient\Response\AsyncContext;
-use Symfony\Component\HttpClient\Response\AsyncResponse;
+use Symfony\Component\HttpClient\Internal\FollowRedirectsTrait;
 use Symfony\Component\HttpFoundation\IpUtils;
-use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -29,6 +27,7 @@ use Symfony\Contracts\Service\ResetInterface;
 final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInterface
 {
     use AsyncDecoratorTrait;
+    use FollowRedirectsTrait;
     use HttpClientTrait;
 
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
@@ -80,19 +79,22 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
     {
         [$url, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions, true);
 
-        $redirectHeaders = parse_url($url['authority']);
-        $host = $redirectHeaders['host'];
+        $host = parse_url($url['authority'], \PHP_URL_HOST);
         $url = implode('', $url);
+
         $dnsCache = $this->dnsCache;
-
-        $ip = self::dnsResolve($dnsCache, $host, $this->ipFlags, $options);
-        self::ipCheck($ip, $this->subnets, $this->allowList, $this->ipFlags, $host, $url);
-
-        $onProgress = $options['on_progress'] ?? null;
         $subnets = $this->subnets;
         $allowList = $this->allowList;
         $ipFlags = $this->ipFlags;
 
+        $checkHost = static function (string $host, string $url, array &$options) use ($dnsCache, $subnets, $allowList, $ipFlags): void {
+            $ip = self::dnsResolve($dnsCache, $host, $ipFlags, $options);
+            self::ipCheck($ip, $subnets, $allowList, $ipFlags, $host, $url);
+        };
+
+        $checkHost($host, $url, $options);
+
+        $onProgress = $options['on_progress'] ?? null;
         $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, $allowList, $ipFlags): void {
             static $lastPrimaryIp = '';
 
@@ -104,64 +106,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
             null !== $onProgress && $onProgress($dlNow, $dlSize, $info);
         };
 
-        if (0 >= $maxRedirects = $options['max_redirects']) {
-            return new AsyncResponse($this->client, $method, $url, $options);
-        }
-
-        $options['max_redirects'] = 0;
-        $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = $options['headers'];
-
-        if (isset($options['normalized_headers']['host']) || isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {
-            $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
-        }
-
-        return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use (&$method, &$options, $maxRedirects, &$redirectHeaders, $subnets, $allowList, $ipFlags, $dnsCache): \Generator {
-            if (null !== $chunk->getError() || $chunk->isTimeout() || !$chunk->isFirst()) {
-                yield $chunk;
-
-                return;
-            }
-
-            $statusCode = $context->getStatusCode();
-
-            if ($statusCode < 300 || 400 <= $statusCode || null === $url = $context->getInfo('redirect_url')) {
-                $context->passthru();
-
-                yield $chunk;
-
-                return;
-            }
-
-            $host = parse_url($url, \PHP_URL_HOST);
-            $ip = self::dnsResolve($dnsCache, $host, $ipFlags, $options);
-            self::ipCheck($ip, $subnets, $allowList, $ipFlags, $host, $url);
-
-            // Do like curl and browsers: turn POST to GET on 301, 302 and 303
-            if (303 === $statusCode || 'POST' === $method && \in_array($statusCode, [301, 302], true)) {
-                $method = 'HEAD' === $method ? 'HEAD' : 'GET';
-                unset($options['body'], $options['json']);
-
-                if (isset($options['normalized_headers']['content-length']) || isset($options['normalized_headers']['content-type']) || isset($options['normalized_headers']['transfer-encoding'])) {
-                    $filterContentHeaders = static fn ($h) => 0 !== stripos($h, 'Content-Length:') && 0 !== stripos($h, 'Content-Type:') && 0 !== stripos($h, 'Transfer-Encoding:');
-                    $options['headers'] = array_filter($options['headers'], $filterContentHeaders);
-                    $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], $filterContentHeaders);
-                    $redirectHeaders['with_auth'] = array_filter($redirectHeaders['with_auth'], $filterContentHeaders);
-                }
-            }
-
-            // Authorization and Cookie headers MUST NOT follow except for the initial host name
-            $port = parse_url($url, \PHP_URL_PORT);
-            $options['headers'] = $redirectHeaders['host'] === $host && ($redirectHeaders['port'] ?? null) === $port ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
-
-            static $redirectCount = 0;
-            $context->setInfo('redirect_count', ++$redirectCount);
-
-            $context->replaceRequest($method, $url, $options);
-
-            if ($redirectCount >= $maxRedirects) {
-                $context->passthru();
-            }
-        });
+        return $this->followRedirects($method, $url, $host, $options, $checkHost);
     }
 
     public function withOptions(array $options): static

--- a/src/Symfony/Component/HttpClient/Tests/DnsResolvingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DnsResolvingHttpClientTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\DnsResolvingHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\Service\ResetInterface;
+
+class DnsResolvingHttpClientTest extends TestCase
+{
+    public function testResolverIsCalledOnRequest()
+    {
+        $resolvedHosts = [];
+        $mockClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('1.2.3.4', $options['resolve']['example.com'] ?? null);
+
+            return new MockResponse('OK');
+        });
+
+        $client = new DnsResolvingHttpClient($mockClient, static function (string $host) use (&$resolvedHosts): ?string {
+            $resolvedHosts[] = $host;
+
+            return '1.2.3.4';
+        });
+        $response = $client->request('GET', 'http://example.com/');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', $response->getContent());
+        $this->assertSame(['example.com'], $resolvedHosts);
+    }
+
+    public function testResolverReturningNullFallsBackToTransport()
+    {
+        $mockClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertArrayNotHasKey('example.com', $options['resolve']);
+
+            return new MockResponse('OK');
+        });
+
+        $client = new DnsResolvingHttpClient($mockClient, static fn (string $host): ?string => null);
+
+        $this->assertSame(200, $client->request('GET', 'http://example.com/')->getStatusCode());
+    }
+
+    public function testResolverIsCalledOnRedirect()
+    {
+        $resolvedHosts = [];
+        $responses = [
+            new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://other.example.com/target']),
+            function (string $method, string $url, array $options) {
+                $this->assertSame('http://other.example.com/target', $url);
+                $this->assertSame('10.0.0.2', $options['resolve']['other.example.com'] ?? null);
+
+                return new MockResponse('Redirected');
+            },
+        ];
+
+        $client = new DnsResolvingHttpClient(new MockHttpClient($responses), static function (string $host) use (&$resolvedHosts): ?string {
+            $resolvedHosts[] = $host;
+
+            return '10.0.0.'.\count($resolvedHosts);
+        });
+        $response = $client->request('GET', 'http://example.com/');
+
+        $this->assertSame('Redirected', $response->getContent());
+        $this->assertSame(['example.com', 'other.example.com'], $resolvedHosts);
+    }
+
+    public function testPostBecomesGetOnRedirect()
+    {
+        $responses = [
+            new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://example.com/target']),
+            function (string $method, string $url, array $options) {
+                $this->assertSame('GET', $method);
+
+                return new MockResponse('Redirected');
+            },
+        ];
+
+        $client = new DnsResolvingHttpClient(new MockHttpClient($responses), static fn (string $host): ?string => '1.2.3.4');
+
+        $this->assertSame('Redirected', $client->request('POST', 'http://example.com/', ['body' => 'foo'])->getContent());
+    }
+
+    #[TestWith(['http://93.184.216.34/'])]
+    #[TestWith(['http://[2606:2800:220:1:248:1893:25c8:1946]/'])]
+    public function testIpHostsAreNotResolved(string $url)
+    {
+        $resolverCalled = false;
+        $client = new DnsResolvingHttpClient(new MockHttpClient(new MockResponse('OK')), static function () use (&$resolverCalled): ?string {
+            $resolverCalled = true;
+
+            return null;
+        });
+
+        $this->assertSame(200, $client->request('GET', $url)->getStatusCode());
+        $this->assertFalse($resolverCalled);
+    }
+
+    public function testExplicitResolveOptionIsNotOverridden()
+    {
+        $resolverCalled = false;
+        $mockClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('5.5.5.5', $options['resolve']['example.com'] ?? null);
+
+            return new MockResponse('OK');
+        });
+
+        $client = new DnsResolvingHttpClient($mockClient, static function () use (&$resolverCalled): ?string {
+            $resolverCalled = true;
+
+            return '9.9.9.9';
+        });
+        $client->request('GET', 'http://example.com/', ['resolve' => ['example.com' => '5.5.5.5']]);
+
+        $this->assertFalse($resolverCalled);
+    }
+
+    public function testWithOptions()
+    {
+        $mockClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('1.2.3.4', $options['resolve']['example.com'] ?? null);
+            $this->assertContains('x-foo: bar', $options['headers']);
+
+            return new MockResponse('OK');
+        });
+
+        $client = (new DnsResolvingHttpClient($mockClient, static fn (string $host): ?string => '1.2.3.4'))
+            ->withOptions(['headers' => ['x-foo' => 'bar']]);
+
+        $this->assertSame(200, $client->request('GET', 'http://example.com/')->getStatusCode());
+    }
+
+    public function testResetIsForwardedToResolver()
+    {
+        $resolver = new class implements ResetInterface {
+            public int $resetCount = 0;
+
+            public function __invoke(string $host): ?string
+            {
+                return null;
+            }
+
+            public function reset(): void
+            {
+                ++$this->resetCount;
+            }
+        };
+
+        $client = new DnsResolvingHttpClient(new MockHttpClient(), $resolver);
+        $client->reset();
+
+        $this->assertSame(1, $resolver->resetCount);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63619 
| License       | MIT

Following the advice on https://github.com/symfony/symfony/pull/63701 I propose this implementation for a decorator of a `HttpClient` that will call a custom DNS resolver before performing the request and for each redirection.

I took some logic from `NoPrivateNetworkHttpClient` ; there might a way be to reduce the complexity and/or factorize some code, I'm not sure I'm qualified enough to evaluate this...

I am ready to rework this PR if needed.

Best regards
