### PR TITLE
[Serializer] Use the discriminator property when several types map to the same class

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow passing an associative array to `CsvEncoder::HEADERS_KEY` to map and reorder columns when encoding
+ * Use the discriminator property of an object to pick its type when several types map to the same class; the first declared type is used when the property is unset or unknown
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
 
 8.1

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
@@ -49,13 +49,35 @@ class ClassDiscriminatorMapping
 
     public function getMappedObjectType(object|string $object): ?string
     {
+        $mappedType = null;
         foreach ($this->typesMapping as $type => $typeClass) {
             if (is_a($object, $typeClass, true)) {
-                return $type;
+                $mappedType = $type;
+                break;
             }
         }
 
-        return null;
+        if (null === $mappedType || !\is_object($object) || !property_exists($object, $this->typeProperty)) {
+            return $mappedType;
+        }
+
+        try {
+            $value = (new \ReflectionProperty($object, $this->typeProperty))->getValue($object);
+        } catch (\Error) {
+            return $mappedType;
+        }
+
+        if ($value instanceof \BackedEnum) {
+            $value = $value->value;
+        }
+
+        // several types can map to the same class, in which case the value carried by the object
+        // decides which of them is used
+        if ((\is_string($value) || \is_int($value)) && ($this->typesMapping[$value] ?? null) === $this->typesMapping[$mappedType]) {
+            return (string) $value;
+        }
+
+        return $mappedType;
     }
 
     public function getTypesMapping(): array

--- a/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorMappingTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorMappingTest.php
@@ -44,4 +44,128 @@ class ClassDiscriminatorMappingTest extends TestCase
         $this->assertNull($mapping->getMappedObjectType(new AbstractDummySecondChild()));
         $this->assertSame('third', $mapping->getMappedObjectType(new AbstractDummyThirdChild()));
     }
+
+    public function testMappedObjectTypeReadsDiscriminatorPropertyWhenSeveralTypesShareTheSameClass()
+    {
+        $mapping = new ClassDiscriminatorMapping('type', [
+            'rf_actual' => DiscriminatorAmbiguousDocument::class,
+            'rf_previous' => DiscriminatorAmbiguousDocument::class,
+        ]);
+
+        $actual = new DiscriminatorAmbiguousDocument();
+        $actual->type = 'rf_actual';
+
+        $previous = new DiscriminatorAmbiguousDocument();
+        $previous->type = 'rf_previous';
+
+        $this->assertSame('rf_actual', $mapping->getMappedObjectType($actual));
+        $this->assertSame('rf_previous', $mapping->getMappedObjectType($previous));
+    }
+
+    public function testMappedObjectTypeUnwrapsBackedEnumDiscriminatorProperty()
+    {
+        $mapping = new ClassDiscriminatorMapping('type', [
+            'rf_actual' => DiscriminatorEnumDocument::class,
+            'rf_previous' => DiscriminatorEnumDocument::class,
+        ]);
+
+        $previous = new DiscriminatorEnumDocument();
+        $previous->type = DiscriminatorEnumDocumentType::RF_PREVIOUS;
+
+        $this->assertSame('rf_previous', $mapping->getMappedObjectType($previous));
+    }
+
+    public function testMappedObjectTypeFallsBackToFirstMatchWhenPropertyValueIsInvalid()
+    {
+        $mapping = new ClassDiscriminatorMapping('type', [
+            'rf_actual' => DiscriminatorAmbiguousDocument::class,
+            'rf_previous' => DiscriminatorAmbiguousDocument::class,
+        ]);
+
+        $invalid = new DiscriminatorAmbiguousDocument();
+        $invalid->type = 'unknown';
+
+        $this->assertSame('rf_actual', $mapping->getMappedObjectType($invalid));
+    }
+
+    public function testMappedObjectTypeIgnoresDiscriminatorPropertyWhenObjectClassIsNotAmbiguous()
+    {
+        $mapping = new ClassDiscriminatorMapping('type', [
+            'base' => DiscriminatorBaseDocument::class,
+            'child' => DiscriminatorChildDocument::class,
+        ]);
+
+        $child = new DiscriminatorChildDocument();
+        $child->type = 'base';
+
+        $this->assertSame('child', $mapping->getMappedObjectType($child));
+    }
+
+    public function testMappedObjectTypeKeepsTheMostSpecificTypeWhenTheParentClassIsMappedTwice()
+    {
+        $mapping = new ClassDiscriminatorMapping('type', [
+            'base_a' => DiscriminatorBaseDocument::class,
+            'base_b' => DiscriminatorBaseDocument::class,
+            'child' => DiscriminatorChildDocument::class,
+        ]);
+
+        $child = new DiscriminatorChildDocument();
+        $child->type = 'base_a';
+
+        $this->assertSame('child', $mapping->getMappedObjectType($child));
+
+        $base = new DiscriminatorBaseDocument();
+        $base->type = 'base_b';
+
+        $this->assertSame('base_b', $mapping->getMappedObjectType($base));
+    }
+
+    public function testMappedObjectTypeSupportsIntBackedEnums()
+    {
+        $mapping = new ClassDiscriminatorMapping('type', [
+            1 => DiscriminatorIntEnumDocument::class,
+            2 => DiscriminatorIntEnumDocument::class,
+        ]);
+
+        $document = new DiscriminatorIntEnumDocument();
+        $document->type = DiscriminatorIntDocumentType::SECOND;
+
+        $this->assertSame('2', $mapping->getMappedObjectType($document));
+    }
+}
+
+class DiscriminatorAmbiguousDocument
+{
+    public ?string $type = null;
+}
+
+enum DiscriminatorEnumDocumentType: string
+{
+    case RF_ACTUAL = 'rf_actual';
+    case RF_PREVIOUS = 'rf_previous';
+}
+
+class DiscriminatorEnumDocument
+{
+    public ?DiscriminatorEnumDocumentType $type = null;
+}
+
+class DiscriminatorBaseDocument
+{
+    public ?string $type = null;
+}
+
+class DiscriminatorChildDocument extends DiscriminatorBaseDocument
+{
+}
+
+enum DiscriminatorIntDocumentType: int
+{
+    case FIRST = 1;
+    case SECOND = 2;
+}
+
+class DiscriminatorIntEnumDocument
+{
+    public ?DiscriminatorIntDocumentType $type = null;
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
@@ -905,6 +906,19 @@ class SerializerTest extends TestCase
         $actual = $serializer->deserialize('value'.\PHP_EOL.',', DummyWithObjectOrNull::class, 'csv', [CsvEncoder::AS_COLLECTION_KEY => false]);
 
         $this->assertEquals(new DummyWithObjectOrNull(null), $actual);
+    }
+
+    public function testSerializeAndDeserializeObjectsWhoseClassIsMappedToSeveralDiscriminatorTypes()
+    {
+        $serializer = $this->serializerWithClassDiscriminator();
+
+        $documents = [new DummyPassportDocument('current'), new DummyPassportDocument('previous')];
+
+        $this->assertSame('[{"type":"current"},{"type":"previous"}]', $serializer->serialize($documents, 'json'));
+
+        foreach ($documents as $document) {
+            $this->assertEquals($document, $serializer->deserialize($serializer->serialize($document, 'json'), DummyIdentityDocument::class, 'json'));
+        }
     }
 
     private function serializerWithClassDiscriminator()
