### PR TITLE
[Mailer] Add a bridge for the Cloudflare email service

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -47,6 +47,7 @@
         "amazon-mailer": "src/Symfony/Component/Mailer/Bridge/Amazon",
         "azure-mailer": "src/Symfony/Component/Mailer/Bridge/Azure",
         "brevo-mailer": "src/Symfony/Component/Mailer/Bridge/Brevo",
+        "cloudflare-mailer": "src/Symfony/Component/Mailer/Bridge/Cloudflare",
         "google-mailer": "src/Symfony/Component/Mailer/Bridge/Google",
         "infobip-mailer": "src/Symfony/Component/Mailer/Bridge/Infobip",
         "mail-pace-mailer": "src/Symfony/Component/Mailer/Bridge/MailPace",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3159,6 +3159,7 @@ class FrameworkExtension extends Extension
             MailerBridge\AhaSend\Transport\AhaSendTransportFactory::class => ['symfony/aha-send-mailer', 'mailer.transport_factory.ahasend'],
             MailerBridge\Azure\Transport\AzureTransportFactory::class => ['symfony/azure-mailer', 'mailer.transport_factory.azure'],
             MailerBridge\Brevo\Transport\BrevoTransportFactory::class => ['symfony/brevo-mailer', 'mailer.transport_factory.brevo'],
