### PR TITLE
[Validator] Add findByCodes() to ConstraintViolationListInterface

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -123,3 +123,8 @@ Uid
 ---
 
  * Add argument `$format` to `Ulid::isValid()`
+
+Validator
+---------
+
+ * Implementing `ConstraintViolationListInterface` without implementing `findByCodes()` is deprecated

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `findByCodes()` to `ConstraintViolationListInterface`
  * Add clock-awareness to comparison and range validators for testable date comparisons
  * Add the `Xml` constraint for validating XML content
 

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -20,6 +20,8 @@ use Symfony\Component\Validator\Exception\OutOfBoundsException;
  *
  * @extends \ArrayAccess<int, ConstraintViolationInterface>
  * @extends \Traversable<int, ConstraintViolationInterface>
+ *
+ * @method static findByCodes(string|string[] $codes) Returns a new instance with violations matching the given error codes. Not implementing it is deprecated since Symfony 8.1.
  */
 interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #63673
| License       | MIT

## Description

`ConstraintViolationList::findByCodes()` has been available since 2016 but was never added to `ConstraintViolationListInterface`. This makes it impossible to use the method when type-hinting against the interface without an assertion or instanceof check.

This PR adds `findByCodes()` to the interface using the `@method` PHPDoc annotation pattern, following the same approach used for `__toString()` in 6.1 (commit 4cead0c8a03). The method can be promoted to a real interface method in 9.0.

## Changes

- Add `@method static findByCodes(string|string[] $codes)` annotation to `ConstraintViolationListInterface`
- Add CHANGELOG entry for 8.1
- Add UPGRADE-8.1.md entry documenting the deprecation

## Note for reviewers

If you consider the BC risk low enough (there is only one known implementation of the interface in the monorepo, and it already has the method), I'm happy to promote `findByCodes()` to a real interface method directly instead of using the `@method` annotation. Let me know which approach you prefer.