### PR TITLE
[Serializer] Fix getAllowedAttributes() when groups contain wildcard '*'

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -250,9 +250,14 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             }
         }
 
-        if (!$ignoreUsed && [] === $groups && $allowExtraAttributes) {
-            // Backward Compatibility with the code using this method written before the introduction of @Ignore
-            return false;
+        if (!$ignoreUsed && $allowExtraAttributes) {
+            if ([] === $groups) {
+                return false;
+            }
+
+            if ([] === $allowedAttributes && \in_array('*', $groups, true)) {
+                return false;
+            }
         }
 
         return $allowedAttributes;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -83,6 +83,16 @@ class AbstractNormalizerTest extends TestCase
         $this->assertEquals(['a1', 'a2', 'a3', 'a4'], $result);
     }
 
+    public function testGetAllowedAttributesWithWildcardGroupAndNoMetadata()
+    {
+        $classMetadata = new ClassMetadata('c');
+
+        $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
+
+        $result = $this->normalizer->getAllowedAttributes('c', [AbstractNormalizer::GROUPS => ['*']], true);
+        $this->assertFalse($result);
+    }
+
     public function testGetAllowedAttributesAsObjects()
     {
         $classMetadata = new ClassMetadata('c');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63846 
| License       | MIT

`getAllowedAttributes()` returns an empty array when the wildcard group `'*'` is used and no class metadata attributes are configured, causing all attributes to be blocked unexpectedly.

This restores backward compatibility by returning `false` (allow all) in this case, consistent with the existing behavior when no groups are specified.

**Before:**
```php
// groups = ['*'], no metadata configured → all attributes blocked
$normalizer->normalize($object, null, [AbstractNormalizer::GROUPS => ['*']]);
// result: []
```

After:
```php
// groups = ['*'], no metadata configured → all attributes allowed
$normalizer->normalize($object, null, [AbstractNormalizer::GROUPS => ['*']]);
// result: ['foo' => 'bar', ...]
```
