### PR TITLE
[Console][Yaml] Add a `gitlab` output format to the `lint:yaml` command

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `InputOption::HIDDEN` and `InputOption::DEPRECATED` modes
  * Add the `listedAt` option to `#[AsCommand]` and the `listed_at` attribute to the `console.command` tag, to list a command only from the given verbosity
  * Allow a callable for the `description` and `help` options of `#[AsCommand]`, and for the `description` option of `#[Argument]` and `#[Option]`
+ * Add `GitlabCiReporter` to emit reports in the GitLab Code Quality format
 
 8.1
 ---

--- a/src/Symfony/Component/Console/CI/GitlabCiReporter.php
+++ b/src/Symfony/Component/Console/CI/GitlabCiReporter.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\CI;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Collects issues and emits a JSON report in the GitLab Code Quality report
+ * format consumed by GitLab CI/CD as a Code Quality artifact
+ * (`artifacts:reports:codequality`).
+ *
+ * @see https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
+ *
+ * @author Daniel Bohnhardt <github@revoltek.de>
+ */
+class GitlabCiReporter
+{
+    /**
+     * @var list<array{description: string, check_name: string, fingerprint: string, severity: string, location: array{path: string, lines: array{begin: int}}}>
+     */
+    private array $issues = [];
+
+    public function __construct(
+        private OutputInterface $output,
+        private string $checkName = 'lint',
+    ) {
+    }
+
+    public static function isGitlabCiEnvironment(): bool
+    {
+        return false !== getenv('GITLAB_CI');
+    }
+
+    public function error(string $description, ?string $file = null, ?int $line = null): void
+    {
+        $this->log('major', $description, $file, $line);
+    }
+
+    public function warning(string $description, ?string $file = null, ?int $line = null): void
+    {
+        $this->log('minor', $description, $file, $line);
+    }
+
+    public function info(string $description, ?string $file = null, ?int $line = null): void
+    {
+        $this->log('info', $description, $file, $line);
+    }
+
+    /**
+     * Writes the collected issues as a JSON array to the output.
+     */
+    public function write(): void
+    {
+        $this->output->writeln(json_encode($this->issues, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+
+    private function log(string $severity, string $description, ?string $file, ?int $line): void
+    {
+        $path = $file ?? '';
+        $beginLine = $line ?? 1;
+
+        $this->issues[] = [
+            'description' => $description,
+            'check_name' => $this->checkName,
+            'fingerprint' => hash('xxh3', $this->checkName.'|'.$path.'|'.$beginLine.'|'.$description),
+            'severity' => $severity,
+            'location' => [
+                'path' => $path,
+                'lines' => [
+                    'begin' => $beginLine,
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Console/Tests/CI/GitlabCiReporterTest.php
+++ b/src/Symfony/Component/Console/Tests/CI/GitlabCiReporterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\CI;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\CI\GitlabCiReporter;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class GitlabCiReporterTest extends TestCase
+{
+    public function testIsGitlabCiEnvironment()
+    {
+        $prev = getenv('GITLAB_CI');
+        putenv('GITLAB_CI');
+
+        try {
+            self::assertFalse(GitlabCiReporter::isGitlabCiEnvironment());
+            putenv('GITLAB_CI=true');
+            self::assertTrue(GitlabCiReporter::isGitlabCiEnvironment());
+        } finally {
+            putenv('GITLAB_CI'.($prev ? "=$prev" : ''));
+        }
+    }
+
+    public function testEmptyReport()
+    {
+        $reporter = new GitlabCiReporter($buffer = new BufferedOutput());
+
+        $reporter->write();
+
+        self::assertSame([], json_decode(trim($buffer->fetch()), true));
+    }
+
+    public function testCollectsIssuesAndEmitsCodeClimateJson()
+    {
+        $reporter = new GitlabCiReporter($buffer = new BufferedOutput(), 'yaml-lint');
+
+        $reporter->error('Unable to parse', 'config/services.yaml', 12);
+        $reporter->warning('Looks suspicious', 'config/routes.yaml', 3);
+        $reporter->info('Just a note');
+
+        $reporter->write();
+
+        $report = json_decode(trim($buffer->fetch()), true);
+        self::assertCount(3, $report);
+
+        self::assertSame('Unable to parse', $report[0]['description']);
+        self::assertSame('yaml-lint', $report[0]['check_name']);
+        self::assertSame('major', $report[0]['severity']);
+        self::assertSame('config/services.yaml', $report[0]['location']['path']);
+        self::assertSame(12, $report[0]['location']['lines']['begin']);
+        self::assertSame(16, \strlen($report[0]['fingerprint']));
+
+        self::assertSame('minor', $report[1]['severity']);
+        self::assertSame('config/routes.yaml', $report[1]['location']['path']);
+        self::assertSame(3, $report[1]['location']['lines']['begin']);
+
+        self::assertSame('info', $report[2]['severity']);
+        self::assertSame('', $report[2]['location']['path']);
+        self::assertSame(1, $report[2]['location']['lines']['begin']);
+    }
+
+    public function testFingerprintIsStableAndUnique()
+    {
+        $reporter = new GitlabCiReporter($buffer = new BufferedOutput());
+
+        $reporter->error('Same error', 'a.yaml', 1);
+        $reporter->error('Same error', 'a.yaml', 1);
+        $reporter->error('Same error', 'b.yaml', 1);
+        $reporter->write();
+
+        $report = json_decode(trim($buffer->fetch()), true);
+
+        self::assertSame($report[0]['fingerprint'], $report[1]['fingerprint']);
+        self::assertNotSame($report[0]['fingerprint'], $report[2]['fingerprint']);
+    }
+}

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for the `!!null`, `!!bool` and `!!int` tags, and accept quoted values for them and for `!!float`
  * Throw a `ParseException` when the value of a `!!float` tag is not a valid float, instead of casting it to `0.0`
+ * Add a `gitlab` output format to the `lint:yaml` command, producing a report in the GitLab Code Quality format
 
 8.0
 ---

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Yaml\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\CI\GithubActionReporter;
+use Symfony\Component\Console\CI\GitlabCiReporter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -154,8 +155,29 @@ class LintCommand extends Command
             'txt' => $this->displayTxt($io, $files),
             'json' => $this->displayJson($io, $files),
             'github' => $this->displayTxt($io, $files, true),
+            'gitlab' => $this->displayGitlab($io, $files),
             default => throw new InvalidArgumentException(\sprintf('Supported formats are "%s".', implode('", "', $this->getAvailableFormatOptions()))),
         };
+    }
+
+    private function displayGitlab(SymfonyStyle $io, array $filesInfo): int
+    {
+        $reporter = new GitlabCiReporter($io, 'yaml-lint');
+        $erroredFiles = 0;
+
+        foreach ($filesInfo as $info) {
+            if ($info['valid']) {
+                continue;
+            }
+
+            ++$erroredFiles;
+
+            $reporter->error($info['message'], $info['file'] ?? 'php://stdin', $info['line']);
+        }
+
+        $reporter->write();
+
+        return min($erroredFiles, 1);
     }
 
     private function displayTxt(SymfonyStyle $io, array $filesInfo, bool $errorAsGithubAnnotations = false): int
@@ -272,6 +294,6 @@ class LintCommand extends Command
     /** @return string[] */
     private function getAvailableFormatOptions(): array
     {
-        return ['txt', 'json', 'github'];
+        return ['txt', 'json', 'github', 'gitlab'];
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -81,6 +81,41 @@ bar';
         self::assertStringMatchesFormat('%A::error file=%s,line=2,col=0::Unable to parse at line 2 (near "bar")%A', trim($tester->getDisplay()));
     }
 
+    public function testLintIncorrectFileWithGitlabFormat()
+    {
+        $incorrectContent = <<<YAML
+            foo:
+            bar
+            YAML;
+        $tester = $this->createCommandTester();
+        $filename = $this->createFile($incorrectContent);
+
+        $tester->execute(['filename' => $filename, '--format' => 'gitlab'], ['decorated' => false]);
+
+        self::assertSame(1, $tester->getStatusCode(), 'Returns 1 in case of error');
+
+        $report = json_decode(trim($tester->getDisplay()), true);
+        self::assertIsArray($report);
+        self::assertCount(1, $report);
+        self::assertSame('yaml-lint', $report[0]['check_name']);
+        self::assertSame('major', $report[0]['severity']);
+        self::assertStringContainsString('Unable to parse at line 2 (near "bar")', $report[0]['description']);
+        self::assertSame($filename, $report[0]['location']['path']);
+        self::assertSame(2, $report[0]['location']['lines']['begin']);
+        self::assertNotEmpty($report[0]['fingerprint']);
+    }
+
+    public function testLintCorrectFileWithGitlabFormat()
+    {
+        $tester = $this->createCommandTester();
+        $filename = $this->createFile('foo: bar');
+
+        $tester->execute(['filename' => $filename, '--format' => 'gitlab'], ['decorated' => false]);
+
+        self::assertSame(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        self::assertSame([], json_decode(trim($tester->getDisplay()), true));
+    }
+
     public function testLintAutodetectsGithubActionEnvironment()
     {
         $prev = getenv('GITHUB_ACTIONS');
@@ -163,7 +198,7 @@ bar';
 
     public static function provideCompletionSuggestions()
     {
-        yield 'option' => [['--format', ''], ['txt', 'json', 'github']];
+        yield 'option' => [['--format', ''], ['txt', 'json', 'github', 'gitlab']];
     }
 
     private function createFile($content): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a `gitlab` output format to the `lint:yaml` command, producing a report in the [GitLab Code Quality format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format), which GitLab CI/CD consumes natively as a Code Quality artifact. Lint findings then appear inline in the merge-request diff view, analogous to what `--format=github` already provides for GitHub Actions.

A new `Symfony\Component\Console\CI\GitlabCiReporter` is added next to the existing `GithubActionReporter`. It is intentionally generic (not Yaml-specific) so the same format can later be wired into `lint:twig`, `lint:container`, `lint:translations`, etc.

### Usage

```yaml
  # .gitlab-ci.yml
  yaml-lint:
    script:
      - bin/console lint:yaml config --format=gitlab > gl-codequality.json
    artifacts:
      reports:
        codequality: gl-codequality.json
      when: always
```

### Example output

```json
  [
      {
          "description": "Unable to parse at line 2 (near \"bar\").",
          "check_name": "yaml-lint",
          "fingerprint": "…",
          "severity": "major",
          "location": {
              "path": "config/services.yaml",
              "lines": { "begin": 2 }
          }
      }
  ]
```

### Notes on design choices

- **Format name `gitlab` (not `codeclimate`)** - consistent with the existing `github` format (named after the platform, not the underlying wire format) and matches the convention used by PHPStan, Psalm and other PHP tools (`--error-format=gitlab`).
- **No environment auto-detection** - unlike `github` (which auto-selects when `GITHUB_ACTIONS=1`), the `gitlab` format is *not* auto-selected under `GITLAB_CI=true`. The intended use is `bin/console lint:yaml --format=gitlab > artifact.json`, which requires explicit invocation anyway. Auto-detection can be added later without BC concerns.
- **Fingerprint** - built from `check_name | path | line | description` and hashed with `xxh3`, so identical errors collapse to the same fingerprint across runs and GitLab can track issue lifetime across MRs.

