### PR TITLE
[VarDumper] Dump class-strings as class stubs with source location and static properties

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Dump class-strings as class stubs with source location and static properties
+
 7.4
 ---
 

--- a/src/Symfony/Component/VarDumper/Caster/ClassDumpStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ClassDumpStub.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Represents a class dumped from its name: source location and static properties.
+ */
+class ClassDumpStub extends Stub
+{
+    public function __construct(string $class)
+    {
+        $r = new \ReflectionClass($class);
+
+        $this->type = self::TYPE_OBJECT;
+        $this->class = $class;
+
+        if ($f = $r->getFileName()) {
+            $this->attr['file'] = $f;
+            $this->attr['line'] = $r->getStartLine();
+        }
+
+        $properties = [];
+        foreach ($r->getProperties(\ReflectionProperty::IS_STATIC) as $p) {
+            $key = match (true) {
+                $p->isPublic() => $p->getName(),
+                $p->isProtected() => Caster::PREFIX_PROTECTED.$p->getName(),
+                default => sprintf(Caster::PATTERN_PRIVATE, $class, $p->getName()),
+            };
+            $properties["$key (static)"] = $p->isInitialized() ? $p->getValue() : new UninitializedStub($p);
+        }
+
+        $this->value = $properties;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Caster/StubCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/StubCaster.php
@@ -61,6 +61,19 @@ class StubCaster
         return $a;
     }
 
+    public static function castClassDump(ClassDumpStub $c, array $a, Stub $stub, bool $isNested): array
+    {
+        if (!$isNested) {
+            return $a;
+        }
+
+        $stub->class = $c->class;
+        $stub->attr = $c->attr;
+        $stub->handle = 0;
+
+        return \is_array($c->value) ? $c->value : [];
+    }
+
     public static function castEnum(EnumStub $c, array $a, Stub $stub, bool $isNested): array
     {
         if ($isNested) {

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -29,6 +29,7 @@ abstract class AbstractCloner implements ClonerInterface
 
         'Symfony\Component\VarDumper\Caster\CutStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castStub'],
         'Symfony\Component\VarDumper\Caster\CutArrayStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castCutArray'],
+        'Symfony\Component\VarDumper\Caster\ClassDumpStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castClassDump'],
         'Symfony\Component\VarDumper\Caster\ConstStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castStub'],
         'Symfony\Component\VarDumper\Caster\EnumStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castEnum'],
         'Symfony\Component\VarDumper\Caster\ScalarStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castScalar'],

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\VarDumper\Cloner;
 
+use Symfony\Component\VarDumper\Caster\ClassDumpStub;
+
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
@@ -84,6 +86,12 @@ class VarCloner extends AbstractCloner
                     case \is_string($v):
                         if ('' === $v) {
                             continue 2;
+                        }
+                        if (0 === $i && class_exists($v, false)) {
+                            $stub = new ClassDumpStub($v);
+                            $a = $stub->value;
+                            $stub->value = null;
+                            break;
                         }
                         if (!preg_match('//u', $v)) {
                             $stub = new Stub();

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\VarDumper\Tests\Dumper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\ClassDumpStub;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Caster\CutStub;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -21,6 +22,7 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\AbstractDumper;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+use Symfony\Component\VarDumper\Tests\Fixtures\ClassStringFixture;
 use Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
@@ -313,6 +315,38 @@ class CliDumperTest extends TestCase
         );
     }
 
+    public function testClassString()
+    {
+        class_exists(ClassStringFixture::class);
+        $this->assertDumpMatchesFormat(<<<'EODUMP'
+            Symfony\Component\VarDumper\Tests\Fixtures\ClassStringFixture {
+            %A+publicStatic (static): "public value"
+            %A#protectedStatic (static): 42
+            %A-privateStatic (static): true
+            %A+notInitialized (static): ? string
+            %A}
+            EODUMP,
+            ClassStringFixture::class
+        );
+    }
+
+    public function testClassDumpStubNested()
+    {
+        class_exists(ClassStringFixture::class);
+        $this->assertDumpMatchesFormat(<<<'EODUMP'
+            array:1 [
+              "foo" => Symfony\Component\VarDumper\Tests\Fixtures\ClassStringFixture {
+            %A+publicStatic (static): "public value"
+            %A#protectedStatic (static): 42
+            %A-privateStatic (static): true
+            %A+notInitialized (static): ? string
+            %A}
+            ]
+            EODUMP,
+            ['foo' => new ClassDumpStub(ClassStringFixture::class)]
+        );
+    }
+
     public function testThrowingCaster()
     {
         $out = fopen('php://memory', 'r+');
@@ -358,7 +392,7 @@ class CliDumperTest extends TestCase
                         › 
                       }
                       %A%eTemplate.php:%d { …}
-                      %s%eTests%eDumper%eCliDumperTest.php:%d { …}
+                      %A%eCliDumperTest.php:%d { …}
                 %A  }
                   }
                 %Awrapper_type: "PHP"

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/ClassStringFixture.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/ClassStringFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Fixtures;
+
+class ClassStringFixture
+{
+    public static string $publicStatic = 'public value';
+    protected static int $protectedStatic = 42;
+    private static bool $privateStatic = true;
+    public static string $notInitialized;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT


When working on a projet full a static properties (Yes, I know! Legacy project...) this will be a game changer !


<img width="792" height="625" alt="image" src="https://github.com/user-attachments/assets/0127228c-ac8b-4a42-bbf4-c0b1fa329487" />

<img width="1245" height="830" alt="image" src="https://github.com/user-attachments/assets/c57414c6-b159-480e-b6e9-0330c58b4a66" />


