### PR TITLE
[Mailer] Fix handling of webhook.test verification event from MailerSend webhook

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/MailerSendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/MailerSendRequestParserTest.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Component\Mailer\Bridge\MailerSend\Tests\Webhook;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\MailerSend\RemoteEvent\MailerSendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\MailerSend\Webhook\MailerSendRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class MailerSendRequestParserTest extends AbstractRequestParserTestCase
@@ -21,5 +23,27 @@ class MailerSendRequestParserTest extends AbstractRequestParserTestCase
     protected function createRequestParser(): RequestParserInterface
     {
         return new MailerSendRequestParser(new MailerSendPayloadConverter());
+    }
+
+    public function testWebhookTest()
+    {
+        $payload = json_encode([
+            'type' => 'webhook.test',
+            'message' => 'This is a ping test message',
+            'created_at' => '2026-04-08T12:19:27.608339Z',
+        ]);
+
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+        ], $payload);
+        $request->headers->set('Signature', '7fb29be5b1cdb588ee67fa43a0a9d1b394cbb9603a0ac0b87924649d715194c2');
+
+        $parser = $this->createRequestParser();
+
+        try {
+            $parser->parse($request, MailerSendRequestParser::TEST_SECRET);
+        } catch (RejectWebhookException $e) {
+            $this->assertSame(202, $e->getStatusCode());
+        }
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Webhook/MailerSendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Webhook/MailerSendRequestParser.php
@@ -24,6 +24,13 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class MailerSendRequestParser extends AbstractRequestParser
 {
+    /**
+     * Fixed secret that is used by MailerSend when doing a webhook.test request.
+     *
+     * @see https://developers.mailersend.com/api/v1/webhooks.html#webhooks-overview
+     */
+    public const TEST_SECRET = 'test_Am3L1GuOIc4blLUuHqAPxxwkZaJyEk8G';
+
     public function __construct(
         private readonly MailerSendPayloadConverter $converter,
     ) {
@@ -39,6 +46,14 @@ final class MailerSendRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
+        $content = $request->toArray();
+
+        if ('webhook.test' === ($content['type'] ?? null)) {
+            $secret = self::TEST_SECRET;
+	} elseif (!isset($content['type'], $content['data']['email']['message']['id'], $content['data']['email']['recipient']['email'])) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
         if ($secret) {
             if (!$request->headers->get('Signature')) {
                 throw new RejectWebhookException(406, 'Signature is required.');
@@ -49,11 +64,10 @@ final class MailerSendRequestParser extends AbstractRequestParser
                 $request->getContent(),
                 $secret,
             );
-        }
 
-        $content = $request->toArray();
-        if (!isset($content['type'], $content['data']['email']['message']['id'], $content['data']['email']['recipient']['email'])) {
-            throw new RejectWebhookException(406, 'Payload is malformed.');
+	    if (self::TEST_SECRET === $secret) {
+                throw new RejectWebhookException(202);
+	    }
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

When creating a webhook, MailerSend sends a `webhook.test` event to verify the URL is reachable. The current implementation rejects this event as malformed because it lacks the `data.email.message.id` and `data.email.recipient.email` fields that are expected for regular activity events.

This fix detects the `webhook.test` event type early and returns `null` to acknowledge it, following the same pattern used by the Mailchimp bridge for its empty webhook verification check.
