### PR TITLE
[Runtime] Add ext-filter to platform reqs

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add argument `bool $debug = false` to `HttpKernelRunner::__construct()`
+ * Add `ext-filter` to platform reqs
 
 5.4
 ---

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "composer-plugin-api": "^1.0|^2.0"
+        "composer-plugin-api": "^1.0|^2.0",
+        "ext-filter": "*"
     },
     "require-dev": {
         "composer/composer": "^1.0.2|^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4, 7.4, 8.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Calling functions like `filter_var` depends on the PHP filter extension, which is absent from the `composer.json` platform requirements.

This has been resolved by adding `ext-filter` to the require section in `composer.json`.