### PR TITLE
[Serializer] Make `BackedEnumNormalizer` unconditionally return `null` on invalid value if `allow_invalid_values` is set

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -59,8 +59,8 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
 
         $allowInvalidValues = $context[self::ALLOW_INVALID_VALUES] ?? false;
 
-        if (null === $data || (!\is_int($data) && !\is_string($data))) {
-            if ($allowInvalidValues && !isset($context['not_normalizable_value_exceptions'])) {
+        if (!\is_int($data) && !\is_string($data)) {
+            if ($allowInvalidValues) {
                 return null;
             }
 
@@ -70,7 +70,7 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
         try {
             return $type::from($data);
         } catch (\ValueError|\TypeError $e) {
-            if ($allowInvalidValues && !isset($context['not_normalizable_value_exceptions'])) {
+            if ($allowInvalidValues) {
                 return null;
             }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -128,30 +128,14 @@ class BackedEnumNormalizerTest extends TestCase
         $this->assertSame(StringBackedEnumDummy::GET, $this->normalizer->denormalize('GET', StringBackedEnumDummy::class, null, [BackedEnumNormalizer::ALLOW_INVALID_VALUES => true]));
     }
 
-    public function testDenormalizeNullWithAllowInvalidAndCollectErrorsThrows()
+    public function testDenormalizeInvalidValueWithAllowInvalidAndCollectErrorsReturnsNull()
     {
-        $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data is neither an integer nor a string');
-
-        $context = [
-            BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
-            'not_normalizable_value_exceptions' => [], // Indicate that we want to collect errors
-        ];
-
-        $this->normalizer->denormalize(null, StringBackedEnumDummy::class, null, $context);
-    }
-
-    public function testDenormalizeInvalidValueWithAllowInvalidAndCollectErrorsThrows()
-    {
-        $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data must belong to a backed enumeration of type');
-
         $context = [
             BackedEnumNormalizer::ALLOW_INVALID_VALUES => true,
             'not_normalizable_value_exceptions' => [],
         ];
 
-        $this->normalizer->denormalize('invalid-value', StringBackedEnumDummy::class, null, $context);
+        $this->assertNull($this->normalizer->denormalize('invalid-value', StringBackedEnumDummy::class, null, $context));
     }
 
     public function testDenormalizeInvalidValueInConstructorContextThrowsPathAwareNotNormalizableValueException()

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
-use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -1800,38 +1799,6 @@ class SerializerTest extends TestCase
 
         $this->assertSame('one', $object->item);
         $this->assertSame('final', $object->type); // Value set in the constructor; must not be changed during deserialization
-    }
-
-    public function testPartialDenormalizationWithInvalidEnumAndAllowInvalid()
-    {
-        $factory = new ClassMetadataFactory(new AttributeLoader());
-        $extractor = new PropertyInfoExtractor(
-            [new SerializerExtractor($factory)],
-            [new ReflectionExtractor()]
-        );
-        $serializer = new Serializer(
-            [
-                new ArrayDenormalizer(),
-                new BackedEnumNormalizer(),
-                new ObjectNormalizer($factory, null, null, $extractor),
-            ],
-        );
-
-        $context = [
-            'collect_denormalization_errors' => true,
-            'allow_invalid_values' => true,
-        ];
-
-        try {
-            $serializer->denormalize(['id' => 123, 'status' => null], SerializerTestRequestDto::class, null, $context);
-            $this->fail('PartialDenormalizationException was not thrown.');
-        } catch (PartialDenormalizationException $exception) {
-            $this->assertCount(1, $exception->getErrors());
-            $error = $exception->getErrors()[0];
-
-            $this->assertSame('status', $error->getPath());
-            $this->assertSame(['int', 'string'], $error->getExpectedTypes());
-        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63961 
| License       | MIT

`allow_invalid_values`’ PHPDoc reads

> If true, will denormalize any invalid value into null.

So it is not supposed to throw, whether errors are collected or not.