### PR TITLE
 Remove needs-review flag for Afrikaans (af)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -24,7 +24,7 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-                <target>Jy moet ten minste {{ limit }} kies.|Jy moet ten minste {{ limit }} keuses kies.</target>
+                <target>Jy moet ten minste {{ limit }} keuse kies.|Jy moet ten minste {{ limit }} keuses kies.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige IP-adres nie.</target>
+                <target>Hierdie waarde is nie 'n geldige IP-adres nie.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target state="needs-review-translation">Geen tydelike gids is in php.ini opgestel nie, of die opgestelde gids bestaan nie.</target>
+                <target>Geen tydelike vouer is in php.ini gekonfigureer nie, of die gekonfigureerde vouer bestaan ​​nie.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
@@ -208,7 +208,7 @@
             </trans-unit>
             <trans-unit id="55">
                 <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-                <target>Hierdie versameling moet {{ limit }} element of minder bevat.|Hierdie versameling moet {{ limit }} elemente of meer bevat.</target>
+                <target>Hierdie versameling moet {{ limit }} element of minder bevat.|Hierdie versameling moet {{ limit }} elemente of minder bevat.</target>
             </trans-unit>
             <trans-unit id="56">
                 <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige Internasionale Bankrekeningnommer (IBAN) nie.</target>
+                <target>Hierdie waarde is nie 'n geldige Internasionale Bankrekeningnommer (IBAN) nie.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige Besigheid Identifiseerder Kode (BIC) nie.</target>
+                <target>Hierdie waarde is nie 'n geldige Besigheid Identifiseerder Kode (BIC) nie.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83" resname="This is not a valid UUID.">
                 <source>This value is not a valid UUID.</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige UUID nie.</target>
+                <target>Hierdie waarde is nie 'n geldige UUID nie.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -360,7 +360,7 @@
             </trans-unit>
             <trans-unit id="93">
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-                <target state="needs-review-translation">Hierdie wagwoord is in 'n data-oortreding uitgelek, dit mag nie gebruik word nie. Gebruik asseblief 'n ander wagwoord.</target>
+                <target>Hierdie wagwoord is in 'n data-oortreding uitgelek, dit mag nie gebruik word nie. Gebruik asseblief 'n ander wagwoord.</target>
             </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
