### PR TITLE
[Security] Document that AbstractLoginFormAuthenticator::getLoginUrl() must return a path

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
@@ -27,6 +27,12 @@ abstract class AbstractLoginFormAuthenticator extends AbstractAuthenticator impl
 {
     /**
      * Return the URL to the login page.
+     *
+     * The default `supports()`implementation below compares this value
+     * character-for-character against the current request path
+     * (`$request->getBaseUrl().$request->getPathInfo()`), so this must return a
+     * path (e.g. `/login`). If you build the URL via `HttpUtils::generateUri()`,
+     * which may produce an absolute URL, also override `supports()`.
      */
     abstract protected function getLoginUrl(Request $request): string;
 
@@ -34,8 +40,10 @@ abstract class AbstractLoginFormAuthenticator extends AbstractAuthenticator impl
      * Override to change the request conditions that have to be
      * matched in order to handle the login form submit.
      *
-     * This default implementation handles all POST requests to the
-     * login path (@see getLoginUrl()).
+     * This default implementation handles POST requests whose path equals
+     * the value returned by `getLoginUrl()`; the comparison is strict,
+     * so `getLoginUrl()` must return a path rather than an absolute URL.
+     * Or this method need to be overriden.
      */
     public function supports(Request $request): bool
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Refs #51382
| License       | MIT

The default `AbstractLoginFormAuthenticator::supports()` compares `getLoginUrl()` character-for-character against `$request->getBaseUrl().$request->getPathInfo()`, which only matches when the subclass returns a path such as `/login`. If the subclass builds the URL via `HttpUtils::generateUri()` — the same idiom used by `FormLoginAuthenticator` — the value can be an absolute URL (`https://host/login`), and the strict comparison silently returns `false`. The form authenticator is then never invoked and the credentials are not checked, with no signal to the developer that anything went wrong. This is the exact scenario described in #51382.

A runtime fix (stripping scheme/host before the comparison, or switching to `HttpUtils::checkRequestPath()`) was considered and dropped: it changes the behaviour observed by every existing subclass that returns an absolute URL today (current behaviour: always `false`; would become: sometimes `true`). That is the backwards compatibility concern @xabbuh raised on the issue (https://github.com/symfony/symfony/issues/51382#issuecomment-2325943251):

> making any changes around it now would probably break backwards compatibility

…and the path he suggested instead (https://github.com/symfony/symfony/issues/51382#issuecomment-2325803001):

> we could possibly add something to the docblock of the `getLoginUrl()` method that it has to return the path or that one has to override the `supports()` method otherwise

This PR follows that suggestion. Two docblocks are clarified:

* `getLoginUrl()`: states that the value is compared verbatim against the request path and must therefore be a path, with a pointer to `supports()` for subclasses that need an absolute URL.
* `supports()`: replaces the misleading `"handles all POST requests to the login path"` wording with an explicit description of the strict comparison and the resulting requirement on `getLoginUrl()`.

No runtime change, no test change — the contract on `getLoginUrl()` is unchanged, only made explicit. Subclasses that already return a path keep working as before; subclasses that return an absolute URL now have a docblock pointing them at the override they need.
