### PR TITLE
[Serializer] Add an option to report attributes the property accessor refuses to write

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow passing an associative array to `CsvEncoder::HEADERS_KEY` to map and reorder columns when encoding
  * Use the discriminator property of an object to pick its type when several types map to the same class; the first declared type is used when the property is unset or unknown
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
+ * Add `ObjectNormalizer::THROW_ON_INACCESSIBLE_ATTRIBUTES` context option, and the matching `ObjectNormalizerContextBuilder::withThrowOnInaccessibleAttributes()`, to report attributes the property accessor refuses to write instead of ignoring them
 
 8.1
 ---

--- a/src/Symfony/Component/Serializer/Context/Normalizer/ObjectNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/ObjectNormalizerContextBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Serializer\Context\Normalizer;
 
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
 /**
  * A helper providing autocompletion for available ObjectNormalizer options.
  *
@@ -18,4 +20,12 @@ namespace Symfony\Component\Serializer\Context\Normalizer;
  */
 final class ObjectNormalizerContextBuilder extends AbstractObjectNormalizerContextBuilder
 {
+    /**
+     * Configures whether to throw when the property accessor refuses to write
+     * an attribute the metadata reports as writable, instead of ignoring it.
+     */
+    public function withThrowOnInaccessibleAttributes(?bool $throwOnInaccessibleAttributes): static
+    {
+        return $this->with(ObjectNormalizer::THROW_ON_INACCESSIBLE_ATTRIBUTES, $throwOnInaccessibleAttributes);
+    }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -35,6 +35,15 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  */
 final class ObjectNormalizer extends AbstractObjectNormalizer
 {
+    /**
+     * Whether to throw when the property accessor refuses to write an attribute the metadata reports as writable.
+     *
+     * Attributes the metadata does not know about are unaffected, they never reach the accessor; use
+     * ALLOW_EXTRA_ATTRIBUTES to reject those. The discriminator type property is also unaffected, since
+     * it is a wire-format marker that usually has no setter.
+     */
+    public const THROW_ON_INACCESSIBLE_ATTRIBUTES = 'throw_on_inaccessible_attributes';
+
     use AccessorCollisionResolverTrait;
 
     private static $reflectionCache = [];
@@ -122,8 +131,15 @@ final class ObjectNormalizer extends AbstractObjectNormalizer
     {
         try {
             $this->propertyAccessor->setValue($object, $attribute, $value);
-        } catch (NoSuchPropertyException) {
-            // Properties not found are ignored
+        } catch (NoSuchPropertyException $e) {
+            if (!($context[self::THROW_ON_INACCESSIBLE_ATTRIBUTES] ?? $this->defaultContext[self::THROW_ON_INACCESSIBLE_ATTRIBUTES] ?? false)
+                || $attribute === $this->classDiscriminatorResolver?->getMappingForMappedObject($object)?->getTypeProperty()
+            ) {
+                // Properties not found are ignored
+                return;
+            }
+
+            throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Failed to denormalize attribute "%s" value for class "%s": %s', $attribute, $object::class, $e->getMessage()), $value, ['unknown'], $context['deserialization_path'] ?? null, false, $e->getCode(), $e);
         } catch (PropertyAccessInvalidArgumentException $e) {
             throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Failed to denormalize attribute "%s" value for class "%s": %s', $attribute, $object::class, $e->getMessage()), $value, $e instanceof InvalidTypeException ? [$e->expectedType] : ['unknown'], $context['deserialization_path'] ?? null, false, $e->getCode(), $e);
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1615,6 +1615,92 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame('FOO', $denormalized->foo);
         $this->assertSame('BAR', $denormalized->bar);
     }
+
+    public function testInaccessibleAttributeIsIgnoredByDefault()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $object = $normalizer->denormalize(['secret' => 'shh', 'known' => 'ok'], InaccessibleAttributesDummy::class);
+
+        $this->assertSame('ok', $object->known);
+        $this->assertSame('', $object->getSecret());
+    }
+
+    public function testInaccessibleAttributeIsReported()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Failed to denormalize attribute "secret" value for class "'.InaccessibleAttributesDummy::class.'": The method "setSecret" in class "'.InaccessibleAttributesDummy::class.'" was found but does not have public access.');
+
+        $normalizer->denormalize(['secret' => 'shh'], InaccessibleAttributesDummy::class, null, [ObjectNormalizer::THROW_ON_INACCESSIBLE_ATTRIBUTES => true]);
+    }
+
+    public function testInaccessibleAttributeIsCollectedWithTheOtherDenormalizationErrors()
+    {
+        $normalizer = new ObjectNormalizer();
+        $exceptions = [];
+
+        $normalizer->denormalize(['secret' => 'shh'], InaccessibleAttributesDummy::class, null, [
+            ObjectNormalizer::THROW_ON_INACCESSIBLE_ATTRIBUTES => true,
+            AbstractObjectNormalizer::COLLECT_DENORMALIZATION_ERRORS => true,
+            'not_normalizable_value_exceptions' => &$exceptions,
+            'deserialization_path' => 'payload',
+        ]);
+
+        $this->assertCount(1, $exceptions);
+        $this->assertSame('payload.secret', $exceptions[0]->getPath());
+    }
+
+    public function testUnknownAndReadOnlyAttributesStayIgnoredWhenReportingIsOn()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $object = $normalizer->denormalize(
+            ['unknown' => 1, 'computed' => 'x', 'known' => 'ok'],
+            InaccessibleAttributesDummy::class,
+            null,
+            [ObjectNormalizer::THROW_ON_INACCESSIBLE_ATTRIBUTES => true],
+        );
+
+        $this->assertSame('ok', $object->known);
+    }
+
+    public function testDiscriminatorTypePropertyStaysIgnoredWhenReportingIsOn()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $denormalized = $normalizer->denormalize(
+            ['type' => ObjectNormalizerDiscriminatorSub::TYPE, 'foo' => 'FOO', 'bar' => 'BAR'],
+            ObjectNormalizerDiscriminatorBase::class,
+            null,
+            [ObjectNormalizer::THROW_ON_INACCESSIBLE_ATTRIBUTES => true, AbstractNormalizer::GROUPS => ['*']],
+        );
+
+        $this->assertInstanceOf(ObjectNormalizerDiscriminatorSub::class, $denormalized);
+        $this->assertSame('BAR', $denormalized->bar);
+    }
+}
+
+class InaccessibleAttributesDummy
+{
+    public string $known = '';
+    private string $secret = '';
+
+    private function setSecret(string $secret): void
+    {
+        $this->secret = $secret;
+    }
+
+    public function getSecret(): string
+    {
+        return $this->secret;
+    }
+
+    public function getComputed(): string
+    {
+        return 'computed';
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #63642
| License       | MIT

`ObjectNormalizer::setAttributeValue()` swallows every `NoSuchPropertyException` the property accessor raises. This adds `ObjectNormalizer::THROW_ON_INACCESSIBLE_ATTRIBUTES`, defaulting to `false`, to report those instead.

The set it covers is narrow on purpose. An attribute only reaches the accessor after `isAllowedAttribute()` has approved it, so the option fires exactly when the metadata says an attribute is writable and the accessor then refuses: a non-public setter, an adder without a matching remover, a dotted key that is not a writable path. Measured on 8.2:

| payload key | reaches `setAttributeValue()` | swallowed today |
| --- | --- | --- |
| unknown field | no | - |
| get-only property | no | - |
| private setter | yes | yes |
| adder without remover | yes | yes |
| writable property | yes | no |

Unknown fields and read-only properties are unaffected, they never get that far; `ALLOW_EXTRA_ATTRIBUTES` is the option for those. That is also why this does not close #63642 on its own, see below.

Changed during review, relative to the first version of this PR:

* **the thrown exception is a Serializer exception.** It was re-throwing `PropertyAccess\Exception\NoSuchPropertyException`, which is not a `Serializer\Exception\ExceptionInterface`, so `catch (SerializerExceptionInterface)` around `deserialize()` missed it. It also broke `COLLECT_DENORMALIZATION_ERRORS`: `AbstractObjectNormalizer::denormalize()` only catches `NotNormalizableValueException`, so the raw exception escaped the attribute loop and discarded every error collected so far. It is now a `NotNormalizableValueException` built the same way as the `PropertyAccessInvalidArgumentException` branch below it, so it carries the attribute name and the deserialization path, collects correctly, and honours the `@throws` on `AbstractObjectNormalizer::setAttributeValue()`;

* **the discriminator type property is exempt.** `ObjectNormalizer::isAllowedAttribute()` returns `true` for it unconditionally, and it usually has no setter, so it relies on the swallow. Without the exemption, enabling the option broke every discriminator map:

  ```
  option on, discriminated payload -> NoSuchPropertyException:
      Could not determine access type for property "type" in class "Sub".
  ```

  An unconditional throw, with no option at all, was also tried: it fails 10 tests in the component for this reason plus promoted readonly properties already consumed by the constructor. The swallow is load-bearing, which is why this stays opt-in;

* **the option moved from `AbstractObjectNormalizer` to `ObjectNormalizer`**, and the builder method from `AbstractObjectNormalizerContextBuilder` to `ObjectNormalizerContextBuilder`. `PropertyNormalizer` and `GetSetMethodNormalizer` have their own `setAttributeValue()` and ignore it entirely, so on the abstract it was a discoverable, autocompleted no-op on two of the three object normalizers;

* **renamed.** `SKIP_UNWRITABLE_PROPERTIES` read as covering every unwritable property, which is not what it reaches, and its polarity was inverted: `withSkipUnwritableProperties(false)` meant "throw". The name now says what happens, matching `ALLOW_EXTRA_ATTRIBUTES` and `REQUIRE_ALL_PROPERTIES`, and the docblock that described "throw" while the parameter was named "skip" is gone;

* **the tests exercise the feature.** The previous three all drove an artificial `'nested.unknown'` dotted key, and the fixture named `DummyWithUnwritableProperty` had no unwritable property. There are now five: default behaviour unchanged, the exception, collection through `COLLECT_DENORMALIZATION_ERRORS` with the path asserted, unknown and read-only attributes still ignored with the option on, and a discriminator map still working with the option on. With the constant kept but the branch reverted, exactly the two behaviour tests fail; the three guard tests pass, which is what they are for.

**On #63642.** The case in the report, a corrupted value of the wrong type, already throws on 8.2 and has since `29a9ddd9f03`:

```
NotNormalizableValueException: Failed to denormalize attribute "structure" value for class
"Payload": Expected argument of type "?array", "true" given at property path "structure".
```

and an unknown field is reported by `ALLOW_EXTRA_ATTRIBUTES => false` as `Extra attributes are not allowed ("nope" is unknown).` What was left uncovered is the contradiction case above, which is what this option addresses.
