### PR TITLE
[HttpFoundation] Add InputBag::isScalar to check value type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -24,6 +24,16 @@ use Symfony\Component\HttpFoundation\Exception\UnexpectedValueException;
 final class InputBag extends ParameterBag
 {
     /**
+     * Check if input value is scalar.
+     */
+    public function isScalar(string $key): bool
+    {
+        $value = parent::get($key);
+
+        return \is_scalar($value);
+    }
+
+    /**
      * Returns a scalar input value by name.
      *
      * @template TDefault of string|int|float|bool|null

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -18,6 +18,25 @@ use Symfony\Component\HttpFoundation\Tests\Fixtures\FooEnum;
 
 class InputBagTest extends TestCase
 {
+    public function testIsScalar()
+    {
+        $bag = new InputBag([
+            'foo' => 'bar',
+            'int' => 1,
+            'float' => 1.0,
+            'bool' => false,
+            'null' => null,
+            'array' => [1, 2, 3],
+        ]);
+
+        $this->assertTrue($bag->isScalar('foo'), '->isScalar() checks a string value');
+        $this->assertTrue($bag->isScalar('int'), '->isScalar() checks an int value');
+        $this->assertTrue($bag->isScalar('float'), '->isScalar() checks a float value');
+        $this->assertTrue($bag->isScalar('bool'), '->isScalar() checks a bool value');
+        $this->assertFalse($bag->isScalar('null'), '->isScalar() checks a null value');
+        $this->assertFalse($bag->isScalar('array'), '->isScalar() checks an array value');
+    }
+
     public function testGet()
     {
         $bag = new InputBag(['foo' => 'bar', 'null' => null, 'int' => 1, 'float' => 1.0, 'bool' => false, 'stringable' => new class implements \Stringable {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #61691 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

The new method `isScalar` gives you a convenient way of checking the value type.
If I use
```
$filter = $request->query->all('filter');
```
I get a `Bad Request` exception with `Unexpected value for parameter "filter": expecting "array", got "string".`.
