### PR TITLE
[Workflow] Fix HTML escaping in `GraphvizDumper` labels

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
@@ -154,7 +154,7 @@ class GraphvizDumper implements DumperInterface
             }
 
             if ($withMetadata) {
-                $escapedLabel = \sprintf('<<B>%s</B>%s>', $this->escape($placeName), $this->addMetadata($place['attributes']['metadata']));
+                $escapedLabel = \sprintf('<<B>%s</B>%s>', $this->escapeHtml($placeName), $this->addMetadata($place['attributes']['metadata']));
                 // Don't include metadata in default attributes used to format the place
                 unset($place['attributes']['metadata']);
             } else {
@@ -176,7 +176,7 @@ class GraphvizDumper implements DumperInterface
 
         foreach ($transitions as $i => $place) {
             if ($withMetadata) {
-                $escapedLabel = \sprintf('<<B>%s</B>%s>', $this->escape($place['name']), $this->addMetadata($place['metadata']));
+                $escapedLabel = \sprintf('<<B>%s</B>%s>', $this->escapeHtml($place['name']), $this->addMetadata($place['metadata']));
             } else {
                 $escapedLabel = '"'.$this->escape($place['name']).'"';
             }
@@ -284,6 +284,18 @@ class GraphvizDumper implements DumperInterface
     /**
      * @internal
      */
+    protected function escapeHtml(string|bool $value): string
+    {
+        if (\is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        return htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
+     * @internal
+     */
     protected function addAttributes(array $attributes): string
     {
         $code = [];
@@ -319,7 +331,7 @@ class GraphvizDumper implements DumperInterface
         }
 
         // currentLabel and metadata to handle
-        return \sprintf('<<B>%s</B>%s>', $this->escape($currentLabel), $this->addMetadata($workflowMetadata));
+        return \sprintf('<<B>%s</B>%s>', $this->escapeHtml($currentLabel), $this->addMetadata($workflowMetadata));
     }
 
     private function addOptions(array $options): string
@@ -344,10 +356,10 @@ class GraphvizDumper implements DumperInterface
 
         foreach ($metadata as $key => $value) {
             if ($skipSeparator) {
-                $code[] = \sprintf('%s: %s', $this->escape($key), $this->escape($value));
+                $code[] = \sprintf('%s: %s', $this->escapeHtml($key), $this->escapeHtml($value));
                 $skipSeparator = false;
             } else {
-                $code[] = \sprintf('%s%s: %s', '<BR/>', $this->escape($key), $this->escape($value));
+                $code[] = \sprintf('%s%s: %s', '<BR/>', $this->escapeHtml($key), $this->escapeHtml($value));
             }
         }
 

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\Workflow\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
 use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\Tests\WorkflowBuilderTrait;
+use Symfony\Component\Workflow\Transition;
 
 class GraphvizDumperTest extends TestCase
 {
@@ -289,6 +292,39 @@ class GraphvizDumperTest extends TestCase
   transition_356a192b7913b04c54574d18c28d46e6395428ab -> place_84a516841ba77a5b4648de2cd0dfcb30ea46dbb4 [style="solid"];
 }
 ';
+    }
+
+    public function testDumpEscapesSpecialCharactersInHtmlLabels()
+    {
+        $transitionWithSpecialChars = new Transition('t1', 'a', 'b');
+        $transitions = [$transitionWithSpecialChars];
+
+        $placesMetadata = [
+            'a' => [
+                'label' => 'A & B <tag>',
+                'description' => 'has "quotes" & <html>',
+            ],
+        ];
+
+        $transitionsMetadata = new \SplObjectStorage();
+        $transitionsMetadata[$transitionWithSpecialChars] = [
+            'label' => 'Run <script>alert(1)</script>',
+            'note' => 'a > b & c < d',
+        ];
+
+        $store = new InMemoryMetadataStore([], $placesMetadata, $transitionsMetadata);
+        $definition = new Definition(['a', 'b'], $transitions, null, $store);
+
+        $dump = (new GraphvizDumper())->dump($definition, null, ['with-metadata' => true, 'label' => 'Title with <b>bold</b> & "quotes"']);
+
+        $this->assertStringContainsString('<<B>A &amp; B &lt;tag&gt;</B>', $dump);
+        $this->assertStringContainsString('description: has &quot;quotes&quot; &amp; &lt;html&gt;', $dump);
+        $this->assertStringContainsString('<<B>Run &lt;script&gt;alert(1)&lt;/script&gt;</B>', $dump);
+        $this->assertStringContainsString('note: a &gt; b &amp; c &lt; d', $dump);
+        $this->assertStringContainsString('<<B>Title with &lt;b&gt;bold&lt;/b&gt; &amp; &quot;quotes&quot;</B>', $dump);
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $dump);
+        $this->assertStringNotContainsString('<tag>', $dump);
     }
 
     public static function provideSimpleWorkflowDumpWithoutMarkingWithMetadata(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A metadata with a special char such as `<`, `>` and `&` makes the whole thing invalid.