### PR TITLE
[Translation] URL-encode tmp path in XliffUtils::shouldEnableEntityLoader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -739,23 +739,24 @@ class XmlFileLoader extends FileLoader
         $tmpfiles = [];
         $imports = '';
         foreach ($schemaLocations as $namespace => $location) {
-            $parts = explode('/', $location);
-            $locationstart = 'file:///';
             if (0 === stripos($location, 'phar://')) {
-                $tmpfile = tempnam(sys_get_temp_dir(), 'symfony');
-                if ($tmpfile) {
+                if ($tmpfile = tempnam(sys_get_temp_dir(), 'symfony')) {
                     copy($location, $tmpfile);
                     $tmpfiles[] = $tmpfile;
-                    $parts = explode('/', str_replace('\\', '/', $tmpfile));
+                    $location = self::getFileUrl($tmpfile);
                 } else {
+                    $parts = explode('/', '\\' === \DIRECTORY_SEPARATOR ? str_replace('\\', '/', $location) : $location);
                     array_shift($parts);
-                    $locationstart = 'phar:///';
+                    $drive = '\\' === \DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
+                    $location = 'phar:///'.$drive.implode('/', array_map('rawurlencode', $parts));
                 }
             } elseif ('\\' === \DIRECTORY_SEPARATOR && str_starts_with($location, '\\\\')) {
-                $locationstart = '';
+                $parts = explode('/', $location);
+                $drive = array_shift($parts).'/';
+                $location = $drive.implode('/', array_map('rawurlencode', $parts));
+            } else {
+                $location = self::getFileUrl($location);
             }
-            $drive = '\\' === \DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
-            $location = $locationstart.$drive.implode('/', array_map('rawurlencode', $parts));
 
             $imports .= \sprintf('  <xsd:import namespace="%s" schemaLocation="%s" />'."\n", $namespace, $location);
         }
@@ -800,7 +801,7 @@ class XmlFileLoader extends FileLoader
             });
             $schema = '<?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:include schemaLocation="file:///'.rawurlencode(str_replace('\\', '/', $tmpfile)).'" />
+  <xsd:include schemaLocation="'.self::getFileUrl($tmpfile).'" />
 </xsd:schema>';
             file_put_contents($tmpfile, '<?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -810,6 +811,19 @@ class XmlFileLoader extends FileLoader
         }
 
         return !@$dom->schemaValidateSource($schema);
+    }
+
+    private static function getFileUrl(string $path): string
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $parts = explode('/', str_replace('\\', '/', $path));
+            $drive = array_shift($parts).'/';
+        } else {
+            $parts = explode('/', $path);
+            $drive = '';
+        }
+
+        return 'file:///'.$drive.implode('/', array_map('rawurlencode', $parts));
     }
 
     private function validateAlias(\DOMElement $alias, string $file): void

