### PR TITLE
[Validator] Add cascadedGroups option to Valid constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add the `Cron` constraint to validate cron expressions
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`
+ * Add the `cascadedGroups` option to the `Valid` constraint to choose the groups the nested object is validated in; an empty array skips the nested validation
 
 8.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/Valid.php
+++ b/src/Symfony/Component/Validator/Constraints/Valid.php
@@ -25,10 +25,22 @@ class Valid extends Constraint
     public bool $traverse = true;
 
     /**
-     * @param string[]|null $groups
-     * @param bool|null     $traverse Whether to validate {@see \Traversable} objects (defaults to true)
+     * Groups to use when validating the nested object.
+     *
+     * If null (default), the current group from the context is used (existing behavior).
+     * If an array is provided, these groups are used instead; an empty array
+     * skips the nested validation entirely.
+     *
+     * @var string[]|null
      */
-    public function __construct(?array $options = null, ?array $groups = null, $payload = null, ?bool $traverse = null)
+    public ?array $cascadedGroups = null;
+
+    /**
+     * @param string[]|null $groups
+     * @param bool|null     $traverse       Whether to validate {@see \Traversable} objects (defaults to true)
+     * @param string[]|null $cascadedGroups Groups to use when validating the nested object
+     */
+    public function __construct(?array $options = null, ?array $groups = null, $payload = null, ?bool $traverse = null, ?array $cascadedGroups = null)
     {
         if (null !== $options) {
             throw new InvalidArgumentException(\sprintf('Passing an array of options to configure the "%s" constraint is no longer supported.', static::class));
@@ -37,6 +49,7 @@ class Valid extends Constraint
         parent::__construct(null, $groups, $payload);
 
         $this->traverse = $traverse ?? $this->traverse;
+        $this->cascadedGroups = $cascadedGroups ?? $this->cascadedGroups;
     }
 
     public function __get(string $option): mixed
@@ -52,6 +65,16 @@ class Valid extends Constraint
     public function addImplicitGroupName(string $group): void
     {
         if (null !== $this->groups) {
+            parent::addImplicitGroupName($group);
+
+            return;
+        }
+
+        // with cascaded groups but no explicit groups, the constraint must join the
+        // default group to be executed at all; without either, cascading is handled
+        // by the metadata (see GenericMetadata::addConstraint()) and it stays group-less
+        if (null !== $this->cascadedGroups) {
+            $this->groups = [self::DEFAULT_GROUP];
             parent::addImplicitGroupName($group);
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/ValidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ValidValidator.php
@@ -30,9 +30,15 @@ class ValidValidator extends ConstraintValidator
             return;
         }
 
+        if ([] === $constraint->cascadedGroups) {
+            return;
+        }
+
+        $groups = $constraint->cascadedGroups ?? $this->context->getGroup();
+
         $this->context
             ->getValidator()
             ->inContext($this->context)
-            ->validate($value, null, $this->context->getGroup());
+            ->validate($value, null, $groups);
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -109,11 +109,16 @@ class GenericMetadata implements MetadataInterface
         }
 
         if ($constraint instanceof Valid && null === $constraint->groups) {
-            $this->cascadingStrategy = CascadingStrategy::CASCADE;
-            $this->traversalStrategy = $constraint->traverse ? TraversalStrategy::IMPLICIT : TraversalStrategy::NONE;
+            if (null !== $constraint->cascadedGroups) {
+                // the constraint must join the default group to be executed, and thus honor its cascaded groups
+                $constraint->groups = [Constraint::DEFAULT_GROUP];
+            } else {
+                $this->cascadingStrategy = CascadingStrategy::CASCADE;
+                $this->traversalStrategy = $constraint->traverse ? TraversalStrategy::IMPLICIT : TraversalStrategy::NONE;
 
-            // The constraint is not added
-            return $this;
+                // The constraint is not added
+                return $this;
+            }
         }
 
         if ($constraint instanceof DisableAutoMapping || $constraint instanceof EnableAutoMapping) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidTest.php
@@ -49,6 +49,31 @@ class ValidTest extends TestCase
         self::assertSame(['my_group'], $cConstraint->groups);
         self::assertSame('some attached data', $cConstraint->payload);
     }
+
+    public function testCascadedGroupsCanBeSet()
+    {
+        $constraint = new Valid(cascadedGroups: ['Default', 'extra']);
+
+        $this->assertSame(['Default', 'extra'], $constraint->cascadedGroups);
+    }
+
+    public function testCascadedGroupsAreNullByDefault()
+    {
+        $constraint = new Valid();
+
+        $this->assertNull($constraint->cascadedGroups);
+    }
+
+    public function testCascadedGroupsWithGroupsAttribute()
+    {
+        $metadata = new ClassMetadata(ValidDummyWithCascadedGroups::class);
+        $loader = new AttributeLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        [$constraint] = $metadata->getPropertyMetadata('nested')[0]->getConstraints();
+        self::assertSame(['trigger_group'], $constraint->groups);
+        self::assertSame(['Default', 'extra'], $constraint->cascadedGroups);
+    }
 }
 
 class ValidDummy
@@ -61,4 +86,10 @@ class ValidDummy
 
     #[Valid(groups: ['my_group'], payload: 'some attached data')]
     private $c;
+}
+
+class ValidDummyWithCascadedGroups
+{
+    #[Valid(groups: ['trigger_group'], cascadedGroups: ['Default', 'extra'])]
+    private $nested;
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
@@ -39,6 +39,62 @@ class ValidValidatorTest extends TestCase
 
         $this->assertCount(0, $violations);
     }
+
+    public function testCascadedGroupsAreUsedForNestedValidation()
+    {
+        $validatorBuilder = new ValidatorBuilder();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
+
+        $parent = new ParentWithCascadedGroups();
+        $violations = $validator->validate($parent, null, ['trigger']);
+
+        // Should have 2 violations: one for Default group constraint, one for extra group constraint
+        $this->assertCount(2, $violations);
+    }
+
+    public function testCascadedGroupsWithoutExplicitGroups()
+    {
+        $validatorBuilder = new ValidatorBuilder();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
+
+        // the natural spelling: no explicit "groups", validated in the Default group
+        $violations = $validator->validate(new ParentWithNaturalCascadedGroups());
+
+        $this->assertCount(2, $violations);
+    }
+
+    public function testEmptyCascadedGroupsSkipTheNestedValidation()
+    {
+        $validatorBuilder = new ValidatorBuilder();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
+
+        $violations = $validator->validate(new ParentWithEmptyCascadedGroups(), null, ['trigger']);
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testCascadedGroupsWithAnExplicitConstraint()
+    {
+        $validatorBuilder = new ValidatorBuilder();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
+
+        $violations = $validator->validate(new ChildWithMultipleGroups(), new Assert\Valid(cascadedGroups: ['Default', 'extra']));
+
+        $this->assertCount(2, $violations);
+    }
+
+    public function testCascadedGroupsDefaultBehaviorPreserved()
+    {
+        $validatorBuilder = new ValidatorBuilder();
+        $validator = $validatorBuilder->enableAttributeMapping()->getValidator();
+
+        // Without cascadedGroups, only the current group should be used
+        $parent = new ParentWithoutCascadedGroups();
+        $violations = $validator->validate($parent, null, ['trigger']);
+
+        // Should have only 1 violation: only the 'trigger' group constraint is validated
+        $this->assertCount(1, $violations);
+    }
 }
 
 class Foo
@@ -67,4 +123,60 @@ class FooBarBaz
 {
     #[Assert\NotBlank(groups: ['nested'])]
     public $foo;
+}
+
+class ParentWithCascadedGroups
+{
+    #[Assert\Valid(groups: ['trigger'], cascadedGroups: ['Default', 'extra'])]
+    public $child;
+
+    public function __construct()
+    {
+        $this->child = new ChildWithMultipleGroups();
+    }
+}
+
+class ParentWithNaturalCascadedGroups
+{
+    #[Assert\Valid(cascadedGroups: ['Default', 'extra'])]
+    public $child;
+
+    public function __construct()
+    {
+        $this->child = new ChildWithMultipleGroups();
+    }
+}
+
+class ParentWithEmptyCascadedGroups
+{
+    #[Assert\Valid(groups: ['trigger'], cascadedGroups: [])]
+    public $child;
+
+    public function __construct()
+    {
+        $this->child = new ChildWithMultipleGroups();
+    }
+}
+
+class ParentWithoutCascadedGroups
+{
+    #[Assert\Valid(groups: ['trigger'])]
+    public $child;
+
+    public function __construct()
+    {
+        $this->child = new ChildWithMultipleGroups();
+    }
+}
+
+class ChildWithMultipleGroups
+{
+    #[Assert\NotBlank]
+    public $defaultField;
+
+    #[Assert\NotBlank(groups: ['extra'])]
+    public $extraField;
+
+    #[Assert\NotBlank(groups: ['trigger'])]
+    public $triggerField;
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Traverse;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\XmlFileLoader;
@@ -55,6 +56,19 @@ class XmlFileLoaderTest extends TestCase
         $metadata = new ClassMetadata('\stdClass');
 
         $this->assertFalse($loader->loadClassMetadata($metadata));
+    }
+
+    public function testLoadValidConstraintWithCascadedGroups()
+    {
+        $loader = new XmlFileLoader(__DIR__.'/valid-cascaded-groups.xml');
+        $metadata = new ClassMetadata(Entity::class);
+
+        $this->assertTrue($loader->loadClassMetadata($metadata));
+
+        [$constraint] = $metadata->getPropertyMetadata('reference')[0]->getConstraints();
+
+        $this->assertInstanceOf(Valid::class, $constraint);
+        $this->assertSame(['Default', 'extra'], $constraint->cascadedGroups);
     }
 
     public function testLoadClassMetadata()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Required;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
@@ -99,6 +100,19 @@ class YamlFileLoaderTest extends TestCase
         $metadata = new ClassMetadata(\stdClass::class);
 
         $this->assertFalse($loader->loadClassMetadata($metadata));
+    }
+
+    public function testLoadValidConstraintWithCascadedGroups()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/valid-cascaded-groups.yml');
+        $metadata = new ClassMetadata(Entity::class);
+
+        $this->assertTrue($loader->loadClassMetadata($metadata));
+
+        [$constraint] = $metadata->getPropertyMetadata('reference')[0]->getConstraints();
+
+        $this->assertInstanceOf(Valid::class, $constraint);
+        $this->assertSame(['Default', 'extra'], $constraint->cascadedGroups);
     }
 
     public function testLoadClassMetadata()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/valid-cascaded-groups.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/valid-cascaded-groups.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+  <class name="Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity">
+    <property name="reference">
+      <constraint name="Valid">
+        <option name="cascadedGroups">
+          <value>Default</value>
+          <value>extra</value>
+        </option>
+      </constraint>
+    </property>
+  </class>
+</constraint-mapping>

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/valid-cascaded-groups.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/valid-cascaded-groups.yml
@@ -1,0 +1,5 @@
+Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
+  properties:
+    reference:
+      - Valid:
+          cascadedGroups: [Default, extra]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Related to #32900
| License       | MIT

## Summary

This adds a `cascadedGroups` option to the `Valid` constraint to choose the groups the nested object is validated in, instead of the current group of the context:

```php
class Order
{
    // the natural spelling: no explicit "groups" needed
    #[Assert\Valid(cascadedGroups: ['Default', 'billing'])]
    public Address $address;
}
```

* If `cascadedGroups` is null (default), the current group is cascaded, as before.
* If a list is given, the nested object is validated in these groups.
* An empty array skips the nested validation entirely.

The option works from the attribute, from XML and YAML mappings, from `ClassMetadata`, and when passing a `Valid` constraint explicitly to `Validator::validate()`.

## Scope note

This covers the static form of #32900: the groups to cascade are a fixed list. The dynamic form (propagating whatever group set the caller is currently validating) is not addressed here, as `ExecutionContextInterface::getGroup()` only exposes a single group. Hence "Related to" rather than "Fix".
