### PR TITLE
[Validator] Check File extensions and mimeTypes independently

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -72,3 +72,16 @@ Validator
  * Add argument `$restrictGroups` to `Valid::__construct()`
  * [BC BREAK] Remove the `GroupSequence::$cascadedGroup` property, it has had no effect since the validator stopped reading it in 2014, and reading it has thrown since 7.4 typed it without a default
  * Add argument `$cascadeCurrentGroup` to `GroupSequenceProvider::__construct()`
+ * The `File` constraint no longer narrows the configured `mimeTypes` option with mime types auto-derived from the matched extension when `extensions` is also configured.
+   The two options are now checked independently: `extensions` validates the file extension, and `mimeTypes` validates the detected mime type.
+
+   In previous versions, the effective mime-type list was narrowed to the mime types auto-derived from the matching extension. For example, a CSV file detected as `text/plain` could be rejected by this constraint because the `mimeTypes` list was narrowed to the mime types derived from `csv`:
+
+   ```php
+   #[Assert\File(
+       extensions: ['csv'],
+       mimeTypes: ['text/csv', 'text/plain'],
+   )]
+   ```
+
+   In Symfony 8.2, the configured `mimeTypes` list is used as-is, while the `csv` extension is still enforced separately.

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add the `restrictGroups` option to the `Valid` constraint
  * Add the `Cron` constraint to validate cron expressions
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`
+ * Stop narrowing the `File` constraint's `mimeTypes` option with mime types auto-derived from the matched extension when `extensions` is configured
 
 8.1
 ---

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -233,9 +233,7 @@ class FileValidator extends ConstraintValidator
                     $v = $mimeTypesHelper->getMimeTypes($k);
                 }
 
-                // when the configured mime types share none with the ones of the matched
-                // extension, keep the configured ones so that the file is still checked
-                $mimeTypes = $mimeTypes ? (array_intersect($v, $mimeTypes) ?: $mimeTypes) : (array) $v;
+                $mimeTypes = $mimeTypes ?: (array) $v;
                 break;
             }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTestCase.php
@@ -618,6 +618,30 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testExtensionsAndMimeTypesAreCheckedIndependently()
+    {
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'FileValidatorTest.csv';
+        file_put_contents($path, 'plain text');
+
+        try {
+            $file = new \Symfony\Component\HttpFoundation\File\File($path);
+
+            try {
+                $file->getMimeType();
+            } catch (\LogicException $e) {
+                $this->markTestSkipped('Guessing the mime type is not possible');
+            }
+
+            $constraint = new File(extensions: ['csv'], mimeTypes: ['text/csv', 'text/plain']);
+
+            $this->validate($file, $constraint);
+
+            $this->assertNoViolation();
+        } finally {
+            @unlink($path);
+        }
+    }
+
     public function testUploadedFileExtensions()
     {
         $file = new UploadedFile(__DIR__.'/Fixtures/bar', 'bar.txt', 'text/plain', \UPLOAD_ERR_OK, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61713
| License       | MIT

### Problem

When the `File` constraint is configured with both `extensions` and `mimeTypes`, the validator used to narrow the configured mime-type allow-list with mime types auto-derived from the matched extension.

That rejects valid declarations such as `extensions: ["csv"]` with `mimeTypes: ["text/csv", "text/plain"]` when mime detection returns `text/plain` for a CSV file.

### Approach

Following the maintainer discussion, this PR makes the two options independent:

- `extensions` still validates the file extension;
- `mimeTypes`, when configured, is used as-is for the detected mime type;
- auto-derived mime types from `extensions` are used only when `mimeTypes` is not configured.

This is the one-line behavior change suggested in review:

```php
$mimeTypes = $mimeTypes ?: (array) $v;
```

### Changes

- `FileValidator` no longer intersects configured `mimeTypes` with mime types derived from the matched extension.
- Adds a regression test for `extensions: ["csv"]` + `mimeTypes: ["text/csv", "text/plain"]` with a file detected as `text/plain`.
- Updates `CHANGELOG.md` and `UPGRADE-8.2.md`.

### Tests

RED: reverting the validator line back to the old intersection makes the new test fail in both object and path validator variants: `0 violation expected. Got 1`.

GREEN: local `./run-ci.sh` on PHP 8.4 passes syntax checks and `FileTest` + `FileValidatorObjectTest` + `FileValidatorPathTest`: `OK (248 tests, 450 assertions)`. 