### PR TITLE
[Dotenv] Fix self-referencing variable resolution with suffix/prefix

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -36,6 +36,7 @@ final class Dotenv
     private string $data;
     private int $end;
     private array $values = [];
+    private array $overriddenValues = [];
     private string $envKey;
     private string $debugKey;
     private array $prodEnvs = ['prod'];
@@ -644,7 +645,15 @@ final class Dotenv
                 throw new FormatException('Loading files containing NUL bytes is not supported.', new FormatExceptionContext($data, $path, 1, 0));
             }
 
-            $this->populate($this->parseRaw($data, $path), $overrideExistingVars);
+            $values = $this->parseRaw($data, $path);
+
+            foreach ($values as $name => $_) {
+                if (!isset($this->overriddenValues[$name]) && isset($_ENV[$name])) {
+                    $this->overriddenValues[$name] = $_ENV[$name];
+                }
+            }
+
+            $this->populate($values, $overrideExistingVars);
         }
     }
 
@@ -731,10 +740,19 @@ final class Dotenv
                 if (isset($selfReferencingVars[$name])) {
                     $envBackup = $_ENV[$name] ?? null;
                     $serverBackup = $_SERVER[$name] ?? null;
-                    unset($_ENV[$name], $_SERVER[$name]);
+                    if (isset($this->overriddenValues[$name])) {
+                        $_ENV[$name] = $this->overriddenValues[$name];
+                        $_SERVER[$name] = $this->overriddenValues[$name];
+                    } else {
+                        unset($_ENV[$name], $_SERVER[$name]);
+                    }
                     if ($this->usePutenv) {
-                        $getenvBackup = $this->usePutenv ? (string) getenv($name) : null;
-                        putenv($name);
+                        $getenvBackup = (string) getenv($name);
+                        if (isset($this->overriddenValues[$name])) {
+                            putenv("$name={$this->overriddenValues[$name]}");
+                        } else {
+                            putenv($name);
+                        }
                     }
                 }
 
@@ -782,6 +800,7 @@ final class Dotenv
         }
 
         $this->values = [];
+        $this->overriddenValues = [];
         unset($this->path, $this->data, $this->lineno, $this->cursor, $this->end);
     }
 }

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -589,6 +589,60 @@ class DotenvTest extends TestCase
         @rmdir($tmpdir);
     }
 
+    public function testLoadSelfReferencingVariableWithSuffix()
+    {
+        $resetContext = static function (): void {
+            unset($_ENV['SYMFONY_DOTENV_VARS'], $_ENV['MY_VAR']);
+            unset($_SERVER['SYMFONY_DOTENV_VARS'], $_SERVER['MY_VAR']);
+            putenv('SYMFONY_DOTENV_VARS');
+            putenv('MY_VAR');
+        };
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $basePath = tempnam($tmpdir, 'sf-');
+        $overridePath = tempnam($tmpdir, 'sf-');
+
+        // Base file sets original value, override file appends suffix
+        file_put_contents($basePath, 'MY_VAR=original');
+        file_put_contents($overridePath, 'MY_VAR="${MY_VAR}_suffix"');
+
+        $resetContext();
+        $dotenv = (new Dotenv())->usePutenv();
+        $dotenv->load($basePath);
+        $dotenv->load($overridePath);
+
+        $this->assertSame('original_suffix', getenv('MY_VAR'));
+
+        // Test with prefix instead of suffix
+        file_put_contents($overridePath, 'MY_VAR="prefix_${MY_VAR}"');
+
+        $resetContext();
+        $dotenv = (new Dotenv())->usePutenv();
+        $dotenv->load($basePath);
+        $dotenv->load($overridePath);
+
+        $this->assertSame('prefix_original', getenv('MY_VAR'));
+
+        // Test chained loads (three files)
+        $thirdPath = tempnam($tmpdir, 'sf-');
+        file_put_contents($overridePath, 'MY_VAR="${MY_VAR}_middle"');
+        file_put_contents($thirdPath, 'MY_VAR="${MY_VAR}_end"');
+
+        $resetContext();
+        $dotenv = (new Dotenv())->usePutenv();
+        $dotenv->load($basePath);
+        $dotenv->load($overridePath);
+        $dotenv->load($thirdPath);
+
+        $this->assertSame('original_middle_end', getenv('MY_VAR'));
+
+        $resetContext();
+        unlink($basePath);
+        unlink($overridePath);
+        unlink($thirdPath);
+        @rmdir($tmpdir);
+    }
+
     public function testLoadEnvSelfReferencingEnvKeyControlsFileLoading()
     {
         $resetContext = static function (): void {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63878
| License       | MIT

Variables like `MY_VAR="${MY_VAR}_suffix"` were incorrectly detected as self-referencing with default syntax, causing the original value to be cleared during resolution.

This fix restricts the self-referencing detection to only match default value syntax (`:-` and `:=`) and preserves previously resolved values across multiple `load()` calls.