### PR TITLE
[HttpKernel][VarDumper][WebProfilerBundle] Forward CSP nonce to dump() instead of disabling CSP

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Forward the CSP nonce to `DumpDataCollector` instead of disabling CSP when `dump()` is used
  * Add console command value resolvers durations to Performances panel
  * Add error indicator to profiler list view for profiles with errors
  * Add cURL copy paste button in the Request/Response tab

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -91,11 +91,14 @@ class WebDebugToolbarListener implements EventSubscriberInterface
 
         $nonces = [];
         if ($this->cspHandler) {
-            if ($this->dumpDataCollector?->getDumpsCount() > 0) {
-                $this->cspHandler->disableCsp();
-            }
-
             $nonces = $this->cspHandler->updateResponseHeaders($request, $response);
+
+            if ($this->dumpDataCollector?->getDumpsCount() > 0) {
+                $this->dumpDataCollector->setNonce(
+                    $nonces['csp_script_nonce'] ?? null,
+                    $nonces['csp_style_nonce'] ?? null,
+                );
+            }
         }
 
         // do not capture redirects or modify XML HTTP Requests

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -287,7 +287,7 @@ class WebDebugToolbarListenerTest extends TestCase
         $this->assertEquals('Exception: This multiline tabbed text should come out on a single plain line', $response->headers->get('X-Debug-Error'));
     }
 
-    public function testCspIsDisabledIfDumperWasUsed()
+    public function testCspNonceIsForwardedToDumpDataCollectorWhenDumperWasUsed()
     {
         $response = new Response('<html><head></head><body></body></html>');
         $response->headers->set('X-Debug-Token', 'xxxxxxxx');
@@ -295,12 +295,19 @@ class WebDebugToolbarListenerTest extends TestCase
         $event = new ResponseEvent($this->createStub(KernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST, $response);
 
         $cspHandler = $this->createMock(ContentSecurityPolicyHandler::class);
-        $cspHandler->expects($this->once())
+        $cspHandler->expects($this->never())
             ->method('disableCsp');
+        $cspHandler->expects($this->once())
+            ->method('updateResponseHeaders')
+            ->willReturn(['csp_script_nonce' => 'script-abc', 'csp_style_nonce' => 'style-xyz']);
+
         $dumpDataCollector = $this->createMock(DumpDataCollector::class);
         $dumpDataCollector->expects($this->once())
             ->method('getDumpsCount')
             ->willReturn(1);
+        $dumpDataCollector->expects($this->once())
+            ->method('setNonce')
+            ->with('script-abc', 'style-xyz');
 
         $listener = new WebDebugToolbarListener($this->getTwigMock(), false, WebDebugToolbarListener::ENABLED, null, '', $cspHandler, $dumpDataCollector);
         $listener->onKernelResponse($event);
@@ -308,7 +315,7 @@ class WebDebugToolbarListenerTest extends TestCase
         $this->assertEquals("<html><head></head><body>\nWDT\n</body></html>", $response->getContent());
     }
 
-    public function testCspIsKeptEnabledIfDumperWasNotUsed()
+    public function testCspNonceIsNotForwardedIfDumperWasNotUsed()
     {
         $response = new Response('<html><head></head><body></body></html>');
         $response->headers->set('X-Debug-Token', 'xxxxxxxx');
@@ -322,6 +329,8 @@ class WebDebugToolbarListenerTest extends TestCase
         $dumpDataCollector->expects($this->once())
             ->method('getDumpsCount')
             ->willReturn(0);
+        $dumpDataCollector->expects($this->never())
+            ->method('setNonce');
 
         $listener = new WebDebugToolbarListener($this->getTwigMock(), false, WebDebugToolbarListener::ENABLED, null, '', $cspHandler, $dumpDataCollector);
         $listener->onKernelResponse($event);

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -20,7 +20,7 @@
         "composer-runtime-api": ">=2.1",
         "symfony/config": "^7.4|^8.0",
         "symfony/framework-bundle": "^7.4|^8.0",
-        "symfony/http-kernel": "^7.4|^8.0",
+        "symfony/http-kernel": "^8.1",
         "symfony/routing": "^7.4|^8.0",
         "symfony/twig-bundle": "^7.4|^8.0"
     },

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `setNonce()` to `DumpDataCollector` to forward CSP nonces to every `HtmlDumper` it instantiates
  * Add `#[MapRequestHeader]` to map a header from `Request` to a controller argument
  * Add `hasErrors()` method to `Profile` to track profiles with errors (exceptions or error-level logs)
  * Validate typed route parameters before calling controllers and return an HTTP error when an invalid value is provided

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -40,6 +40,8 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
     private string $charset;
     private mixed $sourceContextProvider;
     private bool $webMode;
+    private ?string $scriptNonce = null;
+    private ?string $styleNonce = null;
 
     public function __construct(
         private ?Stopwatch $stopwatch = null,
@@ -68,6 +70,18 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
     public function __clone()
     {
         $this->clonesIndex = ++$this->clonesCount;
+    }
+
+    /**
+     * Sets CSP nonces to apply to every {@see HtmlDumper} this collector creates.
+     *
+     * If $styleNonce is omitted, $scriptNonce is reused for both <script> and
+     * <style> tags emitted by the dumper.
+     */
+    public function setNonce(?string $scriptNonce, ?string $styleNonce = null): void
+    {
+        $this->scriptNonce = $scriptNonce;
+        $this->styleNonce = $styleNonce;
     }
 
     public function dump(Data $data): ?string
@@ -121,6 +135,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
         ) {
             if ($response->headers->has('Content-Type') && str_contains($response->headers->get('Content-Type') ?? '', 'html')) {
                 $dumper = new HtmlDumper('php://output', $this->charset);
+                $this->applyNonceTo($dumper);
             } else {
                 $dumper = new CliDumper('php://output', $this->charset);
             }
@@ -130,6 +145,13 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
             foreach ($this->data as $dump) {
                 $this->doDump($dumper, $dump['data'], $dump['name'], $dump['file'], $dump['line'], $dump['label'] ?? '');
             }
+        }
+    }
+
+    private function applyNonceTo(HtmlDumper $dumper): void
+    {
+        if (null !== $this->scriptNonce || null !== $this->styleNonce) {
+            $dumper->setNonce($this->scriptNonce, $this->styleNonce);
         }
     }
 
