### PR TITLE
[DependencyInjection] Allow inline Definition as factory and configurator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add argument `exclude` to `ContainerConfigurator::import()`
  * Add `target` parameter to `#[AsAlias]` to create target-specific autowiring aliases
  * Deprecate named autowiring alias that don't use `#[Target]`
+ * Allow passing a `Definition` instance to `Definition::setFactory()` and `Definition::setConfigurator()`, its `__invoke()` method will be called
 
 8.0
 ---

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -101,17 +101,17 @@ class Definition
     /**
      * Sets a factory.
      *
-     * @param string|array|Reference|null $factory A PHP function, reference or an array containing a class/Reference and a method to call
+     * @param string|array|Definition|Reference|null $factory A PHP function, reference or an array containing a class/Reference and a method to call
      *
      * @return $this
      */
-    public function setFactory(string|array|Reference|null $factory): static
+    public function setFactory(string|array|self|Reference|null $factory): static
     {
         $this->changes['factory'] = true;
 
         if (\is_string($factory) && str_contains($factory, '::')) {
             $factory = explode('::', $factory, 2);
-        } elseif ($factory instanceof Reference) {
+        } elseif ($factory instanceof Reference || $factory instanceof self) {
             $factory = [$factory, '__invoke'];
         }
 
@@ -705,17 +705,17 @@ class Definition
     /**
      * Sets a configurator to call after the service is fully initialized.
      *
-     * @param string|array|Reference|null $configurator A PHP function, reference or an array containing a class/Reference and a method to call
+     * @param string|array|Definition|Reference|null $configurator A PHP function, reference or an array containing a class/Reference and a method to call
      *
      * @return $this
      */
-    public function setConfigurator(string|array|Reference|null $configurator): static
+    public function setConfigurator(string|array|self|Reference|null $configurator): static
     {
         $this->changes['configurator'] = true;
 
         if (\is_string($configurator) && str_contains($configurator, '::')) {
             $configurator = explode('::', $configurator, 2);
-        } elseif ($configurator instanceof Reference) {
+        } elseif ($configurator instanceof Reference || $configurator instanceof self) {
             $configurator = [$configurator, '__invoke'];
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -566,11 +566,13 @@ class ContainerBuilderTest extends TestCase
         $builder->register('qux', 'Bar\FooClass')->setFactory(['Bar\FooClass', 'getInstance']);
         $builder->register('bar', 'Bar\FooClass')->setFactory([new Definition('Bar\FooClass'), 'getInstance']);
         $builder->register('baz', 'Bar\FooClass')->setFactory([new Reference('bar'), 'getInstance']);
+        $builder->register('inline', 'BazClass')->setFactory(new Definition('BazInvokableFactory'));
 
         $this->assertTrue($builder->get('foo')->called, '->createService() calls the factory method to create the service instance');
         $this->assertTrue($builder->get('qux')->called, '->createService() calls the factory method to create the service instance');
         $this->assertTrue($builder->get('bar')->called, '->createService() uses anonymous service as factory');
         $this->assertTrue($builder->get('baz')->called, '->createService() uses another service as factory');
+        $this->assertInstanceOf(\BazClass::class, $builder->get('inline'), '->createService() calls __invoke on inline Definition factory');
     }
 
     public function testCreateServiceMethodCalls()
@@ -610,11 +612,13 @@ class ContainerBuilderTest extends TestCase
         $builder->register('foo3', 'Bar\FooClass')->setConfigurator([new Reference('baz'), 'configure']);
         $builder->register('foo4', 'Bar\FooClass')->setConfigurator([$builder->getDefinition('baz'), 'configure']);
         $builder->register('foo5', 'Bar\FooClass')->setConfigurator('foo');
+        $builder->register('foo6', 'Bar\FooClass')->setConfigurator(new Definition('BazInvokableConfigurator'));
 
         $this->assertTrue($builder->get('foo1')->configured, '->createService() calls the configurator');
         $this->assertTrue($builder->get('foo2')->configured, '->createService() calls the configurator');
         $this->assertTrue($builder->get('foo3')->configured, '->createService() calls the configurator');
         $this->assertTrue($builder->get('foo4')->configured, '->createService() calls the configurator');
+        $this->assertTrue($builder->get('foo6')->configured, '->createService() calls __invoke on inline Definition configurator');
 
         try {
             $builder->get('foo5');

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -42,6 +42,9 @@ class DefinitionTest extends TestCase
 
         $def->setFactory($ref = new Reference('baz'));
         $this->assertSame([$ref, '__invoke'], $def->getFactory(), '->setFactory() converts service reference to class invoke call');
+
+        $def->setFactory($innerDef = new Definition());
+        $this->assertSame([$innerDef, '__invoke'], $def->getFactory(), '->setFactory() converts inline definition to class invoke call');
         $this->assertSame(['factory' => true], $def->getChanges());
     }
 
@@ -212,6 +215,15 @@ class DefinitionTest extends TestCase
         $def = new Definition('stdClass');
         $this->assertSame($def, $def->setConfigurator('foo'), '->setConfigurator() implements a fluent interface');
         $this->assertEquals('foo', $def->getConfigurator(), '->getConfigurator() returns the configurator');
+
+        $def->setConfigurator('Foo::bar');
+        $this->assertEquals(['Foo', 'bar'], $def->getConfigurator(), '->setConfigurator() converts string static method call to the array');
+
+        $def->setConfigurator($ref = new Reference('baz'));
+        $this->assertSame([$ref, '__invoke'], $def->getConfigurator(), '->setConfigurator() converts service reference to class invoke call');
+
+        $def->setConfigurator($innerDef = new Definition());
+        $this->assertSame([$innerDef, '__invoke'], $def->getConfigurator(), '->setConfigurator() converts inline definition to class invoke call');
     }
 
     public function testClearTags()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
@@ -53,6 +53,22 @@ class BazClass
     }
 }
 
+class BazInvokableFactory
+{
+    public function __invoke(): BazClass
+    {
+        return new BazClass();
+    }
+}
+
+class BazInvokableConfigurator
+{
+    public function __invoke($instance): void
+    {
+        $instance->configure();
+    }
+}
+
 class BarUserClass
 {
     public $foo;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Allow passing a `Definition` instance directly to `setFactory()` and `setConfigurator()`. It is wrapped as `[$def, '__invoke']`, consistent with how `Reference` is already handled.

Identified in https://github.com/symfony/monolog-bundle/pull/577#discussion_r3049461436