### PR TITLE
[Contracts] Fix tests requirement using full semver in `#[RequiresPhp]`

### DIFF
--- a/src/Symfony/Contracts/Tests/Service/ServiceMethodsSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceMethodsSubscriberTraitTest.php
@@ -38,7 +38,7 @@ class ServiceMethodsSubscriberTraitTest extends TestCase
         $this->assertEquals($expected, ChildTestService::getSubscribedServices());
     }
 
-    #[RequiresPhp('>= 8.4')]
+    #[RequiresPhp('>= 8.4.0')]
     public function testHookedProperties()
     {
         $this->assertSame([
@@ -66,7 +66,7 @@ class ServiceMethodsSubscriberTraitTest extends TestCase
         NonHookedPropertyService::getSubscribedServices();
     }
 
-    #[RequiresPhp('>= 8.4')]
+    #[RequiresPhp('>= 8.4.0')]
     public function testPropertyWithGetHookRequired()
     {
         $this->expectException(\LogicException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix CI
| License       | MIT

Latest release of PHPUnit 13 requires full semver when using `#[RequiresPhp]` (similar to https://github.com/symfony/symfony/pull/63977)