### PR TITLE
[Console] Allow nullable `#[Autowire]` service references in command arguments

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
@@ -133,7 +133,7 @@ final class RegisterCommandArgumentLocatorsPass implements CompilerPassInterface
                         // Do not attempt to register enum typed arguments if not already present in bindings
                         continue;
                     } elseif (!$p->allowsNull()) {
-                        $invalidBehavior = ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE;
+                        $invalidBehavior = $autowireAttributes ? ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE : ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE;
                     }
 
                     // Skip console-specific types that are resolved by other resolvers
@@ -142,7 +142,6 @@ final class RegisterCommandArgumentLocatorsPass implements CompilerPassInterface
                     }
 
                     if ($autowireAttributes) {
-                        $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
                         $attribute = $autowireAttributes[0]->newInstance();
                         $value = $parameterBag->resolveValue($attribute->value);
 

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/RegisterCommandArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/RegisterCommandArgumentLocatorsPassTest.php
@@ -79,6 +79,24 @@ class RegisterCommandArgumentLocatorsPassTest extends TestCase
         $container->compile();
     }
 
+    #[DoesNotPerformAssertions]
+    public function testProcessNullableAutowireAttributeWithInvalidService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('console.argument_resolver.service')->setSynthetic(true)->addArgument(null);
+
+        $command = new Definition(CommandWithAutowireAttributeNullableInvalidReference::class);
+        $command->setAutowired(true);
+        $command->addTag('console.command', ['command' => 'test:command']);
+        $command->addTag('console.command.service_arguments');
+        $container->setDefinition('test.command', $command);
+
+        $pass = new RegisterCommandArgumentLocatorsPass();
+        $pass->process($container);
+
+        $container->compile();
+    }
+
     public function testProcessThrowsOnInvalidAutowiredService()
     {
         $container = new ContainerBuilder();
@@ -226,6 +244,15 @@ class CommandWithAutowireAttribute
 }
 
 class CommandWithAutowireAttributeInvalidReference
+{
+    public function __invoke(
+        #[Autowire(service: 'invalid.id')]
+        \stdClass $service2,
+    ) {
+    }
+}
+
+class CommandWithAutowireAttributeNullableInvalidReference
 {
     public function __invoke(
         #[Autowire(service: 'invalid.id')]


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Use NULL_ON_INVALID_REFERENCE instead of EXCEPTION_ON_INVALID_REFERENCE when the parameter allows null, so optional services that might not exist can be injected as null rather than causing a build-time error.

See https://github.com/symfony/symfony/pull/63725

/cc @nicolas-grekas 