--- a/src/Symfony/Component/Translation/Tests/Util/XliffUtilsTest.php
+++ b/src/Symfony/Component/Translation/Tests/Util/XliffUtilsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Util\XliffUtils;
+
+class XliffUtilsTest extends TestCase
+{
+    /**
+     * @dataProvider providePaths
+     */
+    public function testGetFileUrlEncodesPathSegments(string $path, string $expected)
+    {
+        $method = new \ReflectionMethod(XliffUtils::class, 'getFileUrl');
+
+        $this->assertSame($expected, $method->invoke(null, $path));
+    }
+
+    public static function providePaths(): iterable
+    {
+        yield 'plain POSIX path' => [
+            '/tmp/symfony123',
+            'file:////tmp/symfony123',
+        ];
+
+        // Windows usernames may contain spaces. Without rawurlencode, the
+        // resulting `file:///` URL is syntactically invalid and triggers a
+        // libxml "Invalid Schema" warning when fed to schemaValidateSource().
+        yield 'POSIX path with spaces' => [
+            '/tmp/dir with space/symfony123',
+            'file:////tmp/dir%20with%20space/symfony123',
+        ];
+
+        yield 'POSIX path with non-ASCII characters' => [
+            '/tmp/中文/symfony123',
+            'file:////tmp/%E4%B8%AD%E6%96%87/symfony123',
+        ];
+    }
+
+    public function testEncodedUrlPreventsLibxmlInvalidSchemaErrors()
+    {
+        $dir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('symfony_xliff_', false).' with space';
+
+        if (!@mkdir($dir) && !is_dir($dir)) {
+            $this->markTestSkipped(\sprintf('Could not create tmp dir "%s".', $dir));
+        }
+
+        $tmpfile = tempnam($dir, 'symfony');
+
+        try {
+            if (!\is_string($tmpfile) || \dirname($tmpfile) !== $dir) {
+                $this->markTestSkipped(\sprintf('tempnam() did not place the file under "%s".', $dir));
+            }
+
+            file_put_contents($tmpfile, '<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:element name="test" type="testType" />
+  <xsd:complexType name="testType"/>
+</xsd:schema>');
+
+            $encodedUrl = (new \ReflectionMethod(XliffUtils::class, 'getFileUrl'))->invoke(null, $tmpfile);
+
+            $result = $this->validateSchemaInclude($encodedUrl);
+            $this->assertSame([], $result['php_warnings'], 'Encoded URL must not emit a "DOMDocument::schemaValidateSource(): Invalid Schema" PHP warning.');
+            $this->assertSame([], $result['libxml_errors'], 'Encoded URL must not produce libxml URI parsing errors when included.');
+        } finally {
+            if (\is_string($tmpfile)) {
+                @unlink($tmpfile);
+            }
+            @rmdir($dir);
+        }
+    }
+
+    /**
+     * @return array{php_warnings: list<string>, libxml_errors: list<string>}
+     */
+    private function validateSchemaInclude(string $schemaLocation): array
+    {
+        $dom = new \DOMDocument();
+        $dom->loadXML('<?xml version="1.0"?><test/>');
+
+        $phpWarnings = [];
+        set_error_handler(static function (int $errno, string $msg) use (&$phpWarnings): bool {
+            if (str_contains($msg, 'Invalid Schema')) {
+                $phpWarnings[] = $msg;
+            }
+
+            return true;
+        }, \E_WARNING);
+
+        $internalErrors = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        try {
+            @$dom->schemaValidateSource('<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:include schemaLocation="'.$schemaLocation.'" />
+</xsd:schema>');
+        } finally {
+            $libxmlErrors = array_values(array_filter(
+                array_map(static fn (\LibXMLError $e): string => trim($e->message), libxml_get_errors()),
+                static fn (string $m): bool => str_contains($m, 'could not build an URI')
+                    || str_contains($m, 'xmlSchemaParseIncludeOrRedefine')
+            ));
+
+            libxml_clear_errors();
+            libxml_use_internal_errors($internalErrors);
+            restore_error_handler();
+        }
+
+        return ['php_warnings' => $phpWarnings, 'libxml_errors' => $libxmlErrors];
+    }
+}

--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -83,31 +83,6 @@ class XliffUtils
         return [];
     }
 
-    private static function shouldEnableEntityLoader(): bool
-    {
-        static $dom, $schema;
-        if (null === $dom) {
-            $dom = new \DOMDocument();
-            $dom->loadXML('<?xml version="1.0"?><test/>');
-
-            $tmpfile = tempnam(sys_get_temp_dir(), 'symfony');
-            register_shutdown_function(static function () use ($tmpfile) {
-                @unlink($tmpfile);
-            });
-            $schema = '<?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:include schemaLocation="file:///'.str_replace('\\', '/', $tmpfile).'" />
-</xsd:schema>';
-            file_put_contents($tmpfile, '<?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:element name="test" type="testType" />
-  <xsd:complexType name="testType"/>
-</xsd:schema>');
-        }
-
-        return !@$dom->schemaValidateSource($schema);
-    }
-
     public static function getErrorsAsString(array $xmlErrors): string
     {
         $errorsAsString = '';
@@ -124,6 +99,44 @@ class XliffUtils
         }
 
         return $errorsAsString;
+    }
+
+    private static function shouldEnableEntityLoader(): bool
+    {
+        static $dom, $schema;
+        if (null === $dom) {
+            $dom = new \DOMDocument();
+            $dom->loadXML('<?xml version="1.0"?><test/>');
+
+            $tmpfile = tempnam(sys_get_temp_dir(), 'symfony');
+            register_shutdown_function(static function () use ($tmpfile) {
+                @unlink($tmpfile);
+            });
+            $schema = '<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:include schemaLocation="'.self::getFileUrl($tmpfile).'" />
+</xsd:schema>';
+            file_put_contents($tmpfile, '<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:element name="test" type="testType" />
+  <xsd:complexType name="testType"/>
+</xsd:schema>');
+        }
+
+        return !@$dom->schemaValidateSource($schema);
+    }
+
+    private static function getFileUrl(string $path): string
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $parts = explode('/', str_replace('\\', '/', $path));
+            $drive = array_shift($parts).'/';
+        } else {
+            $parts = explode('/', $path);
+            $drive = '';
+        }
+
+        return 'file:///'.$drive.implode('/', array_map('rawurlencode', $parts));
     }
 
     private static function getSchema(string $xliffVersion): string
