### PR TITLE
[Runtime] Add FRANKENPHP_RESET_KERNEL to reset the kernel between requests

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Kernel/AbstractKernel.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/AbstractKernel.php
@@ -48,6 +48,7 @@ abstract class AbstractKernel implements KernelInterface
     {
         $this->booted = false;
         $this->container = null;
+        $this->startTime = null;
     }
 
     public function boot(): void

--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `resolveType()` for customizing how types are resolved in runtimes extending `SymfonyRuntime`
  * Add support for apps returning a `Response` object in `FrankenPhpWorkerRunner`
+ * Add `FRANKENPHP_RESET_KERNEL` to reset the kernel between requests
 
 7.4
 ---

--- a/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
@@ -36,7 +36,8 @@ class FrankenPhpWorkerRunner implements RunnerInterface
         ignore_user_abort(true);
 
         $server = array_filter($_SERVER, static fn (string $key) => !str_starts_with($key, 'HTTP_'), \ARRAY_FILTER_USE_KEY);
-        $server['APP_RUNTIME_MODE'] = 'web=1&worker=1';
+        $resetKernel = $this->application instanceof HttpKernelInterface && filter_var($server['FRANKENPHP_RESET_KERNEL'] ?? false, \FILTER_VALIDATE_BOOL);
+        $server['APP_RUNTIME_MODE'] = $resetKernel ? 'web=1&worker=2' : 'web=1&worker=1';
 
         $handler = function () use ($server, &$sfRequest, &$sfResponse): void {
             // Connect to the Xdebug client if it's available
@@ -63,6 +64,9 @@ class FrankenPhpWorkerRunner implements RunnerInterface
 
             if ($this->application instanceof TerminableInterface && $sfRequest && $sfResponse) {
                 $this->application->terminate($sfRequest, $sfResponse);
+            }
+            if ($resetKernel) {
+                $this->application = clone $this->application;
             }
 
             gc_collect_cycles();

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -170,7 +170,7 @@ class SymfonyRuntime extends GenericRuntime
     public function getRunner(?object $application): RunnerInterface
     {
         if ($application instanceof HttpKernelInterface) {
-            if ($_SERVER['FRANKENPHP_WORKER'] ?? false) {
+            if (filter_var($_SERVER['FRANKENPHP_WORKER'] ?? false, \FILTER_VALIDATE_BOOL)) {
                 return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max']);
             }
 
@@ -178,7 +178,7 @@ class SymfonyRuntime extends GenericRuntime
         }
 
         if ($application instanceof Response) {
-            if ($_SERVER['FRANKENPHP_WORKER'] ?? false) {
+            if (filter_var($_SERVER['FRANKENPHP_WORKER'] ?? false, \FILTER_VALIDATE_BOOL)) {
                 return new FrankenPhpWorkerRunner($application, $this->options['worker_loop_max']);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

In FrankenPHP worker mode, the same kernel instance currently handles every request for the lifetime of the worker process. This is a perf win, but it also means any state captured by the kernel or its services may leak across requests.

The typical way to handle this is to implement `ResetInterface` to allow services to become fresh again. Yet, this leads to two issues:
- first is obviously that apps need to be audited for missing "reset" of services — something the Symfony community has cared about for many years for core, but still is a concern in practice, esp. in apps/bundles written without this in mind;
- two, since env vars are typically injected as strings into services, they're resolved only once and cannot be refreshed in high-availability setups. Something I try to address in #63988 but still needs application + bundle adoption.

This PR offers an opt-in escape hatch: setting `FRANKENPHP_RESET_KERNEL=1` makes `FrankenPhpWorkerRunner` clone the application after each request, so the next request starts from a fresh kernel state. `AbstractKernel::__clone()` already resets `booted` and `container`, so the next request boots a kernel from the cached container file instead of reusing the live one.

The default stays as today: kernel is reused across requests, no behavior change for existing apps.

Quick measurement on a stock `symfony new --webapp` (FrameworkBundle + Doctrine + Security + Twig + Monolog, prod, FrankenPHP 1.9.1, PHP 8.4, 5 workers, c=50, 10k requests):

| Mode                                |   RPS |   avg |
| ----------------------------------- | ----: | ----: |
| classic (no worker)                 |   712 |  70ms |
| worker (default)                    | 5 770 | 8.7ms |
| worker, `FRANKENPHP_RESET_KERNEL=1` | 2 163 |  23ms |

So opting into reset costs ~63% throughput on this app — that's the price of a fresh container per request, dominated by lazy-instantiating services that the request needs (router, firewall, listeners, ...). It's still ~3× faster than classic mode while restoring per-request isolation.

In real apps, the difference is likely going to be way smaller, since controllers usually do more than just "Hello World" — DB access etc. typically dominates and in practice alleviates the so-called perf overhead of this new "reset" mode.
