### PR TITLE
[DoctrineBridge] Catch any driver exception in the same-database check

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Doctrine\DBAL\Exception\DatabaseObjectExistsException;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Schema\Name\Identifier;
@@ -89,7 +89,7 @@ abstract class AbstractSchemaListener
 
             try {
                 $exec(\sprintf('DELETE FROM schema_subscriber_check_ WHERE random_key = %s', $connection->getDatabasePlatform()->quoteStringLiteral($key)));
-            } catch (DatabaseObjectNotFoundException|ConnectionException|\PDOException) {
+            } catch (DBALDriverException|\PDOException) {
             }
 
             try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64008
| License       | MIT

The same-database check runs a `DELETE` via a second connection and expects it to fail when the two connections point to different databases. The `catch` enumerated `DatabaseObjectNotFoundException`, `ConnectionException` and `\PDOException`, but missed PostgreSQL's `25P02` ("in failed sql transaction") which surfaces as a generic `DriverException`. Catching the `\Doctrine\DBAL\Driver\Exception` interface covers all DBAL driver exceptions while still letting unrelated errors propagate.