### PR TITLE
[Cache] Ensure internal state is cleared in TagAwareAdapter::reset() …

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -288,10 +288,14 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
      */
     public function reset()
     {
-        $this->commit();
-        $this->knownTagVersions = [];
-        $this->pool instanceof ResettableInterface && $this->pool->reset();
-        $this->tags instanceof ResettableInterface && $this->tags->reset();
+        try {
+            $this->commit();
+        } finally {
+            $this->knownTagVersions = [];
+            $this->deferred = [];
+            $this->pool instanceof ResettableInterface && $this->pool->reset();
+            $this->tags instanceof ResettableInterface && $this->tags->reset();
+        }
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -227,4 +227,29 @@ class TagAwareAdapterTest extends AdapterTestCase
             // run generator
         }
     }
+
+    public function testResetClearsInternalStateEvenOnCommitFailure()
+    {
+        $pool = new class extends ArrayAdapter {
+            public function commit(): bool
+            {
+                return false;
+            }
+        };
+
+        $adapter = new TagAwareAdapter($pool);
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $adapter->saveDeferred($item);
+
+        // Simulate some known tag versions
+        $propertyTags = new \ReflectionProperty($adapter, 'knownTagVersions');
+        $propertyTags->setValue($adapter, ['tag1' => 1]);
+
+        $adapter->reset();
+
+        $propertyDeferred = new \ReflectionProperty($adapter, 'deferred');
+        $this->assertEmpty($propertyDeferred->getValue($adapter), 'The deferred items must be cleared even if commit fails.');
+        $this->assertEmpty($propertyTags->getValue($adapter), 'The known tag versions must be cleared even if commit fails.');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

This PR ensures that the internal state of `TagAwareAdapter` (`$deferred` items and `$knownTagVersions`) is properly cleared during a `reset()`, even if the underlying pool's `commit()` operation fails or throws an exception.

In long-running processes like **FrankenPHP in worker mode** a failed commit during a reset could leave the adapter in an inconsistent state or cause memory leaks as deferred items would persist in memory across requests/resets. By using a `try...finally` block, we guarantee that the adapter is always clean for the next operation.

This edge case was identified using Igor-PHP [https://github.com/igor-php/igor-php](https://github.com/igor-php/igor-php) a static analysis tool I'm developing to audit service state mutations in persistent runtimes (Worker mode).