### PR TITLE
[Translation][hu] Finalize validator messages 121-128

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="hu" datatype="plaintext" original="file.ext">
         <body>
@@ -468,35 +468,35 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Ez az érték nem érvényes Twig sablon.</target>
+                <target>Ez az érték nem érvényes Twig sablon.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Ez a fájl nem érvényes videó.</target>
+                <target>Ez a fájl nem érvényes videó.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">A videó méretét nem sikerült megállapítani.</target>
+                <target>A videó méretét nem sikerült megállapítani.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">A videó szélessége túl nagy ({{ width }}px). A megengedett maximális szélesség {{ max_width }}px.</target>
+                <target>A videó szélessége túl nagy ({{ width }}px). A megengedett maximális szélesség {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">A videó szélessége túl kicsi ({{ width }}px). A várható minimális szélesség {{ min_width }} px.</target>
+                <target>A videó szélessége túl kicsi ({{ width }}px). A várható minimális szélesség {{ min_width }} px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">A videó magassága túl nagy ({{ height }}px). A megengedett maximális magasság {{ max_height }}px.</target>
+                <target>A videó magassága túl nagy ({{ height }}px). A megengedett maximális magasság {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">A videó magassága túl kicsi ({{ height }}px). A minimálisan elvárt magasság {{ min_height }}px.</target>
+                <target>A videó magassága túl kicsi ({{ height }}px). A minimálisan elvárt magasság {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">A videóban túl kevés a képpont ({{ pixels }}). Az elvárt minimális mennyiség {{ min_pixels }}.</target>
+                <target>A videóban túl kevés a képpont ({{ pixels }}). Az elvárt minimális mennyiség {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>


### PR DESCRIPTION
Branch: 6.4
Bug fix: yes
New feature: no
Deprecations: no
Issues: Fix #60462
License: MIT

This change finalizes Hungarian validator translations by promoting reviewed entries to final status for trans-unit IDs 121-128.
It removes review metadata only and keeps the translated text and placeholders unchanged.

Before: Entries were marked as needs-review-translation.
After: Entries are treated as finalized translations with no review-state marker.