@@ -188,6 +210,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
         if ('html' === $format) {
             $dumper = new HtmlDumper($data, $this->charset);
             $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
+            $this->applyNonceTo($dumper);
         } else {
             throw new \InvalidArgumentException(\sprintf('Invalid dump format: "%s".', $format));
         }
@@ -228,6 +251,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
             if ($this->webMode) {
                 $dumper = new HtmlDumper('php://output', $this->charset);
+                $this->applyNonceTo($dumper);
             } else {
                 $dumper = new CliDumper('php://output', $this->charset);
             }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -177,4 +177,33 @@ class DumpDataCollectorTest extends TestCase
         $collector->__destruct();
         $this->assertSame('', ob_get_clean());
     }
+
+    public function testNonceIsForwardedToHtmlDumperOnGetDumps()
+    {
+        $data = new Data([[123]]);
+
+        $collector = new DumpDataCollector();
+        $collector->setNonce('script-abc', 'style-xyz');
+        $collector->dump($data);
+
+        $dumps = $collector->getDumps('html');
+
+        $this->assertCount(1, $dumps);
+        $this->assertStringContainsString('<script nonce="script-abc">', $dumps[0]['data']);
+        $this->assertStringContainsString('<style nonce="style-xyz">', $dumps[0]['data']);
+    }
+
+    public function testNonceFallsBackToScriptNonceForStyle()
+    {
+        $data = new Data([[123]]);
+
+        $collector = new DumpDataCollector();
+        $collector->setNonce('shared-nonce');
+        $collector->dump($data);
+
+        $dumps = $collector->getDumps('html');
+
+        $this->assertStringContainsString('<script nonce="shared-nonce">', $dumps[0]['data']);
+        $this->assertStringContainsString('<style nonce="shared-nonce">', $dumps[0]['data']);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -46,7 +46,7 @@
         "symfony/translation-contracts": "^2.5|^3",
         "symfony/uid": "^7.4|^8.0",
         "symfony/validator": "^7.4|^8.0",
-        "symfony/var-dumper": "^7.4|^8.0",
+        "symfony/var-dumper": "^8.1",
         "symfony/var-exporter": "^7.4|^8.0",
         "twig/twig": "^3.21"
     },
