### PR TITLE
[HttpFoundation] Adding `const` for `X-Robots-Tag` header

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -85,6 +85,8 @@ class Response
     public const HTTP_NOT_EXTENDED = 510;                                                // RFC2774
     public const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;                             // RFC6585
 
+    public const HEADER_X_ROBOTS_TAG = 'X-Robots-Tag';
+
     /**
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | kindof ;-)
| Deprecations? | no
| Issues        | none
| License       | MIT

What about adding some `const`s for commonly used HTTP headers?
To be used at `$response->headers->set(...);`