### PR TITLE
[DependencyInjection] Add #[RequiredBundle], ServicesBundle and ConsoleBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -21,12 +21,8 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use PhpParser\Parser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\Clock\ClockInterface as PsrClockInterface;
-use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\Http\Client\ClientInterface;
-use Psr\Log\LoggerAwareInterface;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -43,18 +39,13 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
-use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileResource;
-use Symfony\Component\Config\ResourceCheckerInterface;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\ArgumentResolver\ValueResolver\ValueResolverInterface as ConsoleValueResolverInterface;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\AsTargetedValueResolver as AsTargetedConsoleValueResolver;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\EventListener\ValidateQuestionInputListener;
 use Symfony\Component\Console\Messenger\RunCommandMessageHandler;
 use Symfony\Component\DependencyInjection\Alias;
@@ -62,23 +53,17 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\EnvVarLoaderInterface;
-use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\Dotenv\Command\DebugCommand;
-use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Dotenv\Command\DebugCommand as DotenvDebugCommand;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -232,10 +217,7 @@ use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\CallbackInterface;
 use Symfony\Contracts\Cache\NamespacedPoolInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\Service\ResetInterface;
-use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 
 /**
@@ -276,17 +258,9 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('serialize_controller_result_listener');
         }
 
-        if (!ContainerBuilder::willBeAvailable('symfony/clock', ClockInterface::class, ['symfony/framework-bundle'])) {
-            $container->removeDefinition('clock');
-            $container->removeAlias(ClockInterface::class);
-            $container->removeAlias(PsrClockInterface::class);
-        }
-
         if (!ContainerBuilder::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/framework-bundle'])) {
             $container->removeDefinition('controller.expression_language');
         }
-
-        $container->registerAliasForArgument('parameter_bag', PsrContainerInterface::class);
 
         $loader->load('process.php');
 
@@ -308,7 +282,7 @@ class FrameworkExtension extends Extension
                 $container->removeDefinition('console.command.translation_lint');
             }
 
-            if (!class_exists(DebugCommand::class)) {
+            if (!class_exists(DotenvDebugCommand::class)) {
                 $container->removeDefinition('console.command.dotenv_debug');
             }
 
@@ -679,37 +653,8 @@ class FrameworkExtension extends Extension
             ->addTag('assets.package');
         $container->registerForAutoconfiguration(AssetCompilerInterface::class)
             ->addTag('asset_mapper.compiler');
-        $container->registerAttributeForAutoconfiguration(AsCommand::class, static function (ChildDefinition $definition, AsCommand $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
-            $tagAttributes = [
-                'command' => $attribute->name,
-                'description' => $attribute->description,
-                'help' => $attribute->help ?? null,
-            ];
-
-            if ($reflector instanceof \ReflectionMethod) {
-                $tagAttributes['method'] = $reflector->getName();
-            }
-
-            $definition->addTag('console.command', $tagAttributes);
-            $definition->addTag('console.command.service_arguments');
-        });
-        $container->registerForAutoconfiguration(Command::class)
-            ->addTag('console.command')
-            ->addTag('console.command.service_arguments');
-        $container->registerForAutoconfiguration(ConsoleValueResolverInterface::class)
-            ->addTag('console.argument_value_resolver');
-        $container->registerForAutoconfiguration(ResourceCheckerInterface::class)
-            ->addTag('config_cache.resource_checker');
-        $container->registerForAutoconfiguration(EnvVarLoaderInterface::class)
-            ->addTag('container.env_var_loader');
-        $container->registerForAutoconfiguration(EnvVarProcessorInterface::class)
-            ->addTag('container.env_var_processor');
         $container->registerForAutoconfiguration(CallbackInterface::class)
             ->addTag('container.reversible');
-        $container->registerForAutoconfiguration(ServiceLocator::class)
-            ->addTag('container.service_locator');
-        $container->registerForAutoconfiguration(ServiceSubscriberInterface::class)
-            ->addTag('container.service_subscriber');
         $container->registerForAutoconfiguration(ValueResolverInterface::class)
             ->addTag('controller.argument_value_resolver');
         $container->registerForAutoconfiguration(AbstractController::class)
@@ -726,14 +671,8 @@ class FrameworkExtension extends Extension
             ->addTag('kernel.cache_clearer');
         $container->registerForAutoconfiguration(CacheWarmerInterface::class)
             ->addTag('kernel.cache_warmer');
-        $container->registerForAutoconfiguration(EventDispatcherInterface::class)
-            ->addTag('event_dispatcher.dispatcher');
-        $container->registerForAutoconfiguration(EventSubscriberInterface::class)
-            ->addTag('kernel.event_subscriber');
         $container->registerForAutoconfiguration(LocaleAwareInterface::class)
             ->addTag('kernel.locale_aware');
-        $container->registerForAutoconfiguration(ResetInterface::class)
-            ->addTag('kernel.reset', ['method' => 'reset']);
         $container->registerForAutoconfiguration(PropertyListExtractorInterface::class)
             ->addTag('property_info.list_extractor');
         $container->registerForAutoconfiguration(PropertyTypeExtractorInterface::class)
@@ -766,19 +705,7 @@ class FrameworkExtension extends Extension
             ->addTag('messenger.transport_factory');
         $container->registerForAutoconfiguration(MimeTypeGuesserInterface::class)
             ->addTag('mime.mime_type_guesser');
-        $container->registerForAutoconfiguration(LoggerAwareInterface::class)
-            ->addMethodCall('setLogger', [new Reference('logger')]);
 
-        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
-            $tagAttributes = get_object_vars($attribute);
-            if ($reflector instanceof \ReflectionMethod) {
-                if (isset($tagAttributes['method'])) {
-                    throw new LogicException(\sprintf('AsEventListener attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
-                }
-                $tagAttributes['method'] = $reflector->getName();
-            }
-            $definition->addTag('kernel.event_listener', $tagAttributes);
-        });
         $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
             $definition->addTag('controller.service_arguments');
         });
@@ -830,20 +757,11 @@ class FrameworkExtension extends Extension
             );
         }
 
-        $container->registerForAutoconfiguration(CompilerPassInterface::class)
-            ->addTag('container.excluded', ['source' => 'because it\'s a compiler pass']);
         $container->registerForAutoconfiguration(Constraint::class)
             ->addTag('container.excluded', ['source' => 'because it\'s a validation constraint']);
-        $container->registerForAutoconfiguration(TestCase::class)
-            ->addTag('container.excluded', ['source' => 'because it\'s a test case']);
-        $container->registerForAutoconfiguration(\UnitEnum::class)
-            ->addTag('container.excluded', ['source' => 'because it\'s an enum']);
         $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition, AsMessage $attribute): void {
             $definition->addTag('container.excluded', ['source' => 'because it\'s a messenger message']);
             $definition->addTag('messenger.message', ['serializedTypeName' => $attribute->serializedTypeName]);
-        });
-        $container->registerAttributeForAutoconfiguration(\Attribute::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a PHP attribute']);
         });
         $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
             $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine entity']);
@@ -861,11 +779,6 @@ class FrameworkExtension extends Extension
                 'list' => $attribute->asList,
             ])->addTag('container.excluded', ['source' => 'because it\'s a streamable JSON']);
         });
-
-        if (!$container->getParameter('kernel.debug')) {
-            // remove tagged iterator argument for resource checkers
-            $container->getDefinition('config_cache_factory')->setArguments([]);
-        }
 
         if (!$config['disallow_search_engine_index']) {
             $container->removeDefinition('disallow_search_engine_index_response_listener');

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProcessorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConsoleArgumentValueResolverPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DeprecateJsonStreamerValueTransformerTagPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ErrorLoggerCompilerPass;
@@ -38,18 +37,16 @@ use Symfony\Component\Cache\DependencyInjection\CachePoolClearerPass;
 use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
 use Symfony\Component\Cache\DependencyInjection\CachePoolPrunerPass;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
-use Symfony\Component\Console\DependencyInjection\RegisterCommandArgumentLocatorsPass;
-use Symfony\Component\Console\DependencyInjection\RemoveEmptyCommandArgumentLocatorsPass;
+use Symfony\Component\Console\ConsoleBundle;
 use Symfony\Component\DependencyInjection\Compiler\AddBehaviorDescribingTagsPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Compiler\RegisterReverseContainerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Kernel\RequiredBundle;
+use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
-use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\Form\DependencyInjection\FormPass;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\HttpClient\DependencyInjection\HttpClientPass;
@@ -112,6 +109,8 @@ class_exists(Registry::class);
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
+#[RequiredBundle(ServicesBundle::class)]
+#[RequiredBundle(ConsoleBundle::class, ignoreOnInvalid: true)]
 class FrameworkBundle extends Bundle
 {
     public function boot(): void
@@ -148,7 +147,6 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new AddEventAliasesPass(
             array_merge(
                 KernelEvents::ALIASES,
-                class_exists(ConsoleEvents::class) ? ConsoleEvents::ALIASES : [],
                 class_exists(FormEvents::class) ? FormEvents::ALIASES : [],
                 class_exists(WorkflowEvents::class) ? WorkflowEvents::ALIASES : [],
             ),
@@ -159,39 +157,21 @@ class FrameworkBundle extends Bundle
                 KernelEvents::RESPONSE,
                 KernelEvents::FINISH_REQUEST,
             ],
-            class_exists(ConsoleEvents::class) ? [
-                ConsoleEvents::COMMAND,
-                ConsoleEvents::TERMINATE,
-                ConsoleEvents::ERROR,
-            ] : []
         ));
 
-        $container->addCompilerPass(new AddBehaviorDescribingTagsPass([
-            'kernel.event_subscriber',
-            'kernel.event_listener',
-            'kernel.locale_aware',
-            'kernel.reset',
-        ]), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
+        $container->addCompilerPass(new AddBehaviorDescribingTagsPass(['kernel.locale_aware']), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
         $container->addCompilerPass(new AssetsContextPass());
         $container->addCompilerPass(new LoggerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass());
         $container->addCompilerPass(new RemoveEmptyControllerArgumentLocatorsPass(), PassConfig::TYPE_BEFORE_REMOVING);
-        $this->addCompilerPassIfExists($container, RegisterCommandArgumentLocatorsPass::class);
-        $this->addCompilerPassIfExists($container, RemoveEmptyCommandArgumentLocatorsPass::class, PassConfig::TYPE_BEFORE_REMOVING);
-        $this->addCompilerPassIfExists($container, ConsoleArgumentValueResolverPass::class);
         $container->addCompilerPass(new RoutingResolverPass());
         $this->addCompilerPassIfExists($container, RoutingControllerPass::class);
         $this->addCompilerPassIfExists($container, DataCollectorTranslatorPass::class);
         $container->addCompilerPass(new ProfilerPass());
-        // must be registered before removing private services as some might be listeners/subscribers
-        // but as late as possible to get resolved parameters
-        $container->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, ControllerAttributesListenerPass::class, PassConfig::TYPE_BEFORE_REMOVING);
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
         $this->addCompilerPassIfExists($container, AttributeMetadataPass::class);
-        $this->addCompilerPassIfExists($container, AddConsoleCommandPass::class, PassConfig::TYPE_BEFORE_REMOVING);
-        // must be registered before the AddConsoleCommandPass
         $container->addCompilerPass(new TranslationLintCommandPass(), PassConfig::TYPE_BEFORE_REMOVING, 10);
         // must be registered as late as possible to get access to all Twig paths registered in
         // twig.template_iterator definition

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -11,25 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Psr\Clock\ClockInterface as PsrClockInterface;
-use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
-use Symfony\Component\Clock\Clock;
-use Symfony\Component\Clock\ClockInterface;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
-use Symfony\Component\Config\ResourceCheckerConfigCacheFactory;
-use Symfony\Component\DependencyInjection\Config\ContainerParametersResourceChecker;
-use Symfony\Component\DependencyInjection\EnvVarProcessor;
 use Symfony\Component\DependencyInjection\Kernel\FileLocator;
 use Symfony\Component\DependencyInjection\Parameter;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\DependencyInjection\ReverseContainer;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface as EventDispatcherInterfaceComponentAlias;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,25 +37,9 @@ use Symfony\Component\Runtime\SymfonyRuntime;
 use Symfony\Component\String\LazyString;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\String\Slugger\SluggerInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
-
-        ->set('parameter_bag', ContainerBag::class)
-            ->args([
-                service('service_container'),
-            ])
-        ->alias(ContainerBagInterface::class, 'parameter_bag')
-        ->alias(ParameterBagInterface::class, 'parameter_bag')
-
-        ->set('event_dispatcher', EventDispatcher::class)
-            ->public()
-            ->tag('container.hot_path')
-            ->tag('event_dispatcher.dispatcher', ['name' => 'event_dispatcher'])
-        ->alias(EventDispatcherInterfaceComponentAlias::class, 'event_dispatcher')
-        ->alias(EventDispatcherInterface::class, 'event_dispatcher')
-        ->alias(PsrEventDispatcherInterface::class, 'event_dispatcher')
 
         ->set('http_kernel', HttpKernel::class)
             ->public()
@@ -129,19 +97,8 @@ return static function (ContainerConfigurator $container) {
                 tagged_iterator('kernel.cache_clearer'),
             ])
 
-        ->set('kernel')
-            ->synthetic()
-            ->public()
         ->alias(KernelInterface::class, 'kernel')
 
-        ->set('filesystem', Filesystem::class)
-        ->alias(Filesystem::class, 'filesystem')
-
-        ->set('file_locator', FileLocator::class)
-            ->args([
-                service('kernel'),
-            ])
-        ->alias(FileLocator::class, 'file_locator')
         ->alias(LegacyFileLocator::class, 'file_locator')
             ->deprecate('symfony/http-kernel', '8.1', 'The "%alias_id%" alias is deprecated, use "'.FileLocator::class.'" instead.')
 
@@ -155,30 +112,9 @@ return static function (ContainerConfigurator $container) {
             ->lazy()
         ->alias(UriSigner::class, 'uri_signer')
 
-        ->set('config_cache_factory', ResourceCheckerConfigCacheFactory::class)
-            ->args([
-                tagged_iterator('config_cache.resource_checker'),
-            ])
-
-        ->set('dependency_injection.config.container_parameters_resource_checker', ContainerParametersResourceChecker::class)
-            ->args([
-                service('service_container'),
-            ])
-            ->tag('config_cache.resource_checker', ['priority' => -980])
-
-        ->set('config.resource.self_checking_resource_checker', SelfCheckingResourceChecker::class)
-            ->tag('config_cache.resource_checker', ['priority' => -990])
-
         ->set('services_resetter', ServicesResetter::class)
             ->public()
         ->alias(ServicesResetterInterface::class, 'services_resetter')
-
-        ->set('reverse_container', ReverseContainer::class)
-            ->args([
-                service('service_container'),
-                service_locator([]),
-            ])
-        ->alias(ReverseContainer::class, 'reverse_container')
 
         ->set('locale_aware_listener', LocaleAwareListener::class)
             ->args([
@@ -186,14 +122,6 @@ return static function (ContainerConfigurator $container) {
                 service('request_stack'),
             ])
             ->tag('kernel.event_subscriber')
-
-        ->set('container.env_var_processor', EnvVarProcessor::class)
-            ->args([
-                service('service_container'),
-                tagged_iterator('container.env_var_loader'),
-            ])
-            ->tag('container.env_var_processor')
-            ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set('slugger', AsciiSlugger::class)
             ->args([
@@ -225,12 +153,7 @@ return static function (ContainerConfigurator $container) {
                 service('container.getenv'),
             ])
 
-        ->set('clock', Clock::class)
-        ->alias(ClockInterface::class, 'clock')
-        ->alias(PsrClockInterface::class, 'clock')
-
         // register as abstract and excluded, aka not-autowirable types
-        ->set(LoaderInterface::class)->abstract()->tag('container.excluded')
         ->set(Request::class)->abstract()->tag('container.excluded')
         ->set(Response::class)->abstract()->tag('container.excluded')
         ->set(SessionInterface::class)->abstract()->tag('container.excluded')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -43,12 +42,12 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\AddBehaviorDescribingTagsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveTaggedIteratorArgumentPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
@@ -2219,33 +2218,6 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($iterator->needsIndexes());
     }
 
-    public function testRemovesResourceCheckerConfigCacheFactoryArgumentOnlyIfNoDebug()
-    {
-        $container = $this->createContainer(['kernel.debug' => true]);
-        (new FrameworkExtension())->load([], $container);
-        $this->assertCount(1, $container->getDefinition('config_cache_factory')->getArguments());
-
-        $container = $this->createContainer(['kernel.debug' => false]);
-        (new FrameworkExtension())->load([], $container);
-        $this->assertSame([], $container->getDefinition('config_cache_factory')->getArguments());
-    }
-
-    public function testLoggerAwareRegistration()
-    {
-        $container = $this->createContainerFromFile('full', [], true, false);
-        $container->addCompilerPass(new ResolveInstanceofConditionalsPass());
-        $container->register('foo', LoggerAwareInterface::class)
-            ->setAutoconfigured(true);
-        $container->compile();
-
-        $calls = $container->findDefinition('foo')->getMethodCalls();
-
-        $this->assertCount(1, $calls, 'Definition should contain 1 method call');
-        $this->assertSame('setLogger', $calls[0][0], 'Method name should be "setLogger"');
-        $this->assertInstanceOf(Reference::class, $calls[0][1][0]);
-        $this->assertSame('logger', (string) $calls[0][1][0], 'Argument should be a reference to "logger"');
-    }
-
     public function testSessionCookieSecureAuto()
     {
         $container = $this->createContainerFromFile('session_cookie_secure_auto');
@@ -2558,13 +2530,27 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testRegisterParameterCollectingBehaviorDescribingTags()
     {
-        $container = $this->createContainerFromFile('default_config');
+        $container = $this->createContainerFromFile('default_config', [], true, false);
+        $container->addCompilerPass(new AddBehaviorDescribingTagsPass([
+            'container.do_not_inline',
+            'container.service_locator',
+            'container.service_subscriber',
+            'kernel.event_subscriber',
+            'kernel.event_listener',
+            'kernel.reset',
+        ]));
+        $container->addCompilerPass(new AddBehaviorDescribingTagsPass(['kernel.locale_aware']));
+        $container->compile();
 
         $this->assertTrue($container->hasParameter('container.behavior_describing_tags'));
         $this->assertEquals([
             'container.do_not_inline',
             'container.service_locator',
             'container.service_subscriber',
+            'kernel.event_subscriber',
+            'kernel.event_listener',
+            'kernel.reset',
+            'kernel.locale_aware',
         ], $container->getParameter('container.behavior_describing_tags'));
     }
 
@@ -3048,7 +3034,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     protected function createContainer(array $data = [])
     {
-        return new ContainerBuilder(new EnvPlaceholderParameterBag(array_merge([
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(array_merge([
             'kernel.bundles' => ['FrameworkBundle' => FrameworkBundle::class],
             'kernel.bundles_metadata' => ['FrameworkBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle', 'path' => __DIR__.'/../..']],
             'kernel.cache_dir' => __DIR__,
@@ -3064,6 +3050,13 @@ abstract class FrameworkExtensionTestCase extends TestCase
             'container.build_id' => hash('crc32', 'Abc123423456789'),
             'container.build_time' => 23456789,
         ], $data)));
+
+        // FrameworkBundle depends on ServicesBundle; ensure its services are loaded during compile
+        $servicesBundle = new ServicesBundle();
+        $container->registerExtension($servicesBundle->getContainerExtension());
+        $container->loadFromExtension('services');
+
+        return $container;
     }
 
     protected function createContainerFromFile(string $file, array $data = [], bool $resetCompilerPasses = true, bool $compile = true, ?FrameworkExtension $extension = null): ContainerBuilder

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -139,7 +139,7 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
 
     public static function provideCompletionSuggestions(): iterable
     {
-        $name = ['foo', 'default_config_test', 'extension_without_config_test', 'framework', 'test', 'test_dump', 'DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'FrameworkBundle', 'TestBundle'];
+        $name = ['foo', 'default_config_test', 'extension_without_config_test', 'services', 'console', 'framework', 'test', 'test_dump', 'DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'ServicesBundle', 'ConsoleBundle', 'FrameworkBundle', 'TestBundle'];
         yield 'name, no debug' => [false, [''], $name];
         yield 'name, debug' => [true, [''], $name];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -236,6 +236,8 @@ class MicroKernelTraitTest extends TestCase
 
         $this->assertSame(['test', 'dev'], $parameters['.container.known_envs']);
         $this->assertSame([
+            'Symfony\Component\DependencyInjection\Kernel\ServicesBundle' => ['all' => true],
+            'Symfony\Component\Console\ConsoleBundle' => ['all' => true],
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all' => true],
             'TestBundle' => ['test' => true, 'dev' => true],
         ], $parameters['.kernel.bundles_definition']);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
 use Symfony\Component\HttpFoundation\Request;
 
 class AddSessionDomainConstraintPassTest extends TestCase
@@ -129,6 +130,7 @@ class AddSessionDomainConstraintPassTest extends TestCase
         $container->setParameter('kernel.charset', 'UTF-8');
         $container->setParameter('kernel.container_class', 'cc');
         $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.environment', 'test');
         $container->setParameter('kernel.project_dir', __DIR__);
         $container->setParameter('kernel.secret', __DIR__);
         if (null !== $sessionStorageOptions) {
@@ -143,6 +145,10 @@ class AddSessionDomainConstraintPassTest extends TestCase
                 'router' => ['resource' => 'dummy'],
             ],
         ];
+
+        if (class_exists(ServicesBundle::class)) {
+            new ServicesBundle()->getContainerExtension()->load([], $container);
+        }
 
         $ext = new FrameworkExtension();
         $ext->load($config, $container);

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `ConsoleBundle` for console applications with DI, autodiscovery and autowiring
  * Add optional `$container` parameter to `Application` for automatic service wiring from a PSR container
  * Add `SymfonyStyle::outlineBlock()` and convenience methods `outlineSuccess()`, `outlineError()`, `outlineWarning()`, `outlineNote()`, `outlineInfo()`, `outlineCaution()` for border-only message blocks with the type label embedded in the top border
  * Add `TraceableValueResolver` to help inspecting value resolvers performances

--- a/src/Symfony/Component/Console/ConsoleBundle.php
+++ b/src/Symfony/Component/Console/ConsoleBundle.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console;
+
+use Symfony\Component\Config\Resource\ClassExistenceResource;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\ValueResolverInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\AsTargetedValueResolver;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
+use Symfony\Component\Console\DependencyInjection\ConsoleArgumentValueResolverPass;
+use Symfony\Component\Console\DependencyInjection\RegisterCommandArgumentLocatorsPass;
+use Symfony\Component\Console\DependencyInjection\RemoveEmptyCommandArgumentLocatorsPass;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Kernel\AbstractBundle;
+use Symfony\Component\DependencyInjection\Kernel\RequiredBundle;
+use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Dotenv\Command\DebugCommand as DotenvDebugCommand;
+use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+#[RequiredBundle(ServicesBundle::class)]
+class ConsoleBundle extends AbstractBundle
+{
+    public function getPath(): string
+    {
+        return $this->path ??= __DIR__;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        $this->addCompilerPassIfExists($container, AddEventAliasesPass::class, arguments: [ConsoleEvents::ALIASES, [], [ConsoleEvents::COMMAND, ConsoleEvents::TERMINATE, ConsoleEvents::ERROR]]);
+        $container->addCompilerPass(new RegisterCommandArgumentLocatorsPass());
+        $container->addCompilerPass(new RemoveEmptyCommandArgumentLocatorsPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new ConsoleArgumentValueResolverPass());
+        $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
+    }
+
+    public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $container): void
+    {
+        $configurator->import('Resources/config/console.php');
+
+        $container->registerForAutoconfiguration(Command::class)
+            ->addTag('console.command')
+            ->addTag('console.command.service_arguments');
+        $container->registerForAutoconfiguration(ValueResolverInterface::class)
+            ->addTag('console.argument_value_resolver');
+        $container->registerAttributeForAutoconfiguration(AsCommand::class, static function (ChildDefinition $definition, AsCommand $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
+            $tagAttributes = [
+                'command' => $attribute->name,
+                'description' => $attribute->description,
+                'help' => $attribute->help ?? null,
+            ];
+
+            if ($reflector instanceof \ReflectionMethod) {
+                $tagAttributes['method'] = $reflector->getName();
+            }
+
+            $definition->addTag('console.command', $tagAttributes);
+            $definition->addTag('console.command.service_arguments');
+        });
+        $container->registerAttributeForAutoconfiguration(AsTargetedValueResolver::class, static function (ChildDefinition $definition, AsTargetedValueResolver $attribute): void {
+            $definition->addTag('console.targeted_value_resolver', $attribute->name ? ['name' => $attribute->name] : []);
+        });
+
+        if (!class_exists(DotenvDebugCommand::class)) {
+            $container->removeDefinition('console.command.dotenv_debug');
+        }
+
+        if (!interface_exists(EventDispatcherInterface::class)) {
+            $container->removeDefinition('console.error_listener');
+        }
+    }
+
+    /**
+     * @template T of CompilerPassInterface
+     *
+     * @param class-string<T> $class
+     *
+     * @return T|null
+     */
+    private function addCompilerPassIfExists(ContainerBuilder $container, string $class, string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION, int $priority = 0, array $arguments = []): CompilerPassInterface
+    {
+        $container->addResource(new ClassExistenceResource($class));
+        $pass = null;
+
+        if (class_exists($class)) {
+            $container->addCompilerPass($pass = new $class(...$arguments), $type, $priority);
+        }
+
+        return $pass;
+    }
+}

