### PR TITLE
[JsonStreamer] Add `DateTimeZone` value object support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
@@ -22,6 +22,7 @@ use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader
 use Symfony\Component\JsonStreamer\Mapping\Write\DateTimeTypePropertyMetadataLoader as WriteDateTimeTypePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\DateTimeToStringValueTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\StringToDateTimeValueTransformer;
 
@@ -109,6 +110,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('json_streamer.value_object_transformer')
 
         ->set('.json_streamer.value_object_transformer.date_interval', DateIntervalValueObjectTransformer::class)
+            ->tag('json_streamer.value_object_transformer')
+
+        ->set('.json_streamer.value_object_transformer.date_time_zone', DateTimeZoneValueObjectTransformer::class)
             ->tag('json_streamer.value_object_transformer')
 
         // cache

--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `DateTimeZone` value object support with `DateTimeZoneValueObjectTransformer`
  * Add `DateInterval` value object support with `DateIntervalValueObjectTransformer`
  * Add timezone support to `DateTimeValueObjectTransformer`
  * Add value object support

--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -23,6 +23,7 @@ use Symfony\Component\JsonStreamer\Read\LazyInstantiator;
 use Symfony\Component\JsonStreamer\Read\StreamReaderGenerator;
 use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 use Symfony\Component\TypeInfo\Type;
@@ -86,6 +87,7 @@ final class JsonStreamReader implements StreamReaderInterface
         $transformers += [
             \DateTimeInterface::class => new DateTimeValueObjectTransformer(),
             \DateInterval::class => new DateIntervalValueObjectTransformer(),
+            \DateTimeZone::class => new DateTimeZoneValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -20,6 +20,7 @@ use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
 use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 use Symfony\Component\JsonStreamer\Write\StreamWriterGenerator;
@@ -108,6 +109,7 @@ final class JsonStreamWriter implements StreamWriterInterface
         $transformers += [
             \DateTimeInterface::class => new DateTimeValueObjectTransformer(),
             \DateInterval::class => new DateIntervalValueObjectTransformer(),
+            \DateTimeZone::class => new DateTimeZoneValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithDateTimeZones.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithDateTimeZones.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithDateTimeZones
+{
+    public \DateTimeZone $timezone;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetad
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateIntervals;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimeZones;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
@@ -209,6 +210,16 @@ class JsonStreamReaderTest extends TestCase
             $this->assertInstanceOf(DummyWithDateIntervals::class, $read);
             $this->assertEquals(new \DateInterval('P2Y6M1DT12H30M5S'), $read->interval);
         }, '{"interval":"P2Y6M1DT12H30M5S"}', Type::object(DummyWithDateIntervals::class));
+    }
+
+    public function testReadObjectWithDateTimeZones()
+    {
+        $reader = JsonStreamReader::create([], $this->streamReadersDir);
+
+        $this->assertRead($reader, function (mixed $read) {
+            $this->assertInstanceOf(DummyWithDateTimeZones::class, $read);
+            $this->assertEquals(new \DateTimeZone('Asia/Tokyo'), $read->timezone);
+        }, '{"timezone":"Asia/Tokyo"}', Type::object(DummyWithDateTimeZones::class));
     }
 
     public function testReadUnion()

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithArray;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateIntervals;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimeZones;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDollarNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithList;
@@ -362,6 +363,18 @@ class JsonStreamWriterTest extends TestCase
             $dummy,
             Type::object(DummyWithDateIntervals::class),
             options: [DateIntervalValueObjectTransformer::FORMAT_KEY => 'P%yY%mM%dDT%hH%iM%sS'],
