### PR TITLE
[Console] Auto-wrap TextDescriptor output based on terminal width

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 
  * Add `ConsoleBundle` for console applications with DI, autodiscovery and autowiring
  * Pad styled `SymfonyStyle` blocks with the ECH ANSI sequence on decorated outputs so trailing cells are excluded from copy selections
+ * Wrap the descriptions in `TextDescriptor` output to the terminal width; pass the `terminal_width` describe option to control it
  * Add optional `$container` parameter to `Application` for automatic service wiring from a PSR container
  * Add `SymfonyStyle::outlineBlock()` and convenience methods `outlineSuccess()`, `outlineError()`, `outlineWarning()`, `outlineNote()`, `outlineInfo()`, `outlineCaution()` for border-only message blocks with the type label embedded in the top border
  * Add `TraceableValueResolver` to help inspecting value resolvers performances

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -15,9 +15,12 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Helper\OutputWrapper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Terminal;
 
 /**
  * Text descriptor.
@@ -28,6 +31,9 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class TextDescriptor extends Descriptor
 {
+    private const MIN_DESCRIPTION_WIDTH = 20;
+    private const FALLBACK_DESCRIPTION_INDENT = 6;
+
     protected function describeInputArgument(InputArgument $argument, array $options = []): void
     {
         if (null !== $argument->getDefault() && (!\is_array($argument->getDefault()) || \count($argument->getDefault()))) {
@@ -38,14 +44,28 @@ class TextDescriptor extends Descriptor
 
         $totalWidth = $options['total_width'] ?? Helper::width($argument->getName());
         $spacingWidth = $totalWidth - Helper::width($argument->getName());
+        $terminalWidth = $this->getTerminalWidth($options);
 
-        $this->writeText(\sprintf('  <info>%s</info>  %s%s%s',
-            $argument->getName(),
-            str_repeat(' ', $spacingWidth),
-            // + 4 = 2 spaces before <info>, 2 spaces after </info>
-            preg_replace('/\s*[\r\n]\s*/', "\n".str_repeat(' ', $totalWidth + 4), $argument->getDescription()),
-            $default
-        ), $options);
+        $description = preg_replace('/\s*[\r\n]\s*/', "\n", $argument->getDescription());
+        $fullDescription = $description.$default;
+
+        // + 4 = 2 spaces before <info>, 2 spaces after </info>
+        $descriptionIndent = $totalWidth + 4;
+        $availableWidth = $terminalWidth - $descriptionIndent;
+
+        if ($availableWidth >= self::MIN_DESCRIPTION_WIDTH) {
+            $this->writeText(\sprintf('  <info>%s</info>  %s%s',
+                $argument->getName(),
+                str_repeat(' ', $spacingWidth),
+                $this->wrapText($fullDescription, $availableWidth, $descriptionIndent)
+            ), $options);
+        } else {
+            $this->writeText(\sprintf("  <info>%s</info>\n%s%s",
+                $argument->getName(),
+                str_repeat(' ', self::FALLBACK_DESCRIPTION_INDENT),
+                $this->wrapText($fullDescription, max(1, $terminalWidth - self::FALLBACK_DESCRIPTION_INDENT), self::FALLBACK_DESCRIPTION_INDENT)
+            ), $options);
+        }
     }
 
     protected function describeInputOption(InputOption $option, array $options = []): void
@@ -72,20 +92,23 @@ class TextDescriptor extends Descriptor
         );
 
         $spacingWidth = $totalWidth - Helper::width($synopsis);
+        $terminalWidth = $this->getTerminalWidth($options);
 
         $synopsis = \sprintf('<%1$s>%2$s</%1$s>', $option->isDeprecated() ? 'fg=gray' : 'info', $synopsis);
 
         $prefix = ($option->isDeprecated() ? '[deprecated] ' : '').($option->isHidden() ? '[hidden] ' : '');
-        $description = trim($prefix.$option->getDescription());
+        $description = preg_replace('/\s*[\r\n]\s*/', "\n", trim($prefix.$option->getDescription()));
+        $fullDescription = $description.$default.($option->isArray() ? '<comment> (multiple values allowed)</comment>' : '');
 
