### PR TITLE
[VarDumper] Skip built-in class names

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -87,7 +87,7 @@ class VarCloner extends AbstractCloner
                         if ('' === $v) {
                             continue 2;
                         }
-                        if (0 === $i && class_exists($v, false)) {
+                        if (0 === $i && class_exists($v, false) && new \ReflectionClass($v)->isUserDefined()) {
                             $stub = new ClassDumpStub($v);
                             $a = $stub->value;
                             $stub->value = null;

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Dumper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarDumper\Caster\ClassDumpStub;
 use Symfony\Component\VarDumper\Caster\ClassStub;
@@ -313,6 +314,14 @@ class CliDumperTest extends TestCase
             EODUMP,
             new VirtualProperty()
         );
+    }
+
+    #[TestWith(['stdClass'])]
+    #[TestWith(['locale'])]
+    #[TestWith(['FFI\CType'])]
+    public function testBuiltInClassString($classString)
+    {
+        $this->assertDumpMatchesFormat('"'.$classString.'"', $classString);
     }
 
     public function testClassString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/symfony/pull/63810#issuecomment-4352224540
| License       | MIT

Prevent false-positive with strings matching class names.
The built-in classes don't have a declaring file name, and probably none of them use static properties. So the custom dumper introduced in #63810 is not useful for them.