### PR TITLE
[FrameworkBundle] Add --sort option to debug:router command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -29,6 +29,7 @@ CHANGELOG
  * Deprecate registering console commands by overriding `Bundle::registerCommands()`, use the `#[AsCommand]` attribute or the `console.command` service tag instead
  * Deprecate calling `FrameworkExtension::load()` directly without first loading `ServicesBundle`'s extension
  * Add support for the `#[RateLimit]` attribute on controllers when `framework.rate_limiter` is configured
+ * Add `--sort` option to `debug:router` command to sort routes by a given column
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -39,6 +39,8 @@ class RouterDebugCommand extends Command
 {
     use BuildDebugContainerTrait;
 
+    private const SORT_COLUMNS = ['name', 'path', 'method', 'scheme', 'host'];
+
     public function __construct(
         private RouterInterface $router,
         private ?FileLinkFormatter $fileLinkFormatter = null,
@@ -55,6 +57,7 @@ class RouterDebugCommand extends Command
                 new InputOption('show-aliases', null, InputOption::VALUE_NONE, 'Show aliases in overview'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, \sprintf('The output format ("%s")', implode('", "', $this->getAvailableFormatOptions())), 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw route(s)'),
+                new InputOption('sort', null, InputOption::VALUE_REQUIRED, \sprintf('Sort routes by the given column ("%s")', implode('", "', self::SORT_COLUMNS))),
                 new InputOption('method', null, InputOption::VALUE_REQUIRED, 'Filter by HTTP method', '', ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']),
             ])
             ->setHelp(<<<'EOF'
@@ -65,6 +68,10 @@ class RouterDebugCommand extends Command
                 The <info>--format</info> option specifies the format of the command output:
 
                   <info>php %command.full_name% --format=json</info>
+
+                The <info>--sort</info> option sorts the routes by the given column:
+
+                  <info>php %command.full_name% --sort=path</info>
 
                 EOF
             )
@@ -98,6 +105,7 @@ class RouterDebugCommand extends Command
                     'show_aliases' => $input->getOption('show-aliases'),
                     'output' => $io,
                     'method' => $method,
+                    'sort' => $input->getOption('sort'),
                 ]);
 
                 return 0;
@@ -129,6 +137,7 @@ class RouterDebugCommand extends Command
                 'output' => $io,
                 'container' => $container,
                 'method' => $method,
+                'sort' => $input->getOption('sort'),
             ]);
         }
 
