### PR TITLE
[HttpFoundation] Consider 204 responses with Location as redirects

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1284,7 +1284,7 @@ class Response
      */
     public function isRedirect(?string $location = null): bool
     {
-        return \in_array($this->statusCode, [201, 301, 302, 303, 307, 308]) && (null === $location ?: $location == $this->headers->get('Location'));
+        return \in_array($this->statusCode, [201, 204, 301, 302, 303, 307, 308]) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1284,7 +1284,15 @@ class Response
      */
     public function isRedirect(?string $location = null): bool
     {
-        return \in_array($this->statusCode, [201, 204, 301, 302, 303, 307, 308]) && (null === $location ?: $location == $this->headers->get('Location'));
+        if (null === $location) {
+            if (\in_array($this->statusCode, [201, 301, 302, 303, 307, 308], true)) {
+                return true;
+            }
+
+            return 204 === $this->statusCode && null !== $this->headers->get('Location');
+        }
+
+        return \in_array($this->statusCode, [201, 204, 301, 302, 303, 307, 308], true) && $location == $this->headers->get('Location');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -916,7 +916,7 @@ class ResponseTest extends ResponseTestCase
 
     public function testIsRedirectRedirection()
     {
-        foreach ([301, 302, 303, 307] as $code) {
+        foreach ([301, 302, 303, 307, 308] as $code) {
             $response = new Response('', $code);
             $this->assertTrue($response->isRedirection());
             $this->assertTrue($response->isRedirect());
@@ -935,6 +935,14 @@ class ResponseTest extends ResponseTestCase
         $this->assertFalse($response->isRedirect());
 
         $response = new Response('', 301, ['Location' => '/good-uri']);
+        $this->assertFalse($response->isRedirect('/bad-uri'));
+        $this->assertTrue($response->isRedirect('/good-uri'));
+
+        $response = new Response('', 204);
+        $this->assertFalse($response->isRedirect());
+
+        $response = new Response('', 204, ['Location' => '/good-uri']);
+        $this->assertTrue($response->isRedirect());
         $this->assertFalse($response->isRedirect('/bad-uri'));
         $this->assertTrue($response->isRedirect('/good-uri'));
     }


### PR DESCRIPTION
Branch: 6.4
Bug fix: yes
New feature: no
Deprecations: no
Issues: Fix #59973
License: MIT

This change treats HTTP 204 responses with a Location header as redirects in redirect detection logic.
It improves profiler/live-component redirect handling and includes regression tests.