+        );
+    }
+
+    public function testWriteObjectWithDateTimeZones()
+    {
+        $dummy = new DummyWithDateTimeZones();
+        $dummy->timezone = new \DateTimeZone('Asia/Tokyo');
+
+        $this->assertWritten(
+            '{"timezone":"Asia\/Tokyo"}',
+            $dummy,
+            Type::object(DummyWithDateTimeZones::class),
         );
     }
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Transformer/DateTimeZoneValueObjectTransformerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Transformer/DateTimeZoneValueObjectTransformerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Transformer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
+
+class DateTimeZoneValueObjectTransformerTest extends TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new DateTimeZoneValueObjectTransformer();
+
+        $this->assertSame('UTC', $transformer->transform(new \DateTimeZone('UTC')));
+        $this->assertSame('Asia/Tokyo', $transformer->transform(new \DateTimeZone('Asia/Tokyo')));
+        $this->assertSame('Europe/Paris', $transformer->transform(new \DateTimeZone('Europe/Paris')));
+    }
+
+    public function testTransformThrowWhenInvalidNativeValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The native value must be an instance of "\DateTimeZone".');
+
+        (new DateTimeZoneValueObjectTransformer())->transform(new \stdClass());
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new DateTimeZoneValueObjectTransformer();
+
+        $this->assertEquals(new \DateTimeZone('UTC'), $transformer->reverseTransform('UTC'));
+        $this->assertEquals(new \DateTimeZone('Asia/Tokyo'), $transformer->reverseTransform('Asia/Tokyo'));
+        $this->assertEquals(new \DateTimeZone('Europe/Paris'), $transformer->reverseTransform('Europe/Paris'));
+    }
+
+    public function testReverseTransformThrowWhenInvalidJsonValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value must be a string, "int" given.');
+
+        (new DateTimeZoneValueObjectTransformer())->reverseTransform(42);
+    }
+
+    public function testReverseTransformThrowWhenInvalidTimezoneString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new DateTimeZoneValueObjectTransformer())->reverseTransform('Jupiter/Europa');
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Transformer/DateIntervalValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/DateIntervalValueObjectTransformer.php
@@ -37,7 +37,7 @@ final class DateIntervalValueObjectTransformer implements ValueObjectTransformer
     /**
      * @param Options $options
      */
-    public function transform(object $object, array $options = []): int|float|string|bool|null
+    public function transform(object $object, array $options = []): string
     {
         if (!$object instanceof \DateInterval) {
             throw new InvalidArgumentException('The native value must be an instance of "\DateInterval".');

--- a/src/Symfony/Component/JsonStreamer/Transformer/DateTimeValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/DateTimeValueObjectTransformer.php
@@ -37,7 +37,7 @@ final class DateTimeValueObjectTransformer implements ValueObjectTransformerInte
     /**
      * @param Options $options
      */
-    public function transform(object $object, array $options = []): int|float|string|bool|null
+    public function transform(object $object, array $options = []): string
     {
         if (!$object instanceof \DateTimeInterface) {
             throw new InvalidArgumentException('The native value must implement the "\DateTimeInterface".');

--- a/src/Symfony/Component/JsonStreamer/Transformer/DateTimeZoneValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/DateTimeZoneValueObjectTransformer.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Transformer;
+
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+/**
+ * Transforms a {@see \DateTimeZone} to a timezone string and vice versa.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @implements ValueObjectTransformerInterface<\DateTimeZone, string>
+ */
+final class DateTimeZoneValueObjectTransformer implements ValueObjectTransformerInterface
+{
+    public function transform(object $object, array $options = []): string
+    {
+        if (!$object instanceof \DateTimeZone) {
+            throw new InvalidArgumentException('The native value must be an instance of "\DateTimeZone".');
+        }
+
+        return $object->getName();
+    }
+
+    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): \DateTimeZone
+    {
+        if (!\is_string($scalar)) {
+            throw new InvalidArgumentException(\sprintf('The JSON value must be a string, "%s" given.', get_debug_type($scalar)));
+        }
+
+        try {
+            return new \DateTimeZone($scalar);
+        } catch (\Throwable $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::STRING>
+     */
+    public static function getStreamValueType(): BuiltinType
+    {
+        return Type::string();
+    }
+
+    public static function getValueObjectClassName(): string
+    {
+        return \DateTimeZone::class;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Add `DateTimeZone` value object support, similar to what `DateTimeZoneNormalizer` does in the Serializer component.

Also narrows the `transform()` return type in value object transformers (before 8.1 is actually released).