### PR TITLE
[DependencyInjection] AsFactory attribute for simple auto-configuration

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/AsFactory.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * Declares that the annotated invokable class or method is a factory for another service.
+ *
+ * The service id to create is given via the $id parameter.
+ * If $id is omitted, the return type of the factory method is used instead.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class AsFactory
+{
+    /**
+     * @param string $id the id of the service this factory creates; auto-detected from the return type when empty
+     */
+    public function __construct(
+        public readonly string $id = '',
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
  * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
  * Add support for injecting a service as a lazy proxy on a per-argument basis, using the `!lazy_proxy` YAML tag, the `@~` reference prefix or the `lazy_proxy()` function in the PHP-DSL
+ * Add `#[AsFactory]` attribute to register a class or method as a factory for another service
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -45,6 +45,7 @@ class PassConfig
                 new ResolveClassPass(),
                 new RegisterAutoconfigureAttributesPass(),
                 new AutowireAsDecoratorPass(),
+                new RegisterAsFactoryPass(),
                 new AttributeAutoconfigurationPass(),
                 new ResolveInstanceofConditionalsPass(),
                 new RegisterEnvVarProcessorsPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterAsFactoryPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterAsFactoryPass.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Attribute\AsFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Reads #[AsFactory] attributes on autoconfigured service definitions and registers
+ * a factory with the declared services, accordingly.
+ */
+final class RegisterAsFactoryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $factoryId => $definition) {
+            if ($definition->hasTag('container.ignore_attributes') || $definition->hasTag('container.excluded') || !$definition->isAutoconfigured() || $definition->isAbstract()) {
+                continue;
+            }
+
+            $class = $container->getReflectionClass($definition->getClass(), false);
+            if (null === $class) {
+                continue;
+            }
+
+            foreach ($class->getAttributes(AsFactory::class) as $attribute) {
+                $this->configureFactory($container, $factoryId, $attribute->newInstance(), $class, null);
+            }
+
+            foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->isConstructor() || $method->isDestructor()) {
+                    continue;
+                }
+
+                foreach ($method->getAttributes(AsFactory::class) as $attribute) {
+                    $this->configureFactory($container, $factoryId, $attribute->newInstance(), $class, $method);
+                }
+            }
+        }
+    }
+
+    private function configureFactory(
+        ContainerBuilder $container,
+        string $factoryId,
+        AsFactory $attribute,
+        \ReflectionClass $class,
+        ?\ReflectionMethod $method,
+    ): void {
+        if (null === $method) {
+            if (!$class->hasMethod('__invoke')) {
+                throw new LogicException(\sprintf('The #[AsFactory] attribute on class "%s" requires the class to be invokable (add a "__invoke" method).', $class->name));
+            }
+            $method = $class->getMethod('__invoke');
+            $factoryCallable = [new Reference($factoryId), '__invoke'];
+        } else {
+            $factoryCallable = $method->isStatic()
+                ? [$class->name, $method->name]
+                : [new Reference($factoryId), $method->name];
+        }
+
+        [$serviceId, $serviceClass] = $this->extractServiceDefinition($attribute, $method, $class);
+
+        if ($container->hasAlias($serviceId)) {
+            throw new LogicException(\sprintf('The #[AsFactory] attribute on "%s" declares service "%s", which is already defined as an alias.', $factoryId, $serviceId));
+        }
+
+        if ($container->hasDefinition($serviceId)) {
+            $definition = $container->getDefinition($serviceId);
+            if ($definition->isAbstract() || $definition->hasTag('container.excluded')) {
+                return;
+            }
+            if (null !== $definition->getFactory()) {
+                throw new LogicException(\sprintf('The #[AsFactory] attribute on "%s" declares service "%s", which already has a factory; remove one of them.', $factoryId, $serviceId));
+            }
+            $definition->setFactory($factoryCallable);
+        } else {
+            $container->register($serviceId, $serviceClass)
+                ->setAutowired(true)
+                ->setFactory($factoryCallable);
+        }
+    }
+
+    /**
+     * @return list{string, class-string}
+     */
+    private function extractServiceDefinition(AsFactory $attribute, \ReflectionMethod $method, \ReflectionClass $class): array
+    {
+        $serviceId = $attribute->id;
+
+        $returnType = $method->getReturnType();
+
+        if ('' === $serviceId) {
+            if (null === $returnType) {
+                throw new LogicException(\sprintf('The #[AsFactory] attribute on "%s::%s()" requires either an explicit "id" or a return type declaration.', $class->name, $method->name));
+            }
+            if ($returnType instanceof \ReflectionUnionType || $returnType instanceof \ReflectionIntersectionType) {
+                throw new LogicException(\sprintf('The #[AsFactory] attribute on "%s::%s()" does not support union or intersection return types; provide an explicit "id".', $class->name, $method->name));
+            }
+            /** @var \ReflectionNamedType $returnType */
+            if ($returnType->isBuiltin()) {
+                throw new LogicException(\sprintf('The #[AsFactory] attribute on "%s::%s()" requires a class or interface return type, got "%s"; provide an explicit "id".', $class->name, $method->name, $returnType->getName()));
+            }
+            $serviceId = $this->extractDeclaringClass($returnType, $class, $method);
+
+            return [$serviceId, $serviceId];
+        }
+
+        if ($returnType instanceof \ReflectionNamedType && !$returnType->isBuiltin()) {
+            return [$serviceId, $this->extractDeclaringClass($returnType, $class, $method)];
+        }
+
+        return [$serviceId, $serviceId];
+    }
+
+    /** @return class-string */
+    private function extractDeclaringClass(\ReflectionIntersectionType|\ReflectionNamedType|\ReflectionUnionType $returnType, \ReflectionClass $class, \ReflectionMethod $method): string
+    {
+        return match (strtolower($name = $returnType->getName())) {
+            'static' => $class->name,
+            'self' => $method->getDeclaringClass()->name,
+            'parent' => $method->getDeclaringClass()->getParentClass()->name,
+            default => $name,
+        };
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAsFactoryPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterAsFactoryPassTest.php
@@ -1,0 +1,395 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\AsFactory;
+use Symfony\Component\DependencyInjection\Compiler\RegisterAsFactoryPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterAsFactoryPassTest extends TestCase
+{
+    public function testInvokableFactoryClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register('factory', InvokableFactory::class)
+            ->setAutoconfigured(true);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $this->assertTrue($container->hasDefinition(FactoryCreatedService::class));
+        $definition = $container->getDefinition(FactoryCreatedService::class);
+        $this->assertSame(FactoryCreatedService::class, $definition->getClass());
+        $this->assertEquals([new Reference('factory'), '__invoke'], $definition->getFactory());
+    }
+
+    public function testNonStaticFactoryMethod()
+    {
+        $container = new ContainerBuilder();
+        $container->register('factory', MethodFactory::class)
+            ->setAutoconfigured(true);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $this->assertTrue($container->hasDefinition(FactoryCreatedService::class));
+        $definition = $container->getDefinition(FactoryCreatedService::class);
+        $this->assertSame(FactoryCreatedService::class, $definition->getClass());
+        $this->assertEquals([new Reference('factory'), 'create'], $definition->getFactory());
+    }
+
+    public function testStaticFactoryMethod()
+    {
+        $container = new ContainerBuilder();
+        $container->register(StaticMethodFactory::class, StaticMethodFactory::class)
+            ->setAutoconfigured(true);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $this->assertTrue($container->hasDefinition(FactoryCreatedService::class));
+        $definition = $container->getDefinition(FactoryCreatedService::class);
+        $this->assertSame(FactoryCreatedService::class, $definition->getClass());
+        $this->assertSame([StaticMethodFactory::class, 'create'], $definition->getFactory());
+    }
+
+    public function testExplicitIdWithReturnTypeDerivesClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register(ExplicitIdFactory::class, ExplicitIdFactory::class)
+            ->setAutoconfigured(true);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $this->assertTrue($container->hasDefinition('explicit.service.id'));
+        $definition = $container->getDefinition('explicit.service.id');
+        $this->assertSame(FactoryCreatedService::class, $definition->getClass());
+        $this->assertEquals([new Reference(ExplicitIdFactory::class), '__invoke'], $definition->getFactory());
+    }
+
+    public function testMergesFactoryIntoExistingDefinition()
+    {
+        $container = new ContainerBuilder();
+        $container->register(InvokableFactory::class, InvokableFactory::class)
+            ->setAutoconfigured(true);
+        $container->register(FactoryCreatedService::class, FactoryCreatedService::class)
+            ->addTag('my.tag')
+            ->setArguments(['pre-existing']);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $definition = $container->getDefinition(FactoryCreatedService::class);
+        $this->assertEquals([new Reference(InvokableFactory::class), '__invoke'], $definition->getFactory());
+        $this->assertTrue($definition->hasTag('my.tag'));
+        $this->assertSame(['pre-existing'], $definition->getArguments());
+    }
+
+    public function testSkipsNonAutoconfiguredServices()
+    {
+        $container = new ContainerBuilder();
+        $container->register(InvokableFactory::class, InvokableFactory::class)
+            ->setAutoconfigured(false);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $this->assertFalse($container->hasDefinition(FactoryCreatedService::class));
+    }
+
+    public function testThrowsWhenClassNotInvokable()
+    {
+        $container = new ContainerBuilder();
+        $container->register(NonInvokableFactory::class, NonInvokableFactory::class)
+            ->setAutoconfigured(true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('requires the class to be invokable');
+        new RegisterAsFactoryPass()->process($container);
+    }
+
+    public function testThrowsWhenNoReturnType()
+    {
+        $container = new ContainerBuilder();
+        $container->register(NoReturnTypeFactory::class, NoReturnTypeFactory::class)
+            ->setAutoconfigured(true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('requires either an explicit "id" or a return type declaration');
+        new RegisterAsFactoryPass()->process($container);
+    }
+
+    public function testThrowsWhenBuiltinReturnType()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BuiltinReturnTypeFactory::class, BuiltinReturnTypeFactory::class)
+            ->setAutoconfigured(true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('requires a class or interface return type');
+        new RegisterAsFactoryPass()->process($container);
+    }
+
+    public function testThrowsOnUnionReturnType()
+    {
+        $container = new ContainerBuilder();
+        $container->register(UnionReturnTypeFactory::class, UnionReturnTypeFactory::class)
+            ->setAutoconfigured(true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('does not support union or intersection return types');
+        new RegisterAsFactoryPass()->process($container);
+    }
+
+    public function testFactoryRegisteredUnderACustomServiceId()
+    {
+        $container = new ContainerBuilder();
+        $container->register('app.my_factory', InvokableFactory::class)
+            ->setAutoconfigured(true);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $definition = $container->getDefinition(FactoryCreatedService::class);
+        $this->assertEquals([new Reference('app.my_factory'), '__invoke'], $definition->getFactory());
+    }
+
+    public function testFactoryMethodInheritedFromParent()
+    {
+        $container = new ContainerBuilder();
+        $container->register('app.child_factory', ChildOfMethodFactory::class)
+            ->setAutoconfigured(true);
+
+        new RegisterAsFactoryPass()->process($container);
+
+        $definition = $container->getDefinition(FactoryCreatedService::class);
+        $this->assertEquals([new Reference('app.child_factory'), 'create'], $definition->getFactory());
+    }
+
+    public function testCreatedServiceInheritsAutowiringSoFactoryArgumentsGetResolved()
+    {
+        $container = new ContainerBuilder();
+        $container->register('app.arg_factory', ArgumentsFactory::class)
+            ->setAutoconfigured(true)
+            ->setAutowired(true);
+        $container->register(FactoryDependency::class, FactoryDependency::class);
+        $container->setAlias('public_alias', FactoryCreatedService::class)->setPublic(true);
+
+        $container->compile();
+
+        $this->assertInstanceOf(FactoryCreatedService::class, $container->get('public_alias'));
+    }
+
+    public function testNamedConstructorReturningStatic()
+    {
+        $container = new ContainerBuilder();
+        $container->register(StaticReturnTypeFactory::class, StaticReturnTypeFactory::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true);
+        $container->compile();
+
+        $definition = $container->getDefinition(StaticReturnTypeFactory::class);
+        $this->assertSame([StaticReturnTypeFactory::class, 'create'], $definition->getFactory());
+    }
+
+    public function testNamedConstructorWithParentReturnType()
+    {
+        $container = new ContainerBuilder();
+        $container->register(ParentFactory::class, ParentFactory::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true);
+        $container->register(ChildFactory::class, ChildFactory::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true);
+        $container->compile();
+
+        $definition = $container->getDefinition(ParentFactory::class);
+        $this->assertSame([ChildFactory::class, 'create'], $definition->getFactory());
+    }
+
+    public function testSkipsExcludedFactories()
+    {
+        $container = new ContainerBuilder();
+        $container->register(InvokableFactory::class, InvokableFactory::class)
+            ->setAutoconfigured(true)
+            ->setAbstract(true)
+            ->addTag('container.excluded');
+
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition(FactoryCreatedService::class));
+    }
+
+    public function testThrowsWhenTwoFactoriesDeclareTheSameServiceId()
+    {
+        $container = new ContainerBuilder();
+        $container->register(ExplicitIdFactory::class, ExplicitIdFactory::class)
+            ->setAutoconfigured(true);
+        $container->register(ConflictingExplicitIdFactory::class, ConflictingExplicitIdFactory::class)
+            ->setAutoconfigured(true);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('which already has a factory');
+        new RegisterAsFactoryPass()->process($container);
+    }
+
+    public function testThrowsWhenTheServiceIdIsAnAlias()
+    {
+        $container = new ContainerBuilder();
+        $container->register(ExplicitIdFactory::class, ExplicitIdFactory::class)
+            ->setAutoconfigured(true);
+        $container->register('some.service', FactoryCreatedService::class);
+        $container->setAlias('explicit.service.id', 'some.service');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('which is already defined as an alias');
+        new RegisterAsFactoryPass()->process($container);
+    }
+
+    public function testThrowsWhenTheServiceAlreadyHasAFactory()
+    {
+        $container = new ContainerBuilder();
+        $container->register(InvokableFactory::class, InvokableFactory::class)
+            ->setAutoconfigured(true);
+        $container->register(FactoryCreatedService::class, FactoryCreatedService::class)
+            ->setFactory([FactoryCreatedService::class, 'create']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('which already has a factory');
+        new RegisterAsFactoryPass()->process($container);
+    }
+}
+
+class FactoryCreatedService
+{
+}
+
+class AnotherFactoryCreatedService
+{
+}
+
+#[AsFactory]
+class InvokableFactory
+{
+    public function __invoke(): FactoryCreatedService
+    {
+        return new FactoryCreatedService();
+    }
+}
+
+class MethodFactory
+{
+    #[AsFactory]
+    public function create(): FactoryCreatedService
+    {
+        return new FactoryCreatedService();
+    }
+}
+
+#[AsFactory(id: 'explicit.service.id')]
+class ExplicitIdFactory
+{
+    public function __invoke(): FactoryCreatedService
+    {
+        return new FactoryCreatedService();
+    }
+}
+
+#[AsFactory]
+class NonInvokableFactory
+{
+    // No __invoke method
+}
+
+#[AsFactory]
+class NoReturnTypeFactory
+{
+    public function __invoke()
+    {
+    }
+}
+
+#[AsFactory]
+class BuiltinReturnTypeFactory
+{
+    public function __invoke(): string
+    {
+        return '';
+    }
+}
+
+class StaticMethodFactory
+{
+    #[AsFactory]
+    public static function create(): FactoryCreatedService
+    {
+        return new FactoryCreatedService();
+    }
+}
+
+#[AsFactory]
+class UnionReturnTypeFactory
+{
+    public function __invoke(): FactoryCreatedService|AnotherFactoryCreatedService
+    {
+        return new FactoryCreatedService();
+    }
+}
+
+class ChildOfMethodFactory extends MethodFactory
+{
+}
+
+class FactoryDependency
+{
+}
+
+class ArgumentsFactory
+{
+    #[AsFactory]
+    public function create(FactoryDependency $dependency): FactoryCreatedService
+    {
+        return new FactoryCreatedService();
+    }
+}
+
+class StaticReturnTypeFactory
+{
+    #[AsFactory]
+    public static function create(): static
+    {
+        return new static();
+    }
+}
+
+#[AsFactory(id: 'explicit.service.id')]
+class ConflictingExplicitIdFactory
+{
+    public function __invoke(): AnotherFactoryCreatedService
+    {
+        return new AnotherFactoryCreatedService();
+    }
+}
+
+class ParentFactory
+{
+    public static function create(): self
+    {
+        return new self();
+    }
+}
+
+class ChildFactory extends ParentFactory
+{
+    #[AsFactory]
+    public static function create(): parent
+    {
+        return parent::create();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | none
| License       | MIT

I wanted to propose adding a `#[AsFactory]` attribute, to enable simple auto-configuration of factories for service definitions. Basic idea is to facilitate creating simple factories (no expressions, special arguments).

So these would be equivalents:

```php
class NewsletterManagerStaticFactory {
  #[AsFactory]
  public static function createNewsletterManager(): NewsletterManager
  {
    return new NewsletterManager();
  }
}
```
instead of 
```yaml
services:
  App\Email\NewsletterManager:
     factory: ['App\Email\NewsletterManagerStaticFactory', 'createNewsletterManager']
```


The proposes solution works with static and non-static methods, as well as invokable classes. The attribute allows passing an ID of the created service. I would suggest also creating a service definition if that ID does not yet exist (otherwise just add the factory). If no ID is given, the class is taken as the identifier.

Another example:
```php
#[AsFactory('my_service_id')]
class InvokableFactory {
  public function __invoke(): NewsletterManager {
    return new NewsletterManager();
  }
}
```
instead of 
```yaml
my_service_id:
  class: NewsletterManager
  factory: ['@InvokableFactory']
```

Very happy for feedback and suggestions.


