### PR TITLE
[Security] Add `enforce_key_usage_verification` option to OIDC discovery

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -59,6 +59,8 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                 new Reference($config['discovery']['cache']['id']),
                 $clients,
                 "$id.oidc_configuration",
+                null,
+                $config['discovery']['enforce_key_usage_verification'],
             ]);
 
             return;
@@ -142,6 +144,10 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                                         ->cannotBeEmpty()
                                     ->end()
                                 ->end()
+                            ->end()
+                            ->booleanNode('enforce_key_usage_verification')
+                                ->info('When enabled, only keys explicitly designated for signature (via "use" or "key_ops") are accepted. When disabled, keys without any usage designation are included.')
+                                ->defaultTrue()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -303,6 +303,8 @@ class AccessTokenFactoryTest extends TestCase
                         ->replaceArgument(0, ['base_uri' => 'https://www.example.com/realms/demo/']),
                     ],
                     'security.access_token_handler.firewall1.oidc_configuration',
+                    null,
+                    true,
                 ],
             ],
         ];
@@ -360,6 +362,8 @@ class AccessTokenFactoryTest extends TestCase
                             ->replaceArgument(0, ['base_uri' => 'https://www.api.com/realms/api/']),
                     ],
                     'security.access_token_handler.firewall1.oidc_configuration',
+                    null,
+                    true,
                 ],
             ],
         ];

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -46,6 +46,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
     private ?AlgorithmManager $decryptionAlgorithms = null;
     private bool $enforceEncryption = false;
 
+    private bool $enforceKeyUsageVerification = true;
     private ?CacheInterface $discoveryCache = null;
     private ?string $oidcConfigurationCacheKey = null;
 
@@ -75,11 +76,12 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
     /**
      * @param HttpClientInterface|HttpClientInterface[] $client
      */
-    public function enableDiscovery(CacheInterface $cache, array|HttpClientInterface $client, string $oidcConfigurationCacheKey): void
+    public function enableDiscovery(CacheInterface $cache, array|HttpClientInterface $client, string $oidcConfigurationCacheKey, bool $enforceKeyUsageVerification = true): void
     {
         $this->discoveryCache = $cache;
         $this->discoveryClients = \is_array($client) ? $client : [$client];
         $this->oidcConfigurationCacheKey = $oidcConfigurationCacheKey;
+        $this->enforceKeyUsageVerification = $enforceKeyUsageVerification;
     }
 
     public function getUserBadgeFrom(string $accessToken): UserBadge
@@ -117,6 +119,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         } catch (\Exception $e) {
             $this->logger?->error('An error occurred while decoding and validating the token.', [
                 'error' => $e->getMessage(),
+                'exception' => $e::class,
                 'trace' => $e->getTraceAsString(),
             ]);
 
@@ -140,7 +143,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         }
         $logger = $this->logger;
         try {
-            $keys = [];
+            $discoveredKeys = [];
             $minTtl = null;
             $configResponses = [];
             $jwkSetResponses = [];
@@ -173,10 +176,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
                     $minTtl = $currentTtl;
                 }
 
-                foreach ($response->toArray()['keys'] as $key) {
-                    if ('sig' === ($key['use'] ?? null)) {
-                        $keys[] = $key;
-                    }
+                $keys = $response->toArray()['keys'];
+                foreach ($this->filterSignatureKeys($keys) as $key) {
+                    $discoveredKeys[] = $key;
                 }
             }
 
@@ -185,7 +187,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
                 $item->expiresAfter(min($minTtl, 30 * 24 * 60 * 60));
             }
 
