### PR TITLE
[Messenger] Alias the AMQP "user" connection option to "login"

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -34,6 +34,21 @@ class ConnectionTest extends TestCase
         Connection::fromDsn('amqp://:');
     }
 
+    public function testUserOptionIsAliasedToLogin()
+    {
+        $r = new \ReflectionProperty(Connection::class, 'connectionOptions');
+
+        $connection = new Connection(['host' => 'localhost', 'user' => 'alice'], ['name' => self::DEFAULT_EXCHANGE_NAME], [self::DEFAULT_EXCHANGE_NAME => []]);
+        $options = $r->getValue($connection);
+        $this->assertSame('alice', $options['login']);
+        $this->assertArrayNotHasKey('user', $options);
+
+        $connection = new Connection(['host' => 'localhost', 'user' => 'alice', 'login' => 'bob'], ['name' => self::DEFAULT_EXCHANGE_NAME], [self::DEFAULT_EXCHANGE_NAME => []]);
+        $options = $r->getValue($connection);
+        $this->assertSame('bob', $options['login']);
+        $this->assertArrayNotHasKey('user', $options);
+    }
+
     public function testItCanBeConstructedWithDefaults()
     {
         $this->assertEquals(

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -105,6 +105,11 @@ class Connection
             throw new LogicException(\sprintf('You cannot use the "%s" as the "amqp" extension is not installed.', __CLASS__));
         }
 
+        if (isset($connectionOptions['user'])) {
+            $connectionOptions['login'] ??= $connectionOptions['user'];
+            unset($connectionOptions['user']);
+        }
+
         $this->connectionOptions = array_replace_recursive([
             'delay' => [
                 'exchange_name' => 'delays',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fixes #61922
| License       | MIT

The AMQP `Connection` documents `user` as an alias for `login` (the only credential key understood by `php-amqp`), and lists both in `AVAILABLE_OPTIONS`. However the alias is only honored by `Connection::fromDsn()` when the user is in the DSN URL part (`user@host`); if it is passed via the constructor or via `?user=…` in the DSN query string, it is stored under `user` but `php-amqp` reads it from `login` and silently falls back to the default `guest` credential, leading to authentication failures that are hard to diagnose.

Normalize `user` to `login` at the top of the constructor: when both are set, the explicit `login` wins (and the `user` entry is dropped); when only `user` is provided, it is moved to `login`. This keeps the documented `user|login` equivalence and removes the inconsistency between DSN URL and DSN query string / direct constructor usage.

Adds two unit tests covering both the alias and the precedence rule.