### PR TITLE
[VarDumper] Ensure that tests are resilient when the Xdebug file link format is defined

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ContextualizedDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ContextualizedDumperTest.php
@@ -29,9 +29,10 @@ class ContextualizedDumperTest extends TestCase
         $_ENV['SYMFONY_IDE'] = $_SERVER['SYMFONY_IDE'] = '';
         $wrappedDumper = new CliDumper('php://output');
         $wrappedDumper->setColors(true);
+        $wrappedDumper->setDisplayOptions(['fileLinkFormat' => 'file://%f#L%l']);
 
         $var = 'example';
-        $href = \sprintf('file://%s#L%s', __FILE__, 40);
+        $href = \sprintf('file://%s#L%s', __FILE__, 41);
         $dumper = new ContextualizedDumper($wrappedDumper, [new SourceContextProvider()]);
         $cloner = new VarCloner();
         $data = $cloner->cloneVar($var);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | kind of
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT


---

See https://github.com/symfony/symfony/pull/63814