### PR TITLE
[Serializer] Remove @internal from ClassMetadataInterface and AttributeMetadataInterface

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -18,7 +18,7 @@ use Symfony\Component\PropertyAccess\PropertyPath;
  *
  * Primarily, the metadata stores serialization groups.
  *
- * @internal
+ * @psalm-inheritors AttributeMetadata
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Serializer\Mapping;
  *
  * There may only exist one metadata for each attribute according to its name.
  *
- * @internal
+ * @psalm-inheritors ClassMetadata
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #63904 
| License       | MIT

`ClassMetadataInterface` and `AttributeMetadataInterface` were marked as `@internal`, but both are already exposed through public APIs:

- `ClassMetadataFactoryInterface::getMetadataFor()` returns `ClassMetadataInterface`
- `ClassMetadataInterface::getAttributesMetadata()` returns `AttributeMetadataInterface[]`
- `LoaderInterface::loadClassMetadata()` takes `ClassMetadataInterface` as a parameter

This forces users who decorate `ClassMetadataFactoryInterface` (e.g. via `#[AsDecorator]`) to reference `@internal` types in public method signatures, causing false positives from static analysis tools such as PHPStan and Psalm.

This PR removes `@internal` from both interfaces to resolve the inconsistency. The concrete implementations (`ClassMetadata`, `AttributeMetadata`) remain `@final`,so external implementations are still discouraged.
**Before:** Static analysis tools report an error when implementing `ClassMetadataFactoryInterface`:

    // Error: Public method return type uses @internal type ClassMetadataInterface
    public function getMetadataFor(string|object $value): ClassMetadataInterface
    {
        // ...
    }

**After:** No suppression needed — both interfaces are part of the public API.