### PR TITLE
[HttpKernel] Fix cache warmers running on every kernel boot instead of only on compilation

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -196,7 +196,14 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
 
     protected function initializeContainer(): void
     {
+        $cachePath = $this->getEffectiveBuildDir().'/'.$this->getContainerClass().'.php';
+        $oldMtime = is_file($cachePath) ? filemtime($cachePath) : false;
+
         $this->doInitializeContainer();
+
+        if (false !== $oldMtime && filemtime($cachePath) === $oldMtime) {
+            return;
+        }
 
         $buildDir = $this->container->getParameter('kernel.build_dir');
         $cacheDir = $this->container->getParameter('kernel.cache_dir');

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -466,6 +466,21 @@ class KernelTest extends TestCase
         $this->assertSame(realpath($kernel->getBuildDir()), $kernel->warmedUpBuildDir);
     }
 
+    public function testWarmupIsNotRunOnSubsequentBoot()
+    {
+        $kernel = new CustomProjectDirKernel();
+        $kernel->boot();
+
+        $this->assertTrue($kernel->warmedUp);
+
+        $kernel->shutdown();
+
+        $kernel = new CustomProjectDirKernel();
+        $kernel->boot();
+
+        $this->assertFalse($kernel->warmedUp);
+    }
+
     public function testServicesResetter()
     {
         $httpKernelMock = $this->getMockBuilder(HttpKernelInterface::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The refactoring in #63710 moved the cache warmer invocation outside of `doInitializeContainer()`, causing warmers to run unconditionally on every boot, not just when the container was freshly compiled. This broke third-party code that injects test data into warmed cache files, as the files would be overwritten on subsequent kernel boots.
