### PR TITLE
[JsonStreamer] Improve error message when unable to encode

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/backed_enum.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield $data ? 'true' : 'false';
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"bool\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool_list.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<bool>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/dict.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"array<string, mixed>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_array.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_array.php
@@ -43,6 +43,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "]";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedArray>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_list.php
@@ -41,6 +41,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "]";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedList>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/iterable.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"iterable\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/list.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<mixed>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/mixed.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/mixed.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"mixed\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_array.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_array.php
@@ -31,6 +31,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "]";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithArray>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_list.php
@@ -30,6 +30,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "]";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithList>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield "null";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"null\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null_list.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<null>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
@@ -13,6 +13,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
@@ -19,6 +19,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|null\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
@@ -26,6 +26,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes>|null\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
@@ -25,6 +25,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes>|null\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object.php
@@ -13,6 +13,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
@@ -20,6 +20,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
@@ -25,6 +25,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         yield \json_encode($data->otherDummyTwo->name, \JSON_THROW_ON_ERROR, 510);
         yield "}}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithOtherDummies\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
@@ -20,6 +20,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"iterable<int|string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
@@ -19,6 +19,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "]";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_dollar_named_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_dollar_named_properties.php
@@ -13,6 +13,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         yield $data->bar ? 'true' : 'false';
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithDollarNamedProperties\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
@@ -23,6 +23,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies']($data, 0);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedDictDummies\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
@@ -23,6 +23,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies']($data, 0);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedListDummies\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_synthetic_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_synthetic_properties.php
@@ -10,6 +10,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader::true(null, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithSyntheticProperties\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
@@ -22,6 +22,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithUnionProperties\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_object.php
@@ -21,6 +21,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithDateTimes\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
@@ -17,6 +17,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::concatRange($data->range, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
         yield "}";
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithValueTransformerAttributes\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/scalar.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/scalar.php
@@ -7,6 +7,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"int\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
@@ -22,6 +22,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy']($data, 0);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummy\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
@@ -23,6 +23,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict']($data, 0);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyDict\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
@@ -23,6 +23,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList']($data, 0);
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyList\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
@@ -28,6 +28,6 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }
     } catch (\JsonException $e) {
-        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
+        throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|int|list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>\" to JSON: {$e->getMessage()}.", 0, $e);
     }
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -484,7 +484,7 @@ class JsonStreamWriterTest extends TestCase
         $writer = JsonStreamWriter::create(streamWritersDir: $this->streamWritersDir);
 
         $this->expectException(NotEncodableValueException::class);
-        $this->expectExceptionMessage('Inf and NaN cannot be JSON encoded');
+        $this->expectExceptionMessage('Cannot encode "int" to JSON: Inf and NaN cannot be JSON encoded.');
 
         (string) $writer->write(\INF, Type::int());
     }

--- a/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
@@ -78,7 +78,7 @@ final class PhpGenerator
             .$this->line('    try {', $context)
             .$yields
             .$this->line('    } catch (\\JsonException $e) {', $context)
-            .$this->line('        throw new \\'.NotEncodableValueException::class.'($e->getMessage(), 0, $e);', $context)
+            .$this->line(\sprintf('        throw new \\%s("Cannot encode \\"%s\\" to JSON: {$e->getMessage()}.", 0, $e);', NotEncodableValueException::class, addcslashes($dataModel->getType(), '\\')), $context)
             .$this->line('    }', $context)
             .$this->line('};', $context);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | not really
| Deprecations? | no
| Issues        | 
| License       | MIT

Currently, error while encoding JSON are a little bit cryptic:
<img width="482" height="92" alt="image" src="https://github.com/user-attachments/assets/5c7933a3-beae-4472-9559-2ebde984eefe" />

Adding the type will make debugging a little bit easier