### PR TITLE
[Translation][mk] Finalize security message id 20

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.mk.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.mk.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="mk" datatype="plaintext" original="file.ext">
         <body>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Претерано многу неуспешни обиди за најавување, ве молиме обидете се повторно за %minutes% минута.|Претерано многу неуспешни обиди за најавување, ве молиме обидете се повторно за %minutes% минути.</target>
+                <target>Претерано многу неуспешни обиди за најавување, ве молиме обидете се повторно за %minutes% минута.|Претерано многу неуспешни обиди за најавување, ве молиме обидете се повторно за %minutes% минути.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Branch: 6.4
Bug fix: yes
New feature: no
Deprecations: no
Issues: Fix #53296
License: MIT

This change finalizes the Macedonian security plural login-attempt message (trans-unit ID 20).
It removes review metadata only and keeps the translated text and placeholders unchanged.

Before: Entry was marked as needs-review-translation.
After: Entry is treated as finalized translation with no review-state marker.