### PR TITLE
[Lock] Avoid aborting outer PostgreSQL transaction on lock contention

### DIFF
--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -103,6 +103,19 @@ class DoctrineDbalStore implements PersistingStoreInterface
     {
         $key->reduceLifetime($this->initialTtl);
 
+        $platform = $this->conn->getDatabasePlatform();
+        if ($platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {
+            $this->doSavePostgres($key);
+        } else {
+            $this->doSave($key);
+        }
+
+        $this->randomlyPrune();
+        $this->checkNotExpired($key);
+    }
+
+    private function doSave(Key $key): void
+    {
         $sql = "INSERT INTO $this->table ($this->idCol, $this->tokenCol, $this->expirationCol) VALUES (?, ?, {$this->getCurrentTimestampStatement()} + $this->initialTtl)";
 
         try {
@@ -133,9 +146,43 @@ class DoctrineDbalStore implements PersistingStoreInterface
             // the lock is already acquired. It could be us. Let's try to put off.
             $this->putOffExpiration($key, $this->initialTtl);
         }
+    }
 
-        $this->randomlyPrune();
-        $this->checkNotExpired($key);
+    /**
+     * On PostgreSQL a constraint violation aborts the surrounding transaction (SQLSTATE 25P02), so
+     * the legacy "try INSERT, catch, fall back to UPDATE" path turns a benign lock contention into
+     * a fatal error for any caller wrapped in a transaction (Messenger doctrine_transaction
+     * middleware, functional tests using DAMADoctrineTestBundle, ...). Using atomic
+     * INSERT ... ON CONFLICT keeps the conflict resolution server-side and never raises,
+     * preserving the outer transaction.
+     */
+    private function doSavePostgres(Key $key): void
+    {
+        $now = $this->getCurrentTimestampStatement();
+        $sql = "INSERT INTO $this->table ($this->idCol, $this->tokenCol, $this->expirationCol) VALUES (?, ?, $now + $this->initialTtl)"
+            ." ON CONFLICT ($this->idCol) DO UPDATE SET $this->tokenCol = EXCLUDED.$this->tokenCol, $this->expirationCol = EXCLUDED.$this->expirationCol"
+            ." WHERE $this->table.$this->tokenCol = EXCLUDED.$this->tokenCol OR $this->table.$this->expirationCol <= $now";
+
+        $params = [
+            $this->getHashedKey($key),
+            $this->getUniqueToken($key),
+        ];
+        $types = [
+            ParameterType::STRING,
+            ParameterType::STRING,
+        ];
+
+        try {
+            $rows = (int) $this->conn->executeStatement($sql, $params, $types);
+        } catch (TableNotFoundException) {
+            // PostgreSQL supports DDL inside a transaction, so we can always create the table.
+            $this->createTable();
+            $rows = (int) $this->conn->executeStatement($sql, $params, $types);
+        }
+
+        if (0 === $rows) {
+            throw new LockConflictedException();
+        }
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -90,12 +90,24 @@ class PdoStore implements PersistingStoreInterface
     {
         $key->reduceLifetime($this->initialTtl);
 
+        if ('pgsql' === $this->getDriver()) {
+            $this->doSavePostgres($key);
+        } else {
+            $this->doSave($key);
+        }
+
+        $this->randomlyPrune();
+        $this->checkNotExpired($key);
+    }
+
+    private function doSave(Key $key): void
+    {
         $sql = "INSERT INTO $this->table ($this->idCol, $this->tokenCol, $this->expirationCol) VALUES (:id, :token, {$this->getCurrentTimestampStatement()} + $this->initialTtl)";
         $conn = $this->getConnection();
         try {
             $stmt = $conn->prepare($sql);
         } catch (\PDOException $e) {
-            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->getDriver(), ['pgsql', 'sqlite', 'sqlsrv'], true))) {
+            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->getDriver(), ['sqlite', 'sqlsrv'], true))) {
                 $this->createTable();
             }
             $stmt = $conn->prepare($sql);
