### PR TITLE
[Serializer] Move type-mismatch and uninitialized-property handling into concrete normalizers

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException as PropertyAccessInvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
@@ -194,8 +193,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $attributeValue = $attribute === $this->classDiscriminatorResolver?->getMappingForMappedObject($object)?->getTypeProperty()
                     ? $this->classDiscriminatorResolver?->getTypeForMappedObject($object)
                     : $this->getAttributeValue($object, $attribute, $format, $attributeContext);
-            } catch (UninitializedPropertyException|\Error $e) {
-                if (($context[self::SKIP_UNINITIALIZED_VALUES] ?? $this->defaultContext[self::SKIP_UNINITIALIZED_VALUES] ?? true) && $this->isUninitializedValueError($e)) {
+            } catch (UninitializedPropertyException $e) {
+                if ($context[self::SKIP_UNINITIALIZED_VALUES] ?? $this->defaultContext[self::SKIP_UNINITIALIZED_VALUES] ?? true) {
                     continue;
                 }
                 throw $e;
@@ -292,6 +291,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      * Gets the attribute value.
      *
      * @return mixed
+     *
+     * @throws UninitializedPropertyException When the attribute exists but is not initialized on the object
      */
     abstract protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []);
 
@@ -388,8 +389,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         ? $discriminatorMapping
                         : $this->getAttributeValue($object, $attribute, $format, $attributeContext);
                 } catch (NoSuchPropertyException) {
-                } catch (UninitializedPropertyException|\Error $e) {
-                    if (!(($context[self::SKIP_UNINITIALIZED_VALUES] ?? $this->defaultContext[self::SKIP_UNINITIALIZED_VALUES] ?? true) && $this->isUninitializedValueError($e))) {
+                } catch (UninitializedPropertyException $e) {
+                    if (!($context[self::SKIP_UNINITIALIZED_VALUES] ?? $this->defaultContext[self::SKIP_UNINITIALIZED_VALUES] ?? true)) {
                         throw $e;
                     }
                 }
@@ -413,16 +414,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $attributeContext);
-            } catch (PropertyAccessInvalidArgumentException $e) {
-                $exception = NotNormalizableValueException::createForUnexpectedDataType(
-                    \sprintf('Failed to denormalize attribute "%s" value for class "%s": '.$e->getMessage(), $attribute, $type),
-                    $data,
-                    ['unknown'],
-                    $attributeContext['deserialization_path'] ?? null,
-                    false,
-                    $e->getCode(),
-                    $e
-                );
+            } catch (NotNormalizableValueException $exception) {
                 if (isset($context['not_normalizable_value_exceptions'])) {
                     $context['not_normalizable_value_exceptions'][] = $exception;
                     continue;
@@ -440,6 +432,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     /**
      * @return void
+     *
+     * @throws NotNormalizableValueException When the value cannot be assigned to the attribute (e.g. type mismatch)
      */
     abstract protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []);
 
@@ -832,17 +826,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // The context cannot be serialized, skip the cache
             return false;
         }
