### PR TITLE
[Messenger] Do not apply --max to --stats unless explicitly set

### DIFF
--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -74,7 +74,8 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         }
 
         if ($input->getOption('stats')) {
-            $this->listMessagesPerClass($failureTransportName, $io, $input->getOption('max'));
+            $max = $input->hasParameterOption(['--max'], true) ? $input->getOption('max') : null;
+            $this->listMessagesPerClass($failureTransportName, $io, $max);
         } elseif (null === $id = $input->getArgument('id')) {
             $this->listMessages($failureTransportName, $io, $errorIo, $input->getOption('max'), $input->getOption('class-filter'));
         } else {
@@ -140,7 +141,7 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         $errorIo->comment(\sprintf('Run <comment>messenger:failed:show {id} --transport=%s -vv</comment> to see message details.', $failedTransportName));
     }
 
-    private function listMessagesPerClass(?string $failedTransportName, SymfonyStyle $io, int $max): void
+    private function listMessagesPerClass(?string $failedTransportName, SymfonyStyle $io, ?int $max): void
     {
         /** @var ListableReceiverInterface $receiver */
         $receiver = $this->getReceiver($failedTransportName);

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -267,6 +267,46 @@ class FailedMessagesShowCommandTest extends TestCase
         $this->assertStringContainsString('stdClass   2', $tester->getDisplay(true));
     }
 
+    public function testStatsIgnoresDefaultMaxAndCountsAllMessages()
+    {
+        $envelope = new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp(15),
+            new SentToFailureTransportStamp('async'),
+            new RedeliveryStamp(0),
+            ErrorDetailsStamp::create(new \RuntimeException('Things are bad!')),
+        ]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(null)->willReturn([$envelope, $envelope, $envelope]);
+
+        $failureTransportName = 'failure_receiver';
+
+        $command = new FailedMessagesShowCommand($failureTransportName, new ServiceLocator([$failureTransportName => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--stats' => true]);
+        $this->assertStringContainsString('stdClass   3', $tester->getDisplay(true));
+    }
+
+    public function testStatsHonorsExplicitMax()
+    {
+        $envelope = new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp(15),
+            new SentToFailureTransportStamp('async'),
+            new RedeliveryStamp(0),
+            ErrorDetailsStamp::create(new \RuntimeException('Things are bad!')),
+        ]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(10)->willReturn([$envelope]);
+
+        $failureTransportName = 'failure_receiver';
+
+        $command = new FailedMessagesShowCommand($failureTransportName, new ServiceLocator([$failureTransportName => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--stats' => true, '--max' => 10]);
+        $this->assertStringContainsString('stdClass   1', $tester->getDisplay(true));
+    }
+
     public function testInvalidMessagesThrowsExceptionWithServiceLocator()
     {
         $receiver = $this->createStub(ListableReceiverInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60821
| License       | MIT

`messenger:failed:show --stats` was applying `--max` (default `50`) to the message count it computes. On any transport that has more than 50 failed messages, the header ("There are N messages pending") and the per-class counts disagreed, e.g.:

```
There are 1582 messages pending in the failure transport.
 ------- -------
  Class   Count
 ------- -------
  Foo     1
  Bar     49
 ------- -------
```

1 + 49 ≠ 1582.

## What changed

When `--max` is not explicitly passed on the command line, `--stats` now asks the receiver for **all** messages (`ListableReceiverInterface::all(null)`) instead of defaulting to 50. Passing `--max=N` alongside `--stats` is still honored, matching the reporter's suggested behavior.

The fix is surgical: one detection via `InputInterface::hasParameterOption(['--max'], true)` and a nullable signature on the private `listMessagesPerClass()` helper. The non-stats listing path is unchanged — its existing `--max=50` default is still applied.

## Test coverage

Two new tests in `FailedMessagesShowCommandTest`:
- `testStatsIgnoresDefaultMaxAndCountsAllMessages` — `--stats` alone passes `null` to `all()` (no cap, all 3 messages counted).
- `testStatsHonorsExplicitMax` — `--stats --max=10` still passes `10` to `all()`.

Full `FailedMessagesShowCommandTest` suite: 18 tests, 42 assertions, green.

---
_Developed with Claude Code_
_Vibe-coded by Ousama_
