### PR TITLE
[DependencyInjection] Add AddBehaviorDescribingTagsPass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -873,16 +873,6 @@ class FrameworkExtension extends Extension
 
         $container->registerForAutoconfiguration(RouteLoaderInterface::class)
             ->addTag('routing.route_loader');
-
-        $container->setParameter('container.behavior_describing_tags', [
-            'container.do_not_inline',
-            'container.service_locator',
-            'container.service_subscriber',
-            'kernel.event_subscriber',
-            'kernel.event_listener',
-            'kernel.locale_aware',
-            'kernel.reset',
-        ]);
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -42,6 +42,7 @@ use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\Console\DependencyInjection\RegisterCommandArgumentLocatorsPass;
 use Symfony\Component\Console\DependencyInjection\RemoveEmptyCommandArgumentLocatorsPass;
+use Symfony\Component\DependencyInjection\Compiler\AddBehaviorDescribingTagsPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Compiler\RegisterReverseContainerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -158,13 +159,22 @@ class FrameworkBundle extends Bundle
                 KernelEvents::RESPONSE,
                 KernelEvents::FINISH_REQUEST,
             ],
-            [
+            class_exists(ConsoleEvents::class) ? [
                 ConsoleEvents::COMMAND,
                 ConsoleEvents::TERMINATE,
                 ConsoleEvents::ERROR,
-            ]
+            ] : []
         ));
 
+        $container->addCompilerPass(new AddBehaviorDescribingTagsPass([
+            'container.do_not_inline',
+            'container.service_locator',
+            'container.service_subscriber',
+            'kernel.event_subscriber',
+            'kernel.event_listener',
+            'kernel.locale_aware',
+            'kernel.reset',
+        ]), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
         $container->addCompilerPass(new AssetsContextPass());
         $container->addCompilerPass(new LoggerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass());

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `AddBehaviorDescribingTagsPass` to allow bundles to extend the list of behavior-describing tags
  * Add Kernel and Bundle infrastructure in the `Kernel\` subnamespace
  * Add `$extensions` parameter to `MergeExtensionConfigurationPass` to ensure registered extensions are implicitly loaded
  * Add support for using service stacks as decorators, including `decorates_tag`

--- a/src/Symfony/Component/DependencyInjection/Compiler/AddBehaviorDescribingTagsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AddBehaviorDescribingTagsPass.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * This pass allows bundles to extend the list of behavior-describing tags.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class AddBehaviorDescribingTagsPass implements CompilerPassInterface
+{
+    /**
+     * @param list<string> $tags
+     */
+    public function __construct(
+        private array $tags,
+    ) {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $tags = $container->hasParameter('container.behavior_describing_tags') ? $container->getParameter('container.behavior_describing_tags') : [];
+
+        $container->setParameter(
+            'container.behavior_describing_tags',
+            array_merge($tags, $this->tags)
+        );
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AddBehaviorDescribingTagsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AddBehaviorDescribingTagsPassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\AddBehaviorDescribingTagsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AddBehaviorDescribingTagsPassTest extends TestCase
+{
+    public function testProcessSetsParameter()
+    {
+        $container = new ContainerBuilder();
+
+        (new AddBehaviorDescribingTagsPass(['kernel.event_subscriber', 'kernel.reset']))->process($container);
+
+        $this->assertSame(['kernel.event_subscriber', 'kernel.reset'], $container->getParameter('container.behavior_describing_tags'));
+    }
+
+    public function testMultiplePassesMerge()
+    {
+        $container = new ContainerBuilder();
+
+        (new AddBehaviorDescribingTagsPass(['kernel.event_subscriber', 'kernel.reset']))->process($container);
+        (new AddBehaviorDescribingTagsPass(['kernel.locale_aware']))->process($container);
+
+        $this->assertSame(['kernel.event_subscriber', 'kernel.reset', 'kernel.locale_aware'], $container->getParameter('container.behavior_describing_tags'));
+    }
+
+    public function testProcessWithExistingParameter()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('container.behavior_describing_tags', ['existing.tag']);
+
+        (new AddBehaviorDescribingTagsPass(['new.tag']))->process($container);
+
+        $this->assertSame(['existing.tag', 'new.tag'], $container->getParameter('container.behavior_describing_tags'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Same as #63875 for `container.behavior_describing_tags`, allowing bundles to add to the list when in need.

As a reminder, this attribute is used in `DecoratorServicePass` and in `ResolveInstanceofConditionalsPass`, thus the high priority.