### PR TITLE
[Serializer] Add support for denormalizing arrays of union types

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -59,6 +59,7 @@ Serializer
 ----------
 
  * Deprecate denormalizing an array that is not a list into a `list`-typed property, in version 9.0 a `Symfony\Component\Serializer\Exception\NotNormalizableValueException` will be thrown when the input does not satisfy `array_is_list()`
+ * Denormalize the elements of a union-typed collection, e.g. `array<Foo|Bar>`, instead of returning the raw data. An element that matches no member of the union, or a key whose type does not match, now throws instead of being returned as-is
 
 Translation
 -----------

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Use the discriminator property of an object to pick its type when several types map to the same class; the first declared type is used when the property is unset or unknown
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
  * Add the `XmlEncoder::BOOLEAN_REPR` context option to choose the strings representing booleans when encoding, e.g. `['true', 'false']`
+ * Add support for denormalizing arrays of union types, e.g. `array<Foo|Bar>`
 
 8.1
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -585,6 +585,35 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         $class = $collectionValueBaseType->getClassName().'[]';
                         $context['key_type'] = $collectionKeyType;
                         $context['value_type'] = $collectionValueType;
+                    } elseif ($collectionValueBaseType instanceof UnionType) {
+                        if (!\is_array($data)) {
+                            throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be one of "array" ("%s" given).', $attribute, $currentClass, get_debug_type($data)), $data, [Type::array()], $context['deserialization_path'] ?? null);
+                        }
+
+                        $keyTypeIdentifiers = array_map('strval', $collectionKeyType instanceof UnionType ? $collectionKeyType->getTypes() : [$collectionKeyType]);
+
+                        $result = [];
+
+                        foreach ($data as $key => $value) {
+                            $childContext = $this->createChildContext($context, $attribute, $format);
+                            $childContext['deserialization_path'] = ($context['deserialization_path'] ?? false) ? \sprintf('%s[%s]', $context['deserialization_path'], $key) : "[$key]";
+
+                            if (!$collectionKeyType->accepts($key)) {
+                                throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the key "%s" must be "%s" ("%s" given).', $key, implode('", "', $keyTypeIdentifiers), get_debug_type($key)), $key, $keyTypeIdentifiers, $childContext['deserialization_path'], true);
+                            }
+
+                            // the wrapped type is passed on so that a nullable element type keeps accepting null
+                            $result[$key] = $this->validateAndDenormalize(
+                                $collectionValueType,
+                                $currentClass,
+                                $attribute,
+                                $value,
+                                $format,
+                                $childContext
+                            );
+                        }
+
+                        return $result;
                     } elseif ($collectionValueBaseType instanceof BuiltinType && TypeIdentifier::ARRAY === $collectionValueBaseType->getTypeIdentifier()) {
                         // get inner type for any nested array
                         $innerType = $collectionValueType;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ArrayOfScalarUnionTypeContainerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ArrayOfScalarUnionTypeContainerDummy.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class ArrayOfScalarUnionTypeContainerDummy
+{
+    /** @param array<int|string> $items */
+    public function __construct(
+        public readonly array $items = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ArrayOfUnionTypeContainerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ArrayOfUnionTypeContainerDummy.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class ArrayOfUnionTypeContainerDummy
+{
+    /** @param array<UnionTypeFooDummy|UnionTypeBarDummy> $items */
+    public function __construct(
+        public readonly array $items = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ArrayOfUnknownClassUnionTypeContainerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ArrayOfUnknownClassUnionTypeContainerDummy.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class ArrayOfUnknownClassUnionTypeContainerDummy
+{
+    /** @param array<UnknownFooDummy|UnknownBarDummy> $items */
+    public function __construct(
+        public readonly array $items = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NullableArrayOfUnionTypeContainerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NullableArrayOfUnionTypeContainerDummy.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class NullableArrayOfUnionTypeContainerDummy
+{
+    /** @param array<UnionTypeFooDummy|UnionTypeBarDummy|null> $items */
+    public function __construct(
+        public readonly array $items = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StringKeyedArrayOfUnionTypeContainerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StringKeyedArrayOfUnionTypeContainerDummy.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class StringKeyedArrayOfUnionTypeContainerDummy
+{
+    /** @param array<string, UnionTypeFooDummy|UnionTypeBarDummy> $items */
+    public function __construct(
+        public readonly array $items = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/UnionTypeBarDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/UnionTypeBarDummy.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class UnionTypeBarDummy
+{
+    public function __construct(
+        public readonly bool $bar,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/UnionTypeContainerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/UnionTypeContainerDummy.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class UnionTypeContainerDummy
+{
+    public function __construct(
+        public readonly UnionTypeFooDummy|UnionTypeBarDummy $fooOrBar,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/UnionTypeFooDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/UnionTypeFooDummy.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class UnionTypeFooDummy
+{
+    public function __construct(
+        public readonly bool $foo,
+    ) {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DenormalizeArrayOfUnionTypesTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DenormalizeArrayOfUnionTypesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Tests\Fixtures\ArrayOfScalarUnionTypeContainerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\ArrayOfUnionTypeContainerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\ArrayOfUnknownClassUnionTypeContainerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\NullableArrayOfUnionTypeContainerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\StringKeyedArrayOfUnionTypeContainerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\UnionTypeBarDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\UnionTypeContainerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\UnionTypeFooDummy;
+
+class DenormalizeArrayOfUnionTypesTest extends TestCase
+{
+    private DenormalizerInterface $denormalizer;
+
+    protected function setUp(): void
+    {
+        $propertyTypeExtractor = new PropertyInfoExtractor(
+            typeExtractors: [new PhpDocExtractor(), new ReflectionExtractor()]
+        );
+
+        $this->denormalizer = new Serializer([
+            new ObjectNormalizer(null, null, null, $propertyTypeExtractor),
+            new ArrayDenormalizer(),
+        ]);
+    }
+
+    public function testDenormalizeDirectUnionType()
+    {
+        $result = $this->denormalizer->denormalize(['fooOrBar' => ['bar' => true]], UnionTypeContainerDummy::class);
+
+        $this->assertInstanceOf(UnionTypeContainerDummy::class, $result);
+        $this->assertInstanceOf(UnionTypeBarDummy::class, $result->fooOrBar);
+        $this->assertTrue($result->fooOrBar->bar);
+    }
+
+    public function testDenormalizeArrayOfUnionTypes()
+    {
+        $data = ['items' => [['foo' => true], ['bar' => true], ['foo' => false]]];
+
+        $result = $this->denormalizer->denormalize($data, ArrayOfUnionTypeContainerDummy::class);
+
+        $this->assertInstanceOf(ArrayOfUnionTypeContainerDummy::class, $result);
+        $this->assertCount(3, $result->items);
+        $this->assertInstanceOf(UnionTypeFooDummy::class, $result->items[0]);
+        $this->assertTrue($result->items[0]->foo);
+        $this->assertInstanceOf(UnionTypeBarDummy::class, $result->items[1]);
+        $this->assertTrue($result->items[1]->bar);
+        $this->assertInstanceOf(UnionTypeFooDummy::class, $result->items[2]);
+        $this->assertFalse($result->items[2]->foo);
+    }
+
+    public function testDenormalizeArrayOfNullableUnionTypes()
+    {
+        $data = ['items' => [['foo' => true], null, ['bar' => false]]];
+
+        $result = $this->denormalizer->denormalize($data, NullableArrayOfUnionTypeContainerDummy::class);
+
+        $this->assertInstanceOf(UnionTypeFooDummy::class, $result->items[0]);
+        $this->assertNull($result->items[1]);
+        $this->assertInstanceOf(UnionTypeBarDummy::class, $result->items[2]);
+        $this->assertFalse($result->items[2]->bar);
+    }
+
+    public function testDenormalizeStringKeyedArrayOfUnionTypes()
+    {
+        $data = ['items' => ['first' => ['foo' => true], 'second' => ['bar' => true]]];
+
+        $result = $this->denormalizer->denormalize($data, StringKeyedArrayOfUnionTypeContainerDummy::class);
+
+        $this->assertInstanceOf(StringKeyedArrayOfUnionTypeContainerDummy::class, $result);
+        $this->assertCount(2, $result->items);
+        $this->assertInstanceOf(UnionTypeFooDummy::class, $result->items['first']);
+        $this->assertTrue($result->items['first']->foo);
+        $this->assertInstanceOf(UnionTypeBarDummy::class, $result->items['second']);
+        $this->assertTrue($result->items['second']->bar);
+    }
+
+    public function testDenormalizeStringKeyedArrayWithInvalidKeyTypeThrows()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('The type of the key "0" must be "string" ("int" given).');
+
+        $this->denormalizer->denormalize(['items' => [0 => ['foo' => true]]], StringKeyedArrayOfUnionTypeContainerDummy::class);
+    }
+
+    public function testDenormalizeArrayOfScalarUnionTypes()
+    {
+        $result = $this->denormalizer->denormalize(['items' => [1, 'two']], ArrayOfScalarUnionTypeContainerDummy::class);
+
+        $this->assertSame([1, 'two'], $result->items);
+    }
+
+    public function testDenormalizeArrayOfScalarUnionTypesRejectsUnmatchedElements()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+
+        $this->denormalizer->denormalize(['items' => [1.5]], ArrayOfScalarUnionTypeContainerDummy::class);
+    }
+
+    public function testDenormalizeArrayOfUnknownClassUnionTypesRejectsElements()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+
+        $this->denormalizer->denormalize(['items' => [['foo' => true]]], ArrayOfUnknownClassUnionTypeContainerDummy::class);
+    }
+
+    public function testDenormalizeNonArrayDataThrows()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage(\sprintf('The type of the "items" attribute for class "%s" must be one of "array" ("string" given).', ArrayOfUnionTypeContainerDummy::class));
+
+        $this->denormalizer->denormalize(['items' => 'not an array'], ArrayOfUnionTypeContainerDummy::class);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62228
| License       | MIT

A property typed as a collection of a union, `array<Foo|Bar>`, was returned as raw data: the denormalizer had no way to pick a member of the union, so the elements stayed as arrays. They are now denormalized, each element against the union:

```php
class Container
{
    /** @param array<Foo|Bar> $items */
    public function __construct(public readonly array $items = []) {}
}

$serializer->denormalize(['items' => [['foo' => 1], ['bar' => 2]]], Container::class);
// items[0] is a Foo, items[1] is a Bar
```

Nullable unions keep their `null` elements, `array<Foo|Bar|null>` accepts `null` in the list. Keys are validated against the collection's key type, so a string key in a `list<Foo|Bar>` reports the same violation as it already does for `array<Foo>`. Errors carry the element's `deserialization_path`, `items[0].bar`, and are collected as usual under `COLLECT_DENORMALIZATION_ERRORS`.

Elements that match no member of the union now throw instead of being returned as-is. That covers a scalar of the wrong type, `1.5` for `array<int|string>`, and classes the denormalizer does not know. This is a behavior change and it is listed in `UPGRADE-8.2.md`.

Out of scope, unchanged for now: a union nested inside another collection, `array<array<Foo|Bar>>`, and `iterable<Foo|Bar>`, which is not a collection type. Both still pass their data through.

Points for the documentation:

* a property typed `array<Foo|Bar>` is now denormalized element by element
* `array<Foo|Bar|null>` keeps `null` elements
* keys are validated against the declared key type
* an element matching no member of the union throws, where it used to be returned as raw data
* nested collections of unions and `iterable<Foo|Bar>` are not covered
