### PR TITLE
[Messenger] Respect SentToFailureTransportStamp when failure transports are configured

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageToFailureTransportListener.php
@@ -50,8 +50,10 @@ class SendFailedMessageToFailureTransportListener implements EventSubscriberInte
 
         $envelope = $event->getEnvelope();
 
-        // avoid re-sending to the failed sender
-        if (!$this->failureTransportsByName && $envelope->last(SentToFailureTransportStamp::class)) {
+        // avoid re-sending to the failed sender: when the envelope has already been marked as sent
+        // to the failure transport of the current receiver (either by a previous run or manually
+        // from a subscriber that wants to opt out of the failure transport)
+        if (($stamp = $envelope->last(SentToFailureTransportStamp::class)) && $stamp->getOriginalReceiverName() === $event->getReceiverName()) {
             return;
         }
         if (($this->failureTransportsByName[$event->getReceiverName()] ?? null) === $event->getReceiverName()) {

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
@@ -124,6 +124,27 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $listener->onMessageFailed($event);
     }
 
+    public function testDoNotRedeliverToFailedWithStampWhenFailureTransportsAreConfigured()
+    {
+        $receiverName = 'my_receiver';
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->never())->method('send');
+
+        // Subscribers may add SentToFailureTransportStamp manually to opt out of the failure transport,
+        // even when $failureTransportsByName is populated (e.g. several transports share one listener).
+        $serviceLocator = new ServiceLocator([
+            $receiverName => static fn () => $sender,
+        ]);
+        $listener = new SendFailedMessageToFailureTransportListener($serviceLocator, null, [$receiverName => 'failed']);
+        $envelope = new Envelope(new \stdClass(), [
+            new SentToFailureTransportStamp($receiverName),
+        ]);
+        $event = new WorkerMessageFailedEvent($envelope, $receiverName, new \Exception());
+
+        $listener->onMessageFailed($event);
+    }
+
     public function testDoNothingIfFailureTransportIsNotDefined()
     {
         $sender = $this->createMock(SenderInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63969
| License       | MIT

Since #63275 the `SendFailedMessageToFailureTransportListener` only honored the `SentToFailureTransportStamp` opt-out when **no** `failureTransportsByName` were configured. Subscribers that add the stamp manually to skip the failure transport (e.g. for transient errors that will be fixed on the next run) no longer had any effect once the bundle registered failure transports — which is the common case.

### Before (current behaviour in 6.4/7.4/8.0/8.1)

```php
// avoid re-sending to the failed sender
if (!$this->failureTransportsByName && $envelope->last(SentToFailureTransportStamp::class)) {
    return;
}
if (($this->failureTransportsByName[$event->getReceiverName()] ?? null) === $event->getReceiverName()) {
    return;
}
```

When `failureTransportsByName` is populated and the envelope carries a `SentToFailureTransportStamp` for the current receiver, the listener falls through to `$failureSender->send($envelope)` and the message ends up on the failure queue — exactly the situation the stamp is meant to prevent.

### After

```php
// avoid re-sending to the failed sender: when the envelope has already been marked as sent
// to the failure transport of the current receiver (either by a previous run or manually
// from a subscriber that wants to opt out of the failure transport)
if (($stamp = $envelope->last(SentToFailureTransportStamp::class)) && $stamp->getOriginalReceiverName() === $event->getReceiverName()) {
    return;
}
if (($this->failureTransportsByName[$event->getReceiverName()] ?? null) === $event->getReceiverName()) {
    return;
}
```

The stamp is honored whenever it was stamped for the current receiver, which covers both the legacy "no `failureTransportsByName`" scenario (preserving `testDoNotRedeliverToFailedWithStampFallback`) and the user-subscriber scenario from the issue. Chained forwarding between different receivers (the feature added in #63275) keeps working: the stamp's original receiver differs from the current one, so the listener proceeds to forward to the next transport.

### Tests

Added `testDoNotRedeliverToFailedWithStampWhenFailureTransportsAreConfigured` reproducing the scenario from the issue. Verified it fails on the pre-patch code and passes with the fix. All other tests in `SendFailedMessageToFailureTransportListenerTest` still pass.

---
_Developed with Claude Code_
_Vibe-coded by Ousama_
