### PR TITLE
[Security] Throw BadCredentialsException on empty JSON login username/password

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -21,6 +21,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
@@ -146,22 +147,30 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         try {
             $credentials['username'] = $this->propertyAccessor->getValue($data, $this->options['username_path']);
 
-            if (!\is_string($credentials['username']) || '' === $credentials['username']) {
-                throw new BadRequestHttpException(\sprintf('The key "%s" must be a non-empty string.', $this->options['username_path']));
+            if (!\is_string($credentials['username'])) {
+                throw new BadRequestHttpException(\sprintf('The key "%s" must be a string.', $this->options['username_path']));
             }
         } catch (AccessException $e) {
             throw new BadRequestHttpException(\sprintf('The key "%s" must be provided.', $this->options['username_path']), $e);
+        }
+
+        if ('' === $credentials['username']) {
+            throw new BadCredentialsException(\sprintf('The key "%s" must not be empty.', $this->options['username_path']));
         }
 
         try {
             $credentials['password'] = $this->propertyAccessor->getValue($data, $this->options['password_path']);
             $this->propertyAccessor->setValue($data, $this->options['password_path'], null);
 
-            if (!\is_string($credentials['password']) || '' === $credentials['password']) {
-                throw new BadRequestHttpException(\sprintf('The key "%s" must be a non-empty string.', $this->options['password_path']));
+            if (!\is_string($credentials['password'])) {
+                throw new BadRequestHttpException(\sprintf('The key "%s" must be a string.', $this->options['password_path']));
             }
         } catch (AccessException $e) {
             throw new BadRequestHttpException(\sprintf('The key "%s" must be provided.', $this->options['password_path']), $e);
+        }
+
+        if ('' === $credentials['password']) {
+            throw new BadCredentialsException(\sprintf('The key "%s" must not be empty.', $this->options['password_path']));
         }
 
         return $credentials;

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
@@ -110,16 +110,16 @@ class JsonLoginAuthenticatorTest extends TestCase
         yield [$request, 'The key "password" must be provided'];
 
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": 1, "password": "foo"}');
-        yield [$request, 'The key "username" must be a non-empty string.'];
+        yield [$request, 'The key "username" must be a string.'];
 
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": "", "password": "foo"}');
-        yield [$request, 'The key "username" must be a non-empty string.'];
+        yield [$request, 'The key "username" must not be empty.', BadCredentialsException::class];
 
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": "dunglas", "password": 1}');
-        yield [$request, 'The key "password" must be a non-empty string.'];
+        yield [$request, 'The key "password" must be a string.'];
 
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '{"username": "dunglas", "password": ""}');
-        yield [$request, 'The key "password" must be a non-empty string.'];
+        yield [$request, 'The key "password" must not be empty.', BadCredentialsException::class];
 
         $username = str_repeat('x', UserBadge::MAX_USERNAME_LENGTH + 1);
         $request = new Request([], [], [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], \sprintf('{"username": "%s", "password": "foo"}', $username));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61100
| License       | MIT

#46118 deprecated passing an empty string as the username or password to `JsonLoginAuthenticator`, and #50866 later promoted that deprecation into a `BadRequestHttpException`. As [the reporter points out](https://github.com/symfony/symfony/issues/61100), rejecting an empty username or password is a security-domain concern — the JSON payload is well-formed — so the current exception type is wrong:

- It surfaces as a `400 Bad Request` via `ExceptionListener` instead of going through `onAuthenticationFailure` and the configured failure handler.
- It diverges from `UserBadge`, which already throws `BadCredentialsException` for the exact same situation (and has done so since #58007).

### Fix

Split the two checks inside `getCredentials()`:

| input                        | before                                              | after                                             |
| ---------------------------- | --------------------------------------------------- | ------------------------------------------------- |
| `{"username": 1, ... }`      | `BadRequestHttpException` (non-empty-string)        | `BadRequestHttpException` (`must be a string`)    |
| `{"username": "", ... }`     | `BadRequestHttpException` (non-empty-string)        | `BadCredentialsException` (`must not be empty`)   |
| `{"password": 1, ... }`      | `BadRequestHttpException`                           | `BadRequestHttpException`                         |
| `{"password": "", ... }`     | `BadRequestHttpException`                           | `BadCredentialsException`                         |

Type-mismatch errors remain `BadRequestHttpException` — those are genuine bad requests. Empty-string rejection becomes `BadCredentialsException`, which is routed by the security system through the authentication failure flow and produces the standard JSON 401 response via `onAuthenticationFailure`.

### Tests

The existing `testAuthenticateInvalid` data provider already distinguished the `Username too long` case as `BadCredentialsException`. Two data rows were converted to cover the new `BadCredentialsException` path, and the two remaining `BadRequestHttpException` rows now assert the refined `must be a string` message. Verified (with PHPUnit 11) that all 4 empty/non-string data rows fail on `7.4` before the fix and pass after it.