### PR TITLE
[Process] Ignore array env values before proc_open

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -336,6 +336,10 @@ class Process implements \IteratorAggregate
 
         $envPairs = [];
         foreach ($env as $k => $v) {
+            if (!\is_scalar($v ?? '') && !$v instanceof \Stringable) {
+                continue;
+            }
+
             if (false !== $v && !\in_array($k = (string) $k, ['', 'argc', 'argv', 'ARGC', 'ARGV'], true) && !str_contains($k, '=') && !str_contains($k, "\0")) {
                 $envPairs[] = $k.'='.$v;
             }

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1588,6 +1588,21 @@ class ProcessTest extends TestCase
         $this->assertSame($env, $p->getEnv());
     }
 
+    public function testEnvNonScalarValuesAreIgnored()
+    {
+        $_ENV['BAD_ARRAY_ENV'] = ['foo', 'bar'];
+        $_ENV['BAD_OBJECT_ENV'] = new \stdClass();
+
+        try {
+            $process = $this->getProcessForCode('echo "OK";');
+            $process->mustRun();
+
+            $this->assertSame('OK', $process->getOutput());
+        } finally {
+            unset($_ENV['BAD_ARRAY_ENV'], $_ENV['BAD_OBJECT_ENV']);
+        }
+    }
+
     public function testEnvVarNamesCastToString()
     {
         $process = $this->getProcess('echo hello');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64057
| License       | MIT

  This PR skips array values when preparing environment variables for `proc_open()`.

  Array values cannot be represented as `KEY=value` environment pairs and currently trigger an `Array to string conversion` warning. With Symfony ErrorHandler enabled,
  this warning can become an exception.

  This follows the existing defensive filtering in `Process`, which already skips `false`, `argc` / `argv`, and invalid environment variable names before calling
  `proc_open()`.

  A regression test covers an array value coming from the default environment data.