### PR TITLE
[HttpClient] add an HTTP/2 client using PHP-Standard-Library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,8 @@
         "pda/pheanstalk": "^5.1|^7.0|^8.0",
         "php-http/discovery": "^1.15",
         "php-http/httplug": "^1.0|^2.0",
+        "php-standard-library/http-client": "dev-next",
+        "php-standard-library/dns": "dev-next",
         "phpdocumentor/reflection-docblock": "^5.2|^6.0",
         "phpstan/phpdoc-parser": "^1.0|^2.0",
         "predis/predis": "^1.1|^2.0",

--- a/src/Symfony/Component/HttpClient/Internal/PslBody.php
+++ b/src/Symfony/Component/HttpClient/Internal/PslBody.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Psl\Async\CancellationTokenInterface;
+use Psl\Async\NullCancellationToken;
+use Psl\IO;
+use Symfony\Component\HttpClient\Exception\TransportException;
+
+/**
+ * Request body wrapper that tracks upload progress for PSL HTTP client.
+ *
+ * @author Seifeddine Gmati <azjezz@carthage.software>
+ *
+ * @internal
+ */
+class PslBody implements IO\ReadHandleInterface
+{
+    use IO\ReadHandleConvenienceMethodsTrait;
+
+    private IO\ReadHandleInterface $body;
+    private ?string $content;
+    private array $info;
+    private ?int $offset = 0;
+    private int $length = -1;
+    private ?int $uploaded = null;
+
+    /**
+     * @param \Closure|IO\ReadHandleInterface|resource|string $body
+     */
+    public function __construct(
+        $body,
+        array &$info,
+        private \Closure $onProgress,
+    ) {
+        $this->info = &$info;
+
+        if ($body instanceof IO\ReadHandleInterface) {
+            if ($body instanceof IO\SeekHandleInterface) {
+                $this->offset = $body->tell();
+            }
+
+            $this->body = $body;
+        } elseif (\is_resource($body)) {
+            $this->offset = ftell($body);
+            $this->length = fstat($body)['size'];
+            $this->body = new IO\SeekReadStreamHandle($body);
+        } elseif (\is_string($body)) {
+            $this->content = $body;
+            $this->body = new IO\MemoryHandle($body);
+        } else {
+            $this->body = new IO\IterableReadHandle((static function () use ($body) {
+                while ('' !== $data = ($body)(16372)) {
+                    if (!\is_string($data)) {
+                        throw new TransportException(\sprintf('Return value of the "body" option callback must be string, "%s" returned.', get_debug_type($data)));
+                    }
+
+                    yield $data;
+                }
+            })());
+        }
+    }
+
+    public function read(
+        ?int $maxBytes = null,
+        CancellationTokenInterface $cancellation = new NullCancellationToken(),
+    ): string {
+        $this->info['size_upload'] += $this->uploaded;
+        $this->uploaded = 0;
+        ($this->onProgress)();
+
+        $data = $this->body->read($maxBytes, $cancellation);
+        $this->uploaded = \strlen($data);
+        if ($this->reachedEndOfDataSource()) {
+            $this->info['upload_content_length'] = $this->info['size_upload'];
+        }
+
+        return $data;
+    }
+
+    public function tryRead(?int $maxBytes = null): string
+    {
+        $data = $this->body->tryRead($maxBytes);
+        if ('' !== $data) {
+            $this->uploaded += \strlen($data);
+        }
+
+        return $data;
+    }
+
+    public function reachedEndOfDataSource(): bool
+    {
+        return $this->body->reachedEndOfDataSource();
+    }
+
+    public function rewind(): void
+    {
+        $this->uploaded = null;
+        if (null !== $this->content) {
+            $this->body = new IO\MemoryHandle($this->content);
+
+            return;
+        }
+
+        if (null !== $this->offset && $this->body instanceof IO\SeekHandleInterface) {
+            $this->body->seek($this->offset);
+        }
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/PslClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/PslClientState.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Psl\Async;
+use Psl\DateTime\Duration;
+use Psl\DNS;
+use Psl\HTTP\Client as PslClient;
+use Psl\HTTP\Client\Connection\ConnectionMetadata;
+use Psl\HTTP\Message;
+use Psl\TCP;
+use Psl\TLS;
+use Psl\URL;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Internal representation of the PSL client's state.
+ *
+ * @author Seifeddine Gmati <azjezz@carthage.software>
+ *
+ * @internal
+ */
+final class PslClientState extends ClientState
+{
+    /** @var array<string, string> */
+    public array $dnsCache = [];
+    public int $responseCount = 0;
+
+    private DNS\BlockingSystemResolver $systemResolver;
+
+    /** @var array<string, array{PslClient\Connection\PooledConnector, PslClient\ClientConfiguration, PslClient\SendConfiguration}> */
+    private array $clients = [];
+
+    public function __construct(
+        private ?LoggerInterface &$logger,
+    ) {
+        $this->systemResolver = new DNS\BlockingSystemResolver();
+    }
+
+    /**
+     * @param array<string, mixed> $options Symfony-prepared request options
+     */
+    public function request(
+        array $options,
+        Message\Request $request,
+        Async\CancellationTokenInterface $cancellation,
+        array &$info,
+        \Closure $onProgress,
+        ?\Closure $onInformationalResponse = null,
+    ): Message\Transaction {
+        $info['start_time'] ??= microtime(true);
+
+        if ($options['proxy']) {
+            if ($request->headers->has('proxy-authorization')) {
+                $options['proxy']['auth'] = $request->headers->get('proxy-authorization');
+            }
+
+            // Matching "no_proxy" should follow the behavior of curl
+            $host = $request->url?->authority->host->toString() ?? '';
+            foreach ($options['proxy']['no_proxy'] as $rule) {
+                $dotRule = '.'.ltrim($rule, '.');
+
+                if ('*' === $rule || $host === $rule || str_ends_with($host, $dotRule)) {
+                    $options['proxy'] = null;
+                    break;
+                }
+            }
+        }
+
+        if ($request->headers->has('proxy-authorization')) {
+            $request = $request->withoutHeader('proxy-authorization');
+        }
+
+        [$pooledConnector, $clientConfig, $sendConfig] = $this->getClient($options);
+
+        $isHttps = null !== $request->url && 'https' === $request->url->scheme;
+        if ($isHttps && !$options['http_version']) {
+            $sendConfig = new PslClient\SendConfiguration(
+                tlsConfiguration: $sendConfig->tlsConfiguration,
+                protocolVersions: [Message\ProtocolVersion::V20, Message\ProtocolVersion::V11],
+            );
+        }
+
+        $connectionTimeout = null;
+        if ($options['max_connect_duration'] > 0) {
+            $connectionTimeout = Duration::nanoseconds((int) ($options['max_connect_duration'] * 1e9));
+        }
+
+        $sendConfig = new PslClient\SendConfiguration(
+            maxResponseHeaderSize: $sendConfig->maxResponseHeaderSize,
+            maxResponseBodySize: $sendConfig->maxResponseBodySize,
+            baseUrl: $sendConfig->baseUrl,
+            tlsConfiguration: $sendConfig->tlsConfiguration,
+            protocolVersions: $sendConfig->protocolVersions,
+            proxyConfiguration: $sendConfig->proxyConfiguration,
+            onInformationalResponse: $onInformationalResponse,
+            onConnection: static function (ConnectionMetadata $metadata) use (&$info, $onProgress): void {
+                $info['primary_ip'] = $metadata->peerAddress->host;
+                $info['primary_port'] = $metadata->peerAddress->port ?? 0;
+                $info['local_ip'] = $metadata->localAddress->host;
+                $info['local_port'] = $metadata->localAddress->port ?? 0;
+                $info['connect_time'] = microtime(true) - $info['start_time'];
+                $info['pretransfer_time'] = $info['connect_time'];
+                $onProgress();
+            },
+            connectionTimeout: $connectionTimeout,
+        );
+
+        $resolver = new PslResolver($this->dnsCache, $this->systemResolver);
+        $connector = new DNS\HTTP\Connector($pooledConnector, $resolver);
+        $client = new PslClient\Client(connector: $connector, configuration: $clientConfig);
+
+        $transaction = $client->send($request, $sendConfig, $cancellation);
+
+        $info['starttransfer_time'] = microtime(true) - $info['start_time'];
+
+        return $transaction;
+    }
+
+    /**
+     * @return array{PslClient\Connection\PooledConnector, PslClient\ClientConfiguration, PslClient\SendConfiguration}
+     */
+    private function getClient(array $options): array
+    {
+        $cacheKey = [
+            'bindto' => $options['bindto'] ?: '0',
+            'verify_peer' => $options['verify_peer'],
+            'capath' => $options['capath'],
+            'cafile' => $options['cafile'],
+            'local_cert' => $options['local_cert'],
+            'local_pk' => $options['local_pk'],
+            'ciphers' => $options['ciphers'],
+            'proxy' => $options['proxy'],
+            'crypto_method' => $options['crypto_method'],
+        ];
+
+        $key = hash('xxh128', serialize($cacheKey));
+
+        if (isset($this->clients[$key])) {
+            return $this->clients[$key];
+        }
+
+        $tlsConfig = new TLS\ClientConfiguration();
+
+        if (!$options['verify_peer']) {
+            $tlsConfig = $tlsConfig->withPeerVerification(false);
+        }
+        if ($options['cafile']) {
+            $tlsConfig = $tlsConfig->withCertificateAuthority($options['cafile']);
+        }
+        if ($options['capath']) {
+            $tlsConfig = $tlsConfig->withCertificateAuthorityPath($options['capath']);
+        }
+        if ($options['local_cert']) {
+            $tlsConfig = $tlsConfig->withCertificate(new TLS\Certificate(
+                certificateFile: $options['local_cert'],
+                keyFile: $options['local_pk'] ?? $options['local_cert'],
+                passphrase: $options['passphrase'] ?? null,
+            ));
+        }
+        if ($options['ciphers']) {
+            $tlsConfig = $tlsConfig->withCiphers($options['ciphers']);
+        }
+        if ($options['peer_fingerprint'] && isset($options['peer_fingerprint']['pin-sha256'])) {
+            $pins = (array) $options['peer_fingerprint']['pin-sha256'];
+            $hexPins = [];
+            foreach ($pins as $pin) {
+                $decoded = base64_decode($pin, true);
+                if (false !== $decoded) {
+                    $hexPins['sha256'] = bin2hex($decoded);
+                }
+            }
+            if ($hexPins) {
+                $tlsConfig = $tlsConfig->withPeerFingerprints($hexPins);
+            }
+        }
+
+        $protocolVersions = [Message\ProtocolVersion::V11];
+        if ($options['http_version']) {
+            $protocolVersions = match ((float) $options['http_version']) {
+                1.0 => [Message\ProtocolVersion::V10],
+                1.1 => [Message\ProtocolVersion::V11],
+                default => [Message\ProtocolVersion::V20, Message\ProtocolVersion::V11],
+            };
+        }
+
+        $unixSocket = null;
+        $bindTo = null;
+        if ($options['bindto']) {
+            if (file_exists($options['bindto'])) {
+                $unixSocket = $options['bindto'];
+            } else {
+                $bindTo = $options['bindto'];
+            }
+        }
+
+        $proxyConfig = null;
+        if ($options['proxy']) {
+            $proxyUrl = str_replace(['tcp://', 'ssl://'], ['http://', 'https://'], $options['proxy']['url']);
+
+            $proxyConfig = new PslClient\ProxyConfiguration(
+                url: URL\parse($proxyUrl),
+                authorization: $options['proxy']['auth'] ?? null,
+                skipProxyFor: $options['proxy']['no_proxy'] ?? [],
+            );
+        }
+
+        $clientConfig = new PslClient\ClientConfiguration(
+            tlsConfiguration: $tlsConfig,
+            protocolVersions: $protocolVersions,
+            unixSocket: $unixSocket,
+            proxyConfiguration: $proxyConfig,
+        );
+
+        $sendConfig = new PslClient\SendConfiguration(
+            tlsConfiguration: $tlsConfig,
+            protocolVersions: $protocolVersions,
+        );
+
+        $tcpConfig = new TCP\ConnectConfiguration(noDelay: true, bindTo: $bindTo);
+        $connector = new PslClient\Connection\PooledConnector(
+            tcpConnector: new TCP\Connector($tcpConfig),
+        );
+
+        return $this->clients[$key] = [$connector, $clientConfig, $sendConfig];
+    }
+}

--- a/src/Symfony/Component/HttpClient/Internal/PslResolver.php
+++ b/src/Symfony/Component/HttpClient/Internal/PslResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Psl\Async\CancellationTokenInterface;
+use Psl\Async\NullCancellationToken;
+use Psl\DateTime\Duration;
+use Psl\DNS\Record\AAAARecord;
+use Psl\DNS\Record\ARecord;
+use Psl\DNS\Record\RecordType;
+use Psl\DNS\ResolverConvenienceMethodsTrait;
+use Psl\DNS\ResolverInterface;
+use Psl\DNS\Response;
+use Psl\DNS\ResponseCode;
+use Psl\IP\Address;
+
+/**
+ * DNS resolver with local hostname-to-IP overrides.
+ *
+ * Checks the DNS map first. If the hostname is found, returns a synthetic
+ * A or AAAA response. If not found, delegates to the fallback resolver.
+ *
+ * @author Seifeddine Gmati <azjezz@carthage.software>
+ *
+ * @internal
+ */
+class PslResolver implements ResolverInterface
+{
+    use ResolverConvenienceMethodsTrait;
+
+    /**
+     * @param array<string, string> $dnsMap Hostname-to-IP map (passed by reference so it stays in sync with PslClientState)
+     */
+    public function __construct(
+        private array &$dnsMap,
+        private ResolverInterface $fallback,
+    ) {
+    }
+
+    public function query(
+        string $name,
+        RecordType $type,
+        CancellationTokenInterface $cancellation = new NullCancellationToken(),
+        array $ednsOptions = [],
+    ): Response {
+        $ip = $this->dnsMap[$name] ?? null;
+
+        if (null === $ip) {
+            return $this->fallback->query($name, $type, $cancellation, $ednsOptions);
+        }
+
+        $isIPv6 = str_contains($ip, ':');
+
+        if ($isIPv6 && RecordType::AAAA !== $type) {
+            return new Response(0, ResponseCode::NonExistentDomain, [], [], []);
+        }
+
+        if (!$isIPv6 && RecordType::A !== $type) {
+            return new Response(0, ResponseCode::NonExistentDomain, [], [], []);
+        }
+
+        $record = $isIPv6
+            ? new AAAARecord($name, Duration::hours(1), Address::parse($ip))
+            : new ARecord($name, Duration::hours(1), Address::parse($ip));
+
+        return new Response(0, ResponseCode::NoError, [$record], [], []);
+    }
+}

--- a/src/Symfony/Component/HttpClient/PslHttpClient.php
+++ b/src/Symfony/Component/HttpClient/PslHttpClient.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Psl\DNS\ResolverInterface;
+use Psl\HTTP\Client as PslClient;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\PslClientState;
+use Symfony\Component\HttpClient\Response\PslResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+if (!interface_exists(PslClient\ClientInterface::class) || !interface_exists(ResolverInterface::class)) {
+    throw new \LogicException('You cannot use "Symfony\Component\HttpClient\PslHttpClient" as the "php-standard-library/http-client" or "php-standard-library/dns" package(s) are not installed. Try running "composer require php-standard-library/http-client php-standard-library/dns".');
+}
+
+/**
+ * An HTTP client implementation based on the PHP Standard Library (PSL).
+ *
+ * @author Seifeddine Gmati <azjezz@carthage.software>
+ */
+final class PslHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
+{
+    use HttpClientTrait;
+    use LoggerAwareTrait;
+
+    private array $defaultOptions = HttpClientInterface::OPTIONS_DEFAULTS;
+    private static array $emptyDefaults = HttpClientInterface::OPTIONS_DEFAULTS;
+    private PslClientState $multi;
+
+    /**
+     * @see HttpClientInterface::OPTIONS_DEFAULTS for available options
+     */
+    public function __construct(array $defaultOptions = [])
+    {
+        $this->defaultOptions['buffer'] ??= self::shouldBuffer(...);
+
+        if ($defaultOptions) {
+            [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);
+        }
+
+        $this->multi = new PslClientState($this->logger);
+    }
+
+    /**
+     * @see HttpClientInterface::OPTIONS_DEFAULTS for available options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        [$url, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions);
+
+        $options['proxy'] = self::getProxy($options['proxy'], $url, $options['no_proxy']);
+
+        if ($options['bindto']) {
+            if (str_starts_with($options['bindto'], 'if!')) {
+                throw new TransportException(__CLASS__.' cannot bind to network interfaces, use e.g. CurlHttpClient instead.');
+            }
+            if (str_starts_with($options['bindto'], 'host!')) {
+                $options['bindto'] = substr($options['bindto'], 5);
+            }
+        }
+
+        if (('' !== $options['body'] || 'POST' === $method || isset($options['normalized_headers']['content-length'])) && !isset($options['normalized_headers']['content-type'])) {
+            $options['headers'][] = 'Content-Type: application/x-www-form-urlencoded';
+        }
+
+        if (!isset($options['normalized_headers']['user-agent'])) {
+            $options['headers'][] = 'User-Agent: Symfony HttpClient (PSL)';
+        }
+
+        if (0 < $options['max_duration']) {
+            $options['timeout'] = min($options['max_duration'], $options['timeout']);
+        }
+
+        if ($options['resolve']) {
+            $this->multi->dnsCache = $options['resolve'] + $this->multi->dnsCache;
+        }
+
+        if ($options['peer_fingerprint'] && !isset($options['peer_fingerprint']['pin-sha256'])) {
+            throw new TransportException(__CLASS__.' supports only "pin-sha256" fingerprints.');
+        }
+
+        $options['url'] = implode('', $url);
+
+        if (str_contains($url['authority'] ?? '', '@') && !isset($options['normalized_headers']['authorization'])) {
+            $parsed = parse_url($options['url']);
+            if (isset($parsed['user'])) {
+                $auth = rawurldecode($parsed['user']);
+                if (isset($parsed['pass'])) {
+                    $auth .= ':'.rawurldecode($parsed['pass']);
+                }
+                $options['headers'][] = 'Authorization: Basic '.base64_encode($auth);
+            }
+        }
+        $options['http_method'] = $method;
+
+        if ($options['http_version']) {
+            // Normalize for PSL
+            $options['http_version'] = match ((float) $options['http_version']) {
+                1.0 => '1.0',
+                1.1 => '1.1',
+                default => '2',
+            };
+        }
+
+        return new PslResponse($this->multi, $options, $this->logger);
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        if ($responses instanceof PslResponse) {
+            $responses = [$responses];
+        }
+
+        return new ResponseStream(PslResponse::stream($responses, $timeout));
+    }
+
+    public function reset(): void
+    {
+        $this->multi->dnsCache = [];
+    }
+}

--- a/src/Symfony/Component/HttpClient/Response/PslResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/PslResponse.php
@@ -1,0 +1,491 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Psl\Async;
+use Psl\DateTime\Duration;
+use Psl\HTTP\Message;
+use Psl\IO;
+use Psl\URL;
+use Psr\Log\LoggerInterface;
+use Revolt\EventLoop;
+use Symfony\Component\HttpClient\Chunk\FirstChunk;
+use Symfony\Component\HttpClient\Chunk\InformationalChunk;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\HttpClientTrait;
+use Symfony\Component\HttpClient\Internal\Canary;
+use Symfony\Component\HttpClient\Internal\ClientState;
+use Symfony\Component\HttpClient\Internal\PslBody;
+use Symfony\Component\HttpClient\Internal\PslClientState;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Seifeddine Gmati <azjezz@carthage.software>
+ *
+ * @internal
+ */
+final class PslResponse implements ResponseInterface, StreamableInterface
+{
+    use CommonResponseTrait;
+    use TransportResponseTrait;
+
+    private static string $nextId = 'a';
+
+    private ?array $options;
+    private \Closure $onProgress;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private PslClientState $multi,
+        array $options,
+        ?LoggerInterface $logger,
+    ) {
+        $this->options = &$options;
+        $this->logger = $logger;
+        $this->timeout = $options['timeout'];
+        $this->shouldBuffer = $options['buffer'];
+
+        if ($this->inflate = \extension_loaded('zlib') && !isset($options['normalized_headers']['accept-encoding'])) {
+            $options['headers'][] = 'Accept-Encoding: gzip';
+        }
+
+        $this->initializer = static fn (self $response) => null !== $response->options;
+
+        $info = &$this->info;
+        $headers = &$this->headers;
+
+        $info['url'] = (string) $options['url'];
+        $info['http_method'] = $options['http_method'];
+        $info['start_time'] = null;
+        $info['redirect_url'] = null;
+        $info['original_url'] = $info['url'];
+        $info['redirect_time'] = 0.0;
+        $info['redirect_count'] = 0;
+        $info['size_upload'] = 0.0;
+        $info['size_download'] = 0.0;
+        $info['upload_content_length'] = -1.0;
+        $info['download_content_length'] = -1.0;
+        $info['user_data'] = $options['user_data'];
+        $info['max_duration'] = $options['max_duration'];
+        $info['max_connect_duration'] = $options['max_connect_duration'];
+        $info['debug'] = '';
+
+        $onProgress = $options['on_progress'] ?? static function () {};
+        $onProgress = $this->onProgress = static function () use (&$info, $onProgress) {
+            $info['total_time'] = microtime(true) - $info['start_time'];
+            $onProgress((int) $info['size_download'], ((int) (1 + $info['download_content_length']) ?: 1) - 1, (array) $info);
+        };
+
+        $pause = 0.0;
+        $this->id = $id = self::$nextId;
+        self::$nextId = str_increment(self::$nextId);
+
+        $info['pause_handler'] = static function (float $duration) use (&$pause) {
+            $pause = $duration;
+        };
+
+        $multi->lastTimeout = null;
+        $multi->openHandles[$id] = new Async\Deferred();
+        ++$multi->responseCount;
+
+        $this->canary = new Canary(static function () use ($multi, $id) {
+            if (isset($multi->openHandles[$id])) {
+                $deferred = $multi->openHandles[$id];
+                if (!$deferred->isComplete()) {
+                    $deferred->complete(null);
+                }
+            }
+            unset($multi->openHandles[$id], $multi->handlesActivity[$id]);
+        });
+
+        EventLoop::queue(static function () use ($multi, $id, &$info, &$headers, &$options, $onProgress, &$pause, $logger) {
+            self::generateResponse($multi, $id, $info, $headers, $options, $onProgress, $pause, $logger);
+        });
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        return null !== $type ? $this->info[$type] ?? null : $this->info;
+    }
+
+    public function __serialize(): array
+    {
+        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+    }
+
+    public function __unserialize(array $data): void
+    {
+        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->doDestruct();
+        } finally {
+            if (0 >= --$this->multi->responseCount) {
+                $this->multi->responseCount = 0;
+                $this->multi->dnsCache = [];
+            }
+        }
+    }
+
+    private static function schedule(self $response, array &$runningResponses): void
+    {
+        if (isset($runningResponses[0])) {
+            $runningResponses[0][1][$response->id] = $response;
+        } else {
+            $runningResponses[0] = [$response->multi, [$response->id => $response]];
+        }
+
+        if (!isset($response->multi->openHandles[$response->id])) {
+            $response->multi->handlesActivity[$response->id][] = null;
+            $response->multi->handlesActivity[$response->id][] = null !== $response->info['error'] ? new TransportException($response->info['error']) : null;
+        }
+    }
+
+    /**
+     * @param PslClientState $multi
+     */
+    private static function perform(ClientState $multi, ?array $responses = null): void
+    {
+        if ($responses) {
+            $activeIds = [];
+            foreach ($responses as $response) {
+                try {
+                    if ($response->info['start_time']) {
+                        $response->info['total_time'] = microtime(true) - $response->info['start_time'];
+                        ($response->onProgress)();
+                    }
+                } catch (\Throwable $e) {
+                    $multi->handlesActivity[$response->id][] = null;
+                    $multi->handlesActivity[$response->id][] = $e;
+                }
+
+                $activeIds[$response->id] = true;
+            }
+
+            foreach ($multi->handlesActivity as $id => $_) {
+                if (!isset($activeIds[$id])) {
+                    unset($multi->handlesActivity[$id]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param PslClientState $multi
+     */
+    private static function select(ClientState $multi, float $timeout): int
+    {
+        $delay = new Async\Deferred();
+        $timerId = EventLoop::delay($timeout, static function () use ($delay): void {
+            if (!$delay->isComplete()) {
+                $delay->complete(null);
+            }
+        });
+
+        try {
+            Async\first((static function () use ($delay, $multi) {
+                yield $delay->getAwaitable();
+
+                foreach ($multi->openHandles as $deferred) {
+                    yield $deferred->getAwaitable();
+                }
+            })());
+        } catch (\Throwable) {
+        }
+
+        if ($delay->isComplete()) {
+            return 0;
+        }
+
+        if (!$delay->isComplete()) {
+            $delay->complete(null);
+        }
+        EventLoop::cancel($timerId);
+
+        return 1;
+    }
+
+    private static function generateResponse(PslClientState $multi, string $id, array &$info, array &$headers, array &$options, \Closure $onProgress, float &$pause, ?LoggerInterface $logger): void
+    {
+        try {
+            $logger?->info(\sprintf('Request: "%s %s"', $info['http_method'], $info['url']));
+
+            [$transaction, $cancellation] = self::followRedirects($multi, $id, $info, $headers, $options, $onProgress, $pause, $logger);
+
+            $options = null;
+
+            $multi->handlesActivity[$id][] = new FirstChunk();
+
+            if ('HEAD' === $info['http_method'] || \in_array($info['http_code'], [204, 304], true)) {
+                $multi->handlesActivity[$id][] = null;
+                $multi->handlesActivity[$id][] = null;
+                self::signal($multi, $id);
+
+                return;
+            }
+
+            if (null !== $contentLength = $transaction->response->headers->get('content-length')) {
+                $info['download_content_length'] = (float) $contentLength;
+            }
+
+            $body = $transaction->response->body;
+
+            while (true) {
+                if (!isset($multi->openHandles[$id])) {
+                    return;
+                }
+
+                self::signal($multi, $id);
+
+                if (0 < $pause) {
+                    Async\sleep(Duration::nanoseconds((int) ($pause * 1e9)));
+                }
+
+                if (null === $body || $body->reachedEndOfDataSource()) {
+                    break;
+                }
+
+                $data = $body->read(65536, $cancellation);
+                if ('' === $data) {
+                    break;
+                }
+
+                $info['size_download'] += \strlen($data);
+                $multi->handlesActivity[$id][] = $data;
+            }
+
+            $multi->handlesActivity[$id][] = null;
+            $multi->handlesActivity[$id][] = null;
+        } catch (\Throwable $e) {
+            $multi->handlesActivity[$id][] = null;
+            $multi->handlesActivity[$id][] = $e;
+        } finally {
+            $info['download_content_length'] = $info['size_download'];
+        }
+
+        self::signal($multi, $id);
+    }
+
+    /**
+     * @return array{Message\Transaction, Async\CancellationTokenInterface}
+     */
+    private static function followRedirects(PslClientState $multi, string $id, array &$info, array &$headers, array &$options, \Closure $onProgress, float &$pause, ?LoggerInterface $logger): array
+    {
+        if (0 < $pause) {
+            Async\sleep(Duration::nanoseconds((int) ($pause * 1e9)));
+        }
+
+        $cancellation = new Async\NullCancellationToken();
+        $maxDuration = $options['max_duration'] ?? 0;
+        if ($maxDuration > 0) {
+            $cancellation = new Async\TimeoutCancellationToken(
+                Duration::nanoseconds((int) ($maxDuration * 1e9)),
+            );
+        }
+
+        $headerPairs = [];
+        foreach ($options['headers'] as $v) {
+            $h = explode(': ', $v, 2);
+            if (2 === \count($h)) {
+                $headerPairs[] = [$h[0], $h[1]];
+            }
+        }
+
+        $body = null;
+        if ('' !== $options['body']) {
+            $body = new PslBody($options['body'], $info, $onProgress);
+        }
+
+        $parsedUrl = URL\parse($info['url']);
+
+        $requestProtocol = Message\ProtocolVersion::V11;
+        if ($options['http_version']) {
+            $requestProtocol = match ((float) $options['http_version']) {
+                1.0 => Message\ProtocolVersion::V10,
+                default => Message\ProtocolVersion::V11,
+            };
+        }
+
+        $request = new Message\Request(
+            method: $info['http_method'],
+            url: $parsedUrl,
+            protocolVersion: $requestProtocol,
+            headers: Message\FieldMap::from($headerPairs),
+            body: $body,
+        );
+
+        $onInformationalResponse = static function (Message\Response $response) use ($multi, $id, &$info): void {
+            $informationalHeaders = [];
+            foreach ($response->headers as [$name, $value]) {
+                $informationalHeaders[strtolower($name)][] = $value;
+                $info['response_headers'][] = $name.': '.$value;
+            }
+            $multi->handlesActivity[$id][] = new InformationalChunk($response->status, $informationalHeaders);
+            self::signal($multi, $id);
+        };
+
+        $info['debug'] .= \sprintf("> %s %s HTTP/?\r\n", $info['http_method'], $parsedUrl->path ?: '/');
+        foreach ($headerPairs as [$name, $value]) {
+            $info['debug'] .= "{$name}: {$value}\r\n";
+        }
+        $info['debug'] .= "\r\n";
+
+        $transaction = $multi->request($options, $request, $cancellation, $info, $onProgress, $onInformationalResponse);
+
+        $previousUrl = null;
+
+        while (true) {
+            self::addResponseHeaders($transaction, $info, $headers);
+            $status = $transaction->response->status;
+
+            if (!\in_array($status, [301, 302, 303, 307, 308], true) || null === $location = $transaction->response->headers->get('location')) {
+                return [$transaction, $cancellation];
+            }
+
+            $urlResolver = new class {
+                use HttpClientTrait {
+                    parseUrl as public;
+                    resolveUrl as public;
+                }
+            };
+
+            try {
+                $previousUrl ??= $urlResolver::parseUrl($info['url']);
+                $location = $urlResolver::parseUrl($location);
+                $location = $urlResolver::resolveUrl($location, $previousUrl);
+                $info['redirect_url'] = implode('', $location);
+            } catch (InvalidArgumentException) {
+                return [$transaction, $cancellation];
+            }
+
+            if (0 >= $options['max_redirects'] || $info['redirect_count'] >= $options['max_redirects']) {
+                return [$transaction, $cancellation];
+            }
+
+            $logger?->info(\sprintf('Redirecting: "%s %s"', $status, $info['url']));
+
+            try {
+                // discard the body.
+                IO\copy($transaction->response->body, new IO\SinkWriteHandle());
+            } catch (\Throwable) {
+            }
+
+            ++$info['redirect_count'];
+            $info['url'] = $info['redirect_url'];
+            $info['redirect_url'] = null;
+            $previousUrl = $location;
+
+            $method = $info['http_method'];
+            $newBody = $body;
+            $newHeaders = $headerPairs;
+
+            if (\in_array($status, [301, 302, 303], true)) {
+                $newHeaders = array_values(array_filter($newHeaders, static fn ($h) => !\in_array(strtolower($h[0]), ['transfer-encoding', 'content-length', 'content-type'], true)));
+
+                if ('POST' === $method || 303 === $status) {
+                    $info['http_method'] = 'HEAD' === $method ? 'HEAD' : 'GET';
+                    $method = $info['http_method'];
+                    $newBody = null;
+                }
+            } else {
+                if ($body instanceof PslBody) {
+                    $body->rewind();
+                }
+            }
+
+            $newParsedUrl = URL\parse($info['url']);
+
+            $originalAuthority = (string) $parsedUrl->authority;
+            $newAuthority = (string) $newParsedUrl->authority;
+
+            if ($newAuthority !== $originalAuthority) {
+                $newHeaders = array_filter($newHeaders, static fn ($h) => !\in_array(strtolower($h[0]), ['authorization', 'cookie', 'host'], true));
+            }
+
+            if (null === $newBody) {
+                $hasContentLength = false;
+                foreach ($newHeaders as [$name]) {
+                    if ('content-length' === strtolower($name)) {
+                        $hasContentLength = true;
+                        break;
+                    }
+                }
+                if (!$hasContentLength) {
+                    $newHeaders[] = ['content-length', '0'];
+                }
+            }
+
+            $info['debug'] .= \sprintf("> %s %s HTTP/?\r\n", $method, $newParsedUrl->path ?: '/');
+            foreach ($newHeaders as [$name, $value]) {
+                $info['debug'] .= "{$name}: {$value}\r\n";
+            }
+            $info['debug'] .= "\r\n";
+
+            $request = new Message\Request(
+                method: $method,
+                url: $newParsedUrl,
+                headers: Message\FieldMap::from($newHeaders),
+                body: $newBody,
+            );
+
+            if (0 < $pause) {
+                Async\sleep(Duration::nanoseconds((int) ($pause * 1e9)));
+            }
+
+            $headers = [];
+            $transaction = $multi->request($options, $request, $cancellation, $info, $onProgress, $onInformationalResponse);
+            $info['redirect_time'] = microtime(true) - $info['start_time'];
+        }
+    }
+
+    private static function addResponseHeaders(Message\Transaction $transaction, array &$info, array &$headers): void
+    {
+        $info['http_code'] = $transaction->response->status;
+
+        if ($headers) {
+            $info['debug'] .= "< \r\n";
+            $headers = [];
+        }
+
+        $version = str_replace('HTTP/', '', $transaction->response->protocolVersion->value);
+        $reason = Message\reason_phrase($transaction->response->status);
+        $h = \sprintf('HTTP/%s %s%s', $version, $transaction->response->status, '' !== $reason ? ' '.$reason : '');
+        $info['debug'] .= "< {$h}\r\n";
+        $info['response_headers'][] = $h;
+
+        foreach ($transaction->response->headers as [$name, $value]) {
+            $headers[strtolower($name)][] = $value;
+            $h = $name.': '.$value;
+            $info['debug'] .= "< {$h}\r\n";
+            $info['response_headers'][] = $h;
+        }
+
+        $info['debug'] .= "< \r\n";
+    }
+
+    private static function signal(PslClientState $multi, string $id): void
+    {
+        if (isset($multi->openHandles[$id])) {
+            $deferred = $multi->openHandles[$id];
+            if (!$deferred->isComplete()) {
+                $deferred->complete(null);
+            }
+            $multi->openHandles[$id] = new Async\Deferred();
+        }
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/PslHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/PslHttpClientTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\HttpClient\PslHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\Test\HttpClientTestCase as BaseHttpClientTestCase;
+
+#[Group('dns-sensitive')]
+class PslHttpClientTest extends HttpClientTestCase
+{
+    #[Group('transient')]
+    public function testNonBlockingStream()
+    {
+        parent::testNonBlockingStream();
+    }
+
+    protected function getHttpClient(string $testCase): HttpClientInterface
+    {
+        return new PslHttpClient(['verify_peer' => false, 'verify_host' => false, 'timeout' => 30]);
+    }
+
+    public function testMaxConnectDurationInfo()
+    {
+        BaseHttpClientTestCase::testMaxConnectDurationInfo();
+    }
+
+    public function testMaxConnectDuration()
+    {
+        BaseHttpClientTestCase::testMaxConnectDuration();
+    }
+}

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -34,6 +34,8 @@
         "guzzlehttp/guzzle": "^7.10",
         "nyholm/psr7": "^1.0",
         "php-http/httplug": "^1.0|^2.0",
+        "php-standard-library/http-client": "dev-next",
+        "php-standard-library/dns": "dev-next",
         "psr/http-client": "^1.0",
         "symfony/dependency-injection": "^7.4|^8.0",
         "symfony/cache": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Add's a new HTTP Client based on `Psl\HTTP\Client\ClientInterface`, offering another option for a pure-php HTTP/2 implementation.

This PR is currently marked as ~Draft~ ( carsonbot does not like that )  as the Psl HTTP Client is not yet released ( 6.2 )

- https://github.com/php-standard-library/http-client
- https://github.com/php-standard-library/dns ( needed for DNS resolution connector )
- https://github.com/php-standard-library/php-standard-library ( monorepo )
