### PR TITLE
[Validator] Make constraint validators reentrant instead of being stateful

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -133,6 +133,20 @@ Uid
 
  * Add argument `$format` to `Ulid::isValid()`
 
+Validator
+---------
+
+* Deprecate `ConstraintValidatorInterface::initialize()` and `ConstraintValidatorInterface::validate()` in
+  favor of `ConstraintValidatorInterface::validateInContext()`. The `ConstraintValidator` abstract class
+  handles the context management when extending it. When writing tests with `ConstraintValidatorTestCase`,
+  use the new `validate` method to abstract the way to use the constraint validator.
+
+  | Your code                                          | Action required
+  |----------------------------------------------------| ---------------
+  | extends `ConstraintValidator`                      | Nothing to do
+  | implements `ConstraintValidatorInterface` directly | Implement `validateInContext()`
+  | tests using `ConstraintValidatorTestCase`          | Call `$this->validate()` instead of `$this->validator->validate()`
+
 VarExporter
 -----------
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -48,6 +48,7 @@ use Symfony\Bridge\Doctrine\Tests\TestRepositoryFactory;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
@@ -132,18 +133,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity1 = new SingleIntIdEntity(1, 'Foo');
         $entity2 = new SingleIntIdEntity(2, 'Foo');
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validate($entity2, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
@@ -176,7 +177,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         // this will load a proxy object
         $entity = $this->em->getReference(SingleIntIdWithPrivateNameEntity::class, 1);
 
-        $this->validator->validate($entity, new UniqueEntity(
+        $this->validate($entity, new UniqueEntity(
             fields: ['name'],
             em: self::EM_NAME,
         ));
@@ -192,7 +193,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity2, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', errorPath: 'bar'));
+        $this->validate($entity2, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', errorPath: 'bar'));
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.bar')
@@ -212,7 +213,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity2);
         $this->em->flush();
 
-        $this->validator->validate($entity1, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo'));
+        $this->validate($entity1, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo'));
 
         $this->assertNoViolation();
     }
@@ -224,18 +225,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity1 = new DoubleNameEntity(1, 'Foo', null);
         $entity2 = new DoubleNameEntity(2, 'Foo', null);
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validate($entity2, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
@@ -257,7 +258,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity1 = new SingleIntIdEntity(1, null);
 
         $this->expectException(ConstraintDefinitionException::class);
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
     }
 
     #[DataProvider('provideConstraintsWithIgnoreNullEnabled')]
@@ -267,18 +268,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity1 = new DoubleNullableNameEntity(1, null, 'Foo');
         $entity2 = new DoubleNullableNameEntity(2, null, 'Foo');
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validate($entity2, $constraint);
 
         $this->assertNoViolation();
     }
@@ -305,18 +306,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity1 = new DoubleNameEntity(1, 'Foo', 'Bar');
         $entity2 = new DoubleNameEntity(2, 'Foo', 'Bar');
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validate($entity2, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name2')
@@ -331,11 +332,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
     {
         $this->em->getRepository(SingleIntIdEntity::class)->result = [];
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
         $entity1 = new SingleIntIdEntity(1, 'foo');
 
-        $this->validator->validate($entity1, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', repositoryMethod: 'findByCustom'));
+        $this->validate($entity1, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', repositoryMethod: 'findByCustom'));
 
         $this->assertNoViolation();
     }
@@ -351,9 +351,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->em->getRepository(SingleIntIdEntity::class)->result = $returnValue;
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
-        $this->validator->validate($entity, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', repositoryMethod: 'findByCustom'));
+        $this->validate($entity, new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo', repositoryMethod: 'findByCustom'));
 
         $this->assertNoViolation();
     }
@@ -370,9 +369,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->em->getRepository(SingleIntIdEntity::class)->result = $result;
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
     }
@@ -406,14 +404,14 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($associated);
         $this->em->flush();
 
-        $this->validator->validate($associated, $constraint);
+        $this->validate($associated, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($associated2);
         $this->em->flush();
 
-        $this->validator->validate($associated2, $constraint);
+        $this->validate($associated2, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.single')
@@ -442,14 +440,14 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($associated);
         $this->em->flush();
 
-        $this->validator->validate($associated, $constraint);
+        $this->validate($associated, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($associated2);
         $this->em->flush();
 
-        $this->validator->validate($associated2, $constraint);
+        $this->validate($associated2, $constraint);
 
         $expectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
 
@@ -477,7 +475,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($associated);
         $this->em->flush();
 
-        $this->validator->validate($associated, $constraint);
+        $this->validate($associated, $constraint);
 
         $this->assertNoViolation();
     }
@@ -489,7 +487,6 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->method('getManagerForClass')
             ->willReturn($this->em);
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
         $entity = new SingleIntIdEntity(1, 'foo');
         $associated = new AssociationEntity();
@@ -502,7 +499,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $dto = new AssociatedEntityDto();
         $dto->singleId = 1;
 
-        $this->validator->validate($dto, new UniqueEntity(
+        $this->validate($dto, new UniqueEntity(
             fields: ['singleId' => 'single'],
             entityClass: AssociationEntity::class,
         ));
@@ -538,7 +535,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity2);
         $this->em->flush();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validate($entity2, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.phoneNumbers')
@@ -560,14 +557,13 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em = null;
         $this->registry = $this->createRegistryMock($this->em);
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
         $entity = new SingleIntIdEntity(1, null);
 
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('Object manager "foo" does not exist.');
 
-        $this->validator->validate($entity, $constraint);
+        $this->validate($entity, $constraint);
     }
 
     public function testEntityManagerNullObject()
@@ -579,20 +575,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         );
 
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
         $entity = new SingleIntIdEntity(1, null);
 
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity"');
 
-        $this->validator->validate($entity, $constraint);
+        $this->validate($entity, $constraint);
     }
 
     public function testValidateUniquenessOnNullResult()
     {
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
         $constraint = new UniqueEntity(
             message: 'myMessage',
@@ -605,7 +599,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity);
         $this->em->flush();
 
-        $this->validator->validate($entity, $constraint);
+        $this->validate($entity, $constraint);
         $this->assertNoViolation();
     }
 
@@ -621,18 +615,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity1 = new Person(1, 'Foo');
         $entity2 = new Employee(2, 'Foo');
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validate($entity2, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
@@ -657,7 +651,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('The "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity" entity repository does not support the "Symfony\Bridge\Doctrine\Tests\Fixtures\Person" entity. The entity should be an instance of or extend "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity".');
 
-        $this->validator->validate($entity, $constraint);
+        $this->validate($entity, $constraint);
     }
 
     public function testValidateUniquenessWithCompositeObjectNoToStringIdEntity()
@@ -682,7 +676,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $newEntity = new CompositeObjectNoToStringIdEntity($objectOne, $objectTwo);
 
-        $this->validator->validate($newEntity, $constraint);
+        $this->validate($newEntity, $constraint);
 
         $expectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
 
@@ -710,7 +704,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $newEntity = new SingleIntIdStringWrapperNameEntity(2, new StringWrapper('foo'));
 
-        $this->validator->validate($newEntity, $constraint);
+        $this->validate($newEntity, $constraint);
 
         $expectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapper")';
 
@@ -737,18 +731,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity1 = new SingleIntIdEntity(1, 'Foo');
         $entity2 = new SingleIntIdEntity(2, 'Foo');
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($entity1);
         $this->em->flush();
 
-        $this->validator->validate($entity1, $constraint);
+        $this->validate($entity1, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($entity2, $constraint);
+        $this->validate($entity2, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
@@ -771,9 +765,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->em->getRepository(SingleIntIdEntity::class)->result = $result;
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
-        $this->validator->validate($entity, $constraint);
+        $this->validate($entity, $constraint);
 
         $this->assertNoViolation();
     }
@@ -788,7 +781,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectException(UnexpectedValueException::class);
 
-        $this->validator->validate('foo', $constraint);
+        $this->validate('foo', $constraint);
     }
 
     public function testValueCanBeNull()
@@ -799,7 +792,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             em: self::EM_NAME,
         );
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->assertNoViolation();
     }
@@ -872,18 +865,18 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $entity = new Person(1, 'Foo');
         $dto = new HireAnEmployee('Foo');
 
-        $this->validator->validate($entity, $constraint);
+        $this->validate($entity, $constraint);
 
         $this->assertNoViolation();
 
         $this->em->persist($entity);
         $this->em->flush();
 
-        $this->validator->validate($entity, $constraint);
+        $this->validate($entity, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
@@ -909,7 +902,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity);
         $this->em->flush();
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
@@ -932,7 +925,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         );
 
         $dto = new HireAnEmployee('Foo');
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
     }
 
     public function testInvalidateEntityFieldName()
@@ -947,7 +940,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         );
 
         $dto = new HireAnEmployee('Foo');
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
     }
 
     public function testValidateDTOUniquenessWhenUpdatingEntity()
@@ -969,7 +962,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $dto = new UpdateEmployeeProfile(2, 'Foo');
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
@@ -997,7 +990,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $dto = new UpdateCompositeIntIdEntity(1, 2, 'Foo');
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
 
         $this->assertNoViolation();
     }
@@ -1026,7 +1019,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $dto = new UpdateCompositeObjectNoToStringIdEntity($objectOne, $objectTwo, 'Foo');
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
 
         $this->assertNoViolation();
     }
@@ -1056,7 +1049,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->flush();
 
         $dto = new UpdateCompositeObjectNoToStringIdEntity($objectOne, $objectTwo, 'Foo');
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
     }
 
     public function testUninitializedValueThrowException()
@@ -1075,7 +1068,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em->persist($entity);
         $this->em->flush();
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
     }
 
     public function testEntityManagerNullObjectWhenDTO()
@@ -1092,11 +1085,10 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->em = null;
         $this->registry = $this->createRegistryMock($this->em);
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
         $dto = new HireAnEmployee('Foo');
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
     }
 
     public function testUuidIdentifierWithSameValueDifferentInstanceDoesNotCauseViolation()
@@ -1115,8 +1107,19 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             em: self::EM_NAME,
         );
 
-        $this->validator->validate($dto, $constraint);
+        $this->validate($dto, $constraint);
 
         $this->assertNoViolation();
+    }
+
+    // TODO remove this in Symfony 9.0 (or earlier, when dropping support for symfony/validator < 8.1)
+    protected function validate(mixed $value, Constraint $constraint): void
+    {
+        if (method_exists(parent::class, 'validate')) {
+            parent::validate($value, $constraint);
+        } else {
+            $this->validator->initialize($this->context);
+            $this->validator->validate($value, $constraint);
+        }
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Validator/Constraints/TwigValidatorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Validator/Constraints/TwigValidatorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Bridge\Twig\Validator\Constraints\Twig;
 use Symfony\Bridge\Twig\Validator\Constraints\TwigValidator;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Twig\DeprecatedCallableInfo;
 use Twig\Environment;
@@ -40,7 +41,7 @@ class TwigValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidValues')]
     public function testTwigIsValid($value)
     {
-        $this->validator->validate($value, new Twig());
+        $this->validate($value, new Twig());
 
         $this->assertNoViolation();
     }
@@ -50,7 +51,7 @@ class TwigValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Twig('myMessageTest');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessageTest')
             ->setParameter('{{ error }}', $message)
@@ -67,7 +68,7 @@ class TwigValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Twig(skipDeprecations: true);
 
-        $this->validator->validate('{{ name|deprecated_filter }}', $constraint);
+        $this->validate('{{ name|deprecated_filter }}', $constraint);
 
         $this->assertNoViolation();
     }
@@ -76,7 +77,7 @@ class TwigValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Twig(skipDeprecations: false);
 
-        $this->validator->validate('{{ name|deprecated_filter }}', $constraint);
+        $this->validate('{{ name|deprecated_filter }}', $constraint);
 
         $this->buildViolation($constraint->message)
             ->setParameter('{{ error }}', 'Since foo/bar 1.1: Twig Filter "deprecated_filter" is deprecated.')
@@ -109,5 +110,15 @@ class TwigValidatorTest extends ConstraintValidatorTestCase
             // Invalid variable syntax
             ['Hello {{ .name }}', 'Unexpected token "operator" of value "." at line 1.', 1],
         ];
+    }
+
+    // TODO remove this in Symfony 9.0 (or earlier, when dropping support for symfony/validator < 8.1)
+    protected function validate(mixed $value, Constraint $constraint): void
+    {
+        if (method_exists(parent::class, 'validate')) {
+            parent::validate($value, $constraint);
+        } else {
+            $this->validator->validate($value, $constraint);
+        }
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -29,6 +29,9 @@ class FormValidator extends ConstraintValidator
      */
     private \SplObjectStorage $resolvedGroups;
 
+    /**
+     * @psalm-suppress ParamNameMismatch
+     */
     public function validate(mixed $form, Constraint $formConstraint): void
     {
         if (!$formConstraint instanceof Form) {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\SubmitButtonBuilder;
 use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -62,7 +63,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['group1', 'group2']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -88,7 +89,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->expectValidateValueAt(1, 'data', $object, [$constraint1], 'group1');
         $this->expectValidateValueAt(2, 'data', $object, [$constraint2, $constraint3], 'group2');
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -111,7 +112,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['group1', 'group2']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -135,7 +136,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertTrue($form->isSynchronized());
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -148,7 +149,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['Default']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -174,7 +175,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->expectValidateValueAt(0, 'data', $object, [$constraint1], 'group1');
         $this->expectValidateValueAt(1, 'data', $object, [$constraint2], 'group2');
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -198,7 +199,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertTrue($form->isSynchronized());
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -222,7 +223,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertTrue($form->isSynchronized());
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -246,7 +247,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertTrue($form->isSynchronized());
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -276,7 +277,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertFalse($form->isSynchronized());
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
@@ -313,7 +314,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertFalse($form->isSynchronized());
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
@@ -346,7 +347,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->buildViolation('invalid_message_key')
             ->setParameter('{{ value }}', 'foo')
@@ -382,7 +383,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->buildViolation('safe message to be used')
             ->setParameters([
@@ -407,7 +408,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->expectValidateAt(0, 'data', $object, 'group1');
         $this->expectValidateAt(1, 'data', $object, 'group2');
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -421,7 +422,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['group1', 'group2']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -435,7 +436,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['header']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -449,7 +450,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['group1', 'group2']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -476,7 +477,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['button_group']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -503,7 +504,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['form_group']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -524,7 +525,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['group']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -545,7 +546,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['group1', 'group2']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -568,7 +569,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['group1', 'group2']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -581,7 +582,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateAt(0, 'data', $object, ['Default']);
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -597,7 +598,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $this->assertTrue($form->isSynchronized());
         $this->expectNoValidate();
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->assertNoViolation();
     }
@@ -617,7 +618,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, 'children[child]', $form->get('child'), new Form());
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->buildViolation('Extra!|Extras!')
             ->setParameter('{{ extra_fields }}', '"foo"')
@@ -642,7 +643,7 @@ class FormValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, 'children[child]', $form->get('child'), new Form());
 
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
         $this->buildViolation('Extra!|Extras!!')
             ->setParameter('{{ extra_fields }}', '"foo", "baz", "quux"')
@@ -661,14 +662,13 @@ class FormValidatorTest extends ConstraintValidatorTestCase
             ->add($this->getBuilder('child'))
             ->getForm();
 
-        $context = new ExecutionContext(Validation::createValidator(), $form, new IdentityTranslator());
+        $this->context = new ExecutionContext(Validation::createValidator(), $form, new IdentityTranslator());
 
         $form->submit(['foo' => 'bar']);
 
-        $this->validator->initialize($context);
-        $this->validator->validate($form, new Form());
+        $this->validate($form, new Form());
 
-        $this->assertCount(0, $context->getViolations());
+        $this->assertCount(0, $this->context->getViolations());
     }
 
     /**
@@ -692,14 +692,13 @@ class FormValidatorTest extends ConstraintValidatorTestCase
             'extra_data' => 'foo',
         ]);
 
-        $context = new ExecutionContext(Validation::createValidator(), $form, new IdentityTranslator());
+        $this->context = new ExecutionContext(Validation::createValidator(), $form, new IdentityTranslator());
         $constraint = new Form();
 
-        $this->validator->initialize($context);
-        $this->validator->validate($form, $constraint);
+        $this->validate($form, $constraint);
 
-        $this->assertCount(1, $context->getViolations());
-        $this->assertSame($constraint, $context->getViolations()->get(0)->getConstraint());
+        $this->assertCount(1, $this->context->getViolations());
+        $this->assertSame($constraint, $this->context->getViolations()->get(0)->getConstraint());
     }
 
     protected function createValidator(): FormValidator
@@ -736,5 +735,16 @@ class FormValidatorTest extends ConstraintValidatorTestCase
         $builder = new SubmitButtonBuilder($name, $options);
 
         return $builder->getForm();
+    }
+
+    // TODO remove this in Symfony 9.0 (or earlier, when dropping support for symfony/validator < 8.1)
+    protected function validate(mixed $value, Constraint $constraint): void
+    {
+        if (method_exists(parent::class, 'validate')) {
+            parent::validate($value, $constraint);
+        } else {
+            $this->validator->initialize($this->context);
+            $this->validator->validate($value, $constraint);
+        }
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTestCase.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTestCase.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
@@ -57,7 +58,7 @@ abstract class UserPasswordValidatorTestCase extends ConstraintValidatorTestCase
             ->with(static::PASSWORD, 'secret', static::SALT)
             ->willReturn(true);
 
-        $this->validator->validate('secret', $constraint);
+        $this->validate('secret', $constraint);
 
         $this->assertNoViolation();
     }
@@ -70,7 +71,7 @@ abstract class UserPasswordValidatorTestCase extends ConstraintValidatorTestCase
             ->with(static::PASSWORD, 'secret', static::SALT)
             ->willReturn(false);
 
-        $this->validator->validate('secret', $constraint);
+        $this->validate('secret', $constraint);
 
         $this->buildViolation('myMessage')
             ->setCode(UserPassword::INVALID_PASSWORD_ERROR)
@@ -91,7 +92,7 @@ abstract class UserPasswordValidatorTestCase extends ConstraintValidatorTestCase
             'message' => 'myMessage',
         ]);
 
-        $this->validator->validate($password, $constraint);
+        $this->validate($password, $constraint);
 
         $this->buildViolation('myMessage')
             ->setCode(UserPassword::INVALID_PASSWORD_ERROR)
@@ -112,11 +113,10 @@ abstract class UserPasswordValidatorTestCase extends ConstraintValidatorTestCase
 
         $this->tokenStorage = $this->createTokenStorage($user);
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
 
         $this->expectException(ConstraintDefinitionException::class);
 
-        $this->validator->validate('secret', new UserPassword());
+        $this->validate('secret', new UserPassword());
     }
 
     protected function createUser()
@@ -175,5 +175,16 @@ abstract class UserPasswordValidatorTestCase extends ConstraintValidatorTestCase
         ;
 
         return $mock;
+    }
+
+    // TODO remove this in Symfony 9.0 (or earlier, when dropping support for symfony/validator < 8.1)
+    protected function validate(mixed $value, Constraint $constraint): void
+    {
+        if (method_exists(parent::class, 'validate')) {
+            parent::validate($value, $constraint);
+        } else {
+            $this->validator->initialize($this->context);
+            $this->validator->validate($value, $constraint);
+        }
     }
 }

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -28,6 +28,9 @@ class UserPasswordValidator extends ConstraintValidator
     ) {
     }
 
+    /**
+     * @psalm-suppress ParamNameMismatch
+     */
     public function validate(mixed $password, Constraint $constraint): void
     {
         if (!$constraint instanceof UserPassword) {

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -6,6 +6,11 @@ CHANGELOG
 
  * Add clock-awareness to comparison and range validators for testable date comparisons
  * Add the `Xml` constraint for validating XML content
+ * Add `ConstraintValidatorTestCase::validate()` to encapsulate the way to call the constraint validator
+ * Deprecate `ConstraintValidatorInterface::initialize()` and `ConstraintValidatorInterface::validate()` in
+   favor of `ConstraintValidatorInterface::validateInContext()`. The `ConstraintValidator` abstract class
+   handles the context management when extending it. When writing tests with `ConstraintValidatorTestCase`,
+   use the new `validate()` method to abstract the way to use the constraint validator.
 
 8.0
 ---

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -31,10 +31,39 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      */
     public const OBJECT_TO_STRING = 2;
 
+    /**
+     * @var array<class-string<self, bool>
+     */
+    private static array $initializeOverrideCache = [];
+
     protected ExecutionContextInterface $context;
+
+    public function validateInContext(mixed $value, Constraint $constraint, ExecutionContextInterface $context): void
+    {
+        $oldContext = $this->context ?? null;
+
+        try {
+            $this->context = $context;
+            if (self::overridesInitialize(static::class)) {
+                trigger_deprecation('symfony/validator', '8.1', \sprintf('Overriding "%s::initialize()" in "%s" is deprecated. Put the additional logic in the "validate()" method instead.', self::class, static::class));
+                $this->initialize($context);
+            }
+            $this->validate($value, $constraint);
+        } finally {
+            if (null !== $oldContext) {
+                $this->context = $oldContext;
+            } else {
+                unset($this->context);
+            }
+        }
+    }
+
+    // TODO make this method protected in Symfony 9.0
+    abstract public function validate(mixed $value, Constraint $constraint): void;
 
     public function initialize(ExecutionContextInterface $context): void
     {
+        trigger_deprecation('symfony/validator', '8.1', 'The "ConstraintValidator::initialize()" method is deprecated. Use the "validateInContext()" method instead of the "initialize()" and "validate()" ones.');
         $this->context = $context;
     }
 
@@ -147,5 +176,19 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
         }
 
         return implode(', ', $values);
+    }
+
+    /**
+     * @param class-string<self> $class
+     */
+    private static function overridesInitialize(string $class): bool
+    {
+        if (isset(self::$initializeOverrideCache[$class])) {
+            return self::$initializeOverrideCache[$class];
+        }
+
+        $ref = new \ReflectionMethod($class, 'initialize');
+
+        return self::$initializeOverrideCache[$class] = self::class !== $ref->class;
     }
 }

