### PR TITLE
[Console] Add native types to Command constants

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -35,9 +35,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Command implements SignalableCommandInterface
 {
     // see https://tldp.org/LDP/abs/html/exitcodes.html
-    public const SUCCESS = 0;
-    public const FAILURE = 1;
-    public const INVALID = 2;
+    public const int SUCCESS = 0;
+    public const int FAILURE = 1;
+    public const int INVALID = 2;
 
     private ?Application $application = null;
     private ?string $name = null;


### PR DESCRIPTION
Hi!

I noticed that the `SUCCESS`, `FAILURE`, and `INVALID` constants in the `Command` class were missing native type hints. This was affecting the type coverage and static analysis in my own project.

I’m submitting this to improve the overall developer experience and the internal code quality of the component. 

Adding native types to these constants ensures better IDE autocompletion and stricter static analysis for everyone extending the Command class.

Hope this isn't absolute garbage, not trying to waste anyone's time.
Keep up the good work!

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A

---