### PR TITLE
[HttpKernel] Move getNamespace() from DI to HttpKernel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -32,6 +32,7 @@ trait MicroKernelTrait
         initializeBundles as protected doInitializeBundles;
         initializeContainer as protected doInitializeContainer;
         getKernelParameters as private doGetKernelParameters;
+        getBundlesDefinition as private doGetBundlesDefinition;
     }
 
     public function getLogDir(): string
@@ -139,8 +140,16 @@ trait MicroKernelTrait
     protected function getKernelParameters(): array
     {
         $parameters = $this->doGetKernelParameters() + parent::getKernelParameters();
-        $parameters['.kernel.bundles_definition'] = $parameters['.kernel.bundles_definition'] ?: [FrameworkBundle::class => ['all' => true]];
+
+        foreach ($this->bundles as $name => $bundle) {
+            $parameters['kernel.bundles_metadata'][$name]['namespace'] = $bundle->getNamespace();
+        }
 
         return $parameters;
+    }
+
+    private function getBundlesDefinition(): array
+    {
+        return $this->doGetBundlesDefinition() ?: [FrameworkBundle::class => ['all' => true]];
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Kernel/AbstractBundle.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/AbstractBundle.php
@@ -32,8 +32,6 @@ abstract class AbstractBundle implements BundleInterface, ConfigurableExtensionI
     protected ?ContainerInterface $container;
     protected string $extensionAlias = '';
 
-    private string $namespace;
-
     public function boot(): void
     {
     }
@@ -71,24 +69,10 @@ abstract class AbstractBundle implements BundleInterface, ConfigurableExtensionI
         return $this->extension ??= new BundleExtension($this, $this->extensionAlias);
     }
 
-    public function getNamespace(): string
-    {
-        if (!isset($this->namespace)) {
-            $this->parseClassName();
-        }
-
-        return $this->namespace;
-    }
-
     public function getPath(): string
     {
-        if (!isset($this->path)) {
-            $reflected = new \ReflectionObject($this);
-            // assume the modern directory structure by default
-            $this->path = \dirname($reflected->getFileName(), 2);
-        }
-
-        return $this->path;
+        // assume the modern directory structure by default
+        return $this->path ??= \dirname((new \ReflectionClass($this))->getFileName(), 2);
     }
 
     /**
@@ -96,22 +80,11 @@ abstract class AbstractBundle implements BundleInterface, ConfigurableExtensionI
      */
     final public function getName(): string
     {
-        if (!isset($this->name)) {
-            $this->parseClassName();
-        }
-
-        return $this->name;
+        return $this->name ??= false === ($pos = strrpos(static::class, '\\')) ? static::class : substr(static::class, $pos + 1);
     }
 
     public function setContainer(?ContainerInterface $container): void
     {
         $this->container = $container;
-    }
-
-    private function parseClassName(): void
-    {
-        $pos = strrpos(static::class, '\\');
-        $this->namespace = false === $pos ? '' : substr(static::class, 0, $pos);
-        $this->name ??= false === $pos ? static::class : substr(static::class, $pos + 1);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Kernel/BundleInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/BundleInterface.php
@@ -48,11 +48,6 @@ interface BundleInterface
     public function getName(): string;
 
     /**
-     * Gets the Bundle namespace.
-     */
-    public function getNamespace(): string;
-
-    /**
      * Gets the Bundle directory path.
      *
      * The path should always be returned as a Unix path (with /).

--- a/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
@@ -547,7 +547,6 @@ trait KernelTrait
             $bundles[$name] = $bundle::class;
             $bundlesMetadata[$name] = [
                 'path' => $bundle->getPath(),
-                'namespace' => $bundle->getNamespace(),
             ];
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
@@ -246,7 +246,6 @@ class AbstractKernelTest extends TestCase
         $this->assertSame(TestAbstractBundle::class, $bundles['TestAbstractBundle']);
         $this->assertArrayHasKey('TestAbstractBundle', $metadata);
         $this->assertArrayHasKey('path', $metadata['TestAbstractBundle']);
-        $this->assertArrayHasKey('namespace', $metadata['TestAbstractBundle']);
     }
 
     public function testGetStartTime()

--- a/src/Symfony/Component/DependencyInjection/Tests/Kernel/AbstractBundleTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Kernel/AbstractBundleTest.php
@@ -34,13 +34,6 @@ class AbstractBundleTest extends TestCase
         $this->assertSame('CustomName', $bundle->getName());
     }
 
-    public function testGetNamespace()
-    {
-        $bundle = new FooBarBundle();
-
-        $this->assertSame(__NAMESPACE__, $bundle->getNamespace());
-    }
-
     public function testGetPath()
     {
         $bundle = new FooBarBundle();

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -23,6 +23,8 @@ use Symfony\Component\DependencyInjection\Kernel\AbstractBundle as BaseAbstractB
  */
 abstract class Bundle extends BaseAbstractBundle implements BundleInterface
 {
+    private string $namespace;
+
     /**
      * Returns the bundle's container extension.
      *
@@ -55,14 +57,14 @@ abstract class Bundle extends BaseAbstractBundle implements BundleInterface
         return $this->extension ?: null;
     }
 
+    public function getNamespace(): string
+    {
+        return $this->namespace ??= false === ($pos = strrpos(static::class, '\\')) ? '' : substr(static::class, 0, $pos);
+    }
+
     public function getPath(): string
     {
-        if (!isset($this->path)) {
-            $reflected = new \ReflectionObject($this);
-            $this->path = \dirname($reflected->getFileName());
-        }
-
-        return $this->path;
+        return $this->path ??= \dirname((new \ReflectionClass($this))->getFileName());
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleAdapter.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleAdapter.php
@@ -21,6 +21,8 @@ use Symfony\Component\DependencyInjection\Kernel\BundleInterface as BaseBundleIn
  */
 final class BundleAdapter implements BundleInterface
 {
+    private string $namespace;
+
     public function __construct(
         private readonly BaseBundleInterface $bundle,
     ) {
@@ -53,7 +55,7 @@ final class BundleAdapter implements BundleInterface
 
     public function getNamespace(): string
     {
-        return $this->bundle->getNamespace();
+        return $this->namespace ??= false === ($pos = strrpos($this->bundle::class, '\\')) ? '' : substr($this->bundle::class, 0, $pos);
     }
 
     public function getPath(): string

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -18,4 +18,5 @@ use Symfony\Component\DependencyInjection\Kernel\BundleInterface as BaseBundleIn
  */
 interface BundleInterface extends BaseBundleInterface
 {
+    public function getNamespace(): string;
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -219,9 +219,15 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
 
     protected function getKernelParameters(): array
     {
-        return $this->doGetKernelParameters() + [
+        $parameters = $this->doGetKernelParameters() + [
             'kernel.charset' => $this->getCharset(),
         ];
+
+        foreach ($this->bundles as $name => $bundle) {
+            $parameters['kernel.bundles_metadata'][$name]['namespace'] = $bundle->getNamespace();
+        }
+
+        return $parameters;
     }
 
     private function preBoot(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Something I missed in #63710
`Bundle::getNamespace()` is not used anywhere except for the bundle -> extension-class resolution. Not something that should be in DI's interface.