### PR TITLE
[Serializer] Capture constructor TypeError when collecting denormalization errors

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -346,6 +346,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             $missingConstructorArguments = [];
             $params = [];
             $unsetKeys = [];
+            $collectedErrorCountBeforeConstructor = \count($context['not_normalizable_value_exceptions'] ?? []);
 
             foreach ($constructorParameters as $constructorParameter) {
                 $paramName = $constructorParameter->name;
@@ -462,6 +463,22 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             } catch (\TypeError $e) {
                 if (!isset($context['not_normalizable_value_exceptions'])) {
                     throw $e;
+                }
+
+                // Only report the TypeError when no constructor-argument error was collected for
+                // this instantiation. When the loop above already recorded missing or invalid
+                // arguments, the TypeError is a downstream consequence of those errors and would
+                // just duplicate the report.
+                if (\count($context['not_normalizable_value_exceptions']) === $collectedErrorCountBeforeConstructor) {
+                    $context['not_normalizable_value_exceptions'][] = NotNormalizableValueException::createForUnexpectedDataType(
+                        \sprintf('Failed to create an instance of "%s" from constructor: %s', $class, $e->getMessage()),
+                        null,
+                        ['unknown'],
+                        $context['deserialization_path'] ?? null,
+                        false,
+                        0,
+                        $e,
+                    );
                 }
 
                 return $reflectionClass->newInstanceWithoutConstructor();

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithObjectConstructor.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyWithObjectConstructor.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummyWithObjectConstructor
+{
+    public function __construct(public DummyFirstChildQuux $nested)
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1554,6 +1554,48 @@ class SerializerTest extends TestCase
         }
     }
 
+    public function testCollectDenormalizationErrorsCapturesConstructorTypeError()
+    {
+        $classStringDenormalizer = new class implements DenormalizerInterface {
+            public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): object
+            {
+                return new $data();
+            }
+
+            public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+            {
+                return \is_string($data) && class_exists($data);
+            }
+
+            public function getSupportedTypes(?string $format): array
+            {
+                return ['*' => false];
+            }
+        };
+
+        $serializer = new Serializer([$classStringDenormalizer, new ObjectNormalizer()]);
+
+        $target = Fixtures\DummyWithObjectConstructor::class;
+        $otherClass = Php74Full::class;
+
+        try {
+            $serializer->denormalize(
+                ['nested' => $otherClass],
+                $target,
+                context: [DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true],
+            );
+            self::fail(\sprintf('Failed asserting that exception of type "%s" is thrown.', PartialDenormalizationException::class));
+        } catch (PartialDenormalizationException $e) {
+            $capturedFromTypeError = array_values(array_filter(
+                $e->getErrors(),
+                static fn (NotNormalizableValueException $error): bool => $error->getPrevious() instanceof \TypeError,
+            ));
+            self::assertCount(1, $capturedFromTypeError, 'Constructor TypeError must be captured exactly once as a NotNormalizableValueException.');
+            self::assertFalse($capturedFromTypeError[0]->canUseMessageForUser());
+            self::assertSame(['unknown'], $capturedFromTypeError[0]->getExpectedTypes());
+        }
+    }
+
     public function testGroupsOnClassSerialization()
     {
         $obj = new Fixtures\Attributes\GroupClassDummy();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62720
| License       | MIT

AbstractNormalizer::instantiateObject() caught the TypeError thrown by newInstanceArgs() when COLLECT_DENORMALIZATION_ERRORS was set but never added any entry to not_normalizable_value_exceptions. The caller got an object without its constructor being called and no error ever surfaced.

The catch now builds a NotNormalizableValueException from the TypeError and appends it to the context, keeping the pre-existing newInstanceWithoutConstructor() fallback. A snapshot of the error count before the constructor-parameter loop prevents duplicating the report when the loop already collected errors that caused the TypeError downstream.