-    }
-
-    /**
-     * This error may occur when specific object normalizer implementation gets attribute value
-     * by accessing a public uninitialized property or by calling a method accessing such property.
-     */
-    private function isUninitializedValueError(\Error|UninitializedPropertyException $e): bool
-    {
-        return $e instanceof UninitializedPropertyException
-            || str_starts_with($e->getMessage(), 'Typed property')
-            && str_ends_with($e->getMessage(), 'must not be accessed before initialization');
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\Serializer\Annotation\Ignore as LegacyIgnore;
 use Symfony\Component\Serializer\Attribute\Ignore;
 
@@ -148,24 +149,31 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
     protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []): mixed
     {
-        $getter = 'get'.$attribute;
-        if (method_exists($object, $getter) && \is_callable([$object, $getter])) {
-            return $object->$getter();
-        }
+        try {
+            $getter = 'get'.$attribute;
+            if (method_exists($object, $getter) && \is_callable([$object, $getter])) {
+                return $object->$getter();
+            }
 
-        $isser = 'is'.$attribute;
-        if (method_exists($object, $isser) && \is_callable([$object, $isser])) {
-            return $object->$isser();
-        }
+            $isser = 'is'.$attribute;
+            if (method_exists($object, $isser) && \is_callable([$object, $isser])) {
+                return $object->$isser();
+            }
 
-        $haser = 'has'.$attribute;
-        if (method_exists($object, $haser) && \is_callable([$object, $haser])) {
-            return $object->$haser();
-        }
+            $haser = 'has'.$attribute;
+            if (method_exists($object, $haser) && \is_callable([$object, $haser])) {
+                return $object->$haser();
+            }
 
-        $caner = 'can'.$attribute;
-        if (method_exists($object, $caner) && \is_callable([$object, $caner])) {
-            return $object->$caner();
+            $caner = 'can'.$attribute;
+            if (method_exists($object, $caner) && \is_callable([$object, $caner])) {
+                return $object->$caner();
+            }
+        } catch (\Error $e) {
+            if (str_starts_with($e->getMessage(), 'Typed property') && str_ends_with($e->getMessage(), 'must not be accessed before initialization')) {
+                throw new UninitializedPropertyException(\sprintf('The property "%s::$%s" is not initialized.', $object::class, $attribute), 0, $e);
+            }
+            throw $e;
         }
 
         return null;

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException as PropertyAccessInvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -20,6 +21,7 @@ use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
 use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AccessorCollisionResolverTrait;
@@ -136,6 +138,8 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             $this->propertyAccessor->setValue($object, $attribute, $value);
         } catch (NoSuchPropertyException) {
             // Properties not found are ignored
+        } catch (PropertyAccessInvalidArgumentException $e) {
+            throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Failed to denormalize attribute "%s" value for class "%s": %s', $attribute, $object::class, $e->getMessage()), $value, ['unknown'], $context['deserialization_path'] ?? null, false, $e->getCode(), $e);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\Normalizer;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
@@ -175,6 +176,10 @@ class PropertyNormalizer extends AbstractObjectNormalizer
         }
 
         if ($reflectionProperty->hasType()) {
+            if (!$reflectionProperty->isInitialized($object)) {
+                throw new UninitializedPropertyException(\sprintf('The property "%s::$%s" is not initialized.', $object::class, $reflectionProperty->name));
+            }
+
             return $reflectionProperty->getValue($object);
         }
 
@@ -207,17 +212,21 @@ class PropertyNormalizer extends AbstractObjectNormalizer
             return;
         }
 
-        if (!$reflectionProperty->isReadOnly()) {
-            $reflectionProperty->setValue($object, $value);
+        try {
+            if (!$reflectionProperty->isReadOnly()) {
+                $reflectionProperty->setValue($object, $value);
 
-            return;
-        }
+                return;
+            }
 
-        if (!$reflectionProperty->isInitialized($object)) {
-            $declaringClass = $reflectionProperty->getDeclaringClass();
-            $declaringClass->getProperty($reflectionProperty->getName())->setValue($object, $value);
+            if (!$reflectionProperty->isInitialized($object)) {
+                $declaringClass = $reflectionProperty->getDeclaringClass();
+                $declaringClass->getProperty($reflectionProperty->getName())->setValue($object, $value);
 
-            return;
+                return;
+            }
+        } catch (\TypeError $e) {
+            throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Failed to denormalize attribute "%s" value for class "%s": %s', $attribute, $object::class, $e->getMessage()), $value, ['unknown'], $context['deserialization_path'] ?? null, false, $e->getCode(), $e);
         }
 
         if ($reflectionProperty->getValue($object) !== $value) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/SkipUninitializedValuesTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/SkipUninitializedValuesTestTrait.php
@@ -58,9 +58,7 @@ trait SkipUninitializedValuesTestTrait
             $normalizer->normalize($object, null, ['skip_uninitialized_values' => false, 'groups' => ['foo']]);
             $this->fail('Normalizing an object with uninitialized property should have failed');
         } catch (UninitializedPropertyException $e) {
-            self::assertSame('The property "Symfony\Component\Serializer\Tests\Normalizer\Features\TypedPropertiesObject::$unInitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.', $e->getMessage());
-        } catch (\Error $e) {
-            self::assertSame('Typed property Symfony\Component\Serializer\Tests\Normalizer\Features\TypedPropertiesObject::$unInitialized must not be accessed before initialization', $e->getMessage());
+            self::assertStringContainsString('unInitialized', $e->getMessage());
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -523,6 +523,18 @@ class GetSetMethodNormalizerTest extends TestCase
         return new GetSetMethodNormalizer(new ClassMetadataFactory(new AttributeLoader()));
     }
 
