### PR TITLE
[PropertyInfo][Serializer] Add opt-in default groups

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 ---
 
  * Add support for property hook settable types in `ReflectionExtractor`
+ * Support `enable_default_groups` context option in `SerializerExtractor`
 
 7.3
 ---

--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -38,11 +38,36 @@ class SerializerExtractor implements PropertyListExtractorInterface
             return null;
         }
 
+        // Read the key as a literal rather than via AbstractNormalizer::ENABLE_DEFAULT_GROUPS, as
+        // PropertyInfo is compatible with older Serializer versions that lack the constant.
+        $enableDefaultGroups = $context['enable_default_groups'] ?? false;
+
+        $groups = $context['serializer_groups'] ?? [];
+        $defaultGroups = ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class];
+
+        $groupsHasBeenDefined = $enableDefaultGroups
+            ? [] !== $groups
+            : null !== ($context['serializer_groups'] ?? null);
+
+        $customGroupsHasBeenDefined = (bool) array_diff($groups, $defaultGroups);
+
+        if ($enableDefaultGroups && !$customGroupsHasBeenDefined) {
+            $groups = array_merge($groups, $defaultGroups);
+        }
+
         $properties = [];
         $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            if (!$serializerAttributeMetadata->isIgnored() && (null === $context['serializer_groups'] || \in_array('*', $context['serializer_groups'], true) || array_intersect($serializerAttributeMetadata->getGroups(), $context['serializer_groups']))) {
+            if ($serializerAttributeMetadata->isIgnored()) {
+                continue;
+            }
+
+            if (!($attributeGroups = $serializerAttributeMetadata->getGroups()) && $enableDefaultGroups && !$customGroupsHasBeenDefined) {
+                $attributeGroups = $defaultGroups;
+            }
+
+            if (!$groupsHasBeenDefined || \in_array('*', $groups, true) || array_intersect($attributeGroups, $groups)) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\GroupPropertyDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IgnorePropertyDummy;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -53,5 +54,86 @@ class SerializerExtractorTest extends TestCase
     public function testGetPropertiesWithNonExistentClassReturnsNull()
     {
         $this->assertNull($this->extractor->getProperties('NonExistent'));
+    }
+
+    public function testGetPropertiesWithDefaultGroups()
+    {
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => null]),
+        );
+
+        $this->assertSame(
+            [],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => []]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['*']]),
+        );
+
+        $this->assertSame(
+            ['customGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['custom']]),
+        );
+
+        $this->assertSame(
+            ['defaultGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['Default']]),
+        );
+
+        $this->assertSame(
+            ['classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, ['serializer_groups' => ['GroupPropertyDummy']]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => null,
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => [],
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['*'],
+            ]),
+        );
+
+        $this->assertSame(
+            ['customGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['custom'],
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['Default'],
+            ]),
+        );
+
+        $this->assertSame(
+            ['noGroup', 'defaultGroup', 'classGroup'],
+            $this->extractor->getProperties(GroupPropertyDummy::class, [
+                'enable_default_groups' => true,
+                'serializer_groups' => ['GroupPropertyDummy'],
+            ]),
+        );
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/GroupPropertyDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/GroupPropertyDummy.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+class GroupPropertyDummy
+{
+    public bool $noGroup = true;
+
+    #[Groups('custom')]
+    public bool $customGroup = true;
+
+    #[Groups('Default')]
+    public bool $defaultGroup = true;
+
+    #[Groups('GroupPropertyDummy')]
+    public bool $classGroup = true;
+}

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
  * Add `COLLECT_EXTRA_ATTRIBUTES_ERRORS` option to `Serializer` to collect extra-attributes errors during denormalization
  * Deprecate `PartialDenormalizationException::getErrors()`, use `getNotNormalizableValueErrors()` instead
  * Enable using `#[WithAccessors]` from the PropertyInfo component with the serializer
