### PR TITLE
[Cache] Remove conflict with dbal<4.3

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -72,6 +72,10 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
         array $options = [],
         ?MarshallerInterface $marshaller = null,
     ) {
+        if (!class_exists(PrimaryKeyConstraint::class)) {
+            throw new \LogicException(\sprintf('Using "%s" requires "doctrine/dbal" 4.3 or higher; try running "composer require doctrine/dbal:^4.3".', __CLASS__));
+        }
+
         if (isset($namespace[0]) && preg_match('#[^-+.A-Za-z0-9]#', $namespace, $match)) {
             throw new InvalidArgumentException(\sprintf('Namespace contains "%s" but only characters in [-+.A-Za-z0-9] are allowed.', $match[0]));
         }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -43,8 +43,7 @@
     },
     "conflict": {
         "ext-redis": "<6.1",
-        "ext-relay": "<0.12.1",
-        "doctrine/dbal": "<4.3"
+        "ext-relay": "<0.12.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Cache\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #63857
| License       | MIT

`doctrine/dbal` is only a dev dependency, i.e. not required to use symfony cache. But the conflict prevents any project using an older dbal version from using cache >8. See #63857 for a more detailed description. 
