### PR TITLE
[VarDumper] Ensure that tests are resilient when the Xdebug file link format is defined

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ContextualizedDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ContextualizedDumperTest.php
@@ -29,9 +29,10 @@ class ContextualizedDumperTest extends TestCase
         $_ENV['SYMFONY_IDE'] = $_SERVER['SYMFONY_IDE'] = '';
         $wrappedDumper = new CliDumper('php://output');
         $wrappedDumper->setColors(true);
+        $wrappedDumper->setDisplayOptions(['fileLinkFormat' => 'file://%f#L%l']);
 
         $var = 'example';
-        $href = \sprintf('file://%s#L%s', __FILE__, 40);
+        $href = \sprintf('file://%s#L%s', __FILE__, 41);
         $dumper = new ContextualizedDumper($wrappedDumper, [new SourceContextProvider()]);
         $cloner = new VarCloner();
         $data = $cloner->cloneVar($var);

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -129,7 +129,7 @@ class HtmlDumperTest extends TestCase
         $out = $dumper->dump($data, true);
 
         $this->assertStringMatchesFormat(<<<EODUMP
-            <foo></foo><bar><span class=sf-dump-note>Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty</span> {<a class=sf-dump-ref>#%i</a><samp data-depth=1 class=sf-dump-expanded>
+            <foo></foo><bar>%A<span class=sf-dump-note>Symfony\Component\VarDumper\Tests\Fixtures\VirtualProperty</span>%A {<a class=sf-dump-ref>#%i</a><samp data-depth=1 class=sf-dump-expanded>
               +<span class=sf-dump-public title="Public property">firstName</span>: "<span class=sf-dump-str title="4 characters">John</span>"
               +<span class=sf-dump-public title="Public property">lastName</span>: "<span class=sf-dump-str title="3 characters">Doe</span>"
               +<span class=sf-dump-virtual><span class=sf-dump-public title="Public property">fullName</span></span>: <span class=sf-dump-virtual><span class=sf-dump-const title="Virtual property">~ string</span></span>


### PR DESCRIPTION
Extraction for:
* 6.4 in https://github.com/symfony/symfony/pull/63815
* 7.4 in https://github.com/symfony/symfony/pull/63816


| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT


<img width="1072" height="909" alt="image" src="https://github.com/user-attachments/assets/2d0e667e-1194-4c25-bd7d-5afafd177d69" />