--- a/src/Symfony/Component/Console/DependencyInjection/ConsoleArgumentValueResolverPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/ConsoleArgumentValueResolverPass.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+namespace Symfony\Component\Console\DependencyInjection;
 
 use Symfony\Component\Console\ArgumentResolver\ValueResolver\TraceableValueResolver;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;

--- a/src/Symfony/Component/Console/Resources/config/console.php
+++ b/src/Symfony/Component/Console/Resources/config/console.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Console\ArgumentResolver\ArgumentResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\BackedEnumValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\BuiltinTypeValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\DateTimeValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\DefaultValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\InputFileValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\MapInputValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\ServiceValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\UidValueResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\VariadicValueResolver;
+use Symfony\Component\Console\EventListener\ErrorListener;
+use Symfony\Component\Dotenv\Command\DebugCommand as DotenvDebugCommand;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('console.error_listener', ErrorListener::class)
+            ->args([
+                service('logger')->nullOnInvalid(),
+            ])
+            ->tag('kernel.event_subscriber')
+            ->tag('monolog.logger', ['channel' => 'console'])
+
+        ->set('console.command.dotenv_debug', DotenvDebugCommand::class)
+            ->args([
+                param('kernel.environment'),
+                param('kernel.project_dir'),
+            ])
+            ->tag('console.command')
+
+        ->set('console.argument_resolver', ArgumentResolver::class)
+            ->public()
+            ->args([
+                abstract_arg('argument value resolvers'),
+                abstract_arg('named argument value resolvers'),
+            ])
+
+        ->set('console.argument_resolver.backed_enum', BackedEnumValueResolver::class)
+            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => BackedEnumValueResolver::class])
+
+        ->set('console.argument_resolver.uid', UidValueResolver::class)
+            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => UidValueResolver::class])
+
+        ->set('console.argument_resolver.input_file', InputFileValueResolver::class)
+            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => InputFileValueResolver::class])
+
+        ->set('console.argument_resolver.builtin_type', BuiltinTypeValueResolver::class)
+            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => BuiltinTypeValueResolver::class])
+
+        ->set('console.argument_resolver.datetime', DateTimeValueResolver::class)
+            ->args([
+                service('clock')->nullOnInvalid(),
+            ])
+            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => DateTimeValueResolver::class])
+
+        ->set('console.argument_resolver.map_input', MapInputValueResolver::class)
+            ->args([
+                service('console.argument_resolver.builtin_type'),
+                service('console.argument_resolver.backed_enum'),
+                service('console.argument_resolver.datetime'),
+                service('validator')->nullOnInvalid(),
+            ])
+            ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => MapInputValueResolver::class])
+
+        ->set('console.argument_resolver.service', ServiceValueResolver::class)
+            ->args([
+                abstract_arg('service locator, set in RegisterCommandArgumentLocatorsPass'),
+            ])
+            ->tag('console.argument_value_resolver', ['priority' => -50, 'name' => ServiceValueResolver::class])
+
+        ->set('console.argument_resolver.default', DefaultValueResolver::class)
+            ->tag('console.argument_value_resolver', ['priority' => -100, 'name' => DefaultValueResolver::class])
+
+        ->set('console.argument_resolver.variadic', VariadicValueResolver::class)
+            ->tag('console.argument_value_resolver', ['priority' => -150, 'name' => VariadicValueResolver::class])
+    ;
+};

