### PR TITLE
[DependencyInjection] Fix excludeSelf not applied when using AutowireLocator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -35,8 +35,12 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($value instanceof ServiceLocatorArgument) {
-            if ($value->getTaggedIteratorArgument()) {
-                $value->setValues($this->findAndSortTaggedServices($value->getTaggedIteratorArgument(), $this->container));
+            if ($taggedIterator = $value->getTaggedIteratorArgument()) {
+                $exclude = $taggedIterator->getExclude();
+                if ($taggedIterator->excludeSelf()) {
+                    $exclude[] = $this->currentId;
+                }
+                $value->setValues($this->findAndSortTaggedServices($taggedIterator, $this->container, $exclude));
             }
 
             return self::register($this->container, $value->getValues());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -249,6 +249,31 @@ class ServiceLocatorTagPassTest extends TestCase
         static::assertInstanceOf(AsTaggedItemServiceDecorator::class, $locator->get('custom_key'));
     }
 
+    public function testExcludeSelfFromTaggedServiceLocator()
+    {
+        $container = new ContainerBuilder();
+
+        $locator = new Definition(Locator::class);
+        $locator->setPublic(true);
+        $locator->addTag('test_tag');
+        $locator->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('test_tag', null, null, true)));
+
+        $container->setDefinition(Locator::class, $locator);
+
+        $service = new Definition(Service::class);
+        $service->setPublic(true);
+        $service->addTag('test_tag');
+
+        $container->setDefinition(Service::class, $service);
+
+        $container->compile();
+
+        /** @var ServiceLocator $locator */
+        $locator = $container->get(Locator::class)->locator;
+        static::assertTrue($locator->has(Service::class), 'Other tagged services should be in the locator');
+        static::assertFalse($locator->has(Locator::class), 'The service itself should be excluded via excludeSelf');
+    }
+
     public function testBindingsAreProcessed()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a service tagged with `mytag` uses `#[AutowireLocator('mytag', excludeSelf: true)]`,
the `excludeSelf` option has no effect and the service includes itself in the locator.

`ServiceLocatorTagPass` processes `ServiceLocatorArgument` wrapping a `TaggedIteratorArgument`
**before** `ResolveTaggedIteratorArgumentPass` — which is where `excludeSelf` support was added
(1cadd46). Since the argument is consumed first, the option is silently ignored.

This PR applies the same `excludeSelf`/`getExclude()` logic to `ServiceLocatorTagPass::processValue()`
and adds the missing test case (equivalent to `testProcesWithAutoExcludeReferencingService` from
`ResolveTaggedIteratorArgumentPassTest`, but for `#[AutowireLocator]`).