### PR TITLE
[DependencyInjection] Log every build parameter removed during compilation

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveBuildParametersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveBuildParametersPass.php
@@ -34,11 +34,15 @@ class RemoveBuildParametersPass implements CompilerPassInterface
         $this->removedParameters = [];
 
         foreach ($parameterBag->all() as $name => $value) {
-            if ('.' === ($name[0] ?? '') && (!$this->preserveArrays || !\is_array($value))) {
+            if ('.' !== ($name[0] ?? '')) {
+                continue;
+            }
+            if (!$this->preserveArrays || !\is_array($value)) {
                 $this->removedParameters[$name] = $value;
-
                 $parameterBag->remove($name);
                 $container->log($this, \sprintf('Removing build parameter "%s".', $name));
+            } else {
+                $container->log($this, \sprintf('Keeping array build parameter "%s" for placeholder resolution.', $name));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveBuildParametersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveBuildParametersPassTest.php
@@ -46,6 +46,10 @@ class RemoveBuildParametersPassTest extends TestCase
         $this->assertTrue($builder->hasParameter('.array'), '".array" parameter must be preserved.');
         $this->assertSame(['baz' => 'qux'], $builder->getParameter('.array'), '".array" parameter must retain its value.');
         $this->assertSame(['.scalar' => 'Bar'], $pass->getRemovedParameters(), 'Only ".scalar" parameter must be returned as removed.');
+
+        $log = $builder->getCompiler()->getLog();
+        $this->assertContains(RemoveBuildParametersPass::class.': Removing build parameter ".scalar".', $log);
+        $this->assertContains(RemoveBuildParametersPass::class.': Keeping array build parameter ".array" for placeholder resolution.', $log);
     }
 
     public function testNonArrayBuildParametersAreAlwaysRemoved()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63387
| License       | MIT

`RemoveBuildParametersPass` only logged `Removing build parameter "%s"` for dot-prefixed parameters that it actually removed from the parameter bag. When instantiated with `preserveArrays = true` — the variant registered at priority `-2048` in `PassConfig::afterRemovingPasses` — array-valued build parameters (e.g. `.serializer.named_serializers`, `.doctrine.orm.proxy_dir`, …) were skipped silently. No log entry appeared in `var/cache/<env>/App_Kernel…ContainerCompiler.log`, yet the dumped container still drops those parameters via `PhpDumper` because it excludes every name starting with `.`.

This PR emits a log line for every dot-prefixed parameter seen by the pass, with a message that accurately reflects what happens to it:

- scalar parameters are removed from the bag → `Removing build parameter "%s".` (unchanged)
- array parameters preserved for placeholder resolution → `Keeping array build parameter "%s" for placeholder resolution.` (new)

The actual removal logic is unchanged: scalar parameters are still removed here, arrays are still preserved so placeholder resolution keeps working.

### Before

```
…
RemoveBuildParametersPass: Removing build parameter ".container.dumper.inline_factories".
RemoveBuildParametersPass: Removing build parameter ".container.dumper.inline_class_loader".
# <-- no entry for .serializer.named_serializers despite it being excluded from the dumped container
```

### After

```
…
RemoveBuildParametersPass: Removing build parameter ".container.dumper.inline_factories".
RemoveBuildParametersPass: Removing build parameter ".container.dumper.inline_class_loader".
RemoveBuildParametersPass: Keeping array build parameter ".serializer.named_serializers" for placeholder resolution.
```

Test coverage extended in `RemoveBuildParametersPassTest::testArrayBuildParametersArePreservedWhenConfigured` to assert that scalar dot-prefixed parameters are logged with `Removing build parameter …` and preserved array ones with `Keeping array build parameter … for placeholder resolution.`.

Ran `./phpunit src/Symfony/Component/DependencyInjection/Tests/Compiler/` locally on `6.4`: 520 tests pass. `RemoveBuildParametersPassTest` alone: 3 tests / 13 assertions.