@@ -107,7 +119,7 @@ class PdoStore implements PersistingStoreInterface
         try {
             $stmt->execute();
         } catch (\PDOException $e) {
-            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->getDriver(), ['pgsql', 'sqlite', 'sqlsrv'], true))) {
+            if ($this->isTableMissing($e) && (!$conn->inTransaction() || \in_array($this->getDriver(), ['sqlite', 'sqlsrv'], true))) {
                 $this->createTable();
 
                 try {
@@ -120,9 +132,56 @@ class PdoStore implements PersistingStoreInterface
                 $this->putOffExpiration($key, $this->initialTtl);
             }
         }
+    }
 
-        $this->randomlyPrune();
-        $this->checkNotExpired($key);
+    /**
+     * On PostgreSQL a constraint violation aborts the surrounding transaction (SQLSTATE 25P02), so
+     * the legacy "try INSERT, catch, fall back to UPDATE" path turns a benign lock contention into
+     * a fatal error for any caller wrapped in a transaction. Using atomic INSERT ... ON CONFLICT
+     * keeps the conflict resolution server-side and never raises, preserving the outer transaction.
+     */
+    private function doSavePostgres(Key $key): void
+    {
+        $now = $this->getCurrentTimestampStatement();
+        $sql = "INSERT INTO $this->table ($this->idCol, $this->tokenCol, $this->expirationCol) VALUES (:id, :token, $now + $this->initialTtl)"
+            ." ON CONFLICT ($this->idCol) DO UPDATE SET $this->tokenCol = EXCLUDED.$this->tokenCol, $this->expirationCol = EXCLUDED.$this->expirationCol"
+            ." WHERE $this->table.$this->tokenCol = EXCLUDED.$this->tokenCol OR $this->table.$this->expirationCol <= $now";
+
+        $conn = $this->getConnection();
+        $id = $this->getHashedKey($key);
+        $token = $this->getUniqueToken($key);
+
+        try {
+            $stmt = $conn->prepare($sql);
+        } catch (\PDOException $e) {
+            if (!$this->isTableMissing($e)) {
+                throw $e;
+            }
+            // PostgreSQL supports DDL inside a transaction, so we can always create the table.
+            $this->createTable();
+            $stmt = $conn->prepare($sql);
+        }
+
+        $stmt->bindValue(':id', $id);
+        $stmt->bindValue(':token', $token);
+
+        try {
+            $stmt->execute();
+        } catch (\PDOException $e) {
+            // Emulated prepares surface 42P01 at execute() time.
+            if (!$this->isTableMissing($e)) {
+                throw $e;
+            }
+            $this->createTable();
+            $stmt = $conn->prepare($sql);
+            $stmt->bindValue(':id', $id);
+            $stmt->bindValue(':token', $token);
+            $stmt->execute();
+        }
+
+        if (0 === $stmt->rowCount()) {
+            throw new LockConflictedException();
+        }
     }
 
     /**

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
@@ -121,6 +122,98 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
         } finally {
             $pdo = new \PDO('pgsql:host='.$host.';user=postgres;password=password');
             $pdo->exec('DROP TABLE IF EXISTS lock_keys');
+        }
+    }
+
+    /**
+     * @requires extension pdo_pgsql
+     *
+     * @group integration
+     */
+    public function testSaveDoesNotAbortSurroundingPostgresTransactionOnLockContention()
+    {
+        if (!$host = getenv('POSTGRES_HOST')) {
+            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+        }
+
+        $config = new Configuration();
+        if (class_exists(DefaultSchemaManagerFactory::class)) {
+            $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+        }
+        $conn = DriverManager::getConnection([
+            'driver' => 'pdo_pgsql',
+            'host' => $host,
+            'user' => 'postgres',
+            'password' => 'password',
+        ], $config);
+
+        $resource = uniqid(__METHOD__, true);
+
+        try {
+            $store = new DoctrineDbalStore($conn);
+            $store->createTable();
+
+            $owner = new Key($resource);
+            $store->save($owner);
+
+            $conn->beginTransaction();
+
+            $contender = new Key($resource);
+            try {
+                $store->save($contender);
+                $this->fail('LockConflictedException was expected.');
+            } catch (LockConflictedException) {
+                // expected
+            }
+
+            $this->assertSame('alive', $conn->fetchOne("SELECT 'alive'"), 'The surrounding transaction must remain usable after a lock conflict.');
+            $conn->rollBack();
+        } finally {
+            if ($conn->isTransactionActive()) {
+                $conn->rollBack();
+            }
+            $conn->executeStatement('DROP TABLE IF EXISTS lock_keys');
+        }
+    }
+
+    /**
+     * @requires extension pdo_pgsql
+     *
+     * @group integration
+     */
+    public function testSavePostgresRefreshesSameKeyInsideTransaction()
+    {
+        if (!$host = getenv('POSTGRES_HOST')) {
+            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+        }
+
+        $config = new Configuration();
+        if (class_exists(DefaultSchemaManagerFactory::class)) {
+            $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+        }
+        $conn = DriverManager::getConnection([
+            'driver' => 'pdo_pgsql',
+            'host' => $host,
+            'user' => 'postgres',
+            'password' => 'password',
+        ], $config);
+
+        try {
+            $store = new DoctrineDbalStore($conn);
+            $store->createTable();
+
+            $key = new Key(uniqid(__METHOD__, true));
+            $store->save($key);
+
+            $conn->beginTransaction();
+            $store->save($key);
+            $this->assertTrue($store->exists($key));
+            $conn->rollBack();
+        } finally {
+            if ($conn->isTransactionActive()) {
+                $conn->rollBack();
+            }
+            $conn->executeStatement('DROP TABLE IF EXISTS lock_keys');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Symfony\Component\Lock\Exception\InvalidTtlException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PdoStore;
@@ -117,6 +118,84 @@ class PdoStoreTest extends AbstractStoreTestCase
             $this->assertTrue($store->exists($key));
         } finally {
             $pdo = new \PDO($dsn);
+            $pdo->exec('DROP TABLE IF EXISTS lock_keys');
+        }
+    }
+
+    /**
+     * @requires extension pdo_pgsql
+     *
+     * @group integration
+     */
+    public function testSaveDoesNotAbortSurroundingPostgresTransactionOnLockContention()
+    {
+        if (!$host = getenv('POSTGRES_HOST')) {
+            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+        }
+
+        $dsn = 'pgsql:host='.$host.';user=postgres;password=password';
+        $pdo = new \PDO($dsn);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $resource = uniqid(__METHOD__, true);
+
+        try {
+            $store = new PdoStore($pdo);
+            $store->createTable();
+
+            $owner = new Key($resource);
+            $store->save($owner);
+
+            $pdo->beginTransaction();
+
+            $contender = new Key($resource);
+            try {
+                $store->save($contender);
+                $this->fail('LockConflictedException was expected.');
+            } catch (LockConflictedException) {
+                // expected
+            }
+
+            $this->assertSame('alive', $pdo->query("SELECT 'alive'")->fetchColumn(), 'The surrounding transaction must remain usable after a lock conflict.');
+            $pdo->rollBack();
+        } finally {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            $pdo->exec('DROP TABLE IF EXISTS lock_keys');
+        }
+    }
+
+    /**
+     * @requires extension pdo_pgsql
+     *
+     * @group integration
+     */
+    public function testSavePostgresRefreshesSameKeyInsideTransaction()
+    {
+        if (!$host = getenv('POSTGRES_HOST')) {
+            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+        }
+
+        $dsn = 'pgsql:host='.$host.';user=postgres;password=password';
+        $pdo = new \PDO($dsn);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        try {
+            $store = new PdoStore($pdo);
+            $store->createTable();
+
+            $key = new Key(uniqid(__METHOD__, true));
+            $store->save($key);
+
+            $pdo->beginTransaction();
+            $store->save($key);
+            $this->assertTrue($store->exists($key));
+            $pdo->rollBack();
+        } finally {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
             $pdo->exec('DROP TABLE IF EXISTS lock_keys');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63967
| License       | MIT

DoctrineDbalStore and PdoStore caught the duplicate-key exception raised by the INSERT and fell back to UPDATE. On PostgreSQL a constraint violation aborts the surrounding transaction (SQLSTATE 25P02), turning a benign lock contention into a fatal error for any caller wrapped in a transaction (Messenger doctrine_transaction middleware, functional tests using DAMADoctrineTestBundle).

Use INSERT ... ON CONFLICT DO UPDATE WHERE on PostgreSQL so the conflict is resolved server-side without raising. The WHERE clause preserves the existing refresh-if-ours / takeover-if-expired / otherwise conflict semantics; an empty rowCount maps to LockConflictedException, the surrounding transaction stays usable. Other platforms keep the existing code path.
