### PR TITLE
[VarExporter] Translate legacy SPL "\0" key to __unserialize() in Hydrator/Instantiator

### DIFF
--- a/src/Symfony/Component/VarExporter/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Hydrator.php
@@ -65,6 +65,17 @@ final class Hydrator
             unset($value);
         }
 
+        if (\is_array($splState = $mangledVars["\0"] ?? null)) {
+            unset($mangledVars["\0"]);
+            if ($instance instanceof \SplObjectStorage) {
+                $instance->__unserialize([$splState, []]);
+            } elseif ($instance instanceof \ArrayObject) {
+                $instance->__unserialize([$splState[1] ?? 0, $splState[0] ?? [], [], $splState[2] ?? \ArrayIterator::class]);
+            } elseif ($instance instanceof \ArrayIterator) {
+                $instance->__unserialize([$splState[1] ?? 0, $splState[0] ?? [], []]);
+            }
+        }
+
         if ($mangledVars) {
             deepclone_hydrate($instance, $mangledVars, \DEEPCLONE_HYDRATE_PRESERVE_REFS);
         }

--- a/src/Symfony/Component/VarExporter/Instantiator.php
+++ b/src/Symfony/Component/VarExporter/Instantiator.php
@@ -50,12 +50,30 @@ final class Instantiator
             unset($value);
         }
 
+        if (\is_array($splState = $mangledVars["\0"] ?? null)) {
+            unset($mangledVars["\0"]);
+        }
+
         try {
-            return deepclone_hydrate($class, $mangledVars, \DEEPCLONE_HYDRATE_PRESERVE_REFS);
+            $instance = deepclone_hydrate($class, $mangledVars, \DEEPCLONE_HYDRATE_PRESERVE_REFS);
         } catch (\DeepClone\ClassNotFoundException $e) {
             throw new ClassNotFoundException($e);
         } catch (\DeepClone\NotInstantiableException $e) {
             throw new NotInstantiableTypeException($e);
         }
+
+        if (!\is_array($splState)) {
+            return $instance;
+        }
+
+        if ($instance instanceof \SplObjectStorage) {
+            $instance->__unserialize([$splState, []]);
+        } elseif ($instance instanceof \ArrayObject) {
+            $instance->__unserialize([$splState[1] ?? 0, $splState[0] ?? [], [], $splState[2] ?? \ArrayIterator::class]);
+        } elseif ($instance instanceof \ArrayIterator) {
+            $instance->__unserialize([$splState[1] ?? 0, $splState[0] ?? [], []]);
+        }
+
+        return $instance;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`deepclone_hydrate()` no longer treats the special `"\0"` key as SPL internal state (see symfony/php-ext-deepclone#17 / symfony/polyfill#584). `ArrayObject`, `ArrayIterator` and `SplObjectStorage` all ship `__serialize` / `__unserialize` since PHP 7.4 — the C extension and polyfill now expect callers to use the standard path.

This PR keeps BC for `Hydrator::hydrate()` and `Instantiator::instantiate()`: when `$mangledVars` contains a `"\0"` key with the legacy shape, it is intercepted and translated to a `__unserialize()` call.

Mapping:
* `SplObjectStorage`: `"\0" => [$obj1, $info1, $obj2, $info2, ...]` → `__unserialize([[$obj1, $info1, ...], []])`
* `ArrayObject`: `"\0" => [$array, $flags?, $iteratorClass?]` → `__unserialize([$flags ?? 0, $array, [], $iteratorClass ?? ArrayIterator::class])`
* `ArrayIterator`: `"\0" => [$array, $flags?]` → `__unserialize([$flags ?? 0, $array, []])`

In `Instantiator::instantiate()`, the `__unserialize()` call happens after instantiation so the constructor is still skipped.

Depends on symfony/polyfill#584 (which depends on symfony/php-ext-deepclone#17).