### PR TITLE
[ErrorHandler] Trigger @method deprecation notices for abstract classes

### DIFF
--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add argument `$deprecationsNamespacesMapping` to `DebugClassLoader::enable()` to configure namespace-to-vendor remapping for deprecation checks
+ * Trigger `@method` deprecation notices on abstract classes
 
 7.3
 ---

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -436,7 +436,7 @@ class DebugClassLoader
                 }
             }
 
-            if ($refl->isInterface() && isset($doc['method'])) {
+            if (($refl->isInterface() || $refl->isAbstract()) && isset($doc['method'])) {
                 foreach ($doc['method'] as $name => [$static, $returnType, $signature, $description]) {
                     if ($refl->hasMethod($static ? '__callStatic' : '__call')) {
                         // When the interface has "virtual" @method declarations but at the same time contains a __call/__callStatic magic method,
@@ -444,6 +444,11 @@ class DebugClassLoader
                         // "@method" annotations never intend to actually add the method to the interface, but are used to document the "virtual"
                         // API provided by the interface through the technical implementation of magic calls. This might cause false negatives
                         // (missing notices) in the case that such interfaces are later amended with actual (real) methods.
+                        continue;
+                    }
+                    if ($refl->hasMethod($name)) {
+                        // The abstract class already declares the method (abstract or with a default implementation),
+                        // so the @method annotation is just documentation; no deprecation should be triggered for subclasses.
                         continue;
                     }
                     self::$method[$class][] = [$class, $static, $returnType, $name.$signature, $description];

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -410,6 +410,44 @@ class DebugClassLoaderTest extends TestCase
         ], $deprecations);
     }
 
+    public function testVirtualUseWithAbstractClass()
+    {
+        // An abstract class can announce @method annotations the same way an interface does, to give
+        // subclasses time to implement the method before it becomes a real abstract requirement.
+        // ExtendsVirtualAbstractClass extends VirtualAbstract (abstract) and does not implement any of its
+        // @method annotations.
+
+        $deprecations = [];
+        set_error_handler(static function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
+        $e = error_reporting(\E_USER_DEPRECATED);
+
+        class_exists('Test\\'.ExtendsVirtualAbstractClass::class, true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $this->assertSame([
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualAbstractClass" should implement method "Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualAbstract::abstractClassMethod(): string".',
+            'Class "Test\Symfony\Component\ErrorHandler\Tests\ExtendsVirtualAbstractClass" should implement method "static Symfony\Component\ErrorHandler\Tests\Fixtures\VirtualAbstract::abstractStaticMethod(): \stdClass": Description.',
+        ], $deprecations);
+    }
+
+    public function testVirtualUseWithAbstractClassImplementingTheMethod()
+    {
+        // When the concrete subclass already declares the announced @method, no deprecation is raised.
+
+        $deprecations = [];
+        set_error_handler(static function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
+        $e = error_reporting(\E_USER_DEPRECATED);
+
+        class_exists('Test\\'.ExtendsVirtualAbstractClassImpl::class, true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $this->assertSame([], $deprecations);
+    }
+
     public function testVirtualUseWithMagicCallInterface()
     {
         // When an interface uses "@method" annotations and, at the same time, requires the __call method to be
@@ -721,6 +759,14 @@ class ClassLoader
         } elseif ('Test\\'.ExtendsVirtualMagicCallInterface::class === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsVirtualMagicCallInterface implements \\'.__NAMESPACE__.'\Fixtures\VirtualInterfaceWithCall {
                 public function __call(string $name, array $arguments): mixed { return null; }
+            }');
+        } elseif ('Test\\'.ExtendsVirtualAbstractClass::class === $class) {
+            eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsVirtualAbstractClass extends \\'.__NAMESPACE__.'\Fixtures\VirtualAbstract {
+            }');
+        } elseif ('Test\\'.ExtendsVirtualAbstractClassImpl::class === $class) {
+            eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsVirtualAbstractClassImpl extends \\'.__NAMESPACE__.'\Fixtures\VirtualAbstract {
+                public function abstractClassMethod(): string { return ""; }
+                public static function abstractStaticMethod(): \stdClass { return new \stdClass(); }
             }');
         } elseif ('Test\\'.ReturnType::class === $class) {
             return $fixtureDir.\DIRECTORY_SEPARATOR.'ReturnType.php';

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/VirtualAbstract.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/VirtualAbstract.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+/**
+ * @method string abstractClassMethod()
+ * @method static \stdClass abstractStaticMethod() Description
+ */
+abstract class VirtualAbstract
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fixes #63633
| License       | MIT

`DebugClassLoader` already collects ``@method`` annotations from interfaces so that subclasses receive a deprecation notice when they fail to implement the announced method. The downstream code (the comment around `$parentInterfaces` near `class_implements`) explicitly assumes that abstract parent classes accumulate methods in `self::$method`, but the population step at the top of `checkClass` only runs when `isInterface()` is true. As a result, ``@method`` annotations on abstract classes were silently ignored.

Extend the population check to ``isInterface() || isAbstract()`` so abstract classes can announce upcoming abstract methods just like interfaces can. When the abstract class itself already declares a method matching the annotation, the corresponding entry is skipped: the annotation is then plain documentation and subclasses do not need to be deprecated.

Adds two tests covering both cases (subclass missing the method, subclass implementing it).