### PR TITLE
[DependencyInjection] Fix instanceof autoconfiguration for anonymous classes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -85,7 +85,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 /** @var ChildDefinition $instanceofDef */
                 $instanceofDef = clone $instanceofDef;
                 $instanceofDef->setAbstract(true)->setParent($parent ?: '.abstract.instanceof.'.$id);
-                $parent = '.instanceof.'.$interface.'.'.$key.'.'.$id;
+                $parent = '.instanceof.'.strtr($interface, "\0\r\n", '---').'.'.$key.'.'.$id;
                 $container->setDefinition($parent, $instanceofDef);
                 $instanceofTags[] = [$interface, $instanceofDef->getTags()];
                 $instanceofBindings = $instanceofDef->getBindings() + $instanceofBindings;
@@ -158,7 +158,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
     private function mergeConditionals(array $autoconfiguredInstanceof, array $instanceofConditionals, ContainerBuilder $container): array
     {
         // make each value an array of ChildDefinition
-        $conditionals = array_map(fn ($childDef) => [$childDef], $autoconfiguredInstanceof);
+        $conditionals = array_map(static fn ($childDef) => [$childDef], $autoconfiguredInstanceof);
 
         foreach ($instanceofConditionals as $interface => $instanceofDef) {
             // make sure the interface/class exists (but don't validate automaticInstanceofConditionals)

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -1180,6 +1180,36 @@ class IntegrationTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $taggedLocator = $s->getLocator());
         self::assertSame($container, $taggedLocator);
     }
+
+    public function testAttributeAutoconfigurationOnAnonymousClass()
+    {
+        $anonymousClass = new class {
+            #[CustomMethodAttribute('static')]
+            public function aMethod()
+            {
+            }
+        };
+
+        $container = new ContainerBuilder();
+        $container->registerAttributeForAutoconfiguration(
+            CustomMethodAttribute::class,
+            static function (ChildDefinition $d, CustomMethodAttribute $a, \ReflectionMethod $_r) {
+                $d->addTag('app.custom_tag', ['attribute' => $a->someAttribute]);
+            }
+        );
+
+        $container->register('test', $anonymousClass::class)
+            ->setPublic(true)
+            ->setSynthetic(true)
+            ->setAutoconfigured(true);
+
+        $collector = new TagCollector();
+        $container->addCompilerPass($collector);
+
+        $container->compile();
+
+        self::assertSame(['test' => [['attribute' => 'static']]], $collector->collectedTags);
+    }
 }
 
 class ServiceSubscriberStub implements ServiceSubscriberInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Anonymous class names contain null bytes, which were leaking into the generated `.instanceof.*` parent service id and breaking attribute-based autoconfiguration.

This strips `\0` from the interface/class segment when building that synthetic parent id, and adds a regression test covering an autoconfigured anonymous class with a method attribute.