--- a/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
@@ -15,16 +15,22 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method void validateInContext(mixed $value, Constraint $constraint, ExecutionContextInterface $context)
  */
 interface ConstraintValidatorInterface
 {
     /**
      * Initializes the constraint validator.
+     *
+     * @deprecated since Symfony 8.1, use "validateInContext()" instead
      */
     public function initialize(ExecutionContextInterface $context): void;
 
     /**
      * Checks if the passed value is valid.
+     *
+     * @deprecated since Symfony 8.1, use "validateInContext()" instead
      */
     public function validate(mixed $value, Constraint $constraint): void;
 }

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -23,6 +23,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class CallbackValidator extends ConstraintValidator
 {
+    /**
+     * @psalm-suppress ParamNameMismatch
+     */
     public function validate(mixed $object, Constraint $constraint): void
     {
         if (!$constraint instanceof Callback) {

--- a/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionSyntaxValidator.php
@@ -29,6 +29,9 @@ class ExpressionSyntaxValidator extends ConstraintValidator
     ) {
     }
 
+    /**
+     * @psalm-suppress ParamNameMismatch
+     */
     public function validate(mixed $expression, Constraint $constraint): void
     {
         if (!$constraint instanceof ExpressionSyntax) {

--- a/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
+++ b/src/Symfony/Component/Validator/Test/CompoundConstraintTestCase.php
@@ -69,9 +69,8 @@ abstract class CompoundConstraintTestCase extends TestCase
 
         $validator = new CompoundValidator();
         $context = $this->createContext();
-        $validator->initialize($context);
 
-        $validator->validate($this->validatedValue, new class($constraints) extends Compound {
+        $validator->validateInContext($this->validatedValue, new class($constraints) extends Compound {
             public function __construct(private array $testedConstraints)
             {
                 parent::__construct();
@@ -81,7 +80,7 @@ abstract class CompoundConstraintTestCase extends TestCase
             {
                 return $this->testedConstraints;
             }
-        });
+        }, $context);
 
         $expectedViolations = iterator_to_array($context->getViolations());
 

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -80,7 +81,15 @@ abstract class ConstraintValidatorTestCase extends TestCase
 
         $this->context = $this->createContext();
         $this->validator = $this->createValidator();
-        $this->validator->initialize($this->context);
+
+        // TODO remove this in Symfony 9.0
+        if (!$this->validator instanceof ConstraintValidator && !method_exists($this->validator, 'validateInContext')) {
+            $this->validator->initialize($this->context);
+        } elseif ($this->validator instanceof ConstraintValidator) {
+            // Keep usages of $this->validator->validate() in tests working for BC for tests not using $this->validate() yet
+            // TODO figure out whether we could make such usages trigger a deprecation
+            (new \ReflectionProperty(ConstraintValidator::class, 'context'))->setValue($this->validator, $this->context);
+        }
 
         if (class_exists(\Locale::class)) {
             $this->defaultLocale = \Locale::getDefault();
@@ -117,6 +126,17 @@ abstract class ConstraintValidatorTestCase extends TestCase
         if (null !== $this->defaultTimezone) {
             date_default_timezone_set($this->defaultTimezone);
             $this->defaultTimezone = null;
+        }
+    }
+
+    protected function validate(mixed $value, Constraint $constraint): void
+    {
+        // TODO remove this in Symfony 9.0
+        if (!$this->validator instanceof ConstraintValidator && !method_exists($this->validator, 'validateInContext')) {
+            $this->validator->initialize($this->context);
+            $this->validator->validate($value, $constraint);
+        } else {
+            $this->validator->validateInContext($value, $constraint, $this->context);
         }
     }
 
@@ -216,7 +236,10 @@ abstract class ConstraintValidatorTestCase extends TestCase
     {
         $this->root = $root;
         $this->context = $this->createContext();
-        $this->validator->initialize($this->context);
+        // TODO remove this in Symfony 9.0
+        if (!$this->validator instanceof ConstraintValidator && !method_exists($this->validator, 'validateInContext')) {
+            $this->validator->initialize($this->context);
+        }
     }
 
     protected function setPropertyPath(string $propertyPath)
@@ -280,8 +303,14 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $validatorClassname = $constraint->validatedBy();
 
         $validator = new $validatorClassname();
-        $validator->initialize($context);
-        $validator->validate($value, $constraint);
+
+        // TODO remove this in Symfony 9.0
+        if ($validator instanceof ConstraintValidator || method_exists($this->validator, 'validateInContext')) {
+            $validator->validateInContext($value, $constraint, $context);
+        } else {
+            $validator->initialize($context);
+            $validator->validate($value, $constraint);
+        }
 
         $this->expectedViolations[] = $context->getViolations();
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -103,7 +103,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
 
         $this->setObject($object);
 
-        $this->validator->validate($comparedValue, $constraint);
+        $this->validate($comparedValue, $constraint);
 
         $this->assertNoViolation();
     }
@@ -114,7 +114,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
 
         $this->setObject(null);
 
-        $this->validator->validate('some data', $constraint);
+        $this->validate('some data', $constraint);
 
         $this->assertNoViolation();
     }
@@ -130,7 +130,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
 
         $this->setObject($object);
 
-        $this->validator->validate(5, $constraint);
+        $this->validate(5, $constraint);
     }
 
     abstract public static function provideValidComparisons(): array;

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -28,7 +28,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new All(new Range(min: 4)));
+        $this->validate(null, new All(new Range(min: 4)));
 
         $this->assertNoViolation();
     }
@@ -36,7 +36,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
     public function testThrowsExceptionIfNotTraversable()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate('foo.barbar', new All(new Range(min: 4)));
+        $this->validate('foo.barbar', new All(new Range(min: 4)));
     }
 
     #[DataProvider('getValidArguments')]
@@ -50,7 +50,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
             $this->expectValidateValueAt($i++, '['.$key.']', $value, [$constraint]);
         }
 
-        $this->validator->validate($array, new All($constraint));
+        $this->validate($array, new All($constraint));
 
         $this->assertNoViolation();
     }
@@ -69,7 +69,7 @@ class AllValidatorTest extends ConstraintValidatorTestCase
             $this->expectValidateValueAt($i++, '['.$key.']', $value, [$constraint1, $constraint2]);
         }
 
-        $this->validator->validate($array, new All($constraints));
+        $this->validate($array, new All($constraints));
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -31,14 +31,14 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Bic());
+        $this->validate(null, new Bic());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Bic());
+        $this->validate('', new Bic());
 
         $this->assertNoViolation();
     }
@@ -51,7 +51,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject($object);
 
-        $this->validator->validate('SOGEFRPP', $constraint);
+        $this->validate('SOGEFRPP', $constraint);
 
         $this->assertNoViolation();
     }
@@ -65,7 +65,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject($object);
 
-        $this->validator->validate('UNCRIT2B912', $constraint);
+        $this->validate('UNCRIT2B912', $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', '"UNCRIT2B912"')
@@ -83,7 +83,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject(new BicDummy());
 
-        $this->validator->validate('UNCRIT2B912', $constraint);
+        $this->validate('UNCRIT2B912', $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', '"UNCRIT2B912"')
@@ -96,7 +96,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new BicTypedDummy());
 
-        $this->validator->validate('UNCRIT2B912', new Bic(ibanPropertyPath: 'iban'));
+        $this->validate('UNCRIT2B912', new Bic(ibanPropertyPath: 'iban'));
 
         $this->assertNoViolation();
     }
@@ -106,7 +106,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Bic(iban: 'FR14 2004 1010 0505 0001 3M02 606');
         $constraint->ibanMessage = 'Constraint Message';
 
-        $this->validator->validate('SOGEFRPP', $constraint);
+        $this->validate('SOGEFRPP', $constraint);
 
         $this->assertNoViolation();
     }
@@ -116,7 +116,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Bic(iban: 'FR14 2004 1010 0505 0001 3M02 606');
         $constraint->ibanMessage = 'Constraint Message';
 
-        $this->validator->validate('UNCRIT2B912', $constraint);
+        $this->validate('UNCRIT2B912', $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', '"UNCRIT2B912"')
@@ -132,7 +132,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
         [$constraint] = $classMetadata->getPropertyMetadata('bic1')[0]->getConstraints();
 
-        $this->validator->validate('UNCRIT2B912', $constraint);
+        $this->validate('UNCRIT2B912', $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', '"UNCRIT2B912"')
@@ -147,7 +147,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject(null);
 
-        $this->validator->validate('UNCRIT2B912', $constraint);
+        $this->validate('UNCRIT2B912', $constraint);
 
         $this->assertNoViolation();
     }
@@ -181,19 +181,19 @@ class BicValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject($object);
 
-        $this->validator->validate('UNCRIT2B912', $constraint);
+        $this->validate('UNCRIT2B912', $constraint);
     }
 
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Bic());
+        $this->validate(new \stdClass(), new Bic());
     }
 
     #[DataProvider('getValidBics')]
     public function testValidBics($bic)
     {
-        $this->validator->validate($bic, new Bic());
+        $this->validate($bic, new Bic());
 
         $this->assertNoViolation();
     }
@@ -218,7 +218,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($bic, $constraint);
+        $this->validate($bic, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$bic.'"')
@@ -231,7 +231,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Bic(message: 'myMessage');
 
-        $this->validator->validate($bic, $constraint);
+        $this->validate($bic, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$bic.'"')
@@ -272,7 +272,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     public function testValidBicSpecialCases(string $bic, string $iban)
     {
         $constraint = new Bic(iban: $iban);
-        $this->validator->validate($bic, $constraint);
+        $this->validate($bic, $constraint);
 
         $this->assertNoViolation();
     }
@@ -310,7 +310,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidBicsWithNormalizerToUpper')]
     public function testValidBicsWithNormalizerToUpper($bic)
     {
-        $this->validator->validate($bic, new Bic(mode: Bic::VALIDATION_MODE_CASE_INSENSITIVE));
+        $this->validate($bic, new Bic(mode: Bic::VALIDATION_MODE_CASE_INSENSITIVE));
 
         $this->assertNoViolation();
     }
@@ -329,10 +329,10 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     public function testFailOnInvalidMode()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->validator->validate('ASPKAT2LXXX', new Bic(mode: 'invalid'));
+        $this->validate('ASPKAT2LXXX', new Bic(mode: 'invalid'));
 
         $this->expectException(InvalidArgumentException::class);
-        $this->validator->validate('ASPKAT2LXXX', new Bic(options: ['mode' => 'invalid']));
+        $this->validate('ASPKAT2LXXX', new Bic(options: ['mode' => 'invalid']));
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -25,14 +25,14 @@ class BlankValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Blank());
+        $this->validate(null, new Blank());
 
         $this->assertNoViolation();
     }
 
     public function testBlankIsValid()
     {
-        $this->validator->validate('', new Blank());
+        $this->validate('', new Blank());
 
         $this->assertNoViolation();
     }
@@ -44,7 +44,7 @@ class BlankValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $valueAsString)

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -53,7 +53,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Callback());
+        $this->validate(null, new Callback());
 
         $this->assertNoViolation();
     }
@@ -63,7 +63,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $object = new CallbackValidatorTest_Object();
         $constraint = new Callback('validate');
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('My message')
             ->setParameter('{{ value }}', 'foobar')
@@ -75,7 +75,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $object = new CallbackValidatorTest_Object();
         $constraint = new Callback(callback: 'validate');
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('My message')
             ->setParameter('{{ value }}', 'foobar')
@@ -87,7 +87,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $object = new CallbackValidatorTest_Object();
         $constraint = new Callback('validateStatic');
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('Static message')
             ->setParameter('{{ value }}', 'baz')
@@ -103,7 +103,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
             return false;
         });
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('My message')
             ->setParameter('{{ value }}', 'foobar')
@@ -118,7 +118,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
             return false;
         });
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->buildViolation('My message')
             ->setParameter('{{ value }}', 'foobar')
@@ -134,7 +134,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
             return false;
         });
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('My message')
             ->setParameter('{{ value }}', 'foobar')
@@ -146,7 +146,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $object = new CallbackValidatorTest_Object();
         $constraint = new Callback([__CLASS__.'_Class', 'validateCallback']);
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('Callback message')
             ->setParameter('{{ value }}', 'foobar')
@@ -157,7 +157,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Callback([__CLASS__.'_Class', 'validateCallback']);
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->buildViolation('Callback message')
             ->setParameter('{{ value }}', 'foobar')
@@ -169,7 +169,7 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $object = new CallbackValidatorTest_Object();
         $constraint = new Callback(callback: [__CLASS__.'_Class', 'validateCallback']);
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('Callback message')
             ->setParameter('{{ value }}', 'foobar')
@@ -218,17 +218,17 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
             callback: $callback,
             payload: 'Hello world!',
         );
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
         $this->assertEquals('Hello world!', $payloadCopy);
 
         $payloadCopy = 'Replace me!';
         $constraint = new Callback(callback: $callback, payload: 'Hello world!');
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
         $this->assertEquals('Hello world!', $payloadCopy);
 
         $payloadCopy = 'Replace me!';
         $constraint = new Callback(callback: $callback);
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
         $this->assertNull($payloadCopy);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -25,14 +25,14 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new CardScheme(schemes: []));
+        $this->validate(null, new CardScheme(schemes: []));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new CardScheme(schemes: []));
+        $this->validate('', new CardScheme(schemes: []));
 
         $this->assertNoViolation();
     }
@@ -40,7 +40,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidNumbers')]
     public function testValidNumbers($scheme, $number)
     {
-        $this->validator->validate($number, new CardScheme(schemes: $scheme));
+        $this->validate($number, new CardScheme(schemes: $scheme));
 
         $this->assertNoViolation();
     }
@@ -48,7 +48,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidNumbers')]
     public function testValidNumbersWithNewLine($scheme, $number)
     {
-        $this->validator->validate($number."\n", new CardScheme(schemes: $scheme, message: 'myMessage'));
+        $this->validate($number."\n", new CardScheme(schemes: $scheme, message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$number."\n\"")
@@ -58,7 +58,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidNumberWithOrderedArguments()
     {
-        $this->validator->validate(
+        $this->validate(
             '5555555555554444',
             new CardScheme([CardScheme::MASTERCARD, CardScheme::VISA])
         );
@@ -74,7 +74,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($number, $constraint);
+        $this->validate($number, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', \is_string($number) ? '"'.$number.'"' : $number)
@@ -84,7 +84,7 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidNumberNamedArguments()
     {
-        $this->validator->validate(
+        $this->validate(
             '2721001234567890',
             eval('use Symfony\Component\Validator\Constraints\CardScheme; return new CardScheme(schemes: [CardScheme::MASTERCARD, CardScheme::VISA], message: "myMessage");')
         );

--- a/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CharsetValidatorTest.php
@@ -28,7 +28,7 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideValidValues')]
     public function testEncodingIsValid(string|\Stringable $value, array|string $encodings)
     {
-        $this->validator->validate($value, new Charset(encodings: $encodings));
+        $this->validate($value, new Charset(encodings: $encodings));
 
         $this->assertNoViolation();
     }
@@ -36,7 +36,7 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideInvalidValues')]
     public function testInvalidValues(string $value, array|string $encodings)
     {
-        $this->validator->validate($value, new Charset(encodings: $encodings));
+        $this->validate($value, new Charset(encodings: $encodings));
 
         $this->buildViolation('The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.')
             ->setParameter('{{ detected }}', 'UTF-8')
@@ -51,7 +51,7 @@ class CharsetValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessageMatches('/Expected argument of type "string", ".*" given/');
 
-        $this->validator->validate($value, new Charset(encodings: ['UTF-8']));
+        $this->validate($value, new Charset(encodings: ['UTF-8']));
     }
 
     public static function provideValidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -53,12 +53,12 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             multiple: true,
         );
 
-        $this->validator->validate('asdf', $constraint);
+        $this->validate('asdf', $constraint);
     }
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Choice(choices: ['foo', 'bar']));
+        $this->validate(null, new Choice(choices: ['foo', 'bar']));
 
         $this->assertNoViolation();
     }
@@ -66,18 +66,18 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
     public function testChoicesOrCallbackExpected()
     {
         $this->expectException(ConstraintDefinitionException::class);
-        $this->validator->validate('foobar', new Choice());
+        $this->validate('foobar', new Choice());
     }
 
     public function testValidCallbackExpected()
     {
         $this->expectException(ConstraintDefinitionException::class);
-        $this->validator->validate('foobar', new Choice(callback: 'abcd'));
+        $this->validate('foobar', new Choice(callback: 'abcd'));
     }
 
     public function testValidChoiceArray()
     {
-        $this->validator->validate('bar', new Choice(choices: ['foo', 'bar']));
+        $this->validate('bar', new Choice(choices: ['foo', 'bar']));
 
         $this->assertNoViolation();
     }
@@ -85,7 +85,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideConstraintsWithCallbackFunction')]
     public function testValidChoiceCallbackFunction(Choice $constraint)
     {
-        $this->validator->validate('bar', $constraint);
+        $this->validate('bar', $constraint);
 
         $this->assertNoViolation();
     }
@@ -104,7 +104,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
         $constraint = new Choice(callback: 'staticCallback');
 
-        $this->validator->validate('bar', $constraint);
+        $this->validate('bar', $constraint);
 
         $this->assertNoViolation();
     }
@@ -119,7 +119,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
         $constraint = new Choice(callback: 'staticCallbackInvalid');
 
-        $this->validator->validate('bar', $constraint);
+        $this->validate('bar', $constraint);
     }
 
     public function testValidChoiceCallbackContextObjectMethod()
@@ -129,14 +129,14 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
         $constraint = new Choice(callback: 'objectMethodCallback');
 
-        $this->validator->validate('bar', $constraint);
+        $this->validate('bar', $constraint);
 
         $this->assertNoViolation();
     }
 
     public function testMultipleChoices()
     {
-        $this->validator->validate(['baz', 'bar'], new Choice(
+        $this->validate(['baz', 'bar'], new Choice(
             choices: ['foo', 'bar', 'baz'],
             multiple: true,
         ));
@@ -146,7 +146,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidChoice()
     {
-        $this->validator->validate('baz', new Choice(choices: ['foo', 'bar'], message: 'myMessage'));
+        $this->validate('baz', new Choice(choices: ['foo', 'bar'], message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"baz"')
@@ -164,7 +164,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate('baz', $constraint);
+        $this->validate('baz', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"baz"')
@@ -175,7 +175,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidChoiceMultiple()
     {
-        $this->validator->validate(['foo', 'baz'], new Choice(
+        $this->validate(['foo', 'baz'], new Choice(
             choices: ['foo', 'bar'],
             multipleMessage: 'myMessage',
             multiple: true,
@@ -195,7 +195,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
         $this->setValue($value);
 
-        $this->validator->validate($value, new Choice(
+        $this->validate($value, new Choice(
             choices: ['foo', 'bar', 'moo', 'maa'],
             multiple: true,
             min: 2,
@@ -216,7 +216,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
         $this->setValue($value);
 
-        $this->validator->validate($value, new Choice(
+        $this->validate($value, new Choice(
             choices: ['foo', 'bar', 'moo', 'maa'],
             multiple: true,
             max: 2,
@@ -235,7 +235,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Choice(choices: [1, 2]);
 
-        $this->validator->validate(2, $constraint);
+        $this->validate(2, $constraint);
 
         $this->assertNoViolation();
     }
@@ -247,7 +247,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate('2', $constraint);
+        $this->validate('2', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"2"')
@@ -264,7 +264,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             multipleMessage: 'myMessage',
         );
 
-        $this->validator->validate([2, '3'], $constraint);
+        $this->validate([2, '3'], $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"3"')
@@ -276,7 +276,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testMatchFalse()
     {
-        $this->validator->validate('foo', new Choice(
+        $this->validate('foo', new Choice(
             choices: ['foo', 'bar'],
             match: false,
         ));
@@ -290,7 +290,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testMatchFalseWithMultiple()
     {
-        $this->validator->validate(['ccc', 'bar', 'zzz'], new Choice(
+        $this->validate(['ccc', 'bar', 'zzz'], new Choice(
             choices: ['foo', 'bar'],
             multiple: true,
             match: false,

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrValidatorTest.php
@@ -30,14 +30,14 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Cidr());
+        $this->validate(null, new Cidr());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Cidr());
+        $this->validate('', new Cidr());
 
         $this->assertNoViolation();
     }
@@ -46,20 +46,20 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedTypeException::class);
 
-        $this->validator->validate('neko', new NotNull());
+        $this->validate('neko', new NotNull());
     }
 
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
 
-        $this->validator->validate(123456, new Cidr());
+        $this->validate(123456, new Cidr());
     }
 
     #[DataProvider('getWithInvalidNetmask')]
     public function testInvalidNetmask(string $cidr)
     {
-        $this->validator->validate($cidr, new Cidr());
+        $this->validate($cidr, new Cidr());
 
         $this
             ->buildViolation('This value is not a valid CIDR notation.')
@@ -70,7 +70,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getWithInvalidIps')]
     public function testInvalidIpValue(string $cidr)
     {
-        $this->validator->validate($cidr, new Cidr());
+        $this->validate($cidr, new Cidr());
 
         $this
             ->buildViolation('This value is not a valid CIDR notation.')
@@ -81,7 +81,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValid')]
     public function testValidCidr(string|\Stringable $cidr, string $version)
     {
-        $this->validator->validate($cidr, new Cidr(version: $version));
+        $this->validate($cidr, new Cidr(version: $version));
 
         $this->assertNoViolation();
     }
@@ -89,7 +89,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getWithInvalidMasksAndIps')]
     public function testInvalidIpAddressAndNetmask(string|\Stringable $cidr)
     {
-        $this->validator->validate($cidr, new Cidr());
+        $this->validate($cidr, new Cidr());
         $this
             ->buildViolation('This value is not a valid CIDR notation.')
             ->setCode(Cidr::INVALID_CIDR_ERROR)
@@ -104,7 +104,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
             netmaskMin: $min,
             netmaskMax: $max,
         );
-        $this->validator->validate($cidr, $cidrConstraint);
+        $this->validate($cidr, $cidrConstraint);
 
         $this
             ->buildViolation('The value of the netmask should be between {{ min }} and {{ max }}.')
@@ -117,7 +117,7 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getWithWrongVersion')]
     public function testWrongVersion(string $cidr, string $version)
     {
-        $this->validator->validate($cidr, new Cidr(version: $version));
+        $this->validate($cidr, new Cidr(version: $version));
 
         $this
             ->buildViolation('This value is not a valid CIDR notation.')
@@ -249,11 +249,11 @@ class CidrValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Cidr();
 
-        $this->validator->validate('1.2.3.4/28', $constraint);
+        $this->validate('1.2.3.4/28', $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate('::1/64', $constraint);
+        $this->validate('::1/64', $constraint);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTestCase.php
@@ -31,7 +31,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Collection(fields: [
+        $this->validate(null, new Collection(fields: [
             'foo' => new Range(min: 4),
         ]));
 
@@ -46,7 +46,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, '[foo]', $data['foo'], [$constraint]);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => $constraint,
         ]));
 
@@ -56,7 +56,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     public function testThrowsExceptionIfNotTraversable()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate('foobar', new Collection(fields: [
+        $this->validate('foobar', new Collection(fields: [
             'foo' => new Range(min: 4),
         ]));
     }
@@ -78,7 +78,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraint,
                 'bar' => $constraint,
@@ -108,7 +108,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraints,
                 'bar' => $constraints,
@@ -129,7 +129,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, '[foo]', $data['foo'], [$constraint]);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraint,
             ],
@@ -152,7 +152,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'baz' => 6,
         ]);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraint,
             ],
@@ -178,7 +178,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, '[foo]', $data['foo'], [$constraint]);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraint,
             ],
@@ -198,7 +198,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, '[foo]', $data['foo'], [$constraint]);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraint,
             ],
@@ -214,7 +214,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new Range(min: 4);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraint,
             ],
@@ -235,7 +235,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new Range(min: 4);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => $constraint,
             ],
@@ -251,7 +251,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'foo' => null,
         ]);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => new Optional(),
         ]));
 
@@ -262,7 +262,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     {
         $data = $this->prepareTestData([]);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => new Optional(),
         ]));
 
@@ -281,7 +281,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => new Optional($constraint),
         ]));
 
@@ -303,7 +303,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => new Optional($constraints),
         ]));
 
@@ -316,7 +316,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
             'foo' => null,
         ]);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => new Required(),
         ]));
 
