### PR TITLE
[ObjectMapper] Auto-inject ObjectMapper into ObjectMapperAwareInterface transforms

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionSource.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionSource.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
+
+#[Map(target: CollectionTarget::class)]
+final class CollectionSource
+{
+    /**
+     * @param CollectionSourceItem[] $items
+     */
+    public function __construct(
+        #[Map(transform: MapCollection::class)]
+        public array $items,
+    ) {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionSourceItem.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionSourceItem.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: CollectionTargetItem::class)]
+final class CollectionSourceItem
+{
+    public function __construct(
+        private string $name,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionTarget.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+final class CollectionTarget
+{
+    /** @var CollectionTargetItem[] */
+    public array $items;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionTargetItem.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ObjectMapper/CollectionTargetItem.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper;
+
+final class CollectionTargetItem
+{
+    private string $name;
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ObjectMapperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ObjectMapperTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\CollectionSource;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\CollectionSourceItem;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\CollectionTarget;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\ObjectMapped;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ObjectMapper\ObjectToBeMapped;
 
@@ -27,5 +30,23 @@ class ObjectMapperTest extends AbstractWebTestCase
         $objectMapper = static::getContainer()->get('object_mapper.alias');
         $mapped = $objectMapper->map(new ObjectToBeMapped());
         $this->assertSame($mapped->a, 'transformed');
+    }
+
+    public function testMapCollectionUsesContainerObjectMapper()
+    {
+        static::bootKernel(['test_case' => 'ObjectMapper']);
+
+        $objectMapper = static::getContainer()->get('object_mapper.alias');
+        $source = new CollectionSource([
+            new CollectionSourceItem('foo'),
+            new CollectionSourceItem('bar'),
+        ]);
+
+        /** @var CollectionTarget $mapped */
+        $mapped = $objectMapper->map($source);
+
+        $this->assertCount(2, $mapped->items);
+        $this->assertSame('foo', $mapped->items[0]->getName());
+        $this->assertSame('bar', $mapped->items[1]->getName());
     }
 }

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -355,6 +355,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         foreach ($transforms as $transform) {
             if ($fn = $this->getCallable($transform, $this->transformCallableLocator)) {
+                if ($fn instanceof ObjectMapperAwareInterface) {
+                    $fn = $fn->withObjectMapper($this->objectMapper ?? $this);
+                }
                 $value = $this->call($fn, $value, $source, $target);
             }
         }

--- a/src/Symfony/Component/ObjectMapper/ObjectMapperAwareInterface.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapperAwareInterface.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\ObjectMapper;
 interface ObjectMapperAwareInterface
 {
     /**
-     * Sets the owning ObjectMapper object.
+     * Returns a clone of the original instance, configured with the given object mapper.
      */
     public function withObjectMapper(ObjectMapperInterface $objectMapper): static;
 }

--- a/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
+++ b/src/Symfony/Component/ObjectMapper/Transform/MapCollection.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\ObjectMapper\Transform;
 
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\ObjectMapperAwareInterface;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\TransformCallableInterface;
 
@@ -21,11 +22,19 @@ use Symfony\Component\ObjectMapper\TransformCallableInterface;
  *
  * @implements TransformCallableInterface<object, T>
  */
-class MapCollection implements TransformCallableInterface
+class MapCollection implements TransformCallableInterface, ObjectMapperAwareInterface
 {
     public function __construct(
-        private ObjectMapperInterface $objectMapper = new ObjectMapper(),
+        private ?ObjectMapperInterface $objectMapper = null,
     ) {
+    }
+
+    public function withObjectMapper(ObjectMapperInterface $objectMapper): static
+    {
+        $clone = clone $this;
+        $clone->objectMapper = $objectMapper;
+
+        return $clone;
     }
 
     public function __invoke(mixed $value, object $source, ?object $target): mixed
@@ -34,9 +43,10 @@ class MapCollection implements TransformCallableInterface
             throw new MappingException(\sprintf('The MapCollection transform expects an iterable, "%s" given.', get_debug_type($value)));
         }
 
+        $objectMapper = $this->objectMapper ??= new ObjectMapper();
         $values = [];
         foreach ($value as $k => $v) {
-            $values[$k] = $this->objectMapper->map($v);
+            $values[$k] = $objectMapper->map($v);
         }
 
         return $values;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63763
| License       | MIT

The `ObjectMapper` now automatically injects itself into transforms implementing `ObjectMapperAwareInterface`. This allows `MapCollection` (and any custom transform) to receive the container's configured ObjectMapper when used with `#[Map(transform: MapCollection::class)]`.