@@ -58,6 +58,7 @@
         "symfony/flex": "<2.10",
         "symfony/http-client-contracts": "<2.5",
         "symfony/translation-contracts": "<2.5",
+        "symfony/var-dumper": "<8.1",
         "twig/twig": "<3.21"
     },
     "autoload": {

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Allow `HtmlDumper::setNonce()` to take a distinct style nonce alongside the script nonce
  * Dump class-strings as class stubs with source location and static properties
 
 7.4

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -76,6 +76,7 @@ class HtmlDumper extends CliDumper
     ];
     private array $extraDisplayOptions = [];
     private string|\Closure|null $nonce = null;
+    private string|\Closure|null $styleNonce = null;
 
     public function __construct($output = null, ?string $charset = null, int $flags = 0)
     {
@@ -129,42 +130,55 @@ class HtmlDumper extends CliDumper
     }
 
     /**
-     * Sets a nonce to be added to <script> and <style> tags for CSP compliance.
+     * Sets nonces to be added to <script> and <style> tags for CSP compliance.
      *
      * Pass a string for a static nonce, or a {@see \Closure} returning a
      * string (or null) to resolve the nonce lazily — useful for per-request
      * nonces in long-running processes (the closure is invoked on every
      * dump, so it can return a fresh value each time).
+     *
+     * If $styleNonce is omitted, $nonce is reused for both <script> and
+     * <style> tags; pass a distinct value when your CSP uses different
+     * nonces for the script-src and style-src directives.
      */
