### PR TITLE
[Routing] Honor the Request's method in UrlMatcher::matchRequest()

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -94,12 +94,15 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     public function matchRequest(Request $request): array
     {
         $this->request = $request;
+        $originalContext = $this->context;
+        $this->context = (clone $originalContext)->fromRequest($request);
 
-        $ret = $this->match($request->getPathInfo());
-
-        $this->request = null;
-
-        return $ret;
+        try {
+            return $this->match($request->getPathInfo());
+        } finally {
+            $this->context = $originalContext;
+            $this->request = null;
+        }
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests\Matcher;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -55,6 +56,33 @@ class UrlMatcherTest extends TestCase
         } catch (MethodNotAllowedException $e) {
             $this->assertEquals(['POST'], $e->getAllowedMethods());
         }
+    }
+
+    public function testMatchRequestHonorsTheRequestsMethodOverTheStaticContext()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo', [], [], [], '', [], ['GET']));
+
+        $matcher = $this->getUrlMatcher($coll, new RequestContext('', 'POST'));
+
+        $this->assertSame(
+            ['_route' => 'foo'],
+            $matcher->matchRequest(Request::create('/foo', 'GET'))
+        );
+    }
+
+    public function testMatchRequestRestoresTheContextAfterwards()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo', [], [], [], '', [], ['GET']));
+
+        $originalContext = new RequestContext('', 'POST', 'example.com');
+        $matcher = $this->getUrlMatcher($coll, $originalContext);
+        $matcher->matchRequest(Request::create('https://other.example/foo', 'GET'));
+
+        $this->assertSame('POST', $originalContext->getMethod());
+        $this->assertSame('example.com', $originalContext->getHost());
+        $this->assertSame($originalContext, $matcher->getContext());
     }
 
     public function testMethodNotAllowedOnRoot()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63901
| License       | MIT

`UrlMatcher::matchRequest(Request)` stored the passed Request on `$this->request` and then delegated to `match($pathInfo)`. But the inner `matchCollection()` reads the HTTP method, host and scheme off `$this->context` — not off the Request — so the Request's method is effectively ignored once the match begins.

In practice this shows up when the matcher's context has been populated from the currently-handled HTTP request (e.g. during a POST) and the caller then validates a freshly-built internal Request with a different method:

```php
// inside a controller responding to a POST request
$router->matchRequest(Request::create('/internal-link', 'GET'));
// → MethodNotAllowedException, even though the target route allows GET
```

The `RequestMatcherInterface` contract explicitly says *"Tries to match a request with a set of routes"* and warns about `MethodNotAllowedException` *"if a matching resource was found but the request method is not allowed"* — clearly talking about the passed Request.

### Fix

Swap `$this->context` for a copy derived from the passed Request (via the existing `RequestContext::fromRequest()`) for the duration of the match, and restore the original context in a `finally` block so side effects are bounded and exception-safe. `$this->request` is reset the same way.

All existing subclasses (`CompiledUrlMatcher`, `RedirectableUrlMatcher`, `TraceableUrlMatcher`) inherit `matchRequest` from this base, so they pick up the fix without changes.

### Tests

Two regression tests added in `UrlMatcherTest`:

- `testMatchRequestHonorsTheRequestsMethodOverTheStaticContext` — the exact scenario from the issue: a POST-context matcher matching a GET Request against a GET-only route now returns the route instead of throwing.
- `testMatchRequestRestoresTheContextAfterwards` — confirms `$this->context` is restored to the original instance (with its original method/host) once matchRequest returns, so callers still see the static context afterwards.

Ran `./phpunit src/Symfony/Component/Routing/Tests/` locally on 6.4 with `php:8.4-cli`: 1179 tests pass (6 risky, pre-existing).
