### PR TITLE
[MonologBridge] Swallow token storage errors in TokenProcessor

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -45,7 +45,17 @@ abstract class AbstractTokenProcessor
     {
         $record['extra'][$this->getKey()] = null;
 
-        if (null !== $token = $this->getToken()) {
+        try {
+            $token = $this->getToken();
+        } catch (\Throwable) {
+            // A log record processor must never throw: it can be triggered from
+            // within an error handler chain (e.g. a deprecation emitted while
+            // the container is still initializing) where the token storage
+            // cannot be resolved yet.
+            return $record;
+        }
+
+        if (null !== $token) {
             $record['extra'][$this->getKey()] = [
                 'authenticated' => (bool) $token->getUser(),
                 'roles' => $token->getRoleNames(),

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 
@@ -38,5 +39,20 @@ class TokenProcessorTest extends TestCase
         $this->assertArrayHasKey('token', $record['extra']);
         $this->assertEquals($token->getUserIdentifier(), $record['extra']['token']['user_identifier']);
         $this->assertEquals(['ROLE_USER'], $record['extra']['token']['roles']);
+    }
+
+    public function testProcessorSwallowsTokenStorageErrors()
+    {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())
+            ->method('getToken')
+            ->willThrowException(new \Error('Call to a member function getRepository() on null'));
+
+        $processor = new TokenProcessor($tokenStorage);
+        $record = RecordFactory::create();
+        $record = $processor($record);
+
+        $this->assertArrayHasKey('token', $record['extra']);
+        $this->assertNull($record['extra']['token']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62148
| License       | MIT

Log processors must never throw. During container bootstrap, `doctrine/orm` 2.20 emits a deprecation while loading `LazyGhostTrait`, which routes through the error handler → Monolog → `TokenProcessor`. That triggers token refresh via `EntityUserProvider::refreshUser()`, which calls `getRepository()` on an `EntityManager` that is still mid-initialization — crash: `Call to a member function getRepository() on null`.

The root cause is re-entrancy between EM bootstrap, security token refresh, and logging, but Monolog Bridge is the right place to put the guard: log record processors by contract must not fail. This PR wraps the `getToken()` call in `AbstractTokenProcessor::doInvoke()` with a `\Throwable` catch and lets the `token` field stay `null` on failure. The existing behavior for the non-throwing path is unchanged.

Reproducer from the original issue: https://github.com/mleyen/token-processor-error

---
_Developed with Claude Code_
_Vibe-coded by Ousama_