### PR TITLE
[Form] remove deprecation: mocks without expectations

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -69,6 +69,7 @@ CHANGELOG
  * Deprecate `PostSubmitEvent::setData()`, use `PreSubmitDataEvent::setData()` or `SubmitDataEvent::setData()` instead
  * Add `duplicate_preferred_choices` option in `ChoiceType`
  * Add `$duplicatePreferredChoices` parameter to `ChoiceListFactoryInterface::createView()`
+ * Remove deprecation `No expectations were configured for the mock object for ...`
 
 6.3
 ---

--- a/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
+++ b/src/Symfony/Component/Form/Test/Traits/ValidatorExtensionTrait.php
@@ -36,10 +36,10 @@ trait ValidatorExtensionTrait
             throw new \Exception(\sprintf('The trait "ValidatorExtensionTrait" can only be added to a class that extends "%s".', TypeTestCase::class));
         }
 
-        $this->validator = $this->createMock(ValidatorInterface::class);
-        $metadata = $this->getMockBuilder(ClassMetadata::class)->setConstructorArgs([''])->onlyMethods(['addPropertyConstraint'])->getMock();
-        $this->validator->expects($this->any())->method('getMetadataFor')->willReturn($metadata);
-        $this->validator->expects($this->any())->method('validate')->willReturn(new ConstraintViolationList());
+        $this->validator = $this->createStub(ValidatorInterface::class);
+        $metadata = $this->getStubBuilder(ClassMetadata::class)->setConstructorArgs([''])->onlyMethods(['addPropertyConstraint'])->getStub();
+        $this->validator->method('getMetadataFor')->willReturn($metadata);
+        $this->validator->method('validate')->willReturn(new ConstraintViolationList());
 
         return new ValidatorExtension($this->validator, $violationMapper);
     }

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -27,7 +27,7 @@ abstract class TypeTestCase extends FormIntegrationTestCase
         parent::setUp();
 
         if (!isset($this->dispatcher)) {
-            $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+            $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
         }
         $this->builder = new FormBuilder('', null, $this->dispatcher, $this->factory);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| License       | MIT

Using mocks without expectations is depracetd as of phpunit@14
```
* No expectations were configured for the mock object for Symfony\Component\Validator\Validator\ValidatorInterface. Consider refactoring your test code to use a test stub instead. The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.

* No expectations were configured for the mock object for Symfony\Component\Validator\Mapping\ClassMetadata. Consider refactoring your test code to use a test stub instead. The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.

* No expectations were configured for the mock object for Symfony\Component\EventDispatcher\EventDispatcherInterface. Consider refactoring your test code to use a test stub instead. The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.

```