### PR TITLE
[Translation][vi] Finalize security message id 20

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="vi" datatype="plaintext" original="file.ext">
         <body>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Quá nhiều lần đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.|Quá nhiều lần đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.</target>
+                <target>Quá nhiều lần đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.|Quá nhiều lần đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Branch: 6.4
Bug fix: yes
New feature: no
Deprecations: no
Issues: Fix #53309
License: MIT

This change finalizes the Vietnamese security plural login-attempt message (trans-unit ID 20).
It removes review metadata only and keeps the translated text and placeholders unchanged.

Before: Entry was marked as needs-review-translation.
After: Entry is treated as finalized translation with no review-state marker.