-        $this->writeText(\sprintf('  %s  %s%s%s%s',
-            $synopsis,
-            str_repeat(' ', $spacingWidth),
-            // + 4 = 2 spaces before the synopsis, 2 spaces after it
-            preg_replace('/\s*[\r\n]\s*/', "\n".str_repeat(' ', $totalWidth + 4), $description),
-            $default,
-            $option->isArray() ? '<comment> (multiple values allowed)</comment>' : ''
-        ), $options);
+        // + 4 = 2 spaces before the synopsis, 2 spaces after it
+        $descriptionIndent = $totalWidth + 4;
+        $availableWidth = $terminalWidth - $descriptionIndent;
+
+        if ($availableWidth >= self::MIN_DESCRIPTION_WIDTH) {
+            $this->writeText(\sprintf('  %s  %s%s', $synopsis, str_repeat(' ', $spacingWidth), $this->wrapText($fullDescription, $availableWidth, $descriptionIndent)), $options);
+        } else {
+            $this->writeText(\sprintf("  %s\n%s%s", $synopsis, str_repeat(' ', self::FALLBACK_DESCRIPTION_INDENT), $this->wrapText($fullDescription, max(1, $terminalWidth - self::FALLBACK_DESCRIPTION_INDENT), self::FALLBACK_DESCRIPTION_INDENT)), $options);
+        }
     }
 
     protected function describeInputDefinition(InputDefinition $definition, array $options = []): void
@@ -131,11 +154,12 @@ class TextDescriptor extends Descriptor
     protected function describeCommand(Command $command, array $options = []): void
     {
         $command->mergeApplicationDefinition(false);
+        $terminalWidth = $this->getTerminalWidth($options);
 
         if ($description = $command->getDescription()) {
             $this->writeText('<comment>Description:</comment>', $options);
             $this->writeText("\n");
-            $this->writeText('  '.$description);
+            $this->writeText('  '.$this->wrapText($description, $terminalWidth - 2, 2));
             $this->writeText("\n\n");
         }
 
@@ -158,7 +182,7 @@ class TextDescriptor extends Descriptor
             $this->writeText("\n");
             $this->writeText('<comment>Help:</comment>', $options);
             $this->writeText("\n");
-            $this->writeText('  '.str_replace("\n", "\n  ", $help), $options);
+            $this->writeText('  '.$this->wrapText($help, $terminalWidth - 2, 2), $options);
             $this->writeText("\n");
         }
     }
@@ -176,6 +200,8 @@ class TextDescriptor extends Descriptor
                 $this->writeText("\n");
             }
         } else {
+            $terminalWidth = $this->getTerminalWidth($options);
+
             if ('' != $help = $application->getHelp()) {
                 $this->writeText("$help\n\n", $options);
             }
@@ -224,7 +250,15 @@ class TextDescriptor extends Descriptor
                     $spacingWidth = $width - Helper::width($name);
                     $command = $commands[$name];
                     $commandAliases = $name === $command->getName() ? $this->getCommandAliasesText($command) : '';
-                    $this->writeText(\sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $commandAliases.$command->getDescription()), $options);
+                    $cmdDescription = $commandAliases.$command->getDescription();
+                    $descriptionIndent = $width + 2;
+                    $availableWidth = $terminalWidth - $descriptionIndent;
+
+                    if ($availableWidth > 0) {
+                        $cmdDescription = $this->wrapText($cmdDescription, $availableWidth, $descriptionIndent);
+                    }
+
+                    $this->writeText(\sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $cmdDescription), $options);
                 }
             }
 
@@ -319,5 +353,31 @@ class TextDescriptor extends Descriptor
         }
 
         return $totalWidth;
