### PR TITLE
[Mailer][Azure] Add webhook support for Azure Communication Services Email events

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3148,6 +3148,7 @@ class FrameworkExtension extends Extension
             $debug = $container->getParameter('kernel.debug');
             $webhookRequestParsers = [
                 MailerBridge\AhaSend\Webhook\AhaSendRequestParser::class => ['symfony/aha-send-mailer', 'mailer.webhook.request_parser.ahasend'],
+                MailerBridge\Azure\Webhook\AzureRequestParser::class => ['symfony/azure-mailer', 'mailer.webhook.request_parser.azure'],
                 MailerBridge\Brevo\Webhook\BrevoRequestParser::class => ['symfony/brevo-mailer', 'mailer.webhook.request_parser.brevo'],
                 MailerBridge\MailerSend\Webhook\MailerSendRequestParser::class => ['symfony/mailer-send-mailer', 'mailer.webhook.request_parser.mailersend'],
                 MailerBridge\Mailchimp\Webhook\MailchimpRequestParser::class => ['symfony/mailchimp-mailer', 'mailer.webhook.request_parser.mailchimp'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_webhook.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Mailer\Bridge\AhaSend\RemoteEvent\AhaSendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\AhaSend\Webhook\AhaSendRequestParser;
+use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
+use Symfony\Component\Mailer\Bridge\Azure\Webhook\AzureRequestParser;
 use Symfony\Component\Mailer\Bridge\Brevo\RemoteEvent\BrevoPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Brevo\Webhook\BrevoRequestParser;
 use Symfony\Component\Mailer\Bridge\Mailchimp\RemoteEvent\MailchimpPayloadConverter;
@@ -40,6 +42,11 @@ use Symfony\Component\Mailer\Bridge\TurboSmtp\Webhook\TurboSmtpRequestParser;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
+        ->set('mailer.payload_converter.azure', AzurePayloadConverter::class)
+        ->set('mailer.webhook.request_parser.azure', AzureRequestParser::class)
+            ->args([service('mailer.payload_converter.azure')])
+        ->alias(AzureRequestParser::class, 'mailer.webhook.request_parser.azure')
+
         ->set('mailer.payload_converter.brevo', BrevoPayloadConverter::class)
         ->set('mailer.webhook.request_parser.brevo', BrevoRequestParser::class)
             ->args([service('mailer.payload_converter.brevo')])

--- a/src/Symfony/Component/Mailer/Bridge/Azure/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add webhook support for Azure Communication Services Email events
+
 7.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Azure/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/README.md
@@ -18,6 +18,24 @@ where:
  - `ACS_RESOURCE_NAME` is your Azure Communication Services endpoint resource name (https://ACS_RESOURCE_NAME.communication.azure.com)
  - `KEY` is your Azure Communication Services Email API Key
 
+Webhook
+-------
+
+Azure Event Grid does not sign the events it delivers. It authenticates itself either with a
+Microsoft Entra bearer token, or by repeating the query parameters of the subscription URL on
+every delivery. This bridge uses the second mechanism, so give the subscription URL a `secret`
+query parameter holding the same value as the webhook secret:
+
+```
+https://example.com/webhook/azure?secret=THE_WEBHOOK_SECRET
+```
+
+Requests whose `secret` parameter does not match are rejected with a 401.
+
+Event Grid's automatic subscription handshake is not supported, as it requires echoing a
+validation code in the response body. Register the endpoint with Event Grid's manual
+validation flow instead.
+
 Sponsor
 -------
 

--- a/src/Symfony/Component/Mailer/Bridge/Azure/RemoteEvent/AzurePayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/RemoteEvent/AzurePayloadConverter.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Azure\RemoteEvent;
+
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\RemoteEvent\PayloadConverterInterface;
+
+final class AzurePayloadConverter implements PayloadConverterInterface
+{
+    public function convert(array $payload): AbstractMailerEvent
+    {
+        $eventType = $payload['eventType'] ?? null;
+
+        if ('Microsoft.Communication.EmailDeliveryReportReceived' === $eventType) {
+            return $this->convertDeliveryEvent($payload['data']);
+        }
+
+        if ('Microsoft.Communication.EmailEngagementTrackingReportReceived' === $eventType) {
+            return $this->convertEngagementEvent($payload['data']);
+        }
+
+        throw new ParseException(\sprintf('Unsupported event type "%s".', $eventType));
+    }
+
+    private function convertDeliveryEvent(array $data): MailerDeliveryEvent
+    {
+        if (!\is_string($data['status'] ?? null) || !\is_string($data['recipient'] ?? null) || !\is_string($data['deliveryAttemptTimeStamp'] ?? null)) {
+            throw new ParseException('Payload is missing one of the "status", "recipient" or "deliveryAttemptTimeStamp" keys, or holds a non-string value for one of them.');
+        }
+
+        $name = match ($data['status']) {
+            'Delivered' => MailerDeliveryEvent::DELIVERED,
+            'Bounced' => MailerDeliveryEvent::BOUNCE,
+            'Suppressed', 'Quarantined', 'FilteredSpam', 'Failed' => MailerDeliveryEvent::DROPPED,
+            'Expanded' => MailerDeliveryEvent::DELIVERED,
+            default => throw new ParseException(\sprintf('Unsupported delivery status "%s".', $data['status'])),
+        };
+
+        $event = new MailerDeliveryEvent($name, $data['messageId'], $data);
+
+        if (\is_string($data['deliveryStatusDetails']['statusMessage'] ?? null)) {
+            $event->setReason($data['deliveryStatusDetails']['statusMessage']);
+        }
+
+        $event->setRecipientEmail($data['recipient']);
+
+        $date = $this->parseDate($data['deliveryAttemptTimeStamp']);
+        $event->setDate($date);
+
+        return $event;
+    }
+
+    private function convertEngagementEvent(array $data): MailerEngagementEvent
+    {
+        if (!\is_string($data['engagementType'] ?? null) || !\is_string($data['recipient'] ?? null) || !\is_string($data['userActionTimeStamp'] ?? null)) {
+            throw new ParseException('Payload is missing one of the "engagementType", "recipient" or "userActionTimeStamp" keys, or holds a non-string value for one of them.');
+        }
+
+        $name = match (strtolower($data['engagementType'])) {
+            'view' => MailerEngagementEvent::OPEN,
+            'click' => MailerEngagementEvent::CLICK,
+            default => throw new ParseException(\sprintf('Unsupported engagement type "%s".', $data['engagementType'])),
+        };
+
+        $event = new MailerEngagementEvent($name, $data['messageId'], $data);
+
+        $event->setRecipientEmail($data['recipient']);
+
+        $date = $this->parseDate($data['userActionTimeStamp']);
+        $event->setDate($date);
+
+        return $event;
+    }
+
+    private function parseDate(string $dateString): \DateTimeImmutable
+    {
+        // Azure uses ISO 8601 format with timezone offset
+        // Microseconds can be 6 or 7 digits, normalize to 6 digits
+        $normalizedDate = preg_replace('/(\.\d{6})\d+/', '$1', $dateString);
+
+        $date = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $normalizedDate)
+            ?: \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $normalizedDate)
+            ?: \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sP', $normalizedDate);
+
+        if (!$date) {
+            throw new ParseException(\sprintf('Invalid date "%s".', $dateString));
+        }
+
+        return $date;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureMalformedPayloadRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureMalformedPayloadRequestParserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Azure\Tests\Webhook;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
+use Symfony\Component\Mailer\Bridge\Azure\Webhook\AzureRequestParser;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
+
+class AzureMalformedPayloadRequestParserTest extends AbstractRequestParserTestCase
+{
+    protected function createRequestParser(): RequestParserInterface
+    {
+        $this->expectException(RejectWebhookException::class);
+
+        return new AzureRequestParser(new AzurePayloadConverter());
+    }
+
+    public static function getPayloads(): iterable
+    {
+        yield 'not a list' => ['{"eventType": "Microsoft.Communication.EmailDeliveryReportReceived"}', []];
+        yield 'no event type' => ['[{"data": {"messageId": "id"}}]', []];
+        yield 'no message id' => ['[{"eventType": "Microsoft.Communication.EmailDeliveryReportReceived", "data": {}}]', []];
+        yield 'unknown event type' => ['[{"eventType": "Microsoft.Communication.Unknown", "data": {"messageId": "id"}}]', []];
+        yield 'unknown delivery status' => ['[{"eventType": "Microsoft.Communication.EmailDeliveryReportReceived", "data": {"messageId": "id", "status": "Teleported", "recipient": "a@b.com", "deliveryAttemptTimeStamp": "2026-03-18T00:22:20.285574+00:00"}}]', []];
+        yield 'non-string recipient' => ['[{"eventType": "Microsoft.Communication.EmailDeliveryReportReceived", "data": {"messageId": "id", "status": "Delivered", "recipient": ["a@b.com"], "deliveryAttemptTimeStamp": "2026-03-18T00:22:20.285574+00:00"}}]', []];
+        yield 'subscription validation' => ['[{"eventType": "Microsoft.EventGrid.SubscriptionValidationEvent", "data": {"validationCode": "code"}}]', []];
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/?secret='.self::SECRET, 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+    }
+
+    protected function getSecret(): string
+    {
+        return self::SECRET;
+    }
+
+    private const SECRET = 'the-webhook-secret';
+}

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureRequestParserTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Azure\Tests\Webhook;
+
+use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
+use Symfony\Component\Mailer\Bridge\Azure\Webhook\AzureRequestParser;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
+
+class AzureRequestParserTest extends AbstractRequestParserTestCase
+{
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new AzureRequestParser(new AzurePayloadConverter());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureSecretRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureSecretRequestParserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Azure\Tests\Webhook;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
+use Symfony\Component\Mailer\Bridge\Azure\Webhook\AzureRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+class AzureSecretRequestParserTest extends TestCase
+{
+    public function testRequestWithoutTheConfiguredSecretIsRejected()
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid secret.');
+
+        $this->parse(Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '[]'), 'the-secret');
+    }
+
+    public function testRequestWithAWrongSecretIsRejected()
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid secret.');
+
+        $this->parse(Request::create('/?secret=nope', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '[]'), 'the-secret');
+    }
+
+    public function testRequestWithTheConfiguredSecretIsAccepted()
+    {
+        $events = $this->parse(Request::create('/?secret=the-secret', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], $this->deliveryPayload()), 'the-secret');
+
+        $this->assertCount(1, $events);
+    }
+
+    private function deliveryPayload(): string
+    {
+        return file_get_contents(__DIR__.'/Fixtures/delivery.json');
+    }
+
+    private function parse(Request $request, string $secret): array
+    {
+        return (new AzureRequestParser(new AzurePayloadConverter()))->parse($request, $secret);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/batch.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/batch.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+    "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000001",
+    "data": {
+      "sender": "test@azure.com",
+      "recipient": "receiver@example.com",
+      "messageId": "00000000-0000-0000-0000-000000000001",
+      "status": "Delivered",
+      "deliveryStatusDetails": {
+        "statusMessage": "Message delivered successfully"
+      },
+      "deliveryAttemptTimeStamp": "2026-03-18T00:22:20.2855741+00:00"
+    },
+    "eventType": "Microsoft.Communication.EmailDeliveryReportReceived",
+    "dataVersion": "1.0",
+    "metadataVersion": "1",
+    "eventTime": "2026-03-18T00:22:20.822Z"
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000004",
+    "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+    "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000005",
+    "data": {
+      "sender": "test@azure.com",
+      "recipient": "receiver@example.com",
+      "messageId": "00000000-0000-0000-0000-000000000005",
+      "userActionTimeStamp": "2026-03-18T10:34:52.130359+00:00",
+      "engagementContext": "",
+      "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+      "engagementType": "View"
+    },
+    "eventType": "Microsoft.Communication.EmailEngagementTrackingReportReceived",
+    "dataVersion": "1.0",
+    "metadataVersion": "1",
+    "eventTime": "2026-03-18T10:34:52.688Z"
+  }
+]

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/batch.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/batch.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$payload = json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true);
+
+$wh1 = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, '00000000-0000-0000-0000-000000000001', $payload[0]['data']);
+$wh1->setRecipientEmail('receiver@example.com');
+$wh1->setReason('Message delivered successfully');
+$wh1->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T00:22:20.285574+00:00'));
+
+$wh2 = new MailerEngagementEvent(MailerEngagementEvent::OPEN, '00000000-0000-0000-0000-000000000005', $payload[1]['data']);
+$wh2->setRecipientEmail('receiver@example.com');
+$wh2->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T10:34:52.130359+00:00'));
+
+return [$wh1, $wh2];

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/bounce.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/bounce.json
@@ -1,0 +1,19 @@
+[{
+  "id": "00000000-0000-0000-0000-000000000002",
+  "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+  "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000003",
+  "data": {
+    "sender": "test@azure.com",
+    "recipient": "invalid@example.com",
+    "messageId": "00000000-0000-0000-0000-000000000003",
+    "status": "Bounced",
+    "deliveryStatusDetails": {
+      "statusMessage": "The email address does not exist"
+    },
+    "deliveryAttemptTimeStamp": "2026-03-18T00:25:30.123456+00:00"
+  },
+  "eventType": "Microsoft.Communication.EmailDeliveryReportReceived",
+  "dataVersion": "1.0",
+  "metadataVersion": "1",
+  "eventTime": "2026-03-18T00:25:30.822Z"
+}]

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/bounce.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/bounce.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, '00000000-0000-0000-0000-000000000003', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true)[0]['data']);
+$wh->setRecipientEmail('invalid@example.com');
+$wh->setReason('The email address does not exist');
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T00:25:30.123456+00:00'));
+
+return [$wh];

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/click.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/click.json
@@ -1,0 +1,18 @@
+[{
+  "id": "00000000-0000-0000-0000-000000000006",
+  "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+  "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000007",
+  "data": {
+    "sender": "test@azure.com",
+    "recipient": "receiver@example.com",
+    "messageId": "00000000-0000-0000-0000-000000000007",
+    "userActionTimeStamp": "2026-03-18T11:45:30.9876543+00:00",
+    "engagementContext": "https://example.com/promo",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    "engagementType": "Click"
+  },
+  "eventType": "Microsoft.Communication.EmailEngagementTrackingReportReceived",
+  "dataVersion": "1.0",
+  "metadataVersion": "1",
+  "eventTime": "2026-03-18T11:45:30.688Z"
+}]

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/click.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/click.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, '00000000-0000-0000-0000-000000000007', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true)[0]['data']);
+$wh->setRecipientEmail('receiver@example.com');
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T11:45:30.987654+00:00'));
+
+return [$wh];

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/delivery.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/delivery.json
@@ -1,0 +1,19 @@
+[{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+  "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000001",
+  "data": {
+    "sender": "test@azure.com",
+    "recipient": "receiver@example.com",
+    "messageId": "00000000-0000-0000-0000-000000000001",
+    "status": "Delivered",
+    "deliveryStatusDetails": {
+      "statusMessage": "Message delivered successfully"
+    },
+    "deliveryAttemptTimeStamp": "2026-03-18T00:22:20.2855741+00:00"
+  },
+  "eventType": "Microsoft.Communication.EmailDeliveryReportReceived",
+  "dataVersion": "1.0",
+  "metadataVersion": "1",
+  "eventTime": "2026-03-18T00:22:20.822Z"
+}]

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/delivery.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/delivery.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, '00000000-0000-0000-0000-000000000001', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true)[0]['data']);
+$wh->setRecipientEmail('receiver@example.com');
+$wh->setReason('Message delivered successfully');
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T00:22:20.285574+00:00'));
+
+return [$wh];

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/expanded.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/expanded.json
@@ -1,0 +1,19 @@
+[{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+  "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000001",
+  "data": {
+    "sender": "test@azure.com",
+    "recipient": "receiver@example.com",
+    "messageId": "00000000-0000-0000-0000-000000000001",
+    "status": "Expanded",
+    "deliveryStatusDetails": {
+      "statusMessage": "Status Expanded"
+    },
+    "deliveryAttemptTimeStamp": "2026-03-18T00:22:20.2855741+00:00"
+  },
+  "eventType": "Microsoft.Communication.EmailDeliveryReportReceived",
+  "dataVersion": "1.0",
+  "metadataVersion": "1",
+  "eventTime": "2026-03-18T00:22:20.822Z"
+}]

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/expanded.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/expanded.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, '00000000-0000-0000-0000-000000000001', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true)[0]['data']);
+$wh->setRecipientEmail('receiver@example.com');
+$wh->setReason('Status Expanded');
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T00:22:20.285574+00:00'));
+
+return [$wh];

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/open.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/open.json
@@ -1,0 +1,18 @@
+[{
+  "id": "00000000-0000-0000-0000-000000000004",
+  "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+  "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000005",
+  "data": {
+    "sender": "test@azure.com",
+    "recipient": "receiver@example.com",
+    "messageId": "00000000-0000-0000-0000-000000000005",
+    "userActionTimeStamp": "2026-03-18T10:34:52.130359+00:00",
+    "engagementContext": "",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    "engagementType": "View"
+  },
+  "eventType": "Microsoft.Communication.EmailEngagementTrackingReportReceived",
+  "dataVersion": "1.0",
+  "metadataVersion": "1",
+  "eventTime": "2026-03-18T10:34:52.688Z"
+}]

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/open.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/open.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, '00000000-0000-0000-0000-000000000005', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true)[0]['data']);
+$wh->setRecipientEmail('receiver@example.com');
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T10:34:52.130359+00:00'));
+
+return [$wh];

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/suppressed.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/suppressed.json
@@ -1,0 +1,19 @@
+[{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "topic": "/subscriptions/{subscription-id}/resourceGroups/{group-name}/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
+  "subject": "sender/test@azure.com/message/00000000-0000-0000-0000-000000000001",
+  "data": {
+    "sender": "test@azure.com",
+    "recipient": "receiver@example.com",
+    "messageId": "00000000-0000-0000-0000-000000000001",
+    "status": "Suppressed",
+    "deliveryStatusDetails": {
+      "statusMessage": "Status Suppressed"
+    },
+    "deliveryAttemptTimeStamp": "2026-03-18T00:22:20.2855741+00:00"
+  },
+  "eventType": "Microsoft.Communication.EmailDeliveryReportReceived",
+  "dataVersion": "1.0",
+  "metadataVersion": "1",
+  "eventTime": "2026-03-18T00:22:20.822Z"
+}]

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/suppressed.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/Fixtures/suppressed.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DROPPED, '00000000-0000-0000-0000-000000000001', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true)[0]['data']);
+$wh->setRecipientEmail('receiver@example.com');
+$wh->setReason('Status Suppressed');
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', '2026-03-18T00:22:20.285574+00:00'));
+
+return [$wh];

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Webhook/AzureRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Webhook/AzureRequestParser.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Azure\Webhook;
+
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+/**
+ * Parses Azure Communication Services Email webhook requests.
+ *
+ * Azure Event Grid sends events in CloudEvents schema or Event Grid schema.
+ * This parser handles the Event Grid schema format.
+ *
+ * Event Grid does not sign its payloads. It authenticates itself either with a
+ * Microsoft Entra bearer token or by repeating the query parameters of the
+ * subscription URL on every delivery. This parser uses the latter: configure the
+ * subscription URL with a "secret" query parameter holding the webhook secret.
+ *
+ * Event Grid's automatic subscription handshake (which requires echoing the
+ * validation code in the response body) is not supported: register the
+ * endpoint using Event Grid's manual validation flow instead.
+ *
+ * @see https://learn.microsoft.com/en-us/azure/event-grid/communication-services-email-events
+ */
+final class AzureRequestParser extends AbstractRequestParser
+{
+    public function __construct(
+        private readonly AzurePayloadConverter $converter,
+    ) {
+    }
+
+    protected function getRequestMatcher(): RequestMatcherInterface
+    {
+        return new ChainRequestMatcher([
+            new MethodRequestMatcher('POST'),
+            new IsJsonRequestMatcher(),
+        ]);
+    }
+
+    /**
+     * @return AbstractMailerEvent[]
+     */
+    protected function doParse(Request $request, #[\SensitiveParameter] string $secret): array
+    {
+        if (!hash_equals($secret, (string) $request->query->get('secret'))) {
+            throw new RejectWebhookException(401, 'Invalid secret.');
+        }
+
+        $payload = $request->toArray();
+
+        // Azure Event Grid sends events as an array
+        if (!isset($payload[0])) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        return array_map($this->parseEvent(...), $payload);
+    }
+
+    private function parseEvent(mixed $event): AbstractMailerEvent
+    {
+        // https://learn.microsoft.com/en-us/azure/event-grid/webhook-event-delivery
+        if ('Microsoft.EventGrid.SubscriptionValidationEvent' === ($event['eventType'] ?? null)) {
+            throw new RejectWebhookException(400, 'Event Grid subscription validation is not supported, use the manual validation flow to register the endpoint.');
+        }
+
+        if (!\is_array($event) || !isset($event['eventType']) || !isset($event['data']['messageId'])) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        try {
+            return $this->converter->convert($event);
+        } catch (ParseException $e) {
+            throw new RejectWebhookException(406, $e->getMessage(), $e);
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Azure/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/composer.json
@@ -20,7 +20,8 @@
         "symfony/mailer": "^7.4|^8.0"
     },
     "require-dev": {
-        "symfony/http-client": "^7.4|^8.0"
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/webhook": "^7.4|^8.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Azure\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59879
| License       | MIT

Adds webhook support to the Azure mailer bridge, so that Azure Communication Services Email events reach the `RemoteEvent` component like the events of the other bridges:

```yaml
framework:
    webhook:
        routing:
            azure:
                service: mailer.webhook.request_parser.azure
                secret: '%env(AZURE_WEBHOOK_SECRET)%'
```

`EmailDeliveryReportReceived` becomes a `MailerDeliveryEvent`, `EmailEngagementTrackingReportReceived` a `MailerEngagementEvent`. Event Grid delivers events in batches, and every event of a batch is converted.

Authenticity is checked with a query parameter. Event Grid does not sign its payloads: it authenticates itself either with a Microsoft Entra bearer token, or by repeating the query parameters of the subscription URL on every delivery. This bridge uses the second mechanism, so the subscription URL must carry a `secret` parameter holding the webhook secret:

```
https://example.com/webhook/azure?secret=THE_WEBHOOK_SECRET
```

Requests whose `secret` does not match are rejected with a 401, and malformed payloads with a 406.

Event Grid's automatic subscription handshake is not supported, since it requires echoing a validation code in the response body, which the `WebhookController` does not do. Register the endpoint with Event Grid's manual validation flow instead. The parser reads the Event Grid schema, not the CloudEvents one.

Points for the documentation:

* the Azure bridge now ships `mailer.webhook.request_parser.azure`
* the subscription URL must carry a `secret` query parameter matching the configured webhook secret, because Event Grid signs nothing
* an alternative is to protect the endpoint with Microsoft Entra ID, in which case the bridge's own check can be satisfied with any shared value
* the automatic subscription handshake is not supported, use the manual validation flow
* the parser expects the Event Grid schema, not CloudEvents
