### PR TITLE
[TypeInfo] Fix collectUses() to support grouped use imports

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithUses.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\TypeInfo\Tests\Fixtures;
 
-use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\{
+    Type,
+    TypeIdentifier as TI,
+};
 use \DateTimeInterface;
 
 use \DateTimeImmutable as DateTime;

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -92,8 +92,9 @@ class TypeContextFactoryTest extends TestCase
 
         $uses = [
             'Type' => Type::class,
-            \DateTimeInterface::class => '\\'.\DateTimeInterface::class,
-            'DateTime' => '\\'.\DateTimeImmutable::class,
+            'TI' => 'Symfony\\Component\\TypeInfo\\TypeIdentifier',
+            \DateTimeInterface::class => \DateTimeInterface::class,
+            'DateTime' => \DateTimeImmutable::class,
         ];
 
         $this->assertSame($uses, $this->typeContextFactory->createFromClassName(DummyWithUses::class)->uses);
@@ -110,8 +111,8 @@ class TypeContextFactoryTest extends TestCase
 
         $uses = [
             'Type' => Type::class,
-            \DateTimeInterface::class => '\\'.\DateTimeInterface::class,
-            'DateTime' => '\\'.\DateTimeImmutable::class,
+            \DateTimeInterface::class => \DateTimeInterface::class,
+            'DateTime' => \DateTimeImmutable::class,
         ];
 
         $this->assertSame($uses, $this->typeContextFactory->createFromClassName(DummyWithUsesWindowsLineEndings::class)->uses);

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextTest.php
@@ -30,7 +30,7 @@ class TypeContextTest extends TestCase
 
         $this->assertSame(DummyWithUses::class, $typeContext->normalize('DummyWithUses'));
         $this->assertSame(Type::class, $typeContext->normalize('Type'));
-        $this->assertSame('\\'.\DateTimeImmutable::class, $typeContext->normalize('DateTime'));
+        $this->assertSame(\DateTimeImmutable::class, $typeContext->normalize('DateTime'));
         $this->assertSame('Symfony\\Component\\TypeInfo\\Tests\\Fixtures\\unknown', $typeContext->normalize('unknown'));
         $this->assertSame('unknown', $typeContext->normalize('\\unknown'));
 

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -166,14 +166,37 @@ final class TypeContextFactory
 
         $uses = [];
         $inUseSection = false;
+        $inGroupedUse = false;
+        $groupPrefix = '';
 
         foreach ($lines as $line) {
+            $trimmed = trim($line, " \t");
+
+            if ($inGroupedUse) {
+                $this->parseGroupedUseMembers($trimmed, $groupPrefix, $uses);
+
+                if (str_contains($trimmed, '}')) {
+                    $inGroupedUse = false;
+                }
+
+                continue;
+            }
+
             if (str_starts_with($line, 'use ')) {
                 $inUseSection = true;
-                $use = explode(' as ', substr($line, 4, -1), 2);
+                $body = substr($trimmed, 4);
 
-                $alias = 1 === \count($use) ? substr($use[0], false !== ($p = strrpos($use[0], '\\')) ? 1 + $p : 0) : $use[1];
-                $uses[$alias] = $use[0];
+                if (str_contains($body, '{')) {
+                    $groupPrefix = substr($body, 0, strpos($body, '{'));
+                    $inGroupedUse = !str_contains($body, '}');
+                    $segment = trim(substr($body, strpos($body, '{')), " \t\r\n{};");
+                    $this->parseGroupedUseMembers($segment, $groupPrefix, $uses);
+                } else {
+                    $use = preg_split('/\s+as\s+/', rtrim($body, ';'), 2);
+                    $fqcn = ltrim($use[0], '\\');
+                    $alias = $use[1] ?? (false !== ($p = strrpos($fqcn, '\\')) ? substr($fqcn, 1 + $p) : $fqcn);
+                    $uses[$alias] = $fqcn;
+                }
             } elseif ($inUseSection) {
                 break;
             }
@@ -185,6 +208,23 @@ final class TypeContextFactory
         }
 
         return array_merge($uses, ...$traitUses);
+    }
+
+    /**
+     * @param array<string, string> $uses
+     */
+    private function parseGroupedUseMembers(string $segment, string $prefix, array &$uses): void
+    {
+        foreach (explode(',', $segment) as $member) {
+            if ('' === $member = trim($member, " \t\r\n};")) {
+                continue;
+            }
+
+            $parts = preg_split('/\s+as\s+/', $member, 2);
+            $fqcn = ltrim($prefix.$parts[0], '\\');
+            $alias = $parts[1] ?? (false !== ($p = strrpos($fqcn, '\\')) ? substr($fqcn, 1 + $p) : $fqcn);
+            $uses[$alias] = $fqcn;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63917
| License       | MIT

`TypeContextFactory::collectUses()` did not parse grouped `use` statements (`use Foo\{Bar, Baz};`), causing wrong PHPDoc type resolution when PropertyInfo uses PhpStanExtractor.

This adds support for both single-line (`use Foo\{Bar, Baz};`) and multiline grouped imports, including `as` aliases within groups.