### PR TITLE
[Mailer][Brevo] Prefer message sender/from in API payload

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -181,4 +181,35 @@ class BrevoApiTransportTest extends TestCase
 
         $this->assertSame('foobar', $message->getMessageId());
     }
+
+    public function testPayloadPrefersMessageFromOverEnvelopeSender()
+    {
+        $email = new Email();
+        $email->from(new Address('from@example.com', 'From Name'));
+
+        $envelope = new Envelope(new Address('envelope@example.com', 'Envelope Name'), [new Address('to@example.com')]);
+
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('from@example.com', $payload['sender']['email']);
+        $this->assertSame('From Name', $payload['sender']['name']);
+    }
+
+    public function testPayloadPrefersMessageSenderOverFromAndEnvelopeSender()
+    {
+        $email = new Email();
+        $email->from(new Address('from@example.com', 'From Name'));
+        $email->sender(new Address('sender@example.com', 'Sender Name'));
+
+        $envelope = new Envelope(new Address('envelope@example.com', 'Envelope Name'), [new Address('to@example.com')]);
+
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('sender@example.com', $payload['sender']['email']);
+        $this->assertSame('Sender Name', $payload['sender']['name']);
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -184,32 +184,50 @@ class BrevoApiTransportTest extends TestCase
 
     public function testPayloadPrefersMessageFromOverEnvelopeSender()
     {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+            $this->assertSame('from@example.com', $body['sender']['email']);
+            $this->assertSame('From Name', $body['sender']['name']);
+
+            return new JsonMockResponse(['messageId' => 'foobar'], ['http_code' => 201]);
+        });
+
+        $transport = new BrevoApiTransport('ACCESS_KEY', $client);
+
         $email = new Email();
-        $email->from(new Address('from@example.com', 'From Name'));
+        $email->subject('Hello!')
+            ->to(new Address('to@example.com', 'To Name'))
+            ->from(new Address('from@example.com', 'From Name'))
+            ->text('Hello there!');
 
-        $envelope = new Envelope(new Address('envelope@example.com', 'Envelope Name'), [new Address('to@example.com')]);
+        $envelope = new Envelope(new Address('envelope@example.com', 'Envelope Name'), [new Address('to@example.com', 'To Name')]);
 
-        $transport = new BrevoApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
-        $payload = $method->invoke($transport, $email, $envelope);
-
-        $this->assertSame('from@example.com', $payload['sender']['email']);
-        $this->assertSame('From Name', $payload['sender']['name']);
+        $message = $transport->send($email, $envelope);
+        $this->assertSame('foobar', $message->getMessageId());
     }
 
     public function testPayloadPrefersMessageSenderOverFromAndEnvelopeSender()
     {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+            $this->assertSame('sender@example.com', $body['sender']['email']);
+            $this->assertSame('Sender Name', $body['sender']['name']);
+
+            return new JsonMockResponse(['messageId' => 'foobar'], ['http_code' => 201]);
+        });
+
+        $transport = new BrevoApiTransport('ACCESS_KEY', $client);
+
         $email = new Email();
-        $email->from(new Address('from@example.com', 'From Name'));
-        $email->sender(new Address('sender@example.com', 'Sender Name'));
+        $email->subject('Hello!')
+            ->to(new Address('to@example.com', 'To Name'))
+            ->from(new Address('from@example.com', 'From Name'))
+            ->sender(new Address('sender@example.com', 'Sender Name'))
+            ->text('Hello there!');
 
-        $envelope = new Envelope(new Address('envelope@example.com', 'Envelope Name'), [new Address('to@example.com')]);
+        $envelope = new Envelope(new Address('envelope@example.com', 'Envelope Name'), [new Address('to@example.com', 'To Name')]);
 
-        $transport = new BrevoApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
-        $payload = $method->invoke($transport, $email, $envelope);
-
-        $this->assertSame('sender@example.com', $payload['sender']['email']);
-        $this->assertSame('Sender Name', $payload['sender']['name']);
+        $message = $transport->send($email, $envelope);
+        $this->assertSame('foobar', $message->getMessageId());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -88,8 +88,13 @@ final class BrevoApiTransport extends AbstractApiTransport
 
     private function getPayload(Email $email, Envelope $envelope): array
     {
+        $sender = $email->getSender();
+        if (!$sender && ($from = $email->getFrom())) {
+            $sender = $from[0];
+        }
+
         $payload = [
-            'sender' => $this->formatAddress($envelope->getSender()),
+            'sender' => $this->formatAddress($sender ?? $envelope->getSender()),
             'to' => $this->formatAddresses($this->getRecipients($email, $envelope)),
             'subject' => $email->getSubject(),
         ];


### PR DESCRIPTION
Branch: 6.4
Bug fix: yes
New feature: no
Deprecations: no
Issues: Fix #54232
License: MIT

This change updates Brevo API payload sender resolution to prefer message-level sender/from over envelope sender.
It aligns payload generation with email header intent and includes tests for precedence behavior.