### PR TITLE
[VarExporter] Bump to ext-deepclone v0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/contracts": "^3.7",
         "symfony/polyfill-ctype": "^1.8",
-        "symfony/polyfill-deepclone": "^1.35",
+        "symfony/polyfill-deepclone": "^1.36",
         "symfony/polyfill-intl-grapheme": "^1.33",
         "symfony/polyfill-intl-icu": "^1.0",
         "symfony/polyfill-intl-idn": "^1.10",

--- a/src/Symfony/Component/VarExporter/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Hydrator.php
@@ -54,6 +54,13 @@ final class Hydrator
      */
     public static function hydrate(object $instance, array $mangledVars = [], array $scopedVars = []): object
     {
-        return deepclone_hydrate($instance, $scopedVars, $mangledVars);
+        if ($mangledVars) {
+            deepclone_hydrate($instance, $mangledVars, \DEEPCLONE_HYDRATE_MANGLED_VARS);
+        }
+        if ($scopedVars) {
+            deepclone_hydrate($instance, $scopedVars);
+        }
+
+        return $instance;
     }
 }

--- a/src/Symfony/Component/VarExporter/Instantiator.php
+++ b/src/Symfony/Component/VarExporter/Instantiator.php
@@ -41,7 +41,15 @@ final class Instantiator
     public static function instantiate(string $class, array $mangledVars = [], array $scopedVars = []): object
     {
         try {
-            return deepclone_hydrate($class, $scopedVars, $mangledVars);
+            $instance = $mangledVars
+                ? deepclone_hydrate($class, $mangledVars, \DEEPCLONE_HYDRATE_MANGLED_VARS)
+                : deepclone_hydrate($class, $scopedVars);
+
+            if ($mangledVars && $scopedVars) {
+                deepclone_hydrate($instance, $scopedVars);
+            }
+
+            return $instance;
         } catch (\DeepClone\ClassNotFoundException $e) {
             throw new ClassNotFoundException($e);
         } catch (\DeepClone\NotInstantiableException $e) {

--- a/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
@@ -17,17 +17,27 @@ use Symfony\Component\VarExporter\Instantiator;
 
 class HydratorTest extends TestCase
 {
-    public function testHydrateInitializedReadonlyProperty()
+    public function testHydrateInitializedReadonlyPropertySameValueIsIdempotent()
     {
         $object = new HydratorTestClass(123);
 
         Hydrator::hydrate($object, [
-            'value' => 456,
+            'value' => 123,
             'status' => 'hydrated',
         ]);
 
         $this->assertSame(123, $object->getValue());
         $this->assertSame('hydrated', $object->status);
+    }
+
+    public function testHydrateInitializedReadonlyPropertyDifferentValueThrows()
+    {
+        $object = new HydratorTestClass(123);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot modify readonly property');
+
+        Hydrator::hydrate($object, ['value' => 456]);
     }
 
     public function testHydrateUninitializedReadonlyProperty()

--- a/src/Symfony/Component/VarExporter/composer.json
+++ b/src/Symfony/Component/VarExporter/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/polyfill-deepclone": "^1.35"
+        "symfony/polyfill-deepclone": "^1.36"
     },
     "require-dev": {
         "symfony/property-access": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

See https://github.com/symfony/php-ext-deepclone/pull/9 for what v0.3.0 brings

`Hydrator::hydrate()` will now throws `Error: Cannot modify readonly property` when writing a *different* value to an already-initialized readonly property; same-value writes remain a silent no-op. Previously, any write to an initialized readonly was silently ignored. I think this behavior is fine to change.