+ * Add `AbstractNormalizer::ENABLE_DEFAULT_GROUPS` context option to opt into implicit `Default` and class-short-name groups for attributes without explicit `#[Groups]`, mirroring Validator group conventions
 
 8.0
 ---

--- a/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
+++ b/src/Symfony/Component/Serializer/Context/Normalizer/AbstractNormalizerContextBuilder.php
@@ -189,4 +189,13 @@ abstract class AbstractNormalizerContextBuilder implements ContextBuilderInterfa
     {
         return $this->with(AbstractNormalizer::REQUIRE_ALL_PROPERTIES, $requireAllProperties);
     }
+
+    /**
+     * Configures whether 'Default' and class-short-name groups are added when no
+     * custom group is specified.
+     */
+    public function withEnableDefaultGroups(?bool $enableDefaultGroups): static
+    {
+        return $this->with(AbstractNormalizer::ENABLE_DEFAULT_GROUPS, $enableDefaultGroups);
+    }
 }

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -82,6 +82,13 @@ final class MetadataAwareNameConverter implements NameConverterInterface
 
         $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
 
+        if ($context[AbstractNormalizer::ENABLE_DEFAULT_GROUPS] ?? false) {
+            $defaultGroups = ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class];
+            if (!array_diff($contextGroups, $defaultGroups)) {
+                $contextGroups = array_merge($contextGroups, $defaultGroups);
+            }
+        }
+
         if (null !== $attributesMetadata[$propertyName]->getSerializedName($contextGroups) && null !== $attributesMetadata[$propertyName]->getSerializedPath($contextGroups)) {
             throw new LogicException(\sprintf('Found SerializedName and SerializedPath attributes on property "%s" of class "%s".', $propertyName, $class));
         }
@@ -120,25 +127,39 @@ final class MetadataAwareNameConverter implements NameConverterInterface
 
         $classMetadata = $this->metadataFactory->getMetadataFor($class);
 
