### PR TITLE
[Messenger] Add routing information to the `debug:messenger` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Auto-configure the `form.data_class` resource tag for classes with the `#[AsFormType]` attribute
  * Add the `cache.adapter.mongodb` and `cache.adapter.mongodb_tag_aware` cache adapters, and the `framework.cache.default_mongodb_provider` option
+ * Add Messenger routing and failure transport information to the `debug:messenger` command
  * Add the `framework.webhook.no_private_network` and `framework.webhook.http_client` options
  * Add the `claim_check` option to Messenger transports
  * Add the `framework.asset_mapper.importmap_entries` option to limit the rendered import map to the entries reachable from the rendered entrypoints

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -823,9 +823,9 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(Constraint::class)
             ->addTag('container.excluded', ['source' => 'because it\'s a validation constraint']);
         $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition, AsMessage $attribute): void {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a messenger message']);
-            $definition->addTag('messenger.message', [
-                'serializedTypeName' => $attribute->serializedTypeName,
+            $definition->addResourceTag('messenger.message', [
+                'transport' => $attribute->transport,
+                'serializedTypeName' => $attribute->serializedTypeName ?? null,
                 'serializedTypeNameAliases' => $attribute->serializedTypeNameAliases ?? [],
             ]);
         });

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -98,6 +98,7 @@ use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\Mime\Crypto\PgpEncrypter;
@@ -1195,7 +1196,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $configurators[0]($definition, new AsMessage(serializedTypeName: 'my.type', serializedTypeNameAliases: ['my.legacy.type']));
 
         $this->assertSame(
-            [['serializedTypeName' => 'my.type', 'serializedTypeNameAliases' => ['my.legacy.type']]],
+            [['transport' => null, 'serializedTypeName' => 'my.type', 'serializedTypeNameAliases' => ['my.legacy.type']]],
             $definition->getTag('messenger.message')
         );
     }
@@ -1288,7 +1289,9 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testMessengerMultipleFailureTransports()
     {
-        $container = $this->createContainerFromFile('messenger_multiple_failure_transports');
+        $container = $this->createContainerFromFile('messenger_multiple_failure_transports', [], true, false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
 
         $failureTransport1Definition = $container->getDefinition('messenger.transport.failure_transport_1');
         $failureTransport1Tags = $failureTransport1Definition->getTag('messenger.receiver')[0];
@@ -1324,11 +1327,19 @@ abstract class FrameworkExtensionTestCase extends TestCase
             return array_shift($values);
         }, $failureTransports);
         $this->assertEquals($expectedTransportsByFailureTransports, $failureTransportsReferences);
+        if (method_exists(SendersLocator::class, 'getSenderAliases')) {
+            $this->assertSame([
+                'transport_1' => 'failure_transport_1',
+                'transport_3' => 'failure_transport_3',
+            ], $container->getDefinition('console.command.messenger_debug')->getArgument(4));
+        }
     }
 
     public function testMessengerMultipleFailureTransportsWithGlobalFailureTransport()
     {
-        $container = $this->createContainerFromFile('messenger_multiple_failure_transports_global');
+        $container = $this->createContainerFromFile('messenger_multiple_failure_transports_global', [], true, false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
 
         $this->assertEquals('messenger.transport.failure_transport_global', (string) $container->getAlias('messenger.failure_transports.default'));
 
@@ -1367,6 +1378,16 @@ abstract class FrameworkExtensionTestCase extends TestCase
             return array_shift($values);
         }, $failureTransports);
         $this->assertEquals($expectedTransportsByFailureTransports, $failureTransportsReferences);
+        if (method_exists(SendersLocator::class, 'getSenderAliases')) {
+            $this->assertSame([
+                'transport_1' => 'failure_transport_1',
+                'transport_2' => 'failure_transport_global',
+                'transport_3' => 'failure_transport_3',
+                'failure_transport_global' => 'failure_transport_global',
+                'failure_transport_1' => 'failure_transport_global',
+                'failure_transport_3' => 'failure_transport_global',
+            ], $container->getDefinition('console.command.messenger_debug')->getArgument(4));
+        }
     }
 
     public function testMessengerTransports()
@@ -1524,6 +1545,23 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $sendersMapping = $senderLocatorDefinition->getArgument(0);
         $this->assertEquals(['amqp'], $sendersMapping[DummyMessage::class]);
