### PR TITLE
[EventDispatcher] Add hot-path and no-preload support to AddEventAliasesPass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -47,8 +47,10 @@ use Symfony\Component\DependencyInjection\Compiler\RegisterReverseContainerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\ErrorHandler;
+use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\Form\DependencyInjection\FormPass;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\HttpClient\DependencyInjection\HttpClientPass;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -91,6 +93,7 @@ use Symfony\Component\VarExporter\Internal\Registry;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowDebugPass;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowGuardListenerPass;
 use Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass;
+use Symfony\Component\Workflow\WorkflowEvents;
 
 // Help opcache.preload discover always-needed symbols
 class_exists(ApcuAdapter::class);
@@ -141,21 +144,26 @@ class FrameworkBundle extends Bundle
     {
         parent::build($container);
 
-        $registerListenersPass = new RegisterListenersPass();
-        $registerListenersPass->setHotPathEvents([
-            KernelEvents::REQUEST,
-            KernelEvents::CONTROLLER,
-            KernelEvents::CONTROLLER_ARGUMENTS,
-            KernelEvents::RESPONSE,
-            KernelEvents::FINISH_REQUEST,
-        ]);
-        if (class_exists(ConsoleEvents::class)) {
-            $registerListenersPass->setNoPreloadEvents([
+        $container->addCompilerPass(new AddEventAliasesPass(
+            array_merge(
+                KernelEvents::ALIASES,
+                class_exists(ConsoleEvents::class) ? ConsoleEvents::ALIASES : [],
+                class_exists(FormEvents::class) ? FormEvents::ALIASES : [],
+                class_exists(WorkflowEvents::class) ? WorkflowEvents::ALIASES : [],
+            ),
+            [
+                KernelEvents::REQUEST,
+                KernelEvents::CONTROLLER,
+                KernelEvents::CONTROLLER_ARGUMENTS,
+                KernelEvents::RESPONSE,
+                KernelEvents::FINISH_REQUEST,
+            ],
+            [
                 ConsoleEvents::COMMAND,
                 ConsoleEvents::TERMINATE,
                 ConsoleEvents::ERROR,
-            ]);
-        }
+            ]
+        ));
 
         $container->addCompilerPass(new AssetsContextPass());
         $container->addCompilerPass(new LoggerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
@@ -170,7 +178,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new ProfilerPass());
         // must be registered before removing private services as some might be listeners/subscribers
         // but as late as possible to get resolved parameters
-        $container->addCompilerPass($registerListenersPass, PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, ControllerAttributesListenerPass::class, PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -19,7 +19,6 @@ use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
 use Symfony\Component\Config\ResourceCheckerConfigCacheFactory;
-use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResourceChecker;
 use Symfony\Component\DependencyInjection\EnvVarProcessor;
 use Symfony\Component\DependencyInjection\Kernel\FileLocator;
@@ -31,7 +30,6 @@ use Symfony\Component\DependencyInjection\ReverseContainer;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface as EventDispatcherInterfaceComponentAlias;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -48,7 +46,6 @@ use Symfony\Component\HttpKernel\HttpCache\Store;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner;
 use Symfony\Component\Runtime\Runner\Symfony\ResponseRunner;
@@ -56,18 +53,9 @@ use Symfony\Component\Runtime\SymfonyRuntime;
 use Symfony\Component\String\LazyString;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\String\Slugger\SluggerInterface;
-use Symfony\Component\Workflow\WorkflowEvents;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 return static function (ContainerConfigurator $container) {
-    // this parameter is used at compile time in RegisterListenersPass
-    $container->parameters()->set('event_dispatcher.event_aliases', array_merge(
-        class_exists(ConsoleEvents::class) ? ConsoleEvents::ALIASES : [],
-        class_exists(FormEvents::class) ? FormEvents::ALIASES : [],
-        KernelEvents::ALIASES,
-        class_exists(WorkflowEvents::class) ? WorkflowEvents::ALIASES : []
-    ));
-
     $container->services()
 
         ->set('parameter_bag', ContainerBag::class)

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -24,7 +24,7 @@
         "symfony/dependency-injection": "^8.1",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^7.4|^8.0",
-        "symfony/event-dispatcher": "^7.4|^8.0",
+        "symfony/event-dispatcher": "^8.1",
         "symfony/filesystem": "^7.4|^8.0",
         "symfony/finder": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add hot-path and no-preload event support to `AddEventAliasesPass`
+ * Deprecate `RegisterListenersPass::setHotPathEvents()` and `setNoPreloadEvents()`, use `AddEventAliasesPass` instead
+
 6.0
 ---
 

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
@@ -15,24 +15,40 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * This pass allows bundles to extend the list of event aliases.
+ * This pass allows bundles to extend the list of event aliases, hot-path events, and no-preload events.
  *
  * @author Alexander M. Turek <me@derrabus.de>
+ * @author Nicolas Grekas <p@tchwork.com>
  */
 class AddEventAliasesPass implements CompilerPassInterface
 {
+    /**
+     * @param array<string, string> $eventAliases
+     * @param list<string>          $hotPathEvents
+     * @param list<string>          $noPreloadEvents
+     */
     public function __construct(
-        private array $eventAliases,
+        private array $eventAliases = [],
+        private array $hotPathEvents = [],
+        private array $noPreloadEvents = [],
     ) {
     }
 
     public function process(ContainerBuilder $container): void
     {
-        $eventAliases = $container->hasParameter('event_dispatcher.event_aliases') ? $container->getParameter('event_dispatcher.event_aliases') : [];
+        if ($this->eventAliases) {
+            $aliases = $container->hasParameter('event_dispatcher.event_aliases') ? $container->getParameter('event_dispatcher.event_aliases') : [];
+            $container->setParameter('event_dispatcher.event_aliases', array_merge($aliases, $this->eventAliases));
+        }
 
-        $container->setParameter(
-            'event_dispatcher.event_aliases',
-            array_merge($eventAliases, $this->eventAliases)
-        );
+        if ($this->hotPathEvents) {
+            $events = $container->hasParameter('event_dispatcher.hot_path_events') ? $container->getParameter('event_dispatcher.hot_path_events') : [];
+            $container->setParameter('event_dispatcher.hot_path_events', array_merge($events, $this->hotPathEvents));
+        }
+
+        if ($this->noPreloadEvents) {
+            $events = $container->hasParameter('event_dispatcher.no_preload_events') ? $container->getParameter('event_dispatcher.no_preload_events') : [];
+            $container->setParameter('event_dispatcher.no_preload_events', array_merge($events, $this->noPreloadEvents));
+        }
     }
 }

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -30,9 +30,13 @@ class RegisterListenersPass implements CompilerPassInterface
 
     /**
      * @return $this
+     *
+     * @deprecated since Symfony 8.1, use AddEventAliasesPass instead
      */
     public function setHotPathEvents(array $hotPathEvents): static
     {
+        trigger_deprecation('symfony/event-dispatcher', '8.1', 'The "%s()" method is deprecated, use "%s" instead.', __METHOD__, AddEventAliasesPass::class);
+
         $this->hotPathEvents = array_flip($hotPathEvents);
 
         return $this;
@@ -40,9 +44,13 @@ class RegisterListenersPass implements CompilerPassInterface
 
     /**
      * @return $this
+     *
+     * @deprecated since Symfony 8.1, use AddEventAliasesPass instead
      */
     public function setNoPreloadEvents(array $noPreloadEvents): static
     {
+        trigger_deprecation('symfony/event-dispatcher', '8.1', 'The "%s()" method is deprecated, use "%s" instead.', __METHOD__, AddEventAliasesPass::class);
+
         $this->noPreloadEvents = array_flip($noPreloadEvents);
 
         return $this;
@@ -58,6 +66,14 @@ class RegisterListenersPass implements CompilerPassInterface
 
         if ($container->hasParameter('event_dispatcher.event_aliases')) {
             $aliases = $container->getParameter('event_dispatcher.event_aliases');
+        }
+
+        if ($container->hasParameter('event_dispatcher.hot_path_events')) {
+            $this->hotPathEvents += array_flip($container->getParameter('event_dispatcher.hot_path_events'));
+        }
+
+        if ($container->hasParameter('event_dispatcher.no_preload_events')) {
+            $this->noPreloadEvents += array_flip($container->getParameter('event_dispatcher.no_preload_events'));
         }
 
         $globalDispatcherDefinition = $container->findDefinition('event_dispatcher');

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\EventDispatcher\Tests\DependencyInjection;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -153,6 +155,8 @@ class RegisterListenersPassTest extends TestCase
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testHotPathEvents()
     {
         $container = new ContainerBuilder();
@@ -165,6 +169,8 @@ class RegisterListenersPassTest extends TestCase
         $this->assertTrue($container->getDefinition('foo')->hasTag('container.hot_path'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testNoPreloadEvents()
     {
         $container = new ContainerBuilder();
@@ -184,6 +190,55 @@ class RegisterListenersPassTest extends TestCase
         $this->assertFalse($container->getDefinition('foo')->hasTag('container.no_preload'));
         $this->assertTrue($container->getDefinition('bar')->hasTag('container.no_preload'));
         $this->assertFalse($container->getDefinition('baz')->hasTag('container.no_preload'));
+    }
+
+    public function testHotPathEventsViaAddEventAliasesPass()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', SubscriberService::class)->addTag('kernel.event_subscriber', []);
+        $container->register('event_dispatcher', 'stdClass');
+
+        (new AddEventAliasesPass([], ['event']))->process($container);
+        (new RegisterListenersPass())->process($container);
+
+        $this->assertTrue($container->getDefinition('foo')->hasTag('container.hot_path'));
+    }
+
+    public function testNoPreloadEventsViaAddEventAliasesPass()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', SubscriberService::class)->addTag('kernel.event_subscriber', []);
+        $container->register('bar')->addTag('kernel.event_listener', ['event' => 'cold_event']);
+        $container->register('baz')
+            ->addTag('kernel.event_listener', ['event' => 'event'])
+            ->addTag('kernel.event_listener', ['event' => 'cold_event']);
+        $container->register('event_dispatcher', 'stdClass');
+
+        (new AddEventAliasesPass([], ['event'], ['cold_event']))->process($container);
+        (new RegisterListenersPass())->process($container);
+
+        $this->assertFalse($container->getDefinition('foo')->hasTag('container.no_preload'));
+        $this->assertTrue($container->getDefinition('bar')->hasTag('container.no_preload'));
+        $this->assertFalse($container->getDefinition('baz')->hasTag('container.no_preload'));
+    }
+
+    public function testMultipleAddEventAliasesPassMerge()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', SubscriberService::class)->addTag('kernel.event_subscriber', []);
+        $container->register('bar')->addTag('kernel.event_listener', ['event' => 'cold_event']);
+        $container->register('event_dispatcher', 'stdClass');
+
+        // Two passes contribute different metadata (like two bundles would)
+        (new AddEventAliasesPass([], ['event']))->process($container);
+        (new AddEventAliasesPass([], [], ['cold_event']))->process($container);
+        (new RegisterListenersPass())->process($container);
+
+        $this->assertTrue($container->getDefinition('foo')->hasTag('container.hot_path'));
+        $this->assertTrue($container->getDefinition('bar')->hasTag('container.no_preload'));
     }
 
     public function testEventSubscriberUnresolvableClassName()

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher-contracts": "^2.5|^3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Having setHotPathEvents and setNoPreloadEvents on RegisterListenersPass makes it impossible for bundles to add to these lists.
We already have a pass implementing the proper approach: AddEventAliasesPass.
This PR makes it able to also deal with hot_path / no_preload kind of events.