### PR TITLE
[Validator] Support property get hooks for uninitialized properties

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -51,6 +51,10 @@ class PropertyMetadata extends MemberMetadata
             // There is no way to check if a property has been unset or if it is uninitialized.
             // When trying to access an uninitialized property, __get method is triggered.
 
+            if ($reflProperty->hasHook(\PropertyHookType::Get)) {
+                return $reflProperty->getValue($object);
+            }
+
             // If __get method is not present, no fallback is possible
             // Otherwise we need to catch an Error in case we are trying to access an uninitialized but set property.
             if (!method_exists($object, '__get')) {

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -79,4 +79,21 @@ class PropertyMetadataTest extends TestCase
         $this->assertNull($notUnsetMetadata->getPropertyValue($entity));
         $this->assertEquals(42, $metadata->getPropertyValue($entity));
     }
+
+    public function testGetPropertyValueUsesPropertyGetHook()
+    {
+        $entity = new EntityWithPropertyGetHook();
+        $metadata = new PropertyMetadata(EntityWithPropertyGetHook::class, 'value');
+
+        $this->assertSame('hook value', $metadata->getPropertyValue($entity));
+    }
+}
+
+class EntityWithPropertyGetHook
+{
+    public string $value {
+        get {
+            return $this->value ?? 'hook value';
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64010
| License       | MIT

Fixes an issue where properties with PHP 8.4 get hooks are treated as uninitialized and return null.

When a typed property is not initialized, the current logic in PropertyMetadata::getPropertyValue() falls back to __get() or returns null. However, with PHP 8.4, properties can define a get hook that provides a value even if the property is not initialized.

This patch checks for the presence of a get hook (PropertyHookType::Get) before falling back to __get logic, ensuring that the hook is invoked correctly.

Before:
- A property with a get hook and no initialized backing value returns null.

After:
- The get hook is invoked and its value is returned.

A test case has been added to demonstrate the correct behavior.

This change only applies to PHP 8.4+, as it relies on property hooks.