### PR TITLE
[WebProfilerBundle] Improve toolbar accessibility for screen reader

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -355,12 +355,14 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     overflow: hidden;
     text-overflow: ellipsis;
 }
-.sf-toolbar-block:hover .sf-toolbar-icon {
+.sf-toolbar-block:hover .sf-toolbar-icon,
+.sf-toolbar-block:focus-within .sf-toolbar-icon {
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     box-shadow: 1px 0 0 var(--sf-toolbar-black), inset 0 -1px 0 var(--sf-toolbar-black);
 }
-.sf-toolbar-block.sf-toolbar-block-right:hover .sf-toolbar-icon {
+.sf-toolbar-block.sf-toolbar-block-right:hover .sf-toolbar-icon,
+.sf-toolbar-block.sf-toolbar-block-right:focus-within .sf-toolbar-icon {
     box-shadow: -1px 0 0 var(--sf-toolbar-black), inset 0 -1px 0 var(--sf-toolbar-black);
 }
 
@@ -383,10 +385,12 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
 }
 
 .sf-toolbar-block:hover,
+.sf-toolbar-block:focus-within,
 .sf-toolbar-block.hover {
     position: relative;
 }
 .sf-toolbar-block:hover .sf-toolbar-icon,
+.sf-toolbar-block:focus-within .sf-toolbar-icon,
 .sf-toolbar-block.hover .sf-toolbar-icon {
     background-color: var(--sf-toolbar-gray-700);
     position: relative;
@@ -396,6 +400,7 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
     z-index: 10001;
 }
 .sf-toolbar-block:hover .sf-toolbar-info,
+.sf-toolbar-block:focus-within .sf-toolbar-info,
 .sf-toolbar-block.hover .sf-toolbar-info {
     display: block;
     padding: 10px;
@@ -554,7 +559,8 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
         margin-left: 0;
     }
 
-    .sf-toolbar-block-request:hover .sf-toolbar-info {
+    .sf-toolbar-block-request:hover .sf-toolbar-info,
+    .sf-toolbar-block-request:focus-within .sf-toolbar-info {
         max-width: none;
     }
 
@@ -621,6 +627,18 @@ div.sf-toolbar  .sf-toolbar-block .sf-toolbar-info-piece.sf-toolbar-info-php-ext
 .sf-full-stack {
     left: 0px;
     font-size: 12px;
+}
+
+.sf-toolbarreset .visually-hidden {
+    border: 0 !important;
+    clip: rect(0, 0, 0, 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+    white-space: nowrap !important;
 }
 
 /***** Media query print: Do not print the Toolbar. *****/

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,6 +1,13 @@
-<div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }} {{ additional_classes|default('') }}" {{ block_attrs|default('')|raw }}>
-    {% if link is not defined or link %}<a href="{{ url('_profiler', {token: token, panel: name}) }}">{% endif %}
-        <div class="sf-toolbar-icon">{{ icon|default('') }}</div>
+{% if accessible_label is not defined %}
+    {% set collector_name = (collector is defined and collector) ? collector.name : name %}
+    {% set collector_name_parts = collector_name|split('.') %}
+    {% set accessible_label = collector_name_parts|length > 1
+        ? (collector_name_parts|first|replace({_: ' '})|title ~ ' ' ~ collector_name_parts|last|replace({_: ' '})|title)
+        : collector_name_parts|first|replace({_: ' '})|title %}
+{% endif %}
+<div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }} {{ additional_classes|default('') }}" data-accessible-label="{{ accessible_label }}" {{ block_attrs|default('')|raw }}>
+    {% if link is not defined or link %}<a href="{{ url('_profiler', {token: token, panel: name}) }}" aria-controls="sf-toolbar-info-{{ name }}-{{ token }}" aria-haspopup="dialog" aria-keyshortcuts="ArrowDown">{% endif %}
+        <div class="sf-toolbar-icon"{% if link is defined and not link %} aria-controls="sf-toolbar-info-{{ name }}-{{ token }}" aria-haspopup="dialog" aria-keyshortcuts="ArrowDown"{% endif %}>{{ icon|default('') }}</div>
     {% if link|default(false) %}</a>{% endif %}
-        <div class="sf-toolbar-info">{{ text|default('') }}</div>
+        <div class="sf-toolbar-info" id="sf-toolbar-info-{{ name }}-{{ token }}" role="dialog" aria-roledescription="details" aria-label="{{ accessible_label }}" tabindex="-1">{{ text|default('') }}</div>
 </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,5 +1,5 @@
 <!-- START of Symfony Web Debug Toolbar -->
