### PR TITLE
[DependencyInjection] Throw on circular reference through a factory's method call

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -31,6 +31,7 @@ use Symfony\Component\DependencyInjection\Exception\EnvParameterException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\LazyServiceDumper;
@@ -993,6 +994,16 @@ class PhpDumper extends Dumper
         [$callCount, $behavior] = $this->serviceCalls[$targetId];
 
         if ($id === $targetId) {
+            if (!$forConstructor && $definition->getFactory()) {
+                // A circular reference loops back to a factory-built service through
+                // a non-constructor edge (method call, property or configurator). The
+                // soft-circular resolution would emit "$instance = $a->build()" before
+                // the inlined builder's method calls have run, returning an unconfigured
+                // instance. There is no safe ordering: bail out instead of producing
+                // broken code.
+                throw new ServiceCircularReferenceException($id, [$id, $id]);
+            }
+
             return $this->addInlineService($id, $definition, $definition);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -994,6 +994,32 @@ class PhpDumperTest extends TestCase
         $this->assertTrue($container->get('bar')->callPassed(), '->dump() initializes properties before method calls');
     }
 
+    public function testCircularReferenceWithFactoryThroughMethodCallIsRejected()
+    {
+        // product is built by a factory whose builder has method calls; one of
+        // those method calls (useExtension) brings the cycle back to product
+        // through a non-constructor edge. Generating an early-instance pattern
+        // here would call the factory before the builder has been configured,
+        // returning a half-built service. Bail out instead of producing broken
+        // code.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useExtension', [new Reference('extension')]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+        $container->register('extension', 'stdClass')
+            ->addArgument(new Reference('product'));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+
+        $this->expectException(ServiceCircularReferenceException::class);
+        $this->expectExceptionMessage('Circular reference detected for service "product"');
+
+        $dumper->dump();
+    }
+
     public function testCircularReferenceAllowanceForLazyServices()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fixes #64059
| License       | MIT

When a circular reference loops back to a factory-built service through a non-constructor edge (a method call, a property setter, or a configurator on the inlined builder), the soft-circular resolution in `PhpDumper` emits ``$instance = $a->build()`` *before* the inlined builder's method calls have run. The factory therefore returns an unconfigured instance, and the subsequent method calls on the builder no longer affect ``$instance`` (the broken instance is then registered in the container and cached). This produces silently wrong objects at runtime instead of an error.

Detect the situation when reentering the inlined service through `addInlineReference` (`$id === $targetId`) on a non-constructor edge and bail out with `ServiceCircularReferenceException`, since there is no safe ordering when a factory is involved in such a loop.