@@ -146,22 +159,21 @@ class XliffUtils
      */
     private static function fixXmlLocation(string $schemaSource, string $xmlUri): string
     {
-        $newPath = str_replace('\\', '/', __DIR__).'/../Resources/schemas/xml.xsd';
-        $parts = explode('/', $newPath);
-        $locationstart = 'file:///';
-        if (0 === stripos($newPath, 'phar://')) {
-            $tmpfile = tempnam(sys_get_temp_dir(), 'symfony');
-            if ($tmpfile) {
-                copy($newPath, $tmpfile);
-                $parts = explode('/', str_replace('\\', '/', $tmpfile));
-            } else {
-                array_shift($parts);
-                $locationstart = 'phar:///';
-            }
-        }
+        $path = __DIR__.'/../Resources/schemas/xml.xsd';
 
-        $drive = '\\' === \DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
-        $newPath = $locationstart.$drive.implode('/', array_map('rawurlencode', $parts));
+        if (0 === stripos($path, 'phar://')) {
+            if ($tmpfile = tempnam(sys_get_temp_dir(), 'symfony')) {
+                copy($path, $tmpfile);
+                $newPath = self::getFileUrl($tmpfile);
+            } else {
+                $parts = explode('/', '\\' === \DIRECTORY_SEPARATOR ? str_replace('\\', '/', $path) : $path);
+                array_shift($parts);
+                $drive = '\\' === \DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
+                $newPath = 'phar:///'.$drive.implode('/', array_map('rawurlencode', $parts));
+            }
+        } else {
+            $newPath = self::getFileUrl($path);
+        }
 
         return str_replace($xmlUri, $newPath, $schemaSource);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63253
| License       | MIT

When the temp directory path contains URL-unsafe characters (spaces, non-ASCII), `XliffUtils::shouldEnableEntityLoader()` concatenates them straight into a `file:///` URL fed to `DOMDocument::schemaValidateSource()`. libxml then emits a `Warning: DOMDocument::schemaValidateSource(): Invalid Schema`, and although the call is `@`-silenced, Symfony's error handler logs it via `SilencedErrorContext` — flooding `dev.log`.

This typically surfaces on Windows where the system temp directory resolves under a user profile name containing a space (e.g. `C:\Users\John Doe\AppData\Local\Temp`).

The fix mirrors the existing `fixXmlLocation()` strategy: split the path, preserve the Windows drive when applicable, `rawurlencode` each remaining segment, then reassemble.

The probe still produces a schema with a non-resolvable include on modern PHP (where libxml does not fetch external entities), so `shouldEnableEntityLoader()`'s return value is unchanged. Only the warning is suppressed at the source.

A new `XliffUtilsTest::testGetTmpFileUrlEncodesPathSegments` data provider asserts segments containing spaces and non-ASCII characters are URL-encoded; it fails before the patch with `'file:////tmp/dir with space/...' !== 'file:////tmp/dir%20with%20space/...'`.
