### PR TITLE
[Workflow] Remove bg_color and description from metadata text in GraphvizDumper

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
@@ -125,7 +125,7 @@ class GraphvizDumper implements DumperInterface
             $metadata = [];
             if ($withMetadata) {
                 $metadata = $workflowMetadata->getTransitionMetadata($transition);
-                unset($metadata['label']);
+                unset($metadata['label'], $metadata['bg_color']);
             }
 
             $transitions[] = [
@@ -154,7 +154,11 @@ class GraphvizDumper implements DumperInterface
             }
 
             if ($withMetadata) {
-                $escapedLabel = \sprintf('<<B>%s</B>%s>', $this->escapeHtml($placeName), $this->addMetadata($place['attributes']['metadata']));
+                unset($place['attributes']['metadata']['bg_color']);
+                $description = $place['attributes']['metadata']['description'] ?? null;
+                unset($place['attributes']['metadata']['description']);
+                $descriptionLabel = null !== $description ? \sprintf('<BR/><I>%s</I>', $this->escapeHtml($description)) : '';
+                $escapedLabel = \sprintf('<<B>%s</B>%s%s>', $this->escapeHtml($placeName), $this->addMetadata($place['attributes']['metadata']), $descriptionLabel);
                 // Don't include metadata in default attributes used to format the place
                 unset($place['attributes']['metadata']);
             } else {
@@ -176,7 +180,10 @@ class GraphvizDumper implements DumperInterface
 
         foreach ($transitions as $i => $place) {
             if ($withMetadata) {
-                $escapedLabel = \sprintf('<<B>%s</B>%s>', $this->escapeHtml($place['name']), $this->addMetadata($place['metadata']));
+                $description = $place['metadata']['description'] ?? null;
+                unset($place['metadata']['description']);
+                $descriptionLabel = null !== $description ? \sprintf('<BR/><I>%s</I>', $this->escapeHtml($description)) : '';
+                $escapedLabel = \sprintf('<<B>%s</B>%s%s>', $this->escapeHtml($place['name']), $this->addMetadata($place['metadata']), $descriptionLabel);
             } else {
                 $escapedLabel = '"'.$this->escape($place['name']).'"';
             }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -184,7 +184,7 @@ class GraphvizDumperTest extends TestCase
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label=<<B>a</B>>, shape=circle style="filled"];
   place_e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98 [label=<<B>b</B>>, shape=circle];
-  place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [label=<<B>c</B><BR/>bg_color: DeepSkyBlue<BR/>description: My custom place description>, shape=circle color="#FF0000" shape="doublecircle" style="filled" fillcolor="DeepSkyBlue"];
+  place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [label=<<B>c</B><BR/><I>My custom place description</I>>, shape=circle color="#FF0000" shape="doublecircle" style="filled" fillcolor="DeepSkyBlue"];
   transition_b6589fc6ab0dc82cf12099d1c2d40ab994e8410c [label=<<B>My custom transition label 2</B><BR/>color: Grey<BR/>arrow_color: Purple>, shape="box" regular="1"];
   transition_356a192b7913b04c54574d18c28d46e6395428ab [label=<<B>t2</B><BR/>arrow_color: Pink>, shape="box" regular="1"];
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 -> transition_b6589fc6ab0dc82cf12099d1c2d40ab994e8410c [style="solid"];
@@ -315,7 +315,7 @@ class GraphvizDumperTest extends TestCase
         $dump = (new GraphvizDumper())->dump($definition, null, ['with-metadata' => true, 'label' => 'Title with <b>bold</b> & "quotes"']);
 
         $this->assertStringContainsString('<<B>A &amp; B &lt;tag&gt;</B>', $dump);
-        $this->assertStringContainsString('description: has &quot;quotes&quot; &amp; &lt;html&gt;', $dump);
+        $this->assertStringContainsString('<BR/><I>has &quot;quotes&quot; &amp; &lt;html&gt;</I>', $dump);
         $this->assertStringContainsString('<<B>Run &lt;script&gt;alert(1)&lt;/script&gt;</B>', $dump);
         $this->assertStringContainsString('note: a &gt; b &amp; c &lt; d', $dump);
         $this->assertStringContainsString('<<B>Title with &lt;b&gt;bold&lt;/b&gt; &amp; &quot;quotes&quot;</B>', $dump);
@@ -333,7 +333,7 @@ class GraphvizDumperTest extends TestCase
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label=<<B>a</B>>, shape=circle style="filled"];
   place_e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98 [label=<<B>b</B>>, shape=circle];
