### PR TITLE
[Serializer] Fix can*() prefix support in GetSetMethodNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.4
 ---
 
+ * Fix `GetSetMethodNormalizer` not extracting `can*()` prefixed methods in `isAllowedAttribute()` and `getAttributeValue()`
  * Add `TranslatableNormalizer`
  * Allow `Context` attribute to target classes
  * Deprecate Doctrine annotations support in favor of native attributes

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -98,7 +98,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
     }
 
     /**
-     * Checks if a method's name matches /^(get|is|has).+$/ and can be called non-statically without parameters.
+     * Checks if a method's name matches /^(get|is|has|can).+$/ and can be called non-statically without parameters.
      */
     private function isGetMethod(\ReflectionMethod $method): bool
     {
@@ -163,6 +163,11 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
             return $object->$haser();
         }
 
+        $caner = 'can'.$attribute;
+        if (method_exists($object, $caner) && \is_callable([$object, $caner])) {
+            return $object->$caner();
+        }
+
         return null;
     }
 
@@ -202,7 +207,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $reflection = self::$reflectionCache[$class];
 
         if ($context['_read_attributes'] ?? true) {
-            foreach (['get', 'is', 'has'] as $getterPrefix) {
+            foreach (['get', 'is', 'has', 'can'] as $getterPrefix) {
                 $getter = $getterPrefix.$attribute;
                 $reflectionMethod = $reflection->hasMethod($getter) ? $reflection->getMethod($getter) : null;
                 if ($reflectionMethod && $this->isGetMethod($reflectionMethod)) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -631,6 +631,28 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->assertArrayNotHasKey('neverProperty', $normalized);
         $this->assertEquals('value', $normalized['normalProperty']);
     }
+
+    public function testNormalizeWithCanPrefixMethods()
+    {
+        $obj = new GetSetDummyWithCanMethods();
+        $obj->setName('Alice');
+
+        $this->assertEquals(
+            ['name' => 'Alice', 'edit' => true, 'delete' => false],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
+    public function testNormalizeWithCanPrefixOnly()
+    {
+        $obj = new GetSetDummyWithCanOnly();
+
+        $this->assertTrue($this->normalizer->supportsNormalization($obj));
+        $this->assertEquals(
+            ['read' => true, 'write' => false],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
 }
 
 class GetSetDummy
@@ -1015,5 +1037,43 @@ class GetSetWithAccessorishMethod
 
     public function isolate()
     {
+    }
+}
+
+class GetSetDummyWithCanMethods
+{
+    private $name;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function canEdit(): bool
+    {
+        return true;
+    }
+
+    public function canDelete(): bool
+    {
+        return false;
+    }
+}
+
+class GetSetDummyWithCanOnly
+{
+    public function canRead(): bool
+    {
+        return true;
+    }
+
+    public function canWrite(): bool
+    {
+        return false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63786
| License       | MIT

`isGetMethod()` recognizes `can*()` as a valid getter prefix, but `isAllowedAttribute()` and `getAttributeValue()` only support `get*`, `is*` and `has*`. This causes `can*()`-derived attributes to be silently dropped during normalization.

The fix adds `'can'` to the prefix list in `isAllowedAttribute()` and adds the corresponding resolution block in `getAttributeValue()`.