### PR TITLE
[Mime] Preserve inline part filename instead of overwriting it with the Content-ID

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -510,7 +510,7 @@ class Email extends Message
                     $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html);
                 }
                 $relatedParts[$name] = $part;
-                $part->setName($part->getContentId())->asInline();
+                $part->setName($part->getName() ?? $part->getContentId())->asInline();
 
                 continue 2;
             }

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -464,6 +464,24 @@ class EmailTest extends TestCase
         $this->assertStringMatchesFormat('<div background=3D"cid:%s@symfony"></div>', $parts[0]->bodyToString());
     }
 
+    public function testInlinedPartReferencedViaCidPreservesFilename()
+    {
+        $image = fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r');
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('html content <img src="cid:logo-image.gif">');
+        $e->addPart((new DataPart($image, 'logo-image.gif'))->asInline());
+
+        $body = $e->getBody();
+        $this->assertInstanceOf(RelatedPart::class, $body);
+        $parts = $body->getParts();
+        $inlinePart = $parts[1];
+
+        $this->assertSame('logo-image.gif', $inlinePart->getName());
+        $headers = $inlinePart->getPreparedHeaders()->toString();
+        $this->assertStringContainsString('name=logo-image.gif', $headers);
+        $this->assertStringNotContainsString('name='.$inlinePart->getContentId(), $headers);
+    }
+
     private function generateSomeParts(): array
     {
         $text = new TextPart('text content');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62423
| License       | MIT

When an inline `DataPart` is matched against a `cid:` reference in an HTML body, `Email::prepareParts()` overwrites the part's name with the auto-generated `Content-ID` (e.g. `abcd...@symfony`). That value then ends up as the `name=` parameter on both `Content-Type` and `Content-Disposition`, where it looks like a filename with an unsupported extension. Some mail providers reject the message with `5.7.1 Forbidden attachment type` (reproduced and acknowledged in #62423).

Before:

```
Content-ID: <divider-500x2@example.com>
Content-Type: image/jpeg; name="divider-500x2@example.com"
Content-Transfer-Encoding: base64
Content-Disposition: inline; name="divider-500x2@example.com";
 filename=divider-500x2.jpg
```

After:

```
Content-ID: <divider-500x2@example.com>
Content-Type: image/jpeg; name=divider-500x2.jpg
Content-Transfer-Encoding: base64
Content-Disposition: inline; name=divider-500x2.jpg;
 filename=divider-500x2.jpg
```

Only fall back to the `Content-ID` when the part has no name (preserves the previous behavior for inline parts created without a filename, e.g. raw `Email::embed()` callers that don't pass a name).
