### PR TITLE
[DependencyInjection] Support autowiring env vars as closures or `Stringable` when using `#[Autowire(env: 'FOO')]`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/EnvClosure.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/EnvClosure.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Argument;
+
+use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class EnvClosure implements \Stringable
+{
+    public function __construct(
+        private \Closure $closure,
+        private mixed $default = null,
+    ) {
+    }
+
+    public function __invoke(): mixed
+    {
+        try {
+            return ($this->closure)();
+        } catch (EnvNotFoundException $e) {
+            return $this->default ?? throw $e;
+        }
+    }
+
+    public function __toString(): string
+    {
+        return $this->__invoke();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Argument/EnvClosureArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/EnvClosureArgument.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Argument;
+
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * Represents an environment variable presented as an invokable and Stringable wrapper.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class EnvClosureArgument implements ArgumentInterface
+{
+    use ArgumentTrait;
+
+    public function __construct(
+        private string $value,
+        private mixed $default = null,
+        private bool $stringable = false,
+    ) {
+        if ($stringable && !\is_string($default ?? '')) {
+            throw new InvalidArgumentException('The default value of a stringable EnvClosureArgument must be a string or null.');
+        }
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Hides the env expression from compiler passes that walk arguments via {@see ArgumentInterface::getValues()},
+     * so that env placeholders inside EnvClosureArgument are not resolved at compile time and stay refreshable at runtime.
+     */
+    public function getValues(): array
+    {
+        return [];
+    }
+
+    public function setValues(array $values): void
+    {
+        if ($values) {
+            throw new InvalidArgumentException('An EnvClosureArgument cannot hold values.');
+        }
+    }
+
+    public function getDefault(): mixed
+    {
+        return $this->default;
+    }
+
+    public function isStringable(): bool
+    {
+        return $this->stringable;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.1
 ---
 
+ * Support autowiring env vars as closures or `Stringable` when using `#[Autowire(env: 'FOO')]`
+ * Add `EnvClosureArgument` and `!env_closure` YAML tag to inject env vars as closures or `Stringable` arguments
  * Add `AddBehaviorDescribingTagsPass` to allow bundles to extend the list of behavior-describing tags
  * Add Kernel and Bundle infrastructure in the `Kernel\` subnamespace
  * Add `$extensions` parameter to `MergeExtensionConfigurationPass` to ensure registered extensions are implicitly loaded

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\Resource\ClassExistenceResource;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 use Symfony\Component\DependencyInjection\Attribute\AutowireInline;
@@ -310,12 +311,33 @@ class AutowirePass extends AbstractRecursivePass
                     $attribute = $attribute->newInstance();
                     $value = $attribute instanceof Autowire ? $attribute->value : null;
 
-                    if (\is_string($value) && str_starts_with($value, '%env(') && str_ends_with($value, ')%')) {
-                        if ($parameter->getType() instanceof \ReflectionNamedType && 'bool' === $parameter->getType()->getName() && !str_starts_with($value, '%env(bool:')) {
-                            $attribute = new Autowire(substr_replace($value, 'bool:', 5, 0));
+                    if (\is_string($value)) {
+                        $isPureEnv = str_starts_with($value, '%env(') && str_ends_with($value, ')%') && !str_contains(substr($value, 5, -2), '%');
+                        $default = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
+
+                        if ($isPureEnv && $parameter->isDefaultValueAvailable() && null === $default && !preg_match('/(?:^%env\(|:)default:/', $value)) {
+                            $value = substr_replace($value, 'default::', 5, 0);
+                            $attribute = new Autowire($value);
                         }
-                        if ($parameter->isDefaultValueAvailable() && $parameter->allowsNull() && null === $parameter->getDefaultValue() && !preg_match('/(^|:)default:/', $value)) {
-                            $attribute = new Autowire(substr_replace($value, 'default::', 5, 0));
+                        if ($isPureEnv && $parameter->getType() instanceof \ReflectionNamedType && 'bool' === $parameter->getType()->getName() && !str_starts_with($value, '%env(bool:')) {
+                            $value = substr_replace($value, 'bool:', 5, 0);
+                            $attribute = new Autowire($value);
+                        }
+
+                        try {
+                            $resolved = $this->container->getParameterBag()->resolveValue($value);
+                        } catch (ParameterNotFoundException) {
+                            $resolved = null;
+                        }
+
+                        if (\is_string($resolved) && preg_match('/env_[a-f0-9]{16}_\w+_[a-f0-9]{32}/', $resolved)) {
+                            foreach (explode('|', $type) as $t) {
+                                if (!\in_array($t, ['Closure', 'Stringable'], true)) {
+                                    continue;
+                                }
+                                $arguments[$index] = new EnvClosureArgument($resolved, $default, 'Stringable' === $t);
+                                continue 3;
+                            }
                         }
                     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\EnvClosure;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -261,6 +263,8 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
                 $class = RewindableGenerator::class;
             } elseif ($value instanceof ServiceClosureArgument) {
                 $class = \Closure::class;
+            } elseif ($value instanceof EnvClosureArgument) {
+                $class = $value->isStringable() ? EnvClosure::class : \Closure::class;
             } elseif ($value instanceof ServiceLocatorArgument) {
                 $class = ServiceLocator::class;
             } elseif (\is_object($value)) {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -22,6 +22,8 @@ use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\Config\Resource\ReflectionClassResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\EnvClosure;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyClosure;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
@@ -1265,6 +1267,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         } elseif ($value instanceof ServiceClosureArgument) {
             $reference = $value->getValues()[0];
             $value = fn () => $this->resolveServices($reference);
+        } elseif ($value instanceof EnvClosureArgument) {
+            $expr = $value->getValue();
+            $envClosure = new EnvClosure(fn () => $this->resolveEnvPlaceholders($expr, true), $value->getDefault());
+            $value = $value->isStringable() ? $envClosure : $envClosure->__invoke(...);
         } elseif ($value instanceof IteratorArgument) {
             $value = new RewindableGenerator(function () use ($value, &$inlineServices) {
                 foreach ($value->getValues() as $k => $v) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -15,6 +15,8 @@ use Composer\Autoload\ClassLoader;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\EnvClosure;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyClosure;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -1892,6 +1894,13 @@ class PhpDumper extends Dumper
                     }
 
                     return \sprintf('%sfn ()%s => %s', $attribute, $returnedType, $code);
+                }
+
+                if ($value instanceof EnvClosureArgument) {
+                    $closure = \sprintf('fn () => %s', $this->export($value->getValue()));
+                    $code = \sprintf('new \\%s(%s, %s)', EnvClosure::class, $closure, $this->export($value->getDefault()));
+
+                    return $value->isStringable() ? $code : (null !== $value->getDefault() ? $code.'->__invoke(...)' : $closure);
                 }
 
                 if ($value instanceof IteratorArgument) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Dumper;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -298,6 +299,20 @@ class XmlDumper extends Dumper
         $withKeys = !array_is_list($parameters);
         foreach ($parameters as $key => $value) {
             $xmlAttr = $withKeys ? \sprintf(' %s="%s"', $keyAttribute, $this->encode($key)) : '';
+
+            if ($value instanceof EnvClosureArgument) {
+                $xmlAttr .= ' type="env_closure"';
+                if ($value->isStringable()) {
+                    $xmlAttr .= ' stringable="true"';
+                }
+                if (null !== $default = $value->getDefault()) {
+                    $xmlAttr .= \sprintf(' default="%s"', $this->encode(self::phpToXml($default)));
+                }
+                $envExpr = $this->container->resolveEnvPlaceholders($value->getValue());
+                yield \sprintf('<%s%s>%s</%1$s>', $type, $xmlAttr, $this->encode($envExpr, 0));
+
+                continue;
+            }
 
             if (($value instanceof TaggedIteratorArgument && $tag = $value)
                 || ($value instanceof ServiceLocatorArgument && $tag = $value->getTaggedIteratorArgument())

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Dumper;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -252,6 +253,16 @@ class YamlDumper extends Dumper
             $value = $value->getValues()[0];
 
             return new TaggedValue('service_closure', $this->dumpValue($value));
+        }
+        if ($value instanceof EnvClosureArgument) {
+            $envExpr = $this->container->resolveEnvPlaceholders($value->getValue());
+            $default = $value->getDefault();
+
+            if (!$value->isStringable()) {
+                return new TaggedValue('env_closure', null === $default ? $envExpr : [$envExpr, $default, false]);
+            }
+
+            return new TaggedValue('env_closure', [$envExpr, $default]);
         }
         if ($value instanceof ArgumentInterface) {
             $tag = $value;

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -24,6 +25,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\VarExporter\DeepCloner;
@@ -769,6 +771,27 @@ trait ContentLoaderTrait
                 $argument = $this->resolveServices($argument, $file, $isParameter);
 
                 return new ServiceClosureArgument($argument);
+            }
+            if ('env_closure' === $value->getTag()) {
+                if (\is_array($argument)) {
+                    $envExpr = $argument[0] ?? null;
+                    $default = $argument[1] ?? null;
+                    $stringable = $argument[2] ?? true;
+                    $validKeys = !array_diff(array_keys($argument), [0, 1, 2]);
+                } else {
+                    [$envExpr, $default, $stringable, $validKeys] = [$argument, null, false, true];
+                }
+
+                if (!\is_string($envExpr) || !\is_bool($stringable) || !$validKeys) {
+                    throw new InvalidArgumentException(\sprintf('"!env_closure" tag only accepts a string value or an array [value, default, stringable] in "%s".', $file));
+                }
+
+                try {
+                    $envExpr = $this->container->getParameterBag()->resolveValue($envExpr);
+                } catch (ParameterNotFoundException) {
+                }
+
+                return new EnvClosureArgument($envExpr, $default, $stringable);
             }
             if ('service_locator' === $value->getTag()) {
                 if (!\is_array($argument)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -24,10 +24,12 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\EnvClosure;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -1634,6 +1636,79 @@ class ContainerBuilderTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testEnvClosureAutowire()
+    {
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag());
+        $container->setParameter('env(FOO)', 'foo');
+        $container->setParameter('env(HOST)', 'example.com');
+        $container->setParameter('env(PORT)', '6379');
+        $container->setParameter('dsn_template', 'redis://%env(HOST)%:%env(PORT)%');
+
+        $container->register('consumer', EnvClosureAutowireConsumer::class)
+            ->setPublic(true)
+            ->setAutowired(true)
+        ;
+        $container->compile();
+
+        $consumer = $container->get('consumer');
+
+        $this->assertInstanceOf(\Closure::class, $consumer->getFoo);
+        $this->assertSame('foo', ($consumer->getFoo)());
+
+        $this->assertInstanceOf(EnvClosure::class, $consumer->getFooStringable);
+        $this->assertSame('foo', (string) $consumer->getFooStringable);
+
+        $this->assertInstanceOf(EnvClosure::class, $consumer->getMissingWithDefault);
+        $this->assertSame('fallback', (string) $consumer->getMissingWithDefault);
+
+        $this->assertInstanceOf(EnvClosure::class, $consumer->getDsn);
+        $this->assertSame('redis://example.com:6379', (string) $consumer->getDsn);
+
+        $this->assertInstanceOf(EnvClosure::class, $consumer->getDsnFromParam);
+        $this->assertSame('redis://example.com:6379', (string) $consumer->getDsnFromParam);
+    }
+
+    public function testEnvClosureAutowireRefreshesAcrossEnvCacheReset()
+    {
+        $previous = [
+            'SYMFONY_TEST_HOST' => $_ENV['SYMFONY_TEST_HOST'] ?? null,
+            'SYMFONY_TEST_PORT' => $_ENV['SYMFONY_TEST_PORT'] ?? null,
+        ];
+        $_ENV['SYMFONY_TEST_HOST'] = 'host-1';
+        $_ENV['SYMFONY_TEST_PORT'] = '6379';
+
+        try {
+            $container = new ContainerBuilder(new EnvPlaceholderParameterBag());
+            $container->setParameter('dsn_template', 'redis://%env(SYMFONY_TEST_HOST)%:%env(SYMFONY_TEST_PORT)%');
+            $container->register('consumer', EnvRefreshConsumer::class)
+                ->setPublic(true)
+                ->setAutowired(true)
+            ;
+            $container->compile(true);
+
+            $consumer = $container->get('consumer');
+
+            $this->assertSame('host-1', ($consumer->host)());
+            $this->assertSame('redis://host-1:6379', (string) $consumer->dsn);
+            $this->assertSame('redis://host-1:6379', (string) $consumer->dsnFromParam);
+
+            $_ENV['SYMFONY_TEST_HOST'] = 'host-2';
+            $container->resetEnvCache();
+
+            $this->assertSame('host-2', ($consumer->host)());
+            $this->assertSame('redis://host-2:6379', (string) $consumer->dsn);
+            $this->assertSame('redis://host-2:6379', (string) $consumer->dsnFromParam);
+        } finally {
+            foreach ($previous as $k => $v) {
+                if (null === $v) {
+                    unset($_ENV[$k]);
+                } else {
+                    $_ENV[$k] = $v;
+                }
+            }
+        }
+    }
+
     public function testServiceLocator()
     {
         $container = new ContainerBuilder();
@@ -2171,5 +2246,35 @@ class E
     {
         $this->first = $first;
         $this->second = $second;
+    }
+}
+
+class EnvClosureAutowireConsumer
+{
+    public function __construct(
+        #[Autowire(env: 'FOO')]
+        public \Closure $getFoo,
+        #[Autowire(env: 'FOO')]
+        public \Stringable $getFooStringable,
+        #[Autowire(env: 'MISSING')]
+        public string|\Stringable $getMissingWithDefault = 'fallback',
+        #[Autowire('redis://%env(HOST)%:%env(PORT)%')]
+        public ?\Stringable $getDsn = null,
+        #[Autowire('%dsn_template%')]
+        public ?\Stringable $getDsnFromParam = null,
+    ) {
+    }
+}
+
+class EnvRefreshConsumer
+{
+    public function __construct(
+        #[Autowire(env: 'SYMFONY_TEST_HOST')]
+        public \Closure $host,
+        #[Autowire('redis://%env(SYMFONY_TEST_HOST)%:%env(SYMFONY_TEST_PORT)%')]
+        public ?\Stringable $dsn = null,
+        #[Autowire('%dsn_template%')]
+        public ?\Stringable $dsnFromParam = null,
+    ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -2053,6 +2053,11 @@ class PhpDumperTest extends TestCase
     public function testAutowireClosure()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('env(FOO)', 'foo');
+        $container->setParameter('env(BAR)', 'foo');
+        $container->setParameter('env(HOST)', 'example.com');
+        $container->setParameter('env(PORT)', '6379');
+        $container->setParameter('dsn_template', 'redis://%env(HOST)%:%env(PORT)%');
         $container->register('foo', Foo::class)
             ->setPublic(true);
         $container->register('my_callable', MyCallable::class)
@@ -2078,10 +2083,18 @@ class PhpDumperTest extends TestCase
         $this->assertInstanceOf(\Closure::class, $bar->foo);
         $this->assertInstanceOf(\Closure::class, $bar->baz);
         $this->assertInstanceOf(\Closure::class, $bar->buz);
+        $this->assertInstanceOf(\Closure::class, $bar->getFoo);
+        $this->assertInstanceOf(\Stringable::class, $bar->getBar);
+        $this->assertInstanceOf(\Stringable::class, $bar->getDsn);
+        $this->assertInstanceOf(\Stringable::class, $bar->getDsnFromParam);
         $this->assertSame($container->get('foo'), ($bar->foo)());
         $this->assertSame($container->get('baz'), $bar->baz);
         $this->assertInstanceOf(Foo::class, $fooClone = ($bar->buz)());
         $this->assertNotSame($container->get('foo'), $fooClone);
+        $this->assertSame('foo', ($bar->getFoo)());
+        $this->assertSame('foo', (string) $bar->getBar);
+        $this->assertSame('redis://example.com:6379', (string) $bar->getDsn);
+        $this->assertSame('redis://example.com:6379', (string) $bar->getDsnFromParam);
     }
 
     public function testLazyClosure()
@@ -2479,6 +2492,14 @@ class LazyClosureConsumer
         public \Closure $buz,
         #[AutowireCallable(service: 'my_callable')]
         public \Closure $bar,
+        #[Autowire(env: 'FOO')]
+        public string|\Closure|null $getFoo = null,
+        #[Autowire(env: 'BAR')]
+        public string|\Stringable $getBar = 'bar',
+        #[Autowire('redis://%env(HOST)%:%env(PORT)%')]
+        public ?\Stringable $getDsn = null,
+        #[Autowire('%dsn_template%')]
+        public ?\Stringable $getDsnFromParam = null,
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -284,6 +285,20 @@ class XmlDumperTest extends TestCase
 
         $dumper = new XmlDumper($container);
         $this->assertXmlStringEqualsGeneratedXmlFile('services_with_service_closure.xml', $dumper->dump());
+    }
+
+    public function testEnvClosure()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', 'Foo')
+            ->addArgument(new EnvClosureArgument('%env(FOO)%'))
+            ->addArgument(new EnvClosureArgument('%env(FOO)%', null, true))
+            ->addArgument(new EnvClosureArgument('%env(BAR)%', 'def', true))
+            ->addArgument(new EnvClosureArgument('%env(FOO)%', 42))
+        ;
+
+        $dumper = new XmlDumper($container);
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_env_closure.xml', $dumper->dump());
     }
 
     public function testDumpAbstractServices()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -152,6 +153,20 @@ class YamlDumperTest extends TestCase
 
         $dumper = new YamlDumper($container);
         $this->assertStringEqualsGeneratedFile('services_with_service_closure.yml', $dumper->dump());
+    }
+
+    public function testEnvClosure()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', 'Foo')
+            ->addArgument(new EnvClosureArgument('%env(FOO)%'))
+            ->addArgument(new EnvClosureArgument('%env(FOO)%', null, true))
+            ->addArgument(new EnvClosureArgument('%env(BAR)%', 'def', true))
+            ->addArgument(new EnvClosureArgument('%env(FOO)%', 42))
+        ;
+
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsGeneratedFile('services_with_env_closure.yml', $dumper->dump());
     }
 
     public function testDumpHandlesEnumeration()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/autowire_closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/autowire_closure.php
@@ -18,6 +18,8 @@ class Symfony_DI_PhpDumper_Test_Autowire_Closure extends Container
 
     public function __construct()
     {
+        $this->parameters = $this->getDefaultParameters();
+
         $this->services = $this->privates = [];
         $this->methodMap = [
             'bar' => 'getBarService',
@@ -46,7 +48,7 @@ class Symfony_DI_PhpDumper_Test_Autowire_Closure extends Container
      */
     protected static function getBarService($container)
     {
-        return $container->services['bar'] = new \Symfony\Component\DependencyInjection\Tests\Dumper\LazyClosureConsumer(#[\Closure(name: 'foo', class: 'Symfony\\Component\\DependencyInjection\\Tests\\Compiler\\Foo')] fn () => ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo()), ($container->services['baz'] ?? self::getBazService($container)), ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo())->cloneFoo(...), ($container->services['my_callable'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable())->__invoke(...));
+        return $container->services['bar'] = new \Symfony\Component\DependencyInjection\Tests\Dumper\LazyClosureConsumer(#[\Closure(name: 'foo', class: 'Symfony\\Component\\DependencyInjection\\Tests\\Compiler\\Foo')] fn () => ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo()), ($container->services['baz'] ?? self::getBazService($container)), ($container->services['foo'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo())->cloneFoo(...), ($container->services['my_callable'] ??= new \Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable())->__invoke(...), fn () => $container->getEnv('default::FOO'), new \Symfony\Component\DependencyInjection\Argument\EnvClosure(fn () => $container->getEnv('BAR'), 'bar'), new \Symfony\Component\DependencyInjection\Argument\EnvClosure(fn () => 'redis://'.$container->getEnv('string:HOST').':'.$container->getEnv('string:PORT'), NULL), new \Symfony\Component\DependencyInjection\Argument\EnvClosure(fn () => 'redis://'.$container->getEnv('string:HOST').':'.$container->getEnv('string:PORT'), NULL));
     }
 
     /**
@@ -77,5 +79,68 @@ class Symfony_DI_PhpDumper_Test_Autowire_Closure extends Container
     protected static function getMyCallableService($container)
     {
         return $container->services['my_callable'] = new \Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable();
+    }
+
+    public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
+    {
+        if (isset($this->loadedDynamicParameters[$name])) {
+            $value = $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        } elseif (\array_key_exists($name, $this->parameters) && '.' !== ($name[0] ?? '')) {
+            $value = $this->parameters[$name];
+        } else {
+            throw new ParameterNotFoundException($name);
+        }
+
+        return $value;
+    }
+
+    public function hasParameter(string $name): bool
+    {
+        return \array_key_exists($name, $this->parameters) || isset($this->loadedDynamicParameters[$name]);
+    }
+
+    public function setParameter(string $name, $value): void
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    public function getParameterBag(): ParameterBagInterface
+    {
+        if (!isset($this->parameterBag)) {
+            $parameters = $this->parameters;
+            foreach ($this->loadedDynamicParameters as $name => $loaded) {
+                $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+            }
+            $this->parameterBag = new FrozenParameterBag($parameters, []);
+        }
+
+        return $this->parameterBag;
+    }
+
+    private $loadedDynamicParameters = [
+        'dsn_template' => false,
+    ];
+    private $dynamicParameters = [];
+
+    private function getDynamicParameter(string $name)
+    {
+        $container = $this;
+        $value = match ($name) {
+            'dsn_template' => 'redis://'.$container->getEnv('string:HOST').':'.$container->getEnv('string:PORT'),
+            default => throw new ParameterNotFoundException($name),
+        };
+        $this->loadedDynamicParameters[$name] = true;
+
+        return $this->dynamicParameters[$name] = $value;
+    }
+
+    protected function getDefaultParameters(): array
+    {
+        return [
+            'env(FOO)' => 'foo',
+            'env(BAR)' => 'foo',
+            'env(HOST)' => 'example.com',
+            'env(PORT)' => '6379',
+        ];
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_env_closure.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_env_closure.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="foo" class="Foo">
+      <argument type="env_closure">%env(FOO)%</argument>
+      <argument type="env_closure" stringable="true">%env(FOO)%</argument>
+      <argument type="env_closure" stringable="true" default="def">%env(BAR)%</argument>
+      <argument type="env_closure" default="42">%env(FOO)%</argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_env_closure.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_env_closure.yml
@@ -1,0 +1,9 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo:
+        class: Foo
+        arguments: [!env_closure '%env(FOO)%', !env_closure ['%env(FOO)%', null], !env_closure ['%env(BAR)%', def], !env_closure ['%env(FOO)%', 42, false]]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -483,6 +484,21 @@ class YamlFileLoaderTest extends TestCase
         $loader->load('services_with_short_service_closure.yml');
 
         $this->assertEquals(new ServiceClosureArgument(new Reference('bar')), $container->getDefinition('foo')->getArgument(0));
+    }
+
+    public function testParseEnvClosure()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_env_closure.yml');
+
+        $arguments = $container->getDefinition('foo')->getArguments();
+        $bag = $container->getParameterBag();
+
+        $this->assertEquals(new EnvClosureArgument($bag->resolveValue('%env(FOO)%')), $arguments[0]);
+        $this->assertEquals(new EnvClosureArgument($bag->resolveValue('%env(FOO)%'), null, true), $arguments[1]);
+        $this->assertEquals(new EnvClosureArgument($bag->resolveValue('%env(BAR)%'), 'def', true), $arguments[2]);
+        $this->assertEquals(new EnvClosureArgument($bag->resolveValue('%env(FOO)%'), 42, false), $arguments[3]);
     }
 
     public function testNameOnlyTagsAreAllowedAsString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60778
| License       | MIT

Using `#[Autowire(env: 'FOO')]`, or any `#[Autowire('…%env(…)%…')]` string value, on a parameter typed `Closure` or `Stringable` injects a callable / stringable that returns the value of the env reference at call time.

Contrary to injecting an env var as a `string` (which is baked at compile time), this stays refreshable across `Container::resetEnvCache()` — i.e. the next call returns the current value of `$_ENV[*]` — as typically done between requests in worker mode.

```php
class Foo
{
    public function __construct(
        #[Autowire(env: 'DB_URL')]
        private \Closure $dbUrl,
        #[Autowire(env: 'APP_NAME')]
        private string|\Stringable $appName = 'default',
        // Embedded env vars in any string also work:
        #[Autowire('redis://%env(HOST)%:%env(PORT)%')]
        private \Stringable $redisDsn,
        // %param% references are resolved through the parameter bag:
        #[Autowire('%dsn_template%')]
        private \Stringable $dsn,
    ) {
    }
}
```

When a default value is declared, it is returned when the env var is not defined (must be a string for `Stringable`, any type for `Closure`).

This PR also adds a matching `EnvClosureArgument` (the DI counterpart of `ServiceClosureArgument`) and an `!env_closure` YAML tag — its value mirrors what you'd write inside `#[Autowire('…')]`:

```yaml
services:
    App\Foo:
        arguments:
            - !env_closure '%env(DB_URL)%'                          # Closure
            - !env_closure ['%env(APP_NAME)%']                      # Stringable, no default
            - !env_closure ['%env(APP_NAME)%', 'default']           # Stringable with default
            - !env_closure ['%env(DB_URL)%', 'sqlite://', false]    # Closure with default
            - !env_closure 'redis://%env(HOST)%:%env(PORT)%'        # template
```

In the plane to Tunis, looks like I can still code without an LLM 😆