### PR TITLE
[DependencyInjection] Fix bundles cache freshness check

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
@@ -98,7 +98,10 @@ trait KernelTrait
     protected function initializeBundles(): void
     {
         $cachePath = $this->getEffectiveBuildDir().'/'.$this->getContainerClass().'.bundles.php';
-        if (is_file($cachePath)) {
+        if (
+            is_file($cachePath)
+            && (!$this->debug || is_file($bundlesPath = $this->getBundlesPath()) && filemtime($cachePath) > filemtime($bundlesPath))
+        ) {
             $this->bundles = require $cachePath;
 
             return;

--- a/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
@@ -287,6 +287,68 @@ class AbstractKernelTest extends TestCase
         $this->assertCount(0, $kernel->getBundles());
     }
 
+    public function testBundleCacheIsNotUsedInDebugWhenNotFresh()
+    {
+        $dir = $this->varDir;
+        @mkdir($dir.'/config', 0o777, true);
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true]];');
+
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertCount(1, $kernel->getBundles());
+        $kernel->shutdown();
+
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true], '.ChildBundle::class.'::class => [\'all\' => true]];');
+
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertCount(2, $kernel->getBundles());
+    }
+
+    public function testBundleCacheIsUsedInDebugWhenFresh()
+    {
+        $dir = $this->varDir;
+        @mkdir($dir.'/config', 0o777, true);
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true]];');
+
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertCount(1, $kernel->getBundles());
+        $kernel->shutdown();
+
+        // Modify bundles.php but backdate it so the cache file remains newer
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true], '.ChildBundle::class.'::class => [\'all\' => true]];');
+        touch($dir.'/config/bundles.php', time() - 10);
+
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertCount(1, $kernel->getBundles(), 'Bundle cache should be used in debug mode when cache is newer than bundles.php');
+    }
+
+    public function testBundleCacheIsUsedInNoDebug()
+    {
+        $dir = $this->varDir;
+        @mkdir($dir.'/config', 0o777, true);
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true]];');
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+
+        $this->assertCount(1, $kernel->getBundles());
+        $kernel->shutdown();
+
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true], '.ChildBundle::class.'::class => [\'all\' => true]];');
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+
+        $this->assertCount(1, $kernel->getBundles(), 'Bundle cache should be used in non-debug mode even when bundles.php changes');
+    }
+
     public function testConfigureContainerHook()
     {
         $kernel = new ConfigureContainerKernel('test', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/63880#discussion_r3048295085
| License       | MIT

Running `symfony new --version=next --webapp my-app` fails with the following error:

> Script importmap:require returned with error code 1
> !!  
> !!  In FileLoader.php line 190:
> !!                                                                                 
> !!    Container extension "debug" is not registered in /my-app/config/packages/debug.yaml (which is being imported from "/my-app/src/Kernel.php").                                                                        
> !!                                                                                 
> !!  
> !!  In ContainerBuilder.php line 220:
> !!                                                    
> !!    Container extension "debug" is not registered.  
> !!   

During `composer require webapp`, the cached `App_KernelDevDebugContainer.bundles.php` is used, so changes to `config/bundles.php` are not taken into account.

This PR ensures `App_KernelDevDebugContainer.bundles.php` is only used if it is newer than `config/bundles.php`.