@@ -327,7 +327,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
     {
         $data = $this->prepareTestData([]);
 
-        $this->validator->validate($data, new Collection(
+        $this->validate($data, new Collection(
             fields: [
                 'foo' => new Required(),
             ],
@@ -354,7 +354,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => new Required($constraint),
         ]));
 
@@ -376,7 +376,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->validate($data, new Collection([
+        $this->validate($data, new Collection([
             'foo' => new Required($constraints),
         ]));
 
@@ -393,7 +393,7 @@ abstract class CollectionValidatorTestCase extends ConstraintValidatorTestCase
 
         $this->expectValidateValueAt(0, '[foo]', $value['foo'], [$constraint]);
 
-        $this->validator->validate($value, new Collection(
+        $this->validate($value, new Collection(
             fields: [
                 'foo' => $constraint,
             ],

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompareWithNullValueAtPropertyAtTestTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompareWithNullValueAtPropertyAtTestTrait.php
@@ -23,7 +23,7 @@ trait CompareWithNullValueAtPropertyAtTestTrait
         $object = new ComparisonTest_Class(null);
         $this->setObject($object);
 
-        $this->validator->validate(5, $constraint);
+        $this->validate(5, $constraint);
 
         $this->assertNoViolation();
     }
@@ -32,7 +32,7 @@ trait CompareWithNullValueAtPropertyAtTestTrait
     {
         $this->setObject(new TypedDummy());
 
-        $this->validator->validate(5, $this->createConstraint([
+        $this->validate(5, $this->createConstraint([
             'message' => 'Constraint Message',
             'propertyPath' => 'value',
         ]));

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompoundValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompoundValidatorTest.php
@@ -24,7 +24,7 @@ class CompoundValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidValue()
     {
-        $this->validator->validate('foo', new DummyCompoundConstraint());
+        $this->validate('foo', new DummyCompoundConstraint());
 
         $this->assertNoViolation();
     }
@@ -36,7 +36,7 @@ class CompoundValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, $value, $constraint->constraints);
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTestCase.php
@@ -32,7 +32,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Count(6));
+        $this->validate(null, new Count(6));
 
         $this->assertNoViolation();
     }
@@ -40,7 +40,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     public function testExpectsCountableType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Count(5));
+        $this->validate(new \stdClass(), new Count(5));
     }
 
     public static function getThreeOrLessElements()
@@ -74,7 +74,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     public function testValidValuesMaxNamed($value)
     {
         $constraint = new Count(max: 3);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -83,7 +83,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     public function testValidValuesMinNamed($value)
     {
         $constraint = new Count(min: 5);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -92,7 +92,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     public function testValidValuesExactNamed($value)
     {
         $constraint = new Count(exactly: 4);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -102,7 +102,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     {
         $constraint = new Count(max: 4, maxMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ count }}', \count($value))
@@ -118,7 +118,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     {
         $constraint = new Count(min: 4, minMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ count }}', \count($value))
@@ -134,7 +134,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
     {
         $constraint = new Count(exactly: 4, exactMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ count }}', \count($value))
@@ -154,7 +154,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
             exactMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ count }}', \count($value))
@@ -196,7 +196,7 @@ abstract class CountValidatorTestCase extends ConstraintValidatorTestCase
             message: 'foo {{ compared_value }}',
         )], $this->group);
 
-        $this->validator->validate(['foo', 'bar', 'ccc'], $constraint);
+        $this->validate(['foo', 'bar', 'ccc'], $constraint);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -43,14 +43,14 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Country());
+        $this->validate(null, new Country());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Country());
+        $this->validate('', new Country());
 
         $this->assertNoViolation();
     }
@@ -58,13 +58,13 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Country());
+        $this->validate(new \stdClass(), new Country());
     }
 
     #[DataProvider('getValidCountries')]
     public function testValidCountries($country)
     {
-        $this->validator->validate($country, new Country());
+        $this->validate($country, new Country());
 
         $this->assertNoViolation();
     }
@@ -83,7 +83,7 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Country(message: 'myMessage');
 
-        $this->validator->validate($country, $constraint);
+        $this->validate($country, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$country.'"')
@@ -102,7 +102,7 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidAlpha3Countries')]
     public function testValidAlpha3Countries($country)
     {
-        $this->validator->validate($country, new Country(alpha3: true));
+        $this->validate($country, new Country(alpha3: true));
 
         $this->assertNoViolation();
     }
@@ -124,7 +124,7 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($country, $constraint);
+        $this->validate($country, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$country.'"')
@@ -144,7 +144,7 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidAlpha3CountryNamed()
     {
-        $this->validator->validate(
+        $this->validate(
             'DE',
             new Country(alpha3: true, message: 'myMessage')
         );
@@ -164,7 +164,7 @@ class CountryValidatorTest extends ConstraintValidatorTestCase
 
         $existingCountry = 'GB';
 
-        $this->validator->validate($existingCountry, new Country());
+        $this->validate($existingCountry, new Country());
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
@@ -27,14 +27,14 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new CssColor(CssColor::HEX_LONG));
+        $this->validate(null, new CssColor(CssColor::HEX_LONG));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new CssColor(CssColor::HEX_LONG));
+        $this->validate('', new CssColor(CssColor::HEX_LONG));
 
         $this->assertNoViolation();
     }
@@ -42,20 +42,20 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new CssColor(CssColor::HEX_LONG));
+        $this->validate(new \stdClass(), new CssColor(CssColor::HEX_LONG));
     }
 
     #[DataProvider('getValidAnyColor')]
     public function testValidAnyColor($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor());
+        $this->validate($cssColor, new CssColor());
         $this->assertNoViolation();
     }
 
     #[DataProvider('getValidAnyColor')]
     public function testValidAnyColorWithNewLine($cssColor)
     {
-        $this->validator->validate($cssColor."\n", new CssColor([], 'myMessage'));
+        $this->validate($cssColor."\n", new CssColor([], 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$cssColor."\n\"")
@@ -85,7 +85,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidHexLongColors')]
     public function testValidHexLongColors($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::HEX_LONG));
+        $this->validate($cssColor, new CssColor(CssColor::HEX_LONG));
         $this->assertNoViolation();
     }
 
@@ -97,7 +97,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidHexLongColorsWithAlpha')]
     public function testValidHexLongColorsWithAlpha($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::HEX_LONG_WITH_ALPHA));
+        $this->validate($cssColor, new CssColor(CssColor::HEX_LONG_WITH_ALPHA));
         $this->assertNoViolation();
     }
 
@@ -109,7 +109,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidHexShortColors')]
     public function testValidHexShortColors($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::HEX_SHORT));
+        $this->validate($cssColor, new CssColor(CssColor::HEX_SHORT));
         $this->assertNoViolation();
     }
 
@@ -121,7 +121,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidHexShortColorsWithAlpha')]
     public function testValidHexShortColorsWithAlpha($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::HEX_SHORT_WITH_ALPHA));
+        $this->validate($cssColor, new CssColor(CssColor::HEX_SHORT_WITH_ALPHA));
         $this->assertNoViolation();
     }
 
@@ -133,7 +133,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidBasicNamedColors')]
     public function testValidBasicNamedColors($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::BASIC_NAMED_COLORS));
+        $this->validate($cssColor, new CssColor(CssColor::BASIC_NAMED_COLORS));
         $this->assertNoViolation();
     }
 
@@ -148,7 +148,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidExtendedNamedColors')]
     public function testValidExtendedNamedColors($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::EXTENDED_NAMED_COLORS));
+        $this->validate($cssColor, new CssColor(CssColor::EXTENDED_NAMED_COLORS));
         $this->assertNoViolation();
     }
 
@@ -163,7 +163,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidSystemColors')]
     public function testValidSystemColors($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::SYSTEM_COLORS));
+        $this->validate($cssColor, new CssColor(CssColor::SYSTEM_COLORS));
         $this->assertNoViolation();
     }
 
@@ -179,7 +179,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidKeywords')]
     public function testValidKeywords($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::KEYWORDS));
+        $this->validate($cssColor, new CssColor(CssColor::KEYWORDS));
         $this->assertNoViolation();
     }
 
@@ -191,7 +191,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidRGB')]
     public function testValidRGB($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::RGB));
+        $this->validate($cssColor, new CssColor(CssColor::RGB));
         $this->assertNoViolation();
     }
 
@@ -207,7 +207,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidRGBA')]
     public function testValidRGBA($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::RGBA));
+        $this->validate($cssColor, new CssColor(CssColor::RGBA));
         $this->assertNoViolation();
     }
 
@@ -224,7 +224,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidHSL')]
     public function testValidHSL($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::HSL));
+        $this->validate($cssColor, new CssColor(CssColor::HSL));
         $this->assertNoViolation();
     }
 
@@ -240,7 +240,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidHSLA')]
     public function testValidHSLA($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor(CssColor::HSLA));
+        $this->validate($cssColor, new CssColor(CssColor::HSLA));
         $this->assertNoViolation();
     }
 
@@ -258,7 +258,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidHexColors($cssColor)
     {
         $constraint = new CssColor([CssColor::HEX_LONG, CssColor::HEX_LONG_WITH_ALPHA], 'myMessage');
-        $this->validator->validate($cssColor, $constraint);
+        $this->validate($cssColor, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$cssColor.'"')
@@ -274,7 +274,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidShortHexColors')]
     public function testInvalidShortHexColors($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor([CssColor::HEX_SHORT, CssColor::HEX_SHORT_WITH_ALPHA], 'myMessage'));
+        $this->validate($cssColor, new CssColor([CssColor::HEX_SHORT, CssColor::HEX_SHORT_WITH_ALPHA], 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$cssColor.'"')
@@ -290,7 +290,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidNamedColors')]
     public function testInvalidNamedColors($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor([
+        $this->validate($cssColor, new CssColor([
             CssColor::BASIC_NAMED_COLORS,
             CssColor::EXTENDED_NAMED_COLORS,
             CssColor::SYSTEM_COLORS,
@@ -311,7 +311,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidRGB')]
     public function testInvalidRGB($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor([
+        $this->validate($cssColor, new CssColor([
             CssColor::BASIC_NAMED_COLORS,
             CssColor::EXTENDED_NAMED_COLORS,
             CssColor::SYSTEM_COLORS,
@@ -332,7 +332,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidRGBA')]
     public function testInvalidRGBA($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor([
+        $this->validate($cssColor, new CssColor([
             CssColor::BASIC_NAMED_COLORS,
             CssColor::EXTENDED_NAMED_COLORS,
             CssColor::SYSTEM_COLORS,
@@ -358,7 +358,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidHSL')]
     public function testInvalidHSL($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor([
+        $this->validate($cssColor, new CssColor([
             CssColor::BASIC_NAMED_COLORS,
             CssColor::EXTENDED_NAMED_COLORS,
             CssColor::SYSTEM_COLORS,
@@ -379,7 +379,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidHSLA')]
     public function testInvalidHSLA($cssColor)
     {
-        $this->validator->validate($cssColor, new CssColor([
+        $this->validate($cssColor, new CssColor([
             CssColor::BASIC_NAMED_COLORS,
             CssColor::EXTENDED_NAMED_COLORS,
             CssColor::SYSTEM_COLORS,

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -43,14 +43,14 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Currency());
+        $this->validate(null, new Currency());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Currency());
+        $this->validate('', new Currency());
 
         $this->assertNoViolation();
     }
@@ -58,13 +58,13 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Currency());
+        $this->validate(new \stdClass(), new Currency());
     }
 
     #[DataProvider('getValidCurrencies')]
     public function testValidCurrencies($currency)
     {
-        $this->validator->validate($currency, new Currency());
+        $this->validate($currency, new Currency());
 
         $this->assertNoViolation();
     }
@@ -76,7 +76,7 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
 
         \Locale::setDefault('en_GB');
 
-        $this->validator->validate($currency, new Currency());
+        $this->validate($currency, new Currency());
 
         $this->assertNoViolation();
     }
@@ -97,7 +97,7 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Currency(message: 'myMessage');
 
-        $this->validator->validate($currency, $constraint);
+        $this->validate($currency, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$currency.'"')
@@ -110,7 +110,7 @@ class CurrencyValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Currency(message: 'myMessage');
 
-        $this->validator->validate($currency, $constraint);
+        $this->validate($currency, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$currency.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -26,14 +26,14 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new DateTime());
+        $this->validate(null, new DateTime());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new DateTime());
+        $this->validate('', new DateTime());
 
         $this->assertNoViolation();
     }
@@ -41,16 +41,16 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new DateTime());
+        $this->validate(new \stdClass(), new DateTime());
     }
 
     public function testDateTimeWithDefaultFormat()
     {
-        $this->validator->validate('1995-05-10 19:33:00', new DateTime());
+        $this->validate('1995-05-10 19:33:00', new DateTime());
 
         $this->assertNoViolation();
 
-        $this->validator->validate('1995-03-24', new DateTime());
+        $this->validate('1995-03-24', new DateTime());
 
         $this->buildViolation('This value is not a valid datetime.')
             ->setParameter('{{ value }}', '"1995-03-24"')
@@ -64,7 +64,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new DateTime(format: $format);
 
-        $this->validator->validate($dateTime, $constraint);
+        $this->validate($dateTime, $constraint);
 
         $this->assertNoViolation();
     }
@@ -88,7 +88,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
             format: $format,
         );
 
-        $this->validator->validate($dateTime, $constraint);
+        $this->validate($dateTime, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$dateTime.'"')
@@ -117,7 +117,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new DateTime(message: 'myMessage', format: 'Y-m-d');
 
-        $this->validator->validate('2010-01-01 00:00:00', $constraint);
+        $this->validate('2010-01-01 00:00:00', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"2010-01-01 00:00:00"')
@@ -128,7 +128,7 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
 
     public function testDateTimeWithTrailingData()
     {
-        $this->validator->validate('1995-05-10 00:00:00', new DateTime(format: 'Y-m-d+'));
+        $this->validate('1995-05-10 00:00:00', new DateTime(format: 'Y-m-d+'));
         $this->assertNoViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -26,14 +26,14 @@ class DateValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Date());
+        $this->validate(null, new Date());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Date());
+        $this->validate('', new Date());
 
         $this->assertNoViolation();
     }
@@ -41,13 +41,13 @@ class DateValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Date());
+        $this->validate(new \stdClass(), new Date());
     }
 
     #[DataProvider('getValidDates')]
     public function testValidDates($date)
     {
-        $this->validator->validate($date, new Date());
+        $this->validate($date, new Date());
 
         $this->assertNoViolation();
     }
@@ -55,7 +55,7 @@ class DateValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidDates')]
     public function testValidDatesWithNewLine(string $date)
     {
-        $this->validator->validate($date."\n", new Date(message: 'myMessage'));
+        $this->validate($date."\n", new Date(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$date."\n\"")
@@ -77,7 +77,7 @@ class DateValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Date(message: 'myMessage');
 
-        $this->validator->validate($date, $constraint);
+        $this->validate($date, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$date.'"')
@@ -89,7 +89,7 @@ class DateValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Date(message: 'myMessage');
 
-        $this->validator->validate('foobar', $constraint);
+        $this->validate('foobar', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"foobar"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -97,7 +97,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage(\sprintf('Expected argument of type "numeric", "%s" given', $expectedGivenType));
 
-        $this->validator->validate($value, $this->createConstraint([
+        $this->validate($value, $this->createConstraint([
             'value' => $comparedValue,
         ]));
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -35,21 +35,21 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Email());
+        $this->validate(null, new Email());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Email());
+        $this->validate('', new Email());
 
         $this->assertNoViolation();
     }
 
     public function testObjectEmptyStringIsValid()
     {
-        $this->validator->validate(new EmptyEmailObject(), new Email());
+        $this->validate(new EmptyEmailObject(), new Email());
 
         $this->assertNoViolation();
     }
@@ -57,13 +57,13 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Email());
+        $this->validate(new \stdClass(), new Email());
     }
 
     #[DataProvider('getValidEmails')]
     public function testValidEmails($email)
     {
-        $this->validator->validate($email, new Email());
+        $this->validate($email, new Email());
 
         $this->assertNoViolation();
     }
@@ -71,7 +71,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidEmails')]
     public function testValidEmailsWithNewLine($email)
     {
-        $this->validator->validate($email."\n", new Email());
+        $this->validate($email."\n", new Email());
 
         $this->buildViolation('This value is not a valid email address.')
             ->setParameter('{{ value }}', '"'.$email."\n\"")
@@ -91,7 +91,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidEmailsWithWhitespaces')]
     public function testValidNormalizedEmails($email)
     {
-        $this->validator->validate($email, new Email(normalizer: 'trim'));
+        $this->validate($email, new Email(normalizer: 'trim'));
 
         $this->assertNoViolation();
     }
@@ -107,7 +107,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidEmailsHtml5')]
     public function testValidEmailsHtml5($email)
     {
-        $this->validator->validate($email, new Email(mode: Email::VALIDATION_MODE_HTML5));
+        $this->validate($email, new Email(mode: Email::VALIDATION_MODE_HTML5));
 
         $this->assertNoViolation();
     }
@@ -127,7 +127,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Email(message: 'myMessage');
 
-        $this->validator->validate($email, $constraint);
+        $this->validate($email, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$email.'"')
@@ -153,7 +153,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
             mode: Email::VALIDATION_MODE_HTML5,
         );
 
-        $this->validator->validate($email, $constraint);
+        $this->validate($email, $constraint);
 
         $this->buildViolation('myMessage')
              ->setParameter('{{ value }}', '"'.$email.'"')
@@ -191,7 +191,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
             mode: Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD,
         );
 
-        $this->validator->validate($email, $constraint);
+        $this->validate($email, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$email.'"')
@@ -214,7 +214,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Email(mode: Email::VALIDATION_MODE_STRICT);
 
-        $this->validator->validate('example@mywebsite.tld', $constraint);
+        $this->validate('example@mywebsite.tld', $constraint);
 
         $this->assertNoViolation();
     }
@@ -223,7 +223,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Email(mode: Email::VALIDATION_MODE_HTML5);
 
-        $this->validator->validate('example@example..com', $constraint);
+        $this->validate('example@example..com', $constraint);
 
         $this->buildViolation('This value is not a valid email address.')
              ->setParameter('{{ value }}', '"example@example..com"')
@@ -235,7 +235,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Email(mode: Email::VALIDATION_MODE_HTML5_ALLOW_NO_TLD);
 
-        $this->validator->validate('example@example', $constraint);
+        $this->validate('example@example', $constraint);
 
         $this->assertNoViolation();
     }
@@ -248,7 +248,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "Symfony\Component\Validator\Constraints\Email::$mode" parameter value is not valid.');
 
-        $this->validator->validate('example@example..com', $constraint);
+        $this->validate('example@example..com', $constraint);
     }
 
     #[DataProvider('getInvalidEmailsForStrictChecks')]
@@ -259,7 +259,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
             mode: Email::VALIDATION_MODE_STRICT,
         );
 
-        $this->validator->validate($email, $constraint);
+        $this->validate($email, $constraint);
 
         $this
             ->buildViolation('myMessage')

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -87,7 +87,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
         $object = new ComparisonTest_Class(null);
         $this->setObject($object);
 
-        $this->validator->validate(5, $constraint);
+        $this->validate(5, $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', '5')
@@ -102,7 +102,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
     {
         $this->setObject(new TypedDummy());
 
-        $this->validator->validate(5, $this->createConstraint([
+        $this->validate(5, $this->createConstraint([
             'message' => 'Constraint Message',
             'propertyPath' => 'value',
         ]));

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionSyntaxValidatorTest.php
@@ -26,21 +26,21 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new ExpressionSyntax());
+        $this->validate(null, new ExpressionSyntax());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new ExpressionSyntax());
+        $this->validate('', new ExpressionSyntax());
 
         $this->assertNoViolation();
     }
 
     public function testExpressionValid()
     {
-        $this->validator->validate('1 + 1', new ExpressionSyntax(
+        $this->validate('1 + 1', new ExpressionSyntax(
             message: 'myMessage',
             allowedVariables: [],
         ));
@@ -50,7 +50,7 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testStringableExpressionValid()
     {
-        $this->validator->validate(new StringableValue('1 + 1'), new ExpressionSyntax(
+        $this->validate(new StringableValue('1 + 1'), new ExpressionSyntax(
             message: 'myMessage',
             allowedVariables: [],
         ));
@@ -60,14 +60,14 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpressionWithoutNames()
     {
-        $this->validator->validate('1 + 1', new ExpressionSyntax(null, 'myMessage', null, []));
+        $this->validate('1 + 1', new ExpressionSyntax(null, 'myMessage', null, []));
 
         $this->assertNoViolation();
     }
 
     public function testExpressionWithAllowedVariableName()
     {
-        $this->validator->validate('a + 1', new ExpressionSyntax(
+        $this->validate('a + 1', new ExpressionSyntax(
             message: 'myMessage',
             allowedVariables: ['a'],
         ));
@@ -77,14 +77,14 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpressionWithNullAllowedVariables()
     {
-        $this->validator->validate('a + 1', new ExpressionSyntax());
+        $this->validate('a + 1', new ExpressionSyntax());
 
         $this->assertNoViolation();
     }
 
     public function testExpressionIsNotValid()
     {
-        $this->validator->validate('a + 1', new ExpressionSyntax(
+        $this->validate('a + 1', new ExpressionSyntax(
             message: 'myMessage',
             allowedVariables: [],
         ));
@@ -98,7 +98,7 @@ class ExpressionSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testStringableExpressionIsNotValid()
     {
-        $this->validator->validate(new StringableValue('a + 1'), new ExpressionSyntax(
+        $this->validate(new StringableValue('a + 1'), new ExpressionSyntax(
             message: 'myMessage',
             allowedVariables: [],
         ));

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -37,7 +37,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'null')
@@ -52,7 +52,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate('', $constraint);
+        $this->validate('', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')
@@ -69,7 +69,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject($object);
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->assertNoViolation();
     }
@@ -86,7 +86,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject($object);
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'object')
@@ -103,7 +103,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject($object);
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->assertNoViolation();
     }
@@ -120,7 +120,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
         $this->setObject($object);
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'toString')
@@ -139,7 +139,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $this->setPropertyPath('data');
         $this->setProperty($object, 'data');
 
-        $this->validator->validate('1', $constraint);
+        $this->validate('1', $constraint);
 
         $this->assertNoViolation();
     }
@@ -158,7 +158,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $this->setPropertyPath('data');
         $this->setProperty($object, 'data');
 
-        $this->validator->validate('2', $constraint);
+        $this->validate('2', $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('data')
@@ -181,7 +181,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $this->setPropertyPath('reference.data');
         $this->setProperty($object, 'data');
 
-        $this->validator->validate('1', $constraint);
+        $this->validate('1', $constraint);
 
         $this->assertNoViolation();
     }
@@ -203,7 +203,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $this->setPropertyPath('reference.data');
         $this->setProperty($object, 'data');
 
-        $this->validator->validate('2', $constraint);
+        $this->validate('2', $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('reference.data')
@@ -224,7 +224,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $this->setPropertyPath('');
         $this->setProperty(null, 'property');
 
-        $this->validator->validate('1', $constraint);
+        $this->validate('1', $constraint);
 
         $this->assertNoViolation();
     }
@@ -244,7 +244,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
         $this->setPropertyPath('');
         $this->setProperty(null, 'property');
 
-        $this->validator->validate('2', $constraint);
+        $this->validate('2', $constraint);
 
         $this->buildViolation('myMessage')
             ->atPath('')
@@ -268,9 +268,9 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
                 return true;
             });
 
-        $validator = new ExpressionValidator($expressionLanguage);
-        $validator->initialize($this->createContext());
-        $validator->validate(null, $constraint);
+        $this->validator = new ExpressionValidator($expressionLanguage);
+
+        $this->validate(null, $constraint);
 
         $this->assertTrue($used, 'Failed asserting that custom ExpressionLanguage instance is used.');
     }
@@ -284,7 +284,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             ],
         );
 
-        $this->validator->validate(1, $constraint);
+        $this->validate(1, $constraint);
 
         $this->assertNoViolation();
     }
@@ -299,7 +299,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             negate: false,
         );
 
-        $this->validator->validate(2, $constraint);
+        $this->validate(2, $constraint);
 
         $this->buildViolation('This value is not valid.')
             ->atPath('property.path')
@@ -324,7 +324,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, $object->data, $constraints);
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->assertNoViolation();
     }
@@ -351,7 +351,7 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             new ConstraintViolation('error_range', '', [], '', '', 7, null, 'range')
         );
 
-        $this->validator->validate($object, $constraint);
+        $this->validate($object, $constraint);
 
         $this->assertCount(2, $this->context->getViolations());
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
@@ -26,7 +26,7 @@ class FileValidatorPathTest extends FileValidatorTestCase
             notFoundMessage: 'myMessage',
         );
 
-        $this->validator->validate('foobar', $constraint);
+        $this->validate('foobar', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ file }}', '"foobar"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTestCase.php
@@ -55,14 +55,14 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new File());
+        $this->validate(null, new File());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new File());
+        $this->validate('', new File());
 
         $this->assertNoViolation();
     }
@@ -70,12 +70,12 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleTypeOrFile()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new File());
+        $this->validate(new \stdClass(), new File());
     }
 
     public function testValidFile()
     {
-        $this->validator->validate($this->path, new File());
+        $this->validate($this->path, new File());
 
         $this->assertNoViolation();
     }
@@ -84,7 +84,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
     {
         file_put_contents($this->path, '1');
         $file = new UploadedFile($this->path, 'originalName', null, null, true);
-        $this->validator->validate($file, new File());
+        $this->validate($file, new File());
 
         $this->assertNoViolation();
     }
@@ -172,7 +172,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             maxSizeMessage: 'myMessage',
         );
 
-        $this->validator->validate($this->getFile($this->path), $constraint);
+        $this->validate($this->getFile($this->path), $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ limit }}', $limitAsString)
@@ -222,7 +222,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             maxSizeMessage: 'myMessage',
         );
 
-        $this->validator->validate($this->getFile($this->path), $constraint);
+        $this->validate($this->getFile($this->path), $constraint);
 
         $this->assertNoViolation();
     }
@@ -268,7 +268,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             maxSizeMessage: 'myMessage',
         );
 
-        $this->validator->validate($this->getFile($this->path), $constraint);
+        $this->validate($this->getFile($this->path), $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ limit }}', $limitAsString)
@@ -288,7 +288,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(maxSize: 10, binaryFormat: true, maxSizeMessage: 'myMessage');
 
-        $this->validator->validate($this->getFile($this->path), $constraint);
+        $this->validate($this->getFile($this->path), $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ limit }}', '10')
@@ -317,7 +317,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(mimeTypes: ['image/png', 'image/jpg']);
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->assertNoViolation();
     }
@@ -339,7 +339,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(mimeTypes: ['image/*']);
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->assertNoViolation();
     }
@@ -359,7 +359,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             ->method('getMimeType')
             ->willReturn('application/pdf');
 
-        $this->validator->validate($file, new File(mimeTypes: ['image/png', 'image/jpg'], mimeTypesMessage: 'myMessage'));
+        $this->validate($file, new File(mimeTypes: ['image/png', 'image/jpg'], mimeTypesMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ type }}', '"application/pdf"')
@@ -390,7 +390,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             mimeTypesMessage: 'myMessage',
         );
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ type }}', '"application/pdf"')
@@ -405,7 +405,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
     {
         ftruncate($this->file, 0);
 
-        $this->validator->validate($this->getFile($this->path), new File(disallowEmptyMessage: 'myMessage'));
+        $this->validate($this->getFile($this->path), new File(disallowEmptyMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ file }}', '"'.$this->path.'"')
@@ -424,7 +424,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             'maxSize' => $maxSize,
         ]);
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameters($params)
@@ -499,7 +499,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(mimeTypes: [], extensions: ['gif', 'txt'], extensionsMessage: 'myMessage');
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->assertNoViolation();
     }
