### PR TITLE
[Form] Preserve collection children added by PRE_SET_DATA listeners

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -31,6 +31,7 @@ class ResizeFormListener implements EventSubscriberInterface
     // BC, to be removed in 8.0
     private bool $overridden = true;
     private bool $usePreSetData = false;
+    private array $preSetDataChildrenStack = [];
 
     public function __construct(
         private string $type,
@@ -65,6 +66,8 @@ class ResizeFormListener implements EventSubscriberInterface
             || __CLASS__ === (new \ReflectionClass($this))->getMethod('preSetData')->getDeclaringClass()->name
         ) {
             // not a child class, or child class does not overload PRE_SET_DATA
+            $this->preSetDataChildrenStack[] = iterator_to_array($event->getForm());
+
             return;
         }
 
@@ -101,18 +104,32 @@ class ResizeFormListener implements EventSubscriberInterface
 
         $form = $event->getForm();
         $data = $event->getData() ?? [];
+        $childrenToRemove = array_pop($this->preSetDataChildrenStack);
 
         if (!\is_array($data) && !($data instanceof \Traversable && $data instanceof \ArrayAccess)) {
             throw new UnexpectedTypeException($data, 'array or (\Traversable and \ArrayAccess)');
         }
 
-        // First remove all rows
-        foreach ($form as $name => $child) {
-            $form->remove($name);
+        if (null === $childrenToRemove) {
+            // First remove all rows
+            foreach ($form as $name => $child) {
+                $form->remove($name);
+            }
+        } else {
+            // First remove all rows that existed before PRE_SET_DATA listeners were called
+            foreach ($childrenToRemove as $name => $child) {
+                if ($form->has($name) && $form->get($name) === $child) {
+                    $form->remove($name);
+                }
+            }
         }
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
+            if ($form->has($name)) {
+                continue;
+            }
+
             $form->add($name, $this->type, array_replace([
                 'property_path' => '['.$name.']',
             ], $this->options));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -14,10 +14,13 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\AuthorType;
 use Symfony\Component\Form\Tests\Fixtures\BlockPrefixedFooTextType;
+use Symfony\Component\Form\Tests\Fixtures\CollectionWithPreSetDataType;
+use Symfony\Component\Form\Tests\Fixtures\CollectionWithRecursiveSetDataType;
 
 class CollectionTypeTest extends BaseTypeTestCase
 {
@@ -59,6 +62,32 @@ class CollectionTypeTest extends BaseTypeTestCase
         $this->assertEquals('foo@baz.com', $form[0]->getData());
         $formAttrs0 = $form[0]->getConfig()->getOption('attr');
         $this->assertEquals(20, $formAttrs0['maxlength']);
+    }
+
+    public function testSetDataPreservesChildrenAddedByPreSetDataListenerInChildType()
+    {
+        $form = $this->factory->create(CollectionWithPreSetDataType::class, null, [
+            'entry_type' => TextTypeTest::TESTED_TYPE,
+        ]);
+
+        $form->setData(['foo@foo.com']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('foo'));
+        $this->assertInstanceOf(TextareaType::class, $form->get('0')->getConfig()->getType()->getInnerType());
+        $this->assertSame('foo@foo.com', $form->get('0')->getData());
+    }
+
+    public function testSetDataPreservesChildrenWhenPreSetDataListenerCallsSetDataRecursively()
+    {
+        $form = $this->factory->create(CollectionWithRecursiveSetDataType::class, null, [
+            'entry_type' => TextTypeTest::TESTED_TYPE,
+        ]);
+
+        $form->setData(['foo@foo.com']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('foo'));
     }
 
     public function testThrowsExceptionIfObjectIsNotTraversable()

--- a/src/Symfony/Component/Form/Tests/Fixtures/CollectionWithPreSetDataType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/CollectionWithPreSetDataType.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+class CollectionWithPreSetDataType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event): void {
+            $event->getForm()
+                ->add('0', TextareaType::class)
+                ->add('foo', TextType::class)
+            ;
+        });
+    }
+
+    public function getParent(): ?string
+    {
+        return CollectionType::class;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/CollectionWithRecursiveSetDataType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/CollectionWithRecursiveSetDataType.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+class CollectionWithRecursiveSetDataType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event): void {
+            $event->getForm()->add('foo', TextType::class);
+        });
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, static function (FormEvent $event): void {
+            $form = $event->getForm();
+            $data = $event->getData();
+            if (!\is_array($data) || !$data || $form->has('reentry_marker')) {
+                return;
+            }
+            $form->add('reentry_marker', TextType::class);
+            $form->setData($data);
+        }, 256);
+    }
+
+    public function getParent(): ?string
+    {
+        return CollectionType::class;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64037
| License       | MIT

`CollectionType` uses `ResizeFormListener` to rebuild collection rows from the configured data. Since Symfony 7.2, this resize is performed on `POST_SET_DATA`.

That changed the effective ordering for child form types extending `CollectionType`: fields added by their own `PRE_SET_DATA` listeners were removed afterwards by `ResizeFormListener::postSetData()`, while they used to be preserved when the resize happened during `PRE_SET_DATA`.

This restores that behavior by remembering the children that existed when `ResizeFormListener::preSetData()` ran and only removing those same child instances during `POST_SET_DATA`. Children added or replaced by later `PRE_SET_DATA` listeners are preserved, while missing collection rows are still added from the data.

Tests cover a child type extending `CollectionType` that adds both an extra field and a replacement collection entry during `PRE_SET_DATA`.

Local checks:

```
/opt/homebrew/opt/php@8.4/bin/php phpunit src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
/opt/homebrew/opt/php@8.4/bin/php phpunit src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
php -l src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
php -l src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
php -l src/Symfony/Component/Form/Tests/Fixtures/CollectionWithPreSetDataType.php
git diff --check
```

I also ran `/opt/homebrew/opt/php@8.4/bin/php phpunit src/Symfony/Component/Form`; it completed with one unrelated locale-formatting failure in `IntegerTypeTest::testArabicLocaleNonHtml5` (`١٢٣٬٤٥٦` expected, `123,456` actual).
