### PR TITLE
[ObjectMapper] Fix mapping of private properties from parent classes

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ClassHierarchyTrait.php
+++ b/src/Symfony/Component/ObjectMapper/ClassHierarchyTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper;
+
+/**
+ * @internal
+ */
+trait ClassHierarchyTrait
+{
+    /**
+     * Returns all properties from a class including private properties from parent classes.
+     *
+     * @return \ReflectionProperty[]
+     */
+    private function getAllProperties(\ReflectionClass $refl): array
+    {
+        $properties = [];
+        $seenNames = [];
+
+        do {
+            foreach ($refl->getProperties() as $property) {
+                $name = $property->getName();
+                if (isset($seenNames[$name])) {
+                    continue;
+                }
+                $seenNames[$name] = true;
+                $properties[] = $property;
+            }
+        } while ($refl = $refl->getParentClass());
+
+        return $properties;
+    }
+
+    /**
+     * Gets a property from a class or its parent hierarchy.
+     */
+    private function getPropertyFromHierarchy(\ReflectionClass $refl, string $propertyName): ?\ReflectionProperty
+    {
+        do {
+            if ($refl->hasProperty($propertyName)) {
+                return $refl->getProperty($propertyName);
+            }
+        } while ($refl = $refl->getParentClass());
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ObjectMapper\Metadata;
 
 use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\ClassHierarchyTrait;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 
 /**
@@ -21,6 +22,8 @@ use Symfony\Component\ObjectMapper\Exception\MappingException;
  */
 final class ReflectionObjectMapperMetadataFactory implements ObjectMapperMetadataFactoryInterface
 {
+    use ClassHierarchyTrait;
+
     private array $reflectionClassCache = [];
     private array $attributesCache = [];
 
@@ -34,7 +37,11 @@ final class ReflectionObjectMapperMetadataFactory implements ObjectMapperMetadat
             }
 
             $refl = $this->reflectionClassCache[$object::class] ??= new \ReflectionClass($object);
-            $attributes = ($property ? $refl->getProperty($property) : $refl)->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
+            $target = $refl;
+            if ($property && null === $target = $this->getPropertyFromHierarchy($refl, $property)) {
+                return $this->attributesCache[$key] = [];
+            }
+            $attributes = $target->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
             $mappings = [];
             foreach ($attributes as $attribute) {
                 $map = $attribute->newInstance();

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -30,6 +30,8 @@ use Symfony\Component\VarExporter\LazyObjectInterface;
  */
 final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInterface
 {
+    use ClassHierarchyTrait;
+
     /**
      * Tracks recursive references.
      */
@@ -130,7 +132,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         $mapToProperties = [];
-        foreach ($refl->getProperties() as $property) {
+        foreach ($this->getAllProperties($refl) as $property) {
             if ($property->isStatic()) {
                 continue;
             }
@@ -139,7 +141,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName);
             foreach ($mappings as $mapping) {
                 $sourcePropertyName = $propertyName;
-                if ($mapping->source && (!$refl->hasProperty($propertyName) || !isset($source->$propertyName))) {
+                if ($mapping->source && !$this->isReadable($source, $propertyName)) {
                     $sourcePropertyName = $mapping->source;
                 }
 
@@ -155,6 +157,12 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     && ($fn = $this->getCallable($if, $this->conditionCallableLocator))
                     && $fn instanceof TargetClass
                     && !$this->call($fn, null, $source, $mappedTarget)
+                ) {
+                    continue;
+                }
+
+                if (!$this->isReadable($source, $sourcePropertyName)
+                    && $this->getPropertyFromHierarchy(new \ReflectionClass($source), $sourcePropertyName)
                 ) {
                     continue;
                 }
@@ -175,8 +183,8 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $sourceProperty = $refl->getProperty($propertyName);
-                if ($refl->isInstance($source) && !$sourceProperty->isInitialized($source)) {
+                $sourceProperty = $this->getPropertyFromHierarchy($refl, $propertyName);
+                if ($sourceProperty && $refl->isInstance($source) && !$sourceProperty->isInitialized($source)) {
                     continue;
                 }
 
@@ -221,6 +229,12 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         if (!property_exists($source, $propertyName)) {
+            // only a private property declared by a parent class is invisible to property_exists();
+            // like any other non-public property, it can only be read through magic __get()
+            if ($this->getPropertyFromHierarchy($refl ??= new \ReflectionClass($source), $propertyName)) {
+                return method_exists($source, '__get');
+            }
+
             return isset($source->{$propertyName});
         }
 
@@ -249,7 +263,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
         }
 
-        if (!property_exists($source, $propertyName) && !isset($source->{$propertyName})) {
+        if (!property_exists($source, $propertyName) && !isset($source->{$propertyName})
+            && !$this->getPropertyFromHierarchy(new \ReflectionClass($source), $propertyName)
+        ) {
             throw new NoSuchPropertyException(\sprintf('The property "%s" does not exist on "%s".', $propertyName, get_debug_type($source)));
         }
 
@@ -409,7 +425,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             return $refl;
         }
 
-        foreach ($refl->getProperties() as $property) {
+        foreach ($this->getAllProperties($refl) as $property) {
             if ($this->metadataFactory->create($source, $property->getName())) {
                 return $refl;
             }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/BaseEntity.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/BaseEntity.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+class BaseEntity
+{
+    private int $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/ChildEntity.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/ChildEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ChildEntityDto::class)]
+class ChildEntity extends BaseEntity
+{
+    public function __construct(
+        int $id,
+        public string $name,
+    ) {
+        parent::__construct($id);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/ChildEntityDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/ChildEntityDto.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+final class ChildEntityDto
+{
+    public function __construct(
+        public ?int $id = null,
+        public ?string $name = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/ConstructorlessChildEntityDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/ConstructorlessChildEntityDto.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+final class ConstructorlessChildEntityDto
+{
+    public ?int $id = null;
+    public ?string $name = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/MappedBaseEntity.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/MappedBaseEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class MappedBaseEntity
+{
+    #[Map(target: 'secret')]
+    private string $hidden = 'shh';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/MappedChildEntity.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/MappedChildEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: MappedChildEntityDto::class)]
+class MappedChildEntity extends MappedBaseEntity
+{
+    public function __construct(
+        public string $name = 'name',
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/MappedChildEntityDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/MappedChildEntityDto.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+final class MappedChildEntityDto
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $secret = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/RedeclaredBaseEntity.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/RedeclaredBaseEntity.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+class RedeclaredBaseEntity
+{
+    /**
+     * Intentionally `private` on the parent — the child redeclares `$tag` as
+     * `public` so the {@see ClassHierarchyTrait::getAllProperties()} dedup
+     * (`seenNames`) is exercised: only the child's version must be returned.
+     */
+    private string $tag = 'parent-tag';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/RedeclaredChildEntity.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/RedeclaredChildEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: RedeclaredChildEntityDto::class)]
+class RedeclaredChildEntity extends RedeclaredBaseEntity
+{
+    public function __construct(
+        public string $tag = 'child-tag',
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/RedeclaredChildEntityDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/PrivateParentProperty/RedeclaredChildEntityDto.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty;
+
+final class RedeclaredChildEntityDto
+{
+    public function __construct(
+        public ?string $tag = null,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -79,6 +79,13 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransfor
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\ChildEntity;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\ChildEntityDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\ConstructorlessChildEntityDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\MappedChildEntity;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\MappedChildEntityDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\RedeclaredChildEntity;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\RedeclaredChildEntityDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Source as PromotedConstructorSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Target as PromotedConstructorTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructorWithMetadata\Source as PromotedConstructorWithMetadataSource;
@@ -819,5 +826,68 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(ChildWithClassTransformTarget::class, $target->childWithBothTransformers);
         $this->assertSame('both', $target->childWithBothTransformers->name);
         $this->assertTrue($target->childWithBothTransformers->classTransformed);
+    }
+
+    public function testMapsPrivatePropertyFromParentClassWithPropertyAccessor()
+    {
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
+
+        $source = new ChildEntity(id: 42, name: 'Test');
+        $target = $mapper->map($source);
+
+        $this->assertInstanceOf(ChildEntityDto::class, $target);
+        $this->assertSame(42, $target->id);
+        $this->assertSame('Test', $target->name);
+    }
+
+    public function testPrivatePropertyFromParentClassIsIgnoredWithoutPropertyAccessor()
+    {
+        $mapper = new ObjectMapper();
+
+        $source = new ChildEntity(id: 42, name: 'Test');
+        $target = $mapper->map($source);
+
+        $this->assertInstanceOf(ChildEntityDto::class, $target);
+        // without a property accessor, getId() is not discoverable and a non-public property is only readable through magic __get()
+        $this->assertNull($target->id);
+        $this->assertSame('Test', $target->name);
+    }
+
+    public function testRedeclaredPrivateParentPropertyResolvesToChildVersion()
+    {
+        $mapper = new ObjectMapper();
+
+        $source = new RedeclaredChildEntity(tag: 'overridden');
+        $target = $mapper->map($source);
+
+        $this->assertInstanceOf(RedeclaredChildEntityDto::class, $target);
+        $this->assertSame('overridden', $target->tag);
+    }
+
+    public function testMapsPrivateParentPropertyToConstructorlessTarget()
+    {
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
+
+        $source = new ChildEntity(id: 42, name: 'Test');
+        $target = $mapper->map($source, ConstructorlessChildEntityDto::class);
+
+        // the target has no constructor, so the value cannot come through the constructor-arguments path:
+        // the private parent $id is mapped only because it is now discovered as a source property
+        $this->assertSame(42, $target->id);
+        $this->assertSame('Test', $target->name);
+    }
+
+    public function testMappedPrivateParentPropertyWithoutAccessorIsSkippedWithoutWarning()
+    {
+        $mapper = new ObjectMapper();
+
+        $source = new MappedChildEntity(name: 'Test');
+        $target = $mapper->map($source);
+
+        // the parent's private property carries a #[Map] but is unreadable without an accessor or magic __get(),
+        // so it is skipped rather than read (which would emit an "Undefined property" warning)
+        $this->assertInstanceOf(MappedChildEntityDto::class, $target);
+        $this->assertSame('Test', $target->name);
+        $this->assertNull($target->secret);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63651
| License       | MIT

## Summary

When a class extends a parent that declares private properties (e.g. `private int $id`),
ObjectMapper now walks the whole class hierarchy to discover and read them, instead of
relying on `ReflectionClass::getProperties()`, which omits inherited private properties.

## Problem

```php
class BaseEntity {
    private int $id;
    public function getId(): int { return $this->id; }
}

#[Map(target: ChildEntityDto::class)]
class ChildEntity extends BaseEntity {
    public function __construct(int $id, public string $name) {
        parent::__construct($id);
    }
}
```

The inherited private `$id` was never seen by the mapper: `getProperties()`,
`hasProperty()`, `property_exists()` and `isset()` all ignore private properties
declared on a parent class.

## Solution

A small stateless `ClassHierarchyTrait` (shared by `ObjectMapper` and the reflection
metadata factory) traverses the hierarchy:

- `getAllProperties()` – every property, including private ones from parents,
  deduplicated so a redeclared property resolves to the child's version
- `getPropertyFromHierarchy()` – looks a property up by name across the hierarchy

The non-public access rule stays consistent with the rest of the component: an
inherited private property is read through a property accessor / magic `__get()`
when available, and skipped otherwise — never through raw reflection.