### PR TITLE
[HttpClient] Don't share CURL_LOCK_DATA_CONNECT to honor max_host_connections

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -71,9 +71,10 @@ final class CurlClientState extends ClientState
             curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_DNS);
             curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_SSL_SESSION);
 
-            if (\defined('CURL_LOCK_DATA_CONNECT')) {
-                curl_share_setopt($this->share, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_CONNECT);
-            }
+            // Don't share CURL_LOCK_DATA_CONNECT: easy handles attached to the same multi handle
+            // already share the connection cache, and adding it here creates a second pool that
+            // bypasses CURLMOPT_MAX_HOST_CONNECTIONS.
+            // See https://curl.se/libcurl/c/CURLSHOPT_SHARE.html#CURLLOCKDATACONNECT
 
             return $this->share;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64040
| License       | MIT

`CURL_LOCK_DATA_CONNECT` was added to the curl_share handle in d4266464fe3 (alongside the `reset()` rework), but easy handles attached to the same multi handle already share the connection cache through the multi. The extra share creates a second connection pool that bypasses the multi handle's per-host accounting, so `CURLMOPT_MAX_HOST_CONNECTIONS` — and thus `max_host_connections` in `CurlHttpClient` — has no effect once the share kicks in.

[libcurl docs](https://curl.se/libcurl/c/CURLSHOPT_SHARE.html#CURLLOCKDATACONNECT) explicitly note:

> Note that when you use the multi interface, all easy handles added to the same multi handle share the connection cache by default without using this option.

DNS and SSL session sharing remain in place; only the redundant connection cache is dropped.

Reproduced via the `translation:push` flow against Loco described in #64040 (≥22 messages → 429). Test is a structural contract assertion: curl share internals are not introspectable from PHP, so the spirit of the "reflection-based contract test" pattern (cf. PR #64034) is applied to the source of the share initialization itself — without the patch, the test fails; with the patch, it passes.

---

*Generated by Ora Studio*
*Vibe coded by ousamabenyounes*

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
