### PR TITLE
[Validator] Fix mapping with get hooks

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -51,6 +51,11 @@ class PropertyMetadata extends MemberMetadata
             // There is no way to check if a property has been unset or if it is uninitialized.
             // When trying to access an uninitialized property, __get method is triggered.
 
+            // If there's a Get hook, use it to get the value
+            if (\PHP_VERSION_ID >= 80400 && $reflProperty->hasHook(\PropertyHookType::Get)) {
+                return $reflProperty->getHook(\PropertyHookType::Get)->invoke($object);
+            }
+
             // If __get method is not present, no fallback is possible
             // Otherwise we need to catch an Error in case we are trying to access an uninitialized but set property.
             if (!method_exists($object, '__get')) {

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityWithHook.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityWithHook.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+class EntityWithHook {
+
+    protected int $id = 1;
+
+    public string $name;
+    protected string $withHook {
+        get{
+            $prop = new \ReflectionProperty(self::class, 'withHook');
+            if (!$prop->isInitialized($this)) {
+                $this->withHook = strtolower($this->name);
+            }
+            return $this->withHook;
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\Validator\Tests\Mapping;
 
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Mapping\PropertyMetadata;
 use Symfony\Component\Validator\Tests\Fixtures\Entity_74;
 use Symfony\Component\Validator\Tests\Fixtures\Entity_74_Proxy;
+use Symfony\Component\Validator\Tests\Fixtures\EntityWithHook;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\EntityParent;
 
@@ -78,5 +80,15 @@ class PropertyMetadataTest extends TestCase
 
         $this->assertNull($notUnsetMetadata->getPropertyValue($entity));
         $this->assertEquals(42, $metadata->getPropertyValue($entity));
+    }
+
+    #[RequiresPhp('>=8.4.0')]
+    public function testGetPropertyValueFromUninitializedPropertyShouldUseHookIfPresent()
+    {
+        $entity = new EntityWithHook();
+        $entity->name = 'FOOBAR';
+        $metadata = new PropertyMetadata(EntityWithHook::class, 'withHook');
+
+        $this->assertEquals('foobar', $metadata->getPropertyValue($entity));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |8.0 
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #64010
| License       | MIT

Adds support for property hooks in the Validator Mapping.
