### PR TITLE
[Cache] Fix Psr16Cache::getMultiple() returning wrapper values when using TTL

### DIFF
--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -69,9 +69,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
         };
         self::$packCacheItem ??= \Closure::bind(
             static function (CacheItem $item) {
-                // Only re-pack if there's timing metadata (for Psr16Adapter compatibility)
-                // Don't re-pack if only tags metadata exists (TagAwareAdapter direct use case)
-                if (!isset($item->metadata[ItemInterface::METADATA_CTIME]) && !isset($item->metadata[ItemInterface::METADATA_EXPIRY])) {
+                if (!isset($item->metadata[ItemInterface::METADATA_CTIME])) {
                     return $item->value;
                 }
 

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -187,6 +187,19 @@ class Psr16CacheTest extends SimpleCacheTest
 
         $this->assertSame(['foo' => 'foo-val', 'bar' => 'bar-val'], $cache->getMultiple(['foo', 'bar']));
     }
+
+    public function testGetMultipleWithTtl()
+    {
+        $cache = new Psr16Cache(new ArrayAdapter());
+
+        $cache->set('foo', 'foo-val', 60);
+        $cache->set('bar', 'bar-val', 60);
+
+        $this->assertSame('foo-val', $cache->get('foo'));
+        $this->assertSame('bar-val', $cache->get('bar'));
+
+        $this->assertSame(['foo' => 'foo-val', 'bar' => 'bar-val'], iterator_to_array($cache->getMultiple(['foo', 'bar'])));
+    }
 }
 
 class NotUnserializable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63850
| License       | MIT

Introduced in #63747