-  place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [label=<<B>c</B><BR/>bg_color: DeepSkyBlue<BR/>description: My custom place description>, shape=circle style="filled" fillcolor="DeepSkyBlue"];
+  place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [label=<<B>c</B><BR/><I>My custom place description</I>>, shape=circle style="filled" fillcolor="DeepSkyBlue"];
   transition_b6589fc6ab0dc82cf12099d1c2d40ab994e8410c [label=<<B>My custom transition label 2</B><BR/>color: Grey<BR/>arrow_color: Purple>, shape="box" regular="1"];
   transition_356a192b7913b04c54574d18c28d46e6395428ab [label=<<B>t2</B><BR/>arrow_color: Pink>, shape="box" regular="1"];
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 -> transition_b6589fc6ab0dc82cf12099d1c2d40ab994e8410c [style="solid"];
@@ -342,5 +342,35 @@ class GraphvizDumperTest extends TestCase
   transition_356a192b7913b04c54574d18c28d46e6395428ab -> place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [style="solid"];
 }
 ';
+    }
+
+    public function testDumpWithMetadataEdgeCases()
+    {
+        $definition = self::createWorkflowWithMetadataEdgeCases();
+        $dump = (new GraphvizDumper())->dump($definition, null, ['with-metadata' => true]);
+
+        $expected = 'digraph workflow {
+  ratio="compress" rankdir="LR"
+  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="false" width="1"];
+  edge [fontsize="9" fontname="Arial" color="#333333" arrowhead="normal" arrowsize="0.5"];
+
+  place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label=<<B>a</B>>, shape=circle style="filled"];
+  place_e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98 [label=<<B>b</B>>, shape=circle style="filled" fillcolor="Orange"];
+  place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [label=<<B>c</B><BR/><I>A &lt;bold&gt; description with &quot;special&quot; chars &amp; entities</I>>, shape=circle];
+  place_3c363836cf4e16666669a25da280a1865c2d2874 [label=<<B>d</B><BR/><I>First line
+Second line</I>>, shape=circle style="filled" fillcolor="Lime"];
+  transition_b6589fc6ab0dc82cf12099d1c2d40ab994e8410c [label=<<B>t1</B>>, shape="box" regular="1"];
+  transition_356a192b7913b04c54574d18c28d46e6395428ab [label=<<B>t2</B>>, shape="box" regular="1"];
+  transition_da4b9237bacccdf19c0760cab7aec4a8359010b0 [label=<<B>t3</B><BR/><I>Transition description</I>>, shape="box" regular="1" style="filled" fillcolor="LightCoral"];
+  place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 -> transition_b6589fc6ab0dc82cf12099d1c2d40ab994e8410c [style="solid"];
+  transition_b6589fc6ab0dc82cf12099d1c2d40ab994e8410c -> place_e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98 [style="solid"];
+  place_e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98 -> transition_356a192b7913b04c54574d18c28d46e6395428ab [style="solid"];
+  transition_356a192b7913b04c54574d18c28d46e6395428ab -> place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [style="solid"];
+  place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 -> transition_da4b9237bacccdf19c0760cab7aec4a8359010b0 [style="solid"];
+  transition_da4b9237bacccdf19c0760cab7aec4a8359010b0 -> place_3c363836cf4e16666669a25da280a1865c2d2874 [style="solid"];
+}
+';
+
+        $this->assertEquals($expected, $dump);
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\Workflow\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Dumper\StateMachineGraphvizDumper;
 use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\Tests\WorkflowBuilderTrait;
