### PR TITLE
[Form] Add a "choice_help" option to ChoiceType

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -211,11 +211,14 @@
 {% block choice_widget_expanded -%}
     <div {{ block('widget_container_attributes') }}>
         {%- for child in form %}
+            {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
             {{- form_widget(child, {
                 parent_label_class: label_attr.class|default(''),
                 translation_domain: choice_translation_domain,
                 valid: valid,
+                attr: child_attr,
             }) -}}
+            {{- form_help(child) -}}
         {% endfor -%}
     </div>
 {%- endblock choice_widget_expanded %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig
@@ -261,11 +261,14 @@
 {%- block choice_widget_expanded -%}
     <div {{ block('widget_container_attributes') }}>
         {%- for child in form %}
+            {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
             {{- form_widget(child, {
                 parent_label_class: label_attr.class|default(''),
                 translation_domain: choice_translation_domain,
                 valid: valid,
+                attr: child_attr,
             }) -}}
+            {{- form_help(child) -}}
         {% endfor -%}
     </div>
 {%- endblock choice_widget_expanded %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
@@ -146,18 +146,24 @@
 {% block choice_widget_expanded -%}
     {%- if '-inline' in label_attr.class|default('') -%}
         {%- for child in form %}
+            {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
             {{- form_widget(child, {
                 parent_label_class: label_attr.class|default(''),
                 translation_domain: choice_translation_domain,
+                attr: child_attr,
             }) -}}
+            {{- form_help(child) -}}
         {% endfor -%}
     {%- else -%}
         <div {{ block('widget_container_attributes') }}>
             {%- for child in form %}
+                {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
                 {{- form_widget(child, {
                     parent_label_class: label_attr.class|default(''),
                     translation_domain: choice_translation_domain,
+                    attr: child_attr,
                 }) -}}
+                {{- form_help(child) -}}
             {%- endfor -%}
         </div>
     {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/daisyui_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/daisyui_5_layout.html.twig
@@ -46,11 +46,13 @@
     <div {{ block('widget_container_attributes') }}>
         {%- for child in form %}
             <label class="flex items-center label mb-2">
-                {{- form_widget(child) -}}
+                {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
+                {{- form_widget(child, {attr: child_attr}) -}}
                 {%- if child.vars.label is not same as(false) -%}
                     {{- form_label(child, null, {translation_domain: choice_translation_domain, label_attr: {class: ''}}) -}}
                 {%- endif -%}
             </label>
+            {{- form_help(child) -}}
         {% endfor -%}
     </div>
 {%- endblock choice_widget_expanded -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -49,8 +49,10 @@
 {%- block choice_widget_expanded -%}
     <div {{ block('widget_container_attributes') }}>
     {%- for child in form %}
-        {{- form_widget(child) -}}
+        {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
+        {{- form_widget(child, {attr: child_attr}) -}}
         {{- form_label(child, null, {translation_domain: choice_translation_domain}) -}}
+        {{- form_help(child) -}}
     {% endfor -%}
     </div>
 {%- endblock choice_widget_expanded -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -180,17 +180,22 @@
     {% if '-inline' in label_attr.class|default('') %}
         <ul class="inline-list">
             {% for child in form %}
+                {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
                 <li>{{ form_widget(child, {
                         parent_label_class: label_attr.class|default(''),
-                    }) }}</li>
+                        attr: child_attr,
+                    }) }}{{ form_help(child) }}</li>
             {% endfor %}
         </ul>
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {% for child in form %}
+                {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
                 {{ form_widget(child, {
                     parent_label_class: label_attr.class|default(''),
+                    attr: child_attr,
                 }) }}
+                {{ form_help(child) }}
             {% endfor %}
         </div>
     {% endif %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/tailwind_2_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/tailwind_2_layout.html.twig
@@ -35,9 +35,11 @@
     <div {{ block('widget_container_attributes') }}>
         {%- for child in form %}
             <div class="flex items-center">
-                {{- form_widget(child) -}}
+                {%- set child_attr = child.vars.help ? child.vars.attr|merge({'aria-describedby': child.vars.id ~ '_help'}) : child.vars.attr -%}
+                {{- form_widget(child, {attr: child_attr}) -}}
                 {{- form_label(child, null, {translation_domain: choice_translation_domain}) -}}
             </div>
+            {{- form_help(child) -}}
         {% endfor -%}
     </div>
 {%- endblock choice_widget_expanded -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -176,6 +176,55 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
         );
     }
 
+    public function testExpandedChoiceHelpIsRenderedAndDescribesTheChoice()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
+            'choices' => ['Apple' => 'a', 'Banana' => 'b'],
+            'choice_help' => ['Apple' => 'A fruit', 'Banana' => 'Yellow'],
+            'expanded' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+            '/div
+    [
+        ./input[@type="radio"][@id="name_0"][@aria-describedby="name_0_help"]
+        /following-sibling::label[@for="name_0"]
+        /following-sibling::div[@id="name_0_help"][.="[trans]A fruit[/trans]"]
+        /following-sibling::input[@type="radio"][@id="name_1"][@aria-describedby="name_1_help"]
+        /following-sibling::label[@for="name_1"]
+        /following-sibling::div[@id="name_1_help"][.="[trans]Yellow[/trans]"]
+    ]
+'
+        );
+    }
+
+    public function testExpandedChoiceWithoutHelpRendersNoHelpElement()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
+            'choices' => ['Apple' => 'a'],
+            'choice_help' => ['Banana' => 'Yellow'],
+            'expanded' => true,
+        ]);
+
+        $html = $this->renderWidget($form->createView());
+
+        $this->assertMatchesXpath($html, '//div[@id="name_0_help"]', 0);
+        $this->assertMatchesXpath($html, '//input[@aria-describedby]', 0);
+    }
+
+    public function testCollapsedChoiceHelpIsNotRenderedButStaysOnTheView()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
+            'choices' => ['Apple' => 'a'],
+            'choice_help' => ['Apple' => 'A fruit'],
+        ]);
+
+        $view = $form->createView();
+
+        $this->assertMatchesXpath($this->renderWidget($view), '//div[@class="help-text"]', 0);
+        $this->assertSame('A fruit', $view->vars['choices'][0]->help);
+    }
+
     public function testHelpHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled
+ * Add the `choice_help` option to `ChoiceType`
+ * Add `$help` parameter to `ChoiceListFactoryInterface::createView()`
 
 8.1
 ---

--- a/src/Symfony/Component/Form/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ChoiceList.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\ChoiceList;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceAttr;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFieldName;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFilter;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceHelp;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLabel;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLoader;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceTranslationParameters;
@@ -105,6 +106,17 @@ final class ChoiceList
     public static function attr(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $attr, mixed $vary = null): ChoiceAttr
     {
         return new ChoiceAttr($formType, $attr, $vary);
+    }
+
+    /**
+     * Decorates a "choice_help" option to make it cacheable.
+     *
+     * @param callable|array $help Any pseudo callable or array to create a help from a choice
+     * @param mixed          $vary Dynamic data used to compute a unique hash when caching the option
+     */
+    public static function help(FormTypeInterface|FormTypeExtensionInterface $formType, callable|array $help, mixed $vary = null): ChoiceHelp
+    {
+        return new ChoiceHelp($formType, $help, $vary);
     }
 
     /**

--- a/src/Symfony/Component/Form/ChoiceList/Factory/Cache/ChoiceHelp.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/Cache/ChoiceHelp.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\ChoiceList\Factory\Cache;
+
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormTypeInterface;
+
+/**
+ * A cacheable wrapper for any {@see FormTypeInterface} or {@see FormTypeExtensionInterface}
+ * which configures a "choice_help" option.
+ *
+ * @internal
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class ChoiceHelp extends AbstractStaticOption
+{
+}

--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -143,8 +143,12 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
         return $this->lists[$hash];
     }
 
-    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView
+    /**
+     * @param array|callable|null $help
+     */
+    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true/* , array|callable|null $help = null */): ChoiceListView
     {
+        $help = \func_num_args() > 8 ? func_get_arg(8) : null;
         $cache = true;
 
         if ($preferredChoices instanceof Cache\PreferredChoice) {
@@ -183,6 +187,12 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
             $cache = false;
         }
 
+        if ($help instanceof Cache\ChoiceHelp) {
+            $help = $help->getOption();
+        } elseif ($help) {
+            $cache = false;
+        }
+
         if (!$cache) {
             return $this->decoratedFactory->createView(
                 $list,
@@ -193,10 +203,11 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
                 $attr,
                 $labelTranslationParameters,
                 $duplicatePreferredChoices,
+                $help,
             );
         }
 
-        $hash = self::generateHash([$list, $preferredChoices, $label, $index, $groupBy, $attr, $labelTranslationParameters, $duplicatePreferredChoices]);
+        $hash = self::generateHash([$list, $preferredChoices, $label, $index, $groupBy, $attr, $labelTranslationParameters, $duplicatePreferredChoices, $help]);
 
         if (!isset($this->views[$hash])) {
             $this->views[$hash] = $this->decoratedFactory->createView(
@@ -208,6 +219,7 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
                 $attr,
                 $labelTranslationParameters,
                 $duplicatePreferredChoices,
+                $help,
             );
         }
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
@@ -80,6 +80,7 @@ interface ChoiceListFactoryInterface
      * @param bool                $duplicatePreferredChoices  Whether the preferred choices should be duplicated
      *                                                        on top of the list and in their original position
      *                                                        or only in the top of the list
+     * @param array|callable|null $help                       The callable generating the choice helps
      */
-    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView;
+    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true/* , array|callable|null $help = null */): ChoiceListView;
 }

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -52,8 +52,12 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         return new LazyChoiceList($loader, $value);
     }
 
