### PR TITLE
[Scheduler] Support command aliases

### DIFF
--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -64,7 +64,7 @@ class AddScheduleMessengerPass implements CompilerPassInterface
                 if ($serviceDefinition->hasTag('console.command')) {
                     /** @var AsCommand|null $attribute */
                     $attribute = ($container->getReflectionClass($serviceDefinition->getClass())->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
-                    $commandName = $attribute?->name ?? $serviceDefinition->getClass()::getDefaultName();
+                    $commandName = explode('|', $attribute?->name ?? $serviceDefinition->getClass()::getDefaultName())[0];
 
                     if (\is_array($arguments = $tagAttributes['arguments'] ?? '')) {
                         $input = (string) new ArrayInput(['command' => $commandName, ...$arguments]);

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -21,14 +21,14 @@ use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
 class AddScheduleMessengerPassTest extends TestCase
 {
     #[DataProvider('processSchedulerTaskCommandProvider')]
-    public function testProcessSchedulerTaskCommand(array $arguments, string $expectedCommand)
+    public function testProcessSchedulerTaskCommand(array $arguments, string $expectedCommand, string $commandClass = SchedulableCommand::class)
     {
         $container = new ContainerBuilder();
 
-        $definition = new Definition(SchedulableCommand::class);
+        $definition = new Definition($commandClass);
         $definition->addTag('console.command');
         $definition->addTag('scheduler.task', $arguments);
-        $container->setDefinition(SchedulableCommand::class, $definition);
+        $container->setDefinition($commandClass, $definition);
 
         (new AddScheduleMessengerPass())->process($container);
 
@@ -56,11 +56,21 @@ class AddScheduleMessengerPassTest extends TestCase
         yield 'empty array arguments' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => []], 'schedulable'];
         yield 'array options' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => ['--option1' => 'first', '--option2' => true, '--option3' => false]], 'schedulable --option1=first --option2=1 --option3'];
         yield 'array arguments and options' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => ['arg1' => 'first_one', 'arg2' => 'second_one', '--option1' => 'first', '--option2' => true, '--option3' => false]], 'schedulable first_one second_one --option1=first --option2=1 --option3'];
+        yield 'alias, no arguments' => [['trigger' => 'every', 'frequency' => '1 hour'], 'schedulable-with-alias', SchedulableCommandWithAlias::class];
+        yield 'alias, with argument' => [['trigger' => 'every', 'frequency' => '1 hour', 'arguments' => 'test'], 'schedulable-with-alias test', SchedulableCommandWithAlias::class];
     }
 }
 
 #[AsCommand(name: 'schedulable')]
 class SchedulableCommand
+{
+    public function __invoke(): void
+    {
+    }
+}
+
+#[AsCommand(name: 'schedulable-with-alias', aliases: ['schedulable-alias'])]
+class SchedulableCommandWithAlias
 {
     public function __invoke(): void
     {


### PR DESCRIPTION
| Q             | A                                                                                                                                                                                                                                      
| ------------- | ---
| Branch?       | 7.4                                                                                                                                                                                                                                   
| Bug fix?      | yes                                     
| New feature?  | no
| Deprecations? | no                                                                                                                                                                                                                                     
| Issues        | Fix #58059
| License       | MIT                                                                                                                                                                                                                                    
                                                            
When a console command tagged with `scheduler.task` declares aliases via the                                                                                                                                                                             
`AsCommand` attribute, the Scheduler component was using the raw `name` string
(e.g. `my:command|my:alias`) as the command name passed to `RunCommandMessage`,                                                                                                                                                                          
causing it to fail at runtime.                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                           
**Before:**                                                                                                                                                                                                                                              
```php                                                    
#[AsCommand(name: 'my:command', aliases: ['my:alias'])]                                                                                                                                                                                                  
// RunCommandMessage received: "my:command|my:alias"      
``` 
                                                                                                                                                                                              
After:

```php
#[AsCommand(name: 'my:command', aliases: ['my:alias'])]                                                                                                                                                                                                  
// RunCommandMessage received: "my:command"               
```                                    
The fix strips aliases from the name by taking only the first segment of the
pipe-separated value that AsCommand stores internally.                                                                                                                                                                                                   
