### PR TITLE
[DoctrineBridge] Map the `DatePoint` property types for Doctrine schema tools

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
 
  * Add option `uid_format` to `EntityType`
  * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`; namespace aliases are no longer supported in Doctrine
+ * Map the `DatePoint`, `DayPoint` and `TimePoint` property types to their Doctrine types, so schema tools detect them without an explicit `type`
 
 8.0
 ---

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
@@ -11,12 +11,17 @@
 
 namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
 
+use Doctrine\ORM\Mapping\ChainTypedFieldMapper;
+use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
 use Symfony\Bridge\Doctrine\Types\DatePointType;
 use Symfony\Bridge\Doctrine\Types\DayPointType;
 use Symfony\Bridge\Doctrine\Types\TimePointType;
 use Symfony\Component\Clock\DatePoint;
+use Symfony\Component\Clock\DayPoint;
+use Symfony\Component\Clock\TimePoint;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 final class RegisterDatePointTypePass implements CompilerPassInterface
 {
@@ -37,5 +42,32 @@ final class RegisterDatePointTypePass implements CompilerPassInterface
         $types['time_point'] ??= ['class' => TimePointType::class];
 
         $container->setParameter('doctrine.dbal.connection_factory.types', $types);
+
+        if (!class_exists(DefaultTypedFieldMapper::class)) {
+            return;
+        }
+
+        $mapperDefinition = new Definition(DefaultTypedFieldMapper::class, [[DatePoint::class => 'date_point', DayPoint::class => 'day_point', TimePoint::class => 'time_point']]);
+
+        foreach ($container->getDefinitions() as $id => $configuration) {
+            if (!preg_match('/^doctrine\.orm\.\w+_configuration$/D', $id)) {
+                continue;
+            }
+
+            $mapper = $mapperDefinition;
+            $calls = [];
+            foreach ($configuration->getMethodCalls() as $call) {
+                if ('setTypedFieldMapper' !== $call[0]) {
+                    $calls[] = $call;
+                    continue;
+                }
+
+                // a mapper configured by the application keeps the first say
+                $mapper = new Definition(ChainTypedFieldMapper::class, [[$call[1][0], $mapperDefinition]]);
+            }
+
+            $calls[] = ['setTypedFieldMapper', [$mapper]];
+            $configuration->setMethodCalls($calls);
+        }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/DatePointMappingTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/DatePointMappingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\DsnParser;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
+use Doctrine\ORM\ORMSetup;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterDatePointTypePass;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\DatePointEntity;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+#[RequiresPhpExtension('pdo_sqlite')]
+class DatePointMappingTest extends TestCase
+{
+    private ?Connection $driverConnection = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->driverConnection?->isConnected()) {
+            $this->driverConnection->close();
+        }
+    }
+
+    public function testDatePointTypeMapper()
+    {
+        if (method_exists(ORMSetup::class, 'createAttributeMetadataConfig')) {
+            $config = ORMSetup::createAttributeMetadataConfig(paths: [__DIR__], isDevMode: true);
+        } else {
+            $config = ORMSetup::createAttributeMetadataConfiguration(paths: [__DIR__], isDevMode: true);
+        }
+        $config->enableNativeLazyObjects(true);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $definition = new Definition();
+        $container->setDefinition('doctrine.orm.default_configuration', $definition);
+
+        (new RegisterDatePointTypePass())->process($container);
+
+        $calls = $container
+            ->getDefinition('doctrine.orm.default_configuration')
+            ->getMethodCalls();
+
+        foreach ($calls as [$method, $args]) {
+            if ('setTypedFieldMapper' === $method) {
+                $mapperDef = $args[0];
+
+                $mapper = new DefaultTypedFieldMapper($mapperDef->getArguments()[0]);
+
+                $config->setTypedFieldMapper($mapper);
+            }
+        }
+
+        $dsn = 'pdo-sqlite://:memory:';
+        $params = (new DsnParser())->parse($dsn);
+        $this->driverConnection = DriverManager::getConnection($params, $config);
+
+        $em = new EntityManager($this->driverConnection, $config);
+
+        $metadata = $em->getClassMetadata(DatePointEntity::class);
+
+        $this->assertTrue($metadata->hasField('activityDate'));
+
+        $fieldMapping = $metadata->activityDate ?? $metadata->getFieldMapping('activityDate');
+
+        $this->assertSame('date_point', $fieldMapping->type ?? $fieldMapping['type']);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
@@ -11,12 +11,19 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
 
+use Doctrine\ORM\Mapping\ChainTypedFieldMapper;
+use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterDatePointTypePass;
 use Symfony\Bridge\Doctrine\Types\DatePointType;
 use Symfony\Bridge\Doctrine\Types\DayPointType;
 use Symfony\Bridge\Doctrine\Types\TimePointType;
+use Symfony\Component\Clock\DatePoint;
+use Symfony\Component\Clock\DayPoint;
+use Symfony\Component\Clock\TimePoint;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 class RegisterDatePointTypePassTest extends TestCase
 {
@@ -33,5 +40,60 @@ class RegisterDatePointTypePassTest extends TestCase
             'time_point' => ['class' => TimePointType::class],
         ];
         $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testTypedFieldMapperIsRegistered()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $definition = new Definition();
+        $container->setDefinition('doctrine.orm.default_configuration', $definition);
+
+        (new RegisterDatePointTypePass())->process($container);
+
+        $calls = array_filter($definition->getMethodCalls(), static fn (array $call) => 'setTypedFieldMapper' === $call[0]);
+        $this->assertCount(1, $calls);
+        $mapperDef = array_values($calls)[0][1][0];
+        $this->assertSame(DefaultTypedFieldMapper::class, $mapperDef->getClass());
+        $this->assertSame([[DatePoint::class => 'date_point', DayPoint::class => 'day_point', TimePoint::class => 'time_point']], $mapperDef->getArguments());
+    }
+
+    public function testAMapperConfiguredByTheApplicationIsChainedFirst()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $definition = new Definition();
+        $userMapper = new Reference('app.typed_field_mapper');
+        $definition->addMethodCall('setTypedFieldMapper', [$userMapper]);
+        $container->setDefinition('doctrine.orm.default_configuration', $definition);
+
+        (new RegisterDatePointTypePass())->process($container);
+
+        $calls = array_filter($definition->getMethodCalls(), static fn (array $call) => 'setTypedFieldMapper' === $call[0]);
+        $this->assertCount(1, $calls);
+        $chainDef = array_values($calls)[0][1][0];
+        $this->assertSame(ChainTypedFieldMapper::class, $chainDef->getClass());
+        $this->assertSame($userMapper, $chainDef->getArgument(0)[0]);
+        $this->assertSame(DefaultTypedFieldMapper::class, $chainDef->getArgument(0)[1]->getClass());
+    }
+
+    public function testEveryEntityManagerConfigurationIsCovered()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+
+        $container->setDefinition('doctrine.orm.default_configuration', $default = new Definition());
+        $container->setDefinition('doctrine.orm.other_configuration', $other = new Definition());
+        $container->setDefinition('doctrine.orm.proxy_cache_warmer', $unrelated = new Definition());
+
+        (new RegisterDatePointTypePass())->process($container);
+
+        foreach ([$default, $other] as $definition) {
+            $calls = array_filter($definition->getMethodCalls(), static fn (array $call) => 'setTypedFieldMapper' === $call[0]);
+            $this->assertCount(1, $calls);
+        }
+        $this->assertSame([], $unrelated->getMethodCalls());
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DatePointEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DatePointEntity.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Clock\DatePoint;
+
+#[ORM\Entity]
+class DatePointEntity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private DatePoint $activityDate;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

The [Clock documentation](https://symfony.com/doc/current/components/clock.html#storing-datepoints-in-the-database) promises that a `DatePoint` column needs no explicit Doctrine type:

```php
#[ORM\Column]
private DatePoint $createdAt;
```

That has never been true: the ORM's `DefaultTypedFieldMapper` matches exact property types it knows, so `doctrine:migrations:diff` and `doctrine:schema:update` fell back to `string`.

`RegisterDatePointTypePass`, which already registers the `date_point`, `day_point` and `time_point` DBAL types, now also gives the ORM a typed field mapper covering the three matching property types, so the documented behaviour works for `DatePoint`, `DayPoint` and `TimePoint` alike.

Semantics, each pinned by a test:

* every `doctrine.orm.*_configuration` definition is covered, so multi-entity-manager setups behave the same on all managers;
* a typed field mapper configured by the application (DoctrineBundle's `typed_field_mapper` option) keeps the first say: it is chained ahead of the bridge mapper via `ChainTypedFieldMapper` instead of being replaced;
* nothing happens when the ORM does not provide `DefaultTypedFieldMapper`.

Documentation needs no change, this makes the existing claim true; the Clock page could mention that `DayPoint` and `TimePoint` autodetect too.
