### PR TITLE
[Security] Add per-username login rate-limit to prevent brute-force attacks

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -76,6 +76,8 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
             ];
             $this->registerRateLimiter($container, $localId = '_login_local_'.$firewallName, $limiterOptions);
 
+            $this->registerRateLimiter($container, $usernameId = '_login_username_'.$firewallName, $limiterOptions);
+
             $limiterOptions['limit'] = 5 * $config['max_attempts'];
             $this->registerRateLimiter($container, $globalId = '_login_global_'.$firewallName, $limiterOptions);
 
@@ -83,6 +85,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface
                 ->addArgument(new Reference('limiter.'.$globalId))
                 ->addArgument(new Reference('limiter.'.$localId))
                 ->addArgument(new Parameter('container.build_hash'))
+                ->addArgument(new Reference('limiter.'.$usernameId))
             ;
         }
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `this` to `#[IsGranted]` subject expression variables when available
  * Add support for closures and `this` in `#[IsCsrfTokenValid]` when evaluating its `id`
  * Deprecate the `$eraseCredentials` argument of `AuthenticatorManager::__construct()`, as the `eraseCredentials()` method was removed in Symfony 8.0
+ * Add a per-username rate limit to `DefaultLoginRateLimiter` to prevent brute-force attacks from multiple IPs targeting a single account
 
 8.0
 ---

--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -20,8 +20,11 @@ use Symfony\Component\Security\Http\SecurityRequestAttributes;
 /**
  * A default login throttling limiter.
  *
- * This limiter prevents breadth-first attacks by enforcing
- * a limit on username+IP and a (higher) limit on IP.
+ * This limiter prevents breadth-first and distributed brute-force attacks by
+ * enforcing three limits in sequence:
+ *   1. IP only (global): blocks wide scans from a single IP;
+ *   2. username + IP (local): blocks targeted attacks from a single IP;
+ *   3. username only: blocks distributed botnet attacks across many IPs.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
@@ -34,6 +37,7 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
         private RateLimiterFactory $globalFactory,
         private RateLimiterFactory $localFactory,
         #[\SensitiveParameter] private string $secret,
+        private ?RateLimiterFactory $usernameFactory = null,
     ) {
         if (!$secret) {
             throw new InvalidArgumentException('A non-empty secret is required.');
@@ -45,10 +49,16 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
         $username = $request->attributes->get(SecurityRequestAttributes::LAST_USERNAME, '');
         $username = preg_match('//u', $username) ? mb_strtolower($username, 'UTF-8') : strtolower($username);
 
-        return [
+        $limiters = [
             $this->globalFactory->create($this->hash($request->getClientIp())),
             $this->localFactory->create($this->hash($username.'-'.$request->getClientIp())),
         ];
+
+        if (null !== $this->usernameFactory) {
+            $limiters[] = $this->usernameFactory->create($this->hash($username));
+        }
+
+        return $limiters;
     }
 
     private function hash(string $data): string

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -35,19 +35,25 @@ class LoginThrottlingListenerTest extends TestCase
     {
         $this->requestStack = new RequestStack();
 
-        $localLimiter = new RateLimiterFactory([
-            'id' => 'login',
-            'policy' => 'fixed_window',
-            'limit' => 3,
-            'interval' => '1 minute',
-        ], new InMemoryStorage());
         $globalLimiter = new RateLimiterFactory([
             'id' => 'login',
             'policy' => 'fixed_window',
             'limit' => 6,
             'interval' => '1 minute',
         ], new InMemoryStorage());
-        $limiter = new DefaultLoginRateLimiter($globalLimiter, $localLimiter, '$3cre7');
+        $localLimiter = new RateLimiterFactory([
+            'id' => 'login',
+            'policy' => 'fixed_window',
+            'limit' => 3,
+            'interval' => '1 minute',
+        ], new InMemoryStorage());
+        $usernameLimiter = new RateLimiterFactory([
+            'id' => 'login',
+            'policy' => 'fixed_window',
+            'limit' => 3,
+            'interval' => '1 minute',
+        ], new InMemoryStorage());
+        $limiter = new DefaultLoginRateLimiter($globalLimiter, $localLimiter, '$3cre7', $usernameLimiter);
 
         $this->listener = new LoginThrottlingListener($this->requestStack, $limiter);
     }
@@ -82,6 +88,25 @@ class LoginThrottlingListenerTest extends TestCase
 
         $this->expectException(TooManyLoginAttemptsAuthenticationException::class);
         $this->listener->checkPassport($this->createCheckPassportEvent($passports[0]));
+    }
+
+    public function testPreventsLoginWhenOverUsernameThreshold()
+    {
+        $passport = $this->createPassport('wouter');
+        // Simulate requests from different IPs
+        for ($i = 0; $i < 3; ++$i) {
+            $request = $this->createRequest('10.0.0.'.$i);
+            $this->requestStack->push($request);
+            $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+            $this->listener->onFailedLogin($this->createLoginFailedEvent($passport));
+            $this->requestStack->pop();
+        }
+
+        // A new IP should still be blocked because the username limit is reached
+        $request = $this->createRequest('10.0.1.0');
+        $this->requestStack->push($request);
+        $this->expectException(TooManyLoginAttemptsAuthenticationException::class);
+        $this->listener->checkPassport($this->createCheckPassportEvent($passport));
     }
 
     public function testPreventsLoginWhenOverGlobalThreshold()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61932
| License       | MIT

Adds a third rate-limiter to DefaultLoginRateLimiter as suggested in https://github.com/symfony/symfony/pull/63997#issuecomment-4341549421