### PR TITLE
[Validator] Support get hooks when validating uninitialized properties

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -51,6 +51,10 @@ class PropertyMetadata extends MemberMetadata
             // There is no way to check if a property has been unset or if it is uninitialized.
             // When trying to access an uninitialized property, __get method is triggered.
 
+            if (method_exists($reflProperty, 'getHook') && null !== ($hook = $reflProperty->getHook(\PropertyHookType::Get))) {
+                return $hook->invoke($object);
+            }
+
             // If __get method is not present, no fallback is possible
             // Otherwise we need to catch an Error in case we are trying to access an uninitialized but set property.
             if (!method_exists($object, '__get')) {

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Entity_84_PropertyHook.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Entity_84_PropertyHook.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class Entity_84_PropertyHook
+{
+    public int $uninitialized {
+        get {
+            if (!(new \ReflectionProperty(self::class, 'uninitialized'))->isInitialized($this)) {
+                $this->uninitialized = 42;
+            }
+
+            return $this->uninitialized;
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -24,6 +24,7 @@ class PropertyMetadataTest extends TestCase
     private const CLASSNAME = Entity::class;
     private const CLASSNAME_74 = 'Symfony\Component\Validator\Tests\Fixtures\Entity_74';
     private const CLASSNAME_74_PROXY = 'Symfony\Component\Validator\Tests\Fixtures\Entity_74_Proxy';
+    private const CLASSNAME_84_PROPERTY_HOOK = 'Symfony\Component\Validator\Tests\Fixtures\Entity_84_PropertyHook';
     private const PARENTCLASS = EntityParent::class;
 
     public function testInvalidPropertyName()
@@ -78,5 +79,18 @@ class PropertyMetadataTest extends TestCase
 
         $this->assertNull($notUnsetMetadata->getPropertyValue($entity));
         $this->assertEquals(42, $metadata->getPropertyValue($entity));
+    }
+
+    public function testGetPropertyValueFromUninitializedPropertyWithGetHook()
+    {
+        if (\PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('PHP 8.4 is required.');
+        }
+
+        $className = self::CLASSNAME_84_PROPERTY_HOOK;
+        $entity = new $className();
+        $metadata = new PropertyMetadata($className, 'uninitialized');
+
+        $this->assertSame(42, $metadata->getPropertyValue($entity));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64010
| License       | MIT

`PropertyMetadata::getPropertyValue()` returned `null` for typed uninitialized properties before considering PHP 8.4 property hooks. This meant validation constraints received `null` even when a property defined a `get` hook capable of producing the value.

This changes the uninitialized-property path to invoke a reflected `get` hook when one exists, before falling back to the existing `__get()` behavior.

A fixture and unit test cover an uninitialized typed property whose `get` hook initializes and returns the value.

Local checks:

```
php -l src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
php -l src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
git diff --check origin/8.0...HEAD
```

I could not run the PHPUnit test locally because this checkout does not have `vendor/symfony/phpunit-bridge/bin/simple-phpunit` installed.
