### PR TITLE
[Config] Normalize `backed-enum` in array shapes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -135,8 +135,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type AppConfig = bool|Param
  * @psalm-type PrototypedConfigConfig = array<string, array{ // Default: []
- *         value?: scalar|Param|null,
- *     }>
+ *     value?: scalar|Param|null,
+ * }>
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,

--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\Definition;
 
+use Symfony\Component\Config\Definition\Builder\ExprBuilder;
 use Symfony\Component\Config\Loader\ParamConfigurator;
 
 /**
@@ -48,7 +49,7 @@ final class ArrayShapeGenerator
 
         if ($node instanceof PrototypedArrayNode) {
             $isHashmap = (bool) $node->getKeyAttribute();
-            $arrayShape = ($isHashmap ? 'array<string, ' : 'list<').self::doGeneratePhpDoc($node->getPrototype(), 1 + $nestingLevel).'>';
+            $arrayShape = ($isHashmap ? 'array<string, ' : 'list<').self::doGeneratePhpDoc($node->getPrototype(), $nestingLevel).'>';
 
             return implode('|', [...self::getNormalizedTypes($node, ['array', 'any']), $arrayShape]);
         }
@@ -138,6 +139,9 @@ final class ArrayShapeGenerator
         }
 
         $types = array_unique($types);
+        if (false !== $backedEnumIndex = array_search(ExprBuilder::TYPE_BACKED_ENUM, $types, true)) {
+            $types[$backedEnumIndex] = '\BackedEnum';
+        }
 
         sort($types);
 

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -102,13 +102,31 @@ class ArrayShapeGeneratorTest extends TestCase
         $proto = new ArrayNodeDefinition('proto');
         $proto
             ->useAttributeAsKey('name')
-            ->acceptAndWrap(['string'])
+            ->acceptAndWrap(['string', 'backed-enum'])
             ->prototype('scalar')->end();
 
         $root = new ArrayNodeDefinition('root');
         $root->append($proto);
 
-        $expected = "array{\n *     proto?: string|array<string, scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null>,\n * }";
+        $expected = "array{\n *     proto?: \BackedEnum|string|array<string, scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null>,\n * }";
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root->getNode()));
+    }
+
+    public function testArrayPrototypePhpDoc()
+    {
+        $proto = new ArrayNodeDefinition('proto');
+        $proto
+            ->arrayPrototype()
+                ->children()
+                    ->booleanNode('nested')->end()
+                ->end()
+            ->end();
+
+        $root = new ArrayNodeDefinition('root');
+        $root->append($proto);
+
+        $expected = "array{\n *     proto?: list<array{ // Default: []\n *         nested?: bool|\Symfony\Component\Config\Loader\ParamConfigurator,\n *     }>,\n * }";
 
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root->getNode()));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64101
| License       | MIT

`backed-enum` now appears as `\BackedEnum` in array shapes.

Also fixed prototype arrays nesting level.