### PR TITLE
[VarExporter] Don't warn for __sleep()-listed uninitialized declared properties

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -165,6 +165,9 @@ class Exporter
             }
             if ($sleep) {
                 foreach ($sleep as $n => $v) {
+                    if (\is_string($n) && $reflector->hasProperty($n)) {
+                        continue;
+                    }
                     trigger_error(\sprintf('serialize(): "%s" returned as member variable from __sleep() but does not exist', $n), \E_USER_NOTICE);
                 }
             }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/SleepUninitialized.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/SleepUninitialized.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures;
+
+abstract class SleepUninitializedBase
+{
+    public string $set;
+    public string $unsetOnParent;
+
+    public function __sleep(): array
+    {
+        return ['set', 'unsetOnParent'];
+    }
+}
+
+class SleepUninitialized extends SleepUninitializedBase
+{
+    public function __construct(string $value)
+    {
+        $this->set = $value;
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\GoodNight;
 use Symfony\Component\VarExporter\Tests\Fixtures\MySerializable;
 use Symfony\Component\VarExporter\Tests\Fixtures\MyWakeup;
 use Symfony\Component\VarExporter\Tests\Fixtures\Php74Serializable;
+use Symfony\Component\VarExporter\Tests\Fixtures\SleepUninitialized;
 use Symfony\Component\VarExporter\VarExporter;
 
 $errorHandler = set_error_handler(static function (int $errno, string $errstr) use (&$errorHandler) {
@@ -263,6 +264,24 @@ class VarExporterTest extends TestCase
     public function testUnicodeDirectionality()
     {
         $this->assertSame('"\0\r\u{202A}\u{202B}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{202C}\u{2069}\n"', VarExporter::export("\0\r\u{202A}\u{202B}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{202C}\u{2069}\n"));
+    }
+
+    public function testSleepListingUninitializedTypedPropertyEmitsNoNotice()
+    {
+        $errors = [];
+        $previous = set_error_handler(static function (int $errno, string $errstr) use (&$errors) {
+            $errors[] = $errstr;
+
+            return true;
+        });
+
+        try {
+            VarExporter::export(new SleepUninitialized('hello'));
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $errors);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63957
| License       | MIT

Native `serialize()` silently skips typed properties listed by `__sleep()` that are uninitialized; VarExporter was incorrectly emitting the `"returned as member variable from __sleep() but does not exist"` notice for them.

This breaks cloning of objects whose `__sleep()` returns inherited typed property names that may be uninitialized on concrete subclasses — e.g. Doctrine ORM's `OneToManyAssociationMapping` whose `mappedBy` is declared on the abstract parent `AssociationMapping`.