@@ -520,7 +520,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(extensions: ['png', 'svg'], extensionsMessage: 'myMessage');
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameters([
@@ -553,7 +553,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(mimeTypesMessage: 'myMessage', extensions: ['gif']);
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameters([
@@ -579,7 +579,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(mimeTypesMessage: 'myMessage', extensions: ['gif', 'txt']);
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameters([
@@ -604,7 +604,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
 
         $constraint = new File(mimeTypesMessage: 'myMessage', extensions: ['txt']);
 
-        $this->validator->validate($file, $constraint);
+        $this->validate($file, $constraint);
 
         $this->assertNoViolation();
     }
@@ -615,7 +615,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
         file_put_contents($this->path, '1');
 
         $file = new UploadedFile($this->path, $filename, null, null, true);
-        $this->validator->validate($file, $constraintFile);
+        $this->validate($file, $constraintFile);
 
         $this->buildViolation($messageViolation)
             ->setParameters([
@@ -659,7 +659,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
         file_put_contents($this->path, '1');
 
         $file = new UploadedFile($this->path, "A\u{0300}", null, null, true);
-        $this->validator->validate($file, new File(filenameMaxLength: $maxLength, filenameCountUnit: $countUnit));
+        $this->validate($file, new File(filenameMaxLength: $maxLength, filenameCountUnit: $countUnit));
 
         $this->assertNoViolation();
     }
@@ -670,7 +670,7 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
         file_put_contents($this->path, '1');
 
         $file = new UploadedFile($this->path, $filename, null, null, true);
-        $this->validator->validate($file, new File(filenameCharset: $charset, filenameCharsetMessage: 'myMessage'));
+        $this->validate($file, new File(filenameCharset: $charset, filenameCharsetMessage: 'myMessage'));
 
         if ($isValid) {
             $this->assertNoViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -89,13 +89,12 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     {
         $clock = new MockClock('2025-01-15 00:00:00 UTC');
         $this->validator = new GreaterThanValidator(null, $clock);
-        $this->validator->initialize($this->context);
 
         // Value is 20 days after the frozen "now", compared to "-10 days" (Jan 5)
         $value = new \DateTimeImmutable('2025-01-20 00:00:00 UTC');
         $constraint = new GreaterThan('-10 days');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -104,13 +103,12 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
     {
         $clock = new MockClock('2025-01-15 00:00:00 UTC');
         $this->validator = new GreaterThanValidator(null, $clock);
-        $this->validator->initialize($this->context);
 
         // Value (Jan 1) is before the frozen "now" (Jan 15) minus 10 days (Jan 5)
         $value = new \DateTimeImmutable('2025-01-01 00:00:00 UTC');
         $constraint = new GreaterThan(value: '-10 days', message: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $comparedValue = $clock->now()->modify('-10 days');
 
@@ -131,7 +129,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
         $value = new \DateTimeImmutable('2025-06-01 00:00:00 UTC');
         $constraint = new GreaterThan('2025-01-01');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -142,7 +140,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
         $value = new \DateTimeImmutable('2000-01-01 UTC');
         $constraint = new GreaterThan('1999-01-01');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/HostnameValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/HostnameValidatorTest.php
@@ -24,14 +24,14 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
 {
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Hostname());
+        $this->validate(null, new Hostname());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Hostname());
+        $this->validate('', new Hostname());
 
         $this->assertNoViolation();
     }
@@ -40,13 +40,13 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
-        $this->validator->validate(new \stdClass(), new Hostname());
+        $this->validate(new \stdClass(), new Hostname());
     }
 
     #[DataProvider('getValidMultilevelDomains')]
     public function testValidTldDomainsPassValidationIfTldRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname());
+        $this->validate($domain, new Hostname());
 
         $this->assertNoViolation();
     }
@@ -54,7 +54,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidMultilevelDomains')]
     public function testValidTldDomainsPassValidationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(requireTld: false));
+        $this->validate($domain, new Hostname(requireTld: false));
 
         $this->assertNoViolation();
     }
@@ -76,7 +76,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidDomains')]
     public function testInvalidDomainsRaiseViolationIfTldRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(message: 'myMessage'));
+        $this->validate($domain, new Hostname(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$domain.'"')
@@ -87,7 +87,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidDomains')]
     public function testInvalidDomainsRaiseViolationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(
+        $this->validate($domain, new Hostname(
             message: 'myMessage',
             requireTld: false,
         ));
@@ -112,7 +112,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getReservedDomains')]
     public function testReservedDomainsPassValidationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(requireTld: false));
+        $this->validate($domain, new Hostname(requireTld: false));
 
         $this->assertNoViolation();
     }
@@ -120,7 +120,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getReservedDomains')]
     public function testReservedDomainsRaiseViolationIfTldRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(
+        $this->validate($domain, new Hostname(
             message: 'myMessage',
             requireTld: true,
         ));
@@ -147,7 +147,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
 
     public function testReservedDomainsRaiseViolationIfTldRequiredNamed()
     {
-        $this->validator->validate(
+        $this->validate(
             'example',
             new Hostname(message: 'myMessage', requireTld: true)
         );
@@ -161,7 +161,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getTopLevelDomains')]
     public function testTopLevelDomainsPassValidationIfTldNotRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(requireTld: false));
+        $this->validate($domain, new Hostname(requireTld: false));
 
         $this->assertNoViolation();
     }
@@ -169,7 +169,7 @@ class HostnameValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getTopLevelDomains')]
     public function testTopLevelDomainsRaiseViolationIfTldRequired($domain)
     {
-        $this->validator->validate($domain, new Hostname(
+        $this->validate($domain, new Hostname(
             message: 'myMessage',
             requireTld: true,
         ));

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -27,14 +27,14 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Iban());
+        $this->validate(null, new Iban());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Iban());
+        $this->validate('', new Iban());
 
         $this->assertNoViolation();
     }
@@ -42,7 +42,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidIbans')]
     public function testValidIbans($iban)
     {
-        $this->validator->validate($iban, new Iban());
+        $this->validate($iban, new Iban());
 
         $this->assertNoViolation();
     }
@@ -50,7 +50,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidIbans')]
     public function testValidIbansWithNewLine(string $iban)
     {
-        $this->validator->validate($iban."\n", new Iban());
+        $this->validate($iban."\n", new Iban());
 
         $this->buildViolation('This is not a valid International Bank Account Number (IBAN).')
             ->setParameter('{{ value }}', '"'.$iban."\n\"")
@@ -458,7 +458,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
 
         [$constraint] = $classMetadata->getPropertyMetadata('iban')[0]->getConstraints();
 
-        $this->validator->validate('DE89 3704 0044 0532 0130 01', $constraint);
+        $this->validate('DE89 3704 0044 0532 0130 01', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"DE89 3704 0044 0532 0130 01"')
@@ -479,7 +479,7 @@ class IbanValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Iban(message: 'myMessage');
 
-        $this->validator->validate($iban, $constraint);
+        $this->validate($iban, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$iban.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -106,7 +106,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
         $object = new ComparisonTest_Class(null);
         $this->setObject($object);
 
-        $this->validator->validate(5, $constraint);
+        $this->validate(5, $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', '5')
@@ -121,7 +121,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
     {
         $this->setObject(new TypedDummy());
 
-        $this->validator->validate(5, $this->createConstraint([
+        $this->validate(5, $this->createConstraint([
             'message' => 'Constraint Message',
             'propertyPath' => 'value',
         ]));

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -53,21 +53,21 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Image());
+        $this->validate(null, new Image());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Image());
+        $this->validate('', new Image());
 
         $this->assertNoViolation();
     }
 
     public function testValidImage()
     {
-        $this->validator->validate($this->image, new Image());
+        $this->validate($this->image, new Image());
 
         $this->assertNoViolation();
     }
@@ -77,7 +77,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
      */
     public function testFileNotFound()
     {
-        $this->validator->validate('foobar', new Image(notFoundMessage: 'myMessage'));
+        $this->validate('foobar', new Image(notFoundMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ file }}', '"foobar"')
@@ -94,14 +94,14 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             maxHeight: 2,
         );
 
-        $this->validator->validate($this->image, $constraint);
+        $this->validate($this->image, $constraint);
 
         $this->assertNoViolation();
     }
 
     public function testWidthTooSmall()
     {
-        $this->validator->validate($this->image, new Image(minWidth: 3, minWidthMessage: 'myMessage'));
+        $this->validate($this->image, new Image(minWidth: 3, minWidthMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', '2')
@@ -112,7 +112,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testWidthTooBig()
     {
-        $this->validator->validate($this->image, new Image(maxWidth: 1, maxWidthMessage: 'myMessage'));
+        $this->validate($this->image, new Image(maxWidth: 1, maxWidthMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', '2')
@@ -123,7 +123,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testHeightTooSmall()
     {
-        $this->validator->validate($this->image, new Image(minHeight: 3, minHeightMessage: 'myMessage'));
+        $this->validate($this->image, new Image(minHeight: 3, minHeightMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ height }}', '2')
@@ -134,7 +134,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testHeightTooBig()
     {
-        $this->validator->validate($this->image, new Image(maxHeight: 1, maxHeightMessage: 'myMessage'));
+        $this->validate($this->image, new Image(maxHeight: 1, maxHeightMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ height }}', '2')
@@ -145,7 +145,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testPixelsTooFew()
     {
-        $this->validator->validate($this->image, new Image(minPixels: 5, minPixelsMessage: 'myMessage'));
+        $this->validate($this->image, new Image(minPixels: 5, minPixelsMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
@@ -158,7 +158,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testPixelsTooMany()
     {
-        $this->validator->validate($this->image, new Image(maxPixels: 3, maxPixelsMessage: 'myMessage'));
+        $this->validate($this->image, new Image(maxPixels: 3, maxPixelsMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
@@ -171,7 +171,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testRatioTooSmall()
     {
-        $this->validator->validate($this->image, new Image(minRatio: 2, minRatioMessage: 'myMessage'));
+        $this->validate($this->image, new Image(minRatio: 2, minRatioMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ ratio }}', 1)
@@ -182,7 +182,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testRatioTooBig()
     {
-        $this->validator->validate($this->image, new Image(maxRatio: 0.5, maxRatioMessage: 'myMessage'));
+        $this->validate($this->image, new Image(maxRatio: 0.5, maxRatioMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ ratio }}', 1)
@@ -195,7 +195,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Image(maxRatio: 1.33);
 
-        $this->validator->validate($this->image4By3, $constraint);
+        $this->validate($this->image4By3, $constraint);
 
         $this->assertNoViolation();
     }
@@ -204,7 +204,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Image(minRatio: 4 / 3);
 
-        $this->validator->validate($this->image4By3, $constraint);
+        $this->validate($this->image4By3, $constraint);
 
         $this->assertNoViolation();
     }
@@ -213,14 +213,14 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Image(maxRatio: 16 / 9);
 
-        $this->validator->validate($this->image16By9, $constraint);
+        $this->validate($this->image16By9, $constraint);
 
         $this->assertNoViolation();
     }
 
     public function testSquareNotAllowed()
     {
-        $this->validator->validate($this->image, new Image(allowSquare: false, allowSquareMessage: 'myMessage'));
+        $this->validate($this->image, new Image(allowSquare: false, allowSquareMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 2)
@@ -231,7 +231,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testLandscapeNotAllowed()
     {
-        $this->validator->validate($this->imageLandscape, new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'));
+        $this->validate($this->imageLandscape, new Image(allowLandscape: false, allowLandscapeMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 2)
@@ -242,7 +242,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testPortraitNotAllowed()
     {
-        $this->validator->validate($this->imagePortrait, new Image(allowPortrait: false, allowPortraitMessage: 'myMessage'));
+        $this->validate($this->imagePortrait, new Image(allowPortrait: false, allowPortraitMessage: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 1)
@@ -259,11 +259,11 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
         $constraint = new Image(detectCorrupted: true, corruptedMessage: 'myMessage');
 
-        $this->validator->validate($this->image, $constraint);
+        $this->validate($this->image, $constraint);
 
         $this->assertNoViolation();
 
-        $this->validator->validate($this->imageCorrupted, $constraint);
+        $this->validate($this->imageCorrupted, $constraint);
 
         $this->buildViolation('myMessage')
             ->setCode(Image::CORRUPTED_IMAGE_ERROR)
@@ -272,7 +272,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidMimeType()
     {
-        $this->validator->validate($this->notAnImage, $constraint = new Image());
+        $this->validate($this->notAnImage, $constraint = new Image());
 
         $this->assertSame('image/*', $constraint->mimeTypes);
 
@@ -287,7 +287,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidMimeTypeWithNarrowedSet()
     {
-        $this->validator->validate($this->image, new Image(mimeTypes: [
+        $this->validate($this->image, new Image(mimeTypes: [
             'image/jpeg',
             'image/png',
         ]));
@@ -304,7 +304,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideSvgWithViolation')]
     public function testSvgWithViolation(string $image, Image $constraint, string $violation, array $parameters = [])
     {
-        $this->validator->validate($image, $constraint);
+        $this->validate($image, $constraint);
 
         $this->buildViolation('myMessage')
             ->setCode($violation)
@@ -404,7 +404,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideSvgWithoutViolation')]
     public function testSvgWithoutViolation(string $image, Image $constraint)
     {
-        $this->validator->validate($image, $constraint);
+        $this->validate($image, $constraint);
 
         $this->assertNoViolation();
     }
@@ -442,7 +442,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Image(mimeTypes: [], extensions: ['gif'], extensionsMessage: 'myMessage');
 
-        $this->validator->validate(new File(__DIR__.'/Fixtures/'.$name), $constraint);
+        $this->validate(new File(__DIR__.'/Fixtures/'.$name), $constraint);
 
         $this->assertNoViolation();
     }
@@ -459,7 +459,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $path = __DIR__.'/Fixtures/'.$name;
         $constraint = new Image(extensions: ['png', 'svg'], extensionsMessage: 'myMessage');
 
-        $this->validator->validate(new File($path), $constraint);
+        $this->validate(new File($path), $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameters([
@@ -483,7 +483,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $path = __DIR__.'/Fixtures/invalid-content.gif';
         $constraint = new Image(mimeTypesMessage: 'myMessage', extensions: ['gif']);
 
-        $this->validator->validate(new File($path), $constraint);
+        $this->validate(new File($path), $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameters([

--- a/src/Symfony/Component/Validator/Tests/Constraints/InvalidComparisonToValueTestTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/InvalidComparisonToValueTestTrait.php
@@ -28,7 +28,7 @@ trait InvalidComparisonToValueTestTrait
         $constraint = $this->createConstraint(['value' => $comparedValue]);
         $constraint->message = 'Constraint Message';
 
-        $this->validator->validate($dirtyValue, $constraint);
+        $this->validate($dirtyValue, $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', $dirtyValueAsString)
@@ -49,7 +49,7 @@ trait InvalidComparisonToValueTestTrait
 
         $this->setObject($object);
 
-        $this->validator->validate($dirtyValue, $constraint);
+        $this->validate($dirtyValue, $constraint);
 
         $this->buildViolation('Constraint Message')
             ->setParameter('{{ value }}', $dirtyValueAsString)

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -27,14 +27,14 @@ class IpValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Ip());
+        $this->validate(null, new Ip());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Ip());
+        $this->validate('', new Ip());
 
         $this->assertNoViolation();
     }
@@ -42,7 +42,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Ip());
+        $this->validate(new \stdClass(), new Ip());
     }
 
     public function testInvalidValidatorVersion()
@@ -54,7 +54,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidIpsV4')]
     public function testValidIpsV4($ip)
     {
-        $this->validator->validate($ip, new Ip(version: Ip::V4));
+        $this->validate($ip, new Ip(version: Ip::V4));
 
         $this->assertNoViolation();
     }
@@ -76,7 +76,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidIpsV4WithWhitespaces')]
     public function testValidIpsV4WithWhitespaces($ip)
     {
-        $this->validator->validate($ip, new Ip(
+        $this->validate($ip, new Ip(
             version: Ip::V4,
             normalizer: 'trim',
         ));
@@ -86,7 +86,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidIpV6WithWhitespacesNamed()
     {
-        $this->validator->validate(
+        $this->validate(
             "\n\t2001:0db8:85a3:0000:0000:8a2e:0370:7334\r\n",
             new Ip(version: Ip::V6, normalizer: 'trim')
         );
@@ -109,7 +109,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidIpsV6')]
     public function testValidIpsV6($ip)
     {
-        $this->validator->validate($ip, new Ip(version: Ip::V6));
+        $this->validate($ip, new Ip(version: Ip::V6));
 
         $this->assertNoViolation();
     }
@@ -142,7 +142,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidIpsAll')]
     public function testValidIpsAll($ip)
     {
-        $this->validator->validate($ip, new Ip(version: Ip::ALL));
+        $this->validate($ip, new Ip(version: Ip::ALL));
 
         $this->assertNoViolation();
     }
@@ -160,7 +160,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -176,7 +176,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -211,7 +211,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidPrivateIpsV4')]
     public function testValidPrivateIpsV4($ip)
     {
-        $this->validator->validate($ip, new Ip(version: Ip::V4_ONLY_PRIVATE));
+        $this->validate($ip, new Ip(version: Ip::V4_ONLY_PRIVATE));
 
         $this->assertNoViolation();
     }
@@ -224,7 +224,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -240,7 +240,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -265,7 +265,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidReservedIpsV4')]
     public function testValidReservedIpsV4($ip)
     {
-        $this->validator->validate($ip, new Ip(version: Ip::V4_ONLY_RESERVED));
+        $this->validate($ip, new Ip(version: Ip::V4_ONLY_RESERVED));
 
         $this->assertNoViolation();
     }
@@ -278,7 +278,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -294,7 +294,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -324,7 +324,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -345,7 +345,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -380,7 +380,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -405,7 +405,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -429,7 +429,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -450,7 +450,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -471,7 +471,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -492,7 +492,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')
@@ -513,7 +513,7 @@ class IpValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($ip, $constraint);
+        $this->validate($ip, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$ip.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
@@ -24,21 +24,21 @@ class IsFalseValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new IsFalse());
+        $this->validate(null, new IsFalse());
 
         $this->assertNoViolation();
     }
 
     public function testFalseIsValid()
     {
-        $this->validator->validate(false, new IsFalse());
+        $this->validate(false, new IsFalse());
 
         $this->assertNoViolation();
     }
 
     public function testTrueIsInvalid()
     {
-        $this->validator->validate(true, new IsFalse(message: 'myMessage'));
+        $this->validate(true, new IsFalse(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'true')

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
@@ -25,7 +25,7 @@ class IsNullValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new IsNull());
+        $this->validate(null, new IsNull());
 
         $this->assertNoViolation();
     }
@@ -35,7 +35,7 @@ class IsNullValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new IsNull(message: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $valueAsString)
@@ -48,7 +48,7 @@ class IsNullValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new IsNull(message: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $valueAsString)

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
@@ -24,21 +24,21 @@ class IsTrueValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new IsTrue());
+        $this->validate(null, new IsTrue());
 
         $this->assertNoViolation();
     }
 
     public function testTrueIsValid()
     {
-        $this->validator->validate(true, new IsTrue());
+        $this->validate(true, new IsTrue());
 
         $this->assertNoViolation();
     }
 
     public function testFalseIsInvalid()
     {
-        $this->validator->validate(false, new IsTrue(message: 'myMessage'));
+        $this->validate(false, new IsTrue(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'false')

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
@@ -124,7 +124,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isbn();
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->assertNoViolation();
     }
@@ -133,7 +133,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isbn();
 
-        $this->validator->validate('', $constraint);
+        $this->validate('', $constraint);
 
         $this->assertNoViolation();
     }
@@ -143,7 +143,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedValueException::class);
         $constraint = new Isbn();
 
-        $this->validator->validate(new \stdClass(), $constraint);
+        $this->validate(new \stdClass(), $constraint);
     }
 
     #[DataProvider('getValidIsbn10')]
@@ -151,14 +151,14 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isbn(type: 'isbn10');
 
-        $this->validator->validate($isbn, $constraint);
+        $this->validate($isbn, $constraint);
 
         $this->assertNoViolation();
     }
 
     public function testInvalidIsbn10Named()
     {
-        $this->validator->validate(
+        $this->validate(
             '978-2723442282',
             new Isbn(type: Isbn::ISBN_10, isbn10Message: 'myMessage')
         );
@@ -174,7 +174,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isbn(type: 'isbn13');
 
-        $this->validator->validate($isbn, $constraint);
+        $this->validate($isbn, $constraint);
 
         $this->assertNoViolation();
     }
@@ -187,7 +187,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
             isbn13Message: 'myMessage',
         );
 
-        $this->validator->validate($isbn, $constraint);
+        $this->validate($isbn, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$isbn.'"')
@@ -200,7 +200,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isbn();
 
-        $this->validator->validate($isbn, $constraint);
+        $this->validate($isbn, $constraint);
 
         $this->assertNoViolation();
     }
@@ -210,7 +210,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isbn(bothIsbnMessage: 'myMessage');
 
-        $this->validator->validate($isbn, $constraint);
+        $this->validate($isbn, $constraint);
 
         // Too long for an ISBN-10, but not long enough for an ISBN-13
         if (Isbn::TOO_LONG_ERROR === $code) {
@@ -228,7 +228,7 @@ class IsbnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isbn(bothIsbnMessage: 'myMessage');
 
-        $this->validator->validate($isbn, $constraint);
+        $this->validate($isbn, $constraint);
 
         // Too short for an ISBN-13, but not short enough for an ISBN-10
         if (Isbn::TOO_SHORT_ERROR === $code) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsinValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsinValidatorTest.php
@@ -26,14 +26,14 @@ class IsinValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Isin());
+        $this->validate(null, new Isin());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Isin());
+        $this->validate('', new Isin());
 
         $this->assertNoViolation();
     }
@@ -41,7 +41,7 @@ class IsinValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidIsin')]
     public function testValidIsin($isin)
     {
-        $this->validator->validate($isin, new Isin());
+        $this->validate($isin, new Isin());
         $this->expectViolationsAt(0, $isin, new Luhn());
         $this->assertNoViolation();
     }
@@ -125,7 +125,7 @@ class IsinValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Isin(message: 'myMessage');
 
-        $this->validator->validate($isin, $constraint);
+        $this->validate($isin, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$isin.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -94,7 +94,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Issn();
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->assertNoViolation();
     }
@@ -103,7 +103,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Issn();
 
-        $this->validator->validate('', $constraint);
+        $this->validate('', $constraint);
 
         $this->assertNoViolation();
     }
@@ -112,7 +112,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedValueException::class);
         $constraint = new Issn();
-        $this->validator->validate(new \stdClass(), $constraint);
+        $this->validate(new \stdClass(), $constraint);
     }
 
     #[DataProvider('getValidLowerCasedIssn')]
@@ -123,7 +123,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($issn, $constraint);
+        $this->validate($issn, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$issn.'"')
@@ -139,7 +139,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($issn, $constraint);
+        $this->validate($issn, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$issn.'"')
@@ -152,7 +152,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Issn();
 
-        $this->validator->validate($issn, $constraint);
+        $this->validate($issn, $constraint);
 
         $this->assertNoViolation();
     }
@@ -162,7 +162,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Issn(message: 'myMessage');
 
-        $this->validator->validate($issn, $constraint);
+        $this->validate($issn, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$issn.'"')
@@ -172,7 +172,7 @@ class IssnValidatorTest extends ConstraintValidatorTestCase
 
     public function testNamedArguments()
     {
-        $this->validator->validate(
+        $this->validate(
             '2162321x',
             new Issn(message: 'myMessage', caseSensitive: true, requireHyphen: true)
         );

--- a/src/Symfony/Component/Validator/Tests/Constraints/JsonValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/JsonValidatorTest.php
@@ -26,7 +26,7 @@ class JsonValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidValues')]
     public function testJsonIsValid($value)
     {
-        $this->validator->validate($value, new Json());
+        $this->validate($value, new Json());
 
         $this->assertNoViolation();
     }
@@ -36,7 +36,7 @@ class JsonValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Json(message: 'myMessageTest');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessageTest')
             ->setParameter('{{ value }}', '"'.$value.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -43,14 +43,14 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Language());
+        $this->validate(null, new Language());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Language());
+        $this->validate('', new Language());
 
         $this->assertNoViolation();
     }
@@ -58,13 +58,13 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Language());
+        $this->validate(new \stdClass(), new Language());
     }
 
     #[DataProvider('getValidLanguages')]
     public function testValidLanguages($language)
     {
-        $this->validator->validate($language, new Language());
+        $this->validate($language, new Language());
 
         $this->assertNoViolation();
     }
@@ -82,7 +82,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Language(message: 'myMessage');
 
-        $this->validator->validate($language, $constraint);
+        $this->validate($language, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$language.'"')
@@ -101,7 +101,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidAlpha3Languages')]
     public function testValidAlpha3Languages($language)
     {
-        $this->validator->validate($language, new Language(alpha3: true));
+        $this->validate($language, new Language(alpha3: true));
 
         $this->assertNoViolation();
     }
@@ -123,7 +123,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($language, $constraint);
+        $this->validate($language, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$language.'"')
@@ -143,7 +143,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidAlpha3LanguageNamed()
     {
-        $this->validator->validate(
+        $this->validate(
             'DE',
             new Language(alpha3: true, message: 'myMessage')
         );
@@ -161,7 +161,7 @@ class LanguageValidatorTest extends ConstraintValidatorTestCase
         \Locale::setDefault('fr_FR');
         $existingLanguage = 'en';
 
-        $this->validator->validate($existingLanguage, new Language(message: 'aMessage'));
+        $this->validate($existingLanguage, new Language(message: 'aMessage'));
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -26,14 +26,14 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Length(exactly: 6));
+        $this->validate(null, new Length(exactly: 6));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsInvalid()
     {
-        $this->validator->validate('', new Length(
+        $this->validate('', new Length(
             exactly: $limit = 6,
             exactMessage: 'myMessage',
         ));
@@ -53,7 +53,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Length(exactly: 5));
+        $this->validate(new \stdClass(), new Length(exactly: 5));
     }
 
     public static function getThreeOrLessCharacters()
@@ -120,7 +120,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testValidValuesMin(int|string $value, int $valueLength)
     {
         $constraint = new Length(min: 5);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -129,7 +129,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testValidValuesMax(int|string $value, int $valueLength)
     {
         $constraint = new Length(max: 3);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -138,7 +138,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testValidValuesExact(int|string $value)
     {
         $constraint = new Length(4);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -147,7 +147,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testValidNormalizedValues($value)
     {
         $constraint = new Length(min: 3, max: 3, normalizer: 'trim');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -155,7 +155,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testValidGraphemesValues()
     {
         $constraint = new Length(min: 1, max: 1, countUnit: Length::COUNT_GRAPHEMES);
-        $this->validator->validate("A\u{0300}", $constraint);
+        $this->validate("A\u{0300}", $constraint);
 
         $this->assertNoViolation();
     }
@@ -163,7 +163,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testValidCodepointsValues()
     {
         $constraint = new Length(min: 2, max: 2, countUnit: Length::COUNT_CODEPOINTS);
-        $this->validator->validate("A\u{0300}", $constraint);
+        $this->validate("A\u{0300}", $constraint);
 
         $this->assertNoViolation();
     }
@@ -171,7 +171,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     public function testValidBytesValues()
     {
         $constraint = new Length(min: 3, max: 3, countUnit: Length::COUNT_BYTES);
-        $this->validator->validate("A\u{0300}", $constraint);
+        $this->validate("A\u{0300}", $constraint);
 
         $this->assertNoViolation();
     }
@@ -184,7 +184,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             minMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -202,7 +202,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Length(min: 4, minMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -223,7 +223,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             maxMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -241,7 +241,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Length(max: 4, maxMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -263,7 +263,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             exactMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -282,7 +282,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Length(exactly: 4, exactMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -305,7 +305,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             exactMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -329,7 +329,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             charsetMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         if ($isValid) {
             $this->assertNoViolation();
@@ -347,7 +347,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Length(min: 1, max: 1, exactMessage: 'myMessage');
 
-        $this->validator->validate("A\u{0300}", $constraint);
+        $this->validate("A\u{0300}", $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'."A\u{0300}".'"')
@@ -365,7 +365,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Length(min: 1, max: 1, countUnit: Length::COUNT_BYTES, exactMessage: 'myMessage');
 
-        $this->validator->validate("A\u{0300}", $constraint);
+        $this->validate("A\u{0300}", $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'."A\u{0300}".'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -99,7 +99,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 
         $extremeDate = (new \DateTimeImmutable())->setDate(185449, 12, 31)->setTime(23, 0, 0);
 
-        $this->validator->validate($extremeDate, $constraint);
+        $this->validate($extremeDate, $constraint);
 
         $violations = $this->context->getViolations();
         $this->assertCount(1, $violations);

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -26,14 +26,14 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Locale());
+        $this->validate(null, new Locale());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Locale());
+        $this->validate('', new Locale());
 
         $this->assertNoViolation();
     }
@@ -41,13 +41,13 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Locale());
+        $this->validate(new \stdClass(), new Locale());
     }
 
     #[DataProvider('getValidLocales')]
     public function testValidLocales($locale)
     {
-        $this->validator->validate($locale, new Locale());
+        $this->validate($locale, new Locale());
 
         $this->assertNoViolation();
     }
@@ -70,7 +70,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Locale(message: 'myMessage');
 
-        $this->validator->validate($locale, $constraint);
+        $this->validate($locale, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$locale.'"')
@@ -91,7 +91,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Locale(message: 'myMessage');
 
         $locale = str_repeat('a', (\defined('INTL_MAX_LOCALE_LEN') ? \INTL_MAX_LOCALE_LEN : 85) + 1);
-        $this->validator->validate($locale, $constraint);
+        $this->validate($locale, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$locale.'"')
@@ -104,7 +104,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Locale(message: 'myMessage');
 
-        $this->validator->validate($locale, $constraint);
+        $this->validate($locale, $constraint);
 
         $this->assertNoViolation();
     }
@@ -117,7 +117,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
             canonicalize: false,
         );
 
-        $this->validator->validate($locale, $constraint);
+        $this->validate($locale, $constraint);
 
         $this->assertNoViolation();
     }
@@ -130,7 +130,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
             canonicalize: false,
         );
 
-        $this->validator->validate($locale, $constraint);
+        $this->validate($locale, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$locale.'"')
@@ -140,7 +140,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidLocaleWithoutCanonicalizationNamed()
     {
-        $this->validator->validate(
+        $this->validate(
             'en-US',
             new Locale(message: 'myMessage', canonicalize: false)
         );

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -26,14 +26,14 @@ class LuhnValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Luhn());
+        $this->validate(null, new Luhn());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Luhn());
+        $this->validate('', new Luhn());
 
         $this->assertNoViolation();
     }
@@ -41,7 +41,7 @@ class LuhnValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidNumbers')]
     public function testValidNumbers($number)
     {
-        $this->validator->validate($number, new Luhn());
+        $this->validate($number, new Luhn());
 
         $this->assertNoViolation();
     }
@@ -75,7 +75,7 @@ class LuhnValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Luhn(message: 'myMessage');
 
-        $this->validator->validate($number, $constraint);
+        $this->validate($number, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$number.'"')
@@ -100,7 +100,7 @@ class LuhnValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedValueException::class);
         $constraint = new Luhn();
 
-        $this->validator->validate($number, $constraint);
+        $this->validate($number, $constraint);
     }
 
     public static function getInvalidTypes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MacAddressValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MacAddressValidatorTest.php
@@ -30,14 +30,14 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new MacAddress());
+        $this->validate(null, new MacAddress());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new MacAddress());
+        $this->validate('', new MacAddress());
 
         $this->assertNoViolation();
     }
@@ -45,7 +45,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new MacAddress());
+        $this->validate(new \stdClass(), new MacAddress());
     }
 
     public function testInvalidValidatorType()
@@ -57,7 +57,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidMacs')]
     public function testValidMac($mac)
     {
-        $this->validator->validate($mac, new MacAddress());
+        $this->validate($mac, new MacAddress());
 
         $this->assertNoViolation();
     }
@@ -65,7 +65,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getNotValidMacs')]
     public function testNotValidMac($mac)
     {
-        $this->validator->validate($mac, new MacAddress());
+        $this->validate($mac, new MacAddress());
 
         $this->buildViolation('This value is not a valid MAC address.')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -156,7 +156,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUniversalMulticastMacs')]
     public function testValidAllNoBroadcastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::ALL_NO_BROADCAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::ALL_NO_BROADCAST));
 
         $this->assertNoViolation();
     }
@@ -166,7 +166,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::ALL_NO_BROADCAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -179,7 +179,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidBroadcastMacs')]
     public function testValidLocalMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::LOCAL_ALL));
+        $this->validate($mac, new MacAddress(type: MacAddress::LOCAL_ALL));
 
         $this->assertNoViolation();
     }
@@ -190,7 +190,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::LOCAL_ALL);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -202,7 +202,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidLocalMulticastMacs')]
     public function testValidLocalNoBroadcastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::LOCAL_NO_BROADCAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::LOCAL_NO_BROADCAST));
 
         $this->assertNoViolation();
     }
@@ -214,7 +214,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::LOCAL_NO_BROADCAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -225,7 +225,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidLocalUnicastMacs')]
     public function testValidLocalUnicastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::LOCAL_UNICAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::LOCAL_UNICAST));
 
         $this->assertNoViolation();
     }
@@ -237,7 +237,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::LOCAL_UNICAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -249,7 +249,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidBroadcastMacs')]
     public function testValidLocalMulticastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::LOCAL_MULTICAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::LOCAL_MULTICAST));
 
         $this->assertNoViolation();
     }
@@ -261,7 +261,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::LOCAL_MULTICAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -272,7 +272,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidLocalMulticastMacs')]
     public function testValidLocalMulticastNoBroadcastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::LOCAL_MULTICAST_NO_BROADCAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::LOCAL_MULTICAST_NO_BROADCAST));
 
         $this->assertNoViolation();
     }
@@ -285,7 +285,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::LOCAL_MULTICAST_NO_BROADCAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -297,7 +297,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUniversalMulticastMacs')]
     public function testValidUniversalMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::UNIVERSAL_ALL));
