### PR TITLE
[WebProfilerBundle] Fix toolbar toggle button accessibility

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -32,7 +32,7 @@
         </div>
     {% endif %}
 
-    <button class="sf-toolbar-toggle-button" type="button" id="sfToolbarToggleButton-{{ token }}" accesskey="D" aria-expanded="true" aria-controls="sfToolbarMainContent-{{ token }}">
+    <button class="sf-toolbar-toggle-button" type="button" id="sfToolbarToggleButton-{{ token }}" accesskey="D" aria-expanded="true" aria-controls="sfToolbarMainContent-{{ token }}" aria-label="Toggle Symfony Toolbar">
         <i class="sf-toolbar-icon-opened" title="Close Toolbar">{{ source('@WebProfiler/Icon/close.svg') }}</i>
         <i class="sf-toolbar-icon-closed" title="Open Toolbar">{{ source('@WebProfiler/Icon/symfony.svg') }}</i>
     </button>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -501,20 +501,25 @@
 
                     showToolbar: function(token) {
                         var sfwdt = this.getSfwdt(token);
+                        var toggleButton = document.querySelector(`#sfToolbarToggleButton-${token}`);
 
                         if ('closed' === getPreference('toolbar/displayState')) {
                             addClass(sfwdt.parentNode, 'sf-toolbar-closed');
                             removeClass(sfwdt.parentNode, 'sf-toolbar-opened');
+                            if (toggleButton) { toggleButton.setAttribute('aria-expanded', 'false'); }
                         } else {
                             addClass(sfwdt.parentNode, 'sf-toolbar-opened');
                             removeClass(sfwdt.parentNode, 'sf-toolbar-closed');
+                            if (toggleButton) { toggleButton.setAttribute('aria-expanded', 'true'); }
                         }
                     },
 
                     hideToolbar: function(token) {
                         var sfwdt = this.getSfwdt(token);
+                        var toggleButton = document.querySelector(`#sfToolbarToggleButton-${token}`);
                         addClass(sfwdt.parentNode, 'sf-toolbar-closed');
                         removeClass(sfwdt.parentNode, 'sf-toolbar-opened');
+                        if (toggleButton) { toggleButton.setAttribute('aria-expanded', 'false'); }
                     },
 
                     initToolbar: function(token) {


### PR DESCRIPTION
| Q             | A
|---------------|---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

In Symfony 7.3, two commits introduced a regression in the accessibility of the Web Debug Toolbar toggle button.
Before the regression, screen readers announced the toolbar button correctly:
- button expanded Alt+D Close Toolbar (when open)
- button collapsed Alt+D Show Symfony toolbar (when closed)
After the regression, screen readers announce:
- button expanded Alt+D (when open)
- button expanded Alt+D Symfony graphic (when closed)
Two issues:
aria-expanded is never updated when the toolbar state changes — it is hardcoded to true in HTML and the JavaScript only toggles CSS classes.
The accessible label is no longer read the title attribute was moved from the <button> to the <i> child elements, which screen readers do not expose.
Root cause
06ed5166aa merged the two separate buttons (sfToolbarMiniToggler with aria-expanded="false" and sfToolbarHideButton with aria-expanded="true") into a single sfToolbarToggleButton. The JavaScript was not updated to reflect the state change.
d7d737e462 moved the title attribute from the </i><i> to the inner <i> tags, which are not reliably announced by screen readers.

Fix:
Add a static aria-label="Toggle Symfony Toolbar" on the <button> so screen readers always announce the button name.
Update aria-expanded dynamically in showToolbar() and hideToolbar() in the JavaScript, with a null guard since the button does not exist in the DOM
After the fix, screen readers announce:
- button expanded Alt+D Toggle Symfony Toolbar (when open)
- button collapsed Alt+D Toggle Symfony Toolbar (when closed)