### PR TITLE
[Dotenv] Fix variable corruption when loading env more than once

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -37,6 +37,7 @@ final class Dotenv
     private int $end;
     private array $values = [];
     private array $overriddenValues = [];
+    private array $loadedRawVars = [];
     private string $envKey;
     private string $debugKey;
     private array $prodEnvs = ['prod'];
@@ -647,9 +648,15 @@ final class Dotenv
 
             $values = $this->parseRaw($data, $path);
 
+            $loadedVars = array_flip(explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? ''));
+            unset($loadedVars['']);
+
             foreach ($values as $name => $_) {
                 if (!isset($this->overriddenValues[$name]) && isset($_ENV[$name])) {
                     $this->overriddenValues[$name] = $_ENV[$name];
+                }
+                if (isset($loadedVars[$name]) || $overrideExistingVars || !isset($_ENV[$name])) {
+                    $this->loadedRawVars[$name] = true;
                 }
             }
 
@@ -706,6 +713,10 @@ final class Dotenv
         $loadedVars = array_flip(explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? ''));
         unset($loadedVars['']);
 
+        $rawVars = $this->loadedRawVars;
+        $this->loadedRawVars = [];
+        unset($rawVars['SYMFONY_DOTENV_VARS']);
+
         $this->values = [];
         $this->path = '';
         $this->data = '';
@@ -717,10 +728,7 @@ final class Dotenv
         // (e.g. MY_VAR="${MY_VAR:-default}") so their own raw value is hidden
         // during resolution, allowing the default to trigger correctly.
         $selfReferencingVars = [];
-        foreach ($loadedVars as $name => $_) {
-            if ('SYMFONY_DOTENV_VARS' === $name) {
-                continue;
-            }
+        foreach ($rawVars as $name => $_) {
             $value = $_ENV[$name] ?? '';
             if (str_contains($value, '$') && preg_match('/\$\{?'.preg_quote($name, '/').'(?![A-Za-z0-9_])/', $value)) {
                 $selfReferencingVars[$name] = true;
@@ -729,10 +737,7 @@ final class Dotenv
 
         for ($pass = 0; $pass < 5; ++$pass) {
             $resolved = [];
-            foreach ($loadedVars as $name => $_) {
-                if ('SYMFONY_DOTENV_VARS' === $name) {
-                    continue;
-                }
+            foreach ($rawVars as $name => $_) {
                 if (!str_contains($value = $_ENV[$name] ?? '', '$')) {
                     continue;
                 }
@@ -786,10 +791,7 @@ final class Dotenv
 
         // Restore literal $ signs and unescape backslashes
         $restored = [];
-        foreach ($loadedVars as $name => $_) {
-            if ('SYMFONY_DOTENV_VARS' === $name) {
-                continue;
-            }
+        foreach ($rawVars as $name => $_) {
             $value = $_ENV[$name] ?? '';
             if ($value !== $newValue = str_replace(["\x00", '\\\\'], ['$', '\\'], $value)) {
                 $restored[$name] = $newValue;

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -238,6 +238,41 @@ class DotenvTest extends TestCase
         $this->assertSame('BAZ', $bar);
     }
 
+    public function testLoadDoesNotReResolveAlreadyLoadedVars()
+    {
+        unset($_ENV['FOO'], $_ENV['BAR'], $_ENV['SYMFONY_DOTENV_VARS']);
+        unset($_SERVER['FOO'], $_SERVER['BAR'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('FOO');
+        putenv('BAR');
+        putenv('SYMFONY_DOTENV_VARS');
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+
+        $path1 = tempnam($tmpdir, 'sf-');
+        $path2 = tempnam($tmpdir, 'sf-');
+
+        file_put_contents($path1, "FOO='This\$isokay'");
+        file_put_contents($path2, "BAR='hello'");
+
+        try {
+            (new Dotenv())->load($path1);
+            $this->assertSame('This$isokay', $_ENV['FOO']);
+
+            (new Dotenv())->load($path2);
+            $this->assertSame('This$isokay', $_ENV['FOO']);
+            $this->assertSame('hello', $_ENV['BAR']);
+        } finally {
+            unset($_ENV['FOO'], $_ENV['BAR'], $_ENV['SYMFONY_DOTENV_VARS']);
+            unset($_SERVER['FOO'], $_SERVER['BAR'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('FOO');
+            putenv('BAR');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path1);
+            unlink($path2);
+            rmdir($tmpdir);
+        }
+    }
+
     public function testLoadEnv()
     {
         $resetContext = static function (): void {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63954
| License       | MIT

`resolveLoadedVars()` iterated over every name in `SYMFONY_DOTENV_VARS`, including vars resolved by a previous `load()`/`loadEnv()` call. By then, the `\x00` markers protecting literal `$` (from single-quoted values) had already been converted back to `$`, so a value like `This$isokay` was re-interpreted as a `$isokay` variable reference and truncated to `This`.

Track the names actually populated during `doLoad()` and limit `resolveLoadedVars()` to that set, leaving previously-resolved values untouched.
