### PR TITLE
[Notifier][Novu] Add `$context` to `NovuOptions` and deprecate recipient-level overrides

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -103,6 +103,11 @@ Messenger
    Note that a message sent to a transport is no longer handled in process, so `RedispatchMessageHandler`
    returns `null` for it instead of the result of the handler
 
+Notifier
+--------
+
+ * Deprecate `NovuSubscriberRecipient::getOverrides()` and its `$overrides` constructor parameter, pass overrides to `NovuOptions` instead
+
 Security
 --------
 

--- a/src/Symfony/Component/Notifier/Bridge/Novu/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `$context` parameter to `NovuOptions`
+ * Deprecate `NovuSubscriberRecipient::getOverrides()` and its `$overrides` constructor parameter, pass overrides to `NovuOptions` instead
+
 6.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuOptions.php
@@ -28,8 +28,17 @@ class NovuOptions implements MessageOptionsInterface
      *                bcc?: string[]
      *            }|null
      *        } $overrides
+     * @param array{
+     *            tenant?: string,
+     *            app?: string,
+     *            extra?: array{
+     *                key?: string,
+     *                value?: string[]
+     *            }
+     *        } $context
      *
-     * @see https://docs.novu.co/channels/email/#sending-email-overrides
+     * @see https://docs.novu.co/platform/integrations/email#sending-email-overrides
+     * @see https://docs.novu.co/platform/workflow/advanced-features/contexts/manage-contexts
      */
     public function __construct(
         private readonly ?string $subscriberId = null,
@@ -41,6 +50,7 @@ class NovuOptions implements MessageOptionsInterface
         private readonly ?string $locale = null,
         private readonly array $overrides = [],
         private readonly array $options = [],
+        private readonly array $context = [],
     ) {
     }
 
@@ -54,6 +64,7 @@ class NovuOptions implements MessageOptionsInterface
             'avatar' => $this->avatar,
             'locale' => $this->locale,
             'overrides' => $this->overrides,
+            'context' => $this->context,
         ]);
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuSubscriberRecipient.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuSubscriberRecipient.php
@@ -28,8 +28,6 @@ class NovuSubscriberRecipient implements RecipientInterface
      *                bcc?: string[]
      *            }|null
      *        } $overrides
-     *
-     * @see https://docs.novu.co/channels/email/#sending-email-overrides
      */
     public function __construct(
         private readonly string $subscriberId,
@@ -41,6 +39,9 @@ class NovuSubscriberRecipient implements RecipientInterface
         private readonly ?string $locale = null,
         private readonly array $overrides = [],
     ) {
+        if ([] !== $overrides) {
+            trigger_deprecation('symfony/novu-notifier', '8.2', 'Passing "$overrides" to "%s()" is deprecated, pass them to "%s" instead.', __METHOD__, NovuOptions::class);
+        }
     }
 
     public function getSubscriberId(): string
@@ -78,8 +79,13 @@ class NovuSubscriberRecipient implements RecipientInterface
         return $this->locale;
     }
 
+    /**
+     * @deprecated since Symfony 8.2, pass overrides to NovuOptions instead
+     */
     public function getOverrides(): array
     {
+        trigger_deprecation('symfony/novu-notifier', '8.2', 'The "%s()" method is deprecated, pass overrides to "%s" instead.', __METHOD__, NovuOptions::class);
+
         return $this->overrides;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransport.php
@@ -67,6 +67,7 @@ class NovuTransport extends AbstractTransport
             ],
             'payload' => json_decode($message->getContent()),
             'overrides' => $options['overrides'] ?? [],
+            'context' => $options['context'] ?? [],
         ];
 
         $endpoint = \sprintf('https://%s/v1/events/trigger', $this->getEndpoint());

--- a/src/Symfony/Component/Notifier/Bridge/Novu/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/README.md
@@ -16,6 +16,28 @@ Notification example
 ```php
 class NovuNotification extends Notification implements PushNotificationInterface
 {
+    /** @var array<string, mixed> */
+    private array $overrides = [];
+
+    /** @var array<string, mixed> */
+    private array $context = [];
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    public function setOverrides(array $overrides): void
+    {
+        $this->overrides = $overrides;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function setContext(array $context): void
+    {
+        $this->context = $context;
+    }
+
     public function asPushMessage(
         NovuSubscriberRecipient|RecipientInterface $recipient,
         ?string $transport = null,
@@ -31,8 +53,9 @@ class NovuNotification extends Notification implements PushNotificationInterface
                 $recipient->getPhone(),
                 $recipient->getAvatar(),
                 $recipient->getLocale(),
-                $recipient->getOverrides(),
+                $this->overrides,
                 [],
+                $this->context,
             ),
         );
     }
@@ -50,6 +73,16 @@ $notification->content(
         ]
     )
 );
+$notification->setOverrides([
+    'email' => [
+        'from' => 'no-reply@toppy.nl',
+        'senderName' => 'No-Reply',
+    ],
+]);
+$notification->setContext([
+    'tenant' => 'tenant-id',
+    'app' => 'app-id',
+]);
 
 $this->notifier->send(
     $notification,
@@ -61,12 +94,6 @@ $this->notifier->send(
         null,
         null,
         null,
-        [
-            'email' => [
-                'from' => 'no-reply@toppy.nl',
-                'senderName' => 'No-Reply',
-            ],
-        ],
     ),
 );
 ```

