### PR TITLE
[DoctrineBridge] MapEntity - use findBy if argument type is array

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/Console/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/Console/EntityValueResolver.php
@@ -56,7 +56,7 @@ final class EntityValueResolver implements ValueResolverInterface
         }
 
         $type = $member->getType();
-        if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+        if (!$type instanceof \ReflectionNamedType || ($type->isBuiltin() && 'array' !== $type->getName())) {
             return [];
         }
 
@@ -99,7 +99,12 @@ final class EntityValueResolver implements ValueResolverInterface
             if (!$criteria = $this->getCriteria($inputName, $input, $options, $manager, $isOption)) {
                 throw new NearMissValueResolverException(\sprintf('Cannot find mapping for "%s": use the #[MapEntity] attribute to configure entity resolution.', $options->class));
             }
-            $object = $this->findOneByCriteria($manager, $options, $criteria);
+
+            if ('array' === $type->getName()) {
+                $object = $this->findByCriteria($manager, $options, $criteria);
+            } else {
+                $object = $this->findOneByCriteria($manager, $options, $criteria);
+            }
         }
 
         if (null === $object && !$member->isNullable()) {

--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -69,8 +69,8 @@ final class EntityValueResolver implements ValueResolverInterface
             if (null === $object = $this->findViaExpression($this->expressionLanguage, $manager, $options, $variables)) {
                 $message = \sprintf(' The expression "%s" returned null.', $options->expr);
             }
-        // find by identifier?
-        } elseif (false === $object = $this->findById($manager, $options, $this->getIdentifier($request, $options, $argument))) {
+        // find by identifier? an array argument maps to a list, so the single-entity identifier lookup does not apply
+        } elseif ('array' === $argument->getType() || false === $object = $this->findById($manager, $options, $this->getIdentifier($request, $options, $argument))) {
             // find by criteria
             if (!$criteria = $this->getCriteria($request, $options, $manager, $argument)) {
                 if (!class_exists(NearMissValueResolverException::class)) {
@@ -79,7 +79,12 @@ final class EntityValueResolver implements ValueResolverInterface
 
                 throw new NearMissValueResolverException(\sprintf('Cannot find mapping for "%s": declare one using either the #[MapEntity] attribute or mapped route parameters.', $options->class));
             }
-            $object = $this->findOneByCriteria($manager, $options, $criteria);
+
+            if ('array' === $argument->getType()) {
+                $object = $this->findByCriteria($manager, $options, $criteria);
+            } else {
+                $object = $this->findOneByCriteria($manager, $options, $criteria);
+            }
         }
 
         if (null === $object && !$argument->isNullable()) {

--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolverTrait.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolverTrait.php
@@ -100,6 +100,18 @@ trait EntityValueResolverTrait
     }
 
     /**
+     * Finds a list of entities by criteria.
+     */
+    private function findByCriteria(ObjectManager $manager, MapEntity $options, array $criteria): array
+    {
+        try {
+            return $manager->getRepository($options->class)->findBy($criteria);
+        } catch (ConversionException) {
+            return [];
+        }
+    }
+
+    /**
      * Finds an entity via closure.
      */
     private function findViaClosure(ObjectManager $manager, MapEntity $options, mixed $context): object|iterable|null

--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -24,21 +24,21 @@ use Symfony\Component\HttpKernel\Attribute\ValueResolver;
 class MapEntity extends ValueResolver
 {
     /**
-     * @param class-string|null          $class         The entity class
-     * @param string|null                $objectManager Specify the object manager used to retrieve the entity
-     * @param string|\Closure<T of ObjectRepository>(Request|InputInterface, T):(object|iterable|null)|null $expr An expression or closure to fetch the entity.
-     *                                                  Any request attribute are available as a variable, and your entity repository in the 'repository' variable.
-     * @param array<string, string>|null $mapping       Configures the properties and values to use with the findOneBy() method
-     *                                                  The key is the route placeholder name and the value is the Doctrine property name.
-     *                                                  On Console commands, the placeholder name is matched against argument/option names
-     *                                                  after a kebab-case transformation (e.g. "userId" maps to "user-id")
-     * @param string[]|null              $exclude       Configures the properties that should be used in the findOneBy() method by excluding
-     *                                                  one or more properties so that not all are used
-     * @param bool|null                  $stripNull     Whether to prevent null values from being used as parameters in the query (defaults to false)
-     * @param string[]|string|null       $id            If an id option is configured and matches a route parameter, then the resolver will find by the primary key.
-     *                                                  On Console commands, the id name is matched against argument/option names after a kebab-case
-     *                                                  transformation (e.g. "userId" looks for "user-id")
-     * @param bool|null                  $evictCache    If true, forces Doctrine to always fetch the entity from the database instead of cache (defaults to false)
+     * @param class-string|null                                                                             $class         The entity class
+     * @param string|null                                                                                   $objectManager Specify the object manager used to retrieve the entity
+     * @param string|\Closure<T of ObjectRepository>(Request|InputInterface, T):(object|iterable|null)|null $expr          An expression or closure to fetch the entity.
+     *                                                                                                                     Any request attribute are available as a variable, and your entity repository in the 'repository' variable.
+     * @param array<string, string>|null                                                                    $mapping       Configures the properties and values to use with the findOneBy()/findBy() method
+     *                                                                                                                     The key is the route placeholder name and the value is the Doctrine property name.
+     *                                                                                                                     On Console commands, the placeholder name is matched against argument/option names
+     *                                                                                                                     after a kebab-case transformation (e.g. "userId" maps to "user-id")
+     * @param string[]|null                                                                                 $exclude       Configures the properties that should be used in the findOneBy()/findBy() method by excluding
+     *                                                                                                                     one or more properties so that not all are used
+     * @param bool|null                                                                                     $stripNull     Whether to prevent null values from being used as parameters in the query (defaults to false)
+     * @param string[]|string|null                                                                          $id            If an id option is configured and matches a route parameter, then the resolver will find by the primary key.
+     *                                                                                                                     On Console commands, the id name is matched against argument/option names after a kebab-case
+     *                                                                                                                     transformation (e.g. "userId" looks for "user-id")
+     * @param bool|null                                                                                     $evictCache    If true, forces Doctrine to always fetch the entity from the database instead of cache (defaults to false)
      */
     public function __construct(
         public ?string $class = null,

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Add option `uid_format` to `EntityType`
  * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`; namespace aliases are no longer supported in Doctrine
  * Map the `DatePoint`, `DayPoint` and `TimePoint` property types to their Doctrine types, so schema tools detect them without an explicit `type`
+ * Load a list of entities into `array`-typed controller and command arguments with `#[MapEntity]`, using `findBy()`
 
 8.0
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -590,6 +590,52 @@ class EntityValueResolverTest extends TestCase
         $this->assertSame([], $resolver->resolve($request, $argument));
     }
 
+    public function testResolveWithFindBy()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('arg1', 1);
+
+        $argument = $this->createArgument('array', new MapEntity(class: \stdClass::class, mapping: ['arg1' => 'arg1']), 'arg1');
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findBy')
+            ->with(['arg1' => 1], null, null, null)
+            ->willReturn([$object = new \stdClass()]);
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with('stdClass')
+            ->willReturn($repository);
+
+        $this->assertSame([[$object]], $resolver->resolve($request, $argument));
+    }
+
+    public function testArrayArgumentSkipsTheIdentifierLookup()
+    {
+        $manager = $this->createStub(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        // without a mapping, a bare "id" route attribute wins the identifier lookup and
+        // would resolve a single entity into the array-typed argument
+        $request = new Request();
+        $request->attributes->set('id', 7);
+
+        $argument = $this->createArgument('array', new MapEntity(class: \stdClass::class), 'posts');
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->never())->method('find');
+        $manager->method('getRepository')->willReturn($repository);
+
+        $this->expectException(NearMissValueResolverException::class);
+        $resolver->resolve($request, $argument);
+    }
+
     private function createArgument(?string $class = null, ?MapEntity $entity = null, string $name = 'arg', bool $isNullable = false): ArgumentMetadata
     {
         return new ArgumentMetadata($name, $class ?? \stdClass::class, false, false, null, $isNullable, $entity ? [$entity] : []);

--- a/src/Symfony/Bridge/Doctrine/Tests/Console/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Console/ArgumentResolver/EntityValueResolverTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ArgumentResolver\Console\EntityValueResolver;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
@@ -253,6 +254,77 @@ class EntityValueResolverTest extends TestCase
         $this->assertSame([$object], iterator_to_array($resolver->resolve('entity', $input, $member)));
     }
 
+    public function testResolveWithStripNull()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $input = new ArrayInput(['entity' => null], new InputDefinition([
+            new InputArgument('entity'),
+        ]));
+
+        $member = $this->createMember('entity', \stdClass::class, new MapEntity(mapping: ['entity'], stripNull: true), nullable: true);
+
+        $manager->expects($this->never())
+            ->method('getClassMetadata');
+
+        $manager->expects($this->never())
+            ->method('getRepository');
+
+        $this->expectException(NearMissValueResolverException::class);
+
+        iterator_to_array($resolver->resolve('entity', $input, $member));
+    }
+
+    public function testAlreadyResolved()
+    {
+        $manager = $this->createStub(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $object = new \stdClass();
+        $input = new ArrayInput(['entity' => $object], new InputDefinition([
+            new InputArgument('entity'),
+        ]));
+
+        $member = $this->createMember('entity', \stdClass::class, new MapEntity());
+
+        $this->assertSame([], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
+    #[TestWith([[12]])]
+    #[TestWith([['foo']])]
+    #[TestWith([[1, 2, 3, 4]])]
+    #[TestWith([['foo', 'bar', 'baz']])]
+    public function testResolveWithFindBy(array $commandArg)
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $input = new ArrayInput(['entity' => $commandArg], new InputDefinition([
+            new InputArgument('entity'),
+        ]));
+
+        $expectedResult = array_fill(0, \count($commandArg), new \stdClass());
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findBy')
+            ->with(['entity' => $commandArg], null, null, null)
+            ->willReturn($expectedResult);
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $member = $this->createMember('entity', 'array', new MapEntity(class: \stdClass::class, mapping: ['entity']));
+
+        $this->assertSame([$expectedResult], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
     public function testResolveWithClosure()
     {
         $manager = $this->createMock(ObjectManager::class);
@@ -310,45 +382,6 @@ class EntityValueResolverTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         iterator_to_array($resolver->resolve('entity', $input, $member));
-    }
-
-    public function testResolveWithStripNull()
-    {
-        $manager = $this->createMock(ObjectManager::class);
-        $registry = $this->createRegistry($manager);
-        $resolver = new EntityValueResolver($registry);
-
-        $input = new ArrayInput(['entity' => null], new InputDefinition([
-            new InputArgument('entity'),
-        ]));
-
-        $member = $this->createMember('entity', \stdClass::class, new MapEntity(mapping: ['entity'], stripNull: true), nullable: true);
-
-        $manager->expects($this->never())
-            ->method('getClassMetadata');
-
-        $manager->expects($this->never())
-            ->method('getRepository');
-
-        $this->expectException(NearMissValueResolverException::class);
-
-        iterator_to_array($resolver->resolve('entity', $input, $member));
-    }
-
-    public function testAlreadyResolved()
-    {
-        $manager = $this->createStub(ObjectManager::class);
-        $registry = $this->createRegistry($manager);
-        $resolver = new EntityValueResolver($registry);
-
-        $object = new \stdClass();
-        $input = new ArrayInput(['entity' => $object], new InputDefinition([
-            new InputArgument('entity'),
-        ]));
-
-        $member = $this->createMember('entity', \stdClass::class, new MapEntity());
-
-        $this->assertSame([], iterator_to_array($resolver->resolve('entity', $input, $member)));
     }
 
     public function testResolveByIdFromOption()
@@ -475,6 +508,9 @@ class EntityValueResolverTest extends TestCase
     {
         $parts = [];
 
+        if (null !== $entity->class) {
+            $parts[] = \sprintf('class: %s', var_export($entity->class, true));
+        }
         if (null !== $entity->id) {
             $parts[] = \sprintf('id: %s', var_export($entity->id, true));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Currently, the only way to load list of entities when using #[MapEntity] is with `expr` option because other findOneBy is always used.
```php
#[Route('/posts_by/{author_id}')]
public function authorPosts(
    #[MapEntity(class: Post::class, expr: 'repository.findBy({"author": author_id})')]
    iterable $posts
): Response {
}
```

But if we detect that argument is array type, we can still use findBy to load list of entites.
So something like this would be valid
```php
#[Route('/posts_by/{author_id}')]
public function authorPosts(
    #[MapEntity(class: Post::class, mapping: ['author_id' => 'author'])]
    array $posts
): Response {
}
```
```php
#[Route('/posts_by/{author}')]
public function authorPosts(
    #[MapEntity(class: Post::class, mapping: ['author'])]
    array $posts
): Response {
}
```
```php
#[Route('/posts_by/{author:posts}')]
public function authorPosts(
    #[MapEntity(class: Post::class)]
    array $posts
): Response {
}
```

Using this you cannot set `orderBy`, `limit` and `offset` but I think that's okay, if you need those options oyu can always use expression, this is just much cleaner syntax when you need simple findBy.

Currently, this is done by detected argument type and checking if it's array. I'm not 100% sure about this approach, the alternative would be maybe new option in `#[MapEntity]`, something like `bool $multiple` (default false).
In that case, last example would be:

```php
#[Route('/posts_by/{author:posts}')]
public function authorPosts(
    #[MapEntity(class: Post::class, multiple: true)]
    array $posts
): Response {
}
```
Previous usage was cleaner, but this is more robust and explicit.
I'm happy to hear any suggestions on this.

The identifier lookup is skipped for `array` arguments, since it resolves a single entity: without it, a bare `{id}` route attribute won the lookup and handed one entity to the array parameter. An empty `findBy()` result resolves to an empty array rather than a 404, as an empty list is a valid result. The same applies to `array`-typed console command arguments.

Documentation should cover: `array`-typed arguments switching to `findBy()`, that `iterable` keeps single-entity behaviour and `expr` stays the tool for limits and ordering, the empty-list semantics, and the console counterpart.
