### PR TITLE
[FrameworkBundle] Detect env placeholders in resolved route parameter values

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -170,6 +170,10 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
 
             $resolved = ($this->paramFetcher)($match[1]);
 
+            if (\is_string($resolved) && preg_match('/env_[a-f0-9]{16}_\w+_[a-f0-9]{32}/Ui', $resolved)) {
+                throw new RuntimeException(\sprintf('The container parameter "%s" resolves to an env var, which is not allowed in routing configuration.', $match[1]));
+            }
+
             if (\is_scalar($resolved)) {
                 $this->collectedParameters[$match[1]] = $resolved;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -341,6 +341,23 @@ class RouterTest extends TestCase
         $router->getRouteCollection();
     }
 
+    public function testEnvPlaceholderInResolvedValue()
+    {
+        $routes = new RouteCollection();
+
+        $route = new Route('foo');
+        $route->setHost('%route.host%');
+        $routes->add('foo', $route);
+
+        $router = new Router($container = $this->getServiceContainer($routes), 'foo');
+        $container->setParameter('route.host', 'env_abcdef1234567890_APP_HOST_abcdef1234567890abcdef1234567890');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The container parameter "route.host" resolves to an env var, which is not allowed in routing configuration.');
+
+        $router->getRouteCollection();
+    }
+
     public function testHostPlaceholders()
     {
         $routes = new RouteCollection();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62111
| License       | MIT

## Description

When a route parameter like `%route.host%` resolves to a value containing an env placeholder (e.g., when `route.host` is set to `%env(APP_HOST)%`), the Router now detects and rejects this during route collection build.

The existing check only detects direct `%env(...)%` patterns in route configuration. However, when a container parameter indirectly references an env var, the container returns an unresolved env placeholder (format: `env_{16hex}_{name}_{32hex}`) during cache warmup.

This PR adds detection for these env placeholders, ensuring that indirect env var usage is also caught and properly reported with a clear error message.

## Example

```yaml
# config/services.yaml
parameters:
    route.host: '%env(APP_HOST)%'

# config/routes.yaml
my_route:
    path: /foo
    host: '%route.host%'  # This now throws a clear error
```

Before this fix, this would silently fail or produce confusing behavior during cache warmup.
