### PR TITLE
 Fix validator get hooks

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -51,6 +51,11 @@ class PropertyMetadata extends MemberMetadata
             // There is no way to check if a property has been unset or if it is uninitialized.
             // When trying to access an uninitialized property, __get method is triggered.
 
+            // If there's a Get hook, use it to get the value
+            if(null !== $reflProperty->getHook(\PropertyHookType::Get)){
+                return $reflProperty->getHook(\PropertyHookType::Get)->invoke($object);
+            }
+
             // If __get method is not present, no fallback is possible
             // Otherwise we need to catch an Error in case we are trying to access an uninitialized but set property.
             if (!method_exists($object, '__get')) {

--- a/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
@@ -80,6 +80,16 @@ class Entity extends EntityParent implements EntityInterfaceB
     #[Assert\Type('integer')]
     protected ?int $other;
 
+    protected string $withHook {
+        get{
+            $prop = new \ReflectionProperty(self::class, 'withHook');
+            if (!$prop->isInitialized($this)) {
+                $this->withHook = $this->firstName;//whatever
+            }
+            return $this->withHook;
+        }
+    }
+
     public function __construct($internal = null)
     {
         $this->internal = $internal;

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -79,4 +79,13 @@ class PropertyMetadataTest extends TestCase
         $this->assertNull($notUnsetMetadata->getPropertyValue($entity));
         $this->assertEquals(42, $metadata->getPropertyValue($entity));
     }
+
+    public function testGetPropertyValueFromUninitializedPropertyShouldUseHookIfPresent()
+    {
+        $entity = new Entity();
+        $entity->firstName = 'foobar';
+        $metadata = new PropertyMetadata(self::CLASSNAME, 'withHook');
+
+        $this->assertEquals('foobar', $metadata->getPropertyValue($entity));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |8.0 
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #64010
| License       | MIT

Adds support for property hooks in the Validator Mapping.
