### PR TITLE
[Form] Use translation_domain for placeholder in expanded ChoiceType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -437,7 +437,7 @@ class ChoiceType extends AbstractType
             'label_html' => $options['label_html'],
             'attr' => $choiceView->attr,
             'label_translation_parameters' => $choiceView->labelTranslationParameters,
-            'translation_domain' => $options['choice_translation_domain'],
+            'translation_domain' => 'placeholder' === $name ? $options['translation_domain'] : $options['choice_translation_domain'],
             'block_name' => 'entry',
         ];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2109,6 +2109,26 @@ class ChoiceTypeTest extends BaseTypeTestCase
         $this->assertSame('choice_translation_domain', $form->children[1]->vars['translation_domain']);
     }
 
+    public function testPlaceholderUsesTranslationDomainInsteadOfChoiceTranslationDomain()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'translation_domain' => 'form_domain',
+            'choices' => [
+                'choice1' => true,
+                'choice2' => false,
+            ],
+            'choice_translation_domain' => 'choice_domain',
+            'expanded' => true,
+            'required' => false,
+            'placeholder' => 'Please select',
+        ])->createView();
+
+        $this->assertCount(3, $form->children);
+        $this->assertSame('form_domain', $form->children['placeholder']->vars['translation_domain']);
+        $this->assertSame('choice_domain', $form->children[0]->vars['translation_domain']);
+        $this->assertSame('choice_domain', $form->children[1]->vars['translation_domain']);
+    }
+
     #[DataProvider('provideTrimCases')]
     public function testTrimIsDisabled($multiple, $expanded)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63233
| License       | MIT

## Summary

When using an expanded `ChoiceType` (or `EntityType`) with a placeholder and different translation domains, the placeholder was incorrectly using `choice_translation_domain` instead of `translation_domain`.

This PR ensures that the placeholder sub-form uses the form's `translation_domain` option, while regular choice children continue to use `choice_translation_domain`.

As suggested by @stof in #63233:
> This should probably be fixed in ChoiceType, by making sure that the special child added for the placeholder does not use `choice_translation_domain` but keeps using `translation_domain`

## Example

```php
$builder->add('field', EntityType::class, [
    'expanded' => true,
    'required' => false,
    'placeholder' => new TranslatableMessage('select_option'),
    'translation_domain' => 'forms',
    'choice_translation_domain' => false, // disable choice translation
    'class' => MyEntity::class,
]);
```

Before this fix, the placeholder would not be translated because it used `choice_translation_domain` (false).
After this fix, the placeholder correctly uses `translation_domain` ('forms') and gets translated.