+    }
+
+    private function getTerminalWidth(array $options): int
+    {
+        if (isset($options['terminal_width'])) {
+            return $options['terminal_width'];
+        }
+
+        if ($this->output instanceof StreamOutput && stream_isatty($this->output->getStream())) {
+            return (new Terminal())->getWidth();
+        }
+
+        return \PHP_INT_MAX;
+    }
+
+    private function wrapText(string $text, int $width, int $indent): string
+    {
+        // 65535 is the PCRE quantifier limit OutputWrapper builds its pattern from; wider means no wrapping anyway
+        if ($width > 0 && $width <= 65535) {
+            // measures the visible width: formatter tags and multibyte characters do not count
+            $text = (new OutputWrapper())->wrap($text, $width);
+        }
+
+        $text = str_replace("\r\n", "\n", $text);
+
+        return str_replace("\n", "\n".str_repeat(' ', $indent), $text);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTestCase.php
@@ -106,7 +106,7 @@ abstract class AbstractDescriptorTestCase extends TestCase
     protected function assertDescription($expectedDescription, $describedObject, array $options = [])
     {
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
-        $this->getDescriptor()->describe($output, $describedObject, $options + ['raw_output' => true]);
+        $this->getDescriptor()->describe($output, $describedObject, $options + ['raw_output' => true, 'terminal_width' => \PHP_INT_MAX]);
         $this->assertEquals($this->normalizeOutput($expectedDescription), $this->normalizeOutput($output->fetch()));
     }
 

--- a/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\Console\Tests\Descriptor;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Descriptor\TextDescriptor;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorApplication2;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorApplicationMbString;
@@ -51,6 +55,96 @@ class TextDescriptorTest extends AbstractDescriptorTestCase
         $this->assertDescription(file_get_contents(__DIR__.'/../Fixtures/application_filtered_namespace.txt'), $application, ['namespace' => 'command4']);
     }
 
