### PR TITLE
[DependencyInjection] Fix tagged_iterator/tagged_locator in array PHP config

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -78,12 +78,12 @@ abstract class AbstractConfigurator
             return (string) $value;
         }
 
-        if ($value instanceof \Closure) {
-            return self::processClosure($value);
-        }
-
         if (\is_scalar($value ?? '') || $value instanceof \UnitEnum) {
             return $value;
+        }
+
+        if ($value instanceof \Closure) {
+            return self::processClosure($value);
         }
 
         if (!$allowServices) {
@@ -107,14 +107,14 @@ abstract class AbstractConfigurator
             throw new InvalidArgumentException(\sprintf('"%s()" can be used only at the root of service configuration files.', $value::FACTORY));
         }
 
-        if ($value instanceof ArgumentInterface
-            || $value instanceof Definition
-            || $value instanceof Expression
-            || $value instanceof Parameter
-            || $value instanceof AbstractArgument
-            || $value instanceof Reference
-        ) {
-            return $value;
+        switch (true) {
+            case $value instanceof ArgumentInterface:
+            case $value instanceof Definition:
+            case $value instanceof Expression:
+            case $value instanceof Parameter:
+            case $value instanceof AbstractArgument:
+            case $value instanceof Reference:
+                return $value;
         }
 
         throw new InvalidArgumentException(\sprintf('Cannot use values of type "%s" in service configuration files.', get_debug_type($value)));

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -107,14 +107,19 @@ class PhpFileLoader extends FileLoader
                 $yamlLoader = new YamlFileLoader($this->container, $this->locator, $this->env, $this->prepend);
                 $yamlLoader->setResolver($this->resolver ?? new LoaderResolver([$this]));
                 $loadContent = new \ReflectionMethod(YamlFileLoader::class, 'loadContent');
-                $result = ContainerConfigurator::processValue($result);
 
                 ++$this->importing;
                 try {
-                    $content = array_intersect_key($result, ['imports' => true, 'parameters' => true, 'services' => true]);
-                    $loadContent->invoke($yamlLoader, $content, $path);
+                    $loadContent->invoke($yamlLoader, [
+                        'imports' => ContainerConfigurator::processValue($result['imports'] ?? []),
+                        'parameters' => ContainerConfigurator::processValue($result['parameters'] ?? []),
+                        'services' => ContainerConfigurator::processValue($result['services'] ?? [], true),
+                    ], $path);
 
                     foreach ($result as $namespace => $config) {
+                        if (!\is_array($config)) {
+                            throw new InvalidArgumentException(\sprintf('The "%s" key should contain an array in "%s".', $namespace, $path));
+                        }
                         if (\in_array($namespace, ['imports', 'parameters', 'services'], true)) {
                             continue;
                         }
@@ -123,7 +128,7 @@ class PhpFileLoader extends FileLoader
                             $this->container->setParameter('.container.known_envs', array_keys($knownEnvs + [substr($namespace, 5) => true]));
                             continue;
                         }
-                        $this->loadExtensionConfig($namespace, $config);
+                        $this->loadExtensionConfig($namespace, ContainerConfigurator::processValue($config));
                     }
 
                     // per-env configuration
@@ -132,12 +137,18 @@ class PhpFileLoader extends FileLoader
                             throw new InvalidArgumentException(\sprintf('The "%s" key should contain an array in "%s".', $when, $path));
                         }
 
-                        $content = array_intersect_key($result[$when], ['imports' => true, 'parameters' => true, 'services' => true]);
-                        $loadContent->invoke($yamlLoader, $content, $path);
+                        $loadContent->invoke($yamlLoader, [
+                            'imports' => ContainerConfigurator::processValue($result[$when]['imports'] ?? []),
+                            'parameters' => ContainerConfigurator::processValue($result[$when]['parameters'] ?? []),
+                            'services' => ContainerConfigurator::processValue($result[$when]['services'] ?? [], true),
+                        ], $path);
 
                         foreach ($result[$when] as $namespace => $config) {
+                            if (!\is_array($config)) {
+                                throw new InvalidArgumentException(\sprintf('The "%s" key should contain an array in "%s".', $namespace, $path));
+                            }
                             if (!\in_array($namespace, ['imports', 'parameters', 'services'], true) && !str_starts_with($namespace, 'when@')) {
-                                $this->loadExtensionConfig($namespace, $config);
+                                $this->loadExtensionConfig($namespace, ContainerConfigurator::processValue($config));
                             }
                         }
                     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_tagged_iterator.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_tagged_iterator.expected.yml
@@ -1,0 +1,16 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
+        public: true
+        autowire: true
+        arguments: [null, !tagged_iterator app.rule]
+    bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
+        public: true
+        autowire: true
+        arguments: [null, !tagged_iterator app.handler, !service { class: Symfony\Component\DependencyInjection\ServiceLocator, tags: [container.service_locator], arguments: [{  }] }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_tagged_iterator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_tagged_iterator.php
@@ -1,0 +1,26 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_locator;
+
+return [
+    'services' => [
+        '_defaults' => [
+            'public' => true,
+            'autowire' => true,
+            'bind' => [
+                'iterable $foo' => tagged_iterator('app.rule'),
+            ],
+        ],
+        Foo::class => null,
+        'bar' => [
+            'class' => Foo::class,
+            'arguments' => [
+                '$foo' => tagged_iterator('app.handler'),
+                '$baz' => tagged_locator('app.handler'),
+            ],
+        ],
+    ],
+];

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -149,6 +149,7 @@ class PhpFileLoaderTest extends TestCase
         yield ['from_callable'];
         yield ['env_param'];
         yield ['array_config'];
+        yield ['array_config_tagged_iterator'];
         yield ['object_array_config'];
         yield ['return_when_env'];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This was originally reported as a docs issue: https://github.com/symfony/symfony-docs/issues/22154

When using the array PHP config format (`App::config()` or plain `return []`), `tagged_iterator()` and `tagged_locator()` throw:
                                                                                
> Cannot use values of type "TaggedIteratorArgument" in service configuration files.
                                                                                
This is because `PhpFileLoader::load()` calls `processValue()` with `$allowServices = false`.