### PR TITLE
[PropertyInfo][Serializer] Enable using `#[WithAccessors]` with the serializer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -81,6 +81,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'property_info.constructor_extractor',
         'property_info.initializable_extractor',
         'property_info.list_extractor',
+        'property_info.name_extractor',
         'property_info.type_extractor',
         'proxy',
         'rate_limiter',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.php
@@ -20,6 +20,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
@@ -35,6 +36,7 @@ return static function (ContainerConfigurator $container) {
         ->alias(PropertyTypeExtractorInterface::class, 'property_info')
         ->alias(PropertyListExtractorInterface::class, 'property_info')
         ->alias(PropertyInitializableExtractorInterface::class, 'property_info')
+        ->alias(PropertyNameExtractorInterface::class, 'property_info')
 
         ->set('property_info.cache', PropertyInfoCacheExtractor::class)
             ->decorate('property_info')
@@ -47,6 +49,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('property_info.constructor_extractor', ['priority' => -1002])
             ->tag('property_info.access_extractor', ['priority' => -1000])
             ->tag('property_info.initializable_extractor', ['priority' => -1000])
+            ->tag('property_info.name_extractor', ['priority' => -1000])
 
         ->alias(PropertyReadInfoExtractorInterface::class, 'property_info.reflection_extractor')
         ->alias(PropertyWriteInfoExtractorInterface::class, 'property_info.reflection_extractor')

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow defining accessors and mutators via a `#[WithAccessors]` attribute
+ * Add `PropertyNameExtractorInterface` and `getPropertyName()` to enable property name extraction from an accessor or mutator
 
 8.1
 ---

--- a/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
+++ b/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
@@ -47,5 +47,8 @@ class PropertyInfoPass implements CompilerPassInterface
 
         $initializableExtractors = $this->findAndSortTaggedServices('property_info.initializable_extractor', $container);
         $definition->setArgument(4, new IteratorArgument($initializableExtractors));
+
+        $nameExtractors = $this->findAndSortTaggedServices('property_info.name_extractor', $container);
+        $definition->setArgument(5, new IteratorArgument($nameExtractors));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -156,7 +156,13 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
     public function getType(string $class, string $property, array $context = []): ?Type
     {
-        [$mutatorReflection, $prefix] = $this->getMutatorMethod($class, $property);
+        try {
+            $refClass = new \ReflectionClass($class);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        [$mutatorReflection, $prefix] = $this->getMutatorMethod($refClass, $property);
 
         if ($mutatorReflection) {
             try {
@@ -171,7 +177,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             }
         }
 
-        [$accessorReflection, $prefix] = $this->getAccessorMethod($class, $property);
+        [$accessorReflection, $prefix] = $this->getAccessorMethod($refClass, $property);
         $allowedPrefixes = array_diff($this->accessorPrefixes, ['is', 'can', 'has']);
         if ($accessorReflection && (\in_array($prefix, $allowedPrefixes, true) || !property_exists($class, $property))) {
             try {
@@ -181,18 +187,13 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         if ($context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction) {
-            try {
-                $reflectionClass = new \ReflectionClass($class);
-                if ($type = $this->extractTypeFromConstructor($reflectionClass, $property)) {
-                    return $type;
-                }
-            } catch (\ReflectionException) {
+            if ($type = $this->extractTypeFromConstructor($refClass, $property)) {
+                return $type;
             }
         }
 
         try {
-            $reflectionClass = new \ReflectionClass($class);
-            $reflectionProperty = $reflectionClass->getProperty($property);
+            $reflectionProperty = $refClass->getProperty($property);
         } catch (\ReflectionException) {
             return null;
         }
@@ -210,7 +211,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         $allowedPrefixes = array_diff($this->accessorPrefixes, $allowedPrefixes);
-        [$accessorReflection, $prefix] = $this->getAccessorMethod($class, $property);
+        [$accessorReflection, $prefix] = $this->getAccessorMethod($refClass, $property);
         if ($accessorReflection && \in_array($prefix, $allowedPrefixes, true)) {
             try {
                 return $this->typeResolver->resolve($accessorReflection);
@@ -218,7 +219,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             }
         }
 
-        if (null === $defaultValue = ($reflectionClass->getDefaultProperties()[$property] ?? null)) {
+        if (null === $defaultValue = ($refClass->getDefaultProperties()[$property] ?? null)) {
             return null;
         }
 
@@ -280,14 +281,20 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return true;
         }
 
+        try {
+            $refClass = new \ReflectionClass($class);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
         // First test with the camelized property name
-        [$reflectionMethod] = $this->getMutatorMethod($class, $this->camelize($property));
+        [$reflectionMethod] = $this->getMutatorMethod($refClass, $this->camelize($property));
         if (null !== $reflectionMethod) {
             return true;
         }
 
         // Otherwise check for the old way
-        [$reflectionMethod] = $this->getMutatorMethod($class, $property);
+        [$reflectionMethod] = $this->getMutatorMethod($refClass, $property);
 
         return null !== $reflectionMethod;
     }
@@ -375,10 +382,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $allowConstruct = $context['enable_constructor_extraction'] ?? $this->enableConstructorExtraction;
         $allowAdderRemover = $context['enable_adder_remover_extraction'] ?? true;
 
-        $camelized = $this->camelize($property);
-        $nonCamelized = ucfirst($property);
         $constructor = $reflClass->getConstructor();
-        $singulars = $this->inflector->singularize($camelized);
         $errors = [];
 
         if (null !== $constructor && $allowConstruct) {
@@ -389,7 +393,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             }
         }
 
-        [$adderAccessName, $removerAccessName, $adderAndRemoverErrors] = $this->findAdderAndRemover($reflClass, $singulars);
+        $camelized = $this->camelize($property);
+        $nonCamelized = ucfirst($property);
+
+        [$adderAccessName, $removerAccessName, $adderAndRemoverErrors] = $this->findAdderAndRemover($reflClass, $camelized);
         if ($allowAdderRemover && null !== $adderAccessName && null !== $removerAccessName) {
             $adderMethod = $reflClass->getMethod($adderAccessName);
             $removerMethod = $reflClass->getMethod($removerAccessName);
@@ -581,13 +588,13 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      * Returns an array with an instance of \ReflectionMethod as the first key
      * and the prefix of the method as the second, or null if not found.
      */
-    private function getAccessorMethod(string $class, string $property): ?array
+    private function getAccessorMethod(\ReflectionClass $refClass, string $property): ?array
     {
         $ucProperty = ucfirst($property);
 
         foreach ($this->accessorPrefixes as $prefix) {
             try {
-                $reflectionMethod = new \ReflectionMethod($class, $prefix.$ucProperty);
+                $reflectionMethod = $refClass->getMethod($prefix.$ucProperty);
                 if ($reflectionMethod->isStatic()) {
                     continue;
                 }
@@ -607,7 +614,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      * Returns an array with an instance of \ReflectionMethod as the first key
      * and the prefix of the method as the second, or null if not found.
      */
-    private function getMutatorMethod(string $class, string $property): ?array
+    private function getMutatorMethod(\ReflectionClass $refClass, string $property): ?array
     {
         $ucProperty = ucfirst($property);
         $ucSingulars = $this->inflector->singularize($ucProperty);
@@ -622,7 +629,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
             foreach ($names as $name) {
                 try {
-                    $reflectionMethod = new \ReflectionMethod($class, $prefix.$name);
+                    $reflectionMethod = $refClass->getMethod($prefix.$name);
                     if ($reflectionMethod->isStatic()) {
                         continue;
                     }
@@ -667,11 +674,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      * Searches for add and remove methods.
      *
      * @param \ReflectionClass $reflClass The reflection class for the given object
-     * @param array            $singulars The singular form of the property name or null
      *
      * @return array An array containing the adder and remover when found and errors
      */
-    private function findAdderAndRemover(\ReflectionClass $reflClass, array $singulars): array
+    private function findAdderAndRemover(\ReflectionClass $reflClass, string $property): array
     {
         if (2 !== \count($this->arrayMutatorPrefixes)) {
             return [null, null, []];
@@ -680,7 +686,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         [$addPrefix, $removePrefix] = $this->arrayMutatorPrefixes;
         $errors = [];
 
-        foreach ($singulars as $singular) {
+        foreach ($this->inflector->singularize($property) as $singular) {
             $addMethod = $addPrefix.$singular;
             $removeMethod = $removePrefix.$singular;
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -16,6 +16,7 @@ use Symfony\Component\PropertyInfo\Exception\MappingException;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -42,7 +43,7 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
  *
  * @final
  */
-class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, PropertyReadInfoExtractorInterface, PropertyWriteInfoExtractorInterface, ConstructorArgumentTypeExtractorInterface
+class ReflectionExtractor implements PropertyListExtractorInterface, PropertyNameExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, PropertyReadInfoExtractorInterface, PropertyWriteInfoExtractorInterface, ConstructorArgumentTypeExtractorInterface
 {
     /**
      * @internal
@@ -133,7 +134,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return null;
         }
 
-        $reflectionProperties = $reflectionClass->getProperties();
+        $reflectionProperties = array_column($reflectionClass->getProperties(), null, 'name');
 
         $properties = [];
         foreach ($reflectionProperties as $reflectionProperty) {
@@ -147,17 +148,33 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 continue;
             }
 
-            $propertyName = $this->getPropertyName($reflectionClass, $reflectionMethod->name, $reflectionProperties);
+            $propertyName = $this->extractPropertyNameFromMethod($reflectionClass, $reflectionMethod->name, $reflectionProperties);
             if (!$propertyName || isset($properties[$propertyName])) {
                 continue;
             }
-            if ($reflectionClass->hasProperty($lowerCasedPropertyName = lcfirst($propertyName)) || (!$reflectionClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName))) {
-                $propertyName = $lowerCasedPropertyName;
-            }
+
             $properties[$propertyName] = $propertyName;
         }
 
         return $properties ? array_values($properties) : null;
+    }
+
+    public function getPropertyName(string $class, string $method, array $context = []): ?string
+    {
+        try {
+            $reflectionMethod = new \ReflectionMethod($class, $method);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        if ($reflectionMethod->isStatic()) {
+            return null;
+        }
+
+        $reflectionClass = $reflectionMethod->getDeclaringClass();
+        $reflectionProperties = array_column($reflectionClass->getProperties(), null, 'name');
+
+        return $this->extractPropertyNameFromMethod($reflectionClass, $method, $reflectionProperties);
     }
 
     public function getType(string $class, string $property, array $context = []): ?Type
@@ -692,7 +709,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         return null;
     }
 
-    private function getPropertyName(\ReflectionClass $refClass, string $methodName, array $reflectionProperties): ?string
+    /**
+     * @param array<string, \ReflectionProperty> $reflectionProperties
+     */
+    private function extractPropertyNameFromMethod(\ReflectionClass $refClass, string $methodName, array $reflectionProperties): ?string
     {
         if (null !== $propertyName = $this->getAccessorMethodFromAttribute($refClass, $reflectionProperties, $methodName)) {
             return $propertyName;
@@ -700,6 +720,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         $pattern = implode('|', array_merge($this->accessorPrefixes, $this->mutatorPrefixes));
 
+        $propertyName = null;
         if ('' !== $pattern && preg_match('/^('.$pattern.')(.+)$/i', $methodName, $matches)) {
             // a lowercase first letter means the prefix is part of a longer word rather than a
             // prefix, e.g. "hash" or "cancel", so the method is not an accessor at all
@@ -707,22 +728,32 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 return null;
             }
 
-            if (!\in_array($matches[1], $this->arrayMutatorPrefixes, true)) {
-                return $matches[2];
-            }
+            $propertyName = $matches[2];
 
-            foreach ($reflectionProperties as $reflectionProperty) {
-                foreach ($this->inflector->singularize($reflectionProperty->name) as $name) {
-                    if (strtolower($name) === strtolower($matches[2])) {
-                        return $reflectionProperty->name;
+            if (\in_array($matches[1], $this->arrayMutatorPrefixes, true)) {
+                foreach ($reflectionProperties as $reflectionProperty) {
+                    foreach ($this->inflector->singularize($reflectionProperty->name) as $name) {
+                        if (strtolower($name) === strtolower($matches[2])) {
+                            return $reflectionProperty->name;
+                        }
                     }
                 }
             }
-
-            return $matches[2];
         }
 
-        return null;
+        if (!$propertyName) {
+            return null;
+        }
+
+        if (isset($reflectionProperties[$propertyName])) {
+            return $propertyName;
+        }
+
+        if ($refClass->hasProperty($lowerCasedPropertyName = lcfirst($propertyName)) || (!$refClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName))) {
+            $propertyName = $lowerCasedPropertyName;
+        }
+
+        return $propertyName;
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -21,7 +21,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @final
  */
-class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface
+class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, PropertyNameExtractorInterface, PropertyInitializableExtractorInterface
 {
     private array $arrayCache = [];
 
@@ -54,6 +54,11 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
     public function getProperties(string $class, array $context = []): ?array
     {
         return $this->extract('getProperties', [$class, $context]);
+    }
+
+    public function getPropertyName(string $class, string $method, array $context = []): ?string
+    {
+        return $this->extract('getPropertyName', [$class, $method, $context]);
     }
 
     public function getType(string $class, string $property, array $context = []): ?Type

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -20,7 +20,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @final
  */
-class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyInitializableExtractorInterface
+class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyNameExtractorInterface, PropertyInitializableExtractorInterface
 {
     /**
      * @param iterable<mixed, PropertyListExtractorInterface>          $listExtractors
@@ -28,6 +28,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
      * @param iterable<mixed, PropertyDescriptionExtractorInterface>   $descriptionExtractors
      * @param iterable<mixed, PropertyAccessExtractorInterface>        $accessExtractors
      * @param iterable<mixed, PropertyInitializableExtractorInterface> $initializableExtractors
+     * @param iterable<mixed, PropertyNameExtractorInterface>          $propertyNameExtractors
      */
     public function __construct(
         private readonly iterable $listExtractors = [],
@@ -35,6 +36,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
         private readonly iterable $descriptionExtractors = [],
         private readonly iterable $accessExtractors = [],
         private readonly iterable $initializableExtractors = [],
+        private readonly iterable $propertyNameExtractors = [],
     ) {
     }
 
@@ -72,6 +74,11 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     public function isWritable(string $class, string $property, array $context = []): ?bool
     {
         return $this->extract($this->accessExtractors, 'isWritable', [$class, $property, $context]);
+    }
+
+    public function getPropertyName(string $class, string $method, array $context = []): ?string
+    {
+        return $this->extract($this->propertyNameExtractors, 'getPropertyName', [$class, $method, $context]);
     }
 
     public function isInitializable(string $class, string $property, array $context = []): ?bool

--- a/src/Symfony/Component/PropertyInfo/PropertyNameExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyNameExtractorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * Extracts the name of the property for the given accessor.
+ */
+interface PropertyNameExtractorInterface
+{
+    public function getPropertyName(string $class, string $method, array $context = []): ?string;
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/AbstractPropertyInfoExtractorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NullExtractor;
@@ -32,7 +33,7 @@ class AbstractPropertyInfoExtractorTest extends TestCase
     protected function setUp(): void
     {
         $extractors = [new NullExtractor(), new DummyExtractor()];
-        $this->propertyInfo = new PropertyInfoExtractor($extractors, $extractors, $extractors, $extractors, $extractors);
+        $this->propertyInfo = new PropertyInfoExtractor($extractors, $extractors, $extractors, $extractors, $extractors, $extractors);
     }
 
     public function testInstanceOf()
@@ -41,6 +42,7 @@ class AbstractPropertyInfoExtractorTest extends TestCase
         $this->assertInstanceOf(PropertyTypeExtractorInterface::class, $this->propertyInfo);
         $this->assertInstanceOf(PropertyDescriptionExtractorInterface::class, $this->propertyInfo);
         $this->assertInstanceOf(PropertyAccessExtractorInterface::class, $this->propertyInfo);
+        $this->assertInstanceOf(PropertyNameExtractorInterface::class, $this->propertyInfo);
         $this->assertInstanceOf(PropertyInitializableExtractorInterface::class, $this->propertyInfo);
     }
 
@@ -72,6 +74,11 @@ class AbstractPropertyInfoExtractorTest extends TestCase
     public function testGetProperties()
     {
         $this->assertEquals(['a', 'b'], $this->propertyInfo->getProperties('Foo'));
+    }
+
+    public function testGetProperty()
+    {
+        $this->assertSame('property', $this->propertyInfo->getPropertyName('Foo', 'getBar'));
     }
 
     public function testIsInitializable()

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithAccessorWithoutProperty;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\FalseAccessorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderValue;
@@ -257,6 +258,67 @@ class ReflectionExtractorTest extends TestCase
         $extractor = new ReflectionExtractor();
 
         self::assertSame(['priority', 'tags', 'mailbox', 'active', 'name'], $extractor->getProperties(Bar::class));
+    }
+
+    // Standard "get" prefix
+    #[TestWith([Dummy::class, 'getA', 'a'])]
+    #[TestWith([Dummy::class, 'getDOB', 'DOB'])]
+    #[TestWith([Dummy::class, 'getId', 'Id'])]
+    #[TestWith([Dummy::class, 'get123', '123'])]
+    #[TestWith([Dummy::class, 'getXTotals', 'xTotals'])]
+    // Standard "set" prefix
+    #[TestWith([Dummy::class, 'setB', 'B'])]
+    #[TestWith([Dummy::class, 'setSelf', 'self'])]
+    #[TestWith([Dummy::class, 'setRealParent', 'realParent'])]
+    #[TestWith([Dummy::class, 'setDate', 'date'])]
+    // "is" / "has" / "can" prefixes
+    #[TestWith([Dummy::class, 'isC', 'c'])]
+    #[TestWith([Dummy::class, 'canD', 'd'])]
+    #[TestWith([Dummy::class, 'hasElement', 'element'])]
+    #[TestWith([DummyWithHasser::class, 'hasUrl', 'url'])]
+    #[TestWith([DummyWithHasser::class, 'isEnabled', 'enabled'])]
+    #[TestWith([DummyWithAccessorWithoutProperty::class, 'canView', 'view'])]
+    #[TestWith([DummyWithAccessorWithoutProperty::class, 'isActive', 'active'])]
+    #[TestWith([DummyWithAccessorWithoutProperty::class, 'hasFromConstructor', 'fromConstructor'])]
+    // Array mutators with singularization
+    #[TestWith([AdderRemoverDummy::class, 'addAnalyse', 'analyses'])]
+    #[TestWith([AdderRemoverDummy::class, 'removeFoot', 'feet'])]
+    #[TestWith([Dummy::class, 'addDate', 'date'])]
+    // False accessors (ctype_lower filter)
+    #[TestWith([FalseAccessorDummy::class, 'hash', null])]
+    #[TestWith([FalseAccessorDummy::class, 'cancel', null])]
+    #[TestWith([FalseAccessorDummy::class, 'gettings', null])]
+    #[TestWith([FalseAccessorDummy::class, 'settings', null])]
+    #[TestWith([FalseAccessorDummy::class, 'isolate', null])]
+    #[TestWith([FalseAccessorDummy::class, 'getValid', 'valid'])]
+    // Uppercase property name
+    #[TestWith([FalseAccessorDummy::class, 'getFoo', 'Foo'])]
+    // Underscore after prefix
+    #[TestWith([FalseAccessorDummy::class, 'get_foo', '_foo'])]
+    // Static methods
+    #[TestWith([Dummy::class, 'getStatic', null])]
+    #[TestWith([Dummy::class, 'staticGetter', null])]
+    #[TestWith([Dummy::class, 'staticSetter', null])]
+    // Non-existent methods
+    #[TestWith([Dummy::class, 'nonExistentMethod', null])]
+    #[TestWith(['NonExistent\\ClassName', 'someMethod', null])]
+    // #[WithAccessors] attribute
+    #[TestWith([Bar::class, 'currentPriority', 'priority'])]
+    #[TestWith([Bar::class, 'changePriority', 'priority'])]
+    #[TestWith([Bar::class, 'allTags', 'tags'])]
+    #[TestWith([Bar::class, 'replaceTags', 'tags'])]
+    #[TestWith([Bar::class, 'attachTag', 'tags'])]
+    #[TestWith([Bar::class, 'detachTag', 'tags'])]
+    #[TestWith([Bar::class, 'isEnabled', 'active'])]
+    #[TestWith([Bar::class, 'retrieveName', 'name'])]
+    #[TestWith([Bar::class, 'renameTo', 'name'])]
+    #[TestWith([JustGetterOrSetter::class, 'checkVisibility', 'visible'])]
+    #[TestWith([JustGetterOrSetter::class, 'updateStatus', 'status'])]
+    #[TestWith([JustAdderAndRemover::class, 'enqueue', 'items'])]
+    #[TestWith([JustAdderAndRemover::class, 'dequeue', 'items'])]
+    public function testGetPropertyName(string $class, string $method, ?string $expectedProperty)
+    {
+        $this->assertSame($expectedProperty, $this->extractor->getPropertyName($class, $method));
     }
 
     public function testReadonlyPropertiesAreNotWriteable()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyExtractor.php
@@ -16,13 +16,14 @@ use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\TypeInfo\Type;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class DummyExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, ConstructorArgumentTypeExtractorInterface
+class DummyExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyNameExtractorInterface, PropertyInitializableExtractorInterface, ConstructorArgumentTypeExtractorInterface
 {
     public function getShortDescription($class, $property, array $context = []): ?string
     {
@@ -57,6 +58,11 @@ class DummyExtractor implements PropertyListExtractorInterface, PropertyDescript
     public function getProperties($class, array $context = []): ?array
     {
         return ['a', 'b'];
+    }
+
+    public function getPropertyName(string $class, string $method, array $context = []): ?string
+    {
+        return 'property';
     }
 
     public function isInitializable(string $class, string $property, array $context = []): ?bool

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/FalseAccessorDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/FalseAccessorDummy.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class FalseAccessorDummy
+{
+    private $Foo;
+
+    public function hash(): void
+    {
+    }
+
+    public function cancel()
+    {
+    }
+
+    public function gettings()
+    {
+    }
+
+    public function settings()
+    {
+    }
+
+    public function isolate()
+    {
+    }
+
+    public function getValid()
+    {
+    }
+
+    public function getFoo()
+    {
+    }
+
+    public function get_foo()
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
@@ -15,6 +15,7 @@ use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\TypeInfo\Type;
 
@@ -23,7 +24,7 @@ use Symfony\Component\TypeInfo\Type;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class NullExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface
+class NullExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyNameExtractorInterface, PropertyInitializableExtractorInterface
 {
     public function getShortDescription($class, $property, array $context = []): ?string
     {
@@ -77,6 +78,11 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     {
         $this->assertIsString($class);
 
+        return null;
+    }
+
+    public function getPropertyName(string $class, string $method, array $context = []): ?string
+    {
         return null;
     }
 

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add `AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION` for scalar type transformation
  * Add `COLLECT_EXTRA_ATTRIBUTES_ERRORS` option to `Serializer` to collect extra-attributes errors during denormalization
  * Deprecate `PartialDenormalizationException::getErrors()`, use `getNotNormalizableValueErrors()` instead
+ * Enable using `#[WithAccessors]` from the PropertyInfo component with the serializer
 
 8.0
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
 use Symfony\Component\Serializer\Attribute\Ignore;
@@ -82,7 +83,11 @@ final class ObjectNormalizer extends AbstractObjectNormalizer
 
         foreach ($reflClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflMethod) {
             $name = $reflMethod->name;
-            $attributeName = $this->getAttributeNameFromAccessor($reflClass, $reflMethod, false);
+            // getProperty() is only advertised through @method on PropertyInfoExtractorInterface, so an
+            // extractor predating it keeps the previous resolution instead of fataling
+            $attributeName = $this->propertyInfoExtractor instanceof PropertyNameExtractorInterface
+                ? $this->propertyInfoExtractor->getPropertyName($class, $name)
+                : $this->getAttributeNameFromAccessor($reflClass, $reflMethod, false);
 
             if ($this->hasPropertyForAccessor($reflMethod->getDeclaringClass(), $name) && (null === $attributeName || $this->hasAttributeNameCollision($reflClass, $attributeName, $name))) {
                 $attributeName = $name;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ContainingWithAccessorsDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ContainingWithAccessorsDummy.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\PropertyInfo\Attribute\WithAccessors;
+
+class ContainingWithAccessorsDummy
+{
+    #[WithAccessors(getter: 'retrieveName', setter: 'renameTo')]
+    private string $name;
+
+    #[WithAccessors(getter: 'currentPriority', setter: 'changePriority')]
+    private int $priority;
+
+    #[WithAccessors(getter: 'isEnabled')]
+    private bool $active;
+
+    public function __construct(string $name = '', int $priority = 0, bool $active = false)
+    {
+        $this->name = $name;
+        $this->priority = $priority;
+        $this->active = $active;
+    }
+
+    public function retrieveName(): string
+    {
+        return $this->name;
+    }
+
+    public function renameTo(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function currentPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function changePriority(int $priority): void
+    {
+        $this->priority = $priority;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->active;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -53,6 +53,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyWithIsPrefixedProperty;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\ContainingWithAccessorsDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyPrivatePropertyWithoutGetter;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyWithObjectConstructor;
@@ -1196,6 +1197,81 @@ class ObjectNormalizerTest extends TestCase
             null,
             $propertyAccessorBuilder->getPropertyAccessor(),
         );
+    }
+
+    public function testNormalizeWithAnExtractorThatDoesNotExtractPropertyNames()
+    {
+        // an extractor written against PropertyInfoExtractorInterface before getProperty() was added to it
+        $extractor = new class implements PropertyInfoExtractorInterface {
+            public function getType(string $class, string $property, array $context = []): ?Type
+            {
+                return null;
+            }
+
+            public function getShortDescription(string $class, string $property, array $context = []): ?string
+            {
+                return null;
+            }
+
+            public function getLongDescription(string $class, string $property, array $context = []): ?string
+            {
+                return null;
+            }
+
+            public function isReadable(string $class, string $property, array $context = []): ?bool
+            {
+                return true;
+            }
+
+            public function isWritable(string $class, string $property, array $context = []): ?bool
+            {
+                return true;
+            }
+
+            public function getProperties(string $class, array $context = []): ?array
+            {
+                return null;
+            }
+        };
+
+        $normalizer = new ObjectNormalizer(propertyInfoExtractor: $extractor);
+        $normalizer->setSerializer(new Serializer([$normalizer]));
+
+        $obj = new ObjectDummy();
+        $obj->setFoo('foo');
+        $obj->bar = 'bar';
+
+        $normalized = $normalizer->normalize($obj);
+
+        $this->assertSame('foo', $normalized['foo']);
+        $this->assertSame('bar', $normalized['bar']);
+    }
+
+    public function testNormalizeContainingWithAccessorsAttribute()
+    {
+        $normalizer = $this->getNormalizerForAccessors();
+
+        $object = new ContainingWithAccessorsDummy('Alice', 5, true);
+        $normalized = $normalizer->normalize($object);
+
+        $this->assertSame([
+            'name' => 'Alice',
+            'priority' => 5,
+            'active' => true,
+        ], $normalized);
+    }
+
+    public function testDenormalizeContainingWithAccessorsAttribute()
+    {
+        $normalizer = $this->getNormalizerForAccessors();
+
+        $object = $normalizer->denormalize([
+            'name' => 'Bob',
+            'priority' => 3,
+        ], ContainingWithAccessorsDummy::class);
+
+        $this->assertSame('Bob', $object->retrieveName());
+        $this->assertSame(3, $object->currentPriority());
     }
 
     public function testNormalizeWithMethodNamesSimilarToAccessors()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follows #63775 and #59529, both merged, and makes `#[WithAccessors]` work through the serializer.

The serializer walks a class's public methods and has to know which attribute each one exposes. It resolved that by stripping accessor prefixes, so a method named `retrieveName()` was invisible to it, and `#[WithAccessors]` had no effect on serialization.

`PropertyNameExtractorInterface` adds the reverse lookup that was missing, from a method to the property it exposes:

```php
public function getPropertyName(string $class, string $method, array $context = []): ?string;
```

`ReflectionExtractor` implements it, consulting `#[WithAccessors]` first and falling back to the prefix conventions. `PropertyInfoExtractor` and `PropertyInfoCacheExtractor` forward it, so the composite and cached extractors expose it too, and the result is cached per class and method.

`ObjectNormalizer` then uses it instead of stripping prefixes itself:

```php
class User
{
    public function __construct(
        #[WithAccessors(getter: 'retrieveName', setter: 'renameTo')]
        private string $name,
    ) {
    }

    public function retrieveName(): string
    {
        return $this->name;
    }

    public function renameTo(string $name): void
    {
        $this->name = $name;
    }
}

$serializer->serialize(new User('John Doe'), 'json');   // {"name":"John Doe"}
$serializer->deserialize('{"name":"John Doe"}', User::class, 'json');
```

The interface is optional. `PropertyInfoExtractorInterface` does not require it, and `ObjectNormalizer` checks `instanceof PropertyNameExtractorInterface` before calling it, falling back to the previous resolution. An extractor written before this interface existed keeps working when passed to the `$propertyInfoExtractor` constructor argument.

Documentation should cover: the new interface and its single method, that `ReflectionExtractor` reads `#[WithAccessors]` and otherwise falls back to the naming conventions, and that a custom extractor only needs to implement the interface if it wants to influence how the serializer names attributes.
