### PR TITLE
 Review and clean up Afrikaans security translations

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.af.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.af.xlf
@@ -72,11 +72,11 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target state="needs-review-translation">Te veel mislukte aanmeldpogings, probeer asseblief weer oor %minutes% minuut.</target>
+                <target>Te veel mislukte aanmeldpogings, probeer asseblief weer oor %minutes% minute.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Te veel mislukte aanmeldpogings, probeer asseblief weer oor %minutes% minute.</target>
+                <target>Te veel mislukte aanmeldpogings, probeer asseblief weer oor %minutes% minute.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Translations
Review and remove needs-review-translation flag for Afrikaans (af) security messages.
Target branch: 6.4 (translation fixes are allowed on the oldest maintained branch).