### PR TITLE
[Messenger] Release deduplication lock on definitive failure

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -118,6 +118,7 @@ use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Bridge as MessengerBridge;
+use Symfony\Component\Messenger\EventListener\ReleaseDeduplicationLockOnFailureListener;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -2409,6 +2410,10 @@ class FrameworkExtension extends Extension
             $defaultMiddleware['before'][] = ['id' => 'deduplicate_middleware'];
         } else {
             $container->removeDefinition('messenger.middleware.deduplicate_middleware');
+            $container->removeDefinition('messenger.failure.release_deduplication_lock_on_failure_listener');
+        }
+        if (!class_exists(ReleaseDeduplicationLockOnFailureListener::class)) {
+            $container->removeDefinition('messenger.failure.release_deduplication_lock_on_failure_listener');
         }
 
         foreach ($config['buses'] as $busId => $bus) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -19,6 +19,7 @@ use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportF
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\EventListener\AddErrorDetailsStampListener;
 use Symfony\Component\Messenger\EventListener\DispatchPcntlSignalListener;
+use Symfony\Component\Messenger\EventListener\ReleaseDeduplicationLockOnFailureListener;
 use Symfony\Component\Messenger\EventListener\ResetMemoryUsageListener;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
@@ -226,6 +227,12 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'messenger'])
 
         ->set('messenger.failure.add_error_details_stamp_listener', AddErrorDetailsStampListener::class)
+            ->tag('kernel.event_subscriber')
+
+        ->set('messenger.failure.release_deduplication_lock_on_failure_listener', ReleaseDeduplicationLockOnFailureListener::class)
+            ->args([
+                service('lock.factory'),
+            ])
             ->tag('kernel.event_subscriber')
 
         ->set('messenger.failure.send_failed_message_to_failure_transport_listener', SendFailedMessageToFailureTransportListener::class)

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `MessageExecutionStrategyInterface` and `SyncMessageExecutionStrategy` to decouple message execution from the `Worker`
  * Allow configuring the service reset interval in the `messenger:consume` command via the `--no-reset` option
  * Add `AmqpPriorityStamp` to set per-message priority on the AMQP transport
+ * Add `ReleaseDeduplicationLockOnFailureListener` that releases the deduplication lock when a message fails and will not be retried
 
 8.0
 ---

--- a/src/Symfony/Component/Messenger/EventListener/ReleaseDeduplicationLockOnFailureListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/ReleaseDeduplicationLockOnFailureListener.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Stamp\DeduplicateStamp;
+
+/**
+ * Releases the deduplication lock when a handled message definitively fails.
+ *
+ * The {@see \Symfony\Component\Messenger\Middleware\DeduplicateMiddleware}
+ * keeps the lock held when a handler throws, so that a message still being
+ * retried cannot be enqueued again. Once the retry flow has decided not to
+ * retry (retries exhausted, unrecoverable exception, or no retry strategy),
+ * the lock must be released to unblock future messages sharing the same key.
+ *
+ * Caveat: a message moved to a failure transport and later replayed via
+ * messenger:failed:retry will not be deduplicated against a parallel dispatch
+ * of the same key, since the lock is released here on definitive failure.
+ */
+final class ReleaseDeduplicationLockOnFailureListener implements EventSubscriberInterface
+{
+    public function __construct(private LockFactory $lockFactory)
+    {
+    }
+
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        if ($event->willRetry()) {
+            return;
+        }
+
+        if (!$stamp = $event->getEnvelope()->last(DeduplicateStamp::class)) {
+            return;
+        }
+
+        if ($stamp->onlyDeduplicateInQueue()) {
+            return;
+        }
+
+        $this->lockFactory->createLockFromKey($stamp->getKey())->release();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // must have lower priority than SendFailedMessageForRetryListener (100) so willRetry() is already set
+            WorkerMessageFailedEvent::class => ['onMessageFailed', 0],
+        ];
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/EventListener/ReleaseDeduplicationLockOnFailureListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/ReleaseDeduplicationLockOnFailureListenerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\EventListener\ReleaseDeduplicationLockOnFailureListener;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
+use Symfony\Component\Messenger\Stamp\DeduplicateStamp;
+
+final class ReleaseDeduplicationLockOnFailureListenerTest extends TestCase
+{
+    public function testLockIsReleasedWhenMessageWillNotRetry()
+    {
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects($this->once())->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->once())->method('createLockFromKey')->willReturn($lock);
+
+        $envelope = new Envelope(new \stdClass(), [new DeduplicateStamp('id')]);
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \Exception('boom'));
+
+        (new ReleaseDeduplicationLockOnFailureListener($lockFactory))->onMessageFailed($event);
+    }
+
+    public function testLockIsNotReleasedWhenMessageWillRetry()
+    {
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->never())->method('createLockFromKey');
+
+        $envelope = new Envelope(new \stdClass(), [new DeduplicateStamp('id')]);
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \Exception('boom'));
+        $event->setForRetry();
+
+        (new ReleaseDeduplicationLockOnFailureListener($lockFactory))->onMessageFailed($event);
+    }
+
+    public function testNoopWhenEnvelopeHasNoDeduplicateStamp()
+    {
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->never())->method('createLockFromKey');
+
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \Exception('boom'));
+
+        (new ReleaseDeduplicationLockOnFailureListener($lockFactory))->onMessageFailed($event);
+    }
+
+    public function testLockIsNotReleasedWhenOnlyDeduplicateInQueue()
+    {
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->never())->method('createLockFromKey');
+
+        $envelope = new Envelope(new \stdClass(), [new DeduplicateStamp('id', onlyDeduplicateInQueue: true)]);
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \Exception('boom'));
+
+        (new ReleaseDeduplicationLockOnFailureListener($lockFactory))->onMessageFailed($event);
+    }
+
+    public function testListenerRunsAfterRetryListener()
+    {
+        $retryPriority = SendFailedMessageForRetryListener::getSubscribedEvents()[WorkerMessageFailedEvent::class][1];
+        $ownPriority = ReleaseDeduplicationLockOnFailureListener::getSubscribedEvents()[WorkerMessageFailedEvent::class][1];
+
+        $this->assertLessThan($retryPriority, $ownPriority, 'Must run after SendFailedMessageForRetryListener so willRetry() is set.');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Companion to #63992 on 7.4. Once that bug fix lands, a message that fails definitively (no retry — moved to a failure transport) leaves the deduplication lock held until its TTL expires (default 300s), silently swallowing fresh dispatches sharing the same key in the meantime.

This PR adds `ReleaseDeduplicationLockOnFailureListener` on `WorkerMessageFailedEvent` at priority `0` — between `SendFailedMessageForRetryListener` (100, sets `willRetry`) and `SendFailedMessageToFailureTransportListener` (-100). It releases the lock when `!willRetry()`, the envelope carries a `DeduplicateStamp`, and the stamp is not `onlyDeduplicateInQueue` (that path is already released by the middleware at consumer entry). Wired in `FrameworkBundle` and removed alongside the deduplication middleware when the Lock component is unavailable.

Caveat: a failed message later replayed via `messenger:failed:retry` is no longer deduplicated against a parallel dispatch using the same key — by design, discussed on #63992.
