### PR TITLE
[Security] Improve authentication debugging in the profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
  * Add the `ldap_users_only` option to the LDAP authenticators, to bind only `LdapUser` instances against the LDAP server
+ * Show the deauthentication reason and the responsible user providers in the security profiler panel
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/EventListener/SecurityDataCollectorListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/EventListener/SecurityDataCollectorListener.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DataCollector\EventListener;
+
+use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
+
+/**
+ * Feeds the {@see SecurityDataCollector} with deauthentication information
+ * gathered from {@see TokenDeauthenticatedEvent}, keeping profiler-specific
+ * plumbing out of the production {@see \Symfony\Component\Security\Http\Firewall\ContextListener}.
+ */
+class SecurityDataCollectorListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private SecurityDataCollector $dataCollector,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            TokenDeauthenticatedEvent::class => 'onTokenDeauthenticated',
+        ];
+    }
+
+    public function onTokenDeauthenticated(TokenDeauthenticatedEvent $event): void
+    {
+        $this->dataCollector->collectDeauthentication($event);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Voter\TraceableVoter;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
@@ -38,6 +39,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
 class SecurityDataCollector extends DataCollector implements LateDataCollectorInterface
 {
     private bool $hasVarDumper;
+    private ?array $deauthentication = null;
 
     public function __construct(
         private ?TokenStorageInterface $tokenStorage = null,
@@ -48,6 +50,15 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         private ?TraceableFirewallListener $firewall = null,
     ) {
         $this->hasVarDumper = class_exists(ClassStub::class);
+    }
+
+    public function collectDeauthentication(TokenDeauthenticatedEvent $event): void
+    {
+        $this->deauthentication = [
+            'reason' => $event->getReason(),
+            'providers' => $event->getProviderClasses(),
+            'user' => $event->getOriginalToken()->getUserIdentifier(),
+        ];
     }
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
@@ -201,6 +212,10 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
         $this->data['authenticators'] = $this->firewall ? $this->firewall->getAuthenticatorsInfo() : [];
 
+        // kept until reset(), which runs before the next main request: sub-requests of the
+        // same request must report it too, the main profile is not always collected first
+        $this->data['deauthentication'] = $this->deauthentication;
+
         if ($this->data['listeners'] && !($this->data['firewall']['stateless'] ?? true)) {
             $authCookieName = "{$this->data['firewall']['name']}_auth_profile_token";
             $deauthCookieName = "{$this->data['firewall']['name']}_deauth_profile_token";
@@ -226,6 +241,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     public function reset(): void
     {
         $this->data = [];
+        $this->deauthentication = null;
     }
 
     public function lateCollect(): void
@@ -373,6 +389,16 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     public function getDeauthProfileToken(): string|Data|null
     {
         return $this->data['deauth_profile_token'] ?? null;
+    }
+
+    /**
+     * Returns information about why the user was deauthenticated, if applicable.
+     *
+     * @return array{reason: ?string, providers: list<class-string>, user: string}|Data|null
+     */
+    public function getDeauthentication(): array|Data|null
+    {
+        return $this->data['deauthentication'] ?? null;
     }
 
     public function getName(): string

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RemoveSecurityDataCollectorListenerPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RemoveSecurityDataCollectorListenerPass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Removes the listener feeding the security data collector when the profiler
+ * is not enabled, as its "kernel.event_subscriber" tag would otherwise keep
+ * it, and the collector, alive in a production container.
+ *
+ * @internal
+ */
+final class RemoveSecurityDataCollectorListenerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('profiler')) {
+            $container->removeDefinition('data_collector.security.listener');
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\SecurityBundle\DataCollector\EventListener\SecurityDataCollectorListener;
 use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
 
 return static function (ContainerConfigurator $container) {
@@ -29,5 +30,12 @@ return static function (ContainerConfigurator $container) {
                 'id' => 'security',
                 'priority' => 270,
             ])
+
+        // removed by RemoveSecurityDataCollectorListenerPass when the profiler is not enabled
+        ->set('data_collector.security.listener', SecurityDataCollectorListener::class)
+            ->args([
+                service('data_collector.security'),
+            ])
+            ->tag('kernel.event_subscriber')
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -261,10 +261,20 @@
                                 {% endif %}
                             </tbody>
                         </table>
+
+                        {% if collector.deauthentication %}
+                            <p class="help">
+                                <strong>{{ collector.deauthentication.user }}</strong> was deauthenticated during this request{% if collector.deauthentication.reason %} because {{ collector.deauthentication.reason }}{% endif %}, before the current token was set.
+                            </p>
+                        {% endif %}
                     {% elseif collector.enabled %}
                         <div class="empty">
                             <p>
-                                There is no security token.
+                                {% if collector.deauthentication %}
+                                    <strong>{{ collector.deauthentication.user }}</strong> has been deauthenticated{% if collector.deauthentication.reason %} because {{ collector.deauthentication.reason }}{% endif %}.
+                                {% else %}
+                                    There is no security token.
+                                {% endif %}
                                 {% if collector.deauthProfileToken %}
                                     It was removed in
                                     <a href="{{ path('_profiler', {token: collector.deauthProfileToken, panel: 'security'}) }}">
@@ -272,6 +282,15 @@
                                     </a>.
                                 {% endif %}
                             </p>
+
+                            {% if collector.deauthentication and collector.deauthentication.providers is not empty %}
+                                <p class="help">
+                                    User provider{{ collector.deauthentication.providers|length > 1 ? 's' }}:
+                                    {% for providerClass in collector.deauthentication.providers %}
+                                        {{ providerClass|abbr_class }}{{ not loop.last ? ', ' }}
+                                    {% endfor %}
+                                </p>
+                            {% endif %}
                         </div>
                     {% endif %}
                 </div>

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterEntryPoin
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterGlobalSecurityEventListenersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterLdapLocatorPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterTokenUsageTrackingPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RemoveSecurityDataCollectorListenerPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\ReplaceDecoratedRememberMeHandlerPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\SortFirewallListenersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\CasTokenHandlerFactory;
@@ -93,6 +94,7 @@ class SecurityBundle extends Bundle
         $container->addCompilerPass(new RegisterCsrfFeaturesPass());
         $container->addCompilerPass(new RegisterTokenUsageTrackingPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
         $container->addCompilerPass(new RegisterLdapLocatorPass());
+        $container->addCompilerPass(new RemoveSecurityDataCollectorListenerPass());
         $container->addCompilerPass(new RegisterEntryPointPass());
         // must be registered after RegisterListenersPass (in the FrameworkBundle)
         $container->addCompilerPass(new RegisterGlobalSecurityEventListenersPass(), PassConfig::TYPE_BEFORE_REMOVING, -200);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/EventListener/SecurityDataCollectorListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/EventListener/SecurityDataCollectorListenerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DataCollector\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DataCollector\EventListener\SecurityDataCollectorListener;
+use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
+
+class SecurityDataCollectorListenerTest extends TestCase
+{
+    public function testDeauthenticationEventIsForwardedToTheCollector()
+    {
+        $collector = new SecurityDataCollector(new TokenStorage());
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new SecurityDataCollectorListener($collector));
+
+        $token = new UsernamePasswordToken(new InMemoryUser('jane', 'password'), 'main', ['ROLE_USER']);
+        $dispatcher->dispatch(new TokenDeauthenticatedEvent($token, new Request(), 'the user has changed', [InMemoryUserProvider::class]));
+
+        $collector->collect(new Request(), new Response());
+
+        $this->assertSame([
+            'reason' => 'the user has changed',
+            'providers' => [InMemoryUserProvider::class],
+            'user' => 'jane',
+        ], $collector->getDeauthentication());
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -35,13 +35,78 @@ use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
 use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\VarDumper\Caster\ClassStub;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class SecurityDataCollectorTest extends TestCase
 {
+    public function testCollectDeauthentication()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('jane', 'password'), 'main', ['ROLE_USER']);
+        $event = new TokenDeauthenticatedEvent($token, new Request(), 'the user has changed', [InMemoryUserProvider::class]);
+
+        $collector = new SecurityDataCollector(new TokenStorage());
+        $collector->collectDeauthentication($event);
+        $collector->collect(new Request(), new Response());
+
+        $this->assertSame([
+            'reason' => 'the user has changed',
+            'providers' => [InMemoryUserProvider::class],
+            'user' => 'jane',
+        ], $collector->getDeauthentication());
+    }
+
+    public function testDeauthenticationReachesEveryProfileOfTheRequest()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('jane', 'password'), 'main', ['ROLE_USER']);
+
+        $collector = new SecurityDataCollector(new TokenStorage());
+        $collector->collectDeauthentication(new TokenDeauthenticatedEvent($token, new Request()));
+
+        // a sub-request finishes before the main one, so it collects first
+        $collector->collect(new Request(), new Response());
+        $this->assertNotNull($collector->getDeauthentication());
+
+        $collector->collect(new Request(), new Response());
+        $this->assertNotNull($collector->getDeauthentication());
+    }
+
+    public function testResetClearsDeauthentication()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('jane', 'password'), 'main', ['ROLE_USER']);
+
+        $collector = new SecurityDataCollector(new TokenStorage());
+        $collector->collectDeauthentication(new TokenDeauthenticatedEvent($token, new Request()));
+        $collector->reset();
+        $collector->collect(new Request(), new Response());
+
+        $this->assertNull($collector->getDeauthentication());
+    }
+
+    public function testGetDeauthenticationAfterLateCollect()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('jane', 'password'), 'main', ['ROLE_USER']);
+
+        $collector = new SecurityDataCollector(new TokenStorage());
+        $collector->collectDeauthentication(new TokenDeauthenticatedEvent($token, new Request(), 'the user could not be found by any user provider', [InMemoryUserProvider::class]));
+        $collector->collect(new Request(), new Response());
+        $collector->lateCollect();
+
+        $deauthentication = $collector->getDeauthentication();
+
+        $this->assertInstanceOf(Data::class, $deauthentication);
+        $this->assertSame([
+            'reason' => 'the user could not be found by any user provider',
+            'providers' => [InMemoryUserProvider::class],
+            'user' => 'jane',
+        ], $deauthentication->getValue(true));
+    }
+
     public function testCollectWhenSecurityIsDisabled()
     {
         $collector = new SecurityDataCollector(null, null, null, null, null, null);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RemoveSecurityDataCollectorListenerPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RemoveSecurityDataCollectorListenerPassTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DataCollector\EventListener\SecurityDataCollectorListener;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RemoveSecurityDataCollectorListenerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+class RemoveSecurityDataCollectorListenerPassTest extends TestCase
+{
+    public function testListenerIsRemovedWhenTheProfilerIsNotEnabled()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('data_collector.security.listener', new Definition(SecurityDataCollectorListener::class));
+
+        (new RemoveSecurityDataCollectorListenerPass())->process($container);
+
+        $this->assertFalse($container->hasDefinition('data_collector.security.listener'));
+    }
+
+    public function testListenerIsKeptWhenTheProfilerIsEnabled()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('profiler', new Definition(Profiler::class));
+        $container->setDefinition('data_collector.security.listener', new Definition(SecurityDataCollectorListener::class));
+
+        (new RemoveSecurityDataCollectorListenerPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition('data_collector.security.listener'));
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/SecurityBundleTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/SecurityBundleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RemoveSecurityDataCollectorListenerPass;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SecurityBundleTest extends TestCase
+{
+    public function testTheDataCollectorListenerRemovalPassIsRegistered()
+    {
+        $bundle = new SecurityBundle();
+        $container = new ContainerBuilder();
+        $container->registerExtension($bundle->getContainerExtension());
+        $bundle->build($container);
+
+        $passes = $container->getCompilerPassConfig()->getBeforeOptimizationPasses();
+        $passes = array_merge($passes, $container->getCompilerPassConfig()->getOptimizationPasses());
+        $passes = array_merge($passes, $container->getCompilerPassConfig()->getBeforeRemovingPasses());
+        $passes = array_merge($passes, $container->getCompilerPassConfig()->getRemovingPasses());
+        $passes = array_merge($passes, $container->getCompilerPassConfig()->getAfterRemovingPasses());
+
+        foreach ($passes as $pass) {
+            if ($pass instanceof RemoveSecurityDataCollectorListenerPass) {
+                $this->addToAssertionCount(1);
+
+                return;
+            }
+        }
+
+        $this->fail(\sprintf('"%s" is not registered by "%s".', RemoveSecurityDataCollectorListenerPass::class, SecurityBundle::class));
+    }
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
+ * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Event/TokenDeauthenticatedEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/TokenDeauthenticatedEvent.php
@@ -30,9 +30,15 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class TokenDeauthenticatedEvent extends Event
 {
+    /**
+     * @param string|null        $reason          A human-readable, free-form sentence explaining the deauthentication
+     * @param list<class-string> $providerClasses The user providers that contributed to the deauthentication decision
+     */
     public function __construct(
         private TokenInterface $originalToken,
         private Request $request,
+        private ?string $reason = null,
+        private array $providerClasses = [],
     ) {
     }
 
@@ -44,5 +50,26 @@ final class TokenDeauthenticatedEvent extends Event
     public function getRequest(): Request
     {
         return $this->request;
+    }
+
+    /**
+     * Returns a human-readable, free-form sentence explaining why the token
+     * was deauthenticated, e.g. for display in the profiler.
+     */
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * Returns the classes of the user providers that contributed to the
+     * deauthentication decision: the providers that detected a change in the
+     * user, or the ones that could not find the user.
+     *
+     * @return list<class-string>
+     */
+    public function getProviderClasses(): array
+    {
+        return $this->providerClasses;
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -129,12 +129,13 @@ class ContextListener extends AbstractListener
             }
 
             $originalToken = $token;
-            $token = $this->refreshUser($token);
+            $refreshResult = $this->refreshUser($token);
+            $token = $refreshResult->token;
 
             if (!$token) {
                 $this->logger?->debug('Token was deauthenticated after trying to refresh it.');
 
-                $this->dispatcher?->dispatch(new TokenDeauthenticatedEvent($originalToken, $request));
+                $this->dispatcher?->dispatch(new TokenDeauthenticatedEvent($originalToken, $request, $refreshResult->deauthenticationReason, $refreshResult->providerClasses));
             }
         } elseif (null !== $token) {
             $this->logger?->warning('Expected a security token from the session, got something else.', ['key' => $this->sessionKey, 'received' => $token]);
@@ -206,13 +207,13 @@ class ContextListener extends AbstractListener
      *
      * @throws \RuntimeException
      */
-    private function refreshUser(TokenInterface $token): ?TokenInterface
+    private function refreshUser(TokenInterface $token): RefreshUserResult
     {
         $user = $token->getUser();
 
-        $userNotFoundByProvider = false;
-        $userDeauthenticated = false;
         $userClass = $user::class;
+        $userChangedBy = [];
+        $userNotFoundBy = [];
 
         foreach ($this->userProviders as $provider) {
             if (!$provider instanceof UserProviderInterface) {
@@ -228,7 +229,7 @@ class ContextListener extends AbstractListener
 
                 // tokens can be deauthenticated if the user has been changed.
                 if ($token instanceof AbstractToken && self::hasUserChanged($token, $user, $refreshedUser)) {
-                    $userDeauthenticated = true;
+                    $userChangedBy[] = $provider::class;
 
                     $this->logger?->debug('Cannot refresh token because user has changed.', ['username' => $refreshedUser->getUserIdentifier(), 'provider' => $provider::class]);
 
@@ -248,22 +249,22 @@ class ContextListener extends AbstractListener
                     $this->logger->debug('User was reloaded from a user provider.', $context);
                 }
 
-                return $token;
+                return new RefreshUserResult($token);
             } catch (UnsupportedUserException) {
                 // let's try the next user provider
             } catch (UserNotFoundException $e) {
                 $this->logger?->info('Username could not be found in the selected user provider.', ['username' => $e->getUserIdentifier(), 'provider' => $provider::class]);
 
-                $userNotFoundByProvider = true;
+                $userNotFoundBy[] = $provider::class;
             }
         }
 
-        if ($userDeauthenticated) {
-            return null;
+        if ($userChangedBy) {
+            return new RefreshUserResult(null, 'the user has changed', $userChangedBy);
         }
 
-        if ($userNotFoundByProvider) {
-            return null;
+        if ($userNotFoundBy) {
+            return new RefreshUserResult(null, 'the user could not be found by any user provider', $userNotFoundBy);
         }
 
         throw new \RuntimeException(\sprintf('There is no user provider for user "%s". Shouldn\'t the "supportsClass()" method of your user provider return true for this classname?', $userClass));

--- a/src/Symfony/Component/Security/Http/Firewall/RefreshUserResult.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RefreshUserResult.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Firewall;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Outcome of a user-refresh attempt performed by {@see ContextListener::refreshUser()}.
+ *
+ * @internal
+ */
+final class RefreshUserResult
+{
+    /**
+     * @param list<class-string> $providerClasses
+     */
+    public function __construct(
+        public readonly ?TokenInterface $token,
+        public readonly ?string $deauthenticationReason = null,
+        public readonly array $providerClasses = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
 use Symfony\Component\Security\Http\Tests\Fixtures\CustomUser;
 use Symfony\Component\Security\Http\Tests\Fixtures\LazyDoctrinePersistenceUser;
@@ -294,6 +295,42 @@ class ContextListenerTest extends TestCase
         $this->assertNull($tokenStorage->getToken());
     }
 
+    public function testDeauthenticatedEventCarriesTheReasonAndProviderWhenTheUserChanged()
+    {
+        $event = $this->dispatchTokenDeauthenticatedEvent([new NotSupportingUserProvider(true), new SupportingUserProvider(new InMemoryUser('foobar', 'baz'))]);
+
+        $this->assertSame('the user has changed', $event->getReason());
+        $this->assertSame([SupportingUserProvider::class], $event->getProviderClasses());
+    }
+
+    public function testDeauthenticatedEventAggregatesEveryProviderThatSawAChange()
+    {
+        $event = $this->dispatchTokenDeauthenticatedEvent([
+            new SupportingUserProvider(new InMemoryUser('foobar', 'baz')),
+            new SupportingUserProvider(new InMemoryUser('foobar', 'qux')),
+        ]);
+
+        $this->assertSame('the user has changed', $event->getReason());
+        $this->assertSame([SupportingUserProvider::class, SupportingUserProvider::class], $event->getProviderClasses());
+    }
+
+    public function testDeauthenticatedEventCarriesTheReasonAndProvidersWhenTheUserWasNotFound()
+    {
+        $event = $this->dispatchTokenDeauthenticatedEvent([new SupportingUserProvider(), new SupportingUserProvider()]);
+
+        $this->assertSame('the user could not be found by any user provider', $event->getReason());
+        $this->assertSame([SupportingUserProvider::class, SupportingUserProvider::class], $event->getProviderClasses());
+    }
+
+    public function testUserChangedTakesPrecedenceOverUserNotFoundInTheDeauthenticatedEvent()
+    {
+        $event = $this->dispatchTokenDeauthenticatedEvent([new SupportingUserProvider(), new SupportingUserProvider(new InMemoryUser('foobar', 'baz'))]);
+
+        // only the provider that detected the change is reported, not the one that did not find the user
+        $this->assertSame('the user has changed', $event->getReason());
+        $this->assertSame([SupportingUserProvider::class], $event->getProviderClasses());
+    }
+
     public function testTokenIsNotDeauthenticatedOnUserChangeIfNotAnInstanceOfAbstractToken()
     {
         $tokenStorage = new TokenStorage();
@@ -530,6 +567,29 @@ class ContextListenerTest extends TestCase
         }
 
         return $session;
+    }
+
+    private function dispatchTokenDeauthenticatedEvent(array $userProviders): TokenDeauthenticatedEvent
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize(new UsernamePasswordToken(new InMemoryUser('foo', 'bar'), 'context_key', ['ROLE_USER'])));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $deauthenticatedEvent = null;
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(TokenDeauthenticatedEvent::class, static function (TokenDeauthenticatedEvent $event) use (&$deauthenticatedEvent) {
+            $deauthenticatedEvent = $event;
+        });
+
+        $listener = new ContextListener(new TokenStorage(), $userProviders, 'context_key', null, $dispatcher);
+        $listener->authenticate(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertInstanceOf(TokenDeauthenticatedEvent::class, $deauthenticatedEvent);
+
+        return $deauthenticatedEvent;
     }
 
     private function handleEventWithPreviousSession($userProviders, ?UserInterface $user = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #36668
| License       | MIT

When a token is deauthenticated during `ContextListener::refreshUser()`, the profiler currently only shows "There is no security token.", which makes these deauthentications hard to debug (see #36668).

This PR surfaces the reason in the profiler:

* `TokenDeauthenticatedEvent` gains `getReason()` (a human-readable, free-form sentence, as suggested by @MatTheCat, so no keyword mapping is needed anywhere) and `getProviderClasses()` (the user providers that contributed to the decision).
* `ContextListener::refreshUser()` returns an internal `RefreshUserResult` value object carrying the outcome, the reason and the responsible providers. When the user changed, only the providers that detected the change are reported, not the ones that merely did not find the user.
* A new `SecurityDataCollectorListener` (registered only when the profiler is enabled, and removed from the container otherwise by a dedicated compiler pass) feeds the `SecurityDataCollector`, keeping profiler plumbing out of the production `ContextListener`.
* The security panel then shows for example: "**jane** has been de-authenticated because the user has changed." with the responsible provider classes below, both when the request ends up with no token and when a re-authentication happened in the same request.

The collected data is limited to the reason sentence, the provider class names and the user identifier; no sensitive values are collected.

## Tests

* `ContextListenerTest`: the event carries the reason and providers for the user-changed and user-not-found cases, and user-changed takes precedence over user-not-found in a multi-provider chain.
* `SecurityDataCollectorTest`: collection, exposure through `getDeauthentication()` (including after `lateCollect()`), no repetition in sub-request profiles, `reset()`.
* `SecurityDataCollectorListenerTest`: the event is forwarded to the collector.
* `RemoveSecurityDataCollectorListenerPassTest`: the listener is removed without the profiler and kept with it.
