### PR TITLE
[Ldap] Cast `default_socket_timeout` to `int`

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -135,7 +135,7 @@ class Connection extends AbstractConnection
             }
 
             if (!isset($parent['network_timeout'])) {
-                $options->setDefault('network_timeout', \ini_get('default_socket_timeout'));
+                $options->setDefault('network_timeout', (int) \ini_get('default_socket_timeout'));
             }
 
             $options->setDefaults([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63926
| License       | MIT

`ini_get('default_socket_timeout')` returns a string. PHP 8.4's ext-ldap strictly requires an int for `LDAP_OPT_NETWORK_TIMEOUT`, so `Connection::bind()` fails with `Could not set value "60" for option "network_timeout"` whenever the fallback default is used (i.e. the user did not set `network_timeout` explicitly).

Casting to int when storing the default fixes the regression on PHP 8.4 and is a no-op on prior versions.

Reproduces with the configuration from the issue (any LDAP adapter on PHP 8.4 with no explicit `network_timeout`); the new `ConnectionTest::testNetworkTimeoutDefaultIsInteger` asserts that the resolved option is `int`, which fails before the patch with `Failed asserting that '60' is of type "int".`.
