### PR TITLE
[FrameworkBundle] Strip --no-fill marker from every translation domain

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
@@ -494,9 +494,11 @@ class TranslationExtractCommand extends Command
 
     private function removeNoFillTranslations(MessageCatalogueInterface $operation): void
     {
-        foreach ($operation->all('messages') as $key => $message) {
-            if (str_starts_with($message, self::NO_FILL_PREFIX)) {
-                $operation->set($key, '', 'messages');
+        foreach ($operation->getDomains() as $domain) {
+            foreach ($operation->all($domain) as $key => $message) {
+                if (str_starts_with($message, self::NO_FILL_PREFIX)) {
+                    $operation->set($key, '', $domain);
+                }
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationExtractCommandTest.php
@@ -184,6 +184,9 @@ class TranslationExtractCommandTest extends TestCase
         // Preparing mock
         $operation = $this->createMock(MessageCatalogueInterface::class);
         $operation
+            ->method('getDomains')
+            ->willReturn(['messages']);
+        $operation
             ->method('all')
             ->willReturnMap([
                 ['messages', $messages],
@@ -197,6 +200,39 @@ class TranslationExtractCommandTest extends TestCase
         $reflection = new \ReflectionObject($translationUpdate);
         $method = $reflection->getMethod('removeNoFillTranslations');
         $method->invokeArgs($translationUpdate, [$operation]);
+    }
+
+    public function testRemoveNoFillTranslationsAcrossAllDomains()
+    {
+        $operation = $this->createMock(MessageCatalogueInterface::class);
+        $operation
+            ->method('getDomains')
+            ->willReturn(['messages', 'validators', 'validators+intl-icu']);
+        $operation
+            ->method('all')
+            ->willReturnMap([
+                ['messages', ['greeting' => "\0NoFill\0Hello"]],
+                ['validators', ['err' => 'plain error']],
+                ['validators+intl-icu', ['desc' => "\0NoFill\0Description is mandatory"]],
+            ]);
+
+        $calls = [];
+        $operation
+            ->expects($this->exactly(2))
+            ->method('set')
+            ->willReturnCallback(static function ($id, $translation, $domain) use (&$calls): void {
+                $calls[] = [$id, $translation, $domain];
+            });
+
+        $translationUpdate = $this->createStub(TranslationExtractCommand::class);
+        $reflection = new \ReflectionObject($translationUpdate);
+        $method = $reflection->getMethod('removeNoFillTranslations');
+        $method->invokeArgs($translationUpdate, [$operation]);
+
+        $this->assertSame([
+            ['greeting', '', 'messages'],
+            ['desc', '', 'validators+intl-icu'],
+        ], $calls);
     }
 
     public static function removeNoFillProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60710
| License       | MIT

`bin/console translation:extract --no-fill <locale>` was leaving the internal `\0NoFill\0` sentinel in YAML files for any catalogue whose translations live outside the default `messages` domain (`validators`, custom domains, or intl-icu variants such as `validators+intl-icu`).

Minimal reproducer from the issue:

```yaml
# before (buggy)
'Description is mandatory': "\0NoFill\0Description is mandatory"

# after (fixed)
'Description is mandatory': ''
```

## Root cause

`TranslationExtractCommand::removeNoFillTranslations()` hardcoded the `'messages'` domain:

```php
foreach ($operation->all('messages') as $key => $message) {
    if (str_starts_with($message, self::NO_FILL_PREFIX)) {
        $operation->set($key, '', 'messages');
    }
}
```

The prefix is added to every extracted message (all domains) at line 185, but only stripped back out for the default domain — so `validators`, `validators+intl-icu`, and any user-defined domain leaked the sentinel to disk.

## Fix

Walk every domain reported by the catalogue:

```php
foreach ($operation->getDomains() as $domain) {
    foreach ($operation->all($domain) as $key => $message) {
        if (str_starts_with($message, self::NO_FILL_PREFIX)) {
            $operation->set($key, '', $domain);
        }
    }
}
```

## Test coverage

Added `testRemoveNoFillTranslationsAcrossAllDomains` — asserts that a catalogue containing NoFill-prefixed messages in `messages`, `validators`, and `validators+intl-icu` has the sentinel cleared from every domain where it appears, leaving untagged entries untouched.

Existing `testRemoveNoFillTranslationsMethod` data provider still passes (updated the mock to return `['messages']` from `getDomains()` so the single-domain behaviour is unchanged).

Full `TranslationExtractCommandTest` suite: 27 tests, 40 assertions, green.

---
_Developed with Claude Code_
_Vibe-coded by Ousama_