+        $this->validate($mac, new MacAddress(type: MacAddress::UNIVERSAL_ALL));
 
         $this->assertNoViolation();
     }
@@ -308,7 +308,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::UNIVERSAL_ALL);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -319,7 +319,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUniversalUnicastMacs')]
     public function testValidUniversalUnicastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::UNIVERSAL_UNICAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::UNIVERSAL_UNICAST));
 
         $this->assertNoViolation();
     }
@@ -331,7 +331,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::UNIVERSAL_UNICAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -342,7 +342,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUniversalMulticastMacs')]
     public function testValidUniversalMulticastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::UNIVERSAL_MULTICAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::UNIVERSAL_MULTICAST));
 
         $this->assertNoViolation();
     }
@@ -354,7 +354,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::UNIVERSAL_MULTICAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -366,7 +366,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUniversalUnicastMacs')]
     public function testUnicastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::UNICAST_ALL));
+        $this->validate($mac, new MacAddress(type: MacAddress::UNICAST_ALL));
 
         $this->assertNoViolation();
     }
@@ -377,7 +377,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::UNICAST_ALL);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -390,7 +390,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidBroadcastMacs')]
     public function testMulticastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::MULTICAST_ALL));
+        $this->validate($mac, new MacAddress(type: MacAddress::MULTICAST_ALL));
 
         $this->assertNoViolation();
     }
