### PR TITLE
[Scheduler] Respect `console.command` DI tag `command` attribute

### DIFF
--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -55,8 +55,11 @@ class AddScheduleMessengerPass implements CompilerPassInterface
                 $serviceDefinition = $container->getDefinition($serviceId);
                 $scheduleName = $tagAttributes['schedule'] ?? 'default';
 
-                if ($serviceDefinition->hasTag('console.command')) {
-                    $commandName = $serviceDefinition->getClass()::getDefaultName();
+                if ($commandTags = $serviceDefinition->getTag('console.command')) {
+                    $aliases = explode('|', $commandTags[0]['command'] ?? $serviceDefinition->getClass()::getDefaultName() ?? '');
+                    if ('' === $commandName = array_shift($aliases)) {
+                        $commandName = array_shift($aliases) ?? '';
+                    }
                     if (\is_array($arguments = $tagAttributes['arguments'] ?? '')) {
                         $input = (string) new ArrayInput(['command' => $commandName, ...$arguments]);
                     } else {

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -46,6 +46,37 @@ class AddScheduleMessengerPassTest extends TestCase
         $this->assertSame($expectedCommand, $command);
     }
 
+    /**
+     * @dataProvider processSchedulerTaskCommandNameFromTagProvider
+     */
+    public function testProcessSchedulerTaskCommandNameFromTag(array $commandTagAttributes, string $expectedCommand)
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command', $commandTagAttributes);
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour']);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $schedulerProvider = $container->getDefinition('scheduler.provider.default');
+        $calls = $schedulerProvider->getMethodCalls();
+
+        $messageDefinition = $calls[0][1][0];
+        $messageArguments = $messageDefinition->getArgument('$message');
+        $command = $messageArguments->getArgument(0);
+
+        $this->assertSame($expectedCommand, $command);
+    }
+
+    public static function processSchedulerTaskCommandNameFromTagProvider(): iterable
+    {
+        yield 'tag command attribute overrides attribute name' => [['command' => 'custom-name'], 'custom-name'];
+        yield 'tag command attribute with aliases' => [['command' => 'custom-name|alias1|alias2'], 'custom-name'];
+        yield 'tag command attribute with hidden leading pipe' => [['command' => '|real-name'], 'real-name'];
+    }
+
     public static function processSchedulerTaskCommandProvider(): iterable
     {
         yield 'no arguments' => [['trigger' => 'every', 'frequency' => '1 hour'], 'schedulable'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Spotted while reviewing #63948

`AddScheduleMessengerPass` hardcoded the command name extraction to `$class::getDefaultName()`, ignoring what `AddConsoleCommandPass` actually uses at runtime.

This broke a few cases:

- command registered purely via DI (tag `console.command` with attribute `command: foo:bar`, no `#[AsCommand]`) produced an empty `RunCommandMessage` input
- DI tag overriding the attribute-declared name caused the scheduler to dispatch under the wrong name
- hidden-command syntax (`|real-name`) and `|`-separated aliases were silently dropped

The fix mirrors `AddConsoleCommandPass`: read `command` from the tag first, fall back to `getDefaultName()`, then split on `|` and honor the leading-empty hidden-command convention.
