### PR TITLE
[HttpFoundation][HttpKernel] Handle any +json/+xml media type in #[MapRequestPayload]

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Deprecate the `Request::$trustedHosts` property, it is never populated anymore
  * Report the actual header value when the `ResponseHeaderSame` constraint fails
  * Add `ClearableSessionHandlerInterface` for clearing all session data
+ * Add `Request::getStructuredSuffixFormat()` to resolve a mime type to the format of its structured syntax suffix, e.g. `application/vnd.api+json` to `json`
 
 8.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1362,11 +1362,8 @@ class Request
             return null;
         }
 
-        if (str_starts_with($canonicalMimeType, 'application/') && str_contains($canonicalMimeType, '+')) {
-            $suffix = substr(strrchr($canonicalMimeType, '+'), 1);
-            if (isset(self::STRUCTURED_SUFFIX_FORMATS[$suffix])) {
-                return self::STRUCTURED_SUFFIX_FORMATS[$suffix];
-            }
+        if (null !== $suffixFormat = self::getStructuredSuffixFormat($canonicalMimeType)) {
+            return $suffixFormat;
         }
 
         if ($subtypeFallback && str_contains($canonicalMimeType, '/')) {
@@ -1380,6 +1377,33 @@ class Request
         }
 
         return null;
+    }
+
+    /**
+     * Gets the format associated with the structured syntax suffix of the mime type.
+     *
+     * Unlike getFormat(), registered formats take no part in the resolution: only
+     * the "+suffix" of an "application/*" mime type is considered, e.g.
+     * "application/vnd.api+json" -> "json". Use it when the underlying
+     * serialization format matters more than the registered alias.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc6839
+     */
+    public static function getStructuredSuffixFormat(?string $mimeType): ?string
+    {
+        if (!$mimeType) {
+            return null;
+        }
+
+        if (false !== $pos = strpos($mimeType, ';')) {
+            $mimeType = trim(substr($mimeType, 0, $pos));
+        }
+
+        if (!str_starts_with($mimeType, 'application/') || false === $suffix = strrchr($mimeType, '+')) {
+            return null;
+        }
+
+        return self::STRUCTURED_SUFFIX_FORMATS[substr($suffix, 1)] ?? null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -625,6 +625,28 @@ b'])]
         ];
     }
 
+    #[DataProvider('getStructuredSuffixFormatProvider')]
+    public function testGetStructuredSuffixFormat(?string $expectedFormat, ?string $mimeType)
+    {
+        $this->assertSame($expectedFormat, Request::getStructuredSuffixFormat($mimeType));
+    }
+
+    public static function getStructuredSuffixFormatProvider()
+    {
+        return [
+            'registered alias resolves to its suffix format' => ['json', 'application/vnd.api+json'],
+            'unregistered media type resolves to its suffix format' => ['json', 'application/vnd.acme.error+json'],
+            'xml suffix' => ['xml', 'application/hal+xml'],
+            'last suffix wins' => ['xml', 'application/foo+bar+xml'],
+            'parameters are ignored' => ['json', 'application/vnd.api+json; charset=utf-8'],
+            'no suffix' => [null, 'application/json'],
+            'unknown suffix' => [null, 'application/foo+bar'],
+            'non-application type' => [null, 'image/svg+xml'],
+            'empty mime type' => [null, ''],
+            'null mime type' => [null, null],
+        ];
+    }
+
     public function testGetUri()
     {
         $server = [];

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Deprecate the `HIncludeFragmentRenderer` class, use the `EsiFragmentRenderer` or `InlineFragmentRenderer`, or Symfony UX Turbo, instead
  * Allow union and intersection type-hints when autowiring controller arguments
  * Add the `$excludedPaths` and `$excludedHttpCodes` arguments to `ProfilerListener::__construct()` to skip profiling some requests
+ * Make `#[MapRequestPayload]` deserialize any media type carrying a structured syntax suffix with the encoder of the suffix format, e.g. `application/vnd.api+json` with the `json` encoder
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException as SerializerInvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
@@ -257,6 +258,10 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
         if ($attribute->acceptFormat && !\in_array($format, (array) $attribute->acceptFormat, true)) {
             throw new UnsupportedMediaTypeHttpException(\sprintf('Unsupported format, expects "%s", but "%s" given.', implode('", "', (array) $attribute->acceptFormat), $format));
+        }
+
+        if (!$this->serializer instanceof DecoderInterface || !$this->serializer->supportsDecoding($format)) {
+            $format = Request::getStructuredSuffixFormat($request->headers->get('CONTENT_TYPE')) ?? $format;
         }
 
         $type = match (true) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Buz;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\BasicTypesController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\ControllerAttributesController;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
@@ -957,6 +958,92 @@ class RequestPayloadValueResolverTest extends TestCase
             'content' => '{"@context": "https://schema.org", "@type": "FakeType", "price": 50}',
             'expectedExceptionMessage' => 'Unsupported format, expects "json", "xml", but "jsonld" given.',
         ];
