### PR TITLE
[Uid] Add `createBoundaries()` to `Ulid`, `UuidV6` and `UuidV7`

### DIFF
--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `TimeOrderedUidInterface`, implemented by `Ulid`, `UuidV6` and `UuidV7`
+ * Add `Ulid::createBoundaries()`, `UuidV6::createBoundaries()` and `UuidV7::createBoundaries()` returning the lowest and highest ids sharing a timestamp
+
 8.1
 ---
 

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Uid\Exception\InvalidArgumentException;
 use Symfony\Component\Uid\MaxUlid;
 use Symfony\Component\Uid\NilUlid;
 use Symfony\Component\Uid\Tests\Fixtures\CustomUlid;
+use Symfony\Component\Uid\TimeOrderedUidInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\UuidV4;
 
@@ -350,5 +351,47 @@ class UlidTest extends TestCase
     public function testToString()
     {
         $this->assertSame('01HK77WP8T7107EZH9CNAES202', (new Ulid('01HK77WP8T7107EZH9CNAES202'))->toString());
+    }
+
+    public function testCreateBoundaries()
+    {
+        $time = new \DateTimeImmutable('2026-04-13 09:30:00.123 UTC');
+        [$min, $max] = Ulid::createBoundaries($time);
+
+        $this->assertSame('01KP32TAHV0000000000000000', (string) $min);
+        $this->assertSame('01KP32TAHVZZZZZZZZZZZZZZZZ', (string) $max);
+        $this->assertSame($time->format('Uv'), $min->getDateTime()->format('Uv'));
+
+        $inside = new Ulid(Ulid::generate($time));
+        $this->assertLessThan(0, $min->compare($inside));
+        $this->assertGreaterThan(0, $max->compare($inside));
+    }
+
+    public function testCreateBoundariesWithoutTime()
+    {
+        [$min, $max] = Ulid::createBoundaries();
+
+        $this->assertSame(substr($min, 0, 10), substr($max, 0, 10));
+        $this->assertEqualsWithDelta(time(), $min->getDateTime()->getTimestamp(), 1);
+    }
+
+    public function testCreateBoundariesOnExtendedClassReturnsStatic()
+    {
+        [$min, $max] = CustomUlid::createBoundaries();
+
+        $this->assertInstanceOf(CustomUlid::class, $min);
+        $this->assertInstanceOf(CustomUlid::class, $max);
+    }
+
+    public function testCreateBoundariesLeavesTheGeneratorClockAlone()
+    {
+        Ulid::createBoundaries(new \DateTimeImmutable('@4102444800'));
+
+        $this->assertLessThan(new \DateTimeImmutable('+1 day'), new Ulid()->getDateTime());
+    }
+
+    public function testTimeOrderedUid()
+    {
+        $this->assertInstanceOf(TimeOrderedUidInterface::class, new Ulid());
     }
 }

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\Uid\Exception\InvalidArgumentException;
 use Symfony\Component\Uid\MaxUuid;
 use Symfony\Component\Uid\NilUuid;
 use Symfony\Component\Uid\Tests\Fixtures\CustomUuid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
+use Symfony\Component\Uid\TimeOrderedUidInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV1;
@@ -567,5 +569,50 @@ class UuidTest extends TestCase
         $uuid = UuidV7::fromString(UuidV7::generate(\DateTimeImmutable::createFromFormat('U.u', $time)));
 
         $this->assertSame($time, $uuid->getDateTime()->format('U.u'));
