### PR TITLE
[ErrorHandler] Fix http_response_code() warning on PHP 8.5 for max execution time errors

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Error/MaxExecutionTimeError.php
+++ b/src/Symfony/Component/ErrorHandler/Error/MaxExecutionTimeError.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler\Error;
+
+class MaxExecutionTimeError extends FatalError
+{
+}

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\ErrorHandler;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\ErrorHandler\Error\FatalError;
+use Symfony\Component\ErrorHandler\Error\MaxExecutionTimeError;
 use Symfony\Component\ErrorHandler\Error\OutOfMemoryError;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\ClassNotFoundErrorEnhancer;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\ErrorEnhancerInterface;
@@ -600,6 +601,8 @@ class ErrorHandler
 
             if (str_starts_with($error['message'], 'Allowed memory') || str_starts_with($error['message'], 'Out of memory')) {
                 $fatalError = new OutOfMemoryError($handler->levels[$error['type']].': '.$error['message'], 0, $error, 2, false, $trace);
+            } elseif (str_starts_with($error['message'], 'Maximum execution time of')) {
+                $fatalError = new MaxExecutionTimeError($handler->levels[$error['type']].': '.$error['message'], 0, $error, 2, false, $trace);
             } else {
                 $fatalError = new FatalError($handler->levels[$error['type']].': '.$error['message'], 0, $error, 2, true, $trace);
             }
