### PR TITLE
[Serializer] Replace call to `fgets()` by `fread()` after PHP 8.6 change

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -68,7 +68,7 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
 
         $splFileObject->rewind();
         while (!$splFileObject->eof()) {
-            $data .= $splFileObject->fgets();
+            $data .= $splFileObject->fread(8192);
         }
 
         if ('text' === explode('/', $mimeType, 2)[0]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix PHP 8.6 compatibility
| License       | MIT

Since https://github.com/php/php-src/pull/21679, `SplFileObject::fgets()` throws when called after the last line is read. `fread()` is not affected, and 8192 is used because it is the default buffer size for streams.