### PR TITLE
[Cache] Ensure internal state is cleared in TagAwareAdapter::reset() even on commit failure

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -288,10 +288,14 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
      */
     public function reset()
     {
-        $this->commit();
-        $this->knownTagVersions = [];
-        $this->pool instanceof ResettableInterface && $this->pool->reset();
-        $this->tags instanceof ResettableInterface && $this->tags->reset();
+        try {
+            $this->commit();
+        } finally {
+            $this->knownTagVersions = [];
+            $this->deferred = [];
+            $this->pool instanceof ResettableInterface && $this->pool->reset();
+            $this->tags instanceof ResettableInterface && $this->tags->reset();
+        }
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Tests\Fixtures\PrunableAdapter;
 use Symfony\Component\Filesystem\Filesystem;
@@ -226,5 +227,27 @@ class TagAwareAdapterTest extends AdapterTestCase
         foreach ($pool->getItems([$itemKey1, $itemKey2]) as $item) {
             // run generator
         }
+    }
+
+    public function testResetClearsInternalStateEvenOnCommitFailure()
+    {
+        $pool = new class extends ArrayAdapter {
+            public function commit(): bool { return false; }
+        };
+
+        $adapter = new TagAwareAdapter($pool);
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $adapter->saveDeferred($item);
+
+        // Simulate some known tag versions
+        $propertyTags = new \ReflectionProperty($adapter, 'knownTagVersions');
+        $propertyTags->setValue($adapter, ['tag1' => 1]);
+
+        $adapter->reset();
+
+        $propertyDeferred = new \ReflectionProperty($adapter, 'deferred');
+        $this->assertEmpty($propertyDeferred->getValue($adapter), 'The deferred items must be cleared even if commit fails.');
+        $this->assertEmpty($propertyTags->getValue($adapter), 'The known tag versions must be cleared even if commit fails.');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

### [Cache] Ensure internal state is cleared in `TagAwareAdapter::reset()` even on commit failure

**What it does and why it's needed:**
This PR ensures that the internal state of `TagAwareAdapter` (`$deferred` items and `$knownTagVersions`) is properly cleared during a `reset()`, even if the underlying pool's `commit()` operation fails or throws an exception.

In long-running processes like **FrankenPHP in worker mode** or Messenger workers, a failed commit during a reset could leave the adapter in an inconsistent state or cause memory leaks as deferred items would persist in memory across requests/resets. By using a `try...finally` block, we guarantee that the adapter is always clean for the next operation.

**A simple example of how it works:**
```php
$adapter = new TagAwareAdapter($pool);
$item = $adapter->getItem('foo');
$adapter->saveDeferred($item);

try {
    // If $pool->commit() fails or throws an exception
    $adapter->reset(); 
} catch (\Exception $e) {
    // Before this fix: $adapter still has 'foo' in its $deferred property
    // After this fix: $adapter's $deferred and $knownTagVersions are empty
}
```

**Contributor guidelines:**
- ✅ Added a test case in `TagAwareAdapterTest` to reproduce and verify the fix.
- 🐞 Targets the lowest maintained branch (6.4).