### PR TITLE
[MonologBridge] Guard against re-entrant calls in AbstractTokenProcessor

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -41,18 +41,29 @@ abstract class AbstractTokenProcessor
 
     abstract protected function getToken(): ?TokenInterface;
 
+    private bool $processing = false;
+
     private function doInvoke(array|LogRecord $record): array|LogRecord
     {
-        $record['extra'][$this->getKey()] = null;
+        if ($this->processing) {
+            return $record;
+        }
 
-        if (null !== $token = $this->getToken()) {
-            $record['extra'][$this->getKey()] = [
-                'authenticated' => (bool) $token->getUser(),
-                'roles' => $token->getRoleNames(),
-            ];
+        $this->processing = true;
+        try {
+            $record['extra'][$this->getKey()] = null;
 
-            // @deprecated since Symfony 5.3, change to $token->getUserIdentifier() in 7.0
-            $record['extra'][$this->getKey()]['user_identifier'] = method_exists($token, 'getUserIdentifier') ? $token->getUserIdentifier() : $token->getUsername();
+            if (null !== $token = $this->getToken()) {
+                $record['extra'][$this->getKey()] = [
+                    'authenticated' => (bool) $token->getUser(),
+                    'roles' => $token->getRoleNames(),
+                ];
+
+                // @deprecated since Symfony 5.3, change to $token->getUserIdentifier() in 7.0
+                $record['extra'][$this->getKey()]['user_identifier'] = method_exists($token, 'getUserIdentifier') ? $token->getUserIdentifier() : $token->getUsername();
+            }
+        } finally {
+            $this->processing = false;
         }
 
         return $record;

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 
@@ -38,5 +39,32 @@ class TokenProcessorTest extends TestCase
         $this->assertArrayHasKey('token', $record['extra']);
         $this->assertEquals($token->getUserIdentifier(), $record['extra']['token']['user_identifier']);
         $this->assertEquals(['ROLE_USER'], $record['extra']['token']['roles']);
+    }
+
+    public function testReentrantCallIsSkipped()
+    {
+        $innerRecord = RecordFactory::create();
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $processor = new TokenProcessor($tokenStorage);
+
+        $tokenStorage->method('getToken')
+            ->willReturnCallback(static function () use ($processor, &$innerRecord) {
+                // Simulate a re-entrant log call triggered during token resolution
+                // (e.g. firewall initializer → EntityManager construction → deprecation warning)
+                $innerRecord = $processor($innerRecord);
+
+                return null;
+            });
+
+        $outerRecord = RecordFactory::create();
+        $outerRecord = $processor($outerRecord);
+
+        // Outer call completed and set the key (to null since getToken() returned null)
+        $this->assertArrayHasKey('token', $outerRecord['extra']);
+        $this->assertNull($outerRecord['extra']['token']);
+
+        // Re-entrant call was silently dropped — record passed through unchanged
+        $this->assertArrayNotHasKey('token', $innerRecord['extra']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62148
| License       | MIT

## Problem

When `AbstractTokenProcessor::doInvoke()` calls `getToken()`, the token storage can trigger the firewall initializer, which calls a user provider, which calls `EntityManager::getRepository()` while the EntityManager is still being constructed. Doctrine ORM fires a deprecation via `trigger_deprecation()` at that point, which goes through the error handler → Monolog → back into `AbstractTokenProcessor` — causing infinite recursion and a fatal error.

This was reported in #62148 and surfaced specifically with Doctrine ORM 2.20+, but the re-entrancy path is a Symfony-side structural issue: the processor has no guard against being called while it is already running.

## Fix

Add a `$processing` flag to `doInvoke()`. If a log record arrives while the processor is already resolving the token, the record is returned unchanged and the call exits immediately. The fix is surgical: one boolean flag, one early return, one `finally` reset — no new dependencies, no change to the normal code path.

This was discussed on #63995 (now closed in favour of this PR). The `try/catch \Throwable` approach in that PR was rightly rejected by @nicolas-grekas and @stof because it masked errors. A re-entrancy guard does not hide anything: it skips enrichment only when enrichment itself is what triggered the recursive call.

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
