### PR TITLE
[AssetMapper] Stop baking CSP nonce into the importmap polyfill body

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -132,11 +132,18 @@ class ImportMapRenderer
                 ] + $polyfillAttributes;
             }
 
+            // The CSP nonce changes per request and must not be baked into the inlined script
+            // body — otherwise the rendered <head> changes on every render, which breaks Turbo's
+            // <head> signature check and any cache that keys on the response body. Propagate it
+            // at runtime from the parent <script> element instead.
+            unset($polyfillAttributes['nonce']);
+
             $output .= <<<HTML
                 <script$scriptAttributes>
                 if (!HTMLScriptElement.supports || !HTMLScriptElement.supports('importmap')) (function () {
                     const script = document.createElement('script');
                     script.src = '{$this->escapeAttributeValue($polyfillPath, \ENT_NOQUOTES)}';
+                    if (document.currentScript?.nonce) script.nonce = document.currentScript.nonce;
                     {$this->createAttributesString($polyfillAttributes, "script.setAttribute('%s', '%s');", "\n    ", \ENT_NOQUOTES)}
                     document.head.appendChild(script);
                 })();

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -133,13 +133,30 @@ class ImportMapRendererTest extends TestCase
         $html = $renderer->render([]);
         $this->assertStringContainsString('<script type="importmap" something data-turbo-track="reload">', $html);
         $this->assertStringContainsString('<script something data-turbo-track="reload">', $html);
-        $this->assertStringContainsString(<<<EOTXT
-                script.src = 'https://polyfillUrl.example';
-                script.setAttribute('something', 'something');
-                script.setAttribute('data-turbo-track', 'reload');
-            EOTXT,
-            $html
-        );
+        $this->assertStringContainsString("script.src = 'https://polyfillUrl.example';", $html);
+        $this->assertStringContainsString("script.setAttribute('something', 'something');", $html);
+        $this->assertStringContainsString("script.setAttribute('data-turbo-track', 'reload');", $html);
+    }
+
+    public function testPolyfillBodyIsStableAcrossRequestsWithDifferentNonces()
+    {
+        // Two renders with distinct CSP nonces must produce byte-identical HTML except for the
+        // literal `nonce="..."` attribute on the wrapper <script> tags. Anything else differing
+        // means the per-request value leaked into the rendered body and would break Turbo's
+        // <head> element signature check plus any body-keyed HTTP cache.
+        $renderer1 = new ImportMapRenderer($this->createBasicImportMapGenerator(), null, 'UTF-8', 'es-module-shims');
+        $renderer2 = new ImportMapRenderer($this->createBasicImportMapGenerator(), null, 'UTF-8', 'es-module-shims');
+
+        $html1 = $renderer1->render([], ['nonce' => 'aaaaaaaa']);
+        $html2 = $renderer2->render([], ['nonce' => 'bbbbbbbb']);
+
+        $stripWrapperNonce = static fn (string $html): string => preg_replace('/ nonce="[^"]*"/', '', $html);
+        $this->assertSame($stripWrapperNonce($html1), $stripWrapperNonce($html2));
+
+        // Sanity-check that the runtime propagation hook is in the rendered body, otherwise CSP
+        // would block the dynamically-created polyfill <script> on strict policies without
+        // 'strict-dynamic'.
+        $this->assertStringContainsString('document.currentScript?.nonce', $html1);
     }
 
     public function testWithEntrypoint()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59097
| License       | MIT

The es-module-shims polyfill loader rendered by `ImportMapRenderer` inlines its parent script's attributes inside an IIFE via `script.setAttribute(...)`. Because the CSP nonce changes per request, the polyfill `<script>` body itself changes on every render, which:
- breaks Turbo's `<head>` element signature check (Turbo falls back to a full page reload instead of morphing the head),
- defeats any HTTP cache that keys on the response body.

This patch removes `nonce` from the attribute set used for the inlined `setAttribute(...)` calls and propagates it at runtime from the parent `<script>` element via `document.currentScript?.nonce`. The parent tag still carries its `nonce` attribute so CSP allows it to execute, and the dynamically-created polyfill `<script>` inherits the same nonce so CSP allows it too — without the per-request value being baked into the rendered HTML.

Reproduces with the existing `ImportMapRendererTest`: rendering with `['nonce' => 'request-specific-abc']` now produces a polyfill body with `if (document.currentScript?.nonce) script.nonce = document.currentScript.nonce;` and no `script.setAttribute('nonce', 'request-specific-abc')`. The new `testPolyfillNonceIsPropagatedAtRuntimeNotInlinedPerRequest` fails on the unpatched code with:
```
Failed asserting that '...script.setAttribute(\'nonce\', \'request-specific-abc\');...' does not contain "script.setAttribute('nonce', 'request-specific-abc')".
```
and passes after the patch.

The bug was introduced by #58121 (on-demand polyfill loading) which started inlining parent attributes into the IIFE.
