### PR TITLE
[EventDispatcher] Fix TraceableEventDispatcher when reset during dispatch

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -280,7 +280,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         }
 
         foreach ($this->dispatcher->getListeners($eventName) as $listener) {
-            $priority = $this->getListenerPriority($eventName, $listener);
+            $priority = $this->getListenerPriority($eventName, $listener) ?? 0;
             $wrappedListener = new WrappedListener($listener instanceof WrappedListener ? $listener->getWrappedListener() : $listener, null, $this->stopwatch, $this);
             $this->wrappedListeners[$eventName][] = $wrappedListener;
             $this->dispatcher->removeListener($eventName, $listener);
@@ -291,7 +291,11 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
     private function postProcess(string $eventName): void
     {
-        --$this->dispatchDepth[$eventName];
+        if (null === $this->callStack) {
+            return;
+        }
+
+        $this->dispatchDepth[$eventName] = ($this->dispatchDepth[$eventName] ?? 1) - 1;
 
         unset($this->wrappedListeners[$eventName]);
         $skipped = false;

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -443,6 +443,18 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertCount(2, $tdispatcher->getCalledListeners());
     }
 
+    public function testResetDuringDispatch()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', function () use ($tdispatcher) {
+            $tdispatcher->reset();
+        });
+
+        $tdispatcher->dispatch(new Event(), 'foo');
+
+        $this->assertSame([], $tdispatcher->getCalledListeners());
+    }
+
     public function testCallStackIsNotLeakingWhenListenerIsRemovedBetweenDispatches()
     {
         $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/63844
| License       | MIT
