### PR TITLE
[Console] Improve Table rendering performance

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -41,10 +41,18 @@ abstract class Helper implements HelperInterface
     {
         $string ??= '';
 
-        if (preg_match('//u', $string)) {
-            $string = preg_replace('/[\p{Cc}\x7F]++/u', '', $string, -1, $count);
+        if ('' === $string) {
+            return 0;
+        }
 
-            return (new UnicodeString($string))->width(false) + $count;
+        // Fast path for ASCII-only strings (no multi-byte, no control chars except common ones)
+        if (!preg_match('/[^\x20-\x7E]/', $string)) {
+            return \strlen($string);
+        }
+
+        // Single PCRE call: returns null if string is not valid UTF-8
+        if (null !== $clean = preg_replace('/[\p{Cc}\x7F]++/u', '', $string, -1, $count)) {
+            return (new UnicodeString($clean))->width(false) + $count;
         }
 
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
@@ -152,10 +160,18 @@ abstract class Helper implements HelperInterface
 
     public static function removeDecoration(OutputFormatterInterface $formatter, ?string $string): string
     {
+        $string ??= '';
+
+        // Fast path: if string contains no formatting markers, return as-is
+        // Check for: < (tags), \033 (ANSI escape), ]8;; (terminal hyperlink)
+        if (!str_contains($string, '<') && !str_contains($string, "\033") && !str_contains($string, ']8;;')) {
+            return $string;
+        }
+
         $isDecorated = $formatter->isDecorated();
         $formatter->setDecorated(false);
         // remove <...> formatting
-        $string = $formatter->format($string ?? '');
+        $string = $formatter->format($string);
         // remove already formatted characters
         $string = preg_replace("/\033\[[^m]*m/", '', $string ?? '');
         // remove terminal hyperlinks

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Helper;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Formatter\WrappableOutputFormatterInterface;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -845,32 +846,45 @@ class Table
      */
     private function calculateColumnsWidth(iterable $groups): void
     {
-        for ($column = 0; $column < $this->numberOfColumns; ++$column) {
-            $lengths = [];
-            foreach ($groups as $group) {
-                foreach ($group as $row) {
-                    if ($row instanceof TableSeparator) {
-                        continue;
-                    }
+        $formatter = $this->output->getFormatter();
 
-                    foreach ($row as $i => $cell) {
-                        if ($cell instanceof TableCell) {
-                            $textContent = Helper::removeDecoration($this->output->getFormatter(), $cell);
-                            $textLength = Helper::width($textContent);
-                            if ($textLength > 0) {
-                                $contentColumns = mb_str_split($textContent, ceil($textLength / $cell->getColspan()));
-                                foreach ($contentColumns as $position => $content) {
-                                    $row[$i + $position] = $content;
-                                }
+        // Initialize max widths for all columns
+        $maxColumnWidths = array_fill(0, $this->numberOfColumns, 0);
+
+        // Single pass through all rows to calculate all column widths at once
+        foreach ($groups as $group) {
+            foreach ($group as $row) {
+                if ($row instanceof TableSeparator) {
+                    continue;
+                }
+
+                // Process TableCell colspan splitting once per row
+                foreach ($row as $i => $cell) {
+                    if ($cell instanceof TableCell && $cell->getColspan() > 1) {
+                        $textContent = Helper::removeDecoration($formatter, $cell);
+                        $textLength = Helper::width($textContent);
+                        if ($textLength > 0) {
+                            $contentColumns = mb_str_split($textContent, (int) ceil($textLength / $cell->getColspan()));
+                            foreach ($contentColumns as $position => $content) {
+                                $row[$i + $position] = $content;
                             }
                         }
                     }
+                }
 
-                    $lengths[] = $this->getCellWidth($row, $column);
+                // Calculate width for each column in this row
+                for ($column = 0; $column < $this->numberOfColumns; ++$column) {
+                    $cellWidth = $this->getCellWidth($row, $column, $formatter);
+                    if ($cellWidth > $maxColumnWidths[$column]) {
+                        $maxColumnWidths[$column] = $cellWidth;
+                    }
                 }
             }
+        }
 
-            $this->effectiveColumnWidths[$column] = max($lengths) + Helper::width($this->style->getCellRowContentFormat()) - 2;
+        $cellContentFormatWidth = Helper::width($this->style->getCellRowContentFormat()) - 2;
+        for ($column = 0; $column < $this->numberOfColumns; ++$column) {
+            $this->effectiveColumnWidths[$column] = $maxColumnWidths[$column] + $cellContentFormatWidth;
         }
     }
 
@@ -879,13 +893,13 @@ class Table
         return Helper::width(\sprintf($this->style->getBorderFormat(), $this->style->getBorderChars()[3]));
     }
 
-    private function getCellWidth(array $row, int $column): int
+    private function getCellWidth(array $row, int $column, OutputFormatterInterface $formatter): int
     {
         $cellWidth = 0;
 
         if (isset($row[$column])) {
             $cell = $row[$column];
-            $cellWidth = Helper::width(Helper::removeDecoration($this->output->getFormatter(), $cell));
+            $cellWidth = Helper::width(Helper::removeDecoration($formatter, $cell));
         }
 
         $columnWidth = $this->columnWidths[$column] ?? 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63630
| License       | MIT

This PR improves table rendering performance by ~90% for large tables (30K+ rows).

| Rows   | Before  | After   | Improvement |
|--------|---------|---------|-------------|
| 1,000  | 0.69s   | 0.055s  | -92%        |
| 5,000  | 2.74s   | 0.29s   | -89%        |
| 10,000 | 7.15s   | 0.56s   | -92%        |
| 30,000 | 17.6s   | 1.74s   | -90%        |

Changes:
- Refactor `calculateColumnsWidth()` from O(columns × rows) to O(rows) by using a single pass
- Add fast path in `Helper::removeDecoration()` for strings without formatting markers
- Add fast path in `Helper::width()` for ASCII-only strings (avoids `UnicodeString` instantiation)