### PR TITLE
 Improve phpdoc types

### DIFF
--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -35,16 +35,16 @@ interface OutputInterface
      * Writes a message to the output.
      *
      * @param bool $newline Whether to add a newline
-     * @param int  $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
-     *                      0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
+     * @param int-mask-of<self::OUTPUT_::*|self::VERBOSITY::*>  $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
+     *                                                                   0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
      */
     public function write(string|iterable $messages, bool $newline = false, int $options = 0): void;
 
     /**
      * Writes a message to the output and adds a newline at the end.
      *
-     * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
-     *                     0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
+     * @param int-mask-of<self::OUTPUT_::*|self::VERBOSITY::*>  $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
+     *                                                                   0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
      */
     public function writeln(string|iterable $messages, int $options = 0): void;
 

--- a/src/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.php
@@ -49,6 +49,8 @@ interface ChoiceLoaderInterface
      * @param string[]      $values An array of choice values. Non-existing
      *                              values in this array are ignored
      * @param callable|null $value  The callable generating the choice values
+     *
+     * @return mixed[]
      */
     public function loadChoicesForValues(array $values, ?callable $value = null): array;
 
@@ -62,7 +64,7 @@ interface ChoiceLoaderInterface
      * The callable receives the choice as only argument.
      * Null may be passed when the choice list contains the empty value.
      *
-     * @param array         $choices An array of choices. Non-existing choices in
+     * @param mixed[]       $choices An array of choices. Non-existing choices in
      *                               this array are ignored
      * @param callable|null $value   The callable generating the choice values
      *

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -39,11 +39,11 @@ interface PropertyAccessorInterface
      *
      * If neither is found, an exception is thrown.
      *
-     * @template T of object|array
+     * @template T of object|mixed[]
      *
      * @param T $objectOrArray
      *
-     * @param-out ($objectOrArray is array ? array : T) $objectOrArray
+     * @param-out ($objectOrArray is object ? T : mixed[]) $objectOrArray
      *
      * @throws Exception\InvalidArgumentException If the property path is invalid
      * @throws Exception\AccessException          If a property/index does not exist or is not public

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -31,7 +31,7 @@ interface VoterInterface
      * ACCESS_GRANTED, ACCESS_DENIED, or ACCESS_ABSTAIN.
      *
      * @param mixed     $subject    The subject to secure
-     * @param array     $attributes An array of attributes associated with the method being invoked
+     * @param mixed[]   $attributes An array of attributes associated with the method being invoked
      * @param Vote|null $vote       Should be used to explain the vote
      *
      * @return self::ACCESS_*

--- a/src/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Serializer\Encoder;
 interface ContextAwareDecoderInterface extends DecoderInterface
 {
     /**
-     * @param array $context options that decoders have access to
+     * @param array<string, mixed> $context options that decoders have access to
      */
     public function supportsDecoding(string $format, array $context = []): bool;
 }

--- a/src/Symfony/Component/Serializer/Encoder/ContextAwareEncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/ContextAwareEncoderInterface.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Serializer\Encoder;
 interface ContextAwareEncoderInterface extends EncoderInterface
 {
     /**
-     * @param array $context options that encoders have access to
+     * @param array<string, mixed> $context options that encoders have access to
      */
     public function supportsEncoding(string $format, array $context = []): bool;
 }

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -21,9 +21,9 @@ interface DecoderInterface
     /**
      * Decodes a string into PHP data.
      *
-     * @param string $data    Data to decode
-     * @param string $format  Format name
-     * @param array  $context Options that decoders have access to
+     * @param string               $data    Data to decode
+     * @param string               $format  Format name
+     * @param array<string, mixed> $context Options that decoders have access to
      *
      * The format parameter specifies which format the data is in; valid values
      * depend on the specific implementation. Authors implementing this interface

--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -21,9 +21,9 @@ interface EncoderInterface
     /**
      * Encodes data into the given format.
      *
-     * @param mixed  $data    Data to encode
-     * @param string $format  Format name
-     * @param array  $context Options that normalizers/encoders have access to
+     * @param mixed                $data    Data to encode
+     * @param string               $format  Format name
+     * @param array<string, mixed> $context Options that normalizers/encoders have access to
      *
      * @throws UnexpectedValueException
      */

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -18,6 +18,9 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class ExtraAttributesException extends RuntimeException
 {
+    /**
+     * @param list<string> $extraAttributes
+     */
     public function __construct(
         private readonly array $extraAttributes,
         ?\Throwable $previous = null,
@@ -29,6 +32,8 @@ class ExtraAttributesException extends RuntimeException
 
     /**
      * Get the extra attributes that are not allowed.
+     *
+     * @return list<string>
      */
     public function getExtraAttributes(): array
     {

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -27,12 +27,12 @@ interface DenormalizableInterface
      * It is important to understand that the denormalize() call should denormalize
      * recursively all child objects of the implementer.
      *
-     * @param DenormalizerInterface       $denormalizer The denormalizer is given so that you
-     *                                                  can use it to denormalize objects contained within this object
-     * @param array|string|int|float|bool $data         The data from which to re-create the object
-     * @param string|null                 $format       The format is optionally given to be able to denormalize
-     *                                                  differently based on different input formats
-     * @param array                       $context      Options for denormalizing
+     * @param DenormalizerInterface         $denormalizer The denormalizer is given so that you
+     *                                                    can use it to denormalize objects contained within this object
+     * @param mixed[]|string|int|float|bool $data         The data from which to re-create the object
+     * @param string|null                   $format       The format is optionally given to be able to denormalize
+     *                                                    differently based on different input formats
+     * @param array<string, mixed>          $context      Options for denormalizing
      */
     public function denormalize(DenormalizerInterface $denormalizer, array|string|int|float|bool $data, ?string $format = null, array $context = []): void;
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
@@ -27,11 +27,11 @@ interface NormalizableInterface
      * It is important to understand that the normalize() call should normalize
      * recursively all child objects of the implementer.
      *
-     * @param NormalizerInterface $normalizer The normalizer is given so that you
-     *                                        can use it to normalize objects contained within this object
-     * @param string|null         $format     The format is optionally given to be able to normalize differently
-     *                                        based on different output formats
-     * @param array               $context    Options for normalizing this object
+     * @param NormalizerInterface  $normalizer The normalizer is given so that you
+     *                                         can use it to normalize objects contained within this object
+     * @param string|null          $format     The format is optionally given to be able to normalize differently
+     *                                         based on different output formats
+     * @param array<string, mixed> $context    Options for normalizing this object
      */
     public function normalize(NormalizerInterface $normalizer, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -28,7 +28,7 @@ interface NormalizerInterface
      * @param string|null          $format  Format the normalization result will be encoded as
      * @param array<string, mixed> $context Context options for the normalizer
      *
-     * @return array|string|int|float|bool|\ArrayObject|null \ArrayObject is used to make sure an empty object is encoded as an object not an array
+     * @return mixed[]|string|int|float|bool|\ArrayObject<array-key, mixed>|null \ArrayObject is used to make sure an empty object is encoded as an object not an array
      *
      * @throws InvalidArgumentException   Occurs when the object given is not a supported type for the normalizer
      * @throws CircularReferenceException Occurs when the normalizer detects a circular reference when no circular


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

As part of my work on removing the usage of stubs in phpstan-symfony in favor of our own types (see https://github.com/phpstan/phpstan-symfony/issues/431), I identified cases where we are missing some types in Symfony while they are available in the stubs.
Most of them are about defining the value type of arrays so that phpstan does not complain about the missing value types when implementing/extending those methods.