-        $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
+        $enableDefaultGroups = $context[AbstractNormalizer::ENABLE_DEFAULT_GROUPS] ?? false;
+
+        $groups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
+        $defaultGroups = ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class];
+
+        $groupsHasBeenDefined = [] !== $groups;
+        $customGroupsHasBeenDefined = (bool) array_diff($groups, $defaultGroups);
+
+        if ($enableDefaultGroups && !$customGroupsHasBeenDefined) {
+            $groups = array_merge($groups, $defaultGroups);
+        }
 
         $cache = [];
         foreach ($classMetadata->getAttributesMetadata() as $name => $metadata) {
-            if (null === $serializedName = $metadata->getSerializedName($contextGroups)) {
+            if (null === $serializedName = $metadata->getSerializedName($groups)) {
                 continue;
             }
 
-            if (null !== $metadata->getSerializedPath($contextGroups)) {
+            if (null !== $metadata->getSerializedPath($groups)) {
                 throw new LogicException(\sprintf('Found SerializedName and SerializedPath attributes on property "%s" of class "%s".', $name, $class));
             }
 
-            $metadataGroups = $metadata->getGroups();
+            $metadataGroups = $metadata->getGroups()
+                ?: ($enableDefaultGroups && !$customGroupsHasBeenDefined ? $defaultGroups : []);
 
-            if ($contextGroups && !$metadataGroups) {
+            if ($metadataGroups && !array_intersect(array_merge($metadataGroups, ['*']), $groups)) {
                 continue;
             }
 
-            if ($metadataGroups && !array_intersect($metadataGroups, $contextGroups) && !\in_array('*', $contextGroups, true)) {
+            // When the flag is off, preserve legacy semantics: any non-empty context
+            // groups (including ['*']) skips ungrouped properties. When the flag is on,
+            // ['*'] keeps them.
+            if (!$metadataGroups && $groupsHasBeenDefined && (!$enableDefaultGroups || !\in_array('*', $groups, true))) {
                 continue;
             }
 
@@ -154,6 +175,6 @@ final class MetadataAwareNameConverter implements NameConverterInterface
             return $class.'-'.$context['cache_key'];
         }
 
-        return $class.hash('xxh128', serialize($context[AbstractNormalizer::GROUPS] ?? []));
+        return $class.hash('xxh128', serialize($context[AbstractNormalizer::GROUPS] ?? []).serialize($context[AbstractNormalizer::ENABLE_DEFAULT_GROUPS] ?? false));
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -148,6 +148,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     public const SKIP_INVALID_ATTRIBUTES = 'skip_invalid_attributes';
 
     /**
+     * Add 'Default' and class-short-name groups when no custom group is specified.
+     */
+    public const ENABLE_DEFAULT_GROUPS = 'enable_default_groups';
+
+    /**
      * @internal
      */
     protected const CIRCULAR_REFERENCE_LIMIT_COUNTERS = 'circular_reference_limit_counters';
@@ -241,24 +246,47 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return false;
         }
 
+        $classMetadata = $this->classMetadataFactory->getMetadataFor($classOrObject);
+        $class = $classMetadata->getName();
+
+        $enableDefaultGroups = $context[self::ENABLE_DEFAULT_GROUPS] ?? $this->defaultContext[self::ENABLE_DEFAULT_GROUPS] ?? false;
+
         $groups = $this->getGroups($context);
         $ignoredGroups = $this->getIgnoredGroups($context);
+        $defaultGroups = ['Default', (false !== $nsSep = strrpos($class, '\\')) ? substr($class, $nsSep + 1) : $class];
+
+        // Capture before the merge below, so it reflects the user's intent rather than
+        // the post-merge state.
+        $groupsHasBeenDefined = [] !== $groups;
+        $customGroupsHasBeenDefined = (bool) array_diff($groups, $defaultGroups);
+
+        if ($enableDefaultGroups && !$customGroupsHasBeenDefined) {
+            $groups = array_merge($groups, $defaultGroups);
+        }
 
         $allowedAttributes = [];
         $ignoreUsed = false;
 
-        foreach ($this->classMetadataFactory->getMetadataFor($classOrObject)->getAttributesMetadata() as $attributeMetadata) {
+        foreach ($classMetadata->getAttributesMetadata() as $attributeMetadata) {
             if ($ignore = $attributeMetadata->isIgnored()) {
                 $ignoreUsed = true;
             }
 
-            // If you update this check, update accordingly the one in Symfony\Component\PropertyInfo\Extractor\SerializerExtractor::getProperties()
-            if (
-                !$ignore
-                && (!$groups || \in_array('*', $groups, true) || array_intersect($attributeMetadata->getGroups(), $groups))
-                && (!$ignoredGroups || !array_intersect($attributeMetadata->getGroups(), $ignoredGroups))
-                && $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
-            ) {
+            // If you update these checks, update accordingly the one in Symfony\Component\PropertyInfo\Extractor\SerializerExtractor::getProperties()
+            if ($ignore || !$this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)) {
+                continue;
+            }
+
+            if (!($attributeGroups = $attributeMetadata->getGroups()) && $enableDefaultGroups && !$customGroupsHasBeenDefined) {
+                $attributeGroups = $defaultGroups;
+            }
+
+            // the synthesized groups count for exclusion too: ignoring "Default" excludes ungrouped attributes
+            if ($ignoredGroups && array_intersect($attributeGroups, $ignoredGroups)) {
+                continue;
+            }
+
+            if (!$groupsHasBeenDefined || \in_array('*', $groups, true) || array_intersect($attributeGroups, $groups)) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/Normalizer/AbstractNormalizerContextBuilderTest.php
@@ -46,6 +46,7 @@ class AbstractNormalizerContextBuilderTest extends TestCase
             ->withCircularReferenceHandler($values[AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER])
             ->withIgnoredAttributes($values[AbstractNormalizer::IGNORED_ATTRIBUTES])
             ->withRequireAllProperties($values[AbstractNormalizer::REQUIRE_ALL_PROPERTIES])
+            ->withEnableDefaultGroups($values[AbstractNormalizer::ENABLE_DEFAULT_GROUPS])
             ->toArray();
 
         $this->assertEquals($values, $context);
@@ -67,6 +68,7 @@ class AbstractNormalizerContextBuilderTest extends TestCase
             AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => static function (): void {},
             AbstractNormalizer::IGNORED_ATTRIBUTES => ['attribute3'],
             AbstractNormalizer::REQUIRE_ALL_PROPERTIES => true,
+            AbstractNormalizer::ENABLE_DEFAULT_GROUPS => false,
         ]];
 
         yield 'With null values' => [[
@@ -80,6 +82,7 @@ class AbstractNormalizerContextBuilderTest extends TestCase
             AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => null,
             AbstractNormalizer::IGNORED_ATTRIBUTES => null,
             AbstractNormalizer::REQUIRE_ALL_PROPERTIES => null,
+            AbstractNormalizer::ENABLE_DEFAULT_GROUPS => null,
         ]];
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/DefaultGroupsDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/DefaultGroupsDummy.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+class DefaultGroupsDummy
+{
+    public string $noGroup = 'noGroup';
+
+    #[Groups(['custom'])]
+    public string $customGroup = 'customGroup';
+
+    #[Groups(['Default'])]
+    public string $defaultGroup = 'defaultGroup';
+
+    #[Groups(['DefaultGroupsDummy'])]
+    public string $classGroup = 'classGroup';
+
+    public function getNoGroup(): string
+    {
+        return $this->noGroup;
+    }
+
+    public function getCustomGroup(): string
+    {
+        return $this->customGroup;
+    }
+
+    public function getDefaultGroup(): string
+    {
+        return $this->defaultGroup;
+    }
+
+    public function getClassGroup(): string
+    {
+        return $this->classGroup;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
@@ -28,6 +28,12 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     private $fooBar;
     private $symfony;
 
+    #[Groups(['Default'])]
+    private $default;
+
+    #[Groups(['GroupDummy'])]
+    private $className;
+
     #[Groups(['b'])]
     public function setBar($bar)
     {
@@ -69,6 +75,26 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     public function getSymfony()
     {
         return $this->symfony;
+    }
+
+    public function setDefault($default)
+    {
+        $this->default = $default;
+    }
+
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    public function setClassName($className)
+    {
+        $this->className = $className;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
     }
 
     public function getQuux()

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
@@ -19,6 +19,18 @@ use Symfony\Component\Serializer\Attribute\SerializedName;
  */
 class OtherSerializedNameDummy
 {
+    #[Groups(['Default']), SerializedName('renamedDefaultGroup')]
+    private $defaultGroup;
+
+    #[Groups(['OtherSerializedNameDummy']), SerializedName('renamedClassGroup')]
+    public $classGroup;
+
+    #[SerializedName('renamedNoGroup')]
+    public $noGroup;
+
+    #[Groups(['custom']), SerializedName('renamedCustomGroup')]
+    public $customGroup;
+
     #[Groups(['a'])]
     private $buz;
 

--- a/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
@@ -47,6 +47,14 @@ class TestClassMetadataFactory
         $symfony = new AttributeMetadata('symfony');
         $expected->addAttributeMetadata($symfony);
 
+        $default = new AttributeMetadata('default');
+        $default->addGroup('Default');
+        $expected->addAttributeMetadata($default);
+
+        $className = new AttributeMetadata('className');
+        $className->addGroup('GroupDummy');
+        $expected->addAttributeMetadata($className);
+
         if ($withParent) {
             $kevin = new AttributeMetadata('kevin');
             $kevin->addGroup('a');

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -145,7 +145,7 @@ final class MetadataAwareNameConverterTest extends TestCase
         $this->assertEquals($expected, $nameConverter->denormalize($propertyName, OtherSerializedNameDummy::class, null, $context));
     }
 
-    #[DataProvider('fallbackAttributeAndContextProvider')]
+    #[DataProvider('denormalizeFallbackAttributeAndContextProvider')]
     public function testDenormalizeWithGroupsAndFallback(string $expected, string $propertyName, array $context = [])
     {
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
@@ -198,6 +198,76 @@ final class MetadataAwareNameConverterTest extends TestCase
             ['puux', 'puxi', ['groups' => ['i']]],
             ['puux', 'puxa', ['groups' => ['a']]],
             ['puux', 'PUUX', ['groups' => ['z']]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => [], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+        ];
+    }
+
+    public static function denormalizeFallbackAttributeAndContextProvider(): array
+    {
+        return [
+            ['buz', 'BUZ', ['groups' => ['a']]],
+            ['buzForExport', 'buz', ['groups' => ['b']]],
+            ['buz', 'BUZ', ['groups' => 'a']],
+            ['buzForExport', 'buz', ['groups' => 'b']],
+            ['buz', 'BUZ', ['groups' => ['c']]],
+            ['buz', 'BUZ', []],
+            ['buzForExport', 'buz', ['groups' => ['*']]],
+            ['duux', 'duxi', ['groups' => ['*']]],
+            ['duux', 'duxa', ['groups' => ['a']]],
+            ['puux', 'PUUX', []],
+            ['puux', 'PUUX', ['groups' => ['*']]],
+            ['puux', 'puxi', ['groups' => ['i']]],
+            ['puux', 'puxa', ['groups' => ['a']]],
+            ['puux', 'PUUX', ['groups' => ['z']]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => [], 'enable_default_groups' => true]],
+            ['customgroup', 'customGroup', ['groups' => [], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['*'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+            ['customgroup', 'customGroup', ['groups' => ['Default'], 'enable_default_groups' => true]],
+
+            ['defaultGroup', 'renamedDefaultGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['classGroup', 'renamedClassGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['noGroup', 'renamedNoGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+            ['customgroup', 'customGroup', ['groups' => ['OtherSerializedNameDummy'], 'enable_default_groups' => true]],
+
+            ['defaultgroup', 'defaultGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['classgroup', 'classGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['nogroup', 'noGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
+            ['customGroup', 'renamedCustomGroup', ['groups' => ['custom'], 'enable_default_groups' => true]],
         ];
     }
 
@@ -210,6 +280,18 @@ final class MetadataAwareNameConverterTest extends TestCase
         $this->assertEquals('buz', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class, null, ['groups' => ['a']]));
         $this->assertEquals('buzForExport', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class, null, ['groups' => ['b']]));
         $this->assertEquals('buz', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class));
+    }
+
+    public function testDenormalizeUngroupedSerializedNameWithStarGroup()
+    {
+        // BC: with the default-groups flag OFF, a property carrying SerializedName
+        // but no #[Groups] must NOT be resolved when groups=['*']. Pre-feature, the
+        // condition `$contextGroups && !$metadataGroups` skipped it; the rewrite
+        // must preserve that.
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+
+        $this->assertEquals('renamedNoGroup', $nameConverter->denormalize('renamedNoGroup', OtherSerializedNameDummy::class, null, ['groups' => ['*']]));
     }
 
     public function testDenormalizeWithNestedPathAndName()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -94,6 +94,24 @@ class AbstractNormalizerTest extends TestCase
         $this->assertEquals(['a1', 'a2', 'a3'], $result);
     }
 
+    public function testIgnoringTheDefaultGroupExcludesUngroupedAttributesWhenDefaultGroupsAreEnabled()
+    {
+        $classMetadata = new ClassMetadata('c');
+        $a1 = new AttributeMetadata('a1');
+        $classMetadata->addAttributeMetadata($a1);
+        $a2 = new AttributeMetadata('a2');
+        $a2->addGroup('g');
+        $classMetadata->addAttributeMetadata($a2);
+
+        $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
+
+        $context = [AbstractNormalizer::ENABLE_DEFAULT_GROUPS => true, AbstractNormalizer::IGNORED_GROUPS => ['Default']];
+        // the synthesized groups count for exclusion too: a1 belongs to them, a2 keeps its own group
+        $this->assertEquals(['a2'], array_values($this->normalizer->getAllowedAttributes('c', $context + [AbstractNormalizer::GROUPS => ['g']], true)));
+        // without explicit groups every non-ignored attribute stays allowed; only a1 is excluded through the synthesized groups
+        $this->assertEquals(['a2'], array_values($this->normalizer->getAllowedAttributes('c', $context, true)));
+    }
+
     public function testGetAllowedAttributesWithWildcardGroupAndNoMetadata()
     {
         $classMetadata = new ClassMetadata('c');

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/GroupsTestTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\DefaultGroupsDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 
 /**
@@ -87,5 +88,140 @@ trait GroupsTestTrait
         $obj->setFoo('foo');
 
         $this->assertEquals([], $normalizer->normalize($obj, null, ['groups' => ['notExist']]));
+    }
+
+    public function testNormalizeWithDefaultGroups()
+    {
+        $normalizer = $this->getNormalizerForGroups();
+
+        $assertNormalizedProperties = function (array $expectedProperties, array $normalized): void {
+            $actualProperties = array_keys($normalized);
+
+            sort($expectedProperties);
+            sort($actualProperties);
+
+            $this->assertSame($expectedProperties, $actualProperties);
+        };
+
+        $assertNormalizedProperties(
+            ['foo', 'fooBar', 'symfony', 'kevin', 'coopTilleuls'],
+            $normalizer->normalize(new GroupDummy(), context: ['groups' => ['a']]),
+        );
+
+        $assertNormalizedProperties(
+            ['bar', 'foo', 'fooBar', 'symfony', 'quux', 'default', 'className', 'kevin', 'coopTilleuls'],
+            $normalizer->normalize(new GroupDummy()),
+        );
+
+        $assertNormalizedProperties(
+            ['bar', 'foo', 'fooBar', 'symfony', 'quux', 'default', 'className', 'kevin', 'coopTilleuls'],
+            $normalizer->normalize(new GroupDummy(), context: ['groups' => []]),
+        );
+
+        $assertNormalizedProperties(
+            ['foo', 'bar', 'quux', 'fooBar', 'symfony', 'default', 'className', 'kevin', 'coopTilleuls'],
+            $normalizer->normalize(new GroupDummy(), context: ['groups' => ['*']]),
+        );
+
+        $assertNormalizedProperties(
+            ['default'],
+            $normalizer->normalize(new GroupDummy(), context: ['groups' => ['Default']]),
+        );
+
+        $assertNormalizedProperties(
+            ['className'],
+            $normalizer->normalize(new GroupDummy(), context: ['groups' => ['GroupDummy']]),
+        );
+
+        $assertNormalizedProperties(
+            ['foo', 'fooBar', 'symfony', 'kevin', 'coopTilleuls'],
+            $normalizer->normalize(new GroupDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => ['a'],
+            ]),
+        );
+
+        $assertNormalizedProperties(
+            ['bar', 'foo', 'fooBar', 'symfony', 'quux', 'default', 'className', 'kevin', 'coopTilleuls'],
+            $normalizer->normalize(new GroupDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => [],
+            ]),
+        );
+
+        $assertNormalizedProperties(
+            ['foo', 'bar', 'quux', 'fooBar', 'symfony', 'default', 'className', 'kevin', 'coopTilleuls'],
+            $normalizer->normalize(new GroupDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => ['*'],
+            ]),
+        );
+
+        $assertNormalizedProperties(
+            ['default', 'className'],
+            $normalizer->normalize(new GroupDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => ['Default'],
+            ]),
+        );
+
+        $assertNormalizedProperties(
+            ['default', 'className'],
+            $normalizer->normalize(new GroupDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => ['GroupDummy'],
+            ]),
+        );
+    }
+
+    public function testNormalizeWithDefaultGroupsAndUngroupedProperty()
+    {
+        $normalizer = $this->getNormalizerForGroups();
+
+        $assertNormalizedProperties = function (array $expectedProperties, array $normalized): void {
+            $actualProperties = array_keys($normalized);
+
+            sort($expectedProperties);
+            sort($actualProperties);
+
+            $this->assertSame($expectedProperties, $actualProperties);
+        };
+
+        // Ungrouped properties match Default and class-short-name groups when the flag is on.
+        $assertNormalizedProperties(
+            ['noGroup', 'defaultGroup', 'classGroup'],
+            $normalizer->normalize(new DefaultGroupsDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => ['Default'],
+            ]),
+        );
+
+        $assertNormalizedProperties(
+            ['noGroup', 'defaultGroup', 'classGroup'],
+            $normalizer->normalize(new DefaultGroupsDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => ['DefaultGroupsDummy'],
+            ]),
+        );
+
+        // A custom group excludes ungrouped properties even when the flag is on.
+        $assertNormalizedProperties(
+            ['customGroup'],
+            $normalizer->normalize(new DefaultGroupsDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => ['custom'],
+            ]),
+        );
+
+        // groups=[] with flag on: $groupsHasBeenDefined must be captured before the
+        // implicit defaultGroups merge, otherwise properties with non-Default groups
+        // (like customGroup) would wrongly be filtered out.
+        $assertNormalizedProperties(
+            ['noGroup', 'customGroup', 'defaultGroup', 'classGroup'],
+            $normalizer->normalize(new DefaultGroupsDummy(), context: [
+                'enable_default_groups' => true,
+                'groups' => [],
+            ]),
+        );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -227,6 +227,8 @@ class PropertyNormalizerTest extends TestCase
                 'coopTilleuls' => 'coop',
                 'fooBar' => null,
                 'symfony' => null,
+                'default' => null,
+                'className' => null,
                 'baz' => 'baz',
             ],
             $this->normalizer->normalize($group, 'any')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #32622
| License       | MIT

Serializing with groups silently drops every attribute that carries no `#[Groups]` attribute, while the Validator has always treated such properties as belonging to the implicit `Default` and class-short-name groups. The new opt-in `AbstractNormalizer::ENABLE_DEFAULT_GROUPS` context flag aligns the Serializer with that convention:

```php
class Book
{
    #[Groups(['read'])]
    public string $name = 'A';

    public string $foo = 'B';   // no #[Groups]
}

$serializer->normalize($book, context: ['groups' => ['read']]);
// ['name' => 'A']                     unchanged: 'read' is a custom group

$serializer->normalize($book, context: ['groups' => ['Default'], 'enable_default_groups' => true]);
// ['name' => 'A', 'foo' => 'B']      $foo belongs to the implicit groups

$serializer->normalize($book, context: ['groups' => ['Book'], 'enable_default_groups' => true]);
// ['name' => 'A', 'foo' => 'B']      the class short name works like in the Validator
```

Semantics, each pinned by a test:

* the implicit groups are `Default` and the class short name, exactly the Validator's convention;
* they only apply while no custom group is requested: as soon as the context asks for a group outside those two, declared groups keep their exact meaning and ungrouped attributes stay excluded;
* everything is byte-for-byte unchanged while the flag is off, including `MetadataAwareNameConverter`, whose regression reverted the previous attempt (#51514);
* the implicit groups count everywhere groups do: attribute visibility, `ignored_groups` exclusion (`ignored_groups: ['Default']` with the flag on excludes ungrouped attributes), per-group `SerializedName`/`SerializedPath` resolution in both directions, and PropertyInfo's `SerializerExtractor` through the `enable_default_groups` context key.

Enable it application-wide through the existing context plumbing, like `enable_max_depth`:

```yaml
framework:
    serializer:
        default_context:
            enable_default_groups: true
```

Continuation of #58656 by @mtarld, itself replacing #51514, which was reverted for BC breaks; the flag makes the behaviour strictly opt-in.

Documentation should cover: the flag and the Validator-parity rule, that custom groups disable the synthesis, the `default_context` configuration, the `ignored_groups` interaction, and the PropertyInfo context key.
