### PR TITLE
[DoctrineBridge] Prevent install with incompatible symfony/property-info versions

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -60,7 +60,7 @@
         "symfony/http-kernel": "<6.2",
         "symfony/lock": "<6.3",
         "symfony/messenger": "<5.4",
-        "symfony/property-info": "<5.4",
+        "symfony/property-info": "<5.4|>=8",
         "symfony/security-bundle": "<5.4",
         "symfony/security-core": "<6.4",
         "symfony/validator": "<6.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63746
| License       | MIT

## Problem

Installing `symfony/doctrine-bridge` 6.4 alongside `symfony/property-info` 8.x (released under the 8.0 branch) produces a PHP fatal error at class load time:

> Class `Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor` contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (`Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface::getType`)

The 6.4 bridge ships a `DoctrineExtractor` that implements the legacy `getTypes()` API, while `property-info` 8.0 replaced the interface with a new `getType()` method returning `Symfony\Component\TypeInfo\Type`. The two are API-incompatible and cannot coexist at runtime.

The 6.4 bridge's `composer.json` already declares a lower-bound conflict (`symfony/property-info: <5.4`) but no upper bound, so Composer happily resolves the broken combination.

## Fix

Widen the existing conflict entry to refuse installing alongside `symfony/property-info` 8.x or later:

```diff
-        "symfony/property-info": "<5.4",
+        "symfony/property-info": "<5.4|>=8",
```

Backporting the new API to 6.4 would require pulling in `symfony/type-info` (a 7.x component), so restricting the metadata is the right scope for the LTS.

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