+            MailerBridge\Cloudflare\Transport\CloudflareTransportFactory::class => ['symfony/cloudflare-mailer', 'mailer.transport_factory.cloudflare'],
             MailerBridge\Google\Transport\GmailTransportFactory::class => ['symfony/google-mailer', 'mailer.transport_factory.gmail'],
             MailerBridge\Infobip\Transport\InfobipTransportFactory::class => ['symfony/infobip-mailer', 'mailer.transport_factory.infobip'],
             MailerBridge\MailerSend\Transport\MailerSendTransportFactory::class => ['symfony/mailer-send-mailer', 'mailer.transport_factory.mailersend'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -15,6 +15,7 @@ use Symfony\Component\Mailer\Bridge\AhaSend\Transport\AhaSendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesTransportFactory;
 use Symfony\Component\Mailer\Bridge\Azure\Transport\AzureTransportFactory;
 use Symfony\Component\Mailer\Bridge\Brevo\Transport\BrevoTransportFactory;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareTransportFactory;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailTransportFactory;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillTransportFactory;
@@ -54,6 +55,7 @@ return static function (ContainerConfigurator $container) {
         'amazon' => SesTransportFactory::class,
         'azure' => AzureTransportFactory::class,
         'brevo' => BrevoTransportFactory::class,
+        'cloudflare' => CloudflareTransportFactory::class,
         'gmail' => GmailTransportFactory::class,
         'infobip' => InfobipTransportFactory::class,
         'mailchimp' => MandrillTransportFactory::class,

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/.gitignore
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/README.md
@@ -1,0 +1,23 @@
+Cloudflare Bridge
+=================
+
+Provides Cloudflare integration for Symfony Mailer.
+
+Configuration example:
+
+```env
+# API
+MAILER_DSN=cloudflare+api://ACCOUNT_ID:API_TOKEN@default
+```
+
+where:
+ - `ACCOUNT_ID` is your Cloudflare Account ID
+ - `API_TOKEN` is your Cloudflare API token (requires write permissions to `Email Sending`)
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareApiTransportTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Cloudflare\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareApiTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author vadage
+ */
+final class CloudflareApiTransportTest extends TestCase
+{
+    #[DataProvider('getTransportData')]
+    public function testToString(CloudflareApiTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): array
+    {
+        return [
+            [
+                new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN'),
+                'cloudflare+api://api.cloudflare.com',
+            ],
+            [
+                new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN')->setHost('example.com'),
+                'cloudflare+api://example.com',
+            ],
+        ];
+    }
+
+    public function testSend()
+    {
+        $email = new Email()
+            ->from(new Address('from@example.com', 'Sender'))
+            ->subject('Test subject')
+            ->to('to@example.com')
+            ->attach('foo', 'example.txt', 'text/plain')
+            ->bcc('bcc@example.com')
+            ->cc('cc@example.com')
+            ->html('<p>Test html</p>')
+            ->replyTo('reply@example.com')
+            ->text('Test text');
+
+        $email->getHeaders()
+            ->add(new MetadataHeader('Custom-Header', 'value'));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.cloudflare.com/client/v4/accounts/ACCOUNT_ID/email/sending/send', $url);
+            $this->assertContains('Authorization: Bearer API_TOKEN', $options['headers']);
+
+            $this->assertSame('from@example.com', $body['from']['address']);
+            $this->assertSame('Sender', $body['from']['name']);
+
+            $this->assertSame('Test subject', $body['subject']);
+
+            $this->assertSame('to@example.com', $body['to'][0]);
+
+            $this->assertSame('Zm9v', $body['attachments'][0]['content']);
+            $this->assertSame('attachment', $body['attachments'][0]['disposition']);
+            $this->assertSame('example.txt', $body['attachments'][0]['filename']);
+            $this->assertSame('text/plain', $body['attachments'][0]['type']);
+
+            $this->assertSame('bcc@example.com', $body['bcc'][0]);
+
+            $this->assertSame('cc@example.com', $body['cc'][0]);
+
+            $this->assertArrayHasKey('X-Metadata-Custom-Header', $body['headers']);
+            $this->assertsame('value', $body['headers']['X-Metadata-Custom-Header']);
+
+            $this->assertSame('<p>Test html</p>', $body['html']);
+
+            $this->assertSame('reply@example.com', $body['reply_to']['address']);
+
+            $this->assertSame('Test text', $body['text']);
+
+            return new JsonMockResponse([], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $mailer = new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN', $client);
+        $mailer->send($email);
+    }
+
+    public function testSendUsesTheEnvelopeRecipients()
+    {
+        $email = new Email()
+            ->from('from@example.com')
+            ->to('to@example.com')
+            ->cc('cc@example.com')
+            ->bcc('bcc@example.com')
+            ->text('Test text');
+
+        $envelope = new Envelope(new Address('sender@example.com'), [new Address('redirected@example.com')]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame('sender@example.com', $body['from']['address']);
+            $this->assertSame(['redirected@example.com'], $body['to']);
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN', $client)->send($email, $envelope);
+    }
+
+    public function testSendWithMultipleRecipientsAndReplyTo()
+    {
+        $email = new Email()
+            ->from('from@example.com')
+            ->to('first@example.com', 'second@example.com')
+            ->cc('cc1@example.com', 'cc2@example.com')
+            ->bcc('bcc1@example.com', 'bcc2@example.com')
+            ->replyTo('reply1@example.com', 'reply2@example.com')
+            ->text('Test text');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame(['first@example.com', 'second@example.com'], $body['to']);
+            $this->assertSame(['cc1@example.com', 'cc2@example.com'], $body['cc']);
+            $this->assertSame(['bcc1@example.com', 'bcc2@example.com'], $body['bcc']);
+            $this->assertSame('reply1@example.com', $body['reply_to']['address']);
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN', $client)->send($email);
+    }
+
+    public function testSendWithInlineAttachment()
+    {
+        $email = new Email()
+            ->from('from@example.com')
+            ->to('to@example.com')
+            ->text('Test text');
+        $email->addPart(new DataPart('logo', 'logo.png', 'image/png')->asInline());
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame('inline', $body['attachments'][0]['disposition']);
+            $this->assertSame('logo.png', $body['attachments'][0]['filename']);
+            $this->assertSame('image/png', $body['attachments'][0]['type']);
+            $this->assertArrayHasKey('content_id', $body['attachments'][0]);
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN', $client)->send($email);
+    }
+
+    public function testSendUsesTheConfiguredHostAndPort()
+    {
+        $email = new Email()
+            ->from('from@example.com')
+            ->to('to@example.com')
+            ->text('Test text');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('https://example.com:8443/client/v4/accounts/ACCOUNT_ID/email/sending/send', $url);
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        $transport = new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN', $client)
+            ->setHost('example.com')
+            ->setPort(8443);
+        $transport->send($email);
+    }
+
+    public function testErrorResponse()
+    {
+        $email = new Email()
+            ->from('from@example.com')
+            ->to('to@example.com')
+            ->text('Test text');
+
+        $client = new MockHttpClient(static fn (): ResponseInterface => new JsonMockResponse([
+            'errors' => [
+                [
+                    'code' => 10004,
+                    'message' => 'email.sending.error.throttled',
+                ],
+            ],
+        ], [
+            'http_code' => 429,
+        ]));
+
+        $mailer = new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN', $client);
+
+        $this->expectException(HttpTransportException::class);
+        $mailer->send($email);
+    }
+
+    public function testMalformedResponse()
+    {
+        $email = new Email()
+            ->from('from@example.com')
+            ->to('to@example.com')
+            ->text('Test text');
+
+        $client = new MockHttpClient(static fn (): ResponseInterface => new MockResponse('Internal server error', [
+            'http_code' => 500,
+        ]));
+
+        $mailer = new CloudflareApiTransport('ACCOUNT_ID', 'API_TOKEN', $client);
+
+        $this->expectException(HttpTransportException::class);
+        $mailer->send($email);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareTransportFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Cloudflare\Tests\Transport;
+
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareApiTransport;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareTransportFactory;
+use Symfony\Component\Mailer\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Mailer\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+/**
+ * @author vadage
+ */
+final class CloudflareTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new CloudflareTransportFactory(null, new MockHttpClient(), new NullLogger());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('cloudflare', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('cloudflare+api', 'default'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            new Dsn('cloudflare', 'default', self::USER, self::PASSWORD),
+            new CloudflareApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, new NullLogger()),
+        ];
+        yield [
+            new Dsn('cloudflare', 'CLOUDFLARE_HOST', self::USER, self::PASSWORD),
+            new CloudflareApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, new NullLogger())->setHost('CLOUDFLARE_HOST'),
+        ];
+        yield [
+            new Dsn('cloudflare+api', 'default', self::USER, self::PASSWORD),
+            new CloudflareApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, new NullLogger()),
+        ];
+        yield [
+            new Dsn('cloudflare+api', 'CLOUDFLARE_HOST', self::USER, self::PASSWORD),
+            new CloudflareApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, new NullLogger())->setHost('CLOUDFLARE_HOST'),
+        ];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield [
+            new Dsn('cloudflare+foo', 'default', self::USER, self::PASSWORD),
+            'The "cloudflare+foo" scheme is not supported; supported schemes for mailer "cloudflare" are: "cloudflare", "cloudflare+api".',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('cloudflare', 'default')];
+        yield [new Dsn('cloudflare', 'default', self::USER)];
+        yield [new Dsn('cloudflare', 'default', null, self::PASSWORD)];
+        yield [new Dsn('cloudflare+api', 'default')];
+        yield [new Dsn('cloudflare+api', 'default', self::USER)];
+        yield [new Dsn('cloudflare+api', 'default', null, self::PASSWORD)];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareApiTransport.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Cloudflare\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author vadage
+ */
+final class CloudflareApiTransport extends AbstractApiTransport
+{
+    private const string HOST = 'api.cloudflare.com';
+
+    public function __construct(
+        private readonly string $accountId,
+        #[\SensitiveParameter] private readonly string $apiToken,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($client, $dispatcher, $logger);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('cloudflare+api://%s', $this->getEndpoint());
+    }
+
+    protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+    {
+        $path = \sprintf('/client/v4/accounts/%1$s/email/sending/send', $this->accountId);
+
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().$path, [
+            'json' => $this->getPayload($email, $envelope),
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->apiToken,
+            ],
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new HttpTransportException('Could not reach the remote Cloudflare server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            try {
+                $result = $response->toArray(false);
+
+                $errorMessages = implode('; ', array_column($result['errors'], 'message'));
+                $message = \sprintf('Unable to send an email: %1$s (code: %2$d)', $errorMessages, $statusCode);
+                throw new HttpTransportException($message, $response);
+            } catch (DecodingExceptionInterface $e) {
+                $message = \sprintf('Unable to send an email: %1$s (code: %2$d)', $response->getContent(false), $statusCode);
+                throw new HttpTransportException($message, $response, 0, $e);
+            }
+        }
+
+        return $response;
+    }
+
+    private function getPayload(Email $email, Envelope $envelope): array
+    {
+        $payload = [
+            'from' => $this->formatAddress($envelope->getSender()),
+            'subject' => $email->getSubject(),
+            'to' => array_map($this->formatPlainAddress(...), $this->getRecipients($email, $envelope)),
+        ];
+
+        if ($headers = $this->prepareHeaders($email->getHeaders())) {
+            $payload['headers'] = $headers;
+        }
+
+        if ($cc = array_map($this->formatPlainAddress(...), $email->getCc())) {
+            $payload['cc'] = $cc;
+        }
+
+        if ($bcc = array_map($this->formatPlainAddress(...), $email->getBcc())) {
+            $payload['bcc'] = $bcc;
+        }
+
+        if ($replyTo = $email->getReplyTo()) {
+            $payload['reply_to'] = $this->formatAddress($replyTo[0]);
+        }
+
+        $htmlBody = $email->getHtmlBody();
+        if (\is_string($htmlBody)) {
+            $payload['html'] = $htmlBody;
+        }
+
+        $textBody = $email->getTextBody();
+        if (\is_string($textBody)) {
+            $payload['text'] = $textBody;
+        }
+
+        if ($attachments = array_map($this->formatAttachment(...), $email->getAttachments())) {
+            $payload['attachments'] = $attachments;
+        }
+
+        return $payload;
+    }
+
+    private function formatAddress(Address $address): array
+    {
+        return [
+            'address' => $address->getAddress(),
+            'name' => $address->getName(),
+        ];
+    }
+
+    private function formatPlainAddress(Address $address): string
+    {
+        return $address->getAddress();
+    }
+
+    private function formatAttachment(DataPart $attachment): array
+    {
+        $disposition = $attachment->getDisposition();
+        $formattedPart = [
+            'content' => base64_encode($attachment->getBody()),
+            'disposition' => $disposition,
+            'filename' => $attachment->getFilename(),
+            'type' => $attachment->getContentType(),
+        ];
+
+        if ('inline' === $disposition) {
+            $formattedPart['content_id'] = $attachment->getContentId();
+        }
+
+        return $formattedPart;
+    }
+
+    private function prepareHeaders(Headers $headers): array
+    {
+        $headersToBypass = ['From', 'Subject', 'To', 'Bcc', 'Cc', 'Reply-To'];
+
+        $preparedHeaders = [];
+        foreach ($headers->all() as $header) {
+            if (\in_array($header->getName(), $headersToBypass, true)) {
+                continue;
+            }
+
+            $preparedHeaders[$header->getName()] = $header->getBodyAsString();
+        }
+
+        return $preparedHeaders;
+    }
+
+    private function getEndpoint(): string
+    {
+        return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareTransportFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Cloudflare\Transport;
+
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+/**
+ * @author vadage
+ */
+final class CloudflareTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+        $accountId = $this->getUser($dsn);
+        $apiToken = $this->getPassword($dsn);
+
+        if ('cloudflare+api' === $scheme || 'cloudflare' === $scheme) {
+            $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+            $port = $dsn->getPort();
+
+            return new CloudflareApiTransport($accountId, $apiToken, $this->client, $this->dispatcher, $this->logger)
+                ->setHost($host)
+                ->setPort($port);
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'cloudflare', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['cloudflare', 'cloudflare+api'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/cloudflare-mailer",
+    "type": "symfony-mailer-bridge",
+    "description": "Symfony Cloudflare Mailer Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "vadage",
+            "homepage": "https://github.com/vadage"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "psr/event-dispatcher": "^1",
+        "psr/log": "^1|^2|^3",
+        "symfony/mailer": "^8.2"
+    },
+    "require-dev": {
+        "symfony/http-client": "^8.2"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Cloudflare\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Cloudflare Mailer Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
@@ -32,6 +32,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Brevo\Transport\BrevoTransportFactory::class,
             'package' => 'symfony/brevo-mailer',
         ],
+        'cloudflare' => [
+            'class' => Bridge\Cloudflare\Transport\CloudflareTransportFactory::class,
+            'package' => 'symfony/cloudflare-mailer',
+        ],
         'gmail' => [
             'class' => Bridge\Google\Transport\GmailTransportFactory::class,
             'package' => 'symfony/google-mailer',

--- a/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mailer\Bridge\AhaSend\Transport\AhaSendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesTransportFactory;
 use Symfony\Component\Mailer\Bridge\Azure\Transport\AzureTransportFactory;
 use Symfony\Component\Mailer\Bridge\Brevo\Transport\BrevoTransportFactory;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareTransportFactory;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailTransportFactory;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillTransportFactory;
@@ -48,6 +49,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             AhaSendTransportFactory::class => false,
             AzureTransportFactory::class => false,
             BrevoTransportFactory::class => false,
+            CloudflareTransportFactory::class => false,
             GmailTransportFactory::class => false,
             InfobipTransportFactory::class => false,
             MailPaceTransportFactory::class => false,
@@ -84,6 +86,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['ahasend', 'symfony/aha-send-mailer'];
         yield ['azure', 'symfony/azure-mailer'];
         yield ['brevo', 'symfony/brevo-mailer'];
+        yield ['cloudflare', 'symfony/cloudflare-mailer'];
         yield ['gmail', 'symfony/google-mailer'];
         yield ['infobip', 'symfony/infobip-mailer'];
         yield ['mailersend', 'symfony/mailersend-mailer'];

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mailer\Bridge\AhaSend\Transport\AhaSendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesTransportFactory;
 use Symfony\Component\Mailer\Bridge\Azure\Transport\AzureTransportFactory;
 use Symfony\Component\Mailer\Bridge\Brevo\Transport\BrevoTransportFactory;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareTransportFactory;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailTransportFactory;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillTransportFactory;
@@ -62,6 +63,7 @@ final class Transport
         AhaSendTransportFactory::class,
         AzureTransportFactory::class,
         BrevoTransportFactory::class,
+        CloudflareTransportFactory::class,
         GmailTransportFactory::class,
         InfobipTransportFactory::class,
         MailerSendTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR implements a Mailer bridge for Cloudflare Email Service using its REST API: https://developers.cloudflare.com/api/resources/email_sending/methods/send

> [!NOTE]
> Cloudflare Email Service is currently in beta. Features and APIs may change before general availability.
