### PR TITLE
[Mailer][Brevo] Add TemplateParametersHeader for mixed-type template params

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.2
 ---
 
+* Add `TemplateParametersHeader` to pass Brevo template parameters with arbitrary types
+  (string, int, bool, array) instead of the generic `ParameterizedHeader` which only accepts strings
 * Allow configuring the SMTP port through the DSN
 
 6.4

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Header/TemplateParametersHeader.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Header/TemplateParametersHeader.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Brevo\Header;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+/**
+ * Carries Brevo template parameters with arbitrary types (string, int, bool, array, …).
+ *
+ * Unlike a generic `ParameterizedHeader`, the Brevo API accepts mixed-type values in the
+ * "params" field of the template payload — integers, arrays and booleans are valid and
+ * commonly used. This header preserves those values as-is instead of forcing them to
+ * strings (which would require a `setParameter()` call that only accepts `?string`).
+ */
+final class TemplateParametersHeader extends UnstructuredHeader
+{
+    public function __construct(
+        private array $parameters,
+    ) {
+        parent::__construct('params', '');
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\Mailer\Bridge\Brevo\Header\TemplateParametersHeader;
 use Symfony\Component\Mailer\Bridge\Brevo\Transport\BrevoApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
@@ -82,6 +83,30 @@ class BrevoApiTransportTest extends TestCase
         $this->assertEquals('bar', $payload['params']['param2']);
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testTemplateParametersHeaderSupportsMixedTypes()
+    {
+        $params = [
+            'name' => 'John',
+            'age' => 30,
+            'subscribed' => true,
+            'tags' => ['vip', 'newsletter'],
+            'address' => ['street' => '123 Main St', 'city' => 'Paris'],
+        ];
+
+        $email = new Email();
+        $email->getHeaders()
+            ->addTextHeader('templateId', 1)
+            ->add(new TemplateParametersHeader($params));
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('params', $payload);
+        $this->assertSame($params, $payload['params']);
     }
 
     public function testSendThrowsForErrorResponse()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63826
| License       | MIT

## Status

This PR is currently waiting for the decision on #64782, which introduces a common `RemoteTemplateEmail` abstraction for provider-rendered templates. If that abstraction is accepted, this bridge-specific header should likely be superseded by that design.

## Problem

The Brevo API accepts template parameters with mixed values in the `params` field. The currently documented `addParameterizedHeader('params', 'params', $params)` path does not preserve those values faithfully.

On current Symfony 8.2, scalar values are coerced by PHP before reaching the API payload:

```php
int   30    -> "30"
true        -> "1"
false       -> ""
float 1.5   -> "1.5"
array [...] -> TypeError
```

So the strongest issue is silent value corruption for values such as `false` and `0`; arrays still throw because `ParameterizedHeader::setParameter()` accepts `?string` values.

## Current branch

This branch adds `Symfony\Component\Mailer\Bridge\Brevo\Header\TemplateParametersHeader`, which carries an array of arbitrary-type parameters and lets `BrevoApiTransport::prepareHeadersAndTags()` read those values as-is for the `params` payload field.

Usage:

```php
use Symfony\Component\Mailer\Bridge\Brevo\Header\TemplateParametersHeader;

$email->getHeaders()->add(new TemplateParametersHeader([
    'name' => 'John',
    'age' => 30,
    'subscribed' => false,
    'tags' => ['vip', 'newsletter'],
]));
```

This is intentionally narrow and keeps existing string-only `addParameterizedHeader()` usage untouched. The larger question is whether Symfony should keep any Brevo-specific remote-template header support at all, or replace it with the provider-neutral abstraction from #64782.

## Test verification

The current branch includes `testTemplateParametersHeaderSupportsMixedTypes`, asserting strings, integers, booleans and nested arrays round-trip into the Brevo API payload without stringification.

Earlier local verification for the branch passed the Brevo API transport test suite. This PR is now rebased on current `8.2`; no functional change was added while waiting for #64782.

