### PR TITLE
[WebProfilerBundle] Improve profiler pages accessibility semantics

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
+++ b/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
@@ -38,7 +38,7 @@
 
 {% block menu %}
     <span class="label {{ collector.dumpsCount == 0 ? 'disabled' }}">
-        <span class="icon">{{ source('@Debug/Profiler/icon.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@Debug/Profiler/icon.svg') }}</span>
         <strong>Debug</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -190,7 +190,7 @@
 
 {% block menu %}
     <span class="label {{ not collector.firewall or not collector.token ? 'disabled' }}">
-        <span class="icon">{{ source('@Security/Collector/icon.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@Security/Collector/icon.svg') }}</span>
         <strong>Security</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -36,7 +36,7 @@
 
 {% block menu %}
     <span class="label {{ collector.totals.calls == 0 ? 'disabled' }}">
-        <span class="icon">
+        <span class="icon" aria-hidden="true">
             {{ source('@WebProfiler/Icon/cache.svg') }}
         </span>
         <strong>Cache</strong>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/command.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/command.html.twig
@@ -2,7 +2,7 @@
 
 {% block menu %}
     <span class="label">
-        <span class="icon">{{ source('@WebProfiler/Icon/command.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/command.svg') }}</span>
         <strong>Console Command</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -171,7 +171,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.symfonyState == 'eol' ? 'red' : collector.symfonyState in ['eom', 'dev'] ? 'yellow' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/config.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/config.svg') }}</span>
         <strong>Configuration</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -2,7 +2,7 @@
 
 {% block menu %}
 <span class="label">