-            return $keys;
+            return $discoveredKeys;
         } catch (\Exception $e) {
             $logger?->error('An error occurred while requesting OIDC certs.', [
                 'error' => $e->getMessage(),
@@ -194,6 +196,37 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
 
             throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
         }
+    }
+
+    private function filterSignatureKeys(array $keys): array
+    {
+        return array_values(array_filter($keys, function (array $jwk): bool {
+            if ($this->enforceKeyUsageVerification) {
+                if (isset($jwk['use']) && 'sig' === $jwk['use']) {
+                    return true;
+                }
+                if (isset($jwk['key_ops']) && \is_array($jwk['key_ops'])) {
+                    return !empty(array_intersect($jwk['key_ops'], ['sign', 'verify']));
+                }
+
+                return false;
+            }
+
+            if (isset($jwk['use']) && 'enc' === $jwk['use']) {
+                return false;
+            }
+            if (isset($jwk['key_ops']) && \is_array($jwk['key_ops'])) {
+                $encOps = ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey', 'deriveKey', 'deriveBits'];
+                $sigOps = ['sign', 'verify'];
+                $hasEnc = !empty(array_intersect($jwk['key_ops'], $encOps));
+                $hasSig = !empty(array_intersect($jwk['key_ops'], $sigOps));
+                if ($hasEnc && !$hasSig) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
     }
 
     private function loadAndVerifyJws(string $accessToken, JWKSet $jwkset): array

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -444,7 +444,98 @@ class OidcTokenHandlerTest extends TestCase
         $handler->getUserBadgeFrom($token);
     }
 
-    public function testDiscoveryIgnoresNonSignatureKeys()
+    public function testDiscoveryExcludesEncryptionKeys()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'https://www.example.com/jwks.json']),
+            new JsonMockResponse([
+                'keys' => [
+                    array_merge(self::getJWK()->all(), ['use' => 'enc']),
+                    array_merge(self::getSecondJWK()->all(), ['use' => 'sig']),
+                ],
+            ]),
+        ]);
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_non_sig_keys', enforceKeyUsageVerification: false);
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->never())->method('expiresAfter');
+        $keys = $handler->computeDiscoveryKeys($item);
+        $this->assertCount(1, $keys);
+        $this->assertSame('sig', $keys[0]['use']);
+    }
+
+    public function testDiscoveryExcludesEncryptionKeyOps()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'https://www.example.com/jwks.json']),
+            new JsonMockResponse([
+                'keys' => [
+                    array_merge(self::getJWK()->all(), ['key_ops' => ['encrypt', 'decrypt']]),
+                    array_merge(self::getSecondJWK()->all(), ['key_ops' => ['sign', 'verify']]),
+                ],
+            ]),
+        ]);
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_enc_key_ops', enforceKeyUsageVerification: false);
+
+        $item = $this->createStub(ItemInterface::class);
+        $keys = $handler->computeDiscoveryKeys($item);
+        $this->assertCount(1, $keys);
+        $this->assertSame(['sign', 'verify'], $keys[0]['key_ops']);
+    }
+
+    public function testDiscoveryIncludesKeysWithoutUsageDesignation()
+    {
+        $time = time();
+        $claims = [
+            'iat' => $time,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'user-no-use-field',
+        ];
+        $token = self::buildJWS(json_encode($claims));
+
+        $jwkData = self::getJWK()->all();
+        unset($jwkData['d']);
+
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'https://www.example.com/jwks.json']),
+            new JsonMockResponse(['keys' => [$jwkData]]),
+        ]);
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_no_use', enforceKeyUsageVerification: false);
+
+        $userBadge = $handler->getUserBadgeFrom($token);
+
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
+        $this->assertSame('user-no-use-field', $userBadge->getUserIdentifier());
+    }
+
+    public function testDiscoveryEnforcedUsageOnlyAcceptsExplicitSignatureKeys()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse(['jwks_uri' => 'https://www.example.com/jwks.json']),
@@ -463,10 +554,36 @@ class OidcTokenHandlerTest extends TestCase
             self::AUDIENCE,
             ['https://www.example.com']
         );
-        $handler->enableDiscovery($cache, $httpClient, 'oidc_non_sig_keys');
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced', enforceKeyUsageVerification: true);
 
         $item = $this->createMock(ItemInterface::class);
         $item->expects($this->never())->method('expiresAfter');
         $this->assertSame([], $handler->computeDiscoveryKeys($item));
+    }
+
+    public function testDiscoveryEnforcedUsageAcceptsKeyOpsSign()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'https://www.example.com/jwks.json']),
+            new JsonMockResponse([
+                'keys' => [
+                    array_merge(self::getJWK()->all(), ['key_ops' => ['sign']]),
+                    array_merge(self::getSecondJWK()->all(), ['key_ops' => ['encrypt']]),
+                ],
+            ]),
+        ]);
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced_ops', enforceKeyUsageVerification: true);
+        $item = $this->createStub(ItemInterface::class);
+        $keys = $handler->computeDiscoveryKeys($item);
+        $this->assertCount(1, $keys);
+        $this->assertSame(['sign'], $keys[0]['key_ops']);
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| Issues        | 
| License       | MIT

Add a filterSignatureKeys method that properly handles JWK key filtering based on both "use" and "key_ops" fields per RFC 7517.

When enforce_key_usage_verification is enabled (default), only keys explicitly designated for signature (use=sig or key_ops containing sign/verify) are accepted. When disabled, keys are included unless they are explicitly marked for encryption only.
