### PR TITLE
[Mailer][Postmark] Handle alternate error payload shapes for Payload Too Large

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -132,6 +132,47 @@ class PostmarkApiTransportTest extends TestCase
         $transport->send($mail);
     }
 
+    public function testSendThrowsForRequestSizeLimitExceededResponse()
+    {
+        // Postmark returns this alternate payload shape (lowercase "message",
+        // no "ErrorCode") when the request exceeds the service-wide size limit.
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse([
+            'message' => 'Request size limit exceeded',
+            'request_id' => 'abc-123',
+        ], ['http_code' => 413]));
+        $transport = new PostmarkApiTransport('KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = (new Email())
+            ->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: Request size limit exceeded (code 0).');
+        $transport->send($mail);
+    }
+
+    public function testSendThrowsWithStatusCodeFallbackWhenResponseHasNoMessage()
+    {
+        $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse([
+            'request_id' => 'abc-123',
+        ], ['http_code' => 502]));
+        $transport = new PostmarkApiTransport('KEY', $client);
+        $transport->setPort(8984);
+
+        $mail = (new Email())
+            ->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: HTTP 502 (code 0).');
+        $transport->send($mail);
+    }
+
     public function testSendDeliveryEventIsDispatched()
     {
         $client = new MockHttpClient(static fn (string $method, string $url, array $options): ResponseInterface => new JsonMockResponse(['Message' => 'Inactive recipient', 'ErrorCode' => 406], [

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -81,14 +81,17 @@ class PostmarkApiTransport extends AbstractApiTransport
         }
 
         if (200 !== $statusCode) {
+            $errorCode = $result['ErrorCode'] ?? 0;
+            $errorMessage = $result['Message'] ?? $result['message'] ?? 'HTTP '.$statusCode;
+
             // Some delivery issues can be handled silently - route those through EventDispatcher
-            if (null !== $this->dispatcher && self::CODE_INACTIVE_RECIPIENT === $result['ErrorCode']) {
-                $this->dispatcher->dispatch(new PostmarkDeliveryEvent($result['Message'], $result['ErrorCode'], $email->getHeaders()));
+            if (null !== $this->dispatcher && self::CODE_INACTIVE_RECIPIENT === $errorCode) {
+                $this->dispatcher->dispatch(new PostmarkDeliveryEvent($errorMessage, $errorCode, $email->getHeaders()));
 
                 return $response;
             }
 
-            throw new HttpTransportException('Unable to send an email: '.$result['Message'].\sprintf(' (code %d).', $result['ErrorCode']), $response);
+            throw new HttpTransportException('Unable to send an email: '.$errorMessage.\sprintf(' (code %d).', $errorCode), $response);
         }
 
         $sentMessage->setMessageId($result['MessageID']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60297
| License       | MIT

## Problem

`PostmarkApiTransport::doSendApi()` assumed every non-200 response would come back shaped like Postmark's standard error envelope:

```json
{ "ErrorCode": 418, "Message": "I'm a teapot" }
```

But Postmark returns a different shape when the upload exceeds the service-wide size limit (HTTP 413):

```json
{ "message": "Request size limit exceeded", "request_id": "abc-123" }
```

No `ErrorCode`, and the message key is lowercased. As a result, sending an email with oversized attachments crashed with `Undefined array key 'ErrorCode'` / `'Message'` inside the transport — hiding the real 413 error from the caller.

## Fix

Read both keys defensively with sensible fallbacks:

```php
$errorCode    = $result['ErrorCode'] ?? 0;
$errorMessage = $result['Message'] ?? $result['message'] ?? '';
```

The standard envelope is unchanged; the size-limit shape now surfaces a correct `HttpTransportException('Unable to send an email: Request size limit exceeded (code 0).')`.

## Test coverage

Added `testSendThrowsForRequestSizeLimitExceededResponse` — feeds the exact 413 payload from the issue and asserts the thrown `HttpTransportException` carries the lowercased `message`.

Existing `testSendThrowsForErrorResponse` (standard envelope, 418) still passes unchanged. Full suite: 11 tests, 28 assertions, green.