+    }
+
+    public function testAsMessageAutoconfigurationUsesResourceTag()
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', []);
+        });
+
+        $this->assertArrayHasKey(AsMessage::class, $container->getAttributeAutoconfigurators());
+        $this->assertCount(1, $container->getAttributeAutoconfigurators()[AsMessage::class]);
+
+        $definition = new ChildDefinition('foo');
+        $autoconfigurator = $container->getAttributeAutoconfigurators()[AsMessage::class][0];
+        $autoconfigurator($definition, new AsMessage(transport: ['async']));
+
+        $this->assertSame([['transport' => ['async'], 'serializedTypeName' => null, 'serializedTypeNameAliases' => []]], $definition->getTag('messenger.message'));
+        $this->assertSame([['source' => 'by tag "messenger.message"']], $definition->getTag('container.excluded'));
     }
 
     public function testMessengerTransportConfiguration()

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add claim check support with `ClaimCheckSerializer` and PSR-6 cache pools
+ * Add routing and failure transport information and a `--message` option to the `debug:messenger` command
  * Add `HandlerStartingEvent`, `HandlerSuccessEvent` and `HandlerFailureEvent`, dispatched around each handler call
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
  * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`

--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -18,8 +18,12 @@ use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\Attribute\AsMessage;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 
 /**
  * A console command to debug Messenger information.
@@ -29,8 +33,19 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand(name: 'debug:messenger', description: 'List messages you can dispatch using the message buses')]
 class DebugCommand extends Command
 {
+    /**
+     * @param array<string, array<string, list<array{0: string, 1: array}>>> $mapping
+     * @param array<string, list<string>>                                    $sendersMap
+     * @param array<string, string>                                          $senderAliases
+     * @param array<string, list<string>>                                    $attributeMessages Message classes discovered via #[AsMessage] attribute mapped to their transports
+     * @param array<string, string>                                          $failureTransports Failure transports mapped by source transport
+     */
     public function __construct(
         private array $mapping,
+        private readonly array $sendersMap = [],
+        private readonly array $senderAliases = [],
+        private readonly array $attributeMessages = [],
+        private readonly array $failureTransports = [],
     ) {
         parent::__construct();
     }
@@ -39,15 +54,24 @@ class DebugCommand extends Command
     {
         $this
             ->addArgument('bus', InputArgument::OPTIONAL, \sprintf('The bus id (one of "%s")', implode('", "', array_keys($this->mapping))))
+            ->addOption('message', null, InputOption::VALUE_REQUIRED, 'A message FQCN to inspect')
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> command displays all messages that can be
-                dispatched using the message buses:
+                dispatched using the message buses, their handlers, routing rules and
+                failure transports:
 
                   <info>php %command.full_name%</info>
 
                 Or for a specific bus only:
 
                   <info>php %command.full_name% command_bus</info>
+
+                Or inspect what happens when dispatching a specific message:
+
+                  <info>php %command.full_name% --message='App\Message\MyMessage'</info>
+
+                Routing is based on configuration and #[AsMessage] attributes.
+                TransportNamesStamp can override this routing at dispatch time.
 
                 EOF
             )
@@ -59,6 +83,15 @@ class DebugCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Messenger');
 
+        $messageClass = $input->getOption('message');
+        if (null !== $messageClass) {
+            $messageClass = ltrim($messageClass, '\\');
+
+            if (!class_exists($messageClass) && !interface_exists($messageClass)) {
+                throw new RuntimeException(\sprintf('Message class "%s" does not exist.', $messageClass));
+            }
+        }
+
         $mapping = $this->mapping;
         if ($bus = $input->getArgument('bus')) {
             if (!isset($mapping[$bus])) {
@@ -69,6 +102,10 @@ class DebugCommand extends Command
 
         foreach ($mapping as $bus => $handlersByMessage) {
             $io->section($bus);
+
+            if (null !== $messageClass) {
+                $handlersByMessage = [$messageClass => $this->getHandlersForMessage($messageClass, $handlersByMessage)];
+            }
 
             $tableRows = [];
             foreach ($handlersByMessage as $message => $handlers) {
@@ -85,6 +122,18 @@ class DebugCommand extends Command
                         $tableRows[] = [\sprintf('               <comment>%s</>', $handlerDescription)];
                     }
                 }
+
+                if (!$handlers) {
+                    $tableRows[] = ['    <comment>not handled</>'];
+                }
+
+                $transportNames = $this->getTransportNamesForMessage($message);
+                foreach ($transportNames as $transportName) {
+                    $tableRows[] = [\sprintf('    routed to <info>%s</>', $transportName)];
+                }
+                if (!$transportNames && null !== $messageClass) {
+                    $tableRows[] = ['    <comment>not routed</>'];
+                }
                 $tableRows[] = [''];
             }
 
@@ -97,7 +146,28 @@ class DebugCommand extends Command
             }
         }
 
+        $this->displayTransportRules($io, $messageClass);
+
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('bus')) {
+            $suggestions->suggestValues(array_keys($this->mapping));
+        }
+
+        if ($input->mustSuggestOptionValuesFor('message')) {
+            $messages = array_keys($this->sendersMap + $this->attributeMessages);
+            foreach ($this->mapping as $handlersByMessage) {
+                $messages = array_merge($messages, array_keys($handlersByMessage));
+            }
+
+            $messages = array_values(array_unique(array_filter($messages, static fn (string $message): bool => class_exists($message) || interface_exists($message))));
+            sort($messages);
+
+            $suggestions->suggestValues($messages);
+        }
     }
 
     private function formatConditions(array $options, string $serviceId): string
@@ -135,10 +205,227 @@ class DebugCommand extends Command
         return '';
     }
 
-    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    /**
+     * @param array<string, list<array{0: string, 1: array}>> $handlersByMessage
+     *
+     * @return list<array{0: string, 1: array}>
+     */
+    private function getHandlersForMessage(string $message, array $handlersByMessage): array
     {
-        if ($input->mustSuggestArgumentValuesFor('bus')) {
-            $suggestions->suggestValues(array_keys($this->mapping));
+        $handlers = [];
+        $seen = [];
+
+        foreach (HandlersLocator::listTypesForClass($message) as $type) {
+            foreach ($handlersByMessage[$type] ?? [] as $handler) {
+                $options = $handler[1];
+                $name = $handler[0].'::'.($options['method'] ?? '__invoke').'@'.($options['alias'] ?? '');
+                if (isset($seen[$name])) {
+                    continue;
+                }
+
+                $seen[$name] = true;
+                $handlers[] = $handler;
+            }
         }
+
+        return $handlers;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getTransportNamesForMessage(string $message): array
+    {
+        if (!class_exists($message) && !interface_exists($message)) {
+            return [];
+        }
+
+        $serviceToAlias = array_flip($this->senderAliases);
+        $transportNames = [];
+
+        foreach (SendersLocator::getSenderAliases($message, $this->sendersMap) as $senderAlias) {
+            $transportName = $serviceToAlias[$senderAlias] ?? $senderAlias;
+            if (!\in_array($transportName, $transportNames, true)) {
+                $transportNames[] = $transportName;
+            }
+        }
+
+        sort($transportNames);
+
+        return $transportNames;
+    }
+
+    private function displayTransportRules(SymfonyStyle $io, ?string $messageClass): void
+    {
+        $rulesByTransport = $this->getRulesByTransport($messageClass);
+        if (!$rulesByTransport && null === $messageClass) {
+            return;
+        }
+
+        $io->section('Transports');
+        $io->info('TransportNamesStamp can override this routing at dispatch time.');
+
+        if (!$rulesByTransport) {
+            $io->text($this->senderAliases ? 'No routing rules apply to this message.' : 'No transports are configured.');
+
+            return;
+        }
+
+        foreach ($rulesByTransport as $transportName => $rules) {
+            $io->writeln(\sprintf('<fg=cyan>%s</>', $transportName));
+            if (!$rules) {
+                $io->writeln('    <comment>No routing rules.</>');
+            } else {
+                foreach ($rules as [$rule, $fromAttribute]) {
+                    $io->writeln('    '.$this->formatRoutingRule($rule, $fromAttribute));
+                }
+            }
+            if ($failureTransport = $this->getFailureTransportName($transportName)) {
+                $io->writeln(\sprintf('    failed messages are routed to <info>%s</>', $failureTransport));
+            }
+            $io->newLine();
+        }
+    }
+
+    /**
+     * @return array<string, list<array{0: string, 1: bool}>>
+     */
+    private function getRulesByTransport(?string $messageClass): array
+    {
+        $serviceToAlias = array_flip($this->senderAliases);
+
+        if (null !== $messageClass) {
+            return $this->getRulesByTransportForMessage($messageClass, $serviceToAlias);
+        }
+
+        $rulesByTransport = array_fill_keys(array_keys($this->senderAliases), []);
+
+        foreach ($this->sendersMap as $rule => $senders) {
+            foreach ($senders as $sender) {
+                $transportName = $serviceToAlias[$sender] ?? $sender;
+                $rulesByTransport[$transportName][] = [$rule, false];
+            }
+        }
+
+        foreach ($this->attributeMessages as $message => $transports) {
+            if ($this->hasConfigurationRouting($message)) {
+                continue;
+            }
+
+            foreach ($transports as $transport) {
+                $transportName = $serviceToAlias[$transport] ?? $transport;
+                if (!\in_array([$message, true], $rulesByTransport[$transportName] ?? [], true)) {
+                    $rulesByTransport[$transportName][] = [$message, true];
+                }
+            }
+        }
+
+        ksort($rulesByTransport);
+        foreach ($rulesByTransport as &$rules) {
+            usort($rules, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
+        }
+        unset($rules);
+
+        return $rulesByTransport;
+    }
+
+    /**
+     * @param array<string, string> $serviceToAlias
+     *
+     * @return array<string, list<array{0: string, 1: bool}>>
+     */
+    private function getRulesByTransportForMessage(string $messageClass, array $serviceToAlias): array
+    {
+        $effectiveSenderAliases = SendersLocator::getSenderAliases($messageClass, $this->sendersMap);
+        $rulesByTransport = [];
+        $seen = [];
+
+        if ($this->hasConfigurationRouting($messageClass)) {
+            foreach (HandlersLocator::listTypesForClass($messageClass) as $rule) {
+                if (str_ends_with($rule, '*') && $seen) {
+                    continue;
+                }
+
+                foreach ($this->sendersMap[$rule] ?? [] as $senderAlias) {
+                    if (isset($seen[$senderAlias]) || !\in_array($senderAlias, $effectiveSenderAliases, true)) {
+                        continue;
+                    }
+
+                    $seen[$senderAlias] = true;
+                    $transportName = $serviceToAlias[$senderAlias] ?? $senderAlias;
+                    $rulesByTransport[$transportName][] = [$rule, false];
+                }
+            }
+        } else {
+            foreach ([$messageClass] + class_parents($messageClass) + class_implements($messageClass) as $rule) {
+                foreach (self::getTransportsFromAttribute($rule) as $senderAlias) {
+                    if (isset($seen[$senderAlias]) || !\in_array($senderAlias, $effectiveSenderAliases, true)) {
+                        continue;
+                    }
+
+                    $seen[$senderAlias] = true;
+                    $transportName = $serviceToAlias[$senderAlias] ?? $senderAlias;
+                    $rulesByTransport[$transportName][] = [$rule, true];
+                }
+            }
+        }
+
+        ksort($rulesByTransport);
+
+        return $rulesByTransport;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function getTransportsFromAttribute(string $class): array
+    {
+        $transports = [];
+
+        foreach ((new \ReflectionClass($class))->getAttributes(AsMessage::class, \ReflectionAttribute::IS_INSTANCEOF) as $refAttr) {
+            $transports = array_merge($transports, (array) ($refAttr->newInstance()->transport ?? []));
+        }
+
+        return $transports;
+    }
+
+    private function hasConfigurationRouting(string $message): bool
+    {
+        foreach (HandlersLocator::listTypesForClass($message) as $type) {
+            if ($this->sendersMap[$type] ?? []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getFailureTransportName(string $transportName): ?string
+    {
+        if (!$failureTransport = $this->failureTransports[$transportName] ?? null) {
+            return null;
+        }
+
+        $failureTransport = array_flip($this->senderAliases)[$failureTransport] ?? $failureTransport;
+
+        return $failureTransport === $transportName ? null : $failureTransport;
+    }
+
+    private function formatRoutingRule(string $rule, bool $fromAttribute): string
+    {
+        $descriptions = [];
+        if ('*' === $rule) {
+            $descriptions[] = 'fallback for messages with no other route';
+        } elseif (str_ends_with($rule, '\\*')) {
+            $descriptions[] = 'namespace';
+        } elseif (interface_exists($rule)) {
+            $descriptions[] = 'interface, matches implementers';
+        }
+
+        if ($fromAttribute) {
+            $descriptions[] = 'from #[AsMessage]';
+        }
+
+        return $rule.($descriptions ? ' ('.implode(', ', $descriptions).')' : '');
     }
 }

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -53,8 +53,8 @@ class MessengerPass implements CompilerPassInterface
         }
 
         $this->registerHandlers($container, $busIds);
-
         $this->registerTypeMapping($container);
+        $this->registerDebugCommandRouting($container);
     }
 
     private function registerHandlers(ContainerBuilder $container, array $busIds): void
@@ -499,5 +499,51 @@ class MessengerPass implements CompilerPassInterface
         }
 
         $container->getDefinition('messenger.transport.symfony_serializer')->setArgument(3, $typeToClassMap);
+    }
+
+    private function registerDebugCommandRouting(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('console.command.messenger_debug') || !$container->hasDefinition('messenger.senders_locator')) {
+            return;
+        }
+
+        $sendersMap = $container->getDefinition('messenger.senders_locator')->getArgument(0);
+        if (!\is_array($sendersMap)) {
+            $sendersMap = [];
+        }
+
+        $senderAliases = [];
+        foreach ($container->findTaggedServiceIds('messenger.receiver') as $id => $tags) {
+            foreach ($tags as $tag) {
+                if (isset($tag['alias'])) {
+                    $senderAliases[$tag['alias']] = $id;
+                }
+            }
+        }
+
+        $attributeMessages = [];
+        foreach ($container->findTaggedResourceIds('messenger.message', false) as $id => $tags) {
+            $class = $container->getDefinition($id)->getClass();
+            foreach ($tags as $tag) {
+                foreach ((array) ($tag['transport'] ?? []) as $transport) {
+                    $attributeMessages[$class][] = $transport;
+                }
+            }
+        }
+
+        $failureTransports = [];
+        if ($container->hasDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')) {
+            $failureTransports = $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')->getArguments()[2] ?? [];
+            if (!\is_array($failureTransports)) {
+                $failureTransports = [];
+            }
+        }
+
+        $container->getDefinition('console.command.messenger_debug')
+            ->setArgument(1, $sendersMap)
+            ->setArgument(2, $senderAliases)
+            ->setArgument(3, $attributeMessages)
+            ->setArgument(4, $failureTransports)
+        ;
     }
 }

--- a/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
@@ -63,8 +63,14 @@ class HandlersLocator implements HandlersLocatorInterface
      */
     public static function listTypes(Envelope $envelope): array
     {
-        $class = $envelope->getMessage()::class;
+        return self::listTypesForClass($envelope->getMessage()::class);
+    }
 
+    /**
+     * @internal
+     */
+    public static function listTypesForClass(string $class): array
+    {
         return self::$typeCache[$class] ??= [$class => $class]
             + class_parents($class)
             + class_implements($class)

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -22,6 +22,9 @@ use Symfony\Component\Messenger\Tests\Fixtures\DummyCommand;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandWithDescription;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandWithDescriptionHandler;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageWithAttribute;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageWithParentWithAttribute;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyQuery;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage;
@@ -160,6 +163,271 @@ class DebugCommandTest extends TestCase
         );
     }
 
+    public function testOutputIncludesRoutingInformationAndGlobalTransportRules()
+    {
+        $command = new DebugCommand(
+            [
+                'command_bus' => [DummyCommand::class => [[DummyCommandHandler::class, []]]],
+                'event_bus' => [DummyCommand::class => [[DummyCommandHandler::class, []]]],
+            ],
+            [
+                DummyCommand::class => ['messenger.transport.async'],
+                DummyMessageInterface::class => ['messenger.transport.async'],
+                'App\\Message\\*' => ['messenger.transport.async'],
+                '*' => ['messenger.transport.fallback'],
+            ],
+            [
+                'async' => 'messenger.transport.async',
+                'fallback' => 'messenger.transport.fallback',
+                'unused' => 'messenger.transport.unused',
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertSame(2, substr_count($display, 'routed to async'));
+        $this->assertSame(1, substr_count($display, 'Transports'));
+        $this->assertStringContainsString(DummyMessageInterface::class.' (interface, matches implementers)', $display);
+        $this->assertStringContainsString('App\\Message\\* (namespace)', $display);
+        $this->assertStringContainsString('* (fallback for messages with no other route)', $display);
+        $this->assertStringContainsString('unused', $display);
+        $this->assertStringContainsString('No routing rules.', $display);
+        $this->assertStringNotContainsString('[WARNING]', $display);
+        $this->assertSame(1, substr_count($display, 'TransportNamesStamp can override this routing at dispatch time.'));
+    }
+
+    public function testOutputForMessageResolvesHandlersAndRouting()
+    {
+        $command = new DebugCommand(
+            [
+                'command_bus' => [DummyMessageInterface::class => [[DummyCommandHandler::class, []]]],
+            ],
+            [
+                DummyMessageInterface::class => ['messenger.transport.configured'],
+                DummyCommand::class => ['messenger.transport.configured'],
+            ],
+            [
+                'configured' => 'messenger.transport.configured',
+                'first_sender' => 'messenger.transport.first_sender',
+                'second_sender' => 'messenger.transport.second_sender',
+                'failed' => 'messenger.transport.failed',
+                'unrelated_failure' => 'messenger.transport.unrelated_failure',
+            ],
+            [
+                DummyMessageWithAttribute::class => ['first_sender', 'second_sender'],
+            ],
+            [
+                'configured' => 'messenger.transport.failed',
+                'first_sender' => 'messenger.transport.unrelated_failure',
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--message' => DummyMessageWithAttribute::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertStringContainsString(DummyMessageWithAttribute::class, $display);
+        $this->assertStringContainsString('handled by '.DummyCommandHandler::class, $display);
+        $this->assertStringContainsString('routed to configured', $display);
+        $this->assertStringContainsString(DummyMessageInterface::class.' (interface, matches implementers)', $display);
+        $this->assertStringNotContainsString(DummyCommand::class.\PHP_EOL, $display);
+        $this->assertStringNotContainsString('routed to first_sender', $display);
+        $this->assertStringNotContainsString('routed to second_sender', $display);
+        $this->assertStringNotContainsString('first_sender', $display);
+        $this->assertStringNotContainsString('second_sender', $display);
+        $this->assertStringContainsString('failed messages are routed to failed', $display);
+        $this->assertStringNotContainsString('unrelated_failure', $display);
+    }
+
+    public function testOutputIncludesEffectiveAttributeRoutingRule()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => []],
+            [],
+            [
+                'first_sender' => 'messenger.transport.first_sender',
+                'second_sender' => 'messenger.transport.second_sender',
+            ],
+            [
+                DummyMessageWithAttribute::class => ['first_sender', 'second_sender'],
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([], ['decorated' => false]);
+
+        $this->assertSame(2, substr_count($tester->getDisplay(true), DummyMessageWithAttribute::class.' (from #[AsMessage])'));
+    }
+
+    public function testOutputIncludesFailureTransportRoutes()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => []],
+            [DummyCommand::class => ['messenger.transport.async']],
+            [
+                'async' => 'messenger.transport.async',
+                'audit' => 'messenger.transport.audit',
+                'failed' => 'messenger.transport.failed',
+            ],
+            [],
+            [
+                'async' => 'messenger.transport.failed',
+                'audit' => 'failed',
+                'failed' => 'failed',
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertSame(2, substr_count($display, 'failed messages are routed to failed'));
+        $this->assertStringContainsString("audit\n    No routing rules.\n    failed messages are routed to failed", $display);
+    }
+
+    public function testOutputForMessageIncludesOnlyEffectiveWildcardRule()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => []],
+            [
+                'Symfony\\Component\\Messenger\\Tests\\Fixtures\\*' => ['messenger.transport.namespace'],
+                '*' => ['messenger.transport.fallback'],
+                DummyQuery::class => ['messenger.transport.unrelated'],
+            ],
+            [
+                'namespace' => 'messenger.transport.namespace',
+                'fallback' => 'messenger.transport.fallback',
+                'unrelated' => 'messenger.transport.unrelated',
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--message' => DummyCommand::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertStringContainsString('routed to namespace', $display);
+        $this->assertStringContainsString('Symfony\\Component\\Messenger\\Tests\\Fixtures\\* (namespace)', $display);
+        $this->assertStringNotContainsString('fallback', $display);
+        $this->assertStringNotContainsString('unrelated', $display);
+    }
+
+    public function testOutputForMessageIncludesOnlyEffectiveAttributeRules()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => []],
+            [],
+            [
+                'first_sender' => 'messenger.transport.first_sender',
+                'second_sender' => 'messenger.transport.second_sender',
+                'third_sender' => 'messenger.transport.third_sender',
+                'unrelated' => 'messenger.transport.unrelated',
+            ],
+            [
+                DummyMessageWithAttribute::class => ['first_sender', 'second_sender'],
+                DummyMessageWithParentWithAttribute::class => ['third_sender'],
+                DummyCommand::class => ['unrelated'],
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--message' => DummyMessageWithParentWithAttribute::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertSame(2, substr_count($display, DummyMessageWithAttribute::class.' (from #[AsMessage])'));
+        $this->assertSame(2, substr_count($display, DummyMessageWithParentWithAttribute::class));
+        $this->assertStringNotContainsString('unrelated', $display);
+    }
+
+    public function testOutputForMessageAcceptsALeadingBackslash()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => [DummyCommand::class => [[DummyCommandHandler::class, []]]]],
+            [DummyCommand::class => ['messenger.transport.async']],
+            ['async' => 'messenger.transport.async'],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--message' => '\\'.DummyCommand::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertStringContainsString('handled by '.DummyCommandHandler::class, $display);
+        $this->assertStringContainsString('routed to async', $display);
+        $this->assertStringNotContainsString('not routed', $display);
+    }
+
+    public function testOutputForMessageResolvesAttributeRulesOfUnregisteredMessages()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => []],
+            [],
+            [
+                'first_sender' => 'messenger.transport.first_sender',
+                'second_sender' => 'messenger.transport.second_sender',
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--message' => DummyMessageWithAttribute::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertStringContainsString('routed to first_sender', $display);
+        $this->assertStringContainsString('routed to second_sender', $display);
+        $this->assertSame(2, substr_count($display, DummyMessageWithAttribute::class.' (from #[AsMessage])'));
+        $this->assertStringNotContainsString('No routing rules apply to this message.', $display);
+    }
+
+    public function testOutputDoesNotListAttributeRuleOverriddenByConfigurationUsingSameTransport()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => []],
+            [DummyMessageInterface::class => ['first_sender']],
+            [
+                'first_sender' => 'messenger.transport.first_sender',
+                'second_sender' => 'messenger.transport.second_sender',
+            ],
+            [
+                DummyMessageWithAttribute::class => ['first_sender', 'second_sender'],
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([], ['decorated' => false]);
+
+        $this->assertStringNotContainsString(DummyMessageWithAttribute::class.' (from #[AsMessage])', $tester->getDisplay(true));
+    }
+
+    public function testOutputForUnroutedMessageIncludesStampCaveat()
+    {
+        $command = new DebugCommand(['command_bus' => []]);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--message' => DummyCommand::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertStringContainsString('not routed', $display);
+        $this->assertStringContainsString('TransportNamesStamp can override this routing at dispatch time.', $display);
+        $this->assertStringContainsString('No transports are configured.', $display);
+    }
+
+    public function testOutputForUnroutedMessageDoesNotListUnrelatedTransports()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => []],
+            [DummyQuery::class => ['messenger.transport.async']],
+            ['async' => 'messenger.transport.async'],
+        );
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--message' => DummyCommand::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertStringContainsString('not routed', $display);
+        $this->assertStringContainsString('No routing rules apply to this message.', $display);
+        $this->assertStringNotContainsString('async', $display);
+    }
+
     public function testExceptionOnUnknownBusArgument()
     {
         $this->expectException(RuntimeException::class);
@@ -173,7 +441,12 @@ class DebugCommandTest extends TestCase
     #[DataProvider('provideCompletionSuggestions')]
     public function testComplete(array $input, array $expectedSuggestions)
     {
-        $command = new DebugCommand(['command_bus' => [], 'query_bus' => []]);
+        $command = new DebugCommand(
+            ['command_bus' => [DummyCommand::class => []], 'query_bus' => []],
+            [DummyMessageInterface::class => [], '*' => [], 'App\\Message\\*' => []],
+            [],
+            [DummyMessageWithAttribute::class => []],
+        );
         $application = new Application();
         $application->addCommand($command);
         $tester = new CommandCompletionTester($application->get('debug:messenger'));
@@ -185,6 +458,11 @@ class DebugCommandTest extends TestCase
         yield 'bus' => [
             [''],
             ['command_bus', 'query_bus'],
+        ];
+
+        yield 'message' => [
+            ['--message='],
+            [DummyCommand::class, DummyMessageInterface::class, DummyMessageWithAttribute::class],
         ];
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -925,6 +925,56 @@ class MessengerPassTest extends TestCase
         ], $container->getDefinition('console.command.messenger_debug')->getArgument(0));
     }
 
+    public function testItAddsRoutingToTheDebugCommand()
+    {
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.senders_locator')->addArgument([
+            DummyCommand::class => ['first_sender'],
+            'Symfony\Component\Messenger\Tests\Fixtures\*' => ['third_sender'],
+        ]);
+
+        $container->register('messenger.transport.first_sender', DummyReceiver::class)
+            ->addTag('messenger.receiver', ['alias' => 'first_sender']);
+        $container->register('messenger.transport.second_sender', DummyReceiver::class)
+            ->addTag('messenger.receiver', ['alias' => 'second_sender']);
+        $container->register('messenger.transport.third_sender', DummyReceiver::class)
+            ->addTag('messenger.receiver', ['alias' => 'third_sender']);
+        $container->register(DummyMessage::class, DummyMessage::class)
+            ->addResourceTag('messenger.message', ['transport' => ['second_sender']]);
+        $container->register('app.dummy_command_message', DummyCommand::class)
+            ->addResourceTag('messenger.message', ['transport' => 'third_sender']);
+        $container->register('messenger.failure.send_failed_message_to_failure_transport_listener')
+            ->setArguments([null, null, [
+                'first_sender' => 'third_sender',
+                'second_sender' => 'third_sender',
+            ]]);
+
+        $container->register('console.command.messenger_debug', DebugCommand::class)
+            ->addArgument([]);
+
+        (new MessengerPass())->process($container);
+
+        $commandDefinition = $container->getDefinition('console.command.messenger_debug');
+        $this->assertSame([
+            DummyCommand::class => ['first_sender'],
+            'Symfony\Component\Messenger\Tests\Fixtures\*' => ['third_sender'],
+        ], $commandDefinition->getArgument(1));
+        $this->assertSame([
+            'first_sender' => 'messenger.transport.first_sender',
+            'second_sender' => 'messenger.transport.second_sender',
+            'third_sender' => 'messenger.transport.third_sender',
+        ], $commandDefinition->getArgument(2));
+        $this->assertSame([
+            DummyMessage::class => ['second_sender'],
+            DummyCommand::class => ['third_sender'],
+        ], $commandDefinition->getArgument(3));
+        $this->assertSame([
+            'first_sender' => 'third_sender',
+            'second_sender' => 'third_sender',
+        ], $commandDefinition->getArgument(4));
+    }
+
     public function testCreatesSigningSerializerChildrenFromMapping()
     {
         $container = $this->getContainerBuilder('message_bus');

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -17,6 +17,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageWithAttribute;
@@ -28,6 +29,21 @@ use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 
 class SendersLocatorTest extends TestCase
 {
+    #[TestWith([DummyMessage::class, [DummyMessage::class => ['first'], '*' => ['fallback']], ['first']])]
+    #[TestWith([DummyMessage::class, [DummyMessage::class => ['first', 'second']], ['first', 'second']])]
+    #[TestWith([ChildDummyMessage::class, [DummyMessage::class => ['parent']], ['parent']])]
+    #[TestWith([DummyMessage::class, ['Symfony\\Component\\Messenger\\Tests\\Fixtures\\*' => ['namespace'], '*' => ['fallback']], ['namespace']])]
+    #[TestWith([SecondMessage::class, [DummyMessage::class => ['first'], '*' => ['fallback']], ['fallback']])]
+    #[TestWith([DummyMessageWithAttribute::class, [], ['first_sender', 'second_sender']])]
+    #[TestWith([DummyMessageWithParentWithAttribute::class, [], ['third_sender', 'first_sender', 'second_sender']])]
+    #[TestWith([DummyMessageWithInterfaceWithAttribute::class, [], ['first_sender', 'third_sender', 'second_sender']])]
+    #[TestWith([DummyMessageWithAttribute::class, [DummyMessageInterface::class => ['configured']], ['configured']])]
+    #[TestWith([DummyMessageWithAttribute::class, ['*' => ['fallback']], ['fallback']])]
+    public function testItGetsSenderAliasesForMessageClass(string $messageClass, array $sendersMap, array $expectedAliases)
+    {
+        $this->assertSame($expectedAliases, SendersLocator::getSenderAliases($messageClass, $sendersMap));
+    }
+
     public function testItReturnsTheSenderBasedOnTheMessageClass()
     {
         $sender = $this->createStub(SenderInterface::class);

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -38,49 +38,53 @@ class SendersLocator implements SendersLocatorInterface
     public function getSenders(Envelope $envelope): iterable
     {
         if ($envelope->all(TransportNamesStamp::class)) {
-            foreach ($envelope->last(TransportNamesStamp::class)->getTransportNames() as $senderAlias) {
-                yield from $this->getSenderFromAlias($senderAlias);
-            }
-
-            return;
+            $senderAliases = $envelope->last(TransportNamesStamp::class)->getTransportNames();
+        } else {
+            $senderAliases = self::getSenderAliases($envelope->getMessage()::class, $this->sendersMap);
         }
 
-        $seen = [];
-        $found = false;
+        foreach ($senderAliases as $senderAlias) {
+            yield from $this->getSenderFromAlias($senderAlias);
+        }
+    }
 
-        foreach (HandlersLocator::listTypes($envelope) as $type) {
-            if (str_ends_with($type, '*') && $seen) {
+    /**
+     * @param array<string, list<string>> $sendersMap
+     *
+     * @return list<string>
+     *
+     * @internal
+     */
+    public static function getSenderAliases(string $messageClass, array $sendersMap): array
+    {
+        $senderAliases = [];
+
+        foreach (HandlersLocator::listTypesForClass($messageClass) as $type) {
+            if (str_ends_with($type, '*') && $senderAliases) {
                 // the '*' acts as a fallback, if other senders already matched
                 // with previous types, skip the senders bound to the fallback
                 continue;
             }
 
-            foreach ($this->sendersMap[$type] ?? [] as $senderAlias) {
-                if (!\in_array($senderAlias, $seen, true)) {
-                    $seen[] = $senderAlias;
-
-                    yield from $this->getSenderFromAlias($senderAlias);
-                    $found = true;
+            foreach ($sendersMap[$type] ?? [] as $senderAlias) {
+                if (!\in_array($senderAlias, $senderAliases, true)) {
+                    $senderAliases[] = $senderAlias;
                 }
             }
         }
 
-        // Let the configuration-driven map upper override message attributes,
-        // this allows environment-specific configuration overriding hardcoded
-        // transport name.
-        if ($found) {
-            return;
+        // Let the configuration-driven map override message attributes. This allows
+        // environment-specific configuration to override hardcoded transport names.
+        if ($senderAliases) {
+            return $senderAliases;
         }
 
-        foreach ($this->getTransportNamesFromAttribute($envelope) as $senderAlias) {
-            yield from $this->getSenderFromAlias($senderAlias);
-        }
+        return self::getTransportNamesFromAttribute($messageClass);
     }
 
-    private function getTransportNamesFromAttribute(Envelope $envelope): array
+    private static function getTransportNamesFromAttribute(string $messageClass): array
     {
         $transports = [];
-        $messageClass = $envelope->getMessage()::class;
 
         foreach ([$messageClass] + class_parents($messageClass) + class_implements($messageClass) as $class) {
             foreach ((new \ReflectionClass($class))->getAttributes(AsMessage::class, \ReflectionAttribute::IS_INSTANCEOF) as $refAttr) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`debug:messenger` now says where each message goes, not only which handlers it has.

Every message in the listing gains a `routed to` line, and a `Transports` section lists the routing rules once, grouped by transport, with the kind of each rule and the failure transport it feeds:

```
Transports
----------

 [INFO] TransportNamesStamp can override this routing at dispatch time.

