### PR TITLE
Add Unicode join normalization coverage

### DIFF
--- a/src/Symfony/Component/String/Tests/UnicodeStringTest.php
+++ b/src/Symfony/Component/String/Tests/UnicodeStringTest.php
@@ -17,6 +17,15 @@ use Symfony\Component\String\UnicodeString;
 
 class UnicodeStringTest extends AbstractUnicodeTestCase
 {
+    public function testJoinNormalizesJoinedStrings(): void
+    {
+        // "é" in NFC (\xC3\xA9) vs NFD (\x65\xCC\x81)
+        $nfc = "\xC3\xA9";
+        $nfd = "\x65\xCC\x81";
+
+        $this->assertSame($nfc.', '.$nfc.' and '.$nfc, (string) (new UnicodeString(', '))->join([$nfd, $nfd, $nfd], ' and '));
+    }
+
     #[DataProvider('provideTrimNormalization')]
     public function testTrimPrefixNormalization(string $expected, string $string, $prefix)
     {


### PR DESCRIPTION

**Repo:** symfony/symfony (⭐ 29000)
**Type:** test
**Files changed:** 1
**Lines:** +9/-0

## What
Adds a focused regression test in the String component to verify that `UnicodeString::join()` returns a normalized NFC result even when the joined input strings are provided in decomposed NFD form.

## Why
`UnicodeString` overrides `join()` specifically to normalize the joined output, but the existing test suite did not lock that behavior in. This test protects against regressions where joining decomposed Unicode strings could return non-normalized output and make later comparisons behave inconsistently.

## Testing
Attempted to run `./phpunit src/Symfony/Component/String/Tests/UnicodeStringTest.php`, but the environment does not have `php` installed (`env: php: No such file or directory`). Ran `git diff --check` successfully.

## Risk
Low - test-only change in a single existing test file, with no production code impact.