+    }
+
+    public function testUuidV7Boundaries()
+    {
+        // 0x017F22E279B0 is the RFC 9562 example timestamp for UUIDv7
+        $time = \DateTimeImmutable::createFromFormat('U.v', '1645557742.000');
+        [$min, $max] = UuidV7::createBoundaries($time);
+
+        $this->assertSame('017f22e2-79b0-7000-8000-000000000000', (string) $min);
+        $this->assertSame('017f22e2-79b0-7fff-bfff-ffffffffffff', (string) $max);
+
+        $inside = new UuidV7(UuidV7::generate($time));
+        $this->assertLessThan(0, $min->compare($inside));
+        $this->assertGreaterThan(0, $max->compare($inside));
+        $this->assertSame($time->format('Uv'), $min->getDateTime()->format('Uv'));
+    }
+
+    public function testUuidV6Boundaries()
+    {
+        $time = new \DateTimeImmutable('2026-04-13 09:30:00.123456 UTC');
+        [$min, $max] = UuidV6::createBoundaries($time);
+
+        $this->assertSame('1f1371b5-7c2f-6280-8000-000000000000', (string) $min);
+        $this->assertSame('1f1371b5-7c2f-6280-bfff-ffffffffffff', (string) $max);
+
+        $inside = new UuidV6(UuidV6::generate($time));
+        $this->assertLessThan(0, $min->compare($inside));
+        $this->assertGreaterThan(0, $max->compare($inside));
+        $this->assertSame($time->format('Uv'), $min->getDateTime()->format('Uv'));
+    }
+
+    public function testCreateBoundariesLeavesTheGeneratorClockAlone()
+    {
+        UuidV7::createBoundaries(new \DateTimeImmutable('@4102444800'));
+
+        $this->assertLessThan(new \DateTimeImmutable('+1 day'), new UuidV7()->getDateTime());
+    }
+
+    public function testTimeOrderedUids()
+    {
+        $this->assertInstanceOf(TimeOrderedUidInterface::class, new UuidV6());
+        $this->assertInstanceOf(TimeOrderedUidInterface::class, new UuidV7());
+
+        $this->assertInstanceOf(TimeBasedUidInterface::class, new UuidV1());
+        $this->assertNotInstanceOf(TimeOrderedUidInterface::class, new UuidV1());
     }
 }

--- a/src/Symfony/Component/Uid/TimeOrderedUidInterface.php
+++ b/src/Symfony/Component/Uid/TimeOrderedUidInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+/**
+ * Interface to describe UIDs that sort in the order of their timestamp.
+ *
+ * Comparing two such UIDs as bytes, as strings or as a database uid column
+ * gives the same order as comparing the dates they carry.
+ */
+interface TimeOrderedUidInterface extends TimeBasedUidInterface
+{
+    /**
+     * Returns the lowest and highest UIDs sharing the timestamp, for range comparisons.
+     *
+     * Every UID created for the given time sorts between the two bounds:
+     *
+     *     [$min, $max] = Ulid::createBoundaries($time);
+     *     // WHERE ulid BETWEEN :min AND :max
+     *
+     * The bounds cover the resolution the UID stores: one millisecond for
+     * ULID and UUIDv7, one clock tick of 100 nanoseconds for UUIDv6.
+     *
+     * @return array{static, static}
+     */
+    public static function createBoundaries(?\DateTimeInterface $time = null): array;
+}

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -20,7 +20,7 @@ use Symfony\Component\Uid\Exception\InvalidArgumentException;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class Ulid extends AbstractUid implements TimeBasedUidInterface
+class Ulid extends AbstractUid implements TimeOrderedUidInterface
 {
     public const FORMAT_BINARY = 1;
     public const FORMAT_BASE_32 = 1 << 1;
@@ -31,6 +31,9 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
 
     protected const NIL = '00000000000000000000000000';
     protected const MAX = '7ZZZZZZZZZZZZZZZZZZZZZZZZZ';
+
+    private const RANDOM_MIN = '0000000000000000';
+    private const RANDOM_MAX = 'ZZZZZZZZZZZZZZZZ';
 
     private static string $time = '';
     private static array $rand = [];
@@ -184,6 +187,30 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
         return \DateTimeImmutable::createFromFormat('U.u', substr_replace($time, '.', -3, 0));
     }
 
