### PR TITLE
[Serializer] Throw NotEncodableValueException when XmlEncoder cannot find a root node

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -134,6 +134,10 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             }
         }
 
+        if (null === $rootNode) {
+            throw new NotEncodableValueException('Root node not found.');
+        }
+
         // todo: throw an exception if the root node name is not correctly configured (bc)
 
         if ($rootNode->hasChildNodes()) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -582,6 +582,23 @@ class XmlEncoderTest extends TestCase
         $this->assertEquals(get_object_vars($obj), $this->encoder->decode($source, 'xml'));
     }
 
+    public function testDecodeWithoutRootNodeThrows()
+    {
+        $source = <<<'XML'
+            <?xml version="1.0"?>
+            <root />
+            XML;
+
+        $this->expectException(NotEncodableValueException::class);
+        $this->expectExceptionMessage('Root node not found.');
+
+        $this->encoder->decode(
+            $source,
+            'xml',
+            [XmlEncoder::DECODER_IGNORED_NODE_TYPES => [\XML_ELEMENT_NODE]]
+        );
+    }
+
     public function testDecodeIgnoreWhiteSpace()
     {
         $source = <<<'XML'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61441
| License       | MIT

`XmlEncoder::decode()` selects the root node by walking `$dom->childNodes` and skipping any whose `nodeType` appears in `DECODER_IGNORED_NODE_TYPES`. If every top-level child gets skipped (e.g. the document only contains processing instructions/comments, or the caller adds `XML_ELEMENT_NODE` to the ignore list), `$rootNode` stays `null` and the next line dereferences it:

```
Error: Call to a member function hasChildNodes() on null
```

The `// todo: throw an exception if the root node name is not correctly configured (bc)` comment that already lives on the line above hints that some validation was expected here. This adds the minimal one: when no root node could be selected, throw the same `NotEncodableValueException` the rest of the encoder uses for malformed input.

Reproduction (added as a regression test):

```php
\$encoder->decode('<?xml version=\"1.0\"?><root />', 'xml', [
    XmlEncoder::DECODER_IGNORED_NODE_TYPES => [\XML_ELEMENT_NODE],
]);
```

Before: `Error: Call to a member function hasChildNodes() on null`.
After: `NotEncodableValueException: Root node not found.`