### PR TITLE
[RateLimiter] Carry over reserved tokens past fixed window resets

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -41,16 +41,19 @@ final class Window implements LimiterStateInterface
 
     public function getExpirationTime(): ?int
     {
-        return $this->intervalInSeconds;
+        // Keep the entry alive long enough for any reservation debt to be
+        // carried forward, otherwise resets that span an idle interval would
+        // re-issue the borrowed tokens and silently double the rate.
+        return $this->intervalInSeconds * max(1, (int) ceil($this->hitCount / $this->maxSize));
     }
 
     public function add(int $hits = 1, ?float $now = null): void
     {
         $now ??= microtime(true);
         if (($now - $this->timer) > $this->intervalInSeconds) {
-            // reset window
+            // carry any reservation debt forward instead of zeroing it
+            $this->hitCount = $this->getCarriedHitCount($now);
             $this->timer = $now;
-            $this->hitCount = 0;
         }
 
         $this->hitCount = max(0, $this->hitCount + $hits);
@@ -63,12 +66,25 @@ final class Window implements LimiterStateInterface
 
     public function getAvailableTokens(float $now): int
     {
-        // if now is more than the window interval in the past, all tokens are available
-        if (($now - $this->timer) > $this->intervalInSeconds) {
-            return $this->maxSize;
+        return $this->maxSize - $this->getCarriedHitCount($now);
+    }
+
+    /**
+     * Returns the hit count after virtually applying any window resets that
+     * have occurred between $this->timer and $now, carrying over reservations
+     * that exceed the previous window's capacity (debt borrowed from future
+     * windows via reserve()).
+     */
+    private function getCarriedHitCount(float $now): int
+    {
+        $elapsed = $now - $this->timer;
+        if ($elapsed <= $this->intervalInSeconds) {
+            return $this->hitCount;
         }
 
-        return $this->maxSize - $this->hitCount;
+        $windowsElapsed = (int) ($elapsed / $this->intervalInSeconds);
+
+        return max(0, $this->hitCount - $windowsElapsed * $this->maxSize);
     }
 
     public function calculateTimeForTokens(int $tokens, float $now): int

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -33,6 +33,8 @@ class FixedWindowLimiterTest extends TestCase
 
         ClockMock::register(InMemoryStorage::class);
         ClockMock::register(RateLimit::class);
+        ClockMock::register(Window::class);
+        ClockMock::register(FixedWindowLimiter::class);
     }
 
     public function testConsume()
@@ -167,6 +169,95 @@ class FixedWindowLimiterTest extends TestCase
         $window = new Window('id', 300, 100, $serverOneClock);
         $this->assertSame(100, $window->getAvailableTokens($serverTwoClock));
         $this->assertSame(100, $window->getAvailableTokens($serverOneClock));
+    }
+
+    public function testWindowCarriesOverReservedTokensAfterReset()
+    {
+        $now = microtime(true);
+        $window = new Window('id', 10, 10, $now);
+
+        // 15 hits = 5 borrowed from the next window
+        $window->add(15, $now);
+        $this->assertSame(15, $window->getHitCount());
+
+        // After one window has elapsed, the 5-token debt must remain instead of being zeroed out
+        $window->add(0, $now + 11);
+        $this->assertSame(5, $window->getHitCount());
+
+        // A second elapsed window clears the remaining debt
+        $window->add(0, $now + 22);
+        $this->assertSame(0, $window->getHitCount());
+    }
+
+    public function testWindowClearsLargeDebtWhenManyWindowsElapse()
+    {
+        $now = microtime(true);
+        $window = new Window('id', 10, 10, $now);
+
+        // 25 hits = 2 full windows of debt + 5
+        $window->add(25, $now);
+        $this->assertSame(25, $window->getHitCount());
+
+        // 35s later, three windows have elapsed (3 * 10 = 30 tokens recovered)
+        $window->add(0, $now + 35);
+        $this->assertSame(0, $window->getHitCount());
+    }
+
+    public function testWindowAvailableTokensAccountsForCarriedDebt()
+    {
+        $now = microtime(true);
+        $window = new Window('id', 10, 10, $now);
+
+        // 15 hits = 5 borrowed from the next window
+        $window->add(15, $now);
+
+        // Inside the current window, 0 tokens are available
+        $this->assertSame(-5, $window->getAvailableTokens($now));
+
+        // After one window has elapsed, only 5 tokens are free (debt subtracted)
+        $this->assertSame(5, $window->getAvailableTokens($now + 11));
+
+        // After two windows, all 10 tokens are free
+        $this->assertSame(10, $window->getAvailableTokens($now + 22));
+    }
+
+    public function testReservedTokensCarryAcrossWindowBoundaryViaStorage()
+    {
+        $limiter = new FixedWindowLimiter('test', 10, new \DateInterval('PT10S'), $this->storage);
+
+        // Window 1: A consumes 8, B reserves 7 — borrows 5 tokens from window 2
+        $this->assertEqualsWithDelta(0.0, $limiter->reserve(8)->getWaitDuration(), 1.0);
+        $this->assertEqualsWithDelta(10.0, $limiter->reserve(7)->getWaitDuration(), 1.0);
+
+        // Cross the window boundary while staying idle. The storage entry must
+        // outlive the bare interval so the carried 5-token debt persists.
+        sleep(11);
+
+        // Only 5 fresh tokens should be available in window 2 — consuming 6 must throttle
+        $this->assertFalse($limiter->consume(6)->isAccepted());
+
+        // Consuming exactly 5 must succeed and leave the window full
+        $rateLimit = $limiter->consume(5);
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+    }
+
+    public function testWindowExpirationGrowsWithCarriedDebt()
+    {
+        $now = microtime(true);
+        $window = new Window('id', 10, 10, $now);
+
+        // No hits yet — TTL is one interval, just to cover the current window
+        $this->assertSame(10, $window->getExpirationTime());
+
+        // 15 hits = 5 debt; entry must outlive 1 extra interval to carry it forward
+        $window->add(15, $now);
+        $this->assertSame(20, $window->getExpirationTime());
+
+        // 25 hits = 15 debt; needs 2 extra intervals
+        $window = new Window('id', 10, 10, $now);
+        $window->add(25, $now);
+        $this->assertSame(30, $window->getExpirationTime());
     }
 
     public function testPeekConsume()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61668
| License       | MIT

`Window::add()` zeroed `hitCount` on reset, discarding any tokens that earlier `reserve()` calls had borrowed from future windows. Callers that had reserved 15 tokens against a limit of 10 then saw 10 fresh tokens after the reset, silently doubling the effective rate.

The fix carries the debt across resets: each elapsed window recovers up to `maxSize` tokens. `getAvailableTokens()` reports the carried state without mutating the window so `FixedWindowLimiter::reserve()` decides correctly before calling `add()`.

`Window::getExpirationTime()` now grows with the outstanding debt — without that, idle limiters would lose their saved state after one interval and re-issue the borrowed tokens anyway. This mirrors the pattern shipped for `token_bucket` in 380bb512317 ("Keep token bucket alive while reservation debt is unpaid"), which addressed the sibling issue #62688.

Verified end-to-end with `testReservedTokensCarryAcrossWindowBoundaryViaStorage` (idles past one interval, asserts only 5 fresh tokens are available in the next window) plus unit tests on `Window::getCarriedHitCount()` and `Window::getExpirationTime()`. All fail when the patch is reverted.