@@ -401,7 +401,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::MULTICAST_ALL);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -413,7 +413,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUniversalMulticastMacs')]
     public function testMulticastNoBroadcastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::MULTICAST_NO_BROADCAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::MULTICAST_NO_BROADCAST));
 
         $this->assertNoViolation();
     }
@@ -425,7 +425,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::MULTICAST_NO_BROADCAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -436,7 +436,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidBroadcastMacs')]
     public function testBroadcastMacs($mac)
     {
-        $this->validator->validate($mac, new MacAddress(type: MacAddress::BROADCAST));
+        $this->validate($mac, new MacAddress(type: MacAddress::BROADCAST));
 
         $this->assertNoViolation();
     }
@@ -449,7 +449,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage', type: MacAddress::BROADCAST);
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')
@@ -460,7 +460,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidMacsWithWhitespaces')]
     public function testValidMacsWithWhitespaces($mac)
     {
-        $this->validator->validate($mac, new MacAddress(normalizer: 'trim'));
+        $this->validate($mac, new MacAddress(normalizer: 'trim'));
 
         $this->assertNoViolation();
     }
@@ -482,7 +482,7 @@ class MacAddressValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new MacAddress('myMessage');
 
-        $this->validator->validate($mac, $constraint);
+        $this->validate($mac, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$mac.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/NoSuspiciousCharactersValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NoSuspiciousCharactersValidatorTest.php
@@ -31,7 +31,7 @@ class NoSuspiciousCharactersValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideNonSuspiciousStrings')]
     public function testNonSuspiciousStrings(string $string, array $options = [])
     {
-        $this->validator->validate($string, new NoSuspiciousCharacters(...$options));
+        $this->validate($string, new NoSuspiciousCharacters(...$options));
 
         $this->assertNoViolation();
     }
@@ -55,7 +55,7 @@ class NoSuspiciousCharactersValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideSuspiciousStrings')]
     public function testSuspiciousStrings(string $string, array $options, array $errors)
     {
-        $this->validator->validate($string, new NoSuspiciousCharacters(...$options));
+        $this->validate($string, new NoSuspiciousCharacters(...$options));
 
         $violations = null;
 
@@ -169,10 +169,9 @@ class NoSuspiciousCharactersValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidatorFiltersEmptyDefaultLocales()
     {
-        $validator = new NoSuspiciousCharactersValidator(['en', '', 'fr', null, 'de']);
-        $validator->initialize($this->context);
+        $this->validator = new NoSuspiciousCharactersValidator(['en', '', 'fr', null, 'de']);
 
-        $validator->validate('abc', new NoSuspiciousCharacters());
+        $this->validate('abc', new NoSuspiciousCharacters());
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -26,7 +26,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidValues')]
     public function testValidValues($value)
     {
-        $this->validator->validate($value, new NotBlank());
+        $this->validate($value, new NotBlank());
 
         $this->assertNoViolation();
     }
@@ -46,7 +46,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new NotBlank(message: 'myMessage');
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'null')
@@ -58,7 +58,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new NotBlank(message: 'myMessage');
 
-        $this->validator->validate('', $constraint);
+        $this->validate('', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')
@@ -70,7 +70,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new NotBlank(message: 'myMessage');
 
-        $this->validator->validate(false, $constraint);
+        $this->validate(false, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'false')
@@ -82,7 +82,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new NotBlank(message: 'myMessage');
 
-        $this->validator->validate([], $constraint);
+        $this->validate([], $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'array')
@@ -97,7 +97,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
             allowNull: true,
         );
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
         $this->assertNoViolation();
     }
 
@@ -108,7 +108,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
             allowNull: false,
         );
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'null')
@@ -124,7 +124,7 @@ class NotBlankValidatorTest extends ConstraintValidatorTestCase
             normalizer: 'trim',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotCompromisedPasswordValidatorTest.php
@@ -53,14 +53,14 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new NotCompromisedPassword());
+        $this->validate(null, new NotCompromisedPassword());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new NotCompromisedPassword());
+        $this->validate('', new NotCompromisedPassword());
 
         $this->assertNoViolation();
     }
@@ -70,7 +70,7 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
         $r = new \ReflectionProperty($this->validator, 'enabled');
         $r->setValue($this->validator, false);
 
-        $this->validator->validate(self::PASSWORD_LEAKED, new NotCompromisedPassword());
+        $this->validate(self::PASSWORD_LEAKED, new NotCompromisedPassword());
 
         $this->assertNoViolation();
     }
@@ -78,7 +78,7 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidPassword()
     {
         $constraint = new NotCompromisedPassword();
-        $this->validator->validate(self::PASSWORD_LEAKED, $constraint);
+        $this->validate(self::PASSWORD_LEAKED, $constraint);
 
         $this->buildViolation($constraint->message)
             ->setCode(NotCompromisedPassword::COMPROMISED_PASSWORD_ERROR)
@@ -88,7 +88,7 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
     public function testThresholdReached()
     {
         $constraint = new NotCompromisedPassword(threshold: 3);
-        $this->validator->validate(self::PASSWORD_LEAKED, $constraint);
+        $this->validate(self::PASSWORD_LEAKED, $constraint);
 
         $this->buildViolation($constraint->message)
             ->setCode(NotCompromisedPassword::COMPROMISED_PASSWORD_ERROR)
@@ -97,22 +97,23 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
 
     public function testThresholdNotReached()
     {
-        $this->validator->validate(self::PASSWORD_LEAKED, new NotCompromisedPassword(threshold: 10));
+        $this->validate(self::PASSWORD_LEAKED, new NotCompromisedPassword(threshold: 10));
 
         $this->assertNoViolation();
     }
 
     public function testValidPassword()
     {
-        $this->validator->validate(self::PASSWORD_NOT_LEAKED, new NotCompromisedPassword());
+        $this->validate(self::PASSWORD_NOT_LEAKED, new NotCompromisedPassword());
 
         $this->assertNoViolation();
     }
 
     public function testNonUtf8CharsetValid()
     {
-        $validator = new NotCompromisedPasswordValidator($this->createHttpClientStub(), 'ISO-8859-5');
-        $validator->validate(mb_convert_encoding(self::PASSWORD_NON_UTF8_NOT_LEAKED, 'ISO-8859-5', 'UTF-8'), new NotCompromisedPassword());
+        $this->validator = new NotCompromisedPasswordValidator($this->createHttpClientStub(), 'ISO-8859-5');
+
+        $this->validate(mb_convert_encoding(self::PASSWORD_NON_UTF8_NOT_LEAKED, 'ISO-8859-5', 'UTF-8'), new NotCompromisedPassword());
 
         $this->assertNoViolation();
     }
@@ -121,11 +122,9 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new NotCompromisedPassword();
 
-        $this->context = $this->createContext();
+        $this->validator = new NotCompromisedPasswordValidator($this->createHttpClientStub(), 'ISO-8859-5');
 
-        $validator = new NotCompromisedPasswordValidator($this->createHttpClientStub(), 'ISO-8859-5');
-        $validator->initialize($this->context);
-        $validator->validate(mb_convert_encoding(self::PASSWORD_NON_UTF8_LEAKED, 'ISO-8859-5', 'UTF-8'), $constraint);
+        $this->validate(mb_convert_encoding(self::PASSWORD_NON_UTF8_LEAKED, 'ISO-8859-5', 'UTF-8'), $constraint);
 
         $this->buildViolation($constraint->message)
             ->setCode(NotCompromisedPassword::COMPROMISED_PASSWORD_ERROR)
@@ -139,16 +138,13 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
         $expectedEndpointUrl = 'https://password-check.internal.example.com/range/50D74';
         $constraint = new NotCompromisedPassword();
 
-        $this->context = $this->createContext();
-
-        $validator = new NotCompromisedPasswordValidator(
+        $this->validator = new NotCompromisedPasswordValidator(
             $this->createHttpClientStubCustomEndpoint($expectedEndpointUrl),
             'UTF-8',
             true,
             $endpoint
         );
-        $validator->initialize($this->context);
-        $validator->validate(self::PASSWORD_LEAKED, $constraint);
+        $this->validate(self::PASSWORD_LEAKED, $constraint);
 
         $this->buildViolation($constraint->message)
             ->setCode(NotCompromisedPassword::COMPROMISED_PASSWORD_ERROR)
@@ -168,14 +164,14 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
             ]
         );
 
-        $validator = new NotCompromisedPasswordValidator(
+        $this->validator = new NotCompromisedPasswordValidator(
             $this->createHttpClientStub($returnValue),
             'UTF-8',
             true,
             'https://password-check.internal.example.com/range/%s'
         );
 
-        $validator->validate(self::PASSWORD_NOT_LEAKED, new NotCompromisedPassword());
+        $this->validate(self::PASSWORD_NOT_LEAKED, new NotCompromisedPassword());
 
         $this->assertNoViolation();
     }
@@ -183,26 +179,26 @@ class NotCompromisedPasswordValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidConstraint()
     {
         $this->expectException(UnexpectedTypeException::class);
-        $this->validator->validate(null, new Luhn());
+        $this->validate(null, new Luhn());
     }
 
     public function testInvalidValue()
     {
         $this->expectException(UnexpectedTypeException::class);
-        $this->validator->validate([], new NotCompromisedPassword());
+        $this->validate([], new NotCompromisedPassword());
     }
 
     public function testApiError()
     {
         $this->expectException(ExceptionInterface::class);
-        $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword());
+        $this->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword());
     }
 
     public function testApiErrorSkipped()
     {
         $this->expectNotToPerformAssertions();
 
-        $this->validator->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword(skipOnError: true));
+        $this->validate(self::PASSWORD_TRIGGERING_AN_ERROR, new NotCompromisedPassword(skipOnError: true));
     }
 
     private function createHttpClientStub(?string $returnValue = null): HttpClientInterface

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
@@ -26,7 +26,7 @@ class NotNullValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidValues')]
     public function testValidValues($value)
     {
-        $this->validator->validate($value, new NotNull());
+        $this->validate($value, new NotNull());
 
         $this->assertNoViolation();
     }
@@ -43,7 +43,7 @@ class NotNullValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsInvalid()
     {
-        $this->validator->validate(null, new NotNull(message: 'myMessage'));
+        $this->validate(null, new NotNull(message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'null')

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorTest.php
@@ -27,7 +27,7 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidValues')]
     public function testValidValues(string|\Stringable $value, int $expectedStrength)
     {
-        $this->validator->validate($value, new PasswordStrength(minScore: $expectedStrength));
+        $this->validate($value, new PasswordStrength(minScore: $expectedStrength));
 
         $this->assertNoViolation();
 
@@ -35,7 +35,7 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
             return;
         }
 
-        $this->validator->validate($value, new PasswordStrength(minScore: $expectedStrength + 1));
+        $this->validate($value, new PasswordStrength(minScore: $expectedStrength + 1));
 
         $this->buildViolation('The password strength is too low. Please use a stronger password.')
             ->setCode(PasswordStrength::PASSWORD_STRENGTH_ERROR)
@@ -55,7 +55,7 @@ class PasswordStrengthValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideInvalidConstraints')]
     public function testThePasswordIsWeak(PasswordStrength $constraint, string $password, string $expectedMessage, string $expectedCode, string $strength)
     {
-        $this->validator->validate($password, $constraint);
+        $this->validate($password, $constraint);
 
         $this->buildViolation($expectedMessage)
             ->setCode($expectedCode)

--- a/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorWithClosureTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PasswordStrengthValidatorWithClosureTest.php
@@ -37,7 +37,7 @@ class PasswordStrengthValidatorWithClosureTest extends ConstraintValidatorTestCa
     #[DataProvider('getValidValues')]
     public function testValidValues(string|\Stringable $value, int $expectedStrength)
     {
-        $this->validator->validate($value, new PasswordStrength(minScore: $expectedStrength));
+        $this->validate($value, new PasswordStrength(minScore: $expectedStrength));
 
         $this->assertNoViolation();
 
@@ -45,7 +45,7 @@ class PasswordStrengthValidatorWithClosureTest extends ConstraintValidatorTestCa
             return;
         }
 
-        $this->validator->validate($value, new PasswordStrength(minScore: $expectedStrength + 1));
+        $this->validate($value, new PasswordStrength(minScore: $expectedStrength + 1));
 
         $this->buildViolation('The password strength is too low. Please use a stronger password.')
             ->setCode(PasswordStrength::PASSWORD_STRENGTH_ERROR)
@@ -64,7 +64,7 @@ class PasswordStrengthValidatorWithClosureTest extends ConstraintValidatorTestCa
     #[DataProvider('provideInvalidConstraints')]
     public function testThePasswordIsWeak(PasswordStrength $constraint, string $password, string $expectedMessage, string $expectedCode, string $strength)
     {
-        $this->validator->validate($password, $constraint);
+        $this->validate($password, $constraint);
 
         $this->buildViolation($expectedMessage)
             ->setCode($expectedCode)

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -32,7 +32,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Range(min: 10, max: 20));
+        $this->validate(null, new Range(min: 10, max: 20));
 
         $this->assertNoViolation();
     }
@@ -75,7 +75,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     public function testValidValuesMinNamed($value)
     {
         $constraint = new Range(min: 10);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -84,7 +84,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     public function testValidValuesMaxNamed($value)
     {
         $constraint = new Range(max: 20);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -93,7 +93,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     public function testValidValuesMinMaxNamed($value)
     {
         $constraint = new Range(min: 10, max: 20);
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -103,7 +103,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Range(min: 10, minMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -117,7 +117,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Range(max: 20, maxMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -131,7 +131,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Range(min: 10, max: 20, notInRangeMessage: 'myNotInRangeMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -146,7 +146,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Range(min: 10, max: 20, notInRangeMessage: 'myNotInRangeMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -219,7 +219,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     public function testValidDatesMin($value)
     {
         $constraint = new Range(min: 'March 10, 2014');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -228,7 +228,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     public function testValidDatesMax($value)
     {
         $constraint = new Range(max: 'March 20, 2014');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -237,7 +237,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     public function testValidDatesMinMax($value)
     {
         $constraint = new Range(min: 'March 10, 2014', max: 'March 20, 2014');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -254,7 +254,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             minMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -275,7 +275,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             maxMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -297,7 +297,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             notInRangeMessage: 'myNotInRangeMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -320,7 +320,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             notInRangeMessage: 'myNotInRangeMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -348,7 +348,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             max: 20,
         );
 
-        $this->validator->validate('abcd', $constraint);
+        $this->validate('abcd', $constraint);
 
         $this->buildViolation($constraint->invalidMessage)
             ->setParameter('{{ value }}', '"abcd"')
@@ -362,7 +362,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             min: 'March 10, 2014',
         );
 
-        $this->validator->validate('abcd', $constraint);
+        $this->validate('abcd', $constraint);
 
         $this->buildViolation($constraint->invalidDateTimeMessage)
             ->setParameter('{{ value }}', '"abcd"')
@@ -376,7 +376,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             max: 'March 20, 2014',
         );
 
-        $this->validator->validate('abcd', $constraint);
+        $this->validate('abcd', $constraint);
 
         $this->buildViolation($constraint->invalidDateTimeMessage)
             ->setParameter('{{ value }}', '"abcd"')
@@ -391,7 +391,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             max: 'March 20, 2014',
         );
 
-        $this->validator->validate('abcd', $constraint);
+        $this->validate('abcd', $constraint);
 
         $this->buildViolation($constraint->invalidDateTimeMessage)
             ->setParameter('{{ value }}', '"abcd"')
@@ -406,7 +406,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             max: 'March 20, 2014',
         );
 
-        $this->validator->validate('abcd', $constraint);
+        $this->validate('abcd', $constraint);
 
         $this->buildViolation($constraint->invalidMessage)
             ->setParameter('{{ value }}', '"abcd"')
@@ -421,7 +421,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             max: 'March 50, 2014',
         );
 
-        $this->validator->validate('abcd', $constraint);
+        $this->validate('abcd', $constraint);
 
         $this->buildViolation($constraint->invalidMessage)
             ->setParameter('{{ value }}', '"abcd"')
@@ -436,7 +436,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             max: 'March 50, 2014',
         );
 
-        $this->validator->validate('abcd', $constraint);
+        $this->validate('abcd', $constraint);
 
         $this->buildViolation($constraint->invalidMessage)
             ->setParameter('{{ value }}', '"abcd"')
@@ -450,7 +450,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $this->validator->validate($value, new Range(
+        $this->validate($value, new Range(
             min: $min,
             max: $max,
         ));
@@ -471,7 +471,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(null);
 
-        $this->validator->validate(1, new Range(
+        $this->validate(1, new Range(
             minPropertyPath: 'minPropertyPath',
             maxPropertyPath: 'maxPropertyPath',
         ));
@@ -484,7 +484,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit(10));
 
-        $this->validator->validate($value, new Range(minPropertyPath: 'value'));
+        $this->validate($value, new Range(minPropertyPath: 'value'));
 
         $this->assertNoViolation();
     }
@@ -494,7 +494,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit(20));
 
-        $this->validator->validate($value, new Range(
+        $this->validate($value, new Range(
             maxPropertyPath: 'value',
         ));
 
@@ -506,7 +506,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit(20));
 
-        $this->validator->validate($value, new Range(maxPropertyPath: 'value'));
+        $this->validate($value, new Range(maxPropertyPath: 'value'));
 
         $this->assertNoViolation();
     }
@@ -516,7 +516,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new MinMax(10, 20));
 
-        $this->validator->validate($value, new Range(
+        $this->validate($value, new Range(
             minPropertyPath: 'min',
             maxPropertyPath: 'max',
         ));
@@ -534,7 +534,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             minMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -554,7 +554,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             maxMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -575,7 +575,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             notInRangeMessage: 'myNotInRangeMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -598,7 +598,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             notInRangeMessage: 'myNotInRangeMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $formattedValue)
@@ -615,7 +615,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(null);
 
-        $this->validator->validate($value, new Range(
+        $this->validate($value, new Range(
             min: 10,
             maxPropertyPath: 'max',
             minMessage: 'myMessage',
@@ -634,7 +634,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(null);
 
-        $this->validator->validate($value, new Range(
+        $this->validate($value, new Range(
             minPropertyPath: 'min',
             max: 20,
             maxMessage: 'myMessage',
@@ -653,7 +653,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $this->setObject(new Limit('March 10, 2014'));
 
-        $this->validator->validate($value, new Range(minPropertyPath: 'value'));
+        $this->validate($value, new Range(minPropertyPath: 'value'));
 
         $this->assertNoViolation();
     }
@@ -664,7 +664,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $this->setObject(new Limit('March 20, 2014'));
 
         $constraint = new Range(maxPropertyPath: 'value');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -675,7 +675,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $this->setObject(new MinMax('March 10, 2014', 'March 20, 2014'));
 
         $constraint = new Range(minPropertyPath: 'min', maxPropertyPath: 'max');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -694,7 +694,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             minMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -718,7 +718,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             maxMessage: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -743,7 +743,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             notInRangeMessage: 'myNotInRangeMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -770,7 +770,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             notInRangeMessage: 'myNotInRangeMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myNotInRangeMessage')
             ->setParameter('{{ value }}', $dateTimeAsString)
@@ -788,7 +788,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $object->max = 5;
         $this->setObject($object);
 
-        $this->validator->validate(5, new Range(minPropertyPath: 'min', maxPropertyPath: 'max'));
+        $this->validate(5, new Range(minPropertyPath: 'min', maxPropertyPath: 'max'));
 
         $this->assertNoViolation();
     }
@@ -799,7 +799,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $object->min = 5;
         $this->setObject($object);
 
-        $this->validator->validate(5, new Range(minPropertyPath: 'min', maxPropertyPath: 'max'));
+        $this->validate(5, new Range(minPropertyPath: 'min', maxPropertyPath: 'max'));
 
         $this->assertNoViolation();
     }
@@ -828,7 +828,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     public function testMessageIfMinAndMaxSet(array $constraintExtraOptions, int $value, string $expectedMessage, string $expectedCode)
     {
         $constraint = new Range(...array_merge(['min' => 1, 'max' => 10], $constraintExtraOptions));
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this
             ->buildViolation($expectedMessage)
@@ -841,13 +841,12 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $clock = new MockClock('2025-01-15 00:00:00 UTC');
         $this->validator = new RangeValidator(null, $clock);
-        $this->validator->initialize($this->context);
 
         // Value is Jan 10, within range [-10 days (Jan 5) .. +10 days (Jan 25)]
         $value = new \DateTimeImmutable('2025-01-10 00:00:00 UTC');
         $constraint = new Range(min: '-10 days', max: '+10 days');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -856,13 +855,12 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $clock = new MockClock('2025-01-15 00:00:00 UTC');
         $this->validator = new RangeValidator(null, $clock);
-        $this->validator->initialize($this->context);
 
         // Value is Feb 1, outside range [-10 days (Jan 5) .. +10 days (Jan 25)]
         $value = new \DateTimeImmutable('2025-02-01 00:00:00 UTC');
         $constraint = new Range(min: '-10 days', max: '+10 days', notInRangeMessage: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $now = $clock->now();
         $this->buildViolation('myMessage')
@@ -877,13 +875,12 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
     {
         $clock = new MockClock('2025-01-15 00:00:00 UTC');
         $this->validator = new RangeValidator(null, $clock);
-        $this->validator->initialize($this->context);
 
         // Absolute dates should still work with a mock clock
         $value = new \DateTimeImmutable('2025-03-15 00:00:00 UTC');
         $constraint = new Range(min: '2025-01-01', max: '2025-12-31');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -894,7 +891,7 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         $value = new \DateTimeImmutable('2025-03-15 00:00:00 UTC');
         $constraint = new Range(min: '2025-01-01', max: '2025-12-31');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -26,14 +26,14 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Regex(pattern: '/^[0-9]+$/'));
+        $this->validate(null, new Regex(pattern: '/^[0-9]+$/'));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Regex(pattern: '/^[0-9]+$/'));
+        $this->validate('', new Regex(pattern: '/^[0-9]+$/'));
 
         $this->assertNoViolation();
     }
@@ -41,14 +41,14 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Regex(pattern: '/^[0-9]+$/'));
+        $this->validate(new \stdClass(), new Regex(pattern: '/^[0-9]+$/'));
     }
 
     #[DataProvider('getValidValues')]
     public function testValidValues($value)
     {
         $constraint = new Regex(pattern: '/^[0-9]+$/');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -57,7 +57,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
     public function testValidValuesWithWhitespacesNamed($value)
     {
         $constraint = new Regex(pattern: '/^[0-9]+$/', normalizer: 'trim');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -95,7 +95,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Regex(pattern: '/^[0-9]+$/', message: 'myMessage');
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
@@ -124,7 +124,7 @@ class RegexValidatorTest extends ConstraintValidatorTestCase
         $pattern = '/<script|([^>]*?)(on\w+\s*=\s*(["\']).*?\3|href\s*=\s*(["\'])javascript:.*?\4)[^>]*?>/is';
         $constraint = new Regex(pattern: $pattern, message: 'myMessage', match: false);
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/SequentiallyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SequentiallyValidatorTest.php
@@ -41,7 +41,7 @@ class SequentiallyValidatorTest extends ConstraintValidatorTestCase
         $this->expectValidateValue(0, $value, [$constraints[0]]);
         $this->expectValidateValue(1, $value, [$constraints[1]]);
 
-        $this->validator->validate($value, new Sequentially($constraints));
+        $this->validate($value, new Sequentially($constraints));
 
         $this->assertNoViolation();
     }
@@ -59,7 +59,7 @@ class SequentiallyValidatorTest extends ConstraintValidatorTestCase
         $this->expectValidateValue(0, $value, [$constraints[0]]);
         $this->expectFailingValueValidation(1, $value, [$constraints[1]], null, new ConstraintViolation('regex error', null, [], null, '', null, null, 'regex'));
 
-        $this->validator->validate($value, new Sequentially($constraints));
+        $this->validate($value, new Sequentially($constraints));
 
         $this->assertCount(1, $this->context->getViolations());
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ThrowsOnInvalidStringDatesTestTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ThrowsOnInvalidStringDatesTestTrait.php
@@ -23,7 +23,7 @@ trait ThrowsOnInvalidStringDatesTestTrait
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
     }
 
     public static function throwsOnInvalidStringDatesProvider(): array

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -26,21 +26,21 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Time());
+        $this->validate(null, new Time());
 
         $this->assertNoViolation();
     }
 
     public function testDefaultWithSeconds()
     {
-        $this->validator->validate('10:15:25', new Time());
+        $this->validate('10:15:25', new Time());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Time());
+        $this->validate('', new Time());
 
         $this->assertNoViolation();
     }
@@ -48,13 +48,13 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Time());
+        $this->validate(new \stdClass(), new Time());
     }
 
     #[DataProvider('getValidTimes')]
     public function testValidTimes($time)
     {
-        $this->validator->validate($time, new Time());
+        $this->validate($time, new Time());
 
         $this->assertNoViolation();
     }
@@ -62,7 +62,7 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidTimes')]
     public function testValidTimesWithNewLine(string $time)
     {
-        $this->validator->validate($time."\n", new Time());
+        $this->validate($time."\n", new Time());
 
         $this->buildViolation('This value is not a valid time.')
             ->setParameter('{{ value }}', '"'.$time."\n".'"')
@@ -82,7 +82,7 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidTimesWithoutSeconds')]
     public function testValidTimesWithoutSeconds(string $time)
     {
-        $this->validator->validate($time, new Time(withSeconds: false));
+        $this->validate($time, new Time(withSeconds: false));
 
         $this->assertNoViolation();
     }
@@ -90,7 +90,7 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidTimesWithoutSeconds')]
     public function testValidTimesWithoutSecondsWithNewLine(string $time)
     {
-        $this->validator->validate($time."\n", new Time(withSeconds: false));
+        $this->validate($time."\n", new Time(withSeconds: false));
 
         $this->buildViolation('This value is not a valid time.')
             ->setParameter('{{ value }}', '"'.$time."\n".'"')
@@ -110,7 +110,7 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidTimesWithoutSeconds')]
     public function testInvalidTimesWithoutSeconds(string $time)
     {
-        $this->validator->validate($time, $constraint = new Time());
+        $this->validate($time, $constraint = new Time());
 
         $this->buildViolation($constraint->message)
             ->setParameter('{{ value }}', '"'.$time.'"')
@@ -132,7 +132,7 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Time(message: 'myMessage');
 
-        $this->validator->validate($time, $constraint);
+        $this->validate($time, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$time.'"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -31,14 +31,14 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Timezone());
+        $this->validate(null, new Timezone());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Timezone());
+        $this->validate('', new Timezone());
 
         $this->assertNoViolation();
     }
@@ -46,13 +46,13 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Timezone());
+        $this->validate(new \stdClass(), new Timezone());
     }
 
     #[DataProvider('getValidTimezones')]
     public function testValidTimezones(string $timezone)
     {
-        $this->validator->validate($timezone, new Timezone());
+        $this->validate($timezone, new Timezone());
 
         $this->assertNoViolation();
     }
@@ -92,7 +92,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Timezone(zone: $zone);
 
-        $this->validator->validate($timezone, $constraint);
+        $this->validate($timezone, $constraint);
 
         $this->assertNoViolation();
     }
@@ -121,7 +121,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Timezone(message: 'myMessage');
 
-        $this->validator->validate($timezone, $constraint);
+        $this->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', \sprintf('"%s"', $timezone))
@@ -145,7 +145,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($timezone, $constraint);
+        $this->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', \sprintf('"%s"', $timezone))
@@ -170,7 +170,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Timezone(zone: \DateTimeZone::AMERICA, message: 'myMessage');
 
-        $this->validator->validate('Europe/Berlin', $constraint);
+        $this->validate('Europe/Berlin', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"Europe/Berlin"')
@@ -186,7 +186,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             countryCode: $country,
         );
 
-        $this->validator->validate($timezone, $constraint);
+        $this->validate($timezone, $constraint);
 
         $this->assertNoViolation();
     }
@@ -222,7 +222,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             countryCode: $countryCode,
         );
 