-<div class="sf-toolbar sf-toolbar-opened" role="region" aria-label="Symfony Web Debug Toolbar" data-frankenphp-hot-reload-preserve>
+<div class="sf-toolbar sf-toolbar-opened" role="toolbar" aria-label="Symfony Web Debug Toolbar" data-frankenphp-hot-reload-preserve>
     <div id="sfwdt{{ token }}">
         {{ include('@WebProfiler/Profiler/toolbar.html.twig', {
             templates: {
@@ -596,29 +596,165 @@
 
                                 /* Handle toolbar-info position */
                                 var toolbarBlocks = [].slice.call(el.querySelectorAll('.sf-toolbar-block'));
+                                var positionToolbarInfo = function () {
+                                    var toolbarInfo = this.querySelectorAll('.sf-toolbar-info')[0];
+                                    var pageWidth = document.body.clientWidth;
+                                    var elementWidth = toolbarInfo.offsetWidth;
+                                    var leftValue = (elementWidth + this.offsetLeft) - pageWidth;
+                                    var rightValue = (elementWidth + (pageWidth - this.offsetLeft)) - pageWidth;
+
+                                    /* Reset right and left value, useful on window resize */
+                                    toolbarInfo.style.right = '';
+                                    toolbarInfo.style.left = '';
+
+                                    if (elementWidth > pageWidth) {
+                                        toolbarInfo.style.left = 0;
+                                    } else if (leftValue > 0 && rightValue > 0) {
+                                        toolbarInfo.style.right = (rightValue * -1) + 'px';
+                                    } else if (leftValue < 0) {
+                                        toolbarInfo.style.left = 0;
+                                    } else {
+                                        toolbarInfo.style.right = '0px';
+                                    }
+                                };
                                 for (i = 0; i < toolbarBlocks.length; ++i) {
+                                    addEventListener(toolbarBlocks[i], 'focusin', positionToolbarInfo);
                                     toolbarBlocks[i].onmouseover = function () {
-                                        var toolbarInfo = this.querySelectorAll('.sf-toolbar-info')[0];
-                                        var pageWidth = document.body.clientWidth;
-                                        var elementWidth = toolbarInfo.offsetWidth;
-                                        var leftValue = (elementWidth + this.offsetLeft) - pageWidth;
-                                        var rightValue = (elementWidth + (pageWidth - this.offsetLeft)) - pageWidth;
-
-                                        /* Reset right and left value, useful on window resize */
-                                        toolbarInfo.style.right = '';
-                                        toolbarInfo.style.left = '';
-
-                                        if (elementWidth > pageWidth) {
-                                            toolbarInfo.style.left = 0;
+                                        /* Transfer focus away from any other toolbar block so that */
+                                        /* :focus-within and :hover are never active simultaneously */
+                                        var focused = document.activeElement;
+                                        if (focused && !this.contains(focused) && focused.closest) {
+                                            var focusedBlock = focused.closest('.sf-toolbar-block');
+                                            if (focusedBlock) {
+                                                focused.blur();
+                                            }
                                         }
-                                        else if (leftValue > 0 && rightValue > 0) {
-                                            toolbarInfo.style.right = (rightValue * -1) + 'px';
-                                        } else if (leftValue < 0) {
-                                            toolbarInfo.style.left = 0;
-                                        } else {
-                                            toolbarInfo.style.right = '0px';
-                                        }
+                                        positionToolbarInfo.call(this);
                                     };
+                                }
+
+                                /* Roving tabindex for WAI-ARIA toolbar pattern */
+                                var triggers = [];
+                                for (i = 0; i < toolbarBlocks.length; ++i) {
+                                    var icon = toolbarBlocks[i].querySelector('.sf-toolbar-icon');
+                                    var trigger = (icon && icon.parentElement.tagName === 'A') ? icon.parentElement : icon;
+                                    if (trigger) {
+                                        trigger.setAttribute('tabindex', triggers.length === 0 ? '0' : '-1');
+                                        triggers.push(trigger);
+                                    }
+
+                                    /* Inject accessible label when no visible SVG <title> provides one */
+                                    var label = toolbarBlocks[i].getAttribute('data-accessible-label');
+                                    if (label) {
+                                        var svg = toolbarBlocks[i].querySelector('.sf-toolbar-icon svg');
+                                        var hasVisibleTitle = svg && svg.querySelector('title') && window.getComputedStyle(svg).display !== 'none' && svg.getAttribute('aria-hidden') !== 'true';
+                                        if (!hasVisibleTitle) {
+                                            var span = document.createElement('span');
+                                            span.className = 'visually-hidden';
+                                            span.textContent = label;
+                                            var parent = trigger || toolbarBlocks[i];
+                                            parent.insertBefore(span, parent.firstChild);
+                                        }
+                                    }
+                                }
+                                var hideButton = document.getElementById('sfToolbarHideButton-' + newToken);
+                                if (hideButton) {
+                                    hideButton.setAttribute('tabindex', triggers.length === 0 ? '0' : '-1');
+                                    triggers.push(hideButton);
+                                }
+
+                                var isTriggerVisible = function(trigger) {
+                                    var block = trigger.closest('.sf-toolbar-block');
+                                    return block && window.getComputedStyle(block).display !== 'none';
+                                };
+
+                                var findVisibleIndex = function(fromIndex, direction) {
+                                    var len = triggers.length;
+                                    for (var step = 1; step < len; step++) {
+                                        var candidate = (fromIndex + direction * step + len) % len;
+                                        if (isTriggerVisible(triggers[candidate])) {
+                                            return candidate;
+                                        }
+                                    }
+                                    return fromIndex;
+                                };
+
+                                var findFirstVisible = function() {
+                                    for (var t = 0; t < triggers.length; t++) {
+                                        if (isTriggerVisible(triggers[t])) return t;
+                                    }
+                                    return 0;
+                                };
+
+                                var findLastVisible = function() {
+                                    for (var t = triggers.length - 1; t >= 0; t--) {
+                                        if (isTriggerVisible(triggers[t])) return t;
+                                    }
+                                    return triggers.length - 1;
+                                };
+
+                                var setRovingFocus = function(newIndex) {
+                                    for (var t = 0; t < triggers.length; t++) {
+                                        triggers[t].setAttribute('tabindex', t === newIndex ? '0' : '-1');
+                                    }
+                                    triggers[newIndex].focus();
+                                };
+
+                                for (i = 0; i < triggers.length; ++i) {
+                                    (function(index) {
+                                        addEventListener(triggers[index], 'keydown', function(event) {
+                                            var handled = true;
+                                            switch (event.key) {
+                                                case 'ArrowRight':
+                                                    setRovingFocus(findVisibleIndex(index, 1));
+                                                    break;
+                                                case 'ArrowLeft':
+                                                    setRovingFocus(findVisibleIndex(index, -1));
+                                                    break;
+                                                case 'Home':
+                                                    setRovingFocus(findFirstVisible());
+                                                    break;
+                                                case 'End':
+                                                    setRovingFocus(findLastVisible());
+                                                    break;
+                                                case 'ArrowDown':
+                                                    var block = triggers[index].closest('.sf-toolbar-block');
+                                                    if (block) {
+                                                        var info = block.querySelector('.sf-toolbar-info');
+                                                        if (info) {
+                                                            info.focus();
+                                                        }
+                                                    }
+                                                    break;
+                                                default:
+                                                    handled = false;
+                                            }
+                                            if (handled) {
+                                                event.preventDefault();
+                                            }
+                                        });
+                                    })(i);
+                                }
+
+                                /* Escape from popover returns focus to trigger */
+                                var infoElements = el.querySelectorAll('.sf-toolbar-info[tabindex]');
+                                for (i = 0; i < infoElements.length; ++i) {
+                                    (function(infoEl) {
+                                        addEventListener(infoEl, 'keydown', function(event) {
+                                            if (event.key === 'Escape') {
+                                                var block = infoEl.closest('.sf-toolbar-block');
+                                                if (block) {
+                                                    removeClass(block, 'hover');
+                                                    var blockIcon = block.querySelector('.sf-toolbar-icon');
+                                                    var trigger = (blockIcon && blockIcon.parentElement.tagName === 'A') ? blockIcon.parentElement : blockIcon;
+                                                    if (trigger) {
+                                                        trigger.focus();
+                                                    }
+                                                }
+                                                event.preventDefault();
+                                            }
+                                        });
+                                    })(infoElements[i]);
                                 }
 
                                 renderAjaxRequests();


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

The Web Debug Toolbar panels are currently only displayed on mouse hover, which makes the toolbar difficult to use with a keyboard and with screen readers.

This PR improves the toolbar accessibility by adding keyboard navigation and accessible labels to toolbar items, while keeping the current mouse behavior unchanged.

In practice, the toolbar can now be entered with the keyboard, items can be navigated with arrow keys, and their details can be exposed on focus as well as on hover.

The implementation also adds the necessary ARIA semantics so assistive technologies can better identify the toolbar, its items, and their associated details panels.

Tested with NVDA, JAWS, and Narrator.