### PR TITLE
[Routing] Refactor inline defaults regex to use the /x modifier for requirment 

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -418,19 +418,32 @@ class Route implements \Serializable
 
         $mapping = $this->getDefault('_route_mapping') ?? [];
 
-        $pattern = preg_replace_callback('#\{(!?)([\w\x80-\xFF]++)(:([\w\x80-\xFF]++)(\.[\w\x80-\xFF]++)?)?(<.*?>)?(\?[^\}]*+)?\}#', function ($m) use (&$mapping) {
-            if (isset($m[7][0])) {
-                $this->setDefault($m[2], '?' !== $m[7] ? substr($m[7], 1) : null);
-            }
-            if (isset($m[6][0])) {
-                $this->setRequirement($m[2], substr($m[6], 1, -1));
-            }
-            if (isset($m[4][0])) {
-                $mapping[$m[2]] = isset($m[5][0]) ? [$m[4], substr($m[5], 1)] : $m[4];
-            }
+        $pattern = preg_replace_callback('/
+            \{
+                (!?)
+                ([\w\x80-\xFF]++)      # The variable name (e.g. "id" or "slug")
+                (
+                :                      # Match the colon for mapping
+                ([\w\x80-\xFF]++)      # The controller argument mapped to
+                (\.[\w\x80-\xFF]++)?   # Optional property path
+            )?
+            (<.*?>)?                   # The requirement
+            (\?[^\}]*+)?               # The default value
+            \}
+            /x',
+            function ($m) use (&$mapping) {
+                if (isset($m[7][0])) {
+                    $this->setDefault($m[2], '?' !== $m[7] ? substr($m[7], 1) : null);
+                }
+                if (isset($m[6][0])) {
+                    $this->setRequirement($m[2], substr($m[6], 1, -1));
+                }
+                if (isset($m[4][0])) {
+                    $mapping[$m[2]] = isset($m[5][0]) ? [$m[4], substr($m[5], 1)] : $m[4];
+                }
 
-            return '{'.$m[1].$m[2].'}';
-        }, $pattern);
+                return '{'.$m[1].$m[2].'}';
+            }, $pattern);
 
         if ($mapping) {
             $this->setDefault('_route_mapping', $mapping);


### PR DESCRIPTION
| Q | A
| ------------- | ---
| Branch? | 8.1
| Bug fix? | no
| New feature? | no
| Deprecations? | no
| Issues |
| License | MIT
| Doc PR |

The current regular expression used to parse inline defaults and requirements in `Route::extractInlineDefaultsAndRequirements()` is highly complex and difficult to read for new contributors.


This PR applies the `/x` (`PCRE_EXTENDED`) modifier to the regex, allowing it to be split across multiple lines with inline comments explaining each capture group.

I have fixed to formatter issue sorry for the noise.