+    /**
+     * Returns the lowest and highest ULIDs sharing the timestamp, for range comparisons.
+     *
+     * Every ULID created during the given millisecond sorts between the two bounds:
+     *
+     *     [$min, $max] = Ulid::createBoundaries($time);
+     *     // WHERE ulid BETWEEN :min AND :max
+     *
+     * @return array{static, static}
+     */
+    public static function createBoundaries(?\DateTimeInterface $time = null): array
+    {
+        if (null === $time) {
+            $time = microtime(false);
+            $time = substr($time, 11).substr($time, 2, 3);
+        } elseif (0 > $time = $time->format('Uv')) {
+            throw new InvalidArgumentException('The timestamp must be positive.');
+        }
+
+        $time = self::timestampToBase32($time);
+
+        return [static::fromString($time.self::RANDOM_MIN), static::fromString($time.self::RANDOM_MAX)];
+    }
+
     public static function generate(?\DateTimeInterface $time = null): string
     {
         if (null === $mtime = $time) {
@@ -222,19 +249,7 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
             $time = self::$time;
         }
 
-        if (\PHP_INT_SIZE >= 8) {
-            $time = base_convert($time, 10, 32);
-        } else {
-            $time = str_pad(bin2hex(BinaryUtil::fromBase($time, BinaryUtil::BASE10)), 12, '0', \STR_PAD_LEFT);
-            $time = \sprintf('%s%04s%04s',
-                base_convert(substr($time, 0, 2), 16, 32),
-                base_convert(substr($time, 2, 5), 16, 32),
-                base_convert(substr($time, 7, 5), 16, 32)
-            );
-        }
-
-        return strtr(\sprintf('%010s%04s%04s%04s%04s',
-            $time,
+        return self::timestampToBase32($time).strtr(\sprintf('%04s%04s%04s%04s',
             base_convert(self::$rand[1], 10, 32),
             base_convert(self::$rand[2], 10, 32),
             base_convert(self::$rand[3], 10, 32),
@@ -268,6 +283,25 @@ class Ulid extends AbstractUid implements TimeBasedUidInterface
         }
 
         return $ulid;
+    }
+
+    /**
+     * @param string $time A timestamp in milliseconds since the Unix epoch
+     */
+    private static function timestampToBase32(string $time): string
+    {
+        if (\PHP_INT_SIZE >= 8) {
+            $time = base_convert($time, 10, 32);
+        } else {
+            $time = str_pad(bin2hex(BinaryUtil::fromBase($time, BinaryUtil::BASE10)), 12, '0', \STR_PAD_LEFT);
+            $time = \sprintf('%s%04s%04s',
+                base_convert(substr($time, 0, 2), 16, 32),
+                base_convert(substr($time, 2, 5), 16, 32),
+                base_convert(substr($time, 7, 5), 16, 32)
+            );
+        }
+
+        return strtr(\sprintf('%010s', $time), 'abcdefghijklmnopqrstuv', 'ABCDEFGHJKMNPQRSTVWXYZ');
     }
 
     private static function binaryToBase32(string $ulid): string

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -20,7 +20,7 @@ use Symfony\Component\Uid\Exception\InvalidArgumentException;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class UuidV6 extends Uuid implements TimeBasedUidInterface
+class UuidV6 extends Uuid implements TimeOrderedUidInterface
 {
     protected const TYPE = 6;
 
@@ -70,6 +70,24 @@ class UuidV6 extends Uuid implements TimeBasedUidInterface
             substr($uuid, -12, 6),
             $time
         ), '-', 8, 0));
+    }
+
+    /**
+     * Returns the lowest and highest UUIDs sharing the timestamp, for range comparisons.
+     *
+     * Every UUIDv6 created for the given clock tick of 100 nanoseconds sorts between the two bounds:
+     *
+     *     [$min, $max] = UuidV6::createBoundaries($time);
+     *     // WHERE uuid BETWEEN :min AND :max
+     *
+     * @return array{static, static}
+     */
+    public static function createBoundaries(?\DateTimeInterface $time = null): array
+    {
+        $time = BinaryUtil::dateTimeToHex($time ?? new \DateTimeImmutable());
+        $time = substr($time, 1, 8).'-'.substr($time, 9, 4).'-6'.substr($time, 13, 3);
+
+        return [static::fromString($time.'-8000-000000000000'), static::fromString($time.'-bfff-ffffffffffff')];
     }
 
     public static function generate(?\DateTimeInterface $time = null, ?Uuid $node = null): string