-        $this->validator->validate($timezone, $constraint);
+        $this->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', \sprintf('"%s"', $timezone))
@@ -247,7 +247,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             countryCode: 'foobar',
         );
 
-        $this->validator->validate('Europe/Amsterdam', $constraint);
+        $this->validate('Europe/Amsterdam', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"Europe/Amsterdam"')
@@ -265,7 +265,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
 
         $constraint = new Timezone(\DateTimeZone::ALL_WITH_BC);
 
-        $this->validator->validate($timezone, $constraint);
+        $this->validate($timezone, $constraint);
 
         $this->assertNoViolation();
     }
@@ -275,7 +275,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Timezone(message: 'myMessage');
 
-        $this->validator->validate($timezone, $constraint);
+        $this->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', \sprintf('"%s"', $timezone))
@@ -320,7 +320,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             intlCompatible: true,
         );
 
-        $this->validator->validate('Europe/Saratov', $constraint);
+        $this->validate('Europe/Saratov', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"Europe/Saratov"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -29,7 +29,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Type(type: 'integer');
 
-        $this->validator->validate(null, $constraint);
+        $this->validate(null, $constraint);
 
         $this->assertNoViolation();
     }
@@ -38,7 +38,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Type(type: 'string');
 
-        $this->validator->validate('', $constraint);
+        $this->validate('', $constraint);
 
         $this->assertNoViolation();
     }
@@ -50,7 +50,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate('', $constraint);
+        $this->validate('', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '""')
@@ -64,7 +64,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Type(type: $type);
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -125,7 +125,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', $valueAsString)
@@ -192,7 +192,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Type(type: $types);
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->assertNoViolation();
     }
@@ -207,7 +207,7 @@ class TypeValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidValuesMultipleTypes()
     {
-        $this->validator->validate('12345', new Type(type: ['boolean', 'array'], message: 'myMessage'));
+        $this->validate('12345', new Type(type: ['boolean', 'array'], message: 'myMessage'));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"12345"')

--- a/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UlidValidatorTest.php
@@ -29,14 +29,14 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Ulid());
+        $this->validate(null, new Ulid());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Ulid());
+        $this->validate('', new Ulid());
 
         $this->assertNoViolation();
     }
@@ -44,26 +44,26 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Ulid());
+        $this->validate(new \stdClass(), new Ulid());
     }
 
     public function testValidUlid()
     {
-        $this->validator->validate('01ARZ3NDEKTSV4RRFFQ69G5FAV', new Ulid());
+        $this->validate('01ARZ3NDEKTSV4RRFFQ69G5FAV', new Ulid());
 
         $this->assertNoViolation();
     }
 
     public function testValidUlidAsBase58()
     {
-        $this->validator->validate('1CCD2w4mK2m455S2BAXFht', new Ulid(format: Ulid::FORMAT_BASE_58));
+        $this->validate('1CCD2w4mK2m455S2BAXFht', new Ulid(format: Ulid::FORMAT_BASE_58));
 
         $this->assertNoViolation();
     }
 
     public function testValidUlidAsRfc4122()
     {
-        $this->validator->validate('01912bf3-feff-fa6c-00f2-90d2f2e00564', new Ulid(format: Ulid::FORMAT_RFC_4122));
+        $this->validate('01912bf3-feff-fa6c-00f2-90d2f2e00564', new Ulid(format: Ulid::FORMAT_RFC_4122));
 
         $this->assertNoViolation();
     }
@@ -73,7 +73,7 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Ulid(message: 'testMessage');
 
