### PR TITLE
[Mime] Add support for binary Content-Transfer-Encoding

### DIFF
--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Support `binary` as a `Content-Transfer-Encoding`
+
 8.0
 ---
 

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -23,7 +23,10 @@ use Symfony\Component\Mime\Header\Headers;
  */
 class TextPart extends AbstractPart
 {
-    private const DEFAULT_ENCODERS = ['quoted-printable', 'base64', '8bit'];
+    private const DEFAULT_ENCODERS = ['quoted-printable', 'base64', '8bit', 'binary'];
+    // "binary" is missing on purpose: it became a default encoder late, so projects
+    // that registered their own must keep being able to do so
+    private const NON_OVERRIDABLE_ENCODERS = ['quoted-printable', 'base64', '8bit'];
 
     private static array $encoders = [];
 
@@ -202,24 +205,16 @@ class TextPart extends AbstractPart
 
     private function getEncoder(): ContentEncoderInterface
     {
-        if ('8bit' === $this->encoding) {
-            return self::$encoders[$this->encoding] ??= new EightBitContentEncoder();
-        }
-
-        if ('quoted-printable' === $this->encoding) {
-            return self::$encoders[$this->encoding] ??= new QpContentEncoder();
-        }
-
-        if ('base64' === $this->encoding) {
-            return self::$encoders[$this->encoding] ??= new Base64ContentEncoder();
-        }
-
-        return self::$encoders[$this->encoding];
+        return self::$encoders[$this->encoding] ??= match ($this->encoding) {
+            '8bit', 'binary' => new EightBitContentEncoder(),
+            'quoted-printable' => new QpContentEncoder(),
+            'base64' => new Base64ContentEncoder(),
+        };
     }
 
     public static function addEncoder(ContentEncoderInterface $encoder): void
     {
-        if (\in_array($encoder->getName(), self::DEFAULT_ENCODERS, true)) {
+        if (\in_array($encoder->getName(), self::NON_OVERRIDABLE_ENCODERS, true)) {
             throw new InvalidArgumentException('You are not allowed to change the default encoders ("quoted-printable", "base64", and "8bit").');
         }
 

--- a/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/DataPartTest.php
@@ -170,6 +170,19 @@ class DataPartTest extends TestCase
         }
     }
 
+    public function testBinaryEncodingPreservesRawBytes()
+    {
+        $body = "\xFF\xFE\x80\x00\x7F\xC3\xA9raw\x01payload";
+        $p = new DataPart($body, 'blob.bin', 'application/octet-stream', 'binary');
+        $this->assertSame($body, $p->bodyToString());
+        $this->assertSame($body, implode('', iterator_to_array($p->bodyToIterable())));
+        $this->assertEquals(new Headers(
+            new ParameterizedHeader('Content-Type', 'application/octet-stream', ['name' => 'blob.bin']),
+            new UnstructuredHeader('Content-Transfer-Encoding', 'binary'),
+            new ParameterizedHeader('Content-Disposition', 'attachment', ['name' => 'blob.bin', 'filename' => 'blob.bin'])
+        ), $p->getPreparedHeaders());
+    }
+
     public function testHasContentId()
     {
         $p = new DataPart('content');

--- a/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
@@ -143,10 +143,35 @@ class TextPartTest extends TestCase
         ), $p->getPreparedHeaders());
     }
 
+    public function testBinaryEncoding()
+    {
+        $body = "raw\x00binary\x01payload";
+        $p = new TextPart($body, null, 'plain', 'binary');
+        $this->assertSame($body, $p->bodyToString());
+        $this->assertSame($body, implode('', iterator_to_array($p->bodyToIterable())));
+        $this->assertEquals(new Headers(
+            new ParameterizedHeader('Content-Type', 'text/plain'),
+            new UnstructuredHeader('Content-Transfer-Encoding', 'binary')
+        ), $p->getPreparedHeaders());
+    }
+
+    public function testBinaryEncodingWithResourceContainingHighBytes()
+    {
+        $body = "\xFF\xFE\x80\x00\x7F\xC3\xA9";
+        $f = fopen('php://memory', 'r+', false);
+        fwrite($f, $body);
+        rewind($f);
+
+        $p = new TextPart($f, null, 'plain', 'binary');
+        $this->assertSame($body, $p->bodyToString());
+        $this->assertSame($body, implode('', iterator_to_array($p->bodyToIterable())));
+        fclose($f);
+    }
+
     public function testCustomEncoderNeedsToRegisterFirst()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The encoding must be one of "quoted-printable", "base64", "8bit", "upper_encoder" ("this_encoding_does_not_exist" given).');
+        $this->expectExceptionMessage('The encoding must be one of "quoted-printable", "base64", "8bit", "binary", "upper_encoder" ("this_encoding_does_not_exist" given).');
 
         $upperEncoder = $this->createStub(ContentEncoderInterface::class);
         $upperEncoder->method('getName')->willReturn('upper_encoder');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60301
| License       | MIT

`binary` is now accepted as a `Content-Transfer-Encoding`, next to `quoted-printable`, `base64` and `8bit`:

```php
$part = new DataPart(fopen($file, 'r'), 'blob', 'application/octet-stream', 'binary');
$part = new TextPart($body, 'utf-8', 'plain', 'binary');
```

The body is written to the wire untouched, and the part carries `Content-Transfer-Encoding: binary`. Until now the only way to get that header was to write a `ContentEncoderInterface` and register it with `TextPart::addEncoder()`.

Nothing changes for existing messages: `binary` is never picked automatically, so a part only uses it when it is asked for explicitly.

Note that `binary` requires a transport able to carry it. Symfony does not check that for you, and plain SMTP without the `BINARYMIME` extension is not such a transport. Use it when you control the delivery path, typically when the part never reaches an SMTP server.

Projects that already registered their own `binary` encoder keep working: it stays overridable through `addEncoder()`, unlike the three encoders that have always been built in.

Points for the documentation:

* `binary` is now a valid value of the `$encoding` argument of `TextPart` and `DataPart`
* it writes the body as is, with no transformation and no line length limit
* it is never chosen automatically, unlike `quoted-printable` and `base64`
* it needs a transport supporting `BINARYMIME` (RFC 3030), which plain SMTP is not