--- a/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuOptionsTest.php
@@ -33,6 +33,10 @@ class NovuOptionsTest extends TestCase
                 ],
             ],
             [],
+            [
+                'tenant' => 'tenant-id',
+                'app' => 'app-id',
+            ],
         );
 
         $this->assertSame(
@@ -48,6 +52,10 @@ class NovuOptionsTest extends TestCase
                         'from' => 'no-reply@example.com',
                         'senderName' => 'No-Reply',
                     ],
+                ],
+                'context' => [
+                    'tenant' => 'tenant-id',
+                    'app' => 'app-id',
                 ],
             ],
             $options->toArray()

--- a/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuSubscriberRecipientTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuSubscriberRecipientTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Novu\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
+use Symfony\Component\Notifier\Bridge\Novu\NovuSubscriberRecipient;
+
+class NovuSubscriberRecipientTest extends TestCase
+{
+    use ExpectUserDeprecationMessageTrait;
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testPassingOverridesIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/novu-notifier 8.2: Passing "$overrides" to "Symfony\Component\Notifier\Bridge\Novu\NovuSubscriberRecipient::__construct()" is deprecated, pass them to "Symfony\Component\Notifier\Bridge\Novu\NovuOptions" instead.');
+
+        new NovuSubscriberRecipient('123', overrides: ['email' => ['from' => 'no-reply@example.com']]);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testGetOverridesIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/novu-notifier 8.2: The "Symfony\Component\Notifier\Bridge\Novu\NovuSubscriberRecipient::getOverrides()" method is deprecated, pass overrides to "Symfony\Component\Notifier\Bridge\Novu\NovuOptions" instead.');
+
+        $this->assertSame([], (new NovuSubscriberRecipient('123'))->getOverrides());
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/Tests/NovuTransportTest.php
@@ -37,7 +37,7 @@ class NovuTransportTest extends TransportTestCase
 
     public static function supportedMessagesProvider(): iterable
     {
-        yield [new PushMessage('test', '{}', new NovuOptions(123, null, null, 'test@example.com', null, null, null, ['email' => ['from' => 'no-reply@example.com', 'senderName' => 'No-Reply']], []))];
+        yield [new PushMessage('test', '{}', new NovuOptions(123, null, null, 'test@example.com', null, null, null, ['email' => ['from' => 'no-reply@example.com', 'senderName' => 'No-Reply']], [], ['tenant' => 'tenant-id', 'app' => 'app-id']))];
     }
 
     public static function unsupportedMessagesProvider(): iterable
@@ -55,6 +55,6 @@ class NovuTransportTest extends TransportTestCase
         $this->expectException(TransportException::class);
         $this->expectExceptionMessageMatches('/400: "subscriberId under property to is not configured"/');
 
-        $transport->send(new PushMessage('test', '{}', new NovuOptions(123, null, null, 'test@example.com', null, null, null, ['email' => ['from' => 'no-reply@example.com', 'senderName' => 'No-Reply']], [])));
+        $transport->send(new PushMessage('test', '{}', new NovuOptions(123, null, null, 'test@example.com', null, null, null, ['email' => ['from' => 'no-reply@example.com', 'senderName' => 'No-Reply']], [], ['tenant' => 'tenant-id', 'app' => 'app-id'])));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Novu/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/notifier": "^7.4|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #64076
| License       | MIT

Two related changes to the Novu notifier bridge.

### `$context` on `NovuOptions`

Novu's `POST /v1/events/trigger` endpoint accepts a `context` object that scopes a notification to a specific `tenant`/`app` (plus an `extra` map), and is required to resolve tenant- and app-level workflow configuration on the Novu side. The bridge already forwarded `payload` and `overrides`; `context` was the missing piece.

```php
new NovuOptions(context: ['tenant' => 'tenant-id', 'app' => 'app-id']);
```

The documented shape is:

```php
array{
    tenant?: string,
    app?: string,
    extra?: array{
        key?: string,
        value?: string[]
    }
}
```

It is the last constructor argument, so existing positional callers are unaffected, and it is forwarded as-is in the trigger request body.

### Deprecate `$overrides` on `NovuSubscriberRecipient`

`NovuSubscriberRecipient` describes a Novu subscriber identity: id, name, email, phone, avatar, locale. Overrides describe how a particular event is sent, not who receives it, so they belong on the message options. The transport never read them from the recipient: they only ever worked through user code copying them into `NovuOptions`, which is what the previous README example did.

Passing `$overrides` to the recipient constructor and calling `getOverrides()` are now deprecated and will be removed in 9.0. Overrides, like the new context, are carried by the notification and passed to `NovuOptions` from `asPushMessage()`. The README shows the updated pattern:

```php
public function asPushMessage(NovuSubscriberRecipient|RecipientInterface $recipient, ?string $transport = null): ?PushMessage
{
    return new PushMessage($this->getSubject(), $this->getContent(), new NovuOptions($recipient->getSubscriberId(), $recipient->getFirstName(), $recipient->getLastName(), $recipient->getEmail(), $recipient->getPhone(), $recipient->getAvatar(), $recipient->getLocale(), $this->overrides, [], $this->context));
}
```

### For the docs

* `NovuOptions` gained a `$context` constructor argument with the shape above
* `NovuSubscriberRecipient::getOverrides()` and its `$overrides` constructor parameter are deprecated, pass overrides to `NovuOptions` instead
