### PR TITLE
[VarExporter] Deprecate Hydrator and Instantiator classes

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -132,3 +132,8 @@ Uid
 ---
 
  * Add argument `$format` to `Ulid::isValid()`
+
+VarExporter
+-----------
+
+ * Deprecate `Hydrator` and `Instantiator` classes, use `deepclone_hydrate()` from the deepclone extension instead

--- a/src/Symfony/Component/VarExporter/CHANGELOG.md
+++ b/src/Symfony/Component/VarExporter/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `DeepCloner` to deep-clone PHP values while preserving copy-on-write benefits
+ * Deprecate `Hydrator` and `Instantiator` classes, use `deepclone_hydrate()` from the deepclone extension instead
 
 8.0
 ---

--- a/src/Symfony/Component/VarExporter/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Hydrator.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\VarExporter;
 
+trigger_deprecation('symfony/var-exporter', '8.1', 'The "%s" class is deprecated, use "deepclone_hydrate()" from the deepclone extension instead.', Hydrator::class);
+
 /**
  * Utility class to hydrate the properties of an object.
  *
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since Symfony 8.1, use deepclone_hydrate() from the deepclone extension instead
  */
 final class Hydrator
 {

--- a/src/Symfony/Component/VarExporter/Instantiator.php
+++ b/src/Symfony/Component/VarExporter/Instantiator.php
@@ -15,10 +15,14 @@ use Symfony\Component\VarExporter\Exception\ClassNotFoundException;
 use Symfony\Component\VarExporter\Exception\ExceptionInterface;
 use Symfony\Component\VarExporter\Exception\NotInstantiableTypeException;
 
+trigger_deprecation('symfony/var-exporter', '8.1', 'The "%s" class is deprecated, use "deepclone_hydrate()" from the deepclone extension instead.', Instantiator::class);
+
 /**
  * A utility class to create objects without calling their constructor.
  *
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since Symfony 8.1, use deepclone_hydrate() from the deepclone extension instead
  */
 final class Instantiator
 {

--- a/src/Symfony/Component/VarExporter/README.md
+++ b/src/Symfony/Component/VarExporter/README.md
@@ -8,13 +8,17 @@ of objects:
   plain PHP code. While doing so, it preserves all the semantics associated with
   the serialization mechanism of PHP (`__wakeup`, `__sleep`, `Serializable`,
   `__serialize`, `__unserialize`);
-- `Instantiator::instantiate()` creates an object and sets its properties without
-  calling its constructor nor any other methods;
-- `Hydrator::hydrate()` can set the properties of an existing object;
 - `DeepCloner` deep-clones PHP values while preserving copy-on-write benefits
   for strings and arrays, making it faster and more memory efficient than
   `unserialize(serialize())`;
 - `Lazy*Trait` can make a class behave as a lazy-loading ghost or virtual proxy.
+
+The component depends on the native [`ext-deepclone`](https://github.com/symfony/php-ext-deepclone)
+extension for maximum performance, or on [its polyfill](https://github.com/symfony/polyfill/tree/main/src/DeepClone)
+as a fallback. In addition to functions `deepclone_to_array()` and `deepclone_from_array()`
+which are leveraged by `DeepCloner` and `VarExporter::export()`, the extension
+provides a `deepclone_hydrate()` function that lets you instantiate / hydrate objects
+without calling their constructor, including private, protected and readonly properties.
 
 VarExporter::export()
 ---------------------
@@ -37,28 +41,6 @@ It also provides a few improvements over `var_export()`/`serialize()`:
  * `Reflection*`, `IteratorIterator` and `RecursiveIteratorIterator` classes
    throw an exception when being serialized (their unserialized version is broken
    anyway, see https://bugs.php.net/76737).
-
-Instantiator and Hydrator
--------------------------
-
-`Instantiator::instantiate($class)` creates an object of the given class without
-calling its constructor nor any other methods.
-
-`Hydrator::hydrate()` sets the properties of an existing object, including
-private and protected ones. For example:
-
-```php
-// Sets the public or protected $object->propertyName property
-Hydrator::hydrate($object, ['propertyName' => $propertyValue]);
-
-// Sets a private property defined on its parent Bar class:
-Hydrator::hydrate($object, ["\0Bar\0privateBarProperty" => $propertyValue]);
-
-// Alternative way to set the private $object->privateBarProperty property
-Hydrator::hydrate($object, [], [
-    Bar::class => ['privateBarProperty' => $propertyValue],
-]);
-```
 
 DeepCloner
 ----------

--- a/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\VarExporter\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarExporter\Hydrator;
 use Symfony\Component\VarExporter\Instantiator;
 
+#[Group('legacy')]
+#[IgnoreDeprecations]
 class HydratorTest extends TestCase
 {
     public function testHydrateInitializedReadonlyPropertySameValueIsIdempotent()

--- a/src/Symfony/Component/VarExporter/Tests/InstantiatorTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/InstantiatorTest.php
@@ -12,11 +12,15 @@
 namespace Symfony\Component\VarExporter\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarExporter\Exception\ClassNotFoundException;
 use Symfony\Component\VarExporter\Exception\NotInstantiableTypeException;
 use Symfony\Component\VarExporter\Instantiator;
 
+#[Group('legacy')]
+#[IgnoreDeprecations]
 class InstantiatorTest extends TestCase
 {
     public function testNotFoundClass()

--- a/src/Symfony/Component/VarExporter/composer.json
+++ b/src/Symfony/Component/VarExporter/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-deepclone": "^1.37"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

`Hydrator::hydrate()` and `Instantiator::instantiate()` are now thin wrappers around `\deepclone_hydrate()` from `symfony/polyfill-deepclone` (or the native `ext-deepclone`). The polyfill provides the same API directly, with a single function call that handles both instantiation and hydration, including private/protected/readonly properties.

This PR deprecates both classes in favor of the lower-level function. The README is also updated: it no longer documents these classes and now mentions `symfony/polyfill-deepclone` and `ext-deepclone` as the source of the `deepclone_*` functions used by `DeepCloner`.