### PR TITLE
[MonologBridge] Add `$subjectMaxLength` option to MailerHandler

### DIFF
--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `subjectMaxLength` option to `MailerHandler` to truncate long email subjects (defaults to 200)
+
 8.0
 ---
 

--- a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
@@ -32,6 +32,7 @@ final class MailerHandler extends AbstractProcessingHandler
         callable|Email $messageTemplate,
         string|int|Level $level = Level::Debug,
         bool $bubble = true,
+        private int $subjectMaxLength = 200,
     ) {
         parent::__construct($level, $bubble);
 
@@ -101,7 +102,13 @@ final class MailerHandler extends AbstractProcessingHandler
 
         if ($records) {
             $subjectFormatter = $this->getSubjectFormatter($message->getSubject());
-            $message->subject($subjectFormatter->format($this->getHighestRecord($records)));
+            $subject = $subjectFormatter->format($this->getHighestRecord($records));
+
+            if ($this->subjectMaxLength && \strlen($subject) > $this->subjectMaxLength) {
+                $subject = substr_replace($subject, '[...]', $this->subjectMaxLength);
+            }
+
+            $message->subject($subject);
         }
 
         if ($this->getFormatter() instanceof HtmlFormatter) {

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/MailerHandlerTest.php
@@ -86,6 +86,62 @@ class MailerHandlerTest extends TestCase
         $handler->handle($this->getRecord(Level::Warning, 'message'));
     }
 
+    public function testSubjectIsTruncatedWithEllipsis()
+    {
+        $handler = new MailerHandler($this->mailer, (new Email())->subject('Alert: %message%'), Level::Debug, true, 50);
+        $handler->setFormatter(new LineFormatter());
+
+        $longMessage = str_repeat('a', 200);
+
+        $this->mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email) {
+                $this->assertSame('Alert: '.str_repeat('a', 43).'[...]', $email->getSubject());
+
+                return true;
+            }))
+        ;
+        $handler->handle($this->getRecord(Level::Warning, $longMessage));
+    }
+
+    public function testSubjectIsNotTruncatedWhenShorterThanMax()
+    {
+        $handler = new MailerHandler($this->mailer, (new Email())->subject('Alert: %message%'), Level::Debug, true, 50);
+        $handler->setFormatter(new LineFormatter());
+
+        $this->mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email) {
+                $this->assertSame('Alert: short', $email->getSubject());
+
+                return true;
+            }))
+        ;
+        $handler->handle($this->getRecord(Level::Warning, 'short'));
+    }
+
+    public function testSubjectDefaultMaxLengthTruncatesLongMessages()
+    {
+        $handler = new MailerHandler($this->mailer, (new Email())->subject('Alert: %message%'));
+        $handler->setFormatter(new LineFormatter());
+
+        $longMessage = str_repeat('a', 500);
+
+        $this->mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email) {
+                $this->assertSame(200 + \strlen('[...]'), \strlen($email->getSubject()));
+                $this->assertStringEndsWith('[...]', $email->getSubject());
+
+                return true;
+            }))
+        ;
+        $handler->handle($this->getRecord(Level::Warning, $longMessage));
+    }
+
     protected function getRecord($level = Level::Warning, $message = 'test', $context = []): array|LogRecord
     {
         return RecordFactory::create($level, $message, context: $context);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix symfony/monolog-bundle#574
| License       | MIT

When using `%%message%%` in the email subject, a long log message can produce a subject that exceeds mail server limits.

This adds an optional `subjectMaxLength` parameter to `MailerHandler` that truncates the formatted subject to a given length using `substr`.