### PR TITLE
[CssSelector] Fix :is() and :where() combining conditions with parent selector

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -236,6 +236,10 @@ class TranslatorTest extends TestCase
             [':scope', '*[1]'],
             ['e:is(section, article) h1', "e[(name() = 'section') or (name() = 'article')]/descendant-or-self::*/h1"],
             ['e:where(section, article) h1', "e[(name() = 'section') or (name() = 'article')]/descendant-or-self::*/h1"],
+            ['[hidden]:where(:is(span))', "*[(@hidden) and (name() = 'span')]"],
+            ['[hidden]:where(:not(span))', "*[(@hidden) and (not(name() = 'span'))]"],
+            ['[hidden]:is(span, div)', "*[(@hidden) and ((name() = 'span') or (name() = 'div'))]"],
+            ['[hidden]:where(:not([hidden=until-found]))', "*[(@hidden) and (not(@hidden = 'until-found'))]"],
         ];
     }
 

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -99,29 +99,32 @@ class NodeExtension extends AbstractExtension
 
     public function translateMatching(Node\MatchingNode $node, Translator $translator): XPathExpr
     {
-        $xpath = $translator->nodeToXPath($node->selector);
-
-        foreach ($node->arguments as $argument) {
-            $expr = $translator->nodeToXPath($argument);
-            $expr->addNameTest();
-            if ($condition = $expr->getCondition()) {
-                $xpath->addCondition($condition, 'or');
-            }
-        }
-
-        return $xpath;
+        return $this->translateMatchingOrSpecificityAdjustment($node->selector, $node->arguments, $translator);
     }
 
     public function translateSpecificityAdjustment(Node\SpecificityAdjustmentNode $node, Translator $translator): XPathExpr
     {
-        $xpath = $translator->nodeToXPath($node->selector);
+        return $this->translateMatchingOrSpecificityAdjustment($node->selector, $node->arguments, $translator);
+    }
 
-        foreach ($node->arguments as $argument) {
+    /**
+     * @param array<Node\NodeInterface> $arguments
+     */
+    private function translateMatchingOrSpecificityAdjustment(Node\NodeInterface $selector, array $arguments, Translator $translator): XPathExpr
+    {
+        $xpath = $translator->nodeToXPath($selector);
+
+        $conditions = [];
+        foreach ($arguments as $argument) {
             $expr = $translator->nodeToXPath($argument);
             $expr->addNameTest();
-            if ($condition = $expr->getCondition()) {
-                $xpath->addCondition($condition, 'or');
+            if ('' !== $condition = $expr->getCondition()) {
+                $conditions[] = $condition;
             }
+        }
+
+        if ($conditions) {
+            $xpath->addCondition(1 === \count($conditions) ? $conditions[0] : '('.implode(') or (', $conditions).')');
         }
 
         return $xpath;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59669
| License       | MIT

When `:is()` or `:where()` is used on a selector that already has a condition (e.g. `[hidden]:where(:is(span))`), the argument conditions were combined with the parent condition using `or` instead of `and`.

This caused `[hidden]:where(:not([hidden=until-found]))` to match all elements (either hidden or not matching the attribute), instead of only hidden elements that do not have `hidden=until-found`.

The fix separates the two concerns:
- Arguments within `:is()`/`:where()` are combined with `or` (selector list semantics)
- The resulting condition is combined with the parent selector condition using `and`

`:is()` / `:where()` support was introduced in 7.1 (c083e1d6b01) so 6.4 is not affected.