### PR TITLE
[Serializer] Deprecate denormalizing non-list arrays into list-typed properties

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -17,3 +17,8 @@ HttpFoundation
 --------------
 
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()`
+
+Serializer
+----------
+
+ * Deprecate denormalizing an array that is not a list into a `list`-typed property, in version 9.0 a `Symfony\Component\Serializer\Exception\NotNormalizableValueException` will be thrown when the input does not satisfy `array_is_list()`

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
+
 8.1
 ---
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -471,9 +471,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
 
             $collectionKeyType = $collectionValueType = null;
+            $isList = false;
             if ($t instanceof CollectionType) {
                 $collectionKeyType = $t->getCollectionKeyType();
                 $collectionValueType = $t->getCollectionValueType();
+                $isList = $t->isList();
             }
 
             while ($t instanceof WrappingTypeInterface) {
@@ -549,6 +551,12 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         case TypeIdentifier::INT:
                             return (int) $data;
                     }
+                }
+
+                if ($isList && \is_array($data) && !array_is_list($data)) {
+                    // In 9.0, throw a NotNormalizableValueException instead of triggering a deprecation:
+                    // throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be a list ("%s" given).', $attribute, $currentClass, get_debug_type($data)), $data, [Type::list()], $context['deserialization_path'] ?? null);
+                    trigger_deprecation('symfony/serializer', '8.2', 'Denormalizing an array that is not a list into the "%s" property of class "%s" is deprecated.', $attribute, $currentClass);
                 }
 
                 if ($collectionValueBaseType = $collectionValueType) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
@@ -1515,6 +1517,59 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame(1, $actual->foo->count());
     }
 
+    public function testDenormalizeList()
+    {
+        $denormalizer = $this->getDenormalizerForListCollection(Type::list(Type::int()));
+
+        /** @var ListCollection $object */
+        $object = $denormalizer->denormalize(
+            ['list' => [1, 2, 3]],
+            ListCollection::class,
+        );
+
+        $this->assertTrue(array_is_list($object->list));
+        $this->assertCount(3, $object->list);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    #[DataProvider('provideDenormalizeListWithArray')]
+    public function testDenormalizeListWithArray(Type $type)
+    {
+        $denormalizer = $this->getDenormalizerForListCollection($type);
+
+        $this->expectUserDeprecationMessage('Since symfony/serializer 8.2: Denormalizing an array that is not a list into the "list" property of class "Symfony\Component\Serializer\Tests\Normalizer\ListCollection" is deprecated.');
+
+        /** @var ListCollection $object */
+        $object = $denormalizer->denormalize(
+            ['list' => [1 => 1, 4 => 2, 'foo' => 3]],
+            ListCollection::class
+        );
+
+        $this->assertFalse(array_is_list($object->list));
+        $this->assertCount(3, $object->list);
+    }
+
+    public static function provideDenormalizeListWithArray()
+    {
+        yield 'list<int>' => [Type::list(Type::int())];
+        yield '?list<int>' => [Type::nullable(Type::list(Type::int()))];
+    }
+
+    private function getDenormalizerForListCollection(Type $type)
+    {
+        $extractor = $this->createStub(PhpDocExtractor::class);
+        $extractor->method('getType')->willReturn($type, null);
+
+        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
+        $arrayDenormalizer = new ArrayDenormalizerDummy();
+        $serializer = new SerializerCollectionDummy([$arrayDenormalizer, $denormalizer]);
+        $arrayDenormalizer->setSerializer($serializer);
+        $denormalizer->setSerializer($serializer);
+
+        return $denormalizer;
+    }
+
     public function testTemplateTypeWhenAnObjectIsPassedToDenormalize()
     {
         $normalizer = new class(new ClassMetadataFactory(new AttributeLoader()), null, new PropertyInfoExtractor([], [new PhpStanExtractor(), new ReflectionExtractor()])) extends AbstractObjectNormalizerDummy {
@@ -1843,6 +1898,12 @@ class StringCollection
 {
     /** @var string[] */
     public $children;
+}
+
+class ListCollection
+{
+    /** @var list<int> */
+    public $list;
 }
 
 class DummyCollection


### PR DESCRIPTION
| Q             | A                                                                                                                                                                                                      
| ------------- | ---                                                                                                                                                                                                    
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #48887
| License       | MIT

This PR builds on the work started in #49056, which was not merged.

Until now, the Serializer treated `list<T>` exactly like `array<int, T>`: a JSON object with non-sequential integer keys, such as `{"5":"foo","1":"bar"}`, was happily denormalized into a `list<string>`-typed property, producing a PHP array that is not actually a list.

The `TypeInfo` component already models this distinction correctly via `CollectionType::isList()`, but `AbstractObjectNormalizer` never read that flag.

This PR wires it up: when denormalizing into a property typed as `list<T>`, if the incoming array is not a list, a deprecation is triggered. The array is still denormalized as before, so no existing code breaks.

## Before

```php                                                                                                                                                                                                                   
class Dummy {
  /** @var list<string> */
  public array $tags = [];
}

$dummy = $serializer->deserialize('{"tags":{"5":"foo","1":"bar"}}', Dummy::class, 'json');
// no error, $dummy->tags = [5 => 'foo', 1 => 'bar']
// array_is_list($dummy->tags) === false (violates the list<string> contract)
```
                                                
## After

Same code now triggers:

`Since symfony/serializer 8.1: Denormalizing an array that is not a list into a list-typed property is deprecated.`

The deprecation gives users a heads-up before a future major turns this into a hard `NotNormalizableValueException`.

## Notes

- No behavior change for valid input (sequential integer keys from 0).
- No behavior change for non-list types (array<int, T>, Type[], array<string, T>, etc.).