### PR TITLE
[DependencyInjection] Fix autowiring nullable intersection types

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -719,7 +719,7 @@ class AutowirePass extends AbstractRecursivePass
     private function getCombinedAlias(string $type, ?string $name = null): ?string
     {
         if (str_contains($type, '&')) {
-            $types = explode('&', $type);
+            $types = explode('&', trim($type, '()'));
         } elseif (str_contains($type, '|')) {
             $types = explode('|', $type);
         } else {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -443,7 +443,7 @@ class AutowirePassTest extends TestCase
     /**
      * @requires PHP 8.2
      */
-    public function testParameterWithNullableIntersectionIsSkipped()
+    public function testParameterWithNullableIntersectionIsSkippedWhenAliasDoesNotExist()
     {
         $container = new ContainerBuilder();
 
@@ -454,6 +454,26 @@ class AutowirePassTest extends TestCase
 
         $definition = $container->getDefinition('opt');
         $this->assertNull($definition->getArgument(0));
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testParameterWithNullableIntersectionIsAutowiredWhenAliasExists()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('b', \stdClass::class);
+        $container->setAlias(CollisionInterface::class, 'b');
+        $container->setAlias(AnotherInterface::class, 'b');
+
+        $optDefinition = $container->register('opt', NullableIntersection::class);
+        $optDefinition->setAutowired(true);
+
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition('opt');
+        $this->assertSame('b', (string) $definition->getArgument(0));
     }
 
     public function testParameterWithNullUnionIsAutowired()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, autowiring intersection types is supported, but nullable intersection types are not.

For example, the following is not supported:

```php
public function __construct(
    private (DecoderInterface&DenormalizerInterface)|null $service
) {}
```

This PR fixes this. 