async
    App\Message\OrderPlaced
    App\Message\Sub\* (namespace)
    App\Message\AuditableInterface (interface, matches implementers)
    failed messages are routed to failed_async

failed
    * (fallback for messages with no other route)
```

Routing is configured once for the whole application, not per bus, so the section is printed once, after the bus sections.

A `--message` option answers "what happens when I dispatch this class":

```bash
php bin/console debug:messenger --message='App\Message\OrderPlaced'
```

It resolves the class the way `dispatch()` does: through its parent classes, its interfaces, namespace wildcards, the `*` fallback and `#[AsMessage]` attributes, with configuration taking precedence over attributes. Handlers registered for a parent class or an interface are listed too. The output is restricted to the transports and rules that apply to that message, it works for message classes that are not registered as services, and a leading backslash in the value is accepted.

`TransportNamesStamp` overrides routing at dispatch time and no static view can see that, so the output says so rather than reading as authoritative.

To keep the command and the runtime from drifting apart, the alias half of `SendersLocator::getSenders()` moved to an internal `SendersLocator::getSenderAliases()` that both call, and `HandlersLocator` gained an internal `listTypesForClass()` taking a class name instead of an envelope. `#[AsMessage]` now records its `transport` on the `messenger.message` resource tag so the compiler pass can list attribute-routed messages in the transports view.

Points the documentation should carry:

* the two views: the whole listing, and `--message` for one class
* the rule kinds shown next to each rule, and that configuration wins over `#[AsMessage]` (including the `*` fallback, which disables attribute routing for every message)
* the failure transport line, and that a transport whose failure transport is itself does not show one
* the `TransportNamesStamp` caveat
