### PR TITLE
[Console] Use ECH sequence for block padding

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ConsoleBundle` for console applications with DI, autodiscovery and autowiring
+ * Pad styled `SymfonyStyle` blocks with the ECH ANSI sequence on decorated outputs so trailing cells are excluded from copy selections
  * Add optional `$container` parameter to `Application` for automatic service wiring from a PSR container
  * Add `SymfonyStyle::outlineBlock()` and convenience methods `outlineSuccess()`, `outlineError()`, `outlineWarning()`, `outlineNote()`, `outlineInfo()`, `outlineCaution()` for border-only message blocks with the type label embedded in the top border
  * Add `TraceableValueResolver` to help inspecting value resolvers performances

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -534,7 +534,13 @@ class SymfonyStyle extends OutputStyle
             }
 
             $line = $prefix.$line;
-            $line .= str_repeat(' ', max($this->lineLength - Helper::width(Helper::removeDecoration($this->getFormatter(), $line)), 0));
+            $paddingLength = max($this->lineLength - Helper::width(Helper::removeDecoration($this->getFormatter(), $line)), 0);
+
+            // ECH paints the trailing cells with the current background and CUF moves the cursor past
+            // them without writing characters, so most terminals trim them when copying the selection.
+            $line .= $style && $this->isDecorated() && 0 < $paddingLength
+                ? \sprintf("\e[%1\$dX\e[%1\$dC", $paddingLength)
+                : str_repeat(' ', $paddingLength);
 
             if ($style) {
                 $line = \sprintf('<%s>%s</>', $style, $line);

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_16.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_16.txt
@@ -1,8 +1,8 @@
 
-[30;42m                                                                                                                        [39;49m
-[30;42m [OK] Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore    [39;49m
-[30;42m      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo    [39;49m
-[30;42m      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. [39;49m
-[30;42m      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum     [39;49m
-[30;42m                                                                                                                        [39;49m
+[30;42m      [114X[114C[39;49m
+[30;42m [OK] Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore[4X[4C[39;49m
+[30;42m      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo[4X[4C[39;49m
+[30;42m      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.[1X[1C[39;49m
+[30;42m      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum[5X[5C[39;49m
+[30;42m      [114X[114C[39;49m
 

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -148,6 +148,42 @@ class SymfonyStyleTest extends TestCase
         $this->assertStringContainsString('Second line.', $display);
     }
 
+    public function testStyledBlockUsesEchPaddingWhenDecorated()
+    {
+        $output = new StreamOutput(fopen('php://memory', 'w', false), decorated: true);
+        $io = new SymfonyStyle(new ArrayInput([]), $output);
+        $io->block('msg', null, 'fg=white;bg=blue', ' ', false);
+
+        rewind($output->getStream());
+        $display = stream_get_contents($output->getStream());
+
+        $this->assertMatchesRegularExpression("/\e\[\d+X\e\[\d+C/", $display);
+    }
+
+    public function testStyledBlockKeepsSpacePaddingWhenNotDecorated()
+    {
+        $output = new StreamOutput(fopen('php://memory', 'w', false), decorated: false);
+        $io = new SymfonyStyle(new ArrayInput([]), $output);
+        $io->block('msg', null, 'fg=white;bg=blue', ' ', false);
+
+        rewind($output->getStream());
+        $display = stream_get_contents($output->getStream());
+
+        $this->assertStringNotContainsString("\e[", $display);
+    }
+
+    public function testUnstyledBlockKeepsSpacePaddingEvenWhenDecorated()
+    {
+        $output = new StreamOutput(fopen('php://memory', 'w', false), decorated: true);
+        $io = new SymfonyStyle(new ArrayInput([]), $output);
+        $io->block('msg', null, null, ' ', false);
+
+        rewind($output->getStream());
+        $display = stream_get_contents($output->getStream());
+
+        $this->assertStringNotContainsString("\e[", $display);
+    }
+
     public function testGetErrorStyle()
     {
         $input = $this->createStub(InputInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63854
| License       | MIT

This uses the ECH (Erase Character) ANSI sequence for block padding instead of space characters. When copying console output, trailing spaces are no longer selected, improving both copy/paste experience and accessibility (screen readers won't read padding spaces).

Only enabled on Unix TTYs; Windows and non-TTY outputs fall back to regular spaces.