-    <span class="icon">{{ source('@WebProfiler/Icon/event.svg') }}</span>
+    <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/event.svg') }}</span>
     <strong>Events</strong>
 </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -12,7 +12,7 @@
 
 {% block menu %}
     <span class="label {{ collector.hasexception ? 'label-status-error' : 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/exception.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/exception.svg') }}</span>
         <strong>Exception</strong>
         {% if collector.hasexception %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -27,7 +27,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.data.nb_errors ? 'error' }} {{ collector.data.forms is empty ? 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/form.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/form.svg') }}</span>
         <strong>Forms</strong>
         {% if collector.data.nb_errors > 0 %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -60,7 +60,7 @@
 
 {% block menu %}
 <span class="label {{ collector.requestCount == 0 ? 'disabled' }}">
-    <span class="icon">{{ source('@WebProfiler/Icon/http-client.svg') }}</span>
+    <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/http-client.svg') }}</span>
     <strong>HTTP Client</strong>
     {% if collector.requestCount %}
         <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -357,7 +357,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.counterrors ? 'error' : collector.countwarnings ? 'warning' : 'none' }} {{ collector.logs is empty ? 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/logger.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/logger.svg') }}</span>
         <strong>Logs</strong>
         {% if collector.counterrors or collector.countdeprecations or collector.countwarnings %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -220,7 +220,7 @@
     {% set events = collector.events %}
 
     <span class="label {{ events.messages is empty ? 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/mailer.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/mailer.svg') }}</span>
 
         <strong>Emails</strong>
         {% if events.messages|length > 0 %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -72,7 +72,7 @@
 
 {% block menu %}
     <span class="label{{ collector.exceptionsCount ? ' label-status-error' }}{{ collector.messages is empty ? ' disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/messenger.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/messenger.svg') }}</span>
         <strong>Messages</strong>
         {% if collector.exceptionsCount > 0 %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -69,7 +69,7 @@
     {% set events = collector.events %}
 
     <span class="label {{ events.messages|length ? '' : 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/notifier.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/notifier.svg') }}</span>
 
         <strong>Notifications</strong>
         {% if events.messages|length > 0 %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -125,7 +125,7 @@
 
 {% block menu %}
     <span class="label">
-        <span class="icon">{{ source('@WebProfiler/Icon/request.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/request.svg') }}</span>
         <strong>Request / Response</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
@@ -4,7 +4,7 @@
 
 {% block menu %}
 <span class="label">
-    <span class="icon">{{ source('@WebProfiler/Icon/router.svg') }}</span>
+    <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/router.svg') }}</span>
     <strong>Routing</strong>
 </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -93,7 +93,7 @@
 
 {% block menu %}
     <span class="label {{ not collector.handledCount ? 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/serializer.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/serializer.svg') }}</span>
         <strong>Serializer</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -66,7 +66,7 @@
 
 {% block menu %}
     <span class="label">
-        <span class="icon">{{ source('@WebProfiler/Icon/time.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/time.svg') }}</span>
         <strong>Performance</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -42,7 +42,7 @@
 
 {% block menu %}
     <span class="label label-status-{{ collector.countMissings ? 'error' : collector.countFallbacks ? 'warning' }} {{ collector.messages is empty ? 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/translation.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/translation.svg') }}</span>
         <strong>Translation</strong>
         {% if collector.countMissings or collector.countFallbacks %}
             {% set error_count = collector.countMissings + collector.countFallbacks %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -84,7 +84,7 @@
 
 {% block menu %}
     <span class="label {{ 0 == collector.templateCount ? 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/twig.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/twig.svg') }}</span>
         <strong>Twig</strong>
     </span>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
@@ -56,7 +56,7 @@
 
 {% block menu %}
     <span class="label {{- collector.violationsCount ? ' label-status-error' }} {{ collector.calls is empty ? 'disabled' }}">
-        <span class="icon">{{ source('@WebProfiler/Icon/validator.svg') }}</span>
+        <span class="icon" aria-hidden="true">{{ source('@WebProfiler/Icon/validator.svg') }}</span>
         <strong>Validator</strong>
         {% if collector.violationsCount > 0 %}
             <span class="count">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/workflow.html.twig
@@ -118,7 +118,7 @@
 
 {% block menu %}
     <span class="label {{ collector.workflows|length == 0 ? 'disabled' }}">
-        <span class="icon">
+        <span class="icon" aria-hidden="true">
             {{ source('@WebProfiler/Icon/workflow.svg') }}
         </span>
         <strong>Workflow</strong>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/header.html.twig
@@ -1,5 +1,5 @@
-<div id="header">
-    <h1><a href="{{ path('_profiler_home') }}">{{ source('@WebProfiler/Icon/symfony.svg') }} Symfony Profiler</a></h1>
+<header id="header">
+    <h1><a href="{{ path('_profiler_home') }}"><span aria-hidden="true">{{ source('@WebProfiler/Icon/symfony.svg') }}</span> Symfony Profiler</a></h1>
 
     <div class="search">
         <form method="get" action="https://symfony.com/search" target="_blank">
@@ -9,4 +9,4 @@
             </div>
        </form>
     </div>
-</div>
+</header>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -21,7 +21,7 @@
     </div>
 
         <div id="content">
-            <div id="main">
+            <main id="main">
                 <div id="sidebar">
                     {% block sidebar %}
                         <div id="sidebar-contents">
@@ -53,7 +53,7 @@
                                         {%- endset %}
                                         {% if menu is not empty %}
                                             <li class="{{ name }} {{ name == panel ? 'selected' }}">
-                                                <a href="{{ path('_profiler', {token: token, panel: name, type: profile_type}) }}">{{ menu|raw }}</a>
+                                                <a href="{{ path('_profiler', {token: token, panel: name, type: profile_type}) }}"{{ name == panel ? ' aria-current="page"' }}>{{ menu|raw }}</a>
                                             </li>
                                         {% endif %}
                                     {% endfor %}
@@ -72,7 +72,7 @@
                         {% block panel '' %}
                     </div>
                 </div>
-            </div>
+            </main>
         </div>
     </div>
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
@@ -13,7 +13,7 @@
 
         {% set source = file_info.pathname|file_excerpt(line, -1) %}
         <div id="content">
-            <div id="main">
+            <main id="main">
                 <div id="source">
                     <h1 class="source-file-name">{{ file }}{% if 0 < line %} <small>line {{ line }}</small>{% endif %}</h1>
 
@@ -45,7 +45,7 @@
 
                     <a class="doc-link" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open this file in your IDE?</a>
                 </div>
-            </div>
+            </main>
         </div>
     </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT


## Improve accessibility of Symfony Profiler pages through better semantics

---

### Summary

This PR improves the accessibility of the Symfony Profiler pages by introducing better semantic structure and reducing redundant information for screen reader users.

---

### 1. Add ARIA landmark elements (`<header>`, `<main>`)

Screen reader users rely on landmark regions to navigate efficiently using keyboard shortcuts.

---

### 2. Hide decorative SVG icons from assistive technologies

Each sidebar item is composed of an icon and a visible text label (e.g. `<strong>Cache</strong>`). Some SVG icons expose a `<title>` or `aria-label`, causing screen readers to announce duplicated information such as:

* “Cache Cache”
* “Security Security”
* “Symfony Symfony Profiler”

Since the icon does not convey additional meaning, it is purely decorative in this context.

* `aria-hidden="true"` was added to the `<span class="icon">` wrapper across all bundles
* This removes the SVG (and its title) from the accessibility tree, leaving only the meaningful label

### 3. Add `aria-current="page"` on the active sidebar link

The current panel is only indicated visually via a CSS class (`selected`), which is not exposed to assistive technologies.

* `aria-current="page"` was added to the active `<a>` element in the sidebar

This allows screen readers to announce, for example:

> “Cache, current page”

This provides immediate contextual feedback without requiring users to infer their position from the page content.
