### PR TITLE
[TypeInfo] Add type narrowing on Type::accepts()

### DIFF
--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -17,6 +17,8 @@ use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ *
+ * @template-covariant T
  */
 abstract class Type implements \Stringable
 {
@@ -67,6 +69,8 @@ abstract class Type implements \Stringable
 
     /**
      * Tells if the type (or one of its wrapped/composed parts) accepts the given $value.
+     *
+     * @psalm-assert-if-true =T $value
      */
     public function accepts(mixed $value): bool
     {

--- a/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BackedEnumType.php
@@ -18,7 +18,7 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
- * @template T of class-string<\BackedEnum>
+ * @template T of \BackedEnum
  * @template U of BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>
  *
  * @extends EnumType<T>
@@ -26,8 +26,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
 final class BackedEnumType extends EnumType
 {
     /**
-     * @param T $className
-     * @param U $backingType
+     * @param class-string<T> $className
+     * @param U               $backingType
      */
     public function __construct(
         string $className,

--- a/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
+++ b/src/Symfony/Component/TypeInfo/Type/BuiltinType.php
@@ -19,6 +19,25 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
  * @template T of TypeIdentifier
+ *
+ * @extends Type<(
+ *     T is TypeIdentifier::ARRAY ? array :
+ *     T is TypeIdentifier::BOOL ? bool :
+ *     T is TypeIdentifier::CALLABLE ? callable :
+ *     T is TypeIdentifier::FALSE ? false :
+ *     T is TypeIdentifier::FLOAT ? float :
+ *     T is TypeIdentifier::INT ? int :
+ *     T is TypeIdentifier::ITERABLE ? iterable :
+ *     T is TypeIdentifier::MIXED ? mixed :
+ *     T is TypeIdentifier::NULL ? null :
+ *     T is TypeIdentifier::OBJECT ? object :
+ *     T is TypeIdentifier::RESOURCE ? resource :
+ *     T is TypeIdentifier::STRING ? string :
+ *     T is TypeIdentifier::TRUE ? true :
+ *     T is TypeIdentifier::NEVER ? never :
+ *     T is TypeIdentifier::VOID ? void :
+ *     mixed
+ * )>
  */
 final class BuiltinType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/CollectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/CollectionType.php
@@ -23,6 +23,14 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType|GenericType
  *
+ * @extends Type<(
+ *     T is BuiltinType<TypeIdentifier::ARRAY> ? array :
+ *     T is BuiltinType<TypeIdentifier::ITERABLE> ? iterable :
+ *     T is GenericType<BuiltinType<TypeIdentifier::ARRAY>> ? array :
+ *     T is GenericType<BuiltinType<TypeIdentifier::ITERABLE>> ? iterable :
+ *     object
+ * )>
+ *
  * @implements WrappingTypeInterface<T>
  */
 class CollectionType extends Type implements WrappingTypeInterface
@@ -185,11 +193,11 @@ class CollectionType extends Type implements WrappingTypeInterface
 
     public function accepts(mixed $value): bool
     {
-        if (!parent::accepts($value)) {
+        if ($this->isList() && (!\is_array($value) || !array_is_list($value))) {
             return false;
         }
 
-        if ($this->isList() && (!\is_array($value) || !array_is_list($value))) {
+        if (!parent::accepts($value)) {
             return false;
         }
 

--- a/src/Symfony/Component/TypeInfo/Type/EnumType.php
+++ b/src/Symfony/Component/TypeInfo/Type/EnumType.php
@@ -15,7 +15,7 @@ namespace Symfony\Component\TypeInfo\Type;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
- * @template T of class-string<\UnitEnum>
+ * @template T of \UnitEnum
  *
  * @extends ObjectType<T>
  */

--- a/src/Symfony/Component/TypeInfo/Type/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/Type/GenericType.php
@@ -23,6 +23,12 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @template T of BuiltinType<TypeIdentifier::ARRAY>|BuiltinType<TypeIdentifier::ITERABLE>|ObjectType
  *
+ * @extends Type<(
+ *     T is BuiltinType<TypeIdentifier::ARRAY> ? array :
+ *     T is BuiltinType<TypeIdentifier::ITERABLE> ? iterable :
+ *     object
+ * )>
+ *
  * @implements WrappingTypeInterface<T>
  */
 final class GenericType extends Type implements WrappingTypeInterface

--- a/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/IntersectionType.php
@@ -20,6 +20,8 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @template T of ObjectType|GenericType<ObjectType>|CollectionType<GenericType<ObjectType>>
  *
+ * @extends Type<object>
+ *
  * @implements CompositeTypeInterface<T>
  */
 final class IntersectionType extends Type implements CompositeTypeInterface

--- a/src/Symfony/Component/TypeInfo/Type/ObjectShapeType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectShapeType.php
@@ -29,6 +29,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * accessors are not visible.
  *
  * @author Benjamin Franzke <ben@bnf.dev>
+ *
+ * @extends Type<object>
  */
 final class ObjectShapeType extends Type
 {

--- a/src/Symfony/Component/TypeInfo/Type/ObjectType.php
+++ b/src/Symfony/Component/TypeInfo/Type/ObjectType.php
@@ -18,12 +18,14 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  *
- * @template T of class-string
+ * @template-covariant T of object
+ *
+ * @extends Type<T>
  */
 class ObjectType extends Type
 {
     /**
-     * @param T $className
+     * @param class-string<T> $className
      */
     public function __construct(
         private readonly string $className,
@@ -36,7 +38,7 @@ class ObjectType extends Type
     }
 
     /**
-     * @return T
+     * @return class-string<T>
      */
     public function getClassName(): string
     {

--- a/src/Symfony/Component/TypeInfo/Type/TemplateType.php
+++ b/src/Symfony/Component/TypeInfo/Type/TemplateType.php
@@ -21,6 +21,8 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @template T of Type
  *
+ * @extends Type<mixed>
+ *
  * @implements WrappingTypeInterface<T>
  */
 final class TemplateType extends Type implements WrappingTypeInterface

--- a/src/Symfony/Component/TypeInfo/Type/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/Type/UnionType.php
@@ -21,6 +21,8 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  *
  * @template T of Type
  *
+ * @extends Type<mixed>
+ *
  * @implements CompositeTypeInterface<T>
  */
 class UnionType extends Type implements CompositeTypeInterface

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -217,9 +217,9 @@ trait TypeFactoryTrait
     }
 
     /**
-     * @template T of class-string
+     * @template T of object
      *
-     * @param T|null $className
+     * @param class-string<T>|null $className
      *
      * @return ($className is class-string ? ObjectType<T> : BuiltinType<TypeIdentifier::OBJECT>)
      */
@@ -250,13 +250,13 @@ trait TypeFactoryTrait
     }
 
     /**
-     * @template T of class-string<\UnitEnum>|class-string<\BackedEnum>
+     * @template T of \UnitEnum
      * @template U of BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>
      *
-     * @param T      $className
-     * @param U|null $backingType
+     * @param class-string<T> $className
+     * @param U|null          $backingType
      *
-     * @return ($className is class-string<\BackedEnum> ? ($backingType is U ? BackedEnumType<T, U> : BackedEnumType<T, BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>>) : EnumType<T>))
+     * @return ($className is class-string<\BackedEnum> ? ($backingType is U ? BackedEnumType<T&\BackedEnum, U> : BackedEnumType<T&\BackedEnum, BuiltinType<TypeIdentifier::INT>|BuiltinType<TypeIdentifier::STRING>>) : EnumType<T>)
      */
     public static function enum(string $className, ?BuiltinType $backingType = null): EnumType
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Add `@template-covariant TPhpValue` to `Type` and `@psalm-assert-if-true T $value` on `Type::accepts()`, so that static analysis tools can narrow variable types after an `accepts()` call.

All concrete subclasses now declare their PHP value type via `@extends Type<...>`: `BuiltinType` uses a conditional mapping from `TypeIdentifier` to PHP types. Plus:
- `ObjectType` (and its `EnumType`/`BackedEnumType` children) maps to the object instance type
- `CollectionType`/`GenericType` resolve to `array`, `iterable`, or `object` depending on the wrapped type
- `IntersectionType`/`ObjectShapeType` resolve to `object`

`ObjectType`'s template is changed from `T of class-string` to `T of object` (with `class-string<T>` on param/return), which is the standard pattern for static analyzers.

`UnionType`, `NullableType`, and `TemplateType` remain without `T` propagation, as extracting template parameters from composed types is not expressible in current PHPStan/Psalm type systems.

Related to #63434