@@ -157,6 +166,10 @@ class RouterDebugCommand extends Command
 
         if ($input->mustSuggestOptionValuesFor('format')) {
             $suggestions->suggestValues($this->getAvailableFormatOptions());
+        }
+
+        if ($input->mustSuggestOptionValuesFor('sort')) {
+            $suggestions->suggestValues(self::SORT_COLUMNS);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -50,7 +50,7 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         match (true) {
-            $object instanceof RouteCollection => $this->describeRouteCollection($this->filterRoutesByHttpMethod($object, $options['method'] ?? ''), $options),
+            $object instanceof RouteCollection => $this->describeRouteCollection($this->sortRouteCollection($this->filterRoutesByHttpMethod($object, $options['method'] ?? ''), $options['sort'] ?? null), $options),
             $object instanceof Route => $this->describeRoute($object, $options),
             $object instanceof ParameterBag => $this->describeContainerParameters($object, $options),
             $object instanceof ContainerBuilder && !empty($options['env-vars']) => $this->describeContainerEnvVars($this->getContainerEnvVars($object), $options),
@@ -430,5 +430,45 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         return $filteredRoutes;
+    }
+
+    private function sortRouteCollection(RouteCollection $routes, ?string $sort): RouteCollection
+    {
+        if (null === $sort) {
+            return $routes;
+        }
+
+        $sort = strtolower($sort);
+        $routesArray = $routes->all();
+
+        $getSortValue = match ($sort) {
+            'name' => static fn (string $name, Route $route) => strtolower($name),
+            'path' => static fn (string $name, Route $route) => strtolower($route->getPath()),
+            'method' => static fn (string $name, Route $route) => $route->getMethods() ? strtolower(implode('|', $route->getMethods())) : '',
+            'scheme' => static fn (string $name, Route $route) => $route->getSchemes() ? strtolower(implode('|', $route->getSchemes())) : '',
+            'host' => static fn (string $name, Route $route) => strtolower($route->getHost()),
+            default => throw new \InvalidArgumentException(\sprintf('The sort column "%s" is not supported.', $sort)),
+        };
+
+        $sortValues = [];
+        foreach ($routesArray as $name => $route) {
+            $sortValues[$name] = $getSortValue($name, $route);
+        }
+        asort($sortValues);
+
+        $sortedRoutes = new RouteCollection();
+        foreach (array_keys($sortValues) as $name) {
+            $sortedRoutes->add($name, $routesArray[$name]);
+        }
+
+        foreach ($routes->getAliases() as $aliasName => $alias) {
+            $newAlias = $sortedRoutes->addAlias($aliasName, $alias->getId());
+            if ($alias->isDeprecated()) {
+                $deprecation = $alias->getDeprecation($aliasName);
+                $newAlias->setDeprecated($deprecation['package'], $deprecation['version'], str_replace($aliasName, '%alias_id%', $deprecation['message']));
+            }
+        }
+
+        return $sortedRoutes;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -90,6 +90,48 @@ class RouterDebugCommandTest extends AbstractWebTestCase
         $tester->execute(['name' => 'gerard'], ['interactive' => true]);
     }
 
+    public function testSortRoutesByPath()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['--sort' => 'path']);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $sessionPos = strpos($display, '/session ');
+        $sessionNamePos = strpos($display, '/session/{name}');
+        $logoutPos = strpos($display, '/session_logout');
+        $testPos = strpos($display, '/test');
+        $this->assertLessThan($sessionNamePos, $sessionPos);
+        $this->assertLessThan($logoutPos, $sessionNamePos);
+        $this->assertLessThan($testPos, $logoutPos);
+    }
+
+    public function testSortRoutesByName()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['--sort' => 'name']);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $logoutPos = strpos($display, 'routerdebug_session_logout');
+        $welcomePos = strpos($display, 'routerdebug_session_welcome ');
+        $welcomeNamePos = strpos($display, 'routerdebug_session_welcome_name');
+        $testPos = strpos($display, 'routerdebug_test');
+        $this->assertLessThan($welcomePos, $logoutPos);
+        $this->assertLessThan($welcomeNamePos, $welcomePos);
+        $this->assertLessThan($testPos, $welcomeNamePos);
+    }
+
+    public function testSortRoutesInvalidColumn()
+    {
+        $tester = $this->createCommandTester();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The sort column "invalid" is not supported');
+
+        $tester->execute(['--sort' => 'invalid']);
+    }
+
     #[DataProvider('provideCompletionSuggestions')]
     public function testComplete(array $input, array $expectedSuggestions)
     {
@@ -114,6 +156,11 @@ class RouterDebugCommandTest extends AbstractWebTestCase
         yield 'option --format' => [
             ['--format', ''],
             ['txt', 'xml', 'json', 'md'],
+        ];
+
+        yield 'option --sort' => [
+            ['--sort', ''],
+            ['name', 'path', 'method', 'scheme', 'host'],
         ];
 
         yield 'route_name' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54847
| License       | MIT

## Description

Adds a `--sort` option to the `debug:router` command, allowing users to sort the route list by a given column (`name`, `path`, `method`, `scheme`, `host`).

**Before:** Routes are displayed in their evaluation order. Sorting required piping through external tools (`awk`, `sort`), which breaks IDE integration (clickable links).

**After:**
```bash
php bin/console debug:router --sort=path
php bin/console debug:router --sort=name
```

## Implementation

- New `--sort` `InputOption` on `RouterDebugCommand` with shell completion
- Sort logic in `Descriptor::sortRouteCollection()` (base class), applied after HTTP method filtering and before dispatching to format-specific descriptors — so all formats (txt, json, xml, md) benefit automatically
- Route aliases are preserved when rebuilding the sorted collection
- Case-insensitive alphabetical sort via `asort()`
- Invalid column names throw `\InvalidArgumentException`

## Tests

- `testSortRoutesByPath`: verifies correct ordering of routes by path
- `testSortRoutesByName`: verifies correct ordering of routes by name
- `testSortRoutesInvalidColumn`: verifies exception on unsupported column
- Completion suggestions test for `--sort`