### PR TITLE
[Tests] Fix "Incomplete version" PHPUnit warnings

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -52,7 +52,7 @@ class ManagerRegistryTest extends TestCase
     }
 
     #[DataProvider('provideResetServiceWithNativeLazyObjectsCases')]
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testResetServiceWithNativeLazyObjects(string $class)
     {
         $container = new $class();

--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 class CoverageListenerTest extends TestCase
 {
     public function test()

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
@@ -19,7 +19,7 @@ use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\Deprecation;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\DeprecationGroup;
 use Symfony\Component\ErrorHandler\DebugClassLoader;
 
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 class ConfigurationTest extends TestCase
 {
     private $files;

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationGroupTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationGroupTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\DeprecationGroup;
 
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 final class DeprecationGroupTest extends TestCase
 {
     public function testItGroupsByMessage()

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationNoticeTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationNoticeTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\DeprecationNotice;
 
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 final class DeprecationNoticeTest extends TestCase
 {
     public function testItGroupsByCaller()

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -18,7 +18,7 @@ use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\Deprecation;
 use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV7;
 
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 class DeprecationTest extends TestCase
 {
     private static $vendorDir;

--- a/src/Symfony/Bridge/PhpUnit/Tests/ExpectDeprecationTraitTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ExpectDeprecationTraitTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 final class ExpectDeprecationTraitTest extends TestCase
 {
     use ExpectDeprecationTrait;

--- a/src/Symfony/Bridge/PhpUnit/Tests/ExpectedDeprecationAnnotationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ExpectedDeprecationAnnotationTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 final class ExpectedDeprecationAnnotationTest extends TestCase
 {
     /**

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/ExpectDeprecationTraitTestFail.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/ExpectDeprecationTraitTestFail.php
@@ -23,7 +23,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
  * This class is deliberately suffixed with *TestFail.php so that it is ignored
  * by PHPUnit. This test is designed to fail. See ../expectdeprecationfail.phpt.
  */
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 final class ExpectDeprecationTraitTestFail extends TestCase
 {
     use ExpectDeprecationTrait;

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestNotRisky.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestNotRisky.php
@@ -19,7 +19,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
  * This class is deliberately suffixed with *TestRisky.php so that it is ignored
  * by PHPUnit. This test is designed to fail. See ../expectnotrisky.phpt.
  */
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 final class NoAssertionsTestNotRisky extends TestCase
 {
     use ExpectDeprecationTrait;

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestRisky.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestRisky.php
@@ -20,7 +20,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
  * This class is deliberately suffixed with *TestRisky.php so that it is ignored
  * by PHPUnit. This test is designed to fail. See ../expectrisky.phpt.
  */
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 final class NoAssertionsTestRisky extends TestCase
 {
     use ExpectDeprecationTrait;

--- a/src/Symfony/Bridge/PhpUnit/Tests/ProcessIsolationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ProcessIsolationTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @runTestsInSeparateProcesses
  */
-#[RequiresPhpunit('<10')]
+#[RequiresPhpunit('<10.0.0')]
 #[Group('legacy')]
 class ProcessIsolationTest extends TestCase
 {

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
@@ -66,7 +66,7 @@ class LazyServiceDumperTest extends TestCase
         $dumper->getProxyCode($definition);
     }
 
-    #[RequiresPhp('>=8.3')]
+    #[RequiresPhp('>=8.3.0')]
     public function testReadonlyClass()
     {
         $dumper = new LazyServiceDumper();

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Image;
 use Symfony\Component\DomCrawler\Link;
 
-#[RequiresPhp('>=8.4')]
+#[RequiresPhp('>=8.4.0')]
 class CrawlerTest extends TestCase
 {
     public static function getDoctype(): string

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyHtml5ParserCrawlerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use Symfony\Component\DomCrawler\Crawler;
 
-#[RequiresPhp('<8.4')]
+#[RequiresPhp('<8.4.0')]
 class LegacyHtml5ParserCrawlerTest extends CrawlerTest
 {
     public function testHtml()

--- a/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LegacyParserCrawlerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\DomCrawler\Tests;
 
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
-#[RequiresPhp('<8.4')]
+#[RequiresPhp('<8.4.0')]
 class LegacyParserCrawlerTest extends CrawlerTest
 {
     public static function getDoctype(): string
@@ -86,12 +86,12 @@ class LegacyParserCrawlerTest extends CrawlerTest
         libxml_use_internal_errors($internalErrors);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAddHtml5()
     {
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testHtml5ParserParseContentStartingWithValidHeading(string $content)
     {
     }

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -478,7 +478,7 @@ class DebugClassLoaderTest extends TestCase
         ], $deprecations);
     }
 
-    #[RequiresPhp('>=8.3')]
+    #[RequiresPhp('>=8.3.0')]
     public function testReturnTypePhp83()
     {
         $deprecations = [];

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -338,7 +338,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
     }
 
     #[RequiresPhpExtension('intl')]
-    #[RequiresPhp('< 8.5')]
+    #[RequiresPhp('< 8.5.0')]
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
         $errorLevel = ini_set('intl.error_level', \E_WARNING);
@@ -367,7 +367,7 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
     }
 
     #[RequiresPhpExtension('intl')]
-    #[RequiresPhp('< 8.5')]
+    #[RequiresPhp('< 8.5.0')]
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {
         $initialUseExceptions = ini_set('intl.use_exceptions', 1);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -648,7 +648,7 @@ class NumberToLocalizedStringTransformerTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
-    #[RequiresPhp('< 8.5')]
+    #[RequiresPhp('< 8.5.0')]
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
         $errorLevel = ini_set('intl.error_level', \E_WARNING);
@@ -677,7 +677,7 @@ class NumberToLocalizedStringTransformerTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
-    #[RequiresPhp('< 8.5')]
+    #[RequiresPhp('< 8.5.0')]
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {
         $initialUseExceptions = ini_set('intl.use_exceptions', 1);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -485,7 +485,7 @@ class PercentToLocalizedStringTransformerTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
-    #[RequiresPhp('< 8.5')]
+    #[RequiresPhp('< 8.5.0')]
     public function testReverseTransformWrapsIntlErrorsWithErrorLevel()
     {
         $errorLevel = ini_set('intl.error_level', \E_WARNING);
@@ -514,7 +514,7 @@ class PercentToLocalizedStringTransformerTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
-    #[RequiresPhp('< 8.5')]
+    #[RequiresPhp('< 8.5.0')]
     public function testReverseTransformWrapsIntlErrorsWithExceptionsAndErrorLevel()
     {
         $initialUseExceptions = ini_set('intl.use_exceptions', 1);

--- a/src/Symfony/Component/HtmlSanitizer/Tests/Parser/NativeParserTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/Parser/NativeParserTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HtmlSanitizer\Parser\NativeParser;
 
-#[RequiresPhp('>=8.4')]
+#[RequiresPhp('>=8.4.0')]
 class NativeParserTest extends TestCase
 {
     public function testParseValid()

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestFunctionalTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 
-#[RequiresPhp('>=8.4')]
+#[RequiresPhp('>=8.4.0')]
 class RequestFunctionalTest extends TestCase
 {
     /** @var resource|false */

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1424,7 +1424,7 @@ b'])]
         $this->disableHttpMethodParameterOverride();
     }
 
-    #[RequiresPhp('< 8.4')]
+    #[RequiresPhp('<8.4.0')]
     #[DataProvider('provideMethodsRequiringExplicitBodyParsing')]
     public function testFormUrlEncodedBodyParsing(string $method)
     {

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
@@ -33,7 +33,7 @@ class LazyInstantiatorTest extends TestCase
         }
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testCreateLazyGhostUsingVarExporter()
     {
         $ghost = (new LazyInstantiator($this->lazyGhostsDir))->instantiate(ClassicDummy::class, static function (ClassicDummy $object): void {
@@ -43,7 +43,7 @@ class LazyInstantiatorTest extends TestCase
         $this->assertSame(123, $ghost->id);
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testCreateCacheFile()
     {
         // use DummyForLazyInstantiation class to be sure that the instantiated object is not already in cache.
@@ -52,7 +52,7 @@ class LazyInstantiatorTest extends TestCase
         $this->assertCount(1, glob($this->lazyGhostsDir.'/*'));
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testThrowIfLazyGhostDirNotDefined()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -61,7 +61,7 @@ class LazyInstantiatorTest extends TestCase
         });
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCreateLazyGhostUsingPhp()
     {
         $ghost = (new LazyInstantiator())->instantiate(ClassicDummy::class, static function (ClassicDummy $object): void {

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -460,7 +460,7 @@ final class ObjectMapperTest extends TestCase
         $this->assertTrue($lazy->isLazyObjectInitialized());
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testMapInitializesNativePhp84LazyObject()
     {
         $initialized = false;
@@ -585,7 +585,7 @@ final class ObjectMapperTest extends TestCase
         $this->assertEquals([new TransformCollectionD('a'), new TransformCollectionD('b')], $transformed->foo);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testEmbedsAreLazyLoadedByDefault()
     {
         $mapper = new ObjectMapper();

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
@@ -100,7 +100,7 @@ class NativePasswordHasherTest extends TestCase
         $this->assertTrue($hasher->verify($hasher->hash($plainPassword), $plainPassword));
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testBcryptWithNulByteWithNativePasswordHash()
     {
         $hasher = new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT);

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
@@ -74,7 +74,7 @@ class SodiumPasswordHasherTest extends TestCase
         $this->assertTrue($hasher->verify((new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT))->hash($plainPassword), $plainPassword));
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testBcryptWithNulByteWithNativePasswordHash()
     {
         $hasher = new SodiumPasswordHasher(null, null);

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -1055,7 +1055,7 @@ class PropertyAccessorTest extends TestCase
         return (new \ReflectionClass(UninitializedObjectProperty::class))->newLazyGhost(static fn () => null);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testIsWritableWithAsymmetricVisibility()
     {
         $object = new AsymmetricVisibility();
@@ -1067,7 +1067,7 @@ class PropertyAccessorTest extends TestCase
         $this->assertFalse($this->propertyAccessor->isWritable($object, 'virtualNoSetHook'));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testIsReadableWithAsymmetricVisibility()
     {
         $object = new AsymmetricVisibility();
@@ -1079,7 +1079,7 @@ class PropertyAccessorTest extends TestCase
         $this->assertTrue($this->propertyAccessor->isReadable($object, 'virtualNoSetHook'));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[DataProvider('setValueWithAsymmetricVisibilityDataProvider')]
     public function testSetValueWithAsymmetricVisibility(string $propertyPath, ?string $expectedException)
     {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -710,7 +710,7 @@ class ReflectionExtractorTest extends TestCase
         ];
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAsymmetricVisibility()
     {
         $this->assertTrue($this->extractor->isReadable(AsymmetricVisibility::class, 'publicPrivate'));
@@ -721,7 +721,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($this->extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAsymmetricVisibilityAllowPublicOnly()
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC);
@@ -734,7 +734,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAsymmetricVisibilityAllowProtectedOnly()
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PROTECTED);
@@ -747,7 +747,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAsymmetricVisibilityAllowPrivateOnly()
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PRIVATE);
@@ -760,7 +760,7 @@ class ReflectionExtractorTest extends TestCase
         $this->assertTrue($extractor->isWritable(AsymmetricVisibility::class, 'protectedPrivate'));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testVirtualProperties()
     {
         $this->assertTrue($this->extractor->isReadable(VirtualProperties::class, 'virtualNoSetHook'));
@@ -772,7 +772,7 @@ class ReflectionExtractorTest extends TestCase
     }
 
     #[DataProvider('provideAsymmetricVisibilityMutator')]
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAsymmetricVisibilityMutator(string $property, string $readVisibility, string $writeVisibility)
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE);
@@ -795,7 +795,7 @@ class ReflectionExtractorTest extends TestCase
     }
 
     #[DataProvider('provideVirtualPropertiesMutator')]
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testVirtualPropertiesMutator(string $property, string $readVisibility, string $writeVisibility)
     {
         $extractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE);

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeWithClosureListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeWithClosureListenerTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Security\Http\EventListener\IsGrantedAttributeListener;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsGrantedAttributeMethodsWithClosureController;
 use Symfony\Component\Security\Http\Tests\Fixtures\IsGrantedAttributeWithClosureController;
 
-#[RequiresPhp('>=8.5')]
+#[RequiresPhp('>=8.5.0')]
 class IsGrantedAttributeWithClosureListenerTest extends TestCase
 {
     public function testAttribute()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/NumberNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/NumberNormalizerTest.php
@@ -52,7 +52,7 @@ class NumberNormalizerTest extends TestCase
         yield 'null' => [null, false];
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[RequiresPhpExtension('bcmath')]
     #[DataProvider('normalizeGoodBcMathNumberValueProvider')]
     public function testNormalizeBcMathNumber(Number $data, string $expected)
@@ -100,7 +100,7 @@ class NumberNormalizerTest extends TestCase
         yield 'null' => [null];
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[RequiresPhpExtension('bcmath')]
     public function testSupportsBcMathNumberDenormalization()
     {
@@ -118,7 +118,7 @@ class NumberNormalizerTest extends TestCase
         $this->assertFalse($this->normalizer->supportsDenormalization(null, \stdClass::class));
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[RequiresPhpExtension('bcmath')]
     #[DataProvider('denormalizeGoodBcMathNumberValueProvider')]
     public function testDenormalizeBcMathNumber(string|int $data, string $type, Number $expected)
@@ -150,7 +150,7 @@ class NumberNormalizerTest extends TestCase
         }
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[RequiresPhpExtension('bcmath')]
     #[DataProvider('denormalizeBadBcMathNumberValueProvider')]
     public function testDenormalizeBadBcMathNumberValueThrows(mixed $data, string $type, string $expectedException, string $expectedExceptionMessage)

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -193,7 +193,7 @@ class PropertyNormalizerTest extends TestCase
         $this->assertSame('childProp', $object->childProp);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testDenormalizeWithAsymmetricPropertyVisibility()
     {
         /** @var SpecialBookDummy $object */

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1823,7 +1823,7 @@ class SerializerTest extends TestCase
         }
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testDeserializeObjectWithAsymmetricPropertyVisibility()
     {
         $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/WhenTest.php
@@ -123,7 +123,7 @@ final class WhenTest extends TestCase
         self::assertSame(['foo'], $quuxConstraint->groups);
     }
 
-    #[RequiresPhp('>=8.5')]
+    #[RequiresPhp('>=8.5.0')]
     public function testAttributesWithClosure()
     {
         $loader = new AttributeLoader();

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DOMCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DOMCasterTest.php
@@ -33,7 +33,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernImplementation()
     {
         $implementation = new \Dom\Implementation();
@@ -63,7 +63,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernNode()
     {
         $doc = \Dom\XMLDocument::createFromString('<foo><bar/></foo>');
@@ -97,7 +97,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastXMLDocument()
     {
         $doc = \Dom\XMLDocument::createFromString('<foo><bar/></foo>');
@@ -116,7 +116,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastHTMLDocument()
     {
         $doc = \Dom\HTMLDocument::createFromString('<!DOCTYPE html><html><body><p>foo</p></body></html>');
@@ -143,7 +143,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernText()
     {
         $text = \Dom\HTMLDocument::createEmpty()->createTextNode('foo');
@@ -169,7 +169,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernAttr()
     {
         $attr = \Dom\HTMLDocument::createEmpty()->createAttribute('attr');
@@ -196,7 +196,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernElement()
     {
         $attr = \Dom\HTMLDocument::createEmpty()->createElement('foo');
@@ -226,7 +226,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernDocumentType()
     {
         $implementation = new \Dom\Implementation();
@@ -254,7 +254,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernProcessingInstruction()
     {
         $entity = \Dom\HTMLDocument::createEmpty()->createProcessingInstruction('target', 'data');
@@ -282,7 +282,7 @@ class DOMCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testCastModernXPath()
     {
         $entity = new \Dom\XPath(\Dom\HTMLDocument::createEmpty());

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -454,7 +454,7 @@ class ReflectionCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testGeneratorPriorTo84()
     {
         if (\extension_loaded('xdebug')) {
@@ -527,7 +527,7 @@ class ReflectionCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $generator);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testGenerator()
     {
         if (\extension_loaded('xdebug')) {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ResourceCasterTest.php
@@ -50,7 +50,7 @@ class ResourceCasterTest extends TestCase
         ResourceCaster::castGd($gd, [], new Stub(), false);
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     #[RequiresPhpExtension('dba')]
     public function testCastDbaPriorToPhp84()
     {
@@ -82,7 +82,7 @@ class ResourceCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     #[RequiresPhpExtension('dba')]
     public function testCastDbaOnBuggyPhp84()
     {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SocketCasterTest.php
@@ -21,7 +21,7 @@ class SocketCasterTest extends TestCase
 {
     use VarDumperTestTrait;
 
-    #[RequiresPhp('>=8.3')]
+    #[RequiresPhp('>=8.3.0')]
     public function testCastSocket()
     {
         $socket = socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
@@ -39,7 +39,7 @@ class SocketCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('<8.3')]
+    #[RequiresPhp('<8.3.0')]
     public function testCastSocketPriorToPhp83()
     {
         $socket = socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
@@ -56,7 +56,7 @@ class SocketCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.3')]
+    #[RequiresPhp('>=8.3.0')]
     public function testCastSocketIpV6()
     {
         $socket = socket_create(\AF_INET6, \SOCK_STREAM, \SOL_TCP);
@@ -75,7 +75,7 @@ class SocketCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('<8.3')]
+    #[RequiresPhp('<8.3.0')]
     public function testCastSocketIpV6PriorToPhp83()
     {
         $socket = socket_create(\AF_INET6, \SOCK_STREAM, \SOL_TCP);
@@ -93,7 +93,7 @@ class SocketCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.3')]
+    #[RequiresPhp('>=8.3.0')]
     public function testCastUnixSocket()
     {
         $socket = socket_create(\AF_UNIX, \SOCK_STREAM, 0);
@@ -112,7 +112,7 @@ class SocketCasterTest extends TestCase
         );
     }
 
-    #[RequiresPhp('<8.3')]
+    #[RequiresPhp('<8.3.0')]
     public function testCastUnixSocketPriorToPhp83()
     {
         $socket = socket_create(\AF_UNIX, \SOCK_STREAM, 0);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/StubCasterTest.php
@@ -104,7 +104,7 @@ class StubCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $args);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testVirtualPropertyStub()
     {
         $class = new \ReflectionClass(VirtualProperty::class);
@@ -119,7 +119,7 @@ class StubCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $args);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testVirtualPropertyWithoutTypeStub()
     {
         $class = new \ReflectionClass(VirtualProperty::class);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -36,7 +36,7 @@ class XmlReaderCasterTest extends TestCase
         $this->reader->close();
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testParserPropertyPriorToPhp84()
     {
         $this->reader->setParserProperty(\XMLReader::SUBST_ENTITIES, true);
@@ -55,7 +55,7 @@ class XmlReaderCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $this->reader);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testParserProperty()
     {
         $this->reader->setParserProperty(\XMLReader::SUBST_ENTITIES, true);
@@ -80,7 +80,7 @@ class XmlReaderCasterTest extends TestCase
      * and their values are not dumped.
      */
     #[DataProvider('provideNodes')]
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testNodes($seek, $expectedDump)
     {
         while ($seek--) {
@@ -271,7 +271,7 @@ class XmlReaderCasterTest extends TestCase
         ];
     }
 
-    #[RequiresPhp('<8.4')]
+    #[RequiresPhp('<8.4.0')]
     public function testWithUninitializedXMLReaderPriorToPhp84()
     {
         $this->reader = new \XMLReader();
@@ -286,7 +286,7 @@ class XmlReaderCasterTest extends TestCase
         $this->assertDumpMatchesFormat($expectedDump, $this->reader);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testWithUninitializedXMLReader()
     {
         $this->reader = new \XMLReader();

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -301,7 +301,7 @@ class CliDumperTest extends TestCase
         putenv('DUMP_STRING_LENGTH=');
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testVirtualProperties()
     {
         $this->assertDumpEquals(<<<EODUMP

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -119,7 +119,7 @@ class HtmlDumperTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testVirtualProperties()
     {
         $dumper = new HtmlDumper('php://output');

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -52,7 +52,7 @@ try {
     restore_error_handler();
 }
 
-#[RequiresPhp('>=8.4')]
+#[RequiresPhp('>=8.4.0')]
 class LazyProxyTraitTest extends TestCase
 {
     public function testGetter()
@@ -311,7 +311,7 @@ class LazyProxyTraitTest extends TestCase
         $this->assertSame(234, $object->foo);
     }
 
-    #[RequiresPhp('>=8.3')]
+    #[RequiresPhp('>=8.3.0')]
     public function testReinitReadonlyLazyProxy()
     {
         $object = $this->createLazyProxy(ReadOnlyClass::class, static fn () => new ConcreteReadOnlyClass(123));
@@ -323,7 +323,7 @@ class LazyProxyTraitTest extends TestCase
         $this->assertSame(234, $object->foo);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testConcretePropertyHooks()
     {
         $initialized = false;
@@ -350,7 +350,7 @@ class LazyProxyTraitTest extends TestCase
         $this->assertSame(345, $object->backed);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAbstractPropertyHooks()
     {
         $initialized = false;
@@ -382,7 +382,7 @@ class LazyProxyTraitTest extends TestCase
         $this->assertTrue($initialized);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAsymmetricVisibility()
     {
         $object = $this->createLazyProxy(AsymmetricVisibility::class, static fn () => new AsymmetricVisibility(123, 234));

--- a/src/Symfony/Component/VarExporter/Tests/LegacyLazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LegacyLazyGhostTraitTest.php
@@ -266,7 +266,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertSame([123], $proxy->foo);
     }
 
-    #[RequiresPhp('>=8.3')]
+    #[RequiresPhp('>=8.3.0')]
     public function testReadOnlyClass()
     {
         $proxy = $this->createLazyGhost(ReadOnlyClass::class, static fn ($proxy) => $proxy->__construct(123));
@@ -320,7 +320,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertSame(3, $object->public);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testPropertyHooks()
     {
         $initialized = false;
@@ -343,7 +343,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertSame(345, $object->backed);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testPropertyHooksWithDefaultValue()
     {
         $initialized = false;
@@ -369,7 +369,7 @@ class LegacyLazyGhostTraitTest extends TestCase
         $this->assertTrue($object->backedBoolWithDefault);
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testAsymmetricVisibility()
     {
         $object = $this->createLazyGhost(AsymmetricVisibility::class, static function ($instance) {

--- a/src/Symfony/Component/VarExporter/Tests/LegacyLazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LegacyLazyProxyTraitTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\TestOverwritePropClas
 
 #[IgnoreDeprecations]
 #[Group('legacy')]
-#[RequiresPhp('<8.4')]
+#[RequiresPhp('<8.4.0')]
 class LegacyLazyProxyTraitTest extends LazyProxyTraitTest
 {
     public function testLazyDecoratorClass()

--- a/src/Symfony/Component/VarExporter/Tests/LegacyProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LegacyProxyHelperTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\StringMagicGetClass;
 
 #[IgnoreDeprecations]
 #[Group('legacy')]
-#[RequiresPhp('<8.4')]
+#[RequiresPhp('<8.4.0')]
 class LegacyProxyHelperTest extends ProxyHelperTest
 {
     public function testGenerateLazyProxy()

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Hooked;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\Php82NullStandaloneReturnType;
 
-#[RequiresPhp('>=8.4')]
+#[RequiresPhp('>=8.4.0')]
 class ProxyHelperTest extends TestCase
 {
     #[DataProvider('provideExportSignature')]
@@ -278,7 +278,7 @@ class ProxyHelperTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>=8.4')]
+    #[RequiresPhp('>=8.4.0')]
     public function testPropertyHooks()
     {
         $proxyCode = ProxyHelper::generateLazyProxy(new \ReflectionClass(Hooked::class));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PHPUnit 13.1 (see [sebastianbergmann/phpunit#6451](https://github.com/sebastianbergmann/phpunit/issues/6451)) now emits an `Incomplete version requirement "X.Y"` warning when `#[RequiresPhp]` / `#[RequiresPhpunit]` are used with a comparison operator and a version that is not a full `X.Y.Z` semver. This currently breaks the CI.

This PR pads every such occurrence to a 3-part version so PHPUnit stops warning (no behavioral change: `>=8.5` and `>=8.5.0` compare identically against `PHP_VERSION`).