@@ -404,155 +404,155 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-review-translation">Die lêernaam is te lank. Dit moet {{ filename_max_length }} karakter of minder hê.|Die lêernaam is te lank. Dit moet {{ filename_max_length }} karakters of minder hê.</target>
+                <target>Die lêernaam is te lank. Dit moet {{ filename_max_length }} karakters of minder hê.|Die lêernaam is te lank. Dit moet {{ filename_max_length }} karakters of minder hê.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-review-translation">Die wagwoordsterkte is te laag. Gebruik asseblief 'n sterker wagwoord.</target>
+                <target>Die wachtwoord sterkte is te laag. Gebruik asseblief 'een sterker wachtwoord.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-review-translation">Hierdie waarde bevat karakters wat nie toegelaat word deur die huidige beperkingsvlak nie.</target>
+                <target>Hierdie waarde bevat karakters wat nie toegelaat word deur die huidige beperkingsvlak nie.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-review-translation">Die gebruik van onsigbare karakters word nie toegelaat nie.</target>
+                <target>Die gebruik van onsigbare karakters word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-review-translation">Die meng van nommers van verskillende skrifte word nie toegelaat nie.</target>
+                <target>Die meng van nommers van verskillende skrifte word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-review-translation">Die gebruik van verborge oorvleuelende karakters word nie toegelaat nie.</target>
+                <target>Die gebruik van verborgen oorvleuelende karakters word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-review-translation">Die uitbreiding van die lêer is ongeldig ({{ extension }}). Toegelate uitbreidings is {{ extensions }}.</target>
+                <target>Die uitbreiding van de lêer is ongeldig ({{ extension }}). Toegelaten uitbreidings is {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-review-translation">Die opgespoorde karakterkodering is ongeldig ({{ detected }}). Toegelate koderings is {{ encodings }}.</target>
+                <target>Die opgespoorde karakterkodering is ongeldig ({{ detected }}). Toegelate koderings is {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige MAC-adres nie.</target>
+                <target>Hierdie waarde is nie 'n geldige MAC-adres nie.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target state="needs-review-translation">Die URL mis 'n topvlakdomein.</target>
+                <target>Die URL mis 'n topvlakdomein.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target state="needs-review-translation">Hierdie waarde is te kort. Dit moet ten minste een woord bevat.|Hierdie waarde is te kort. Dit moet ten minste {{ min }} woorde bevat.</target>
+                <target>Hierdie waarde is te kort. Dit moet ten minste een woord bevat.|Hierdie waarde is te kort. Dit moet ten minste {{ min }} woorde bevat.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target state="needs-review-translation">Hierdie waarde is te lank. Dit moet een woord bevat.,Hierdie waarde is te lank. Dit moet {{ max }} woorde of minder bevat.</target>
+                <target>Hierdie waarde is te lank. Dit moet een woord bevat.,Hierdie waarde is te lank. Dit moet {{ max }} woorde of minder bevat.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target state="needs-review-translation">Hierdie waarde stel nie 'n geldige week in die ISO 8601-formaat voor nie.</target>
+                <target>Hierdie waarde stel nie 'n geldige week in die ISO 8601-formaat voor nie.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige week nie.</target>
+                <target>Hierdie waarde is nie 'n geldige week nie.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target state="needs-review-translation">Hierdie waarde mag nie voor week "{{ min }}" wees nie.</target>
+                <target>Hierdie waarde mag niet voor week "{{ min }}" wees nie.</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target state="needs-review-translation">Hierdie waarde mag nie na week "{{ max }}" kom nie.</target>
+                <target>Hierdie waarde mag nie na week "{{ max }}" kom nie.</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige Twig-sjabloon nie.</target>
+                <target>Hierdie waarde is nie 'n geldige Twig-sjabloon nie.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Hierdie lêer is nie 'n geldige video nie.</target>
+                <target>Hierdie lêer is nie 'n geldige video nie.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Die grootte van die video kon nie bepaal word nie.</target>
+                <target>Die grootte van die video kon nie bepaal word nie.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Die videowydte is te groot ({{ width }}px). Toegelate maksimum wydte is {{ max_width }}px.</target>
+                <target>Die videowydte is te groot ({{ width }}px). Toegelate maksimum wydte is {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Die videobreedte is te klein ({{ width }}px). Minimum verwagte breedte is {{ min_width }}px.</target>
+                <target>Die videobreedte is te klein ({{ width }}px). Minimum verwagte breedte is {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Die videohoogte is te groot ({{ height }}px). Toegelate maksimum hoogte is {{ max_height }}px.</target>
+                <target>Die videohoogte is te groot ({{ height }}px). Toegestane maximum hoogte is {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Die videohoogte is te klein ({{ height }}px). Minimum hoogte verwag is {{ min_height }}px.</target>
+                <target>Die videohoogte is te klein ({{ height }}px). Minimum hoogte verwag is {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Die video het te min pixels ({{ pixels }}). Minimum hoeveelheid verwag is {{ min_pixels }}.</target>
+                <target>Die video het te min pixels ({{ pixels }}). Minimum hoeveelheid verwag is {{ min_pixels }} pixels.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Die video het te veel pixels ({{ pixels }}). Maksimum verwagte hoeveelheid is {{ max_pixels }}.</target>
+                <target>Die video het te veel pixels ({{ pixels }}). Maksimum verwagte hoeveelheid is {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Die videoratio is te groot ({{ ratio }}). Toegelate maksimum ratio is {{ max_ratio }}.</target>
+                <target>Die videoratio is te groot ({{ ratio }}). Toegelate maksimum ratio is {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Die videoratio is te klein ({{ ratio }}). Minimum verwagte ratio is {{ min_ratio }}.</target>
+                <target>Die videoratio is te klein ({{ ratio }}). Minimum verwagte ratio is {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Die video is vierkantig ({{ width }}x{{ height }}px). Vierkantige video's word nie toegelaat nie.</target>
+                <target>Die video is vierkantig ({{ width }}x{{ height }}px). Vierkantige video's word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Die video is landskap georiënteer ({{ width }}x{{ height }} px). Landskapvideo's word nie toegelaat nie.</target>
+                <target>Die video is landskap georiënteer ({{ width }}x{{ height }} px). Landskapvideo's word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Die video is portretgeoriënteerd ({{ width }}x{{ height }}px). Portretgeoriënteerde video's word nie toegelaat nie.</target>
+                <target>Die video is portretgeoriënteerd ({{ width }}x{{ height }}px). Portretgeoriënteerde video's word nie toegelaat nie.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Die videolêer is korrup.</target>
+                <target>Die videolêer is korrup.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Die video bevat veelvuldige strome. Slegs een stroom word toegelaat.</target>
+                <target>Die video bevat veelvuldige strome. Slegs een stroom word toegelaat.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Nie-ondersteunde videokodek "{{ codec }}".</target>
+                <target>Nie-ondersteunde videokodek "{{ codec }}".</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Nie-ondersteunde videohouer "{{ container }}".</target>
+                <target>Nie-ondersteunde videohouer "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Die beeldlêer is beskadig.</target>
+                <target>Die beeldlêer is beskadig.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Die beeld het te min pixels ({{ pixels }}). Minimum hoeveelheid verwag is {{ min_pixels }}.</target>
+                <target>Die beeld het te min pixels ({{ pixels }}). Minimum hoeveelheid verwag is {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Die beeld het te veel pixels ({{ pixels }}). Maksimum verwagte aantal is {{ max_pixels }}.</target>
+                <target>Die beeld het te veel pixels ({{ pixels }}). Maksimum verwagte aantal is {{ max_pixels }} pixels.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Hierdie lêernaam stem nie ooreen met die verwagte karakterstel nie.</target>
+                <target>Hierdie lêernaam stem nie ooreen met die verwagte karakterstel nie.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q                  | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

**Translations**  
Review and remove `needs-review-translation` flag for Afrikaans (af) validator messages.  
Target branch: 6.4 (translation fixes are allowed on the oldest maintained branch).