@@ -2258,4 +2272,16 @@ class SerializerTestRequestDto
         public SerializerTestBackedEnum $status,
     ) {
     }
+}
+
+#[DiscriminatorMap('type', ['current' => DummyPassportDocument::class, 'previous' => DummyPassportDocument::class])]
+abstract class DummyIdentityDocument
+{
+    public function __construct(public string $type)
+    {
+    }
+}
+
+class DummyPassportDocument extends DummyIdentityDocument
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #59327
| License       | MIT

A `#[DiscriminatorMap]` may point several type names at the same class, which is how an alias is expressed. `ClassDiscriminatorMapping::getMappedObjectType()` resolved the type from the object's class alone, so every instance collapsed to the first matching entry, and `AbstractObjectNormalizer::normalize()` then overwrote the discriminator attribute with it. A round trip lost which of the aliases the object actually carried.

Denormalization was never affected: `getClassForType()` is a plain array lookup and both aliases resolve to the same class.

Classified as a feature, per @stof and @nicolas-grekas on the issue: reading the discriminator from a property is not something the `DiscriminatorMap` system supported. The underlying first-match loop is identical from 6.4 up, so the symptom is old, but this must not be backported.

Reworked during review. The previous guard asked whether the class named by the property *value* was duplicated, rather than whether the entry the lookup picked was. Those differ as soon as a subclass is mapped alongside a doubly-mapped parent:

```php
#[DiscriminatorMap('type', [
    'invoice' => Bill::class,
    'bill' => Bill::class,          // legacy alias for the same class
    'credit_note' => CreditNote::class,   // CreditNote extends Bill
])]
```

A `CreditNote` whose `$type` still held `'bill'` was normalized as `"type":"bill"` and denormalized back into `Bill`, dropping the subclass fields. It now resolves the class first and only lets the property choose between entries that map to that same class, so a subclass can never be reported as its parent type.

Int-backed enums and integer map keys work too. The previous `is_string()` check rejected them, so a map like `[1 => Doc::class, 2 => Doc::class]` always returned the first entry.

Tie-break when the property is unset, uninitialized or holds an unknown value: the first declared entry wins, which is what the code did before. The CHANGELOG entry says so.

Tests: two unit tests for the subclass case and for int-backed enums, both failing on the previous guard, plus a functional test through `Serializer` and `ObjectNormalizer`, which is the layer the reported defect appears at and which fails on a clean 8.2.
