### PR TITLE
 Bump FrankenPHP image to use PHP 8.4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,7 +139,7 @@ jobs:
           KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper:2181'
         options: --name=kafka
       frankenphp:
-        image: dunglas/frankenphp:1.1.0
+        image: dunglas/frankenphp:1.12.1-php8.4
         ports:
           - 80:80
           - 8681:81


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | [Fix CI](https://github.com/symfony/symfony/actions/runs/23905173545/job/69711933788?pr=63715)
| License       | MIT

The usage of property hooks in 8b2209e3972 revealed that FrankenPHP must be updated in our CI to match the min requirement of 8.1 branch (it currently uses PHP 8.3). This fixes integration tests.