--- a/src/Symfony/Component/Console/Tests/ConsoleBundleTest.php
+++ b/src/Symfony/Component/Console/Tests/ConsoleBundleTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleBundle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Kernel\AbstractKernel;
+use Symfony\Component\DependencyInjection\Kernel\KernelTrait;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class ConsoleBundleTest extends TestCase
+{
+    private string $varDir;
+
+    protected function setUp(): void
+    {
+        $this->varDir = sys_get_temp_dir().'/sf_console_bundle_test';
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->varDir);
+    }
+
+    public function testCommandsAreDiscovered()
+    {
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $app = new Application('test', '1.0', $kernel->getContainer());
+        $app->setAutoExit(false);
+
+        $this->assertTrue($app->has('test:hello'));
+    }
+
+    public function testEventDispatcherIsRegistered()
+    {
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertTrue($kernel->getContainer()->has('event_dispatcher'));
+        $this->assertInstanceOf(EventDispatcherInterface::class, $kernel->getContainer()->get('event_dispatcher'));
+    }
+
+    public function testArgumentResolverIsRegistered()
+    {
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertTrue($kernel->getContainer()->has('console.argument_resolver'));
+    }
+
+    public function testCommandLoaderIsRegistered()
+    {
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertTrue($kernel->getContainer()->has('console.command_loader'));
+    }
+
+    public function testApplicationWiresServicesFromContainer()
+    {
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $app = new Application('test', '1.0', $kernel->getContainer());
+        $app->setAutoExit(false);
+
+        $app->all();
+
+        $this->assertNotNull($app->getDispatcher());
+        $this->assertNotNull($app->getArgumentResolver());
+    }
+
+    public function testCommandCanBeRun()
+    {
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $app = new Application('test', '1.0', $kernel->getContainer());
+        $app->setAutoExit(false);
+
+        $tester = new ApplicationTester($app);
+        $tester->run(['command' => 'test:hello']);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Hello!', $tester->getDisplay());
+    }
+
+    private function createKernel(): TestConsoleKernel
+    {
+        return new TestConsoleKernel('test', true, $this->varDir);
+    }
+}
+
+class TestConsoleKernel extends AbstractKernel
+{
+    use KernelTrait;
+
+    public function __construct(string $env, bool $debug, private string $dir)
+    {
+        parent::__construct($env, $debug);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->dir;
+    }
+
+    public function registerBundles(): iterable
+    {
+        yield new ConsoleBundle();
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->register(ConsoleBundleTestCommand::class, ConsoleBundleTestCommand::class)
+            ->addTag('console.command');
+    }
+}
+
+#[AsCommand(name: 'test:hello', description: 'A test command')]
+class ConsoleBundleTestCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->write('Hello!');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/ConsoleArgumentValueResolverPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/ConsoleArgumentValueResolverPassTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+namespace Symfony\Component\Console\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConsoleArgumentValueResolverPass;
 use Symfony\Component\Console\ArgumentResolver\ArgumentResolver;
