### PR TITLE
[PasswordHasher] Add warning to `UserPasswordHashCommand` when passing plain password as argument

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
+++ b/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
@@ -101,6 +101,11 @@ class UserPasswordHashCommand extends Command
         $input->isInteractive() ? $errorIo->title('Symfony Password Hash Utility') : $errorIo->newLine();
 
         $password = $input->getArgument('password');
+
+        if ($password) {
+            $errorIo->warning('Using a password as a command argument is insecure. Use the interactive mode instead.');
+        }
+
         $userClass = $this->getUserClass($input, $io);
         $emptySalt = $input->getOption('empty-salt');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #-
| License       | MIT

Adds a warning to inform users and encourage the use of the safer interactive mode

>  [WARNING] Using a password as a command argument is insecure. Use the interactive mode instead.


Tools like MySQL/mysqldump and Docker also address this with an explicit warning:

|||
|---|---|
| `mysql` | `[Warning] Using a password on the command line interface can be insecure.` |
| `docker` | `WARNING! Using --password via the CLI is insecure. Use --password-stdin.` |