### PR TITLE
[WebProfilerBundle] Ignore Chrome DevTools automatic workspace folders probes in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
  * Add error indicator to profiler list view for profiles with errors
  * Add cURL copy paste button in the Request/Response tab
  * Add support for streamed responses in the debug toolbar
+ * Disable the profiler for Chrome DevTools `automatic workspace folders` probes
+   (`/.well-known/appspecific/com.chrome.devtools.json`) to avoid polluting the
+   profile list
 
 8.0
 ---

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebProfilerChromeDevToolsListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebProfilerChromeDevToolsListener.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+/**
+ * Disables the profiler on Chrome DevTools "automatic workspace folders" probes
+ * to prevent polluting the profile list with 404 entries.
+ *
+ * @see https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
+ *
+ * @author Michael Thieulin <michael.thieulin@gmail.com>
+ *
+ * @internal
+ */
+final class WebProfilerChromeDevToolsListener implements EventSubscriberInterface
+{
+    private const DEVTOOLS_PROBE_PATH = '/.well-known/appspecific/com.chrome.devtools.json';
+
+    public function __construct(
+        private readonly ?Profiler $profiler = null,
+    ) {
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if (self::DEVTOOLS_PROBE_PATH !== $event->getRequest()->getPathInfo()) {
+            return;
+        }
+
+        $this->profiler?->disable();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        // priority higher than RouterListener (32), which throws NotFoundHttpException
+        // on unknown paths and prevents later request listeners from running
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 35],
+        ];
+    }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController;
 use Symfony\Bundle\WebProfilerBundle\Controller\RouterController;
 use Symfony\Bundle\WebProfilerBundle\Csp\ContentSecurityPolicyHandler;
 use Symfony\Bundle\WebProfilerBundle\Csp\NonceGenerator;
+use Symfony\Bundle\WebProfilerBundle\EventListener\WebProfilerChromeDevToolsListener;
 use Symfony\Bundle\WebProfilerBundle\Profiler\CodeExtension;
 use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
@@ -84,5 +85,9 @@ return static function (ContainerConfigurator $container) {
         ->set('twig.extension.code', CodeExtension::class)
             ->args([service('debug.file_link_formatter'), param('kernel.project_dir'), param('kernel.charset')])
             ->tag('twig.extension')
+
+        ->set('web_profiler.chrome_devtools_listener', WebProfilerChromeDevToolsListener::class)
+            ->args([service('profiler')->nullOnInvalid()])
+            ->tag('kernel.event_subscriber')
     ;
 };

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebProfilerChromeDevToolsListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebProfilerChromeDevToolsListenerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\EventListener;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\WebProfilerBundle\EventListener\WebProfilerChromeDevToolsListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+class WebProfilerChromeDevToolsListenerTest extends TestCase
+{
+    public function testDisablesProfilerOnDevToolsPath()
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->once())->method('disable');
+
+        $listener = new WebProfilerChromeDevToolsListener($profiler);
+        $listener->onKernelRequest($this->createEvent('/.well-known/appspecific/com.chrome.devtools.json'));
+    }
+
+    public function testDisablesProfilerWithQueryString()
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->once())->method('disable');
+
+        $listener = new WebProfilerChromeDevToolsListener($profiler);
+        $listener->onKernelRequest($this->createEvent('/.well-known/appspecific/com.chrome.devtools.json?foo=bar'));
+    }
+
+    #[DataProvider('provideNonMatchingPaths')]
+    public function testDoesNothingOnOtherPaths(string $path)
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->never())->method('disable');
+
+        $listener = new WebProfilerChromeDevToolsListener($profiler);
+        $listener->onKernelRequest($this->createEvent($path));
+    }
+
+    public static function provideNonMatchingPaths(): iterable
+    {
+        yield 'unrelated path' => ['/foo'];
+        yield 'sibling well-known' => ['/.well-known/appspecific/other.json'];
+        yield 'trailing slash' => ['/.well-known/appspecific/com.chrome.devtools.json/'];
+        yield 'suffix extension' => ['/.well-known/appspecific/com.chrome.devtools.json.bak'];
+        yield 'percent-encoded dot' => ['/.well-known/appspecific/com.chrome.devtools%2Ejson'];
+    }
+
+    public function testIgnoresSubRequests()
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->never())->method('disable');
+
+        $listener = new WebProfilerChromeDevToolsListener($profiler);
+        $listener->onKernelRequest($this->createEvent('/.well-known/appspecific/com.chrome.devtools.json', HttpKernelInterface::SUB_REQUEST));
+    }
+
+    public function testWorksWithoutProfiler()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $listener = new WebProfilerChromeDevToolsListener(null);
+        $listener->onKernelRequest($this->createEvent('/.well-known/appspecific/com.chrome.devtools.json'));
+        $listener->onKernelRequest($this->createEvent('/foo'));
+    }
+
+    private function createEvent(string $pathWithQuery, int $type = HttpKernelInterface::MAIN_REQUEST): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createStub(KernelInterface::class),
+            Request::create($pathWithQuery),
+            $type,
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63795
| License       | MIT

Chrome DevTools emits automatic probes to `/.well-known/appspecific/com.chrome.devtools.json`
(the ["automatic workspace folders"](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md)
feature). These requests produce 404s that pollute the profiler list during development.

This PR adds a small `kernel.request` subscriber in `WebProfilerBundle` that disables
the profiler when the incoming path matches the DevTools probe. The priority (35) is
higher than `RouterListener` (32), so the profiler is disabled before routing throws
`NotFoundHttpException` and short-circuits later request listeners. The HTTP response
itself is untouched — Symfony still returns its normal 404.

Possible follow-ups (out of scope here):
- serve a minimal/workspace JSON to silence Chrome's Network panel too
- introduce a generic `framework.profiler.exclude_paths` if more well-known probes emerge