### PR TITLE
[Notifier][Ntfy] Fix Basic auth header by keeping base64 padding

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
@@ -83,7 +83,7 @@ final class NtfyTransport extends AbstractTransport
         $headers = [];
 
         if (null !== $this->user && null !== $this->password) {
-            $headers['Authorization'] = 'Basic '.rtrim(base64_encode($this->user.':'.$this->password), '=');
+            $headers['Authorization'] = 'Basic '.base64_encode($this->user.':'.$this->password);
         } elseif (null !== $this->password) {
             $headers['Authorization'] = 'Bearer '.$this->password;
         }

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
@@ -100,7 +100,7 @@ final class NtfyTransportTest extends TransportTestCase
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
             $expectedBody = json_encode(['topic' => 'test', 'title' => 'Hello', 'message' => 'World']);
-            $expectedAuthorization = 'Authorization: Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ';
+            $expectedAuthorization = 'Authorization: Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ=';
             $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);
             $this->assertTrue(\in_array($expectedAuthorization, $options['headers']));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58085
| License       | MIT

The Ntfy transport stripped the `=` padding from the Basic auth header value. RFC 4648 requires base64-encoded credentials in `Authorization: Basic <token>` to keep their padding, so servers (including self-hosted ntfy) reject the request as unauthorized whenever the `user:password` byte length is not a multiple of 3.

Before:
```
Authorization: Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ
```

After:
```
Authorization: Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ=
```

The existing `testSendWithUserAndPassword` was updated accordingly: it asserted the broken (un-padded) value, so reverting the production change makes the test fail and applying it makes it pass.