-    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView
+    /**
+     * @param array|callable|null $help
+     */
+    public function createView(ChoiceListInterface $list, array|callable|null $preferredChoices = null, callable|false|null $label = null, ?callable $index = null, ?callable $groupBy = null, array|callable|null $attr = null, array|callable $labelTranslationParameters = [], bool $duplicatePreferredChoices = true/* , array|callable|null $help = null */): ChoiceListView
     {
+        $help = \func_num_args() > 8 ? func_get_arg(8) : null;
         $preferredViews = [];
         $preferredViewsOrder = [];
         $otherViews = [];
@@ -89,6 +93,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                     $index,
                     $attr,
                     $labelTranslationParameters,
+                    $help,
                     $preferredChoices,
                     $preferredViews,
                     $preferredViewsOrder,
@@ -128,6 +133,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $index,
                 $attr,
                 $labelTranslationParameters,
+                $help,
                 $preferredChoices,
                 $preferredViews,
                 $preferredViewsOrder,
@@ -144,7 +150,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
     /**
      * @param-immediately-invoked-callable $isPreferred
      */
-    private static function addChoiceView($choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
+    private static function addChoiceView($choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, $help, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
     {
         // $value may be an integer or a string, since it's stored in the array
         // keys. We want to guarantee it's a string though.
@@ -169,6 +175,16 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             }
         }
 
+        if (\is_callable($help)) {
+            $help = $help($choice, $key, $value);
+        } else {
+            $help = $help[$key] ?? null;
+        }
+
+        if (null !== $help && !$help instanceof TranslatableInterface) {
+            $help = (string) $help;
+        }
+
         $view = new ChoiceView(
             $choice,
             $value,
@@ -178,7 +194,8 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             \is_callable($attr) ? $attr($choice, $key, $value) : ($attr[$key] ?? []),
             // The label translation parameters may be a callable or a mapping from choice indices
             // to nested arrays
-            \is_callable($labelTranslationParameters) ? $labelTranslationParameters($choice, $key, $value) : ($labelTranslationParameters[$key] ?? [])
+            \is_callable($labelTranslationParameters) ? $labelTranslationParameters($choice, $key, $value) : ($labelTranslationParameters[$key] ?? []),
+            $help,
         );
 
         // $isPreferred may be null if no choices are preferred
@@ -194,7 +211,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
         }
     }
 
-    private static function addChoiceViewsFromStructuredValues(array $values, $label, array $choices, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
+    private static function addChoiceViewsFromStructuredValues(array $values, $label, array $choices, array $keys, &$index, $attr, $labelTranslationParameters, $help, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
     {
         foreach ($values as $key => $value) {
             if (null === $value) {
@@ -214,6 +231,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                     $index,
                     $attr,
                     $labelTranslationParameters,
+                    $help,
                     $isPreferred,
                     $preferredViewsForGroup,
                     $preferredViewsOrder,
@@ -241,6 +259,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $index,
                 $attr,
                 $labelTranslationParameters,
+                $help,
                 $isPreferred,
                 $preferredViews,
                 $preferredViewsOrder,
@@ -254,7 +273,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
      * @param-immediately-invoked-callable $groupBy
      * @param-immediately-invoked-callable $isPreferred
      */
-    private static function addChoiceViewsGroupedByCallable(callable $groupBy, $choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
+    private static function addChoiceViewsGroupedByCallable(callable $groupBy, $choice, string $value, $label, array $keys, &$index, $attr, $labelTranslationParameters, $help, ?callable $isPreferred, array &$preferredViews, array &$preferredViewsOrder, array &$otherViews, bool $duplicatePreferredChoices): void
     {
         $groupLabels = $groupBy($choice, $keys[$value], $value);
 
@@ -268,6 +287,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $index,
                 $attr,
                 $labelTranslationParameters,
+                $help,
                 $isPreferred,
                 $preferredViews,
                 $preferredViewsOrder,
@@ -299,6 +319,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $index,
                 $attr,
                 $labelTranslationParameters,
+                $help,
                 $isPreferred,
                 $preferredViews[$groupLabel]->choices,
                 $preferredViewsOrder[$groupLabel],

--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -109,8 +109,12 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
         return $this->decoratedFactory->createListFromLoader($loader, $value, $filter);
     }
 
-    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true): ChoiceListView
+    /**
+     * @param array|callable|null $help
+     */
+    public function createView(ChoiceListInterface $list, mixed $preferredChoices = null, mixed $label = null, mixed $index = null, mixed $groupBy = null, mixed $attr = null, mixed $labelTranslationParameters = [], bool $duplicatePreferredChoices = true/* , array|callable|null $help = null */): ChoiceListView
     {
+        $help = \func_num_args() > 8 ? func_get_arg(8) : null;
         $accessor = $this->propertyAccessor;
 
         if (\is_string($label)) {
@@ -175,6 +179,14 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $labelTranslationParameters = static fn ($choice) => $accessor->getValue($choice, $labelTranslationParameters);
         }
 
+        if (\is_string($help)) {
+            $help = new PropertyPath($help);
+        }
+
+        if ($help instanceof PropertyPathInterface) {
+            $help = static fn ($choice) => $accessor->getValue($choice, $help);
+        }
+
         return $this->decoratedFactory->createView(
             $list,
             $preferredChoices,
@@ -184,6 +196,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $attr,
             $labelTranslationParameters,
             $duplicatePreferredChoices,
+            $help,
         );
     }
 }

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -28,6 +28,7 @@ class ChoiceView
      * @param string|TranslatableInterface|false $label                      The label displayed to humans; pass false to discard the label
      * @param array                              $attr                       Additional attributes for the HTML tag
      * @param array                              $labelTranslationParameters Additional parameters used to translate the label
+     * @param string|TranslatableInterface|null  $help                       The help displayed to humans next to the choice
      */
     public function __construct(
         public mixed $data,
@@ -35,6 +36,7 @@ class ChoiceView
         public string|TranslatableInterface|false $label,
         public array $attr = [],
         public array $labelTranslationParameters = [],
+        public string|TranslatableInterface|null $help = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceAttr;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFieldName;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceFilter;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceHelp;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLabel;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLoader;
 use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceTranslationParameters;
@@ -362,6 +363,7 @@ class ChoiceType extends AbstractType
             'choice_name' => null,
             'choice_value' => null,
             'choice_attr' => null,
+            'choice_help' => null,
             'choice_translation_parameters' => [],
             'preferred_choices' => [],
             'separator' => '-------------------',
@@ -395,6 +397,7 @@ class ChoiceType extends AbstractType
         $resolver->setAllowedTypes('choice_name', ['null', 'callable', 'string', PropertyPath::class, ChoiceFieldName::class]);
         $resolver->setAllowedTypes('choice_value', ['null', 'callable', 'string', PropertyPath::class, ChoiceValue::class]);
         $resolver->setAllowedTypes('choice_attr', ['null', 'array', 'callable', 'string', PropertyPath::class, ChoiceAttr::class]);
+        $resolver->setAllowedTypes('choice_help', ['null', 'array', 'callable', 'string', PropertyPath::class, ChoiceHelp::class]);
         $resolver->setAllowedTypes('choice_translation_parameters', ['null', 'array', 'callable', ChoiceTranslationParameters::class]);
         $resolver->setAllowedTypes('placeholder_attr', ['array']);
         $resolver->setAllowedTypes('preferred_choices', ['array', \Traversable::class, 'callable', 'string', PropertyPath::class, PreferredChoice::class]);
@@ -438,6 +441,8 @@ class ChoiceType extends AbstractType
             'value' => $choiceView->value,
             'label' => $choiceView->label,
             'label_html' => $options['label_html'],
+            'help' => $choiceView->help,
+            'help_html' => $options['help_html'],
             'attr' => $choiceView->attr,
             'label_translation_parameters' => $choiceView->labelTranslationParameters,
             'translation_domain' => 'placeholder' === $name ? $options['translation_domain'] : $options['choice_translation_domain'],
@@ -487,6 +492,7 @@ class ChoiceType extends AbstractType
             $options['choice_attr'],
             $options['choice_translation_parameters'],
             $options['duplicate_preferred_choices'],
+            $options['choice_help'],
         );
     }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -392,6 +392,44 @@ class CachingFactoryDecoratorTest extends TestCase
         $this->assertEquals(new ChoiceListView(), $view2);
     }
 
+    public function testCreateViewSameHelpClosure()
+    {
+        $helps = static function () {};
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, $helps);
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, $helps);
+
+        $this->assertNotSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
+    public function testCreateViewSameHelpClosureUseCache()
+    {
+        $helpCallback = static function () {};
+        $type = new FormType();
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, ChoiceList::help($type, $helpCallback));
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, ChoiceList::help($type, static function () {}));
+
+        $this->assertSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
+    public function testCreateViewDifferentHelpClosure()
+    {
+        $helps1 = static function () {};
+        $helps2 = static function () {};
+        $list = new ArrayChoiceList([]);
+        $view1 = $this->factory->createView($list, null, null, null, null, null, [], true, $helps1);
+        $view2 = $this->factory->createView($list, null, null, null, null, null, [], true, $helps2);
+
+        $this->assertNotSame($view1, $view2);
+        $this->assertEquals(new ChoiceListView(), $view1);
+        $this->assertEquals(new ChoiceListView(), $view2);
+    }
+
     public function testCreateViewSameIndexClosure()
     {
         $index = static function () {};

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1876,6 +1876,62 @@ class ChoiceTypeTest extends BaseTypeTestCase
         ], $view->vars['choices']);
     }
 
