### PR TITLE
[DependencyInjection] Fix empty bundle cache when container is rebuilt

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
@@ -103,6 +103,7 @@ trait KernelTrait
             && (!$this->debug || is_file($bundlesPath = $this->getBundlesPath()) && filemtime($cachePath) > filemtime($bundlesPath))
         ) {
             $this->bundles = require $cachePath;
+            $this->bundleClasses = array_map('get_class', $this->bundles);
 
             return;
         }
@@ -376,7 +377,7 @@ trait KernelTrait
             'inline_factories' => $buildParameters['.container.dumper.inline_factories'] ?? false,
             'inline_class_loader' => $buildParameters['.container.dumper.inline_class_loader'] ?? $this->debug,
             'build_time' => $container->hasParameter('kernel.container_build_time') ? $container->getParameter('kernel.container_build_time') : $buildTime,
-            'preload_classes' => array_map('get_class', $this->bundles),
+            'preload_classes' => $this->bundleClasses,
         ]);
 
         $rootCode = array_pop($content);

--- a/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
@@ -349,6 +349,28 @@ class AbstractKernelTest extends TestCase
         $this->assertCount(1, $kernel->getBundles(), 'Bundle cache should be used in non-debug mode even when bundles.php changes');
     }
 
+    public function testBundleCacheStaysPopulatedWhenContainerIsRebuilt()
+    {
+        $dir = $this->varDir;
+        @mkdir($dir.'/config', 0o777, true);
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true]];');
+        touch($dir.'/config/bundles.php', time() - 10);
+
+        $kernel = $this->createKernel();
+        @mkdir($kernel->getBuildDir(), 0o777, true);
+        file_put_contents($kernel->getBuildDir().'/'.$kernel->getTestContainerClass().'.bundles.php', '<?php return [\'TestAbstractBundle\' => new \Symfony\Component\DependencyInjection\Tests\TestAbstractBundle()];');
+
+        $kernel->boot();
+
+        $this->assertCount(1, $kernel->getBundles());
+        $kernel->shutdown();
+
+        $kernel = $this->createKernel();
+        $kernel->boot();
+
+        $this->assertCount(1, $kernel->getBundles());
+    }
+
     public function testConfigureContainerHook()
     {
         $kernel = new ConfigureContainerKernel('test', true);
@@ -486,6 +508,11 @@ class TestKernel extends AbstractKernel
     public function isBooted(): bool
     {
         return $this->booted;
+    }
+
+    public function getTestContainerClass(): string
+    {
+        return $this->getContainerClass();
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When the bundle cache file exists but the container needs rebuilding (e.g. due to a config change), `initializeBundles()` uses the cached file and returns early, populating `$this->bundles` but leaving `$this->bundleClasses` empty.

`initializeContainer()` then rebuilds the container and dumps the bundle cache using `$this->bundleClasses`, which is empty. This results in an empty `bundles.php` cache file.

On the next boot, the kernel reads the empty cache and starts with no bundles, even though the original cached bundle list was valid.