### PR TITLE
[Config] Fix array-shape generator dropping alternative types on nested PrototypedArrayNode

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -62,13 +62,7 @@ final class ArrayShapeGenerator
         foreach ($children as $child) {
             $arrayShape .= str_repeat('    ', $nestingLevel).self::dumpNodeKey($child, $node).': ';
 
-            if ($child instanceof PrototypedArrayNode) {
-                $isHashmap = (bool) $child->getKeyAttribute();
-                $childArrayType = ($isHashmap ? 'array<string, ' : 'list<').self::doGeneratePhpDoc($child->getPrototype(), 1 + $nestingLevel).'>';
-                $arrayShape .= $child->hasDefaultValue() && null === $child->getDefaultValue() ? $childArrayType.'|null' : $childArrayType;
-            } else {
-                $arrayShape .= self::doGeneratePhpDoc($child, 1 + $nestingLevel);
-            }
+            $arrayShape .= self::doGeneratePhpDoc($child, 1 + $nestingLevel);
 
             $arrayShape .= \sprintf(",%s\n", !$child instanceof ArrayNode ? self::generateInlinePhpDocForNode($child) : '');
         }

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -97,6 +97,22 @@ class ArrayShapeGeneratorTest extends TestCase
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root));
     }
 
+    public function testPrototypedArrayNodePhpDocWithAcceptAndWrap()
+    {
+        $proto = new ArrayNodeDefinition('proto');
+        $proto
+            ->useAttributeAsKey('name')
+            ->acceptAndWrap(['string'])
+            ->prototype('scalar')->end();
+
+        $root = new ArrayNodeDefinition('root');
+        $root->append($proto);
+
+        $expected = "array{\n *     proto?: string|array<string, scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null>,\n * }";
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root->getNode()));
+    }
+
     public function testPhpDocHandlesRequiredNode()
     {
         $child = new BooleanNode('node');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62889
| License       | MIT

When a `PrototypedArrayNode` is rendered as a child of another array node, `ArrayShapeGenerator` duplicates the shape logic and skips the call to `getNormalizedTypes()`. Alternative types declared via `acceptAndWrap()` therefore disappear from the generated PHPDoc.

For instance, on `framework.asset_mapper.paths` (which calls `acceptAndWrap(['string'])`), the previous output was:

```
paths?: array<string, scalar|Param|null>
```

while the same node generated as a root produced the correct shape:

```
string|array<string, scalar|Param|null>
```

This caused the PHPStan error reported in #62889 when writing config in PHP, since `'paths' => ['assets/']` is documented but the array-shape disallowed the wrapped form.

The fix removes the duplicated branch and delegates child rendering to `doGeneratePhpDoc()`, which is the same path used at the root and already includes both the normalized-types alternatives and the optional `|null` from a `null` default.