### PR TITLE
[Serializer] Add XmlEncoder::BOOLEAN_REPR context option

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow passing an associative array to `CsvEncoder::HEADERS_KEY` to map and reorder columns when encoding
  * Use the discriminator property of an object to pick its type when several types map to the same class; the first declared type is used when the property is unset or unknown
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
+ * Add the `XmlEncoder::BOOLEAN_REPR` context option to choose the strings representing booleans when encoding, e.g. `['true', 'false']`
 
 8.1
 ---

--- a/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Encoder/XmlEncoderContextBuilder.php
@@ -176,4 +176,14 @@ final class XmlEncoderContextBuilder implements ContextBuilderInterface
     {
         return $this->with(XmlEncoder::PRESERVE_NUMERIC_KEYS, $preserveNumericKeys);
     }
+
+    /**
+     * Configures the strings representing true and false when encoding, e.g. ['true', 'false'] or ['yes', 'no'].
+     *
+     * @param array{0: string, 1: string}|null $booleanRepr
+     */
+    public function withBooleanRepr(?array $booleanRepr): static
+    {
+        return $this->with(XmlEncoder::BOOLEAN_REPR, $booleanRepr);
+    }
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Encoder;
 
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -64,6 +65,12 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     public const IGNORE_EMPTY_ATTRIBUTES = 'ignore_empty_attributes';
     public const PRESERVE_NUMERIC_KEYS = 'preserve_numeric_keys';
 
+    /**
+     * A two-element list with the strings representing true and false when encoding,
+     * e.g. ['true', 'false'] or ['yes', 'no']. Booleans are encoded as 1/0 by default.
+     */
+    public const BOOLEAN_REPR = 'xml_boolean_repr';
+
     private array $defaultContext = [
         self::AS_COLLECTION => false,
         self::DECODER_IGNORED_NODE_TYPES => [\XML_PI_NODE, \XML_COMMENT_NODE],
@@ -78,6 +85,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         self::CDATA_WRAPPING_PATTERN => '/[<>&]/',
         self::IGNORE_EMPTY_ATTRIBUTES => false,
         self::PRESERVE_NUMERIC_KEYS => false,
+        self::BOOLEAN_REPR => null,
     ];
 
     public function __construct(array $defaultContext = [])
@@ -360,7 +368,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
                         $data = $this->serializer->normalize($data, $format, $context);
                     }
                     if (\is_bool($data)) {
-                        $data = (int) $data;
+                        $data = null !== ($booleanRepr = $this->getBooleanRepr($context)) ? $booleanRepr[$data ? 0 : 1] : (int) $data;
                     }
 
                     if ($context[self::IGNORE_EMPTY_ATTRIBUTES] ?? $this->defaultContext[self::IGNORE_EMPTY_ATTRIBUTES]) {
@@ -421,7 +429,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $this->appendNode($parentNode, $data, $format, $context, 'data');
         }
 
