### PR TITLE
[DoctrineBridge] Allow custom doctrine type registration using attribute

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Attribute/AsDoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/AsDoctrineType.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Attribute;
+
+/**
+ * Registers a custom Doctrine DBAL type automatically.
+ *
+ * When used on a class extending {@see \Doctrine\DBAL\Types\Type}, the type
+ * will be registered without needing manual configuration in doctrine.yaml.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsDoctrineType
+{
+    /**
+     * @param string|null $name The name under which the type is registered in Doctrine.
+     *                          Defaults to the fully-qualified class name if not provided.
+     */
+    public function __construct(
+        public readonly ?string $name = null,
+    ) {
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Attribute/AsDoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/AsDoctrineType.php
@@ -14,7 +14,8 @@ namespace Symfony\Bridge\Doctrine\Attribute;
 /**
  * Registers a custom Doctrine DBAL type automatically.
  *
- * When used on a class extending {@see \Doctrine\DBAL\Types\Type}, the type
+ * When used on a class extending {@see \Doctrine\DBAL\Types\Type} that is
+ * registered as a service (i.e. present as a container definition), the type
  * will be registered without needing manual configuration in doctrine.yaml.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `#[AsDoctrineType]` attribute to auto-register custom Doctrine DBAL types
  * Add option `uid_format` to `EntityType`
  * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`. Namespace aliases are no longer supported in Doctrine.
 

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
@@ -34,7 +34,7 @@ final class RegisterCustomTypePass implements CompilerPassInterface
             return;
         }
 
-        /** @var array<string, array{class: class-string<Type>}> $types */
+        /** @var array<string, mixed> $types */
         $types = $container->getParameter('doctrine.dbal.connection_factory.types');
 
         foreach ($container->getDefinitions() as $definition) {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
@@ -34,6 +34,7 @@ final class RegisterCustomTypePass implements CompilerPassInterface
             return;
         }
 
+        /** @var array<string, array{class: class-string<Type>}> $types */
         $types = $container->getParameter('doctrine.dbal.connection_factory.types');
 
         foreach ($container->getDefinitions() as $definition) {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
@@ -40,11 +40,22 @@ final class RegisterCustomTypePass implements CompilerPassInterface
         foreach ($container->getDefinitions() as $definition) {
             $class = $definition->getClass();
 
-            if (null === $class || !class_exists($class) || !is_a($class, Type::class, true)) {
+            if (null === $class) {
                 continue;
             }
 
-            $reflectionClass = new \ReflectionClass($class);
+            $class = $container->getParameterBag()->resolveValue($class);
+
+            if (!\is_string($class)) {
+                continue;
+            }
+
+            $reflectionClass = $container->getReflectionClass($class);
+
+            if (null === $reflectionClass || !$reflectionClass->isSubclassOf(Type::class)) {
+                continue;
+            }
+
             $attributes = $reflectionClass->getAttributes(AsDoctrineType::class);
 
             if ([] === $attributes) {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterCustomTypePass.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
+
+use Doctrine\DBAL\Types\Type;
+use Symfony\Bridge\Doctrine\Attribute\AsDoctrineType;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Registers Doctrine DBAL types from classes annotated with #[AsDoctrineType].
+ *
+ * The pass scans all container definitions for the attribute and registers
+ * matching types in the doctrine.dbal.connection_factory.types parameter.
+ *
+ * Usage in DoctrineBundle::build():
+ *
+ *     $container->addCompilerPass(new RegisterCustomTypePass());
+ */
+final class RegisterCustomTypePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('doctrine.dbal.connection_factory.types')) {
+            return;
+        }
+
+        $types = $container->getParameter('doctrine.dbal.connection_factory.types');
+
+        foreach ($container->getDefinitions() as $definition) {
+            $class = $definition->getClass();
+
+            if (null === $class || !class_exists($class) || !is_a($class, Type::class, true)) {
+                continue;
+            }
+
+            $reflectionClass = new \ReflectionClass($class);
+            $attributes = $reflectionClass->getAttributes(AsDoctrineType::class);
+
+            if ([] === $attributes) {
+                continue;
+            }
+
+            $attribute = $attributes[0]->newInstance();
+            $name = $attribute->name ?? $class;
+
+            $types[$name] ??= ['class' => $class];
+        }
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', $types);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterCustomTypePassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterCustomTypePassTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterCustomTypePass;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\CustomType;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\CustomTypeNoName;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapperType;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class RegisterCustomTypePassTest extends TestCase
+{
+    public function testRegisteredWithExplicitName()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+        $container->setDefinition(CustomType::class, new Definition(CustomType::class));
+
+        (new RegisterCustomTypePass())->process($container);
+
+        $expected = [
+            'custom' => ['class' => CustomType::class],
+        ];
+        $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testRegisteredWithoutNameDefaultsToClassName()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+        $container->setDefinition(CustomTypeNoName::class, new Definition(CustomTypeNoName::class));
+
+        (new RegisterCustomTypePass())->process($container);
+
+        $expected = [
+            CustomTypeNoName::class => ['class' => CustomTypeNoName::class],
+        ];
+        $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testDoesNotOverrideExistingTypes()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', [
+            'custom' => ['class' => 'App\ExistingType'],
+        ]);
+        $container->setDefinition(CustomType::class, new Definition(CustomType::class));
+
+        (new RegisterCustomTypePass())->process($container);
+
+        $expected = [
+            'custom' => ['class' => 'App\ExistingType'],
+        ];
+        $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testPreservesExistingTypes()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', ['foo' => 'bar']);
+        $container->setDefinition(CustomType::class, new Definition(CustomType::class));
+
+        (new RegisterCustomTypePass())->process($container);
+
+        $expected = [
+            'foo' => 'bar',
+            'custom' => ['class' => CustomType::class],
+        ];
+        $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testSkipsWhenParameterIsMissing()
+    {
+        $container = new ContainerBuilder();
+        (new RegisterCustomTypePass())->process($container);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testSkipsTypeWithoutAttribute()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+        $container->setDefinition(StringWrapperType::class, new Definition(StringWrapperType::class));
+
+        (new RegisterCustomTypePass())->process($container);
+
+        $this->assertSame([], $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testMultipleTypesRegistered()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', []);
+        $container->setDefinition(CustomType::class, new Definition(CustomType::class));
+        $container->setDefinition(CustomTypeNoName::class, new Definition(CustomTypeNoName::class));
+
+        (new RegisterCustomTypePass())->process($container);
+
+        $expected = [
+            'custom' => ['class' => CustomType::class],
+            CustomTypeNoName::class => ['class' => CustomTypeNoName::class],
+        ];
+        $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/CustomType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/CustomType.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Symfony\Bridge\Doctrine\Attribute\AsDoctrineType;
+
+#[AsDoctrineType('custom')]
+class CustomType extends Type
+{
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getStringTypeDeclarationSQL($column);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/CustomTypeNoName.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/CustomTypeNoName.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Symfony\Bridge\Doctrine\Attribute\AsDoctrineType;
+
+#[AsDoctrineType]
+class CustomTypeNoName extends Type
+{
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getStringTypeDeclarationSQL($column);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

I am introducing this PR because it would help when writing custom Doctrine types. I do a lot of DDD and like using value objects in my entities, which means I end up creating custom types regularly. Currently I have to manually register every single one in `doctrine.yaml`:

```yaml
doctrine:
    dbal:
        types:
            App\Bridge\Doctrine\DBAL\Types\NotificationSettingsType: App\Bridge\Doctrine\DBAL\Types\NotificationSettingsType
```

This PR adds an `#[AsDoctrineType]` attribute so types can be registered where they're defined:

```php
#[AsDoctrineType(name: 'notification_settings')]
final class NotificationSettingsType extends Type
{
    // ...
}
```

The name is optional and defaults to the FQCN.

I have to open also a PR on the [DoctrineBundle](https://github.com/doctrine/doctrinebundle)


There I need to register the compiler pass:

```php
$container->addCompilerPass(new RegisterCustomTypePass());
```