### PR TITLE
 Remove usage of `Kernel::VERSION`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
+use Composer\InstalledVersions;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Helper;
@@ -69,7 +70,7 @@ class AboutCommand extends Command
         $rows = [
             ['<info>Symfony</>'],
             new TableSeparator(),
-            ['Version', Kernel::VERSION],
+            ['Version', class_exists(InstalledVersions::class) ? InstalledVersions::getPrettyVersion('symfony/http-kernel') ?? InstalledVersions::getPrettyVersion('symfony/symfony') : Kernel::MAJOR_VERSION.'.'.Kernel::MINOR_VERSION],
             ['Long-Term Support', 4 === Kernel::MINOR_VERSION ? 'Yes' : 'No'],
             ['End of maintenance', Kernel::END_OF_MAINTENANCE.(self::isExpired(Kernel::END_OF_MAINTENANCE) ? ' <error>Expired</>' : ' (<comment>'.self::daysBeforeExpiration(Kernel::END_OF_MAINTENANCE).'</>)')],
             ['End of life', Kernel::END_OF_LIFE.(self::isExpired(Kernel::END_OF_LIFE) ? ' <error>Expired</>' : ' (<comment>'.self::daysBeforeExpiration(Kernel::END_OF_LIFE).'</>)')],

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console;
 
+use Composer\InstalledVersions;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\ListCommand;
@@ -36,7 +37,7 @@ class Application extends BaseApplication
     public function __construct(
         private KernelInterface $kernel,
     ) {
-        parent::__construct('Symfony', Kernel::VERSION);
+        parent::__construct('Symfony', class_exists(InstalledVersions::class) ? InstalledVersions::getPrettyVersion('symfony/http-kernel') ?? InstalledVersions::getPrettyVersion('symfony/symfony') : Kernel::MAJOR_VERSION.'.'.Kernel::MINOR_VERSION);
 
         $inputDefinition = $this->getDefinition();
         $inputDefinition->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', $kernel->getEnvironment()));

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
@@ -42,7 +42,7 @@ class EmptyAppTest extends TestCase
 
     private function deleteTempDir()
     {
-        if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel')) {
+        if (!file_exists($dir = sys_get_temp_dir().'/EmptyAppKernel')) {
             return;
         }
 
@@ -69,11 +69,11 @@ class EmptyAppKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/cache/'.$this->environment;
+        return sys_get_temp_dir().'/EmptyAppKernel/cache/'.$this->environment;
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/logs';
+        return sys_get_temp_dir().'/EmptyAppKernel/logs';
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -44,7 +44,7 @@ class NoTemplatingEntryTest extends TestCase
 
     protected function deleteTempDir()
     {
-        if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel')) {
+        if (!file_exists($dir = sys_get_temp_dir().'/NoTemplatingEntryKernel')) {
             return;
         }
 
@@ -86,11 +86,11 @@ class NoTemplatingEntryKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/cache/'.$this->environment;
+        return sys_get_temp_dir().'/NoTemplatingEntryKernel/cache/'.$this->environment;
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/logs';
+        return sys_get_temp_dir().'/NoTemplatingEntryKernel/logs';
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
@@ -43,7 +43,7 @@
                         </dd>
                     </dl>
 
-                    <a class="doc-link" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open this file in your IDE?</a>
+                    <a class="doc-link" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::MAJOR_VERSION') }}.{{ constant('Symfony\\Component\\HttpKernel\\Kernel::MINOR_VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open this file in your IDE?</a>
                 </div>
             </div>
         </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -50,20 +50,15 @@ class WebProfilerBundleKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-        $config = [
+        $container->loadFromExtension('framework', [
             'http_method_override' => false,
+            'handle_all_throwables' => true,
             'php_errors' => ['log' => true],
             'secret' => 'foo-secret',
             'profiler' => ['only_exceptions' => false, 'collect_serializer_data' => true],
             'session' => ['handler_id' => null, 'storage_factory_id' => 'session.storage.factory.mock_file', 'cookie-secure' => 'auto', 'cookie-samesite' => 'lax'],
             'router' => ['utf8' => true],
-        ];
-
-        if (Kernel::VERSION_ID >= 60400) {
-            $config['handle_all_throwables'] = true;
-        }
-
-        $container->loadFromExtension('framework', $config);
+        ]);
 
         $container->loadFromExtension('web_profiler', [
             'toolbar' => true,

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
@@ -17,13 +17,13 @@
             );
         </script>
 
-        <?php if (class_exists(\Symfony\Component\HttpKernel\Kernel::class)) { ?>
+        <?php if (class_exists(\Composer\InstalledVersions::class) && \Composer\InstalledVersions::isInstalled('symfony/http-kernel')) { ?>
             <header>
                 <div class="container">
                     <h1 class="logo"><?= $this->include('assets/images/symfony-logo.svg'); ?> Symfony Exception</h1>
 
                     <div class="help-link">
-                        <a href="https://symfony.com/doc/<?= Symfony\Component\HttpKernel\Kernel::VERSION; ?>/index.html">
+                        <a href="https://symfony.com/doc/<?= preg_match('/^v?(\d+\.\d+)/', \Composer\InstalledVersions::getPrettyVersion('symfony/http-kernel') ?? \Composer\InstalledVersions::getPrettyVersion('symfony/symfony'), $m) ? $m[1] : 'current'; ?>/index.html">
                             <span class="icon"><?= $this->include('assets/images/icon-book.svg'); ?></span>
                             <span class="hidden-xs-down">Symfony</span> Docs
                         </a>

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\DataCollector;
 
+use Composer\InstalledVersions;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
@@ -45,7 +46,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
 
         $this->data = [
             'token' => $response->headers->get('X-Debug-Token'),
-            'symfony_version' => Kernel::VERSION,
+            'symfony_version' => class_exists(InstalledVersions::class) ? InstalledVersions::getPrettyVersion('symfony/http-kernel') ?? InstalledVersions::getPrettyVersion('symfony/symfony') : Kernel::MAJOR_VERSION.'.'.Kernel::MINOR_VERSION,
             'symfony_minor_version' => \sprintf('%s.%s', Kernel::MAJOR_VERSION, Kernel::MINOR_VERSION),
             'symfony_lts' => 4 === Kernel::MINOR_VERSION,
             'symfony_state' => $this->determineSymfonyState(),

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -183,9 +183,8 @@ class RouterListener implements EventSubscriberInterface
 
     private function createWelcomeResponse(): Response
     {
-        $version = Kernel::VERSION;
         $projectDir = realpath((string) $this->projectDir).\DIRECTORY_SEPARATOR;
-        $docVersion = substr(Kernel::VERSION, 0, 3);
+        $version = $docVersion = Kernel::MAJOR_VERSION.'.'.Kernel::MINOR_VERSION;
 
         ob_start();
         include \dirname(__DIR__).'/Resources/welcome.html.php';

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\DataCollector;
 
+use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,7 +36,7 @@ class ConfigDataCollectorTest extends TestCase
         $this->assertSame(\PHP_INT_SIZE * 8, $c->getPhpArchitecture());
         $this->assertSame(class_exists(\Locale::class, false) && \Locale::getDefault() ? \Locale::getDefault() : 'n/a', $c->getPhpIntlLocale());
         $this->assertSame(date_default_timezone_get(), $c->getPhpTimezone());
-        $this->assertSame(Kernel::VERSION, $c->getSymfonyVersion());
+        $this->assertSame(InstalledVersions::getPrettyVersion('symfony/http-kernel') ?? InstalledVersions::getPrettyVersion('symfony/symfony'), $c->getSymfonyVersion());
         $this->assertSame(4 === Kernel::MINOR_VERSION, $c->isSymfonyLts());
         $this->assertNull($c->getToken());
         $this->assertSame(\extension_loaded('xdebug'), $c->hasXDebug());
@@ -63,7 +64,7 @@ class ConfigDataCollectorTest extends TestCase
         $this->assertSame(\PHP_INT_SIZE * 8, $c->getPhpArchitecture());
         $this->assertSame(class_exists(\Locale::class, false) && \Locale::getDefault() ? \Locale::getDefault() : 'n/a', $c->getPhpIntlLocale());
         $this->assertSame(date_default_timezone_get(), $c->getPhpTimezone());
-        $this->assertSame(Kernel::VERSION, $c->getSymfonyVersion());
+        $this->assertSame(InstalledVersions::getPrettyVersion('symfony/http-kernel') ?? InstalledVersions::getPrettyVersion('symfony/symfony'), $c->getSymfonyVersion());
         $this->assertSame(4 === Kernel::MINOR_VERSION, $c->isSymfonyLts());
         $this->assertNull($c->getToken());
         $this->assertSame(\extension_loaded('xdebug'), $c->hasXDebug());

--- a/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Runtime\Runner\Symfony;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Symfony\Component\Runtime\RunnerInterface;
 
@@ -34,19 +33,15 @@ class HttpKernelRunner implements RunnerInterface
     {
         $response = $this->kernel->handle($this->request);
 
-        if (Kernel::VERSION_ID >= 60400) {
-            $response->send(false);
+        $response->send(false);
 
-            if (\function_exists('fastcgi_finish_request') && !$this->debug) {
-                fastcgi_finish_request();
-            } elseif (\function_exists('litespeed_finish_request') && !$this->debug) {
-                litespeed_finish_request();
-            } else {
-                Response::closeOutputBuffers(0, true);
-                flush();
-            }
+        if (\function_exists('fastcgi_finish_request') && !$this->debug) {
+            fastcgi_finish_request();
+        } elseif (\function_exists('litespeed_finish_request') && !$this->debug) {
+            litespeed_finish_request();
         } else {
-            $response->send();
+            Response::closeOutputBuffers(0, true);
+            flush();
         }
 
         if ($this->kernel instanceof TerminableInterface) {

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -28,7 +28,8 @@
         "symfony/http-kernel": "^6.4|^7.0|^8.0"
     },
     "conflict": {
-        "symfony/dotenv": "<6.4"
+        "symfony/dotenv": "<6.4",
+        "symfony/http-foundation": "<6.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64382
| License       | MIT

I'd like to deprecate `Kernel::VERSION` but keep all other version related constants in `Kernel`.

The problem with `Kernel::VERSION` is that it changes for every patch release, which means that `symfony/http-kernel` is always released even when the component itself has no significant changes.

Using Composer directly seems like the better way here. 