+    public function testUnrelatedErrorFromGetterIsNotSwallowed()
+    {
+        $normalizer = new GetSetMethodNormalizer();
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('intentional getter failure');
+
+        $normalizer->normalize(new GetSetDummyWithThrowingGetter(), null, [
+            'skip_uninitialized_values' => true,
+        ]);
+    }
+
     public function testNormalizeWithDiscriminator()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
@@ -805,6 +817,14 @@ class GetConstructorOptionalArgsDummy
     public function otherMethod()
     {
         throw new \RuntimeException('Dummy::otherMethod() should not be called');
+    }
+}
+
+class GetSetDummyWithThrowingGetter
+{
+    public function getValue(): string
+    {
+        throw new \TypeError('intentional getter failure');
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
@@ -36,8 +37,10 @@ use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -408,6 +411,33 @@ class ObjectNormalizerTest extends TestCase
         $normalizer->denormalize($data, DummyWithUnion::class, 'xml', [
             AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,
         ]);
+    }
+
+    public function testTypeMismatchOnTypedPropertyIsCollectedAsDenormalizationError()
+    {
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, $extractor)]);
+
+        try {
+            $serializer->denormalize(
+                ['name' => ['oops']],
+                ObjectTypedDummy::class,
+                null,
+                [
+                    DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+                    AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true,
+                ],
+            );
+
+            $this->fail(\sprintf('Expected a "%s".', PartialDenormalizationException::class));
+        } catch (PartialDenormalizationException $e) {
+            $this->assertCount(1, $e->getErrors());
+            $error = $e->getErrors()[0];
+            $this->assertInstanceOf(NotNormalizableValueException::class, $error);
+            $this->assertSame('name', $error->getPath());
+            $this->assertSame('array', $error->getCurrentType());
+            $this->assertSame(['unknown'], $error->getExpectedTypes());
+        }
     }
 
     // attributes
@@ -2091,4 +2121,9 @@ class ObjectWithMetadata
     {
         return 'Hello i am '.$this->getName();
     }
+}
+
+class ObjectTypedDummy
+{
+    public string $name;
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -569,6 +571,73 @@ class PropertyNormalizerTest extends TestCase
 
         $this->assertInstanceOf(PropertyDiscriminatedDummyOne::class, $obj);
     }
