### PR TITLE
[Mailer] Add support for mixed types in Brevo template params

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/README.md
@@ -20,7 +20,12 @@ where:
 With API, you can use custom headers.
 
 ```php
-$params = ['param1' => 'foo', 'param2' => 'bar'];
+// Template params with mixed types (arrays, integers, booleans)
+$params = [
+    'name' => 'John',
+    'age' => 30,
+    'items' => ['apple', 'banana'],
+];
 $json = json_encode(['custom_header_1' => 'custom_value_1']);
 
 $email = new Email();
@@ -31,7 +36,7 @@ $email
     ->add(new TagHeader('TagInHeaders2'))
     ->addTextHeader('sender.ip', '1.2.3.4')
     ->addTextHeader('templateId', 1)
-    ->addParameterizedHeader('params', 'params', $params)
+    ->addTextHeader('params', json_encode($params))
     ->addTextHeader('foo', 'bar')
 ;
 ```

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -84,6 +84,34 @@ class BrevoApiTransportTest extends TestCase
         $this->assertEquals('bar', $payload['headers']['foo']);
     }
 
+    public function testParamsWithMixedTypes()
+    {
+        $params = [
+            'name' => 'John',
+            'age' => 30,
+            'active' => true,
+            'address' => ['street' => '123 Main St', 'city' => 'Paris'],
+            'items' => ['apple', 'banana'],
+        ];
+
+        $email = new Email();
+        $email->getHeaders()
+            ->addTextHeader('templateId', 1)
+            ->addTextHeader('params', json_encode($params));
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('params', $payload);
+        $this->assertSame('John', $payload['params']['name']);
+        $this->assertSame(30, $payload['params']['age']);
+        $this->assertTrue($payload['params']['active']);
+        $this->assertSame(['street' => '123 Main St', 'city' => 'Paris'], $payload['params']['address']);
+        $this->assertSame(['apple', 'banana'], $payload['params']['items']);
+    }
+
     public function testSendThrowsForErrorResponse()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -22,6 +22,7 @@ use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Header\ParameterizedHeader;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -159,7 +160,13 @@ final class BrevoApiTransport extends AbstractApiTransport
                 continue;
             }
             if ('params' === $name) {
-                $headersAndTags[$header->getName()] = $header->getParameters();
+                if ($header instanceof ParameterizedHeader) {
+                    // Legacy: ParameterizedHeader only supports string values
+                    $headersAndTags['params'] = $header->getParameters();
+                } else {
+                    // JSON-encoded params support mixed types (arrays, integers, booleans)
+                    $headersAndTags['params'] = json_decode($header->getBodyAsString(), true, 512, \JSON_THROW_ON_ERROR);
+                }
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -79,12 +79,7 @@ final class BrevoApiTransport extends AbstractApiTransport
      */
     private function formatAddresses(array $addresses): array
     {
-        $formattedAddresses = [];
-        foreach ($addresses as $address) {
-            $formattedAddresses[] = $this->formatAddress($address);
-        }
-
-        return $formattedAddresses;
+        return array_map($this->formatAddress(...), $addresses);
     }
 
     private function getPayload(Email $email, Envelope $envelope): array
@@ -98,7 +93,7 @@ final class BrevoApiTransport extends AbstractApiTransport
             $payload['attachment'] = $attachments;
         }
         if ($emails = $email->getReplyTo()) {
-            $payload['replyTo'] = current($this->formatAddresses($emails));
+            $payload['replyTo'] = $this->formatAddress($emails[0]);
         }
         if ($emails = $email->getCc()) {
             $payload['cc'] = $this->formatAddresses($emails);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63826
| License       | MIT

This adds support for JSON-encoded template params via `addTextHeader('params', json_encode($params))`, allowing mixed types (arrays, integers, booleans) as expected by the Brevo API.

The legacy `addParameterizedHeader()` approach remains supported for backward compatibility with string-only params.