### PR TITLE
[Console] Keep _complete output visible with SHELL_VERBOSITY=-1

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -992,6 +992,12 @@ class Application implements ResetInterface
                 break;
         }
 
+        // Keep completion output visible even when SHELL_VERBOSITY is inherited as quiet.
+        if ('_complete' === $input->getFirstArgument()) {
+            $shellVerbosity = 0;
+            $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+        }
+
         if (true === $input->hasParameterOption(['--quiet', '-q'], true)) {
             $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
             $shellVerbosity = -1;

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\CompleteCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\LazyCommand;
@@ -55,6 +56,27 @@ use Symfony\Component\Process\Process;
 
 class ApplicationTest extends TestCase
 {
+
+    public function testCompleteCommandIsNotMutedByNegativeShellVerbosity()
+    {
+        putenv('SHELL_VERBOSITY=-1');
+        $_ENV['SHELL_VERBOSITY'] = '-1';
+        $_SERVER['SHELL_VERBOSITY'] = '-1';
+
+        $application = new Application();
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run([
+            'command' => '_complete',
+            '--shell' => 'bash',
+            '--api-version' => CompleteCommand::COMPLETION_API_VERSION,
+            '--current' => 1,
+            '--input' => ['bin/console'],
+        ], ['decorated' => false]);
+
+        $this->assertStringContainsString("help\n", $tester->getDisplay(true));
+    }
     protected static string $fixturesPath;
 
     private string|false $colSize;

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Console\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Command\CompleteCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\LazyCommand;
@@ -56,7 +55,6 @@ use Symfony\Component\Process\Process;
 
 class ApplicationTest extends TestCase
 {
-
     public function testCompleteCommandIsNotMutedByNegativeShellVerbosity()
     {
         putenv('SHELL_VERBOSITY=-1');
@@ -77,6 +75,7 @@ class ApplicationTest extends TestCase
 
         $this->assertStringContainsString("help\n", $tester->getDisplay(true));
     }
+
     protected static string $fixturesPath;
 
     private string|false $colSize;


### PR DESCRIPTION

-- | --
Branch? | 6.4
Bug fix? | yes
New feature? | no
Deprecations? | no
Issues | Fix #63829


------------------------------------


This change fixes bash completion when SHELL_VERBOSITY is set to -1.
The internal _complete command no longer inherits quiet mode from the parent shell environment, so completion suggestions are still returned.

Example:
With SHELL_VERBOSITY=-1, running completion for bin/console now still prints suggestions like help, list, completion.

Before:
Completion output was muted when quiet shell verbosity was inherited.

After:
Completion output stays visible for _complete, while normal command verbosity behavior remains unchanged.

If you want, I can also prepare the final PR titles list in one copy-paste block matching these descriptions.