--- a/src/Symfony/Component/Uid/UuidV7.php
+++ b/src/Symfony/Component/Uid/UuidV7.php
@@ -22,7 +22,7 @@ use Symfony\Component\Uid\Exception\InvalidArgumentException;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class UuidV7 extends Uuid implements TimeBasedUidInterface
+class UuidV7 extends Uuid implements TimeOrderedUidInterface
 {
     protected const TYPE = 7;
 
@@ -53,6 +53,31 @@ class UuidV7 extends Uuid implements TimeBasedUidInterface
         $time .= substr(1000 + (hexdec(substr($this->uid, 14, 4)) >> 2 & 0x3FF), -3);
 
         return \DateTimeImmutable::createFromFormat('U.u', substr_replace($time, '.', -6, 0));
+    }
+
+    /**
+     * Returns the lowest and highest UUIDs sharing the millisecond, for range comparisons.
+     *
+     * Every UUIDv7 created during the given millisecond sorts between the two bounds:
+     *
+     *     [$min, $max] = UuidV7::createBoundaries($time);
+     *     // WHERE uuid BETWEEN :min AND :max
+     *
+     * @return array{static, static}
+     */
+    public static function createBoundaries(?\DateTimeInterface $time = null): array
+    {
+        if (null === $time) {
+            $time = microtime(false);
+            $time = substr($time, 11).substr($time, 2, 3);
+        } elseif (0 > $time = $time->format('Uv')) {
+            throw new InvalidArgumentException('The timestamp must be positive.');
+        }
+
+        $time = \PHP_INT_SIZE >= 8 ? \sprintf('%012x', $time) : str_pad(bin2hex(BinaryUtil::fromBase($time, BinaryUtil::BASE10)), 12, '0', \STR_PAD_LEFT);
+        $time = substr_replace($time, '-', 8, 0);
+
+        return [static::fromString($time.'-7000-8000-000000000000'), static::fromString($time.'-7fff-bfff-ffffffffffff')];
     }
 
     public static function generate(?\DateTimeInterface $time = null): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Filtering rows by a timestamp needs the lowest and highest ids of that moment, so that a range query can include every id created then:

```php
[$min, $max] = Ulid::createBoundaries($time);
// WHERE ulid BETWEEN :min AND :max
```

The method is on the three id types whose byte order follows their timestamp:

```php
[$min, $max] = Ulid::createBoundaries($time);    // 01KP32TAHV0000000000000000, 01KP32TAHVZZZZZZZZZZZZZZZZ
[$min, $max] = UuidV7::createBoundaries($time);  // 017f22e2-79b0-7000-8000-000000000000, 017f22e2-79b0-7fff-bfff-ffffffffffff
[$min, $max] = UuidV6::createBoundaries($time);  // 1f1371b5-7c2f-6280-8000-000000000000, 1f1371b5-7c2f-6280-bfff-ffffffffffff
```

Called without a time, they use now.

Both bounds are computed from the timestamp alone. They draw no entropy, and they leave alone the state that `Ulid::generate()` and `UuidV7::generate()` keep to stay monotonic, so asking for the bounds of a future date does not move the timestamp of the ids created next.

The bounds cover the resolution each type stores: one millisecond for ULID and UUIDv7, one clock tick of 100 nanoseconds for UUIDv6. They hold for byte-wise comparison, which is what a database `uuid` or `BINARY(16)` column does.

The new `TimeOrderedUidInterface` extends `TimeBasedUidInterface`, describes the ids that sort in the order of their timestamp, and declares the method. `Ulid`, `UuidV6` and `UuidV7` implement it. `UuidV1` does not: it carries a date but does not store it in byte order, so `BETWEEN` bounds on it would not correspond to a time range.

Documentation should cover: the new interface and which ids implement it, the three methods, the range-query use case, the resolution each type bounds, and why v1 is excluded.
