### PR TITLE
[FrameworkBundle] Deprecate calling `FrameworkExtension::load()` directly without first loading `ServicesBundle`'s extension

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -60,6 +60,15 @@ FrameworkBundle
  * Deprecate setting `framework.http_client.default_options.caching.max_ttl` to `null`, use a positive integer instead
  * Deprecate `senders` nesting level for messenger routing config; use string or a list of strings instead
  * Deprecate registering console commands by overriding `Bundle::registerCommands()`, use the `#[AsCommand]` attribute or the `console.command` service tag instead
+ * Deprecate calling `FrameworkExtension::load()` directly without first loading `ServicesBundle`'s extension. Tests that wire up a `ContainerBuilder` by hand should now do:
+
+   ```diff
+   +new ServicesBundle()->getContainerExtension()->load([], $container);
+
+    new FrameworkExtension()->load($config, $container);
+   ```
+
+   For real kernels, `FrameworkBundle` carries a `#[RequiredBundle(ServicesBundle::class)]` attribute that should be processed already.
 
 HttpClient
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -27,6 +27,7 @@ CHANGELOG
  * Deprecate `senders` nesting level for messenger routing config; use string or a list of strings instead
  * Allow configuring Webhook's header names and signing algo
  * Deprecate registering console commands by overriding `Bundle::registerCommands()`, use the `#[AsCommand]` attribute or the `console.command` service tag instead
+ * Deprecate calling `FrameworkExtension::load()` directly without first loading `ServicesBundle`'s extension
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -53,6 +53,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -60,6 +61,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
@@ -235,6 +237,12 @@ class FrameworkExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
+        if (!$container instanceof MergeExtensionConfigurationContainerBuilder && !$container->hasDefinition('parameter_bag')) {
+            trigger_deprecation('symfony/framework-bundle', '8.1', 'Loading "%s" without first loading "%s" is deprecated; call "new %s()->getContainerExtension()->load([], $container);" before "%s::load()".', self::class, ServicesBundle::class, ServicesBundle::class, self::class);
+
+            new ServicesBundle()->getContainerExtension()->load([], $container);
+        }
+
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
 
         if (class_exists(InstalledVersions::class) && InstalledVersions::isInstalled('symfony/symfony') && 'symfony/symfony' !== (InstalledVersions::getRootPackage()['name'] ?? '')) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -130,7 +130,6 @@ class AddSessionDomainConstraintPassTest extends TestCase
         $container->setParameter('kernel.charset', 'UTF-8');
         $container->setParameter('kernel.container_class', 'cc');
         $container->setParameter('kernel.debug', true);
-        $container->setParameter('kernel.environment', 'test');
         $container->setParameter('kernel.project_dir', __DIR__);
         $container->setParameter('kernel.secret', __DIR__);
         if (null !== $sessionStorageOptions) {

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionTrait.php
@@ -30,7 +30,7 @@ trait ExtensionTrait
 {
     private function executeConfiguratorCallback(ContainerBuilder $container, \Closure $callback, ConfigurableExtensionInterface $subject, bool $prepend = false): void
     {
-        $env = $container->getParameter('kernel.environment');
+        $env = $container->hasParameter('kernel.environment') ? $container->getParameter('kernel.environment') : null;
         $loader = $this->createContainerLoader($container, $env, $prepend);
         $file = (new \ReflectionObject($subject))->getFileName();
         $bundleLoader = $loader->getResolver()->resolve($file);
@@ -48,7 +48,7 @@ trait ExtensionTrait
         }
     }
 
-    private function createContainerLoader(ContainerBuilder $container, string $env, bool $prepend): DelegatingLoader
+    private function createContainerLoader(ContainerBuilder $container, ?string $env, bool $prepend): DelegatingLoader
     {
         $locator = new FileLocator();
         $resolver = new LoaderResolver([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

This mostly affects tests that build a `ContainerBuilder` by hand, since real kernels register `ServicesBundle` via the `#[RequiredBundle]` attribute on `FrameworkBundle`