### PR TITLE
[Messenger] Move `--time-limit` handling to Worker for proper capping with `--sleep`

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -32,7 +32,6 @@ use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnFailureLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMemoryLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
-use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Worker;
 
@@ -210,7 +209,6 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             }
 
             $stopsWhen[] = "been running for {$timeLimit}s";
-            $this->eventDispatcher->addSubscriber(new StopWorkerOnTimeLimitListener($timeLimit, $this->logger));
         }
 
         $stopsWhen[] = 'received a stop signal via the messenger:stop-workers command';
@@ -236,6 +234,7 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
         $this->worker = new Worker($receivers, $bus, $this->eventDispatcher, $this->logger, $rateLimiters);
         $options = [
             'sleep' => $input->getOption('sleep') * 1000000,
+            'time_limit' => null !== $timeLimit ? (int) $timeLimit : null,
         ];
         if ($queues = $input->getOption('queues')) {
             $options['queues'] = $queues;

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -338,6 +338,54 @@ class WorkerTest extends TestCase
         $this->assertEquals(new \DateTimeImmutable('2023-03-19 14:00:00+00:00'), $clock->now());
     }
 
+    public function testWorkerCapsIdleSleepToRemainingTimeLimitAfterMessageConsumption()
+    {
+        $clock = new MockClock('2023-03-19 14:00:00+00:00');
+        $receiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('API'))],
+            [],
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, static function (WorkerRunningEvent $event) use ($clock) {
+            if (!$event->isWorkerIdle()) {
+                $clock->sleep(50);
+            }
+        });
+
+        $worker = new Worker([$receiver], new MessageBus(), $dispatcher, clock: $clock);
+        $worker->run(['sleep' => 20000000, 'time_limit' => 60]);
+
+        $this->assertEquals(new \DateTimeImmutable('2023-03-19 14:01:00+00:00'), $clock->now());
+    }
+
+    public function testWorkerLogsWhenStoppedDueToTimeLimit()
+    {
+        $clock = new MockClock('2023-03-19 14:00:00+00:00');
+        $receiver = new DummyReceiver([[]]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('info')
+            ->willReturnCallback(function (string $message, array $context = []) use (&$timeLimitLogged) {
+                if ('Worker stopped due to time limit of {timeLimit}s exceeded' === $message) {
+                    $this->assertSame(['timeLimit' => 60], $context);
+                    $timeLimitLogged = true;
+                }
+            });
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, static function (WorkerRunningEvent $event) use ($clock) {
+            if ($event->isWorkerIdle()) {
+                $clock->sleep(70);
+            }
+        });
+
+        $worker = new Worker([$receiver], new MessageBus(), $dispatcher, $logger, clock: $clock);
+        $worker->run(['sleep' => 1000000, 'time_limit' => 60]);
+
+        $this->assertTrue($timeLimitLogged ?? false);
+    }
+
     public function testWorkerWithMultipleReceivers()
     {
         // envelopes, in their expected delivery order

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -68,14 +68,17 @@ class Worker
      *
      * Valid options are:
      *  * sleep (default: 1000000): Time in microseconds to sleep after no messages are found
+     *  * time_limit: The time limit in seconds the worker can handle new messages
      *  * queues: The queue names to consume from, instead of consuming from all queues. When this is used, all receivers must implement the QueueReceiverInterface
      */
     public function run(array $options = []): void
     {
         $options = array_merge([
             'sleep' => 1000000,
+            'time_limit' => null,
         ], $options);
         $queueNames = $options['queues'] ?? null;
+        $endTime = null !== $options['time_limit'] ? $this->clock->now()->format('U.u') + $options['time_limit'] : null;
 
         $this->metadata->set(['queueNames' => $queueNames]);
 
@@ -91,6 +94,11 @@ class Worker
         }
 
         while (!$this->shouldStop) {
+            if (null !== $endTime && $this->clock->now()->format('U.u') >= $endTime) {
+                $this->logger?->info('Worker stopped due to time limit of {timeLimit}s exceeded', ['timeLimit' => $options['time_limit']]);
+                break;
+            }
+
             $envelopeHandled = false;
             $envelopeHandledStart = $this->clock->now();
             foreach ($this->receivers as $transportName => $receiver) {
@@ -132,7 +140,13 @@ class Worker
                 }
 
                 if (0 < $sleep = (int) ($options['sleep'] - 1e6 * ($this->clock->now()->format('U.u') - $envelopeHandledStart->format('U.u')))) {
-                    $this->clock->sleep($sleep / 1e6);
+                    if (null !== $endTime) {
+                        $sleep = min($sleep, (int) (1e6 * ($endTime - $this->clock->now()->format('U.u'))));
+                    }
+
+                    if (0 < $sleep) {
+                        $this->clock->sleep($sleep / 1e6);
+                    }
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Currently, when using `messenger:consume --time-limit` combined with `--sleep`, the worker can still sleep for the configured `--sleep` duration after the time limit was effectively reached.

Example: `messenger:consume --time-limit=60 --sleep=20`

Now if idle sleep starts at `t=50`, it will still sleep for `20` seconds rather than the remaining `10` seconds configured by `--time-limit` causing the worker process to run longer than actually configured.

The problem with this is that currently, the `Worker` knows about `sleep` but not about `time-limit` because this is handled via `StopWorkerOnTimeLimitListener`.

This PR internalizes time-limit handling into `Worker` as well, so we can properly cap the sleep time. `StopWorkerOnTimeLimitListener` is left untouched for BC — `ConsumeMessagesCommand` no longer wires it, but users who registered it manually will still see it work.