+
+    /**
+     * @dataProvider provideTypedPropertyDummies
+     */
+    public function testTypeMismatchOnTypedPropertyIsCollectedAsDenormalizationError(string $class)
+    {
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+        $serializer = new Serializer([new PropertyNormalizer(null, null, $extractor)]);
+
+        try {
+            $serializer->denormalize(
+                ['name' => ['oops']],
+                $class,
+                null,
+                [
+                    DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+                    AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true,
+                ],
+            );
+
+            $this->fail(\sprintf('Expected a "%s".', PartialDenormalizationException::class));
+        } catch (PartialDenormalizationException $e) {
+            $this->assertCount(1, $e->getErrors());
+            $error = $e->getErrors()[0];
+            $this->assertInstanceOf(NotNormalizableValueException::class, $error);
+            $this->assertSame('name', $error->getPath());
+            $this->assertSame('array', $error->getCurrentType());
+            $this->assertSame(['unknown'], $error->getExpectedTypes());
+            $this->assertInstanceOf(\TypeError::class, $error->getPrevious());
+        }
+    }
+
+    public static function provideTypedPropertyDummies(): iterable
+    {
+        yield 'readonly typed property' => [PropertyReadonlyTypedDummy::class];
+        yield 'plain typed property' => [PropertyTypedDummy::class];
+    }
+
+    public function testTypeMismatchOnTypedPropertyIsRethrownAsNotNormalizableValueException()
+    {
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+        $serializer = new Serializer([new PropertyNormalizer(null, null, $extractor)]);
+
+        try {
+            $serializer->denormalize(
+                ['name' => ['oops']],
+                PropertyTypedDummy::class,
+                null,
+                [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true],
+            );
+
+            $this->fail(\sprintf('Expected a "%s".', NotNormalizableValueException::class));
+        } catch (NotNormalizableValueException $e) {
+            $this->assertSame('name', $e->getPath());
+            $this->assertInstanceOf(\TypeError::class, $e->getPrevious());
+        }
+    }
+}
+
+class PropertyReadonlyTypedDummy
+{
+    public readonly string $name;
+}
+
+class PropertyTypedDummy
+{
+    public string $name;
 }
 
 class PropertyDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #60405
| License       | MIT

`AbstractObjectNormalizer::denormalize()` already converts `PropertyAccessInvalidArgumentException` thrown by `setAttributeValue()` into a `NotNormalizableValueException` so it aggregates under `COLLECT_DENORMALIZATION_ERRORS`. `PropertyNormalizer` writes attributes via `\ReflectionProperty::setValue()`, which throws raw `\TypeError`, so that path leaked past the parent's catch and aborted the denormalization even when partial denormalization was requested.

Rather than widening the parent catch to also cover `\TypeError`, the catch-and-translate is moved into each concrete normalizer. The parent now catches a single Serializer-native exception and stays agnostic of which property-access strategy a subclass uses:

- `ObjectNormalizer::setAttributeValue()` translates `PropertyAccessInvalidArgumentException` → `NotNormalizableValueException`.
- `PropertyNormalizer::setAttributeValue()` translates `\TypeError` → `NotNormalizableValueException`.
- `AbstractObjectNormalizer::denormalize()` catches `NotNormalizableValueException`.

The read-side had the same architectural smell: the parent caught `UninitializedPropertyException|\Error` and discriminated via a private helper that string-matched the exception message (`"Typed property … must not be accessed before initialization"`). That has also been moved down:

- `PropertyNormalizer::getAttributeValue()` proactively checks `\ReflectionProperty::isInitialized()` on typed properties and throws `UninitializedPropertyException` itself, removing the need to catch `\Error` entirely.
- `GetSetMethodNormalizer::getAttributeValue()` catches the `\Error` from a getter accessing an uninitialized typed property and re-throws as `UninitializedPropertyException`; unrelated `\Error`s still propagate.
- `AbstractObjectNormalizer::normalize()` catches `UninitializedPropertyException`. The `isUninitializedValueError()` helper is removed.

Both abstract methods now declare their `@throws` contracts explicitly.

Behavior outside `COLLECT_DENORMALIZATION_ERRORS` is unchanged for `ObjectNormalizer`. For `PropertyNormalizer`, a single type mismatch now surfaces as `NotNormalizableValueException` (carrying the `\TypeError` as `previous`) rather than a raw `\TypeError` — aligning the two implementations.

Tests: the regression test for #60405 is parameterized over readonly and non-readonly typed properties, plus a second test pinning the no-`COLLECT` path. Parallel coverage is added for `ObjectNormalizer`. A `GetSetMethodNormalizer` test asserts unrelated getter `\Error`s still propagate even with `skip_uninitialized_values` enabled.