### PR TITLE
[DependencyInjection] Reject circular references through a factory builder's setup

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckFactoryBuilderCircularReferencePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckFactoryBuilderCircularReferencePass.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Detects cycles where a service's factory is `[Definition $b, $method]` and $b's
+ * own properties/method calls/configurator transitively require that same service
+ * through constructor references.
+ *
+ * The soft-circular instantiation pattern relies on storing the service's instance
+ * before deferred edges fire, but a factory consumes the builder's state at call
+ * time: deferring $b's setup until after `$b->method(...)` would feed the factory
+ * an unconfigured builder. The cycle is unresolvable; bail out instead of letting
+ * the dumper produce silently wrong code or `ContainerBuilder::createService()`
+ * silently return a half-built instance.
+ */
+class CheckFactoryBuilderCircularReferencePass implements CompilerPassInterface
+{
+    private ContainerBuilder $container;
+    private array $visited;
+    private array $path;
+    private string $currentId;
+
+    public function process(ContainerBuilder $container): void
+    {
+        $this->container = $container;
+
+        try {
+            foreach ($container->getDefinitions() as $id => $definition) {
+                $factory = $definition->getFactory();
+                if (!\is_array($factory) || !$factory[0] instanceof Definition) {
+                    continue;
+                }
+
+                $builder = $factory[0];
+                if (!$builder->getMethodCalls() && !$builder->getProperties() && null === $builder->getConfigurator()) {
+                    continue;
+                }
+
+                $this->currentId = $id;
+                $this->visited = [$id => true];
+                $this->path = [$id];
+
+                $setup = [$builder->getProperties(), $builder->getMethodCalls(), $builder->getConfigurator()];
+                if ($this->setupReferencesCurrent($setup)) {
+                    $this->path[] = $id;
+
+                    throw new ServiceCircularReferenceException($id, $this->path);
+                }
+            }
+        } finally {
+            unset($this->container, $this->visited, $this->path, $this->currentId);
+        }
+    }
+
+    private function setupReferencesCurrent(mixed $value): bool
+    {
+        if (\is_array($value)) {
+            foreach ($value as $v) {
+                if ($this->setupReferencesCurrent($v)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($value instanceof Reference) {
+            $id = (string) $value;
+            while ($this->container->hasAlias($id)) {
+                $id = (string) $this->container->getAlias($id);
+            }
+
+            if ($id === $this->currentId) {
+                return true;
+            }
+
+            if (isset($this->visited[$id]) || !$this->container->hasDefinition($id)) {
+                return false;
+            }
+
+            $def = $this->container->getDefinition($id);
+
+            // Lazy services break the eager-construction chain through a proxy.
+            if ($def->isLazy() || $def->isSynthetic()) {
+                return false;
+            }
+
+            $this->visited[$id] = true;
+            $this->path[] = $id;
+
+            // Only constructor edges propagate the "needed during construction" reachability.
+            if ($this->setupReferencesCurrent([$def->getArguments(), $def->getFactory()])) {
+                return true;
+            }
+
+            array_pop($this->path);
+
+            return false;
+        }
+
+        if ($value instanceof Definition) {
+            // Inlined sub-definition: every part of it runs while the outer service
+            // is still being constructed, so walk its full structure.
+            return $this->setupReferencesCurrent([
+                $value->getArguments(),
+                $value->getFactory(),
+                $value->getProperties(),
+                $value->getMethodCalls(),
+                $value->getConfigurator(),
+            ]);
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -87,6 +87,7 @@ class PassConfig
             new CheckExceptionOnInvalidReferenceBehaviorPass(),
             new InlineServiceDefinitionsPass(new AnalyzeServiceReferencesPass()),
             new AnalyzeServiceReferencesPass(),
+            new CheckFactoryBuilderCircularReferencePass(),
             new DefinitionErrorExceptionPass(),
         ]];
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckFactoryBuilderCircularReferencePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckFactoryBuilderCircularReferencePassTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CheckFactoryBuilderCircularReferencePassTest extends TestCase
+{
+    public function testThrowsWhenInlinedConsumerReferencesProduct()
+    {
+        // The consumer ("extension") is private and used only by the builder's
+        // method call, so it gets inlined into the builder. The dumper would emit
+        // "$instance = $a->build()" before "$a->useExtension(...)" and silently
+        // produce a half-built service.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useExtension', [new Reference('extension')]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+        $container->register('extension', 'stdClass')
+            ->addArgument(new Reference('product'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
+        $this->expectExceptionMessage('Circular reference detected for service "product"');
+
+        $container->compile();
+    }
+
+    public function testThrowsWhenPublicConsumerReferencesProduct()
+    {
+        // The consumer ("extension") is public, so it stays a Reference inside
+        // the inlined builder's setter args. Same broken pattern, different graph
+        // shape: the previous dumper-side check missed this one.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useExtension', [new Reference('extension')]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+        $container->register('extension', 'stdClass')
+            ->setPublic(true)
+            ->addArgument(new Reference('product'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
+        $this->expectExceptionMessage('Circular reference detected for service "product", path: "product -> extension -> product"');
+
+        $container->compile();
+    }
+
+    public function testAllowsBuilderWithoutSetup()
+    {
+        // The factory builder has no method calls/properties/configurator, so the
+        // soft-circular pattern works: the cycle is on the produced service's own
+        // setter, not on the builder.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass');
+        $container->register('product', 'stdClass')
+            ->setPublic(true)
+            ->setFactory([new Reference('builder'), 'build'])
+            ->addMethodCall('setExtension', [new Reference('extension')]);
+        $container->register('extension', 'stdClass')
+            ->addArgument(new Reference('product'));
+
+        $container->compile();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAllowsStringFactoryWithSelfSetterCycle()
+    {
+        $container = new ContainerBuilder();
+        $container->register('product', 'stdClass')
+            ->setPublic(true)
+            ->setFactory('create_product')
+            ->addMethodCall('setExtension', [new Reference('extension')]);
+        $container->register('extension', 'stdClass')
+            ->addArgument(new Reference('product'));
+
+        $container->compile();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAllowsConstructorArgInlinedSetterCycle()
+    {
+        // FooCircular-style: foo's constructor takes bar; bar's setter takes foobar;
+        // foobar's constructor takes foo. The inlined sub-Definition (bar) is a
+        // *constructor arg*, not a factory, so foo holds bar and bar's deferred
+        // setter is observable through that reference. Legit soft-circular.
+        $container = new ContainerBuilder();
+        $container->register('foo', 'stdClass')
+            ->setPublic(true)
+            ->addArgument(new Reference('bar'));
+        $container->register('bar', 'stdClass')
+            ->addMethodCall('addFoobar', [new Reference('foobar')]);
+        $container->register('foobar', 'stdClass')
+            ->addArgument(new Reference('foo'));
+
+        $container->compile();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testIgnoresLazyConsumer()
+    {
+        // The consumer is lazy: it gets a proxy, the eager construction chain is
+        // broken. The same shape as Case B but with `extension` lazy.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useExtension', [new Reference('extension')]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+        $container->register('extension', 'stdClass')
+            ->setPublic(true)
+            ->setLazy(true)
+            ->addArgument(new Reference('product'));
+
+        $container->compile();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testFollowsTransitiveConstructorChain()
+    {
+        // builder's setter doesn't reference product directly, but the chain
+        // builder -> mid -> product still requires product before the factory
+        // call. Same shape, one hop further.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useMid', [new Reference('mid')]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+        $container->register('mid', 'stdClass')
+            ->setPublic(true)
+            ->addArgument(new Reference('extension'));
+        $container->register('extension', 'stdClass')
+            ->setPublic(true)
+            ->addArgument(new Reference('product'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
+
+        $container->compile();
+    }
+
+    public function testIgnoresInlinedDefinitionFactoryWithoutCycle()
+    {
+        // The factory builder has setters but they don't lead back to the
+        // produced service. Should compile cleanly.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useUnrelated', [new Reference('unrelated')]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+        $container->register('unrelated', 'stdClass')
+            ->setPublic(true);
+
+        $container->compile();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testInlinedExtensionDefinitionRouteAlsoCaught()
+    {
+        // Same as Case A but using a literal Definition argument (mimicking what
+        // InlineServiceDefinitionsPass produces) so we exercise the
+        // walk-Definition path of the pass.
+        $container = new ContainerBuilder();
+        $extension = new Definition('stdClass');
+        $extension->addArgument(new Reference('product'));
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useExtension', [$extension]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+
+        $this->expectException(ServiceCircularReferenceException::class);
+
+        $container->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64059
| License       | MIT

A service whose factory is `[Definition $builder, $method]` and whose `$builder` has properties / method calls / configurator can end up in an unresolvable cycle when `$builder`'s setup transitively requires the produced service. Today neither `PhpDumper` nor `ContainerBuilder` notices: both silently produce a half-built service.

Reproducer:

```php
$container->register('builder', 'stdClass')
    ->addMethodCall('useExtension', [new Reference('extension')]);
$container->register('product', 'stdClass')
    ->setFactory([new Reference('builder'), 'build'])
    ->setPublic(true);
$container->register('extension', 'stdClass')
    ->addArgument(new Reference('product'));
```

Dumped today:

```php
$a = new \stdClass();
$container->services['product'] = $instance = $a->build(); // factory called BEFORE
$a->useExtension(new \stdClass($instance));                 // setup runs AFTER, no effect
```

`build()` consumes the builder's state at call time, so deferring `useExtension(...)` until after the factory call leaves `product` unconfigured. The soft-circular instantiation pattern works for setters on the produced service (the instance is shared early, post-hoc setters land on the right object) but is unsound for setters on a *factory builder*: the produced service does not hold a reference to the builder, so post-build mutation is invisible.

`ContainerBuilder::createService()` reproduces the same bug at runtime: `callMethod()` resolves setter args with `$isConstructorArgument = false`, so `doGet()` swallows the `ServiceCircularReferenceException` and re-enters `createService()` against the unconfigured builder.

This PR adds a compiler pass (`CheckFactoryBuilderCircularReferencePass`) that runs after `InlineServiceDefinitionsPass` and walks each affected service's factory builder setup, following only constructor edges through transitive references. If the chain reaches the originating service, it throws `ServiceCircularReferenceException` at compile time. Lazy and synthetic services break the chain. Inlined sub-Definitions are walked fully.

The detection is precise enough to leave existing soft-circular patterns untouched: cycles on the produced service's own setter (FooCircular-style), string-based factories, factory builders without setup, and lazy proxies all keep compiling.