### PR TITLE
[Serializer] Improve `NotNormalizableValueException` message in `BackedEnumNormalizer`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -360,8 +360,8 @@ class RequestPayloadValueResolverTest extends TestCase
             $this->assertSame(422, $e->getStatusCode());
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertContains($validationFailedException->getViolations()[0]->getMessage(), [
+                'This value was of an unexpected type.',
                 'This value should be of type int|string.',
-                'The data must belong to a backed enumeration of type Symfony\\Component\\HttpKernel\\Tests\\Controller\\ArgumentResolver\\RequestMethod',
             ]);
         }
     }

--- a/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/BackedEnumNormalizer.php
@@ -79,7 +79,12 @@ final class BackedEnumNormalizer implements NormalizerInterface, DenormalizerInt
                 throw NotNormalizableValueException::createForUnexpectedDataType('The data must be of type '.$backingType, $data, [$backingType], $context['deserialization_path'] ?? null, true, 0, $e);
             }
 
-            throw NotNormalizableValueException::createForUnexpectedDataType('The data must belong to a backed enumeration of type '.$type, $data, ['int', 'string'], $context['deserialization_path'] ?? null, true, 0, $e);
+            $expectedValues = array_map(
+                static fn ($type) => \sprintf('%s%s%1$s', \is_string($type->value) ? '"' : '', $type->value),
+                $type::cases(),
+            );
+
+            throw new NotNormalizableValueException('The data must be one of the following values: '.implode(', ', $expectedValues), 0, $e, $type, null, $context['deserialization_path'] ?? null, true);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/BackedEnumNormalizerTest.php
@@ -103,7 +103,7 @@ class BackedEnumNormalizerTest extends TestCase
     public function testDenormalizeInvalidIntegerBackedValueThrowsException()
     {
         $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data must belong to a backed enumeration of type '.IntegerBackedEnumDummy::class);
+        $this->expectExceptionMessage('The data must be one of the following values: 200, 404');
 
         $this->normalizer->denormalize(300, IntegerBackedEnumDummy::class);
     }
@@ -111,7 +111,7 @@ class BackedEnumNormalizerTest extends TestCase
     public function testDenormalizeInvalidStringBackedValueThrowsException()
     {
         $this->expectException(NotNormalizableValueException::class);
-        $this->expectExceptionMessage('The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class);
+        $this->expectExceptionMessage('The data must be one of the following values: "GET", "OPTIONS"');
 
         $this->normalizer->denormalize('POST', StringBackedEnumDummy::class);
     }
@@ -173,10 +173,10 @@ class BackedEnumNormalizerTest extends TestCase
             self::fail(\sprintf('Failed asserting that exception of type "%s" is thrown.', NotNormalizableValueException::class));
         } catch (NotNormalizableValueException $e) {
             $this->assertSame('get', $e->getPath());
-            $this->assertSame('string', $e->getCurrentType());
-            $this->assertSame(['int', 'string'], $e->getExpectedTypes());
+            $this->assertSame(StringBackedEnumDummy::class, $e->getCurrentType());
+            $this->assertNull($e->getExpectedTypes());
             $this->assertTrue($e->canUseMessageForUser());
-            $this->assertSame('The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class, $e->getMessage());
+            $this->assertSame('The data must be one of the following values: "GET", "OPTIONS"', $e->getMessage());
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1544,9 +1544,9 @@ class SerializerTest extends TestCase
 
         $expected = [
             [
-                'currentType' => 'string',
+                'currentType' => StringBackedEnumDummy::class,
                 'useMessageForUser' => true,
-                'message' => 'The data must belong to a backed enumeration of type '.StringBackedEnumDummy::class,
+                'message' => 'The data must be one of the following values: "GET", "OPTIONS"',
             ],
         ];
 
@@ -1578,10 +1578,10 @@ class SerializerTest extends TestCase
 
             $this->assertSame([
                 [
-                    'currentType' => 'string',
+                    'currentType' => StringBackedEnumDummy::class,
                     'path' => 'get',
                     'useMessageForUser' => true,
-                    'message' => 'The data must belong to a backed enumeration of type Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy',
+                    'message' => 'The data must be one of the following values: "GET", "OPTIONS"',
                 ],
             ], $exceptionsAsArray);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/62574#issuecomment-4244091498
| License       | MIT

A part of #62574 has been removed by a merge commit; this PR reinstates it.