### PR TITLE
[Validator] fix mapping properties using property hooks

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -51,9 +51,9 @@ class PropertyMetadata extends MemberMetadata
             // There is no way to check if a property has been unset or if it is uninitialized.
             // When trying to access an uninitialized property, __get method is triggered.
 
-            // If __get method is not present, no fallback is possible
+            // If there is neither __get method nor get hook, no fallback is possible
             // Otherwise we need to catch an Error in case we are trying to access an uninitialized but set property.
-            if (!method_exists($object, '__get')) {
+            if (!method_exists($object, '__get') && (\PHP_VERSION_ID < 80400 || !$reflProperty->hasHook(\PropertyHookType::Get))) {
                 return null;
             }
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityWithHook.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityWithHook.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class EntityWithHook
+{
+    public string $name;
+
+    protected int $id = 1;
+
+    protected string $withHook {
+        get {
+            $this->withHook ??= strtolower($this->name);
+
+            return $this->withHook;
+        }
+    }
+
+    protected string $withHookOnSelf {
+        get => strtolower($this->withHookOnSelf);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Mapping\PropertyMetadata;
 use Symfony\Component\Validator\Tests\Fixtures\Entity_74;
 use Symfony\Component\Validator\Tests\Fixtures\Entity_74_Proxy;
+use Symfony\Component\Validator\Tests\Fixtures\EntityWithHook;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\EntityParent;
 
@@ -76,5 +77,40 @@ class PropertyMetadataTest extends TestCase
 
         $this->assertNull($notUnsetMetadata->getPropertyValue($entity));
         $this->assertEquals(42, $metadata->getPropertyValue($entity));
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testGetPropertyValueFromUninitializedPropertyShouldUseHookIfPresent()
+    {
+        $entity = new EntityWithHook();
+        $entity->name = 'FOOBAR';
+        $metadata = new PropertyMetadata(EntityWithHook::class, 'withHook');
+
+        $this->assertEquals('foobar', $metadata->getPropertyValue($entity));
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testGetPropertyValueFromUninitializedPropertyShouldReturnNullIfHookFails()
+    {
+        $entity = new EntityWithHook();
+        // $withHook uses $entity->name but it's not initialized
+        $metadata = new PropertyMetadata(EntityWithHook::class, 'withHook');
+
+        $this->assertNull($metadata->getPropertyValue($entity));
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testGetPropertyValueFromUninitializedPropertyWithHookReferencingItself()
+    {
+        $entity = new EntityWithHook();
+        $metadata = new PropertyMetadata(EntityWithHook::class, 'withHookOnSelf');
+
+        $this->assertNull($metadata->getPropertyValue($entity));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64010 
| License       | MIT

This adds the missing support for php 8.4's property hooks on validator mapping, adding to the already supported __get methods.
