### PR TITLE
[Serializer] Fix denormalization of nested array with key types

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -534,18 +534,18 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     $builtinType = Type::BUILTIN_TYPE_OBJECT;
                     $class = $collectionValueType->getClassName().'[]';
 
-                    if (\count($collectionKeyType = $type->getCollectionKeyTypes()) > 0) {
+                    if ($collectionKeyType = $type->getCollectionKeyTypes()) {
                         $context['key_type'] = \count($collectionKeyType) > 1 ? $collectionKeyType : $collectionKeyType[0];
                     }
 
                     $context['value_type'] = $collectionValueType;
-                } elseif ($type->isCollection() && \count($collectionValueType = $type->getCollectionValueTypes()) > 0 && Type::BUILTIN_TYPE_ARRAY === $collectionValueType[0]->getBuiltinType()) {
+                } elseif ($type->isCollection() && ($collectionValueType = $type->getCollectionValueTypes()) && Type::BUILTIN_TYPE_ARRAY === $collectionValueType[0]->getBuiltinType()) {
                     // get inner type for any nested array
                     [$innerType] = $collectionValueType;
 
                     // note that it will break for any other builtinType
                     $dimensions = '[]';
-                    while (\count($innerType->getCollectionValueTypes()) > 0 && Type::BUILTIN_TYPE_ARRAY === $innerType->getBuiltinType()) {
+                    while ($innerType->getCollectionValueTypes() && Type::BUILTIN_TYPE_ARRAY === $innerType->getBuiltinType()) {
                         $dimensions .= '[]';
                         [$innerType] = $innerType->getCollectionValueTypes();
                     }
@@ -554,6 +554,12 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         // the builtinType is the inner one and the class is the class followed by []...[]
                         $builtinType = $innerType->getBuiltinType();
                         $class = $innerType->getClassName().$dimensions;
+
+                        if ($collectionKeyType = $type->getCollectionKeyTypes()) {
+                            $context['key_type'] = \count($collectionKeyType) > 1 ? $collectionKeyType : $collectionKeyType[0];
+                        }
+
+                        $context['value_type'] = $collectionValueType[0];
                     } else {
                         // default fallback (keep it as array)
                         $builtinType = $type->getBuiltinType();

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -62,6 +62,17 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
             return $keyType->getBuiltinType();
         }, \is_array($keyType = $context['key_type'] ?? []) ? $keyType : [$keyType]);
 
+        $valueType = $context['value_type'] ?? null;
+        if ($valueType instanceof Type && $valueType->isCollection()) {
+            if ($collectionKeyTypes = $valueType->getCollectionKeyTypes()) {
+                $context['key_type'] = \count($collectionKeyTypes) > 1 ? $collectionKeyTypes : $collectionKeyTypes[0];
+            }
+
+            if ($collectionValueTypes = $valueType->getCollectionValueTypes()) {
+                $context['value_type'] = $collectionValueTypes[0];
+            }
+        }
+
         foreach ($data as $key => $value) {
             $subContext = $context;
             $subContext['deserialization_path'] = ($context['deserialization_path'] ?? false) ? \sprintf('%s[%s]', $context['deserialization_path'], $key) : "[$key]";

--- a/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
@@ -102,6 +102,30 @@ EOF;
         self::assertArrayHasKey(3, $zoo->animalsGenerics);
         self::assertInstanceOf(Animal::class, $zoo->animalsGenerics[3]);
     }
+
+    public function testNestedArrayWithStringKeyUnderList()
+    {
+        $json = <<<EOF
+            {
+                "foos": [{"operators": {"something": [{"name": "Bug"}]}}]
+            }
+            EOF;
+        $serializer = new Serializer([
+            new ObjectNormalizer(null, null, null, new PhpDocExtractor()),
+            new ArrayDenormalizer(),
+        ], ['json' => new JsonEncoder()]);
+
+        /** @var BarWithNestedKeyTypes $bar */
+        $bar = $serializer->deserialize($json, BarWithNestedKeyTypes::class, 'json');
+
+        self::assertCount(1, $bar->foos);
+        self::assertInstanceOf(FooWithStringKeyedList::class, $bar->foos[0]);
+        self::assertCount(1, $bar->foos[0]->operators);
+        self::assertArrayHasKey('something', $bar->foos[0]->operators);
+        self::assertCount(1, $bar->foos[0]->operators['something']);
+        self::assertInstanceOf(Animal::class, $bar->foos[0]->operators['something'][0]);
+        self::assertSame('Bug', $bar->foos[0]->operators['something'][0]->getName());
+    }
 }
 
 class Zoo
@@ -176,5 +200,21 @@ class Animal
     public function setName($name)
     {
         $this->name = $name;
+    }
+}
+
+class FooWithStringKeyedList
+{
+    /** @param array<string, list<Animal>> $operators */
+    public function __construct(public array $operators = [])
+    {
+    }
+}
+
+class BarWithNestedKeyTypes
+{
+    /** @param list<FooWithStringKeyedList> $foos */
+    public function __construct(public array $foos = [])
+    {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60036
| License       | MIT

The nested-array branch in `AbstractObjectNormalizer::validateAndDenormalize` did not propagate `key_type`/`value_type` into the context, unlike the non-nested branch. This caused the parent collection's `key_type` to leak into child properties.

The fix propagates these context keys in `AbstractObjectNormalizer` and advances them to the next nesting level in `ArrayDenormalizer`.