### PR TITLE
[ObjectMapper] Apply transform-only Map attributes on reverse class mapping

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -61,10 +61,16 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
 
             foreach ($attributes as $attribute) {
                 $map = $attribute->newInstance();
-                // We're forcing the target on a reverse mapping to the property name, doesn't make sense without a source
-                if ($map->source) {
-                    $mappings[] = new Mapping($reflProperty->getName(), $map->source, $map->if, $map->transform);
+                // When no source is given, the implicit source is the target property name.
+                // This lets `#[Map(transform: ...)]` alone apply to same-named properties.
+                $source = $map->source ?? $reflProperty->getName();
+                $sourceRoot = explode('.', str_replace('?.', '.', $source))[0];
+
+                if ($sourceRoot !== $property) {
+                    continue;
                 }
+
+                $mappings[] = new Mapping($reflProperty->getName(), $source, $map->if, $map->transform);
             }
         }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/QuoteWithToys.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/QuoteWithToys.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class QuoteWithToys
+{
+    /**
+     * @param list<Cost> $toys
+     */
+    public function __construct(
+        public string $id,
+        public array $toys = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/QuoteWithToysRequestView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/QuoteWithToysRequestView.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
+
+#[Map(source: QuoteWithToys::class)]
+final class QuoteWithToysRequestView
+{
+    public string $id;
+
+    /** @var list<CostRequestView> */
+    #[Map(transform: new MapCollection(targetClass: CostRequestView::class))]
+    public array $toys = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -32,6 +32,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteWithToys;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteWithToysRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\A as ClassRuleA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\B as ClassRuleB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\C as ClassRuleC;
@@ -823,6 +825,27 @@ final class ObjectMapperTest extends TestCase
 
         $this->assertInstanceOf(CostRequestWithSourceView::class, $costRequestView);
         $this->assertEquals('bar', $costRequestView->foo);
+    }
+
+    public function testClassMapAppliesTransformWithoutExplicitSource()
+    {
+        $classMap = [
+            QuoteWithToys::class => QuoteWithToysRequestView::class,
+            Cost::class => CostRequestView::class,
+        ];
+
+        $quote = new QuoteWithToys('q1', [new Cost(10, 20), new Cost(30, 40)]);
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+
+        $view = $mapper->map($quote);
+
+        $this->assertInstanceOf(QuoteWithToysRequestView::class, $view);
+        $this->assertSame('q1', $view->id);
+        $this->assertCount(2, $view->toys);
+        $this->assertContainsOnlyInstancesOf(CostRequestView::class, $view->toys);
+        $this->assertSame(10, $view->toys[0]->amount);
+        $this->assertSame(40, $view->toys[1]->tax);
     }
 
     public function testMissingSourcePropertiesAreIgnored()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63646
| License       | MIT

## Problem

`ReverseClassObjectMapperMetadataFactory` silently dropped any `Map` attribute that did not carry an explicit `source`:

```php
foreach ($attributes as $attribute) {
    $map = $attribute->newInstance();
    // doesn't make sense without a source
    if ($map->source) {
        $mappings[] = new Mapping($reflProperty->getName(), $map->source, $map->if, $map->transform);
    }
}
```

So the common "transform-only" pattern from the docs was skipped:

```php
final class Store
{
    /** @var list<Toy> */
    #[Map(transform: new MapCollection())]
    public array $toys = [];
}
```

…and the consumer ended up getting the raw `PersistentCollection` straight from Doctrine, breaking property access with:

> Expected argument of type "array", "Doctrine\ORM\PersistentCollection" given at property path "toys".

## Fix

Default the source to the target property name when it is not set explicitly — mirroring how `ReflectionObjectMapperMetadataFactory` already handles same-named mappings — and filter the returned mappings to the requested property's source root so transforms declared on unrelated target properties are no longer broadcast:

```php
foreach ($attributes as $attribute) {
    $map = $attribute->newInstance();
    $source = $map->source ?? $reflProperty->getName();
    $sourceRoot = explode('.', str_replace('?.', '.', $source))[0];

    if ($sourceRoot !== $property) {
        continue;
    }

    $mappings[] = new Mapping($reflProperty->getName(), $source, $map->if, $map->transform);
}
```

The `?.` → `.` normalization keeps nullable-access notation (`contact?.email`) working.

## Test

Added `testClassMapAppliesTransformWithoutExplicitSource` plus two new fixtures (`QuoteWithToys` / `QuoteWithToysRequestView`). The view declares:

```php
#[Map(transform: new MapCollection(targetClass: CostRequestView::class))]
public array $toys = [];
```

The test maps a `QuoteWithToys` with two `Cost` entries and asserts that:
- The property is recognized despite having no `source`.
- Each element is transformed into the expected `CostRequestView`.

Full `ObjectMapperTest` suite: 62 tests, 183 assertions, green (was 61 baseline).