-        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : \sprintf('%s resource', get_resource_type($data))));
+        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : \sprintf('"%s" resource', get_resource_type($data))));
     }
 
     /**
@@ -457,6 +465,24 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     }
 
     /**
+     * @return array{0: string, 1: string}|null
+     */
+    private function getBooleanRepr(array $context): ?array
+    {
+        $booleanRepr = \array_key_exists(self::BOOLEAN_REPR, $context) ? $context[self::BOOLEAN_REPR] : $this->defaultContext[self::BOOLEAN_REPR];
+
+        if (null === $booleanRepr) {
+            return null;
+        }
+
+        if (!\is_array($booleanRepr) || [0, 1] !== array_keys($booleanRepr) || '' === $booleanRepr[0] || '' === $booleanRepr[1] || !\is_string($booleanRepr[0]) || !\is_string($booleanRepr[1])) {
+            throw new InvalidArgumentException(\sprintf('The "%s" context option must be a list of the two non-empty strings representing true and false, e.g. ["true", "false"].', self::BOOLEAN_REPR));
+        }
+
+        return [$booleanRepr[0], $booleanRepr[1]];
+    }
+
+    /**
      * Tests the value being passed and decide what sort of element to create.
      *
      * @throws NotEncodableValueException
@@ -486,6 +512,10 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         } elseif (\is_string($val)) {
             return $this->appendText($node, $val);
         } elseif (\is_bool($val)) {
+            if (null !== $booleanRepr = $this->getBooleanRepr($context)) {
+                return $this->appendText($node, $booleanRepr[$val ? 0 : 1]);
+            }
+
             return $this->appendText($node, (int) $val);
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Encoder/XmlEncoderContextBuilderTest.php
@@ -47,6 +47,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             ->withCdataWrapping($values[XmlEncoder::CDATA_WRAPPING])
             ->withCdataWrappingPattern($values[XmlEncoder::CDATA_WRAPPING_PATTERN])
             ->withIgnoreEmptyAttributes($values[XmlEncoder::IGNORE_EMPTY_ATTRIBUTES])
+            ->withBooleanRepr($values[XmlEncoder::BOOLEAN_REPR])
             ->toArray();
 
         $this->assertSame($values, $context);
@@ -70,6 +71,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::CDATA_WRAPPING => false,
             XmlEncoder::CDATA_WRAPPING_PATTERN => '/[<>&"\']/',
             XmlEncoder::IGNORE_EMPTY_ATTRIBUTES => true,
+            XmlEncoder::BOOLEAN_REPR => ['true', 'false'],
         ]];
 
         yield 'With null values' => [[
@@ -88,6 +90,7 @@ class XmlEncoderContextBuilderTest extends TestCase
             XmlEncoder::CDATA_WRAPPING => null,
             XmlEncoder::CDATA_WRAPPING_PATTERN => null,
             XmlEncoder::IGNORE_EMPTY_ATTRIBUTES => null,
+            XmlEncoder::BOOLEAN_REPR => null,
         ]];
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
@@ -863,6 +864,94 @@ class XmlEncoderTest extends TestCase
         $this->assertEquals($expectedXml, $actualXml);
     }
 
+    public function testEncodeXmlWithBooleanRepr()
+    {
+        $expectedXml = <<<'XML'
+            <?xml version="1.0"?>
+            <response active="true"><foo>true</foo><bar>false</bar></response>
+
+            XML;
+
+        $actualXml = $this->encoder->encode(['@active' => true, 'foo' => true, 'bar' => false], 'xml', [XmlEncoder::BOOLEAN_REPR => ['true', 'false']]);
+
+        $this->assertEquals($expectedXml, $actualXml);
+    }
+
+    public function testEncodeXmlWithCustomBooleanRepr()
+    {
+        $expectedXml = <<<'XML'
+            <?xml version="1.0"?>
+            <response enabled="yes"><foo>yes</foo><bar>no</bar></response>
+
+            XML;
+
+        $encoder = new XmlEncoder([XmlEncoder::BOOLEAN_REPR => ['yes', 'no']]);
+        $actualXml = $encoder->encode(['@enabled' => true, 'foo' => true, 'bar' => false], 'xml');
+
+        $this->assertEquals($expectedXml, $actualXml);
+    }
+
+    public function testEncodeScalarRootBooleanWithBooleanRepr()
+    {
+        $expectedXml = <<<'XML'
+            <?xml version="1.0"?>
+            <response>true</response>
+
+            XML;
+
+        $actualXml = $this->encoder->encode(true, 'xml', [XmlEncoder::BOOLEAN_REPR => ['true', 'false']]);
+
+        $this->assertEquals($expectedXml, $actualXml);
+    }
+
+    public function testEncodeBooleansAsIntegersByDefault()
+    {
+        $expectedXml = <<<'XML'
+            <?xml version="1.0"?>
+            <response active="1"><foo>1</foo><bar>0</bar></response>
+
+            XML;
+
+        $actualXml = $this->encoder->encode(['@active' => true, 'foo' => true, 'bar' => false], 'xml');
+
+        $this->assertEquals($expectedXml, $actualXml);
+    }
+
+    #[DataProvider('provideInvalidBooleanRepr')]
+    public function testEncodeWithInvalidBooleanReprThrows(mixed $booleanRepr)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "xml_boolean_repr" context option must be a list of the two non-empty strings representing true and false, e.g. ["true", "false"].');
+
+        $this->encoder->encode(['foo' => true], 'xml', [XmlEncoder::BOOLEAN_REPR => $booleanRepr]);
+    }
+
+    public static function provideInvalidBooleanRepr(): iterable
+    {
+        yield 'not an array' => ['true'];
+        yield 'one element' => [['true']];
+        yield 'three elements' => [['true', 'false', 'maybe']];
+        yield 'non-string elements' => [[1, 0]];
+        yield 'associative array' => [['true' => 'yes', 'false' => 'no']];
+        yield 'empty true' => [['', 'no']];
+        yield 'empty false' => [['yes', '']];
+    }
+
+    public function testEncodeXmlWithBooleanReprDisabledInContext()
+    {
+        $encoder = new XmlEncoder([XmlEncoder::BOOLEAN_REPR => ['yes', 'no']]);
+
+        $expectedXml = <<<'XML'
+            <?xml version="1.0"?>
+            <response active="1"><foo>0</foo></response>
+
+            XML;
+
+        $actualXml = $encoder->encode(['@active' => true, 'foo' => false], 'xml', [XmlEncoder::BOOLEAN_REPR => null]);
+
+        $this->assertEquals($expectedXml, $actualXml);
+    }
+
     public function testEncodeXmlWithDomNodeValue()
     {
         $expectedXml = <<<'XML'
@@ -898,7 +987,7 @@ class XmlEncoderTest extends TestCase
     public function testNotEncodableValueExceptionMessageForAResource()
     {
         $this->expectException(NotEncodableValueException::class);
-        $this->expectExceptionMessage('An unexpected value could not be serialized: stream resource');
+        $this->expectExceptionMessage('An unexpected value could not be serialized: "stream" resource');
 
         (new XmlEncoder())->encode(tmpfile(), 'xml');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58305
| License       | MIT

Booleans are encoded as `1` and `0` in XML. The new `XmlEncoder::BOOLEAN_REPR` context option says how they should be written instead, as the pair of strings meaning true and false:

```php
$encoder->encode(['@active' => true, 'enabled' => false], 'xml', [
    XmlEncoder::BOOLEAN_REPR => ['true', 'false'],
]);
// <response active="true"><enabled>false</enabled></response>
```

Any pair works, so `['yes', 'no']` or `['Y', 'N']` are equally valid. It applies to element text and to attributes alike, and it can be set on the encoder for the whole application:

```php
new XmlEncoder([XmlEncoder::BOOLEAN_REPR => ['true', 'false']]);
```

Passing `null` in a per-call context turns it back off, which restores the `1` and `0` output for that call. `XmlEncoderContextBuilder::withBooleanRepr()` is available for both.

Nothing changes without the option: booleans are still written as `1` and `0` by default.

Decoding is unchanged and out of scope, as discussed in #58305: `<foo>true</foo>` decodes to the string `"true"`, exactly as `<foo>1</foo>` decodes to `"1"` today.

Points for the documentation:

* `XmlEncoder::BOOLEAN_REPR` takes a list of exactly two non-empty strings, the first meaning true
* it applies to element text and to attributes
* it can be set in the constructor's default context, per call, or through `XmlEncoderContextBuilder::withBooleanRepr()`
* `null` per call disables it and restores the default `1` and `0`
* decoding is not affected, values still come back as strings
