### PR TITLE
[DoctrineBridge] Allow using `\Closure` in `#[MapEntity]`

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/Console/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/Console/EntityValueResolver.php
@@ -86,7 +86,11 @@ final class EntityValueResolver implements ValueResolverInterface
         }
 
         $message = '';
-        if (null !== $options->expr) {
+        if ($options->expr instanceof \Closure) {
+            if (null === $object = $this->findViaClosure($manager, $options, $input)) {
+                $message = ' The closure returned null.';
+            }
+        } elseif (null !== $options->expr) {
             $variables = array_merge($input->getArguments(), $input->getOptions(), ['input' => $input]);
             if (null === $object = $this->findViaExpression($this->expressionLanguage, $manager, $options, $variables)) {
                 $message = \sprintf(' The expression "%s" returned null.', $options->expr);

--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -60,7 +60,11 @@ final class EntityValueResolver implements ValueResolverInterface
         }
 
         $message = '';
-        if (null !== $options->expr) {
+        if ($options->expr instanceof \Closure) {
+            if (null === $object = $this->findViaClosure($manager, $options, $request)) {
+                $message = ' The closure returned null.';
+            }
+        } elseif (null !== $options->expr) {
             $variables = array_merge($request->attributes->all(), ['request' => $request]);
             if (null === $object = $this->findViaExpression($this->expressionLanguage, $manager, $options, $variables)) {
                 $message = \sprintf(' The expression "%s" returned null.', $options->expr);

--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolverTrait.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolverTrait.php
@@ -100,6 +100,18 @@ trait EntityValueResolverTrait
     }
 
     /**
+     * Finds an entity via closure.
+     */
+    private function findViaClosure(ObjectManager $manager, MapEntity $options, mixed $context): object|iterable|null
+    {
+        try {
+            return ($options->expr)($context, $manager->getRepository($options->class));
+        } catch (NoResultException|ConversionException) {
+            return null;
+        }
+    }
+
+    /**
      * Finds an entity by criteria.
      */
     private function findOneByCriteria(ObjectManager $manager, MapEntity $options, array $criteria): ?object

--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Bridge\Doctrine\Attribute;
 
+use Doctrine\Persistence\ObjectRepository;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\ValueResolver;
 
 /**
@@ -23,7 +26,7 @@ class MapEntity extends ValueResolver
     /**
      * @param class-string|null          $class         The entity class
      * @param string|null                $objectManager Specify the object manager used to retrieve the entity
-     * @param string|null                $expr          An expression to fetch the entity using the {@see https://symfony.com/doc/current/components/expression_language.html ExpressionLanguage} syntax.
+     * @param string|\Closure<T of ObjectRepository>(Request|InputInterface, T):(object|iterable|null)|null $expr An expression or closure to fetch the entity.
      *                                                  Any request attribute are available as a variable, and your entity repository in the 'repository' variable.
      * @param array<string, string>|null $mapping       Configures the properties and values to use with the findOneBy() method
      *                                                  The key is the route placeholder name and the value is the Doctrine property name.
@@ -40,7 +43,7 @@ class MapEntity extends ValueResolver
     public function __construct(
         public ?string $class = null,
         public ?string $objectManager = null,
-        public ?string $expr = null,
+        public string|\Closure|null $expr = null,
         public ?array $mapping = null,
         public ?array $exclude = null,
         public ?bool $stripNull = null,

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -6,12 +6,13 @@ CHANGELOG
 
  * Add IterableToArrayCollectionTransformer for ObjectMapper
  * Throw a `ConstraintDefinitionException` from `UniqueEntity` when a checked field holds an array or is a to-many association, instead of building a query that cannot match
+ * Allow using closures with the `#[MapEntity]` attribute
 
 8.1
 ---
 
  * Add option `uid_format` to `EntityType`
- * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`. Namespace aliases are no longer supported in Doctrine.
+ * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`; namespace aliases are no longer supported in Doctrine
 
 8.0
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -490,6 +490,92 @@ class EntityValueResolverTest extends TestCase
         $resolver->resolve($request, $argument);
     }
 
+    public function testClosureMapsToArgument()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('id', 5);
+        $argument = $this->createArgument(
+            'stdClass',
+            new MapEntity(expr: static fn (Request $request, ObjectRepository $repository) => $repository->findOneBy(['id' => $request->attributes->get('id')])),
+            'arg1'
+        );
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->never())
+            ->method('find');
+        $repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['id' => 5])
+            ->willReturn($object = new \stdClass());
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $this->assertSame([$object], $resolver->resolve($request, $argument));
+    }
+
+    public function testClosureReturnsNullThrows404()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $argument = $this->createArgument(
+            'stdClass',
+            new MapEntity(expr: static fn () => null),
+            'arg1'
+        );
+
+        $repository = self::createStub(ObjectRepository::class);
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $resolver->resolve($request, $argument);
+    }
+
+    public function testClosureFailureReturns404()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $argument = $this->createArgument(
+            'stdClass',
+            new MapEntity(expr: static function (Request $request, ObjectRepository $repository) {
+                $repository->findOneBy(['id' => $request->attributes->get('id')]);
+
+                throw new ConversionException();
+            }),
+            'arg1'
+        );
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['id' => null]);
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $resolver->resolve($request, $argument);
+    }
+
     public function testAlreadyResolved()
     {
         $manager = $this->createStub(ObjectManager::class);

--- a/src/Symfony/Bridge/Doctrine/Tests/Console/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Console/ArgumentResolver/EntityValueResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Console\ArgumentResolver;
 
+use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
@@ -24,6 +25,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
@@ -249,6 +251,65 @@ class EntityValueResolverTest extends TestCase
         $member = $this->createMember('entity', \stdClass::class, new MapEntity(expr: 'repository.findOneByCustomMethod(entity)'));
 
         $this->assertSame([$object], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
+    public function testResolveWithClosure()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry, null, new MapEntity(expr: static fn (InputInterface $input, ObjectRepository $repository) => $repository->findOneBy(['id' => $input->getArgument('entity')])));
+
+        $input = new ArrayInput(['entity' => 1], new InputDefinition([
+            new InputArgument('entity'),
+        ]));
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->never())
+            ->method('find');
+        $repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['id' => 1])
+            ->willReturn($object = new \stdClass());
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $member = $this->createMember('entity', \stdClass::class);
+
+        $this->assertSame([$object], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
+    public function testResolveWithClosureFailureThrowsException()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry, null, new MapEntity(expr: static function (InputInterface $input, ObjectRepository $repository) {
+            $repository->findOneBy(['id' => $input->getArgument('entity')]);
+
+            throw new ConversionException();
+        }));
+
+        $input = new ArrayInput(['entity' => 1], new InputDefinition([
+            new InputArgument('entity'),
+        ]));
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['id' => 1]);
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $member = $this->createMember('entity', \stdClass::class);
+
+        $this->expectException(RuntimeException::class);
+
+        iterator_to_array($resolver->resolve('entity', $input, $member));
     }
 
     public function testResolveWithStripNull()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds the ability to use closures with the `#[MapEntity]` attribute.

### Example

```php
class PostController
{
    #[Route('/posts-by/{authorId}')]
    public function index(
        #[MapEntity(
            class: Post::class,
            expr: static function (Request $request, PostRepository $repository) {
                return $repository->findBy(['author' => $request->attributes->get('authorId')], [], 10);
            },
        )]
        iterable $posts,
    ): Response {
        // ...
    }
}
```