### PR TITLE
[Form][TwigBridge] Render the name attribute of the <form> element through attr

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add the `normalize` filter to normalize values with the Serializer component
  * Add the `impersonation_form()` and `impersonation_exit_form()` functions to build a form that switches the user with a POST
  * Render an `id` attribute on the `<form>` element when a child uses `form_attr`, so that the reference resolves
+ * Render the `name` attribute of the `<form>` element through `attr`, so that `attr: {name: false}` disables it and `attr: {name: '...'}` overrides it
  * Render `<optgroup>` labels from `ChoiceGroupView::$label`, which allows translatable choice group labels
  * Deprecate the `render_hinclude()` Twig function; use `render_esi()` or `render()`, or Symfony UX Turbo, instead
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -414,7 +414,7 @@
     {%- else -%}
         {% set form_method = 'POST' %}
     {%- endif -%}
-    <form{% if name != '' %} name="{{ name }}"{% endif %} method="{{ form_method|lower }}"{% if action != '' %} action="{{ action }}"{% endif %}{{ block('attributes') }}{% if multipart %} enctype="multipart/form-data"{% endif %}>
+    <form{% if name != '' and attr.name is not defined %} name="{{ name }}"{% endif %} method="{{ form_method|lower }}"{% if action != '' %} action="{{ action }}"{% endif %}{{ block('attributes') }}{% if multipart %} enctype="multipart/form-data"{% endif %}>
     {%- if form_method != method -%}
         <input type="hidden" name="_method" value="{{ method }}" />
     {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -2571,6 +2571,41 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         $this->assertSame('<form name="form" method="get" action="http://example.com/directory" class="foobar">', $html);
     }
 
+    public function testStartTagRendersTheFormNameByDefault()
+    {
+        $form = $this->factory->createNamedBuilder('my_form', 'Symfony\Component\Form\Extension\Core\Type\FormType')
+            ->getForm();
+
+        $html = $this->renderStart($form->createView());
+
+        $this->assertStringContainsString(' name="my_form"', $html);
+    }
+
+    public function testStartTagWithNameDisabledFromAttr()
+    {
+        $form = $this->factory->createNamedBuilder('my_form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
+            'attr' => ['name' => false],
+        ])
+            ->getForm();
+
+        $html = $this->renderStart($form->createView());
+
+        $this->assertStringNotContainsString(' name="', $html);
+    }
+
+    public function testStartTagWithNameOverriddenFromAttr()
+    {
+        $form = $this->factory->createNamedBuilder('my_form', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
+            'attr' => ['name' => 'custom'],
+        ])
+            ->getForm();
+
+        $html = $this->renderStart($form->createView());
+
+        $this->assertStringContainsString(' name="custom"', $html);
+        $this->assertStringNotContainsString('my_form', $html);
+    }
+
     public function testWidgetAttributes()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #63617
| License       | MIT
| Doc PR        | -

Follow-up to #48013.

The `name` attribute on `<form>` is an archaism from HTML4: everything it does is covered by `id` (element references such as `form="..."`, CSS selectors, `document.forms[...]` — see #63617), and since #48013 the `<form>` element renders an id whenever something references it. Yet `name` is the last attribute of the form tag an application cannot control: it is hardcoded in `form_start`, always rendered, and setting `attr: {name: '...'}` even renders the attribute twice.

This PR renders `name` through `attr`, exactly like #48013 does for the id:

```twig
{%- if name != '' and attr.name is not defined -%}
    {%- set attr = attr|merge({name: name}) -%}
{%- endif -%}
```

* By default nothing changes: the form name is still rendered.
* `attr: {name: false}` removes the attribute, as for any attribute.
* `attr: {name: 'other'}` overrides it — and no longer renders it twice.

The only visible difference by default is the position of the attribute inside the tag, since it now goes through the `attributes` block:

```html
<!-- Before -->
<form name="my_form" method="post">
<!-- After -->
<form method="post" name="my_form">
```

The PR is now TwigBridge-only: no new option, no Form component change. All themes inherit `form_start` from `form_div_layout`, so they all gain the behavior; a custom theme overriding `form_start` keeps its current markup.

Whether the name should stop being rendered by default in 9.0 — now that references resolve through the id — remains open for discussion in #63617; this PR only makes the attribute controllable, with no BC impact.
