### PR TITLE
[Messenger] Deprecate `StopWorkerOnTimeLimitListener` in favor of time_limit worker option

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -109,6 +109,7 @@ Messenger
  * Receivers no longer delete messages from the queue on decode failure;
    they are routed through the normal retry/failure transport path instead
  * Add argument `$fetchSize` to `ReceiverInterface::get()` and `QueueReceiverInterface::getFromQueues()`
+ * Deprecate `StopWorkerOnTimeLimitListener` in favor of using the `time_limit` worker option
 
 Security
 --------

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Allow configuring the service reset interval in the `messenger:consume` command via the `--no-reset` option
  * Add `AmqpPriorityStamp` to set per-message priority on the AMQP transport
  * Add `ReleaseDeduplicationLockOnFailureListener` that releases the deduplication lock when a message fails and will not be retried
+ * Deprecate `StopWorkerOnTimeLimitListener` in favor of the `time_limit` worker option
 
 8.0
 ---

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
@@ -17,9 +17,13 @@ use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 
+trigger_deprecation('symfony/messenger', '8.1', '"%s" is deprecated, use the "time_limit" worker option instead.', StopWorkerOnTimeLimitListener::class);
+
 /**
  * @author Simon Delicata <simon.delicata@free.fr>
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @deprecated since Symfony 8.1, use the "time_limit" worker option instead
  */
 class StopWorkerOnTimeLimitListener implements EventSubscriberInterface
 {

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnTimeLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnTimeLimitListenerTest.php
@@ -14,15 +14,21 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
 use Symfony\Component\Messenger\Worker;
 
 class StopWorkerOnTimeLimitListenerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     #[Group('time-sensitive')]
+    #[Group('legacy')]
     public function testWorkerStopsWhenTimeLimitIsReached()
     {
+        $this->expectDeprecation('Since symfony/messenger 8.1: "Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener" is deprecated, use the "time_limit" worker option instead.');
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('info')
             ->with('Worker stopped due to time limit of {timeLimit}s exceeded', ['timeLimit' => 1]);

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=8.4.1",
         "psr/log": "^1|^2|^3",
-        "symfony/clock": "^7.4|^8.0"
+        "symfony/clock": "^7.4|^8.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | 
| License       | MIT

This deprecates the `StopWorkerOnTimeLimitListener` as discussed in https://github.com/symfony/symfony/pull/64086.