+use Symfony\Component\Workflow\Transition;
 
 class StateMachineGraphvizDumperTest extends TestCase
 {
@@ -75,5 +78,28 @@ class StateMachineGraphvizDumperTest extends TestCase
         $dump = (new StateMachineGraphvizDumper())->dump($definition, $marking);
 
         $this->assertEquals($expected, $dump);
+    }
+
+    public function testDumpWithMetadata()
+    {
+        $places = ['open', 'in_progress', 'done'];
+        $transitions = [];
+        $transitions[] = new Transition('start', 'open', 'in_progress');
+        $transitions[] = new Transition('finish', 'in_progress', 'done');
+
+        $placesMetadata = [
+            'open' => ['bg_color' => 'Gold', 'description' => 'Initial state'],
+            'done' => ['bg_color' => 'LimeGreen'],
+        ];
+        $inMemoryMetadataStore = new InMemoryMetadataStore([], $placesMetadata);
+
+        $definition = new Definition($places, $transitions, null, $inMemoryMetadataStore);
+        $dump = (new StateMachineGraphvizDumper())->dump($definition, null, ['with-metadata' => true]);
+
+        // bg_color should not appear as text, description should be in italics
+        $this->assertStringContainsString('fillcolor="Gold"', $dump);
+        $this->assertStringNotContainsString('bg_color', $dump);
+        $this->assertStringContainsString('<I>Initial state</I>', $dump);
+        $this->assertStringContainsString('fillcolor="LimeGreen"', $dump);
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
@@ -87,6 +87,41 @@ trait WorkflowBuilderTrait
         // +---+     +----+     +---+     +----+     +---+
     }
 
+    private static function createWorkflowWithMetadataEdgeCases(): Definition
+    {
+        $places = range('a', 'd');
+
+        $transitions = [];
+        $transitions[] = new Transition('t1', 'a', 'b');
+        $transitions[] = new Transition('t2', 'b', 'c');
+        $transitionWithDescription = new Transition('t3', 'c', 'd');
+        $transitions[] = $transitionWithDescription;
+
+        $placesMetadata = [];
+        // bg_color only, no description
+        $placesMetadata['b'] = [
+            'bg_color' => 'Orange',
+        ];
+        // description only, no bg_color
+        $placesMetadata['c'] = [
+            'description' => 'A <bold> description with "special" chars & entities',
+        ];
+        // multiline description with bg_color
+        $placesMetadata['d'] = [
+            'bg_color' => 'Lime',
+            'description' => "First line\nSecond line",
+        ];
+
+        $transitionsMetadata = new \SplObjectStorage();
+        $transitionsMetadata[$transitionWithDescription] = [
+            'bg_color' => 'LightCoral',
+            'description' => 'Transition description',
+        ];
+        $inMemoryMetadataStore = new InMemoryMetadataStore([], $placesMetadata, $transitionsMetadata);
+
+        return new Definition($places, $transitions, null, $inMemoryMetadataStore);
+    }
+
     private static function createWorkflowWithSameNameTransition(): Definition
     {
         $places = range('a', 'c');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60210
| License       | MIT

## Description

When using `workflow:dump --with-metadata`, `bg_color` and `description` metadata were displayed as raw key-value text in node labels, adding visual clutter:

- `bg_color` was redundant since it is already applied as the node's `fillcolor` attribute
- `description` was shown as `description: value` instead of having a distinct format

This PR:

- **Removes `bg_color`** from the metadata text for both places and transitions (it was already visually applied as `fillcolor`)
- **Renders `description` in italics** (`<I>...</I>` in DOT HTML) instead of displaying it as raw `description: value` text
- Applies these improvements consistently to both places and transitions

## Test coverage

- Updated existing tests to reflect the new output format
- Added new `createWorkflowWithMetadataEdgeCases()` fixture covering:
  - Place with `bg_color` only (no description)
  - Place with `description` only (no `bg_color`)
  - Multiline description with `bg_color`
  - Transition with both `bg_color` and `description`
  - Description containing special characters (`<`, `>`, `&`, `"`)
- Added `StateMachineGraphvizDumper` metadata test (inherits from `GraphvizDumper`)