### PR TITLE
[RateLimiter] Keep token bucket alive while reservation debt is unpaid

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
@@ -78,7 +78,12 @@ final class TokenBucket implements LimiterStateInterface
 
     public function getExpirationTime(): int
     {
-        return $this->rate->calculateTimeForTokens($this->burstSize);
+        // The bucket must persist long enough to cover both a natural refill
+        // back to the burst size and any outstanding reservation debt — the
+        // latter is tracked by a negative token count. Evicting early would
+        // lose the debt and let a fresh bucket hand out already-reserved
+        // tokens.
+        return $this->rate->calculateTimeForTokens(max($this->burstSize, $this->burstSize - $this->tokens));
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -240,6 +240,21 @@ class TokenBucketLimiterTest extends TestCase
         }
     }
 
+    public function testReservationDebtSurvivesCacheExpiration()
+    {
+        $rate = new Rate(\DateInterval::createFromDateString('10 seconds'), 10);
+        $limiter = $this->createLimiter(10, $rate);
+
+        $limiter->consume(10);
+
+        $this->assertEquals(10, $limiter->reserve(1)->getWaitDuration());
+
+        sleep(11);
+
+        $this->assertEquals(0, $limiter->reserve(9)->getWaitDuration());
+        $this->assertEquals(10, $limiter->reserve(1)->getWaitDuration());
+    }
+
     private function createLimiter($initialTokens = 10, ?Rate $rate = null)
     {
         return new TokenBucketLimiter('test', $initialTokens, $rate ?? Rate::perSecond(10), $this->storage);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62688
| License       | MIT

`TokenBucket::getExpirationTime()` returned `calculateTimeForTokens(burstSize)` — the time it takes to refill an empty bucket. When `reserve()` drives the token count below zero (for a reservation that has to wait for the next refill), the bucket still gets saved back to storage with that same short TTL. If the cache evicts the bucket before the debt is paid off, the next `fetch()` returns `null`, a fresh full bucket is created, and the pending reservation silently vanishes — letting the client claim tokens that were already promised elsewhere.

This PR makes the TTL track the outstanding debt: `max(burstSize, burstSize - tokens)`. For non-negative `tokens` the expression equals the old value, so behavior is unchanged on the happy path. Added a regression test that consumes the bucket, reserves a token against the next window, sleeps past the previous TTL, and confirms that the debt survives the round-trip.

This fixes the **TokenBucket** half of the reporter's analysis. #61668 tracks the analogous FixedWindow case; I kept that one out of scope since the state shape differs and the fix there is not the same mechanical change.

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