+    }
+
+    #[DataProvider('provideStructuredSuffixContext')]
+    public function testPayloadWithStructuredSuffixMediaTypeUsesSuffixFormat(mixed $acceptFormat, string $contentType, string $content)
+    {
+        $encoders = ['json' => new JsonEncoder(), 'xml' => new XmlEncoder()];
+        $serializer = new Serializer([new ObjectNormalizer()], $encoders);
+        $validator = (new ValidatorBuilder())->getValidator();
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => $contentType], $content);
+
+        $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(acceptFormat: $acceptFormat),
+        ]);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertEquals([new RequestPayload(50)], $event->getArguments());
+    }
+
+    public static function provideStructuredSuffixContext(): iterable
+    {
+        yield 'registered +json alias uses the json encoder' => [
+            'acceptFormat' => null,
+            'contentType' => 'application/vnd.api+json',
+            'content' => '{"price": 50}',
+        ];
+
+        yield 'unregistered +json media type uses the json encoder' => [
+            'acceptFormat' => null,
+            'contentType' => 'application/vnd.acme.error+json',
+            'content' => '{"price": 50}',
+        ];
+
+        yield 'registered +xml alias uses the xml encoder' => [
+            'acceptFormat' => null,
+            'contentType' => 'application/hal+xml',
+            'content' => '<?xml version="1.0"?><request><price>50</price></request>',
+        ];
+
+        yield 'acceptFormat matches the alias before normalization' => [
+            'acceptFormat' => 'jsonapi',
+            'contentType' => 'application/vnd.api+json',
+            'content' => '{"price": 50}',
+        ];
+    }
+
+    public function testPayloadFormatSupportedByTheSerializerIsNotNormalized()
+    {
+        $jsonapiDecoder = new class implements DecoderInterface {
+            public function decode(string $data, string $format, array $context = []): mixed
+            {
+                $decoded = json_decode($data, true);
+                $decoded['price'] *= 21;
+
+                return $decoded;
+            }
+
+            public function supportsDecoding(string $format): bool
+            {
+                return 'jsonapi' === $format;
+            }
+        };
+
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder(), 'jsonapi' => $jsonapiDecoder]);
+        $validator = (new ValidatorBuilder())->getValidator();
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/vnd.api+json'], '{"price": 50}');
+
+        $argument = new ArgumentMetadata('valid', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertEquals([new RequestPayload(1050)], $event->getArguments());
     }
 
     #[DataProvider('provideValidationGroupsOnManyTypes')]

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -21,7 +21,7 @@
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^7.4|^8.0",
         "symfony/event-dispatcher": "^7.4|^8.0",
-        "symfony/http-foundation": "^7.4|^8.0",
+        "symfony/http-foundation": "^8.2",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60701
| License       | MIT

`#[MapRequestPayload]` rejects any media type whose registered format name has no matching Serializer encoder, even when the underlying payload is plain JSON or XML: `application/vnd.api+json` resolves to the `jsonapi` format, no `jsonapi` encoder exists out of the box, so the request fails with a 415 (#60701).

`mapRequestPayload()` now normalizes the format to its structured syntax suffix (RFC 6839) before deserializing, through a new `Request::getStructuredSuffixFormat()` helper (`getFormat()` delegates its existing suffix parsing to it, so the logic lives in one place). Media types that start working out of the box:

- `application/vnd.api+json`, `application/ld+json`, `application/problem+json` and `application/hal+json` are deserialized by the `json` encoder;
- `application/hal+xml` and `application/atom+xml` by the `xml` encoder;
- `application/xhtml+xml` moves from the undecodable `html` format to `xml`.

Two guards keep existing behavior intact, each pinned by a test:

- the normalization happens after the `acceptFormat` check, so `acceptFormat: 'jsonapi'` keeps matching the alias;
- it is skipped when the application serializer already decodes the original format (`supportsDecoding()`), so custom encoders and format-scoped normalizers (e.g. API Platform`s `jsonld`/`jsonapi`) keep receiving their own format.

Unregistered `application/*+json` media types already resolved to `json` through the suffix fallback of `getFormat()`; this PR does not change them.