-        $this->validator->validate($ulid, $constraint);
+        $this->validate($ulid, $constraint);
 
         $this->buildViolation('testMessage')
             ->setParameters([
@@ -100,7 +100,7 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Ulid(message: 'testMessage', format: Ulid::FORMAT_BASE_58);
 
-        $this->validator->validate($ulid, $constraint);
+        $this->validate($ulid, $constraint);
 
         $this->buildViolation('testMessage')
             ->setParameters([
@@ -126,7 +126,7 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Ulid(message: 'testMessage', format: Ulid::FORMAT_RFC_4122);
 
-        $this->validator->validate($ulid, $constraint);
+        $this->validate($ulid, $constraint);
 
         $this->buildViolation('testMessage')
             ->setParameters([
@@ -153,7 +153,7 @@ class UlidValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Ulid(message: 'testMessage');
 
-        $this->validator->validate('01ARZ3NDEKTSV4RRFFQ69G5FA', $constraint);
+        $this->validate('01ARZ3NDEKTSV4RRFFQ69G5FA', $constraint);
 
         $this->buildViolation('testMessage')
             ->setParameters([

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -29,13 +29,13 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsUniqueConstraintCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate('', new Unique());
+        $this->validate('', new Unique());
     }
 
     #[DataProvider('getValidValues')]
     public function testValidValues($value)
     {
-        $this->validator->validate($value, new Unique());
+        $this->validate($value, new Unique());
 
         $this->assertNoViolation();
     }
@@ -61,7 +61,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidValues($value, $expectedMessageParam)
     {
         $constraint = new Unique(message: 'myMessage');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessage')
              ->setParameter('{{ value }}', $expectedMessageParam)
@@ -86,7 +86,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidValueNamed()
     {
         $constraint = new Unique(message: 'myMessage');
-        $this->validator->validate([1, 2, 3, 3], $constraint);
+        $this->validate([1, 2, 3, 3], $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '3')
@@ -111,7 +111,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
         $value = [$object1, $object2, $object3];
 
-        $this->validator->validate($value, new Unique(normalizer: $callback));
+        $this->validate($value, new Unique(normalizer: $callback));
 
         $this->assertNoViolation();
     }
@@ -133,7 +133,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
         $value = [$object1, $object2, $object3];
 
-        $this->validator->validate($value, new Unique(
+        $this->validate($value, new Unique(
             message: 'myMessage',
             normalizer: $callback,
         ));
@@ -157,7 +157,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpectsInvalidNonStrictComparison()
     {
-        $this->validator->validate([1, '1', 1.0, '1.0'], new Unique(
+        $this->validate([1, '1', 1.0, '1.0'], new Unique(
             message: 'myMessage',
             normalizer: 'intval',
         ));
@@ -172,7 +172,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     {
         $callback = static fn ($item) => (int) $item;
 
-        $this->validator->validate([1, '2', 3, '4.0'], new Unique(normalizer: $callback));
+        $this->validate([1, '2', 3, '4.0'], new Unique(normalizer: $callback));
 
         $this->assertNoViolation();
     }
@@ -181,7 +181,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     {
         $callback = static fn ($item) => mb_strtolower($item);
 
-        $this->validator->validate(['Hello', 'hello', 'HELLO', 'hellO'], new Unique(
+        $this->validate(['Hello', 'hello', 'HELLO', 'hellO'], new Unique(
             message: 'myMessage',
             normalizer: $callback,
         ));
@@ -196,14 +196,14 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     {
         $callback = static fn ($item) => mb_strtolower($item);
 
-        $this->validator->validate(['Hello', 'World'], new Unique(normalizer: $callback));
+        $this->validate(['Hello', 'World'], new Unique(normalizer: $callback));
 
         $this->assertNoViolation();
     }
 
     public function testCollectionFieldsAreOptional()
     {
-        $this->validator->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique(fields: 'id'));
+        $this->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique(fields: 'id'));
 
         $this->assertNoViolation();
     }
@@ -214,7 +214,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedTypeException::class);
         $this->expectExceptionMessage(\sprintf('Expected argument of type "string", "%s" given', $type));
 
-        $this->validator->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique(fields: [$field]));
+        $this->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique(fields: [$field]));
     }
 
     public static function getInvalidFieldNames(): array
@@ -229,7 +229,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidCollectionValues')]
     public function testValidCollectionValues(array $value, array $fields)
     {
-        $this->validator->validate($value, new Unique(fields: $fields));
+        $this->validate($value, new Unique(fields: $fields));
 
         $this->assertNoViolation();
     }
@@ -251,7 +251,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getInvalidCollectionValues')]
     public function testInvalidCollectionValues(array $value, array $fields, string $expectedMessageParam)
     {
-        $this->validator->validate($value, new Unique(
+        $this->validate($value, new Unique(
             message: 'myMessage',
             fields: $fields,
         ));
@@ -303,7 +303,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $array[1]->code = '2';
         $array[2]->code = '3';
 
-        $this->validator->validate(
+        $this->validate(
             $array,
             new Unique(
                 normalizer: [self::class, 'normalizeDummyClassOne'],
@@ -326,7 +326,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $array[1]->code = 'a2';
         $array[2]->code = 'a1';
 
-        $this->validator->validate(
+        $this->validate(
             $array,
             new Unique(
                 normalizer: [self::class, 'normalizeDummyClassOne'],
@@ -354,7 +354,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $array[1]->code = 'a2';
         $array[2]->code = 'a1';
 
-        $this->validator->validate(
+        $this->validate(
             $array,
             new Unique(
                 normalizer: [self::class, 'normalizeDummyClassOne'],
@@ -382,7 +382,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $array['b']->code = 'a2';
         $array['c']->code = 'a1';
 
-        $this->validator->validate(
+        $this->validate(
             $array,
             new Unique(
                 normalizer: [self::class, 'normalizeDummyClassOne'],
@@ -400,7 +400,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
     public function testWithoutStopOnFirstError()
     {
-        $this->validator->validate(
+        $this->validate(
             ['a1', 'a2', 'a1', 'a1', 'a2'],
             new Unique(stopOnFirstError: false),
         );
@@ -440,7 +440,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $array[3]->code = 'a1';
         $array[4]->code = 'a2';
 
-        $this->validator->validate(
+        $this->validate(
             $array,
             new Unique(
                 normalizer: [self::class, 'normalizeDummyClassOne'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -26,21 +26,21 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Url(requireTld: true));
+        $this->validate(null, new Url(requireTld: true));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Url(requireTld: true));
+        $this->validate('', new Url(requireTld: true));
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringFromObjectIsValid()
     {
-        $this->validator->validate(new EmailProvider(), new Url(requireTld: true));
+        $this->validate(new EmailProvider(), new Url(requireTld: true));
 
         $this->assertNoViolation();
     }
@@ -48,13 +48,13 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Url(requireTld: true));
+        $this->validate(new \stdClass(), new Url(requireTld: true));
     }
 
     #[DataProvider('getValidUrls')]
     public function testValidUrls($url)
     {
-        $this->validator->validate($url, new Url(requireTld: false));
+        $this->validate($url, new Url(requireTld: false));
 
         $this->assertNoViolation();
     }
@@ -62,7 +62,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUrls')]
     public function testValidUrlsWithNewLine($url)
     {
-        $this->validator->validate($url."\n", new Url(requireTld: false));
+        $this->validate($url."\n", new Url(requireTld: false));
 
         $this->buildViolation('This value is not a valid URL.')
             ->setParameter('{{ value }}', '"'.$url."\n".'"')
@@ -73,7 +73,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidUrlsWithWhitespaces')]
     public function testValidUrlsWithWhitespaces($url)
     {
-        $this->validator->validate($url, new Url(
+        $this->validate($url, new Url(
             normalizer: 'trim',
             requireTld: true,
         ));
@@ -90,7 +90,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             requireTld: false,
         );
 
-        $this->validator->validate($url, $constraint);
+        $this->validate($url, $constraint);
 
         $this->assertNoViolation();
     }
@@ -101,7 +101,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Url(relativeProtocol: true, requireTld: false);
 
-        $this->validator->validate($url."\n", $constraint);
+        $this->validate($url."\n", $constraint);
 
         $this->buildViolation('This value is not a valid URL.')
             ->setParameter('{{ value }}', '"'.$url."\n".'"')
@@ -126,7 +126,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
         ];
 
         foreach ($validUrls as $url) {
-            $this->validator->validate($url, $constraint);
+            $this->validate($url, $constraint);
             $this->assertNoViolation();
         }
     }
@@ -146,7 +146,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
 
         foreach ($invalidUrls as $url) {
             $this->setUp();
-            $this->validator->validate($url, $constraint);
+            $this->validate($url, $constraint);
 
             $this->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', '"'.$url.'"')
@@ -159,10 +159,10 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Url(protocols: ['*'], relativeProtocol: true, requireTld: true);
 
-        $this->validator->validate('custom://example.com', $constraint);
+        $this->validate('custom://example.com', $constraint);
         $this->assertNoViolation();
 
-        $this->validator->validate('//example.com', $constraint);
+        $this->validate('//example.com', $constraint);
         $this->assertNoViolation();
     }
 
@@ -170,10 +170,10 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Url(protocols: ['*'], requireTld: true);
 
-        $this->validator->validate('custom://example.com', $constraint);
+        $this->validate('custom://example.com', $constraint);
         $this->assertNoViolation();
 
-        $this->validator->validate('custom://localhost', $constraint);
+        $this->validate('custom://localhost', $constraint);
         $this->buildViolation($constraint->tldMessage)
             ->setParameter('{{ value }}', '"custom://localhost"')
             ->setCode(Url::MISSING_TLD_ERROR)
@@ -192,11 +192,11 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
         ];
 
         foreach ($validUrls as $url) {
-            $this->validator->validate($url, $constraint);
+            $this->validate($url, $constraint);
             $this->assertNoViolation();
         }
 
-        $this->validator->validate('ftp://example.com', $constraint);
+        $this->validate('ftp://example.com', $constraint);
         $this->buildViolation($constraint->message)
             ->setParameter('{{ value }}', '"ftp://example.com"')
             ->setCode(Url::INVALID_URL_ERROR)
@@ -321,7 +321,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             requireTld: false,
         );
 
-        $this->validator->validate($url, $constraint);
+        $this->validate($url, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$url.'"')
@@ -339,7 +339,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             requireTld: false,
         );
 
-        $this->validator->validate($url, $constraint);
+        $this->validate($url, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$url.'"')
@@ -419,7 +419,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             requireTld: $requireTld,
         );
 
-        $this->validator->validate($url, $constraint);
+        $this->validate($url, $constraint);
 
         $this->assertNoViolation();
     }
@@ -438,7 +438,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Url(requireTld: $requireTld);
 
-        $this->validator->validate($url, $constraint);
+        $this->validate($url, $constraint);
 
         if ($isValid) {
             $this->assertNoViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UuidValidatorTest.php
@@ -31,14 +31,14 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Uuid());
+        $this->validate(null, new Uuid());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Uuid());
+        $this->validate('', new Uuid());
 
         $this->assertNoViolation();
     }
@@ -49,13 +49,13 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectException(UnexpectedTypeException::class);
 
-        $this->validator->validate('216fff40-98d9-11e3-a5e2-0800200c9a66', $constraint);
+        $this->validate('216fff40-98d9-11e3-a5e2-0800200c9a66', $constraint);
     }
 
     public function testExpectsStringCompatibleType()
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->validator->validate(new \stdClass(), new Uuid());
+        $this->validate(new \stdClass(), new Uuid());
     }
 
     #[DataProvider('getValidStrictUuids')]
@@ -67,7 +67,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
             $constraint->versions = $versions;
         }
 
-        $this->validator->validate($uuid, $constraint);
+        $this->validate($uuid, $constraint);
 
         $this->assertNoViolation();
     }
@@ -96,7 +96,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
             $constraint->versions = $versions;
         }
 
-        $this->validator->validate($uuid, $constraint);
+        $this->validate($uuid, $constraint);
 
         $this->assertNoViolation();
     }
@@ -115,7 +115,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidStrictUuidWithWhitespacesNamed()
     {
-        $this->validator->validate(
+        $this->validate(
             "\x09\x09216fff40-98d9-11e3-a5e2-0800200c9a66",
             new Uuid(normalizer: 'trim', versions: [Uuid::V1_MAC])
         );
@@ -132,7 +132,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
             $constraint->versions = $versions;
         }
 
-        $this->validator->validate($uuid, $constraint);
+        $this->validate($uuid, $constraint);
 
         $this->buildViolation('testMessage')
             ->setParameter('{{ value }}', '"'.$uuid.'"')
@@ -188,7 +188,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Uuid(strict: false);
 
-        $this->validator->validate($uuid, $constraint);
+        $this->validate($uuid, $constraint);
 
         $this->assertNoViolation();
     }
@@ -218,7 +218,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessage',
         );
 
-        $this->validator->validate($uuid, $constraint);
+        $this->validate($uuid, $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$uuid.'"')
@@ -241,7 +241,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidNonStrictUuidNamed()
     {
-        $this->validator->validate(
+        $this->validate(
             '216fff40-98d9-11e3-a5e2_0800200c9a66',
             new Uuid(strict: false, message: 'myMessage')
         );
@@ -257,7 +257,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Uuid(versions: Uuid::TIME_BASED_VERSIONS);
 
-        $this->validator->validate($uid, $constraint);
+        $this->validate($uid, $constraint);
 
         if ($expectedTimeBased) {
             $this->assertNoViolation();
@@ -285,7 +285,7 @@ class UuidValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Uuid(versions: 7);
 
-        $this->validator->validate('0184c292-b133-7e10-a3b4-d49c1ab49b2a', $constraint);
+        $this->validate('0184c292-b133-7e10-a3b4-d49c1ab49b2a', $constraint);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidComparisonToValueTrait.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidComparisonToValueTrait.php
@@ -20,7 +20,7 @@ trait ValidComparisonToValueTrait
     {
         $constraint = $this->createConstraint(['value' => $comparisonValue]);
 
-        $this->validator->validate($dirtyValue, $constraint);
+        $this->validate($dirtyValue, $constraint);
 
         $this->assertNoViolation();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/VideoValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/VideoValidatorTest.php
@@ -34,21 +34,21 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Video());
+        $this->validate(null, new Video());
 
         $this->assertNoViolation();
     }
 
     public function testEmptyStringIsValid()
     {
-        $this->validator->validate('', new Video());
+        $this->validate('', new Video());
 
         $this->assertNoViolation();
     }
 
     public function testValidVideo()
     {
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', new Video());
+        $this->validate(__DIR__.'/Fixtures/test.mp4', new Video());
 
         $this->assertNoViolation();
     }
@@ -56,7 +56,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testFileNotFound()
     {
         $constraint = new Video(notFoundMessage: 'myMessage');
-        $this->validator->validate('foobar', $constraint);
+        $this->validate('foobar', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ file }}', '"foobar"')
@@ -73,7 +73,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
             maxHeight: 2,
         );
 
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->assertNoViolation();
     }
@@ -81,7 +81,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testWidthTooSmall()
     {
         $constraint = new Video(minWidth: 3, minWidthMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', '2')
@@ -93,7 +93,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testWidthTooBig()
     {
         $constraint = new Video(maxWidth: 1, maxWidthMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', '2')
@@ -105,7 +105,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testHeightTooSmall()
     {
         $constraint = new Video(minHeight: 3, minHeightMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ height }}', '2')
@@ -117,7 +117,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testHeightTooBig()
     {
         $constraint = new Video(maxHeight: 1, maxHeightMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ height }}', '2')
@@ -129,7 +129,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testPixelsTooFew()
     {
         $constraint = new Video(minPixels: 5, minPixelsMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
@@ -143,7 +143,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testPixelsTooMany()
     {
         $constraint = new Video(maxPixels: 3, maxPixelsMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
@@ -157,7 +157,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testRatioTooSmall()
     {
         $constraint = new Video(minRatio: 2, minRatioMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ ratio }}', 1)
@@ -169,7 +169,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testRatioTooBig()
     {
         $constraint = new Video(maxRatio: 0.5, maxRatioMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ ratio }}', 1)
@@ -182,7 +182,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Video(maxRatio: 1.33);
 
-        $this->validator->validate(__DIR__.'/Fixtures/test_4by3.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test_4by3.mp4', $constraint);
 
         $this->assertNoViolation();
     }
@@ -191,7 +191,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Video(minRatio: 4 / 3);
 
-        $this->validator->validate(__DIR__.'/Fixtures/test_4by3.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test_4by3.mp4', $constraint);
 
         $this->assertNoViolation();
     }
@@ -200,7 +200,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Video(maxRatio: 16 / 9);
 
-        $this->validator->validate(__DIR__.'/Fixtures/test_16by9.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test_16by9.mp4', $constraint);
 
         $this->assertNoViolation();
     }
@@ -208,7 +208,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testSquareNotAllowed()
     {
         $constraint = new Video(allowSquare: false, allowSquareMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 2)
@@ -220,7 +220,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testLandscapeNotAllowed()
     {
         $constraint = new Video(allowLandscape: false, allowLandscapeMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test_landscape.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test_landscape.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 2)
@@ -232,7 +232,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     public function testPortraitNotAllowed()
     {
         $constraint = new Video(allowPortrait: false, allowPortraitMessage: 'myMessage');
-        $this->validator->validate(__DIR__.'/Fixtures/test_portrait.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test_portrait.mp4', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ width }}', 1)
@@ -245,7 +245,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Video(maxRatio: 1);
 
-        $this->validator->validate(__DIR__.'/Fixtures/test_corrupted.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test_corrupted.mp4', $constraint);
 
         $this->buildViolation('The video file is corrupted.')
             ->setCode(Video::CORRUPTED_VIDEO_ERROR)
@@ -254,7 +254,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
 
     public function testInvalidMimeType()
     {
-        $this->validator->validate(__DIR__.'/Fixtures/ccc.txt', $constraint = new Video());
+        $this->validate(__DIR__.'/Fixtures/ccc.txt', $constraint = new Video());
 
         $this->assertSame('video/*', $constraint->mimeTypes);
 
@@ -273,7 +273,7 @@ class VideoValidatorTest extends ConstraintValidatorTestCase
             'video/mkv',
             'video/mov',
         ]);
-        $this->validator->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
+        $this->validate(__DIR__.'/Fixtures/test.mp4', $constraint);
 
         $this->buildViolation('The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.')
             ->setParameter('{{ file }}', \sprintf('"%s/Fixtures/test.mp4"', __DIR__))

--- a/src/Symfony/Component/Validator/Tests/Constraints/WeekValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WeekValidatorTest.php
@@ -29,7 +29,7 @@ class WeekValidatorTest extends ConstraintValidatorTestCase
     public function testWeekIsValidWeekNumber(string|\Stringable $value, bool $expectedViolation)
     {
         $constraint = new Week();
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         if ($expectedViolation) {
             $this->buildViolation('This value is not a valid week.')
@@ -55,10 +55,10 @@ class WeekValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Week(min: '2015-W10', max: '2016-W25');
 
-        $this->validator->validate('2015-W10', $constraint);
+        $this->validate('2015-W10', $constraint);
         $this->assertNoViolation();
 
-        $this->validator->validate('2016-W25', $constraint);
+        $this->validate('2016-W25', $constraint);
         $this->assertNoViolation();
     }
 
@@ -66,7 +66,7 @@ class WeekValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Week(min: '2015-W10');
 
-        $this->validator->validate('2015-W08', $constraint);
+        $this->validate('2015-W08', $constraint);
         $this->buildViolation('This value should not be before week "{{ min }}".')
             ->setInvalidValue('2015-W08')
             ->setParameter('{{ min }}', '2015-W10')
@@ -78,7 +78,7 @@ class WeekValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Week(max: '2016-W25');
 
-        $this->validator->validate('2016-W30', $constraint);
+        $this->validate('2016-W30', $constraint);
         $this->buildViolation('This value should not be after week "{{ max }}".')
             ->setInvalidValue('2016-W30')
             ->setParameter('{{ max }}', '2016-W25')
@@ -88,7 +88,7 @@ class WeekValidatorTest extends ConstraintValidatorTestCase
 
     public function testWithNewLine()
     {
-        $this->validator->validate("2015-W10\n", new Week());
+        $this->validate("2015-W10\n", new Week());
 
         $this->buildViolation('This value does not represent a valid week in the ISO 8601 format.')
             ->setCode(Week::INVALID_FORMAT_ERROR)
@@ -98,7 +98,7 @@ class WeekValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideInvalidValues')]
     public function testInvalidValues(string $value)
     {
-        $this->validator->validate($value, new Week());
+        $this->validate($value, new Week());
 
         $this->buildViolation('This value does not represent a valid week in the ISO 8601 format.')
             ->setCode(Week::INVALID_FORMAT_ERROR)
@@ -111,7 +111,7 @@ class WeekValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessageMatches('/Expected argument of type "string", ".*" given/');
 
-        $this->validator->validate($value, new Week());
+        $this->validate($value, new Week());
     }
 
     public static function provideInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenValidatorTest.php
@@ -34,7 +34,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'Foo', $constraints);
 
-        $this->validator->validate('Foo', new When(
+        $this->validate('Foo', new When(
             expression: 'true',
             constraints: $constraints,
         ));
@@ -49,7 +49,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'Foo', $constraints);
 
-        $this->validator->validate('Foo', new When(
+        $this->validate('Foo', new When(
             expression: static fn () => true,
             constraints: $constraints,
         ));
@@ -60,7 +60,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         $subject = new \stdClass();
         $this->setObject($subject);
 
-        $this->validator->validate($subject, new When(
+        $this->validate($subject, new When(
             expression: static function ($closureSubject) use ($subject) {
                 self::assertSame($subject, $closureSubject);
             },
@@ -73,7 +73,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
         $constraint = new NotNull();
         $this->expectValidateValue(0, 'Foo', [$constraint]);
 
-        $this->validator->validate('Foo', new When(
+        $this->validate('Foo', new When(
             expression: 'true',
             constraints: $constraint,
         ));
@@ -86,7 +86,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'Foo', [$otherwise]);
 
-        $this->validator->validate('Foo', new When(
+        $this->validate('Foo', new When(
             expression: 'false',
             constraints: $constraint,
             otherwise: $otherwise,
@@ -100,7 +100,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'Foo', [$otherwise]);
 
-        $this->validator->validate('Foo', new When(
+        $this->validate('Foo', new When(
             expression: static fn () => false,
             constraints: $constraint,
             otherwise: $otherwise,
@@ -115,7 +115,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, null, $constraints);
 
-        $this->validator->validate(null, new When(
+        $this->validate(null, new When(
             expression: 'true',
             constraints: $constraints,
         ));
@@ -136,7 +136,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, $number->value, $constraints);
 
-        $this->validator->validate($number->value, new When(
+        $this->validate($number->value, new When(
             expression: 'this.type === "positive"',
             constraints: $constraints,
         ));
@@ -161,7 +161,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, $number->value, $constraints);
 
-        $this->validator->validate($number->value, new When(
+        $this->validate($number->value, new When(
             expression: 'context.getRoot().ok === true',
             constraints: $constraints,
         ));
@@ -175,7 +175,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'foo', $constraints);
 
-        $this->validator->validate('foo', new When(
+        $this->validate('foo', new When(
             expression: 'value === "foo"',
             constraints: $constraints,
         ));
@@ -189,7 +189,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, 'foo', $constraints);
 
-        $this->validator->validate('foo', new When(
+        $this->validate('foo', new When(
             expression: 'activated && value === compared_value',
             constraints: $constraints,
             values: [
@@ -208,7 +208,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate('', new When(
+        $this->validate('', new When(
             expression: 'false',
             constraints: $constraints,
         ));
@@ -222,7 +222,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectValidateValue(0, '', $constraints);
 
-        $this->validator->validate('', new When(
+        $this->validate('', new When(
             expression: 'true',
             constraints: $constraints,
             otherwise: new Length(exactly: 10),
@@ -246,7 +246,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate($number->value, new When(
+        $this->validate($number->value, new When(
             expression: 'this.type !== "positive"',
             constraints: $constraints,
         ));
@@ -262,7 +262,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate('foo', new When(
+        $this->validate('foo', new When(
             expression: 'value === null',
             constraints: $constraints,
         ));
@@ -278,7 +278,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
 
         $this->expectNoValidate();
 
-        $this->validator->validate('foo', new When(
+        $this->validate('foo', new When(
             expression: 'activated && value === compared_value',
             constraints: $constraints,
             values: [
@@ -314,7 +314,7 @@ final class WhenValidatorTest extends ConstraintValidatorTestCase
             ),
         );
 
-        $this->validator->validate('foo', new When('true', $constraints));
+        $this->validate('foo', new When('true', $constraints));
     }
 
     protected function createValidator(): WhenValidator

--- a/src/Symfony/Component/Validator/Tests/Constraints/WordCountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WordCountValidatorTest.php
@@ -30,7 +30,7 @@ class WordCountValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('provideValidValues')]
     public function testValidWordCount(string|\Stringable|null $value, int $expectedWordCount)
     {
-        $this->validator->validate($value, new WordCount(min: $expectedWordCount, max: $expectedWordCount));
+        $this->validate($value, new WordCount(min: $expectedWordCount, max: $expectedWordCount));
 
         $this->assertNoViolation();
     }
@@ -38,7 +38,7 @@ class WordCountValidatorTest extends ConstraintValidatorTestCase
     public function testTooShort()
     {
         $constraint = new WordCount(min: 4, minMessage: 'myMessage');
-        $this->validator->validate('my ascii string', $constraint);
+        $this->validate('my ascii string', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ count }}', 3)
@@ -51,7 +51,7 @@ class WordCountValidatorTest extends ConstraintValidatorTestCase
     public function testTooLong()
     {
         $constraint = new WordCount(max: 3, maxMessage: 'myMessage');
-        $this->validator->validate('my beautiful ascii string', $constraint);
+        $this->validate('my beautiful ascii string', $constraint);
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ count }}', 4)
@@ -67,7 +67,7 @@ class WordCountValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessageMatches('/Expected argument of type "string", ".*" given/');
 
-        $this->validator->validate($value, new WordCount(min: 1));
+        $this->validate($value, new WordCount(min: 1));
     }
 
     public static function provideValidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/XmlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/XmlValidatorTest.php
@@ -31,7 +31,7 @@ class XmlValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidXmlFormatValues')]
     public function testValidXmlFormatValue($value)
     {
-        $this->validator->validate($value, new Xml());
+        $this->validate($value, new Xml());
         $this->assertNoViolation();
     }
 
@@ -50,7 +50,7 @@ class XmlValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidXmlFormatValue($value)
     {
         $constraint = new Xml(formatMessage: 'myMessage');
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$value.'"')
             ->setCode(Xml::INVALID_XML_ERROR)
@@ -77,7 +77,7 @@ class XmlValidatorTest extends ConstraintValidatorTestCase
 
         $constraint = new Xml(schemaPath: __DIR__.'/Fixtures/example.xsd');
 
-        $this->validator->validate($xml, $constraint);
+        $this->validate($xml, $constraint);
         $this->assertNoViolation();
     }
 
@@ -93,7 +93,7 @@ class XmlValidatorTest extends ConstraintValidatorTestCase
 
         $constraint = new Xml(schemaPath: __DIR__.'/Fixtures/example.xsd');
 
-        $this->validator->validate($xml, $constraint);
+        $this->validate($xml, $constraint);
 
         // Since the exact error message depends on libxml, we'll just check that a violation was raised
         // with the correct error code
@@ -109,7 +109,7 @@ class XmlValidatorTest extends ConstraintValidatorTestCase
         // Use LIBXML_NONET flag to disallow network access during validation
         $constraint = new Xml(schemaPath: __DIR__.'/Fixtures/example.xsd', schemaFlags: \LIBXML_NONET);
 
-        $this->validator->validate($xml, $constraint);
+        $this->validate($xml, $constraint);
         $this->assertNoViolation();
     }
 
@@ -122,6 +122,6 @@ class XmlValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('The XSD schema file "%s" is not valid.', realpath(__DIR__.'/Fixtures/invalid.xsd')));
 
-        $this->validator->validate($xml, $constraint);
+        $this->validate($xml, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/YamlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/YamlValidatorTest.php
@@ -30,14 +30,14 @@ class YamlValidatorTest extends ConstraintValidatorTestCase
     #[DataProvider('getValidValues')]
     public function testYamlIsValid($value)
     {
-        $this->validator->validate($value, new Yaml());
+        $this->validate($value, new Yaml());
 
         $this->assertNoViolation();
     }
 
     public function testYamlWithFlags()
     {
-        $this->validator->validate('date: 2023-01-01', new Yaml(flags: YamlParser::PARSE_DATETIME));
+        $this->validate('date: 2023-01-01', new Yaml(flags: YamlParser::PARSE_DATETIME));
         $this->assertNoViolation();
     }
 
@@ -48,7 +48,7 @@ class YamlValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessageTest',
         );
 
-        $this->validator->validate($value, $constraint);
+        $this->validate($value, $constraint);
 
         $this->buildViolation('myMessageTest')
             ->setParameter('{{ error }}', $message)
@@ -60,7 +60,7 @@ class YamlValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidFlags()
     {
         $value = 'tags: [!tagged app.myclass]';
-        $this->validator->validate($value, new Yaml());
+        $this->validate($value, new Yaml());
         $this->buildViolation('This value is not valid YAML.')
             ->setParameter('{{ error }}', 'Tags support is not enabled. Enable the "Yaml::PARSE_CUSTOM_TAGS" flag to use "!tagged" at line 1 (near "tags: [!tagged app.myclass]").')
             ->setParameter('{{ line }}', 1)
@@ -79,7 +79,7 @@ class YamlValidatorTest extends ConstraintValidatorTestCase
             message: 'myMessageTest',
             flags: YamlParser::PARSE_OBJECT,
         );
-        $this->validator->validate($yamlValue, $constraint);
+        $this->validate($yamlValue, $constraint);
         $this->buildViolation('myMessageTest')
             ->setParameter('{{ error }}', $expectedError)
             ->setParameter('{{ line }}', $yamlLine)

--- a/src/Symfony/Component/Validator/Tests/Test/ConstraintValidatorTestCaseTest.php
+++ b/src/Symfony/Component/Validator/Tests/Test/ConstraintValidatorTestCaseTest.php
@@ -34,7 +34,7 @@ class ConstraintValidatorTestCaseTest extends ConstraintValidatorTestCase
             new DateTime(),
         ]);
 
-        $this->validator->validate('ccc', $this->constraint);
+        $this->validate('ccc', $this->constraint);
 
         $contextualValidator = $this->context->getValidator()->inContext($this->context);
         // Simulate __destruct to assert it throws

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Constraints\Composite;
 use Symfony\Component\Validator\Constraints\Existence;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
@@ -747,14 +748,22 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             $context->setConstraint($constraint);
 
             $validator = $this->validatorFactory->getInstance($constraint);
-            $validator->initialize($context);
+            if (!$validator instanceof ConstraintValidator && !method_exists($validator, 'validateInContext')) {
+                // BC layer for constraint validators not implementing the new API. DebugClassLoader already triggers a deprecation.
+                $validator->initialize($context);
+            }
 
             if ($value instanceof LazyProperty) {
                 $value = $value->getPropertyValue();
             }
 
             try {
-                $validator->validate($value, $constraint);
+                if ($validator instanceof ConstraintValidator || method_exists($validator, 'validateInContext')) {
+                    $validator->validateInContext($value, $constraint, $context);
+                } else {
+                    // BC layer for constraint validators not implementing the new API. DebugClassLoader already triggers a deprecation.
+                    $validator->validate($value, $constraint);
+                }
             } catch (UnexpectedValueException $e) {
                 $context->buildViolation('This value should be of type {{ type }}.')
                     ->setParameter('{{ type }}', $e->getExpectedType())

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-ctype": "^1.8",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/translation-contracts": "^2.5|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | 
| License       | MIT

Reusing the validator multiple times from a constraint validator is hard to get right (if that recursive validation could reach the same constraint validator) due to the mutable state for the context. This is an issue identified since a long time, with special handling for such case in CollectionValidator since symfony 2.4: https://github.com/symfony/symfony/blob/a2e1e8375ea02ddbafea10fbdfcae934948b76a0/src/Symfony/Component/Validator/Constraints/CollectionValidator.php#L38-L46

This finally resolves this (without changing the CollectionValidator or other validators doing similar things for now, even though they _could_ be simplified).
It introduces a new `validateInContext` method instead of adding the argument in the `validate` signature to make it easier to provide a BC layer. Custom constraint validators extending the abstract `ConstraintValidator` won't have any BC break as the abstract class handles the context management.
Tests written using `ConstraintValidatorTestCase` can use the new `validate` method to validate a value (using the context that is used in the assertion methods). Packages needing to support older Symfony versions can polyfill it easily (`symfony/doctrine-bridge` has an example in this PR) 