### PR TITLE
[FrameworkBundle] Restore error and exception handlers on shutdown

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -94,6 +94,8 @@ class_exists(Registry::class);
  */
 class FrameworkBundle extends Bundle
 {
+    private ?ErrorHandler $registeredErrorHandler = null;
+
     /**
      * @return void
      */
@@ -106,6 +108,7 @@ class FrameworkBundle extends Bundle
             restore_error_handler();
         } else {
             $handler = [ErrorHandler::register(null, false)];
+            $this->registeredErrorHandler = $handler[0];
         }
 
         if (!$this->container->has('debug.error_handler_configurator')) {
@@ -128,6 +131,38 @@ class FrameworkBundle extends Bundle
         // The service is made public by AddMimeTypeGuesserPass only when custom guessers are tagged.
         if ($this->container->has('mime_types')) {
             $this->container->get('mime_types');
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function shutdown()
+    {
+        if (null === $this->registeredErrorHandler) {
+            return;
+        }
+
+        $registered = $this->registeredErrorHandler;
+        $this->registeredErrorHandler = null;
+
+        // Restore the error handler we registered in boot() if it is still on top
+        // of the stack. Otherwise leave the stack untouched — another component
+        // pushed its own handler on top and is responsible for popping it.
+        // ErrorHandler::register() installs the handler as `[$instance, 'handleError']`
+        // / `[$instance, 'handleException']`, so the active callable is an array
+        // whose first element is the ErrorHandler instance — that is what we
+        // compare against.
+        $current = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+        if (\is_array($current) && ($current[0] ?? null) === $registered) {
+            restore_error_handler();
+        }
+
+        $current = set_exception_handler(static fn () => null);
+        restore_exception_handler();
+        if (\is_array($current) && ($current[0] ?? null) === $registered) {
+            restore_exception_handler();
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/FrameworkBundleTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/FrameworkBundleTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+class FrameworkBundleTest extends TestCase
+{
+    /**
+     * Regression test for #63693: when symfony/runtime is not present,
+     * FrameworkBundle::boot() registered an ErrorHandler via
+     * ErrorHandler::register(null, false) but never restored it. PHPUnit
+     * then flagged the test as risky with "Test code or tested code did
+     * not remove its own exception handlers".
+     */
+    public function testShutdownRestoresErrorAndExceptionHandlersRegisteredInBoot()
+    {
+        $initialErrorHandler = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+        $initialExceptionHandler = set_exception_handler(static fn () => null);
+        restore_exception_handler();
+
+        $bundle = new FrameworkBundle();
+
+        // Reproduce the no-runtime branch of FrameworkBundle::boot() without
+        // wiring a container: register an ErrorHandler and bind it on the
+        // bundle's private property the same way boot() does.
+        $registered = ErrorHandler::register(null, false);
+        (new \ReflectionProperty(FrameworkBundle::class, 'registeredErrorHandler'))->setValue($bundle, $registered);
+
+        $afterRegisterError = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+        $this->assertNotSame($initialErrorHandler, $afterRegisterError, 'Sanity check: ErrorHandler::register() must change the active error handler.');
+
+        $bundle->shutdown();
+
+        $afterShutdownError = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+        $afterShutdownException = set_exception_handler(static fn () => null);
+        restore_exception_handler();
+
+        $this->assertSame($initialErrorHandler, $afterShutdownError, 'shutdown() must restore the error handler that was active before boot() registered ours.');
+        $this->assertSame($initialExceptionHandler, $afterShutdownException, 'shutdown() must restore the exception handler that was active before boot() registered ours.');
+    }
+
+    public function testShutdownIsNoOpWhenBootDidNotRegisterHandler()
+    {
+        $initialErrorHandler = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+
+        // No registration — simulates the SymfonyRuntime branch of boot() where
+        // FrameworkBundle does not own the handler stack.
+        (new FrameworkBundle())->shutdown();
+
+        $afterShutdownError = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+
+        $this->assertSame($initialErrorHandler, $afterShutdownError);
+    }
+
+    public function testShutdownPreservesHandlerStackedAboveOurs()
+    {
+        $initialErrorHandler = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+        $initialExceptionHandler = set_exception_handler(static fn () => null);
+        restore_exception_handler();
+
+        $bundle = new FrameworkBundle();
+
+        $registered = ErrorHandler::register(null, false);
+        (new \ReflectionProperty(FrameworkBundle::class, 'registeredErrorHandler'))->setValue($bundle, $registered);
+
+        // Another component pushes its own error handler on top of ours.
+        $foreign = static fn (): bool => false;
+        set_error_handler($foreign);
+
+        $bundle->shutdown();
+
+        try {
+            // Foreign handler must still be on top — shutdown() only restores when
+            // our handler is the one currently active.
+            $current = set_error_handler(static fn (): bool => false);
+            restore_error_handler();
+            $this->assertSame($foreign, $current, 'shutdown() must not pop a handler stacked above ours.');
+
+            // shutdown() did pop our exception handler since nothing was stacked
+            // above it; the exception stack is therefore back to its initial state.
+            $currentException = set_exception_handler(static fn () => null);
+            restore_exception_handler();
+            $this->assertSame($initialExceptionHandler, $currentException);
+        } finally {
+            // Restore the error stack ourselves: pop $foreign, then pop $registered
+            // that shutdown() deliberately left in place. Runs even on assertion
+            // failure so the next test starts from a clean stack.
+            restore_error_handler();
+            restore_error_handler();
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63693, Fix #53812
| License       | MIT

When `symfony/runtime` is not installed, `FrameworkBundle::boot()` falls into the `else` branch and registers a Symfony `ErrorHandler` via `ErrorHandler::register(null, false)`. The handler stays on the PHP error/exception handler stack for the lifetime of the process — `boot()` never has a counterpart that pops it. In a `KernelTestCase`, PHPUnit ≥11 detects the leak after `tearDown()` and flags the test as risky:

```
1) Test::test
Test code or tested code did not remove its own exception handlers
```

This was originally reported in #53812 ("Cleanup error and exception handlers on Kernel shutdown"), with the suggested fix being:

> Introduce `FrameworkBundle::shutdown()` that would cleanup error handler set in `boot()`. IMO it's reasonable to have some cleanup in shutdown() of things initiated in boot().

#58372 addressed the case where `symfony/runtime` *is* loaded — the runtime takes ownership of the handler stack itself, so `FrameworkBundle::boot()` no longer pushes anything. The fallback path remained unfixed and the leak is still observable today, as confirmed by @lyrixx on https://github.com/symfony/symfony/pull/58372#discussion_r2657504553 and re-reported in #63693.

This PR finally introduces the `FrameworkBundle::shutdown()` originally proposed in #53812. It pops the handler we registered in `boot()`, but only when our handler is still on top of the stack. If another component pushed its own handler above ours, that component is responsible for popping it — we leave the stack untouched in that case. The check uses the same "peek-and-restore" idiom (`set_error_handler(static fn () => …); restore_error_handler();`) already used in `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener`.

Reproduces with the snippet from #63693 (PHPUnit 12+, `symfony/framework-bundle`, no `symfony/runtime`):

```
There was 1 risky test:
1) Test::test
Test code or tested code did not remove its own exception handlers
```

After the patch, the same test runs cleanly without the risky-test warning.

### Test coverage

`FrameworkBundleTest` (new file under `Tests/`) ships three cases:

* `testShutdownRestoresErrorAndExceptionHandlersRegisteredInBoot` — snapshots the active error/exception handlers, reproduces the no-runtime branch of `boot()` via reflection on the new private `$registeredErrorHandler` property (avoids wiring a full container in a unit test), then asserts both handlers are back to their initial values after `shutdown()`. Verified empirically that this case fails when the patch is reverted.
* `testShutdownIsNoOpWhenBootDidNotRegisterHandler` — covers the `symfony/runtime` branch where `boot()` does not register anything; `shutdown()` must not touch the handler stack at all.
* `testShutdownPreservesHandlerStackedAboveOurs` — asserts that a foreign handler pushed on top of ours after `boot()` is preserved by `shutdown()`. This guards the conditional-restore semantics.
