### PR TITLE
[FrameworkBundle][Translation] Set Loco HTTP client max host connections to 10

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1673,18 +1673,20 @@ class FrameworkExtension extends Extension
         }
 
         $classToServices = [
-            TranslationBridge\Crowdin\CrowdinProviderFactory::class => 'translation.provider_factory.crowdin',
-            TranslationBridge\Loco\LocoProviderFactory::class => 'translation.provider_factory.loco',
-            TranslationBridge\Lokalise\LokaliseProviderFactory::class => 'translation.provider_factory.lokalise',
-            TranslationBridge\Phrase\PhraseProviderFactory::class => 'translation.provider_factory.phrase',
+            TranslationBridge\Crowdin\CrowdinProviderFactory::class => ['symfony/crowdin-translation-provider', ['translation.provider_factory.crowdin']],
+            TranslationBridge\Loco\LocoProviderFactory::class => ['symfony/loco-translation-provider', ['translation.provider_factory.loco', 'translation.provider_factory.loco.http_client']],
+            TranslationBridge\Lokalise\LokaliseProviderFactory::class => ['symfony/lokalise-translation-provider', ['translation.provider_factory.lokalise']],
+            TranslationBridge\Phrase\PhraseProviderFactory::class => ['symfony/phrase-translation-provider', ['translation.provider_factory.phrase']],
         ];
 
         $parentPackages = ['symfony/framework-bundle', 'symfony/translation', 'symfony/http-client'];
 
-        foreach ($classToServices as $class => $service) {
-            $package = substr($service, \strlen('translation.provider_factory.'));
+        foreach ($classToServices as $class => [$package, $services]) {
+            if ($container->hasDefinition('http_client') && ContainerBuilder::willBeAvailable($package, $class, $parentPackages)) {
+                continue;
+            }
 
-            if (!$container->hasDefinition('http_client') || !ContainerBuilder::willBeAvailable(\sprintf('symfony/%s-translation-provider', $package), $class, $parentPackages)) {
+            foreach ($services as $service) {
                 $container->removeDefinition($service);
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_providers.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_providers.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Translation\Bridge\Crowdin\CrowdinProviderFactory;
 use Symfony\Component\Translation\Bridge\Loco\LocoProviderFactory;
 use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProviderFactory;
@@ -18,6 +19,7 @@ use Symfony\Component\Translation\Bridge\Phrase\PhraseProviderFactory;
 use Symfony\Component\Translation\Provider\NullProviderFactory;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Provider\TranslationProviderCollectionFactory;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -46,9 +48,19 @@ return static function (ContainerConfigurator $container) {
             ])
             ->tag('translation.provider_factory')
 
+        ->set('translation.provider_factory.loco.http_client', HttpClientInterface::class)
+            ->factory([HttpClient::class, 'create'])
+            ->args([
+                [], // default options
+                10, // max host connections
+            ])
+            ->call('setLogger', [service('logger')])
+            ->tag('http_client.client')
+            ->tag('monolog.logger', ['channel' => 'http_client'])
+
         ->set('translation.provider_factory.loco', LocoProviderFactory::class)
             ->args([
-                service('http_client'),
+                service('translation.provider_factory.loco.http_client'),
                 service('logger'),
                 param('kernel.default_locale'),
                 service('translation.loader.xliff'),

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\Translation\Bridge\Loco;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
+use Symfony\Component\HttpClient\RetryableHttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Provider\AbstractProviderFactory;
@@ -45,8 +48,8 @@ final class LocoProviderFactory extends AbstractProviderFactory
         $endpoint .= $dsn->getPort() ? ':'.$dsn->getPort() : '';
         $restrictToStatus = $dsn->getOption('status');
 
-        $client = $this->client->withOptions([
-            'base_uri' => 'https://'.$endpoint.'/api/',
+        $client = new RetryableHttpClient($this->client, new GenericRetryStrategy(), 3, $this->logger);
+        $client = ScopingHttpClient::forBaseUri($client, 'https://'.$endpoint.'/api/', [
             'headers' => [
                 'Authorization' => 'Loco '.$this->getUser($dsn),
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix part of  #62289
| License       | MIT

From the maker of Loco:

> The Loco API […] does restrict parallel HTTP requests to a buffer of 10 pending requests per API key.