### PR TITLE
[Translation][sr_Latn] Finalize validator messages 121-128

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="sr-Latn" datatype="plaintext" original="file.ext">
         <body>
@@ -468,35 +468,35 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Ova vrednost nije važeći Twig šablon.</target>
+                <target>Ova vrednost nije važeći Twig šablon.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Ova datoteka nije važeći video.</target>
+                <target>Ova datoteka nije važeći video.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Nije bilo moguće utvrditi veličinu video snimka.</target>
+                <target>Nije bilo moguće utvrditi veličinu video snimka.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
+                <target>Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je previše mala ({{ width }}px). Očekivana minimalna širina je {{ min_width }}px.</target>
+                <target>Širina videa je previše mala ({{ width }}px). Očekivana minimalna širina je {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
+                <target>Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je premala ({{ height }}px). Očekivana minimalna visina je {{ min_height }}px.</target>
+                <target>Visina videa je premala ({{ height }}px). Očekivana minimalna visina je {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video ima premalo piksela ({{ pixels }}). Očekivana minimalna količina je {{ min_pixels }}.</target>
+                <target>Video ima premalo piksela ({{ pixels }}). Očekivana minimalna količina je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>


### PR DESCRIPTION
Branch: 6.4
Bug fix: yes
New feature: no
Deprecations: no
Issues: Fix #60471
License: MIT

This change finalizes Serbian Latin validator translations by promoting reviewed entries to final status for trans-unit IDs 121-128.
It removes review metadata only and keeps the translated text and placeholders unchanged.

Before: Entries were marked as needs-review-translation.
After: Entries are treated as finalized translations with no review-state marker.