### PR TITLE
[HttpFoundation] Add InputBag::getValue to fetch scalar & non-scalar values

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -137,6 +137,22 @@ final class InputBag extends ParameterBag
     }
 
     /**
+     * Returns an input value by name.
+     *
+     * @template TDefault of string|int|float|bool|array|null
+     *
+     * @param TDefault $default The default value if the input key does not exist
+     *
+     * @return TDefault|TInput
+     */
+    public function getValue(string $key, mixed $default = null): string|int|float|bool|array|null
+    {
+        $value = parent::get($key, $this);
+
+        return $this === $value ? $default : $value;
+    }
+
+    /**
      * @throws BadRequestException if the input value is an array and \FILTER_REQUIRE_ARRAY or \FILTER_FORCE_ARRAY is not set
      * @throws BadRequestException if the input value is invalid and \FILTER_NULL_ON_FAILURE is not set
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -91,6 +91,30 @@ class InputBagTest extends TestCase
         $this->assertNull($bag->get('foo[bar]'));
     }
 
+    public function testGetValue()
+    {
+        $bag = new InputBag([
+            'foo' => 'bar',
+            'null' => null,
+            'int' => 1,
+            'float' => 1.0,
+            'bool' => false,
+            'array' => [1, 2, 3],
+        ]);
+
+        $this->assertSame('bar', $bag->getValue('foo'), '->getValue() gets the value of a string parameter');
+        $this->assertSame('default', $bag->getValue('unknown', 'default'), '->getValue() returns second argument as default if a parameter is not defined');
+        $this->assertNull($bag->getValue('null', 'default'), '->getValue() returns null if null is set');
+        $this->assertSame(1, $bag->getValue('int'), '->getValue() gets the value of an int parameter');
+        $this->assertSame(1.0, $bag->getValue('float'), '->getValue() gets the value of a float parameter');
+        $this->assertFalse($bag->getValue('bool'), '->getValue() gets the value of a bool parameter');
+        $this->assertSame(1, $bag->getValue('int'), '->getValue() gets the value of an int parameter');
+        $this->assertCount(3, $bag->getValue('array'), '->getValue() gets the value of an array parameter');
+        $this->assertSame(1, $bag->getValue('array')[0], '->getValue() gets the value of an array parameter');
+        $this->assertSame(2, $bag->getValue('array')[1], '->getValue() gets the value of an array parameter');
+        $this->assertSame(3, $bag->getValue('array')[2], '->getValue() gets the value of an array parameter');
+    }
+
     public function testFilterArray()
     {
         $bag = new InputBag([


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #61691
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

Issue is described in #61691. If you use `$query = $request->query->get('q');` (or `{{ app.request.query.get('q') }}` in Twig) it will throw an `BadRequestException` `Input value "q" contains a non-scalar value.` if the user uses `?q[]=test` or `?q[]=1&q[]=2` in the URL. The new method `getValue` gives you a convenient way of accessing values without having to add an if statement around.