@@ -631,22 +634,22 @@ class ErrorHandler
     {
         $renderer = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? new CliErrorRenderer() : new HtmlErrorRenderer($this->debug);
 
-        $exception = $renderer->render($exception);
+        $flattenedException = $renderer->render($exception);
 
-        if (!headers_sent()) {
-            http_response_code($exception->getStatusCode());
+        if (!headers_sent() && !$exception instanceof OutOfMemoryError && !$exception instanceof MaxExecutionTimeError) {
+            http_response_code($flattenedException->getStatusCode());
 
-            foreach ($exception->getHeaders() as $name => $value) {
+            foreach ($flattenedException->getHeaders() as $name => $value) {
                 header($name.': '.$value, false);
             }
         }
 
-        echo $exception->getAsString();
+        echo $flattenedException->getAsString();
     }
 
     public function enhanceError(\Throwable $exception): \Throwable
     {
-        if ($exception instanceof OutOfMemoryError) {
+        if ($exception instanceof OutOfMemoryError || $exception instanceof MaxExecutionTimeError) {
             return $exception;
         }
 

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -20,6 +20,8 @@ use Psr\Log\NullLogger;
 use Symfony\Component\ErrorHandler\BufferingLogger;
 use Symfony\Component\ErrorHandler\Error\ClassNotFoundError;
 use Symfony\Component\ErrorHandler\Error\FatalError;
+use Symfony\Component\ErrorHandler\Error\MaxExecutionTimeError;
+use Symfony\Component\ErrorHandler\Error\OutOfMemoryError;
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\ErrorHandler\Exception\SilencedErrorContext;
 use Symfony\Component\ErrorHandler\Tests\Fixtures\ErrorHandlerThatUsesThePreviousOne;
@@ -550,6 +552,84 @@ class ErrorHandlerTest extends TestCase
     }
 
     #[WithoutErrorHandler]
+    public function testHandleFatalErrorCreatesOutOfMemoryError()
+    {
+        try {
+            $handler = ErrorHandler::register();
+
+            $error = [
+                'type' => \E_ERROR,
+                'message' => 'Allowed memory size of 536870912 bytes exhausted (tried to allocate 4096 bytes)',
+                'file' => 'bar',
+                'line' => 123,
+            ];
+
+            $handler->setExceptionHandler(static function () use (&$args) {
+                $args = \func_get_args();
+            });
+
+            $handler->handleFatalError($error);
+
+            $this->assertInstanceOf(OutOfMemoryError::class, $args[0]);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
+
+    #[WithoutErrorHandler]
+    public function testHandleFatalErrorCreatesOutOfMemoryErrorForOutOfMemoryMessage()
+    {
+        try {
+            $handler = ErrorHandler::register();
+
+            $error = [
+                'type' => \E_ERROR,
+                'message' => 'Out of memory (allocated 536870912) (tried to allocate 4096 bytes)',
+                'file' => 'bar',
+                'line' => 123,
+            ];
+
+            $handler->setExceptionHandler(static function () use (&$args) {
+                $args = \func_get_args();
+            });
+
+            $handler->handleFatalError($error);
+
+            $this->assertInstanceOf(OutOfMemoryError::class, $args[0]);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
+
+    #[WithoutErrorHandler]
+    public function testHandleFatalErrorCreatesMaxExecutionTimeError()
+    {
+        try {
+            $handler = ErrorHandler::register();
+
+            $error = [
+                'type' => \E_ERROR,
+                'message' => 'Maximum execution time of 30 seconds exceeded',
+                'file' => 'bar',
+                'line' => 123,
+            ];
+
+            $handler->setExceptionHandler(static function () use (&$args) {
+                $args = \func_get_args();
+            });
+
+            $handler->handleFatalError($error);
+
+            $this->assertInstanceOf(MaxExecutionTimeError::class, $args[0]);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
+
+    #[WithoutErrorHandler]
     public function testHandleErrorException()
     {
         $exception = new \Error("Class 'IReallyReallyDoNotExistAnywhereInTheRepositoryISwear' not found");
@@ -589,6 +669,46 @@ class ErrorHandlerTest extends TestCase
         $response = ob_get_clean();
 
         self::assertStringContainsString('Class Foo not found', $response);
+    }
+
+    #[WithoutErrorHandler]
+    public function testRenderExceptionWithOutOfMemoryError()
+    {
+        $handler = new ErrorHandler();
+        $handler->setExceptionHandler([$handler, 'renderException']);
+
+        $error = [
+            'type' => \E_ERROR,
+            'message' => 'Allowed memory size of 536870912 bytes exhausted',
+            'file' => 'foo.php',
+            'line' => 1,
+        ];
+
+        ob_start();
+        $handler->handleException(new OutOfMemoryError('', 0, $error));
+        $response = ob_get_clean();
+
+        self::assertStringContainsString('Allowed memory size of 536870912 bytes exhausted', $response);
+    }
+
+    #[WithoutErrorHandler]
+    public function testRenderExceptionWithMaxExecutionTimeError()
+    {
+        $handler = new ErrorHandler();
+        $handler->setExceptionHandler([$handler, 'renderException']);
+
+        $error = [
+            'type' => \E_ERROR,
+            'message' => 'Maximum execution time of 30 seconds exceeded',
+            'file' => 'foo.php',
+            'line' => 1,
+        ];
+
+        ob_start();
+        $handler->handleException(new MaxExecutionTimeError('', 0, $error));
+        $response = ob_get_clean();
+
+        self::assertStringContainsString('Maximum execution time of 30 seconds exceeded', $response);
     }
 
     #[DataProvider('errorHandlerWhenLoggingProvider')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes and no
| New feature?  | yes and no
| Deprecations? | 
| Issues        | Fix #63082
| License       | MIT

On PHP 8.5, calling `http_response_code()` after `header('HTTP/...')` has already been called triggers a warning:

>  http_response_code(): Calling http_response_code() after header('HTTP/...') has no effect

This happens in production when a request completes normally (i.e. `Response::sendHeaders()` calls `header('HTTP/1.1 200 OK')`) but then post-response work (terminate listeners) exceeds `max_execution_time`.
The shutdown handler invokes `ErrorHandler::renderException()`, which calls `http_response_code(500)` — triggering the PHP 8.5 warning since an HTTP status header was already sent via `header()`.

The fix introduces `MaxExecutionTimeError` (mirroring the existing `OutOfMemoryError`) and applies three changes:

- `handleFatalError()` now detects \"Maximum execution time\" messages  and wraps them in `MaxExecutionTimeError`
- `renderException()` skips `http_response_code()` and `header()` calls  for this error type (as it already does for `OutOfMemoryError`)
- `enhanceError()` skips error enhancement for this error type to avoid  loading classes during a fatal state

The variable `$exception` in `renderException()` was also renamed to `$flattenedException` after rendering, to avoid shadowing the original exception parameter.

Reproduced and verified using PHP's built-in web server with `output_buffering=4096` and `display_errors=0` to match production conditions.

/cc @xabbuh @nicolas-grekas 