### PR TITLE
[TwigBundle] Add EnvironmentConfiguratorInterface for decorators

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 8.1
 ---
 
+ * Register `Twig\Runtime\EscaperRuntime` as the `twig.runtime.escaper` service, tagged as `twig.runtime`.
+   This makes `EscaperRuntime` decoratable and configurable via DI without breaking Twig's lazy-loading,
+   providing a better extension point than decorating the environment configurator.
  * Add `EnvironmentConfiguratorInterface` to allow decorating the Twig environment configurator via an interface
 
 8.0

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `EnvironmentConfiguratorInterface` to allow decorating the Twig environment configurator via an interface
+
 8.0
 ---
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
@@ -20,7 +20,7 @@ use Twig\Extension\CoreExtension;
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-class EnvironmentConfigurator
+class EnvironmentConfigurator implements EnvironmentConfiguratorInterface
 {
     public function __construct(
         private string $dateFormat,

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfiguratorInterface.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfiguratorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\DependencyInjection\Configurator;
+
+use Twig\Environment;
+
+interface EnvironmentConfiguratorInterface
+{
+    public function configure(Environment $environment): void;
+}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -106,6 +106,9 @@ class TwigExtension extends Extension
         $envConfiguratorDefinition->replaceArgument(4, $config['number_format']['decimal_point']);
         $envConfiguratorDefinition->replaceArgument(5, $config['number_format']['thousands_separator']);
 
+        $container->getDefinition('twig.runtime.escaper')
+            ->replaceArgument(0, $config['charset']);
+
         $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.native_filesystem');
 
         // register user-configured paths

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -35,6 +35,7 @@ use Symfony\Bridge\Twig\Extension\YamlExtension;
 use Symfony\Bridge\Twig\Translation\TwigExtractor;
 use Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheWarmer;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfigurator;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfiguratorInterface;
 use Symfony\Bundle\TwigBundle\TemplateIterator;
 use Twig\Cache\ChainCache;
 use Twig\Cache\FilesystemCache;
@@ -171,6 +172,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('decimal point, set in TwigExtension'),
                 abstract_arg('thousands separator, set in TwigExtension'),
             ])
+        ->alias(EnvironmentConfiguratorInterface::class, 'twig.configurator.environment')
 
         ->set('twig.runtime_loader', ContainerRuntimeLoader::class)
             ->args([abstract_arg('runtime locator')])

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -51,6 +51,7 @@ use Twig\ExtensionSet;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
 use Twig\Profiler\Profile;
+use Twig\Runtime\EscaperRuntime;
 use Twig\RuntimeLoader\ContainerRuntimeLoader;
 use Twig\Template;
 use Twig\TemplateWrapper;
@@ -147,6 +148,11 @@ return static function (ContainerConfigurator $container) {
 
         ->set('twig.runtime.httpkernel', HttpKernelRuntime::class)
             ->args([service('fragment.handler'), service('fragment.uri_generator')->ignoreOnInvalid()])
+            ->tag('twig.runtime')
+
+        ->set('twig.runtime.escaper', EscaperRuntime::class)
+            ->args([abstract_arg('charset, set in TwigExtension')])
+            ->tag('twig.runtime')
 
         ->set('twig.extension.httpfoundation', HttpFoundationExtension::class)
             ->args([service('url_helper')])
@@ -189,6 +195,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('twig.runtime.serializer', SerializerRuntime::class)
             ->args([service('serializer')])
+            ->tag('twig.runtime')
 
         ->set('twig.extension.serializer', SerializerExtension::class)
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfiguratorInterface;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\RuntimeLoaderPass;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfiguratorInterface;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use Symfony\Bundle\TwigBundle\Tests\DependencyInjection\AcmeBundle\AcmeBundle;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfiguratorInterface;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\RuntimeLoaderPass;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use Symfony\Bundle\TwigBundle\Tests\DependencyInjection\AcmeBundle\AcmeBundle;
@@ -184,6 +185,17 @@ class TwigExtensionTest extends TestCase
         $this->assertSame(2, $environmentConfigurator->getArgument(3));
         $this->assertSame(',', $environmentConfigurator->getArgument(4));
         $this->assertSame('.', $environmentConfigurator->getArgument(5));
+    }
+
+    public function testEnvironmentConfiguratorInterfaceAlias()
+    {
+        $container = $this->createContainer();
+        $container->registerExtension(new TwigExtension());
+        $container->loadFromExtension('twig');
+        $this->compileContainer($container);
+
+        $this->assertTrue($container->hasAlias(EnvironmentConfiguratorInterface::class));
+        $this->assertSame('twig.configurator.environment', (string) $container->getAlias(EnvironmentConfiguratorInterface::class));
     }
 
     public function testGlobalsWithDifferentTypesAndValues()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63808
| License       | MIT

Adds a TwigBundle interface and service alias for the environment configurator so decorators can type-hint it safely.