+    public function testOptionDescriptionWrapsAtTerminalWidth()
+    {
+        $option = new InputOption('verbose', 'v', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug');
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $this->getDescriptor()->describe($output, $option, ['raw_output' => true, 'terminal_width' => 80]);
+        $result = strip_tags($output->fetch());
+
+        $this->assertStringContainsString('-v, --verbose', $result);
+        $this->assertGreaterThan(1, \count(explode("\n", trim($result))), 'Long description should wrap to multiple lines');
+        foreach (explode("\n", trim($result)) as $line) {
+            $this->assertLessThanOrEqual(80, \strlen($line), \sprintf('Line exceeds terminal width: "%s"', $line));
+        }
+    }
+
+    public function testOptionDescriptionFallbackOnNarrowTerminal()
+    {
+        $option = new InputOption('update-with-all-dependencies', null, InputOption::VALUE_NONE, 'Allows all inherited dependencies to be updated, including those that are root requirements.');
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $this->getDescriptor()->describe($output, $option, ['raw_output' => true, 'terminal_width' => 50]);
+        $result = strip_tags($output->fetch());
+        $lines = explode("\n", trim($result));
+
+        $this->assertStringContainsString('--update-with-all-dependencies', $lines[0]);
+        $this->assertStringNotContainsString('Allows', $lines[0], 'Description should be on the next line when terminal is narrow');
+        $this->assertStringContainsString('Allows', $lines[1]);
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(50, \strlen($line), \sprintf('Line exceeds terminal width: "%s"', $line));
+        }
+    }
+
+    public function testOptionDescriptionWithDefaultWraps()
+    {
+        $option = new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'The output format for this very long description that should wrap', 'txt');
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $this->getDescriptor()->describe($output, $option, ['raw_output' => true, 'terminal_width' => 60]);
+        $result = strip_tags($output->fetch());
+
+        $lines = explode("\n", trim($result));
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(60, \strlen($line), \sprintf('Line exceeds terminal width: "%s"', $line));
+        }
+        $this->assertStringContainsString('[default: "txt"]', $result);
+    }
+
+    public function testHelpTextWrapsAtTerminalWidth()
+    {
+        $command = new Command('test:wrap');
+        $command->setDescription('Test command');
+        $command->setHelp('This is a very long help text that should be automatically wrapped when the terminal width is not wide enough to display it on a single line.');
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $this->getDescriptor()->describe($output, $command, ['raw_output' => true, 'terminal_width' => 60]);
+        $result = strip_tags($output->fetch());
+
+        $this->assertStringContainsString("Help:\n", $result);
+        $helpStart = strpos($result, "Help:\n") + 6;
+        $helpSection = substr($result, $helpStart);
+        foreach (explode("\n", trim($helpSection)) as $line) {
+            $this->assertLessThanOrEqual(60, \strlen($line), \sprintf('Help line exceeds terminal width: "%s"', $line));
+        }
+    }
+
+    public function testCommandListDescriptionWraps()
+    {
+        $application = new DescriptorApplication2();
+        $application->find('completion')->setHelp('');
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $this->getDescriptor()->describe($output, $application, ['raw_output' => true, 'terminal_width' => 60]);
+        $result = strip_tags($output->fetch());
+
+        foreach (explode("\n", $result) as $line) {
+            $this->assertLessThanOrEqual(60, \strlen($line), \sprintf('Line exceeds terminal width: "%s"', $line));
+        }
+    }
+
+    public function testNoWrappingWhenContentFits()
+    {
+        $option = new InputOption('quiet', 'q', InputOption::VALUE_NONE, 'Suppress output');
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $this->getDescriptor()->describe($output, $option, ['raw_output' => true, 'terminal_width' => 80]);
+        $result = trim(strip_tags($output->fetch()));
+
+        $this->assertStringNotContainsString("\n", $result);
+    }
+
     protected function getDescriptor()
     {
         return new TextDescriptor();
@@ -59,5 +153,39 @@ class TextDescriptorTest extends AbstractDescriptorTestCase
     protected static function getFormat()
     {
         return 'txt';
+    }
+
+    public function testWrappingMeasuresVisibleWidthNotBytes()
+    {
+        $output = new BufferedOutput();
+        $option = new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Précède les caractères accentués événement téléphone préférée');
+        (new TextDescriptor())->describe($output, $option, ['terminal_width' => 60, 'raw_output' => true]);
+
+        $lines = explode("\n", rtrim($output->fetch()));
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(60, Helper::width(Helper::removeDecoration(new OutputFormatter(), $line)));
+        }
+        // wrapping on bytes would count the accents twice and break one word earlier
+        $this->assertStringEndsWith('accentués', Helper::removeDecoration(new OutputFormatter(), $lines[0]));
+    }
+
+    public function testWrappingDoesNotCountFormatterTags()
+    {
+        $output = new BufferedOutput();
+        $option = new InputOption('flag', null, InputOption::VALUE_REQUIRED, 'Chooses the mode used for processing', 'super-long-default-value');
+        (new TextDescriptor())->describe($output, $option, ['terminal_width' => 60, 'raw_output' => true]);
+
+        $lines = explode("\n", rtrim($output->fetch()));
+        $this->assertStringEndsWith('processing', Helper::removeDecoration(new OutputFormatter(), $lines[0]));
+        $this->assertStringContainsString('[default: "super-long-default-value"]', $lines[1]);
+    }
+
+    public function testUnboundedOutputWhenNotATty()
+    {
+        $output = new BufferedOutput();
+        $option = new InputOption('name', null, InputOption::VALUE_REQUIRED, str_repeat('long description ', 30));
+        (new TextDescriptor())->describe($output, $option, ['raw_output' => true]);
+
+        $this->assertCount(1, explode("\n", rtrim($output->fetch())));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #43081
| License       | MIT

`TextDescriptor` rendered option, argument, help and command-list descriptions as single unbounded lines, so a narrow terminal hard-wrapped them mid-word. Descriptions now wrap at the terminal width, with two layouts:

- inline: with at least 20 columns available after the name column, the description wraps beside it, continuation lines aligned to the same column;
- fallback: when the terminal is too narrow for that, the description moves below the name with a fixed 6-space indent.

Wrapping only engages when the output stream is an interactive terminal. Piped or redirected output stays unbounded, so scripts parsing `bin/console list` output, generated docs and every existing test fixture are byte-for-byte unchanged. The `terminal_width` describe option gives explicit control and works on any stream.

Width is measured through `OutputWrapper`, so formatter tags do not consume visible columns, multibyte characters count as their display width, and a wrap never lands inside a tag.

Documentation should cover: the automatic wrapping and its two layouts, that it applies to interactive terminals only, the `terminal_width` option, and that `--format=txt` output piped to a file keeps single-line descriptions.