-    public function setNonce(string|\Closure|null $nonce): void
+    public function setNonce(string|\Closure|null $nonce, string|\Closure|null $styleNonce = null): void
     {
         $this->headerIsDumped = false;
         $this->nonce = $nonce;
+        $this->styleNonce = $styleNonce;
     }
 
     private function applyNonce(string $html): string
     {
-        if ($this->nonce instanceof \Closure) {
-            $nonce = ($this->nonce)();
+        $scriptNonce = $this->resolveNonce($this->nonce);
+        $styleNonce = null !== $this->styleNonce ? $this->resolveNonce($this->styleNonce) : $scriptNonce;
 
-            if (null !== $nonce && !\is_string($nonce)) {
-                throw new \LogicException(\sprintf('The nonce closure passed to "%s::setNonce()" must return a string or null, "%s" returned.', self::class, get_debug_type($nonce)));
-            }
-        } else {
-            $nonce = $this->nonce;
+        $replacements = [];
+        if (null !== $scriptNonce) {
+            $replacements['<script>'] = '<script nonce="'.esc($scriptNonce).'">';
+        }
+        if (null !== $styleNonce) {
+            $replacements['<style>'] = '<style nonce="'.esc($styleNonce).'">';
         }
 
-        if (null === $nonce) {
+        if (!$replacements) {
             return $html;
         }
 
-        $escaped = esc($nonce);
+        return str_replace(array_keys($replacements), array_values($replacements), $html);
+    }
 
-        return str_replace(
-            ['<script>', '<style>'],
-            ['<script nonce="'.$escaped.'">', '<style nonce="'.$escaped.'">'],
-            $html,
-        );
+    private function resolveNonce(string|\Closure|null $nonce): ?string
+    {
+        if (!$nonce instanceof \Closure) {
+            return $nonce;
+        }
+
+        if (!\is_string($value = $nonce() ?? '')) {
+            throw new \LogicException(\sprintf('The nonce closure passed to "%s::setNonce()" must return a string or null, "%s" returned.', self::class, get_debug_type($value)));
+        }
+
+        return $value;
     }
 
     public function dump(Data $data, $output = null, array $extraDisplayOptions = []): ?string

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -246,7 +246,7 @@ class HtmlDumperTest extends TestCase
         $dumper = new HtmlDumper('php://output');
         $cloner = new VarCloner();
         $current = 'first';
-        $dumper->setNonce(function () use (&$current): string { return $current; });
+        $dumper->setNonce(static function () use (&$current): string { return $current; });
 
         ob_start();
         $dumper->dump($cloner->cloneVar('foo'));
@@ -295,5 +295,21 @@ class HtmlDumperTest extends TestCase
         } finally {
             ob_end_clean();
         }
+    }
+
+    public function testDistinctScriptAndStyleNonces()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $dumper->setNonce('script-abc', 'style-xyz');
+        $cloner = new VarCloner();
+
+        ob_start();
+        $dumper->dump($cloner->cloneVar('foo'));
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('<script nonce="script-abc">', $out);
+        $this->assertStringContainsString('<style nonce="style-xyz">', $out);
+        $this->assertStringNotContainsString('<script nonce="style-xyz">', $out);
+        $this->assertStringNotContainsString('<style nonce="script-abc">', $out);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49068
| License       | MIT

Follow-up to #63762.

Currently, when `dump()` is used in dev with the Web Profiler enabled, `WebDebugToolbarListener` **disables CSP entirely** (`ContentSecurityPolicyHandler::disableCsp()`) — a sledgehammer that opens the door to inline scripts/styles for every other piece of the page too.

This PR plugs `HtmlDumper::setNonce()` (introduced in #63762) into the existing CSP pipeline so dumps stay CSP-compliant without weakening the policy:

- `DumpDataCollector::setNonce(?string $scriptNonce, ?string $styleNonce = null)` stores the nonce(s) and forwards them to every `HtmlDumper` it instantiates (in `getDumps()`, `collect()`, and `__destruct()`).
- `WebDebugToolbarListener::onKernelResponse()` no longer calls `disableCsp()` — it now forwards the nonces returned by `ContentSecurityPolicyHandler::updateResponseHeaders()` directly to the `DumpDataCollector`. The CSP itself stays enabled and the profiler keeps generating the same `script-src` / `style-src` nonces it already did for its own toolbar.
- `HtmlDumper::setNonce()` is extended to accept an **optional second nonce** for `<style>` tags. Symfony emits distinct `csp_script_nonce` / `csp_style_nonce` per directive, so we honor that. Single-argument usage keeps the previous behavior (script nonce reused for style).

### Result

- The toolbar template, the inline dumps, **and** the rest of the page all keep their CSP — no more global `unsafe-inline` window opened just to display a `dump()`.
- Apps with strict CSP that already wire a per-request nonce keep working unchanged: the profiler simply uses its own nonces internally.
- Long-running processes (PHP-PM, RoadRunner, FrankenPHP, …) can still pass a `\Closure` to `HtmlDumper::setNonce()` (#63762) for their own use cases — that path is untouched.

Tests added in `HtmlDumperTest`, `DumpDataCollectorTest` and `WebDebugToolbarListenerTest`. The previous `testCspIsDisabledIfDumperWasUsed` is replaced by the symmetric `testCspNonceIsForwardedToDumpDataCollectorWhenDumperWasUsed`.

cc @nicolas-grekas @Spomky — this is the follow-up that prompted reopening #49068.