### PR TITLE
[FrameworkBundle] Apply tagged MIME type guessers in File::getMimeType()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -123,6 +123,12 @@ class FrameworkBundle extends Bundle
         if ($this->container->hasParameter('kernel.trust_x_sendfile_type_header') && $this->container->getParameter('kernel.trust_x_sendfile_type_header')) {
             BinaryFileResponse::trustXSendfileTypeHeader();
         }
+
+        // Instantiate the mime_types service so its setDefault() call fires.
+        // The service is made public by AddMimeTypeGuesserPass only when custom guessers are tagged.
+        if ($this->container->has('mime_types')) {
+            $this->container->get('mime_types');
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/MimeType/CustomMimeTypeGuesser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/MimeType/CustomMimeTypeGuesser.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\MimeType;
+
+use Symfony\Component\Mime\MimeTypeGuesserInterface;
+
+class CustomMimeTypeGuesser implements MimeTypeGuesserInterface
+{
+    public const FAKE_MIME_TYPE = 'application/x-test-custom-guesser';
+
+    public function isGuesserSupported(): bool
+    {
+        return true;
+    }
+
+    public function guessMimeType(string $path): ?string
+    {
+        return self::FAKE_MIME_TYPE;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MimeTypeGuesserBootTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MimeTypeGuesserBootTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\MimeType\CustomMimeTypeGuesser;
+use Symfony\Component\Mime\MimeTypes;
+
+/**
+ * @group functional
+ */
+class MimeTypeGuesserBootTest extends AbstractWebTestCase
+{
+    /**
+     * Verifies that booting the kernel eagerly instantiates the "mime_types" service,
+     * so that MimeTypes::setDefault() fires before any code calls MimeTypes::getDefault().
+     *
+     * Without this, File::getMimeType() (and any other static call site) silently
+     * falls back to a fresh, default-only MimeTypes instance, dropping every guesser
+     * tagged "mime.mime_type_guesser" in the container.
+     */
+    public function testCustomGuesserIsAppliedAfterKernelBootEvenWithoutExplicitContainerLookup()
+    {
+        // Reset the MimeTypes static default so any prior test cannot leak its instance
+        // into this one. Replace it with a fresh, default-only MimeTypes — mimicking the
+        // "no DI container has touched it yet" runtime state described in the bug report.
+        $defaultProperty = new \ReflectionProperty(MimeTypes::class, 'default');
+        $defaultProperty->setValue(null, new MimeTypes());
+
+        $kernel = static::createKernel(['test_case' => 'MimeType', 'root_config' => 'config.yml']);
+        $kernel->boot();
+
+        // Intentionally do NOT call $kernel->getContainer()->get('mime_types') —
+        // the bug being covered is that nothing in the request lifecycle fetches
+        // it, leaving MimeTypes::getDefault() pointing at a fresh, default-only
+        // instance that ignores every container-tagged guesser.
+        $this->assertSame(CustomMimeTypeGuesser::FAKE_MIME_TYPE, MimeTypes::getDefault()->guessMimeType(__FILE__));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/MimeType/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/MimeType/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/MimeType/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/MimeType/config.yml
@@ -1,0 +1,3 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: services.yml }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/MimeType/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/MimeType/services.yml
@@ -1,0 +1,6 @@
+services:
+    _defaults:
+        public: true
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\MimeType\CustomMimeTypeGuesser:
+        tags: ['mime.mime_type_guesser']

--- a/src/Symfony/Component/Mime/DependencyInjection/AddMimeTypeGuesserPass.php
+++ b/src/Symfony/Component/Mime/DependencyInjection/AddMimeTypeGuesserPass.php
@@ -27,11 +27,16 @@ class AddMimeTypeGuesserPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->has('mime_types')) {
-            $definition = $container->findDefinition('mime_types');
-            foreach ($container->findTaggedServiceIds('mime.mime_type_guesser', true) as $id => $attributes) {
-                $definition->addMethodCall('registerGuesser', [new Reference($id)]);
-            }
+        if (!$container->has('mime_types')) {
+            return;
+        }
+        $definition = $container->findDefinition('mime_types');
+        $id = null;
+        foreach ($container->findTaggedServiceIds('mime.mime_type_guesser', true) as $id => $attributes) {
+            $definition->addMethodCall('registerGuesser', [new Reference($id)]);
+        }
+        if (null !== $id) {
+            $definition->setPublic(true);
         }
     }
 }

--- a/src/Symfony/Component/Mime/Tests/DependencyInjection/AddMimeTypeGuesserPassTest.php
+++ b/src/Symfony/Component/Mime/Tests/DependencyInjection/AddMimeTypeGuesserPassTest.php
@@ -39,4 +39,28 @@ class AddMimeTypeGuesserPassTest extends TestCase
         $this->assertEquals('registerGuesser', $calls[0][0]);
         $this->assertEquals(new Reference('some_mime_type_guesser'), $calls[0][1][0]);
     }
+
+    public function testMimeTypesIsMadePublicWhenGuessersAreTagged()
+    {
+        $container = new ContainerBuilder();
+
+        $guesser = new Definition(FileinfoMimeTypeGuesser::class);
+        $guesser->addTag('mime.mime_type_guesser');
+        $container->setDefinition('some_mime_type_guesser', $guesser);
+        $container->register('mime_types', MimeTypes::class);
+
+        (new AddMimeTypeGuesserPass())->process($container);
+
+        $this->assertTrue($container->getDefinition('mime_types')->isPublic());
+    }
+
+    public function testMimeTypesStaysPrivateWhenNoGuesserIsTagged()
+    {
+        $container = new ContainerBuilder();
+        $container->register('mime_types', MimeTypes::class);
+
+        (new AddMimeTypeGuesserPass())->process($container);
+
+        $this->assertFalse($container->getDefinition('mime_types')->isPublic());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61711
| License       | MIT

`File::getMimeType()` (and `UploadedFile`'s inherited form) relies on the static `MimeTypes::getDefault()` to look up MIME guessers. The `mime_types` service is wired with `->call('setDefault', [service('mime_types')])`, so its instantiation is what registers the container-managed instance — including every service tagged `mime.mime_type_guesser` — as the static default.

When nothing in the request lifecycle resolves `MimeTypesInterface` (no Serializer, no user code typehinting it), the service is never instantiated, `setDefault()` never fires, and `MimeTypes::getDefault()` returns a fresh, default-only `MimeTypes` instance. Custom guessers are silently dropped.

This PR:

 * makes `FrameworkBundle::boot()` eagerly fetch `mime_types` from the container so `setDefault()` fires once per boot;
 * makes `AddMimeTypeGuesserPass` promote `mime_types` to public only when at least one guesser is tagged, so the service stays private (and removable) for applications that don't register any.