### PR TITLE
[Mailer][AzureMailer] Fix inline attachments

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class AzureApiTransportTest extends TestCase
@@ -99,6 +100,34 @@ class AzureApiTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testInlineAttachment()
+    {
+        $inlinePart = (new DataPart('image-content', 'image.png', 'image/png'))->asInline();
+        $expectedCid = $inlinePart->getContentId();
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use ($expectedCid): ResponseInterface {
+            $body = json_decode($options['body'], true);
+
+            $this->assertCount(1, $body['attachments']);
+            $this->assertSame('image.png', $body['attachments'][0]['name']);
+            $this->assertSame($expectedCid, $body['attachments'][0]['contentId']);
+            $this->assertArrayNotHasKey('content_id', $body['attachments'][0]);
+
+            return new JsonMockResponse(['id' => 'foobar'], ['http_code' => 202]);
+        });
+
+        $transport = new AzureApiTransport('KEY', 'my-acs-resource', false, '2023-03-31', $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->html(\sprintf('<img src="cid:%s">', $expectedCid))
+            ->addPart($inlinePart);
+
+        $transport->send($mail);
     }
 
     public function testTagAndMetadataHeaders()

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
@@ -153,7 +153,7 @@ final class AzureApiTransport extends AbstractApiTransport
             ];
 
             if ('inline' === $disposition) {
-                $att['content_id'] = $filename;
+                $att['contentId'] = $attachment->getContentId();
             }
 
             $attachments[] = $att;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

Inline images embedded via `$message->embed()` are sent as regular attachments instead of being linked to their `cid:` references in the HTML body. The recipient's mail client displays them as file attachments rather than rendering them inline.

## Root cause

`getMessageAttachments()` has two mistakes when handling inline parts:

1. The field is named `content_id` (snake_case), but the ACS REST API expects `contentId` (camelCase). The field is silently ignored, so ACS generates its own random Content-Id that never matches the `cid:…` reference already written into the HTML.
2. The value is set to `$filename` instead of the actual Content-Id of the MIME part (`$attachment->getContentId()`).

## Fix

```diff
- $att['content_id'] = $filename;
+ $att['contentId'] = $attachment->getContentId();
```

A test covering inline attachment payload is added to `AzureApiTransportTest`.
