### PR TITLE
[Messenger] Keep deduplication lock when handler throws

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/DeduplicateMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DeduplicateMiddleware.php
@@ -38,12 +38,10 @@ final class DeduplicateMiddleware implements MiddlewareInterface
             $this->lockFactory->createLockFromKey($stamp->getKey())->release();
         }
 
-        try {
-            $envelope = $stack->next()->handle($envelope, $stack);
-        } finally {
-            if ($envelope->last(ReceivedStamp::class) && !$stamp->onlyDeduplicateInQueue()) {
-                $this->lockFactory->createLockFromKey($stamp->getKey())->release();
-            }
+        $envelope = $stack->next()->handle($envelope, $stack);
+
+        if ($envelope->last(ReceivedStamp::class) && !$stamp->onlyDeduplicateInQueue()) {
+            $this->lockFactory->createLockFromKey($stamp->getKey())->release();
         }
 
         return $envelope;

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DeduplicateMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DeduplicateMiddlewareTest.php
@@ -65,4 +65,32 @@ final class DeduplicateMiddlewareTest extends MiddlewareTestCase
         $envelope3 = new Envelope($message3, [new DeduplicateStamp('id')]);
         $decorator->handle($envelope3, $this->getStackMock(true));
     }
+
+    public function testLockIsNotReleasedWhenHandlerThrows()
+    {
+        $store = SemaphoreStore::isSupported() ? new SemaphoreStore() : new FlockStore();
+        $decorator = new DeduplicateMiddleware(new LockFactory($store));
+
+        // Enqueue step — acquires the lock.
+        $enqueue = new Envelope(new DummyMessage('Hello'), [new DeduplicateStamp('id')]);
+        $decorator->handle($enqueue, $this->getStackMock(true));
+
+        // Consumer step — handler throws; the lock must NOT be released so the
+        // failed message keeps its deduplication guarantee while waiting for retry.
+        $consumed = $enqueue->with(new ReceivedStamp('transport'));
+
+        try {
+            $decorator->handle($consumed, $this->getThrowingStackMock());
+            $this->fail('The handler exception must propagate.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Thrown from next middleware.', $e->getMessage());
+        }
+
+        // A new enqueue with the same key must be swallowed (lock still held).
+        $duplicate = new Envelope(new DummyMessage('Hello'), [new DeduplicateStamp('id')]);
+        $decorator->handle($duplicate, $this->getStackMock(false));
+
+        // Release the lock so the test leaves no stale state for re-runs.
+        $decorator->handle($consumed, $this->getStackMock(true));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61917 (part 1)
| License       | MIT

## Problem

`DeduplicateMiddleware` releases the deduplication lock from a `finally` block:

```php
try {
    $envelope = $stack->next()->handle($envelope, $stack);
} finally {
    if ($envelope->last(ReceivedStamp::class) && !$stamp->onlyDeduplicateInQueue()) {
        $this->lockFactory->createLockFromKey($stamp->getKey())->release();
    }
}
```

When the handler throws — which is how Messenger triggers a retry — the exception propagates but the `finally` has already released the lock. While the failed envelope is still sitting on the retry transport, the original producer can enqueue the same key again:

1. Producer dispatches message with key `order-42` → lock acquired.
2. Worker picks it up, handler throws → message goes to retry queue, lock released.
3. User clicks "submit" again → producer dispatches `order-42` again → lock acquired (no deduplication).
4. Retry kicks in → second copy now in flight → duplicate work.

## Fix

Move the release out of `finally` so the lock is only released on successful processing:

```php
$envelope = $stack->next()->handle($envelope, $stack);

if ($envelope->last(ReceivedStamp::class) && !$stamp->onlyDeduplicateInQueue()) {
    $this->lockFactory->createLockFromKey($stamp->getKey())->release();
}
```

On failure the exception still propagates; the lock stays held until either the retry eventually succeeds, or the TTL expires.

## Test

New `testLockIsNotReleasedWhenHandlerThrows`:
- Enqueue step acquires the lock.
- Consumer step throws; the exception is asserted to propagate.
- A fresh enqueue with the same key is then dispatched — `next()` is asserted to never be called, proving the lock is still held and the duplicate was swallowed.

## Scope

Bug fix only, intentionally narrow to fit a maintenance branch:

- Fixes the retry race — the worse failure mode (window = retry-queue residence time, often minutes/hours).
- The complementary failure-transport case raised by @GromNaN (releasing the lock when a definitively failed message is moved to a failure transport) is bounded here by the lock's TTL (default 300s, self-healing). The strict fix requires a new event listener — new public API — so it lives in a follow-up PR on 8.1 that adds `ReleaseDeduplicationLockOnFailureListener`.
- Part 2 of #61917 (TTL renewal on retry) remains deferred.