+    public function testPassChoiceHelpToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'choices' => ['A' => 'a', 'B' => 'b'],
+            'choice_attr' => ['A' => ['class' => 'x']],
+            'choice_help' => ['A' => 'Help of A'],
+        ])
+            ->createView();
+
+        $this->assertEquals([
+            new ChoiceView('a', 'a', 'A', ['class' => 'x'], [], 'Help of A'),
+            new ChoiceView('b', 'b', 'B'),
+        ], $view->vars['choices']);
+    }
+
+    public function testChoiceHelpFromACallable()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'choices' => ['A' => 'a'],
+            'choice_help' => static fn ($choice, $key, $value) => $key.'/'.$value,
+        ])
+            ->createView();
+
+        $this->assertSame('A/a', $view->vars['choices'][0]->help);
+    }
+
+    public function testChoiceHelpFromAPropertyPath()
+    {
+        $obj = (object) ['value' => 'a', 'label' => 'A', 'description' => 'Help of A'];
+
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'choices' => [$obj],
+            'choice_label' => 'label',
+            'choice_value' => 'value',
+            'choice_help' => 'description',
+        ])
+            ->createView();
+
+        $this->assertSame('Help of A', $view->vars['choices'][0]->help);
+    }
+
+    public function testExpandedChoiceHelpIsPassedToTheChildren()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'choices' => ['A' => 'a', 'B' => 'b'],
+            'choice_help' => ['A' => 'Help of A'],
+            'choice_translation_domain' => 'choices',
+            'expanded' => true,
+        ])
+            ->createView();
+
+        $this->assertSame('Help of A', $view->children[0]->vars['help']);
+        $this->assertNull($view->children[1]->vars['help']);
+        $this->assertSame('choices', $view->children[0]->vars['translation_domain']);
+    }
+
     public function testAdjustFullNameForMultipleNonExpanded()
     {
         $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, [

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -5,6 +5,7 @@
         "own": [
             "choice_attr",
             "choice_filter",
+            "choice_help",
             "choice_label",
             "choice_lazy",
             "choice_loader",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -7,24 +7,24 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
  ------------------------------- -------------------- ------------------------------ ----------------------- 
   choice_attr                     FormType             FormType                       FormTypeCsrfExtension  
   choice_filter                  -------------------- ------------------------------ ----------------------- 
-  choice_label                    compound             action                         csrf_field_name        
-  choice_lazy                     data_class           allow_file_upload              csrf_message           
-  choice_loader                   empty_data           attr                           csrf_protection        
-  choice_name                     error_bubbling       attr_translation_parameters    csrf_token_id          
-  choice_translation_domain       invalid_message      auto_initialize                csrf_token_manager     
-  choice_translation_parameters   trim                 block_name                                            
-  choice_value                                         block_prefix                                          
-  choices                                              by_reference                                          
-  duplicate_preferred_choices                          data                                                  
-  expanded                                             disabled                                              
-  group_by                                             form_attr                                             
-  multiple                                             getter                                                
-  placeholder                                          help                                                  
-  placeholder_attr                                     help_attr                                             
-  preferred_choices                                    help_html                                             
-  separator                                            help_translation_parameters                           
-  separator_html                                       inherit_data                                          
-                                                       invalid_message_parameters                            
+  choice_help                     compound             action                         csrf_field_name        
+  choice_label                    data_class           allow_file_upload              csrf_message           
+  choice_lazy                     empty_data           attr                           csrf_protection        
+  choice_loader                   error_bubbling       attr_translation_parameters    csrf_token_id          
+  choice_name                     invalid_message      auto_initialize                csrf_token_manager     
+  choice_translation_domain       trim                 block_name                                            
+  choice_translation_parameters                        block_prefix                                          
+  choice_value                                         by_reference                                          
+  choices                                              data                                                  
+  duplicate_preferred_choices                          disabled                                              
+  expanded                                             form_attr                                             
+  group_by                                             getter                                                
+  multiple                                             help                                                  
+  placeholder                                          help_attr                                             
+  placeholder_attr                                     help_html                                             
+  preferred_choices                                    help_translation_parameters                           
+  separator                                            inherit_data                                          
+  separator_html                                       invalid_message_parameters                            
                                                        is_empty_callback                                     
                                                        label                                                 
                                                        label_attr                                            
@@ -52,4 +52,3 @@ Type extensions
 ---------------
 
  * Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension
-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #50823
| License       | MIT

`ChoiceType` gains a `choice_help` option, a per-choice description resolved exactly like `choice_label`:

```php
$builder->add('category', ChoiceType::class, [
    'choices' => $categories,
    'choice_label' => 'name',
    'choice_help' => 'description',
    'expanded' => true,
]);
```

It accepts an array keyed by choice key, a callable receiving `($choice, $key, $value)`, a property path, or a `ChoiceList::help()` wrapper. The resolved value lands on `ChoiceView::$help` and is translated with `choice_translation_domain`, like the label.

## Rendering

Expanded choices render the help through the existing `form_help()` machinery, so each radio or checkbox gets a help element and an `aria-describedby` pointing at it:

```html
<input type="radio" id="form_category_0" aria-describedby="form_category_0_help">
<label for="form_category_0">Fruits</label>
<div id="form_category_0_help" class="help-text">Things that grow on trees</div>
```

All seven themes that define `choice_widget_expanded` render it: `form_div_layout`, `bootstrap_base`, `bootstrap_4`, `bootstrap_5`, `foundation_5`, `tailwind_2` and `daisyui_5`.

A collapsed `<select>` renders nothing, because an `<option>` cannot contain block content. This is not a temporary shortcut: Rails exposes the same thing as raw per-`<option>` attributes through `options_for_select`, Django as a `create_option()` override, and every library that renders per-option descriptions does so by replacing the native select with a `role="listbox"` widget. The value is still on `ChoiceView::$help`, so a custom theme can render it, and native customizable select would let the shipped themes do so later without an API change.

## Why not choice_attr

`choice_attr` can already carry a description into an HTML attribute:

```php
'choice_attr' => fn ($choice) => ['data-help' => $choice->getDescription()],
```

What it cannot do is give the description an element to live in, which is what `aria-describedby` has to point at, and it does not go through `choice_translation_domain`. Those two are what this option adds.

## Notes

`ChoiceListFactoryInterface::createView()` takes `$help` as a commented parameter read through `func_get_args()`, the same route `$duplicatePreferredChoices` took in 6.4, so implementations outside the tree keep working. `ChoiceList::help()` joins the ten existing static-option wrappers and a `Cache\ChoiceHelp` wrapper keeps `CachingFactoryDecorator` caching the view. `choice_attr` is untouched, and there is no `choice_help_html`: expanded children reuse `help_html`, the way they already reuse `label_html`.

There is no rendering for collapsed selects and no per-choice help on `EntityType` groups beyond what the class map gives; both are documented limitations rather than open work.
