### PR TITLE
[Security] Fix local login rate limiter to key on username only

### DIFF
--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\SecurityRequestAttributes;
  * A default login throttling limiter.
  *
  * This limiter prevents breadth-first attacks by enforcing
- * a limit on username+IP and a (higher) limit on IP.
+ * a limit on username and a (higher) limit on IP.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
@@ -52,7 +52,7 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
 
         return [
             $this->globalFactory->create($this->hash($request->getClientIp())),
-            $this->localFactory->create($this->hash($username.'-'.$request->getClientIp())),
+            $this->localFactory->create($this->hash($username)),
         ];
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -84,6 +84,24 @@ class LoginThrottlingListenerTest extends TestCase
         $this->listener->checkPassport($this->createCheckPassportEvent($passports[0]));
     }
 
+    public function testLocalLimiterIsPerUsernameAcrossIPs()
+    {
+        $passports = [$this->createPassport('wouter'), $this->createPassport('wouter')];
+
+        for ($i = 0; $i < 3; ++$i) {
+            $request = $this->createRequest('192.168.1.'.$i);
+            $this->requestStack->push($request);
+            $this->listener->checkPassport($this->createCheckPassportEvent($passports[0]));
+            $this->listener->onFailedLogin($this->createLoginFailedEvent($passports[0]));
+            $this->requestStack->pop();
+        }
+
+        $request = $this->createRequest('192.168.1.99');
+        $this->requestStack->push($request);
+        $this->expectException(TooManyLoginAttemptsAuthenticationException::class);
+        $this->listener->checkPassport($this->createCheckPassportEvent($passports[1]));
+    }
+
     public function testPreventsLoginWhenOverGlobalThreshold()
     {
         $request = $this->createRequest();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61932
| License       | MIT

Using the client IP in the local login rate limiter exposes the risk of brute force attacks (bypassed by rotating IPs).

This patch fixes it by relying on username only.
