### PR TITLE
[DoctrineBridge] Fail with a clear exception when symfony/form is missing

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -36,6 +36,10 @@ use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
 
+if (!interface_exists(FormTypeGuesserInterface::class)) {
+    throw new \LogicException('You cannot use the "Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser" class as the "symfony/form" package is not installed. Try running "composer require symfony/form".');
+}
+
 class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 {
     protected $registry;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63671
| License       | MIT

## Problem

When `doctrine/doctrine-bundle` is used without `symfony/form`, loading `Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser` produces a PHP fatal error because the class declares `implements FormTypeGuesserInterface` and the interface is missing:

> Fatal error: Interface `Symfony\Component\Form\FormTypeGuesserInterface` not found in .../vendor/symfony/doctrine-bridge/Form/DoctrineOrmTypeGuesser.php on line 39

This surfaces in practice when `Debug::enable()` is active (e.g. `APP_DEBUG=1 bin/console cache:clear`) and the debug class loader resolves the guesser. It has been latent since the class was introduced but became visible in 7.4.7 after the `DebugClassLoader` reworked interface traversal (#63671).

## Fix

Adopt the same guard pattern the codebase already uses for classes that depend on an optional component — see `Symfony\Component\String\Slugger\AsciiSlugger` and `Symfony\Component\HttpClient\HttplugClient`:

```php
if (!interface_exists(FormTypeGuesserInterface::class)) {
    throw new \LogicException('You cannot use the "Symfony\\Bridge\\Doctrine\\Form\\DoctrineOrmTypeGuesser" class as the "symfony/form" package is not installed. Try running "composer require symfony/form".');
}
```

The guard runs before the `class` keyword, so PHP never tries to resolve the missing interface. Users now get a catchable `LogicException` with an actionable message instead of an unrecoverable PHP fatal, which is also what the DI container and DebugClassLoader paths expect — a standard exception can be surfaced normally.

When `symfony/form` is installed (the supported setup), the guard is transparent: `interface_exists()` short-circuits and the class is defined exactly as before.

## Verified

- `php -l` clean
- Direct `require` of the file in a PHP runtime without `symfony/form`: throws the expected `LogicException` with the correct message
- No change to the class body, no change to signatures — existing consumers keep working

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
