### PR TITLE
[Config] Allow env placeholders in NumericNode min/max checks

### DIFF
--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -34,6 +34,10 @@ class NumericNode extends ScalarNode
     {
         $value = parent::finalizeValue($value);
 
+        if ($this->isHandlingPlaceholder()) {
+            return $value;
+        }
+
         $errorMsg = null;
         if (isset($this->min) && $value < $this->min) {
             $errorMsg = \sprintf('The value %s is too small for path "%s". Should be greater than or equal to %s', $value, $this->getPath(), $this->min);

--- a/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/FloatNodeTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Config\Tests\Definition;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 use Symfony\Component\Config\Definition\FloatNode;
+use Symfony\Component\Config\Definition\NumericNode;
 
 class FloatNodeTest extends TestCase
 {
@@ -75,5 +76,17 @@ class FloatNodeTest extends TestCase
             [['foo' => 'bar']],
             [new \stdClass()],
         ];
+    }
+
+    public function testFinalizeAcceptsEnvPlaceholderBelowMin()
+    {
+        $node = new FloatNode('multiplier', null, 1);
+        NumericNode::setPlaceholder('env_FOO', ['float' => 0.0]);
+
+        try {
+            $this->assertSame('env_FOO', $node->finalize('env_FOO'));
+        } finally {
+            NumericNode::resetPlaceholders();
+        }
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Config\Tests\Definition;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 use Symfony\Component\Config\Definition\IntegerNode;
+use Symfony\Component\Config\Definition\NumericNode;
 
 class IntegerNodeTest extends TestCase
 {
@@ -72,5 +73,17 @@ class IntegerNodeTest extends TestCase
             [['foo' => 'bar']],
             [new \stdClass()],
         ];
+    }
+
+    public function testFinalizeAcceptsEnvPlaceholderBelowMin()
+    {
+        $node = new IntegerNode('max_retries', null, 1);
+        NumericNode::setPlaceholder('env_BAR', ['int' => 0]);
+
+        try {
+            $this->assertSame('env_BAR', $node->finalize('env_BAR'));
+        } finally {
+            NumericNode::resetPlaceholders();
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62370
| License       | MIT

`floatNode()->min(1)` and `integerNode()->min(1)` reject typed env-var placeholders at compile time because Symfony substitutes fixture values (`0.0` for float, `0` for int) when validating env placeholders, and those fixtures fall below the configured minimum.

The [reported case](https://github.com/symfony/symfony/issues/62370) uses `multiplier: '%env(float:MESSENGER_MULTIPLIER)%'` on a Messenger transport's `retry_strategy`:

```
The value 0 is too small for path "framework.messenger.transports.async.retry_strategy.multiplier". Should be greater than or equal to 1
```

This skips the min/max check in `NumericNode::finalizeValue()` while a placeholder is being resolved, mirroring the existing `isHandlingPlaceholder()` guards in `ScalarNode::isValueEmpty()` and `VariableNode::finalize()`. The compile-time fixture is a sentinel, never the real value — enforcing numeric ranges against it is incorrect for any min/max combination.

Note on prior art: #63706 attempted the same goal by changing `TYPE_FIXTURES` from `0` to `1`, which @stof correctly rejected because it still fails for `min(2)` and higher. The present patch does not depend on the fixture value at all — the check is bypassed whenever a placeholder is in play, so it works for any min/max constraint.

Two regression tests are added — one on `FloatNode`, one on `IntegerNode` — that fail without the patch with the exact error from the issue and pass with it.