+use Symfony\Component\Console\DependencyInjection\ConsoleArgumentValueResolverPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -25,8 +25,8 @@
     "require-dev": {
         "psr/log": "^1|^2|^3",
         "symfony/config": "^7.4|^8.0",
-        "symfony/dependency-injection": "^7.4|^8.0",
-        "symfony/event-dispatcher": "^7.4|^8.0",
+        "symfony/dependency-injection": "^8.1",
+        "symfony/event-dispatcher": "^8.1",
         "symfony/filesystem": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0",
@@ -41,6 +41,10 @@
     },
     "provide": {
         "psr/log-implementation": "1.0|2.0|3.0"
+    },
+    "conflict": {
+        "symfony/dependency-injection": "<8.1",
+        "symfony/event-dispatcher": "<8.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Console\\": "" },

--- a/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
@@ -47,6 +47,8 @@ class_exists(ConfigCache::class);
  */
 trait KernelTrait
 {
+    private array $bundleClasses = [];
+
     public function getCacheDir(): string
     {
         if (null !== $dir = $_SERVER['APP_CACHE_DIR'] ?? null) {
@@ -95,14 +97,20 @@ trait KernelTrait
 
     protected function initializeBundles(): void
     {
-        $this->bundles = [];
-        foreach ($this->registerBundles() as $bundle) {
-            $name = $bundle->getName();
-            if (isset($this->bundles[$name])) {
-                throw new \LogicException(\sprintf('Trying to register two bundles with the same name "%s".', $name));
-            }
-            $this->bundles[$name] = $bundle;
+        $cachePath = $this->getEffectiveBuildDir().'/'.$this->getContainerClass().'.bundles.php';
+        if (is_file($cachePath)) {
+            $this->bundles = require $cachePath;
+
+            return;
         }
+
+        $this->bundles = [];
+        $registered = [];
+        foreach ($this->registerBundles() as $bundle) {
+            $this->registerBundle($bundle, $registered);
+        }
+
+        $this->bundleClasses = array_map('get_class', $this->bundles);
     }
 
     protected function initializeContainer(): void
@@ -383,6 +391,14 @@ trait KernelTrait
         }
 
         $cache->write($rootCode, $container->getResources());
+
+        // Dump resolved bundle list so initializeBundles() can skip reflection on next boot
+        $code = "<?php\n\nreturn [\n";
+        foreach ($this->bundleClasses as $name => $bundleClass) {
+            $code .= \sprintf("    %s => new \\%s(),\n", var_export($name, true), $bundleClass);
+        }
+        $code .= "];\n";
+        $fs->dumpFile($this->getEffectiveBuildDir().'/'.$class.'.bundles.php', $code);
     }
 
     protected function getContainerLoader(ContainerInterface $container): DelegatingLoader
@@ -463,8 +479,14 @@ trait KernelTrait
     private function getBundlesDefinition(): array
     {
         $bundlesPath = $this->getBundlesPath();
+        $bundles = is_file($bundlesPath) ? require $bundlesPath : [];
 
-        return is_file($bundlesPath) ? require $bundlesPath : [];
+        $resolved = [];
+        foreach ($bundles as $class => $envs) {
+            $this->resolveRequiredBundles($class, $envs, $bundles, $resolved);
+        }
+
+        return $resolved;
     }
 
     private function registerBundles(): iterable
@@ -515,7 +537,8 @@ trait KernelTrait
             }
 
             $file = (new \ReflectionObject($this))->getFileName();
-            $kernelLoader = $loader->getResolver()->resolve($file);
+            $kernelLoader = new PhpFileLoader($container, new FileLocator($this), $this->getEnvironment());
+            $kernelLoader->setResolver($loader->getResolver());
             $kernelLoader->setCurrentDir(\dirname($file));
             $instanceof = &\Closure::bind(fn &() => $this->instanceof, $kernelLoader, $kernelLoader)();
 
@@ -594,5 +617,59 @@ trait KernelTrait
         }
 
         return $this->getProjectDir().'/'.$dir.'/'.$this->environment;
+    }
+
+    private function resolveRequiredBundles(string $class, array $envs, array $bundles, array &$resolved, array &$visiting = []): void
+    {
+        if (isset($resolved[$class]) || isset($visiting[$class])) {
+            return;
+        }
+
+        if (!class_exists($class)) {
+            $resolved[$class] = $envs;
+
+            return;
+        }
+
+        $visiting[$class] = true;
+
+        foreach ((new \ReflectionClass($class))->getAttributes(RequiredBundle::class) as $attribute) {
+            $required = $attribute->newInstance();
+            if ($required->ignoreOnInvalid && !class_exists($required->class)) {
+                continue;
+            }
+            if (!isset($bundles[$required->class])) {
+                $this->resolveRequiredBundles($required->class, $envs, $bundles, $resolved, $visiting);
+            }
+        }
+
+        $resolved[$class] = $envs;
+    }
+
+    private function registerBundle(BundleInterface $bundle, array &$registered): void
+    {
+        $class = $bundle::class;
+
+        if (isset($registered[$class])) {
+            return;
+        }
+        $registered[$class] = true;
+
+        foreach ((new \ReflectionClass($class))->getAttributes(RequiredBundle::class) as $attribute) {
+            $required = $attribute->newInstance();
+            if (isset($registered[$required->class])) {
+                continue;
+            }
+            if ($required->ignoreOnInvalid && !class_exists($required->class)) {
+                continue;
+            }
+            $this->registerBundle(new $required->class(), $registered);
+        }
+
+        $name = $bundle->getName();
+        if (isset($this->bundles[$name])) {
+            throw new \LogicException(\sprintf('Trying to register two bundles with the same name "%s".', $name));
+        }
+        $this->bundles[$name] = $bundle;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Kernel/RequiredBundle.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/RequiredBundle.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Kernel;
+
+/**
+ * Declares a bundle dependency that should be auto-registered.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class RequiredBundle
+{
+    /**
+     * @param class-string<BundleInterface> $class           The bundle class to require
+     * @param bool                          $ignoreOnInvalid Whether to silently skip if the class doesn't exist
+     */
+    public function __construct(
+        public string $class,
+        public bool $ignoreOnInvalid = false,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Kernel/Resources/config/services.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/Resources/config/services.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Psr\Clock\ClockInterface as PsrClockInterface;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
+use Symfony\Component\Config\ResourceCheckerConfigCacheFactory;
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResourceChecker;
+use Symfony\Component\DependencyInjection\EnvVarProcessor;
+use Symfony\Component\DependencyInjection\Kernel\FileLocator;
+use Symfony\Component\DependencyInjection\Kernel\KernelInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\DependencyInjection\ReverseContainer;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+
+        ->set('kernel')
+            ->synthetic()
+            ->public()
+        ->alias(KernelInterface::class, 'kernel')
+
+        ->set('parameter_bag', ContainerBag::class)
+            ->args([
+                service('service_container'),
+            ])
+        ->alias(ContainerBagInterface::class, 'parameter_bag')
+        ->alias(ParameterBagInterface::class, 'parameter_bag')
+
+        ->set('event_dispatcher', EventDispatcher::class)
+            ->public()
+            ->tag('container.hot_path')
+            ->tag('event_dispatcher.dispatcher', ['name' => 'event_dispatcher'])
+        ->alias(EventDispatcherInterface::class, 'event_dispatcher')
+        ->alias(ContractsEventDispatcherInterface::class, 'event_dispatcher')
+        ->alias(PsrEventDispatcherInterface::class, 'event_dispatcher')
+
+        ->set('filesystem', Filesystem::class)
+        ->alias(Filesystem::class, 'filesystem')
+
+        ->set('file_locator', FileLocator::class)
+            ->args([
+                service('kernel'),
+            ])
+        ->alias(FileLocator::class, 'file_locator')
+
+        ->set('config_cache_factory', ResourceCheckerConfigCacheFactory::class)
+            ->args([
+                tagged_iterator('config_cache.resource_checker'),
+            ])
+
+        ->set('dependency_injection.config.container_parameters_resource_checker', ContainerParametersResourceChecker::class)
+            ->args([
+                service('service_container'),
+            ])
+            ->tag('config_cache.resource_checker', ['priority' => -980])
+
+        ->set('config.resource.self_checking_resource_checker', SelfCheckingResourceChecker::class)
+            ->tag('config_cache.resource_checker', ['priority' => -990])
+
+        ->set('reverse_container', ReverseContainer::class)
+            ->args([
+                service('service_container'),
+                service_locator([]),
+            ])
+        ->alias(ReverseContainer::class, 'reverse_container')
+
+        ->set('container.env_var_processor', EnvVarProcessor::class)
+            ->args([
+                service('service_container'),
+                tagged_iterator('container.env_var_loader'),
+            ])
+            ->tag('container.env_var_processor')
+            ->tag('kernel.reset', ['method' => 'reset'])
+
+        ->set('clock', Clock::class)
+        ->alias(ClockInterface::class, 'clock')
+        ->alias(PsrClockInterface::class, 'clock')
+
+        // register as abstract and excluded, aka not-autowirable types
+        ->set(LoaderInterface::class)->abstract()->tag('container.excluded')
+    ;
+};

--- a/src/Symfony/Component/DependencyInjection/Kernel/ServicesBundle.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/ServicesBundle.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Kernel;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface as PsrClockInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
+use Psr\Log\LoggerAwareInterface;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Config\ResourceCheckerInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\AddBehaviorDescribingTagsPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\EnvVarLoaderInterface;
+use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+use Symfony\Contracts\Service\ResetInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+/**
+ * Provides core DI infrastructure services (event dispatcher, filesystem, clock, etc.).
+ */
+class ServicesBundle extends AbstractBundle
+{
+    public function getPath(): string
+    {
+        return $this->path ??= __DIR__;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        if (class_exists(RegisterListenersPass::class)) {
+            $container->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        }
+        $container->addCompilerPass(new AddBehaviorDescribingTagsPass([
+            'container.do_not_inline',
+            'container.service_locator',
+            'container.service_subscriber',
+            'kernel.event_subscriber',
+            'kernel.event_listener',
+            'kernel.reset',
+        ]));
+    }
+
+    public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $container): void
+    {
+        $configurator->import('Resources/config/services.php');
+
+        $container->registerAliasForArgument('parameter_bag', PsrContainerInterface::class);
+
+        $container->registerForAutoconfiguration(ResourceCheckerInterface::class)
+            ->addTag('config_cache.resource_checker');
+        $container->registerForAutoconfiguration(EnvVarLoaderInterface::class)
+            ->addTag('container.env_var_loader');
+        $container->registerForAutoconfiguration(EnvVarProcessorInterface::class)
+            ->addTag('container.env_var_processor');
+        $container->registerForAutoconfiguration(ServiceLocator::class)
+            ->addTag('container.service_locator');
+        $container->registerForAutoconfiguration(EventDispatcherInterface::class)
+            ->addTag('event_dispatcher.dispatcher');
+        $container->registerForAutoconfiguration(ResetInterface::class)
+            ->addTag('kernel.reset', ['method' => 'reset']);
+        $container->registerForAutoconfiguration(ServiceSubscriberInterface::class)
+            ->addTag('container.service_subscriber');
+        $container->registerForAutoconfiguration(EventSubscriberInterface::class)
+            ->addTag('kernel.event_subscriber');
+        $container->registerForAutoconfiguration(LoggerAwareInterface::class)
+            ->addMethodCall('setLogger', [new Reference('logger', $container::IGNORE_ON_INVALID_REFERENCE)]);
+
+        $container->registerForAutoconfiguration(CompilerPassInterface::class)
+            ->addTag('container.excluded', ['source' => 'because it\'s a compiler pass']);
+        $container->registerForAutoconfiguration(TestCase::class)
+            ->addTag('container.excluded', ['source' => 'because it\'s a test case']);
+        $container->registerForAutoconfiguration(\UnitEnum::class)
+            ->addTag('container.excluded', ['source' => 'because it\'s an enum']);
+        $container->registerAttributeForAutoconfiguration(\Attribute::class, static function (ChildDefinition $definition) {
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a PHP attribute']);
+        });
+        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
+            $tagAttributes = get_object_vars($attribute);
+            if ($reflector instanceof \ReflectionMethod) {
+                if (isset($tagAttributes['method'])) {
+                    throw new LogicException(\sprintf('AsEventListener attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
+                }
+                $tagAttributes['method'] = $reflector->getName();
+            }
+            $definition->addTag('kernel.event_listener', $tagAttributes);
+        });
+
+        if (!$container::willBeAvailable('symfony/event-dispatcher', EventDispatcherInterface::class, ['symfony/dependency-injection'])) {
+            $container->removeDefinition('event_dispatcher');
+            $container->removeAlias(EventDispatcherInterface::class);
+            $container->removeAlias(ContractsEventDispatcherInterface::class);
+            $container->removeAlias(PsrEventDispatcherInterface::class);
+        }
+
+        if (!interface_exists(ClockInterface::class)) {
+            $container->removeDefinition('clock');
+        }
+        if (!$container::willBeAvailable('symfony/clock', ClockInterface::class, ['symfony/dependency-injection'])) {
+            $container->removeAlias(ClockInterface::class);
+            $container->removeAlias(PsrClockInterface::class);
+        }
+
+        if (!$container->getParameter('kernel.debug')) {
+            $container->getDefinition('config_cache_factory')->setArguments([]);
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Kernel\AbstractBundle;
 use Symfony\Component\DependencyInjection\Kernel\AbstractKernel;
 use Symfony\Component\DependencyInjection\Kernel\BundleInterface;
 use Symfony\Component\DependencyInjection\Kernel\KernelTrait;
+use Symfony\Component\DependencyInjection\Kernel\RequiredBundle;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -329,6 +330,70 @@ class AbstractKernelTest extends TestCase
         $this->assertTrue($kernel->getContainer()->hasParameter('compiler_pass.processed'));
     }
 
+    public function testRequiredBundleChildrenAreRegisteredBeforeParent()
+    {
+        $kernel = new RequiredBundleKernel('test', true, $this->varDir, [MetaParentBundle::class => ['all' => true]]);
+        $kernel->boot();
+
+        $this->assertSame(['ChildBundle', 'MetaParentBundle'], array_keys($kernel->getBundles()));
+    }
+
+    public function testRequiredBundleDeduplicatesByClass()
+    {
+        // ChildBundle is listed explicitly AND required by MetaParentBundle
+        $kernel = new RequiredBundleKernel('test', true, $this->varDir, [
+            ChildBundle::class => ['all' => true],
+            MetaParentBundle::class => ['all' => true],
+        ]);
+        $kernel->boot();
+
+        $this->assertSame(['ChildBundle', 'MetaParentBundle'], array_keys($kernel->getBundles()));
+    }
+
+    public function testNestedRequiredBundles()
+    {
+        $kernel = new RequiredBundleKernel('test', true, $this->varDir, [TopMetaBundle::class => ['all' => true]]);
+        $kernel->boot();
+
+        $this->assertSame(['LeafBundle', 'MiddleMetaBundle', 'TopMetaBundle'], array_keys($kernel->getBundles()));
+    }
+
+    public function testTwoRequiredBundlesWithSameChild()
+    {
+        $kernel = new RequiredBundleKernel('test', true, $this->varDir, [
+            MetaParentBundle::class => ['all' => true],
+            SecondMetaParentBundle::class => ['all' => true],
+        ]);
+        $kernel->boot();
+
+        $this->assertSame(['ChildBundle', 'MetaParentBundle', 'SecondMetaParentBundle'], array_keys($kernel->getBundles()));
+    }
+
+    public function testRequiredBundleSelfReferenceIsDeduped()
+    {
+        $kernel = new RequiredBundleKernel('test', true, $this->varDir, [SelfReferencingMetaBundle::class => ['all' => true]]);
+        $kernel->boot();
+
+        $this->assertSame(['SelfReferencingMetaBundle'], array_keys($kernel->getBundles()));
+    }
+
+    public function testRequiredBundleCircularReferenceIsDeduped()
+    {
+        $kernel = new RequiredBundleKernel('test', true, $this->varDir, [CircularMetaBundleA::class => ['all' => true]]);
+        $kernel->boot();
+
+        // Both bundles are registered (circular reference doesn't cause infinite loop)
+        $this->assertSame(['CircularMetaBundleB', 'CircularMetaBundleA'], array_keys($kernel->getBundles()));
+    }
+
+    public function testRequiredBundleIgnoreOnInvalid()
+    {
+        $kernel = new RequiredBundleKernel('test', true, $this->varDir, [IgnoreOnInvalidBundle::class => ['all' => true]]);
+        $kernel->boot();
+
+        $this->assertSame(['IgnoreOnInvalidBundle'], array_keys($kernel->getBundles()));
+    }
+
     private function createKernel(string $env = 'test', bool $debug = true): TestKernel
     {
         return new TestKernel($env, $debug, $this->varDir);
@@ -342,7 +407,9 @@ class AbstractKernelTest extends TestCase
 
 class TestKernel extends AbstractKernel
 {
-    use KernelTrait;
+    use KernelTrait {
+        registerBundles as public;
+    }
 
     public function __construct(string $env, bool $debug, private string $dir = '')
     {
@@ -428,5 +495,75 @@ class ImplicitExtensionBundle extends AbstractBundle
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $builder->setParameter('implicit_extension.loaded', true);
+    }
+}
+
+class ChildBundle extends AbstractBundle
+{
+}
+
+#[RequiredBundle(ChildBundle::class)]
+class MetaParentBundle extends AbstractBundle
+{
+}
+
+class LeafBundle extends AbstractBundle
+{
+}
+
+#[RequiredBundle(LeafBundle::class)]
+class MiddleMetaBundle extends AbstractBundle
+{
+}
+
+#[RequiredBundle(MiddleMetaBundle::class)]
+class TopMetaBundle extends AbstractBundle
+{
+}
+
+#[RequiredBundle(ChildBundle::class)]
+class SecondMetaParentBundle extends AbstractBundle
+{
+}
+
+#[RequiredBundle('NonExistent\\Bundle\\ThatDoesNotExist', ignoreOnInvalid: true)]
+class IgnoreOnInvalidBundle extends AbstractBundle
+{
+}
+
+#[RequiredBundle(self::class)]
+class SelfReferencingMetaBundle extends AbstractBundle
+{
+}
+
+#[RequiredBundle(CircularMetaBundleB::class)]
+class CircularMetaBundleA extends AbstractBundle
+{
+}
+
+#[RequiredBundle(CircularMetaBundleA::class)]
+class CircularMetaBundleB extends AbstractBundle
+{
+}
+
+class RequiredBundleKernel extends TestKernel
+{
+    use KernelTrait {
+        registerBundles as public;
+    }
+
+    public function __construct(string $env, bool $debug, private string $testDir, private array $bundlesDefinition)
+    {
+        parent::__construct($env, $debug, $testDir);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->testDir;
+    }
+
+    private function getBundlesDefinition(): array
+    {
+        return $this->bundlesDefinition;
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -14,13 +14,14 @@ namespace Symfony\Component\EventDispatcher\Tests\DependencyInjection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\AttributeAutoconfigurationPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -585,10 +586,13 @@ class RegisterListenersPassTest extends TestCase
     private function createContainerBuilder(): ContainerBuilder
     {
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.debug', true);
-        $container->setParameter('kernel.project_dir', __DIR__);
-        $container->setParameter('kernel.container_class', 'testContainer');
-        (new FrameworkExtension())->load([], $container);
+        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute, \ReflectionClass|\ReflectionMethod $reflector) {
+            $tagAttributes = get_object_vars($attribute);
+            if ($reflector instanceof \ReflectionMethod) {
+                $tagAttributes['method'] = $reflector->getName();
+            }
+            $definition->addTag('kernel.event_listener', $tagAttributes);
+        });
 
         return $container;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -320,12 +320,8 @@ class KernelTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Trying to register two bundles with the same name "DuplicateName"');
-        $fooBundle = $this->createStub(BundleInterface::class);
-        $fooBundle->method('getName')->willReturn('DuplicateName');
-        $barBundle = $this->createStub(BundleInterface::class);
-        $barBundle->method('getName')->willReturn('DuplicateName');
 
-        $kernel = new KernelForTest('test', false, true, [$fooBundle, $barBundle]);
+        $kernel = new KernelForTest('test', false, true, [new DuplicateNameBundleA(), new DuplicateNameBundleB()]);
         $kernel->boot();
     }
 
@@ -881,4 +877,14 @@ class KernelForTestWithLoadClassCache extends KernelForTest
     public function doLoadClassCache(): void
     {
     }
+}
+
+class DuplicateNameBundleA extends Bundle
+{
+    protected string $name = 'DuplicateName';
+}
+
+class DuplicateNameBundleB extends Bundle
+{
+    protected string $name = 'DuplicateName';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a `#[RequiredBundle]` attribute that can be used on bundle classes to declare which additional bundles should be loaded before the current one.

This capability is then leveraged by `FrameworkBundle` to split it in `ConsoleBundle` and `ServicesBundle`.

This replaces #63715, which on its own proves how a standalone `ConsoleBundle` enables writing smaller DI-enabled console apps.
This PR takes the extra miles to deduplicate service definitions.

Shrinking FrameworkBundle for the first time!

I see a future where each component would ship its own standalone bundle (`WorkflowBundle`, `FormBundle`, etc), with a smooth upgrade path from `FrameworkBundle`, which would still be the one bundle we install, but then each component would be responsible for defining how its wired. We're not there yet and I don't plan do work on that step for 8.1. But this opens the path nonetheless! (also moving cache:clear and others to DI would make sense, 8.2 earliest also)
