### PR TITLE
[Ldap] Make the Adapter resettable

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterLdapLocatorPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterLdapLocatorPass.php
@@ -30,8 +30,9 @@ class RegisterLdapLocatorPass implements CompilerPassInterface
         $definition = $container->setDefinition('security.ldap_locator', new Definition(ServiceLocator::class));
 
         $locators = [];
-        foreach ($container->findTaggedServiceIds('ldap') as $serviceId => $tags) {
-            $locators[$serviceId] = new ServiceClosureArgument(new Reference($serviceId));
+        foreach ($container->findTaggedServiceIds('ldap') as $id => $tags) {
+            $locators[$id] = new ServiceClosureArgument(new Reference($id));
+            $container->getDefinition($id)->addTag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore']);
         }
 
         $definition->addArgument($locators);

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
@@ -67,4 +67,9 @@ class Adapter implements AdapterInterface
 
         return $value;
     }
+
+    public function reset(): void
+    {
+        unset($this->entryManager, $this->connection);
+    }
 }

--- a/src/Symfony/Component/Ldap/Ldap.php
+++ b/src/Symfony/Component/Ldap/Ldap.php
@@ -49,6 +49,13 @@ final class Ldap implements LdapInterface
         return $this->adapter->escape($subject, $ignore, $flags);
     }
 
+    public function reset(): void
+    {
+        if (method_exists($this->adapter, 'reset')) {
+            $this->adapter->reset();
+        }
+    }
+
     /**
      * Creates a new Ldap instance.
      *

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -34,6 +34,22 @@ class AdapterTest extends LdapTestCase
         $this->assertEquals('\20foo\3dbar\0d(baz)*\20', $ldap->escape(" foo=bar\r(baz)* ", '', LdapInterface::ESCAPE_DN));
     }
 
+    public function testResetClearsConnectionAndEntryManager()
+    {
+        $adapter = new Adapter();
+
+        $connection1 = $adapter->getConnection();
+        $entryManager1 = $adapter->getEntryManager();
+
+        $adapter->reset();
+
+        $connection2 = $adapter->getConnection();
+        $entryManager2 = $adapter->getEntryManager();
+
+        $this->assertNotSame($connection1, $connection2);
+        $this->assertNotSame($entryManager1, $entryManager2);
+    }
+
     /**
      * @group functional
      */

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -79,4 +79,51 @@ class LdapTest extends TestCase
         $this->expectException(DriverNotFoundException::class);
         Ldap::create('foo');
     }
+
+    public function testResetDelegatesToAdapter()
+    {
+        $adapter = new class implements AdapterInterface {
+            public bool $resetCalled = false;
+
+            public function getConnection(): ConnectionInterface
+            {
+                throw new \BadMethodCallException();
+            }
+
+            public function createQuery(string $dn, string $query, array $options = []): QueryInterface
+            {
+                throw new \BadMethodCallException();
+            }
+
+            public function getEntryManager(): \Symfony\Component\Ldap\Adapter\EntryManagerInterface
+            {
+                throw new \BadMethodCallException();
+            }
+
+            public function escape(string $subject, string $ignore = '', int $flags = 0): string
+            {
+                throw new \BadMethodCallException();
+            }
+
+            public function reset(): void
+            {
+                $this->resetCalled = true;
+            }
+        };
+
+        $ldap = new Ldap($adapter);
+        $ldap->reset();
+
+        $this->assertTrue($adapter->resetCalled);
+    }
+
+    public function testResetWithAdapterWithoutResetMethod()
+    {
+        $adapter = $this->createMock(AdapterInterface::class);
+
+        $ldap = new Ldap($adapter);
+        $ldap->reset();
+
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53442 
| License       | MIT

As described in #53442 , the `Adapter` service in the Ldap component holds a `Connection` object, and with the FrankenPHP worker mode, the ldap connection never rebind correctly.

The solution would be to add a method in the `Adpater` service to trigger the `_destruct` of the `Connection` object.
In this MR, I added the `ResetInterface`, but I can be removed it's considered as a BC. In this case, developers would have to tag the adapter with the `kernel.reset` tag to trigger the reset.

Of course, the `_destruct` method would be called only if there is no remaining reference of it in the app. But I guess it's ok since it shouldn't be stored anywhere but only accessed through the Adapter.
