### PR TITLE
[Yaml] fix flow collection drops `&anchor` and `!!str &anchor` items

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -381,6 +381,7 @@ class Inline
                     $value = self::parseMapping($sequence, $flags, $i, $references);
                     break;
                 default:
+                    $hasAnchorAtStart = null === $tag && isset($sequence[$i]) && '&' === $sequence[$i];
                     $value = self::parseScalar($sequence, $flags, [',', ']'], $i, null === $tag, $references, $isQuoted);
 
                     // the value can be an array if a reference has been resolved to an array var
@@ -416,9 +417,9 @@ class Inline
                         }
                     }
 
-                    if (!$isQuoted && \is_string($value) && '' !== $value && '&' === $value[0] && Parser::preg_match(Parser::REFERENCE_PATTERN, $value, $matches)) {
-                        $references[$matches['ref']] = $matches['value'];
-                        $value = $matches['value'];
+                    if ($hasAnchorAtStart && !$isQuoted && \is_string($value) && '' !== $value && '&' === $value[0] && Parser::preg_match(Parser::REFERENCE_PATTERN, $value, $matches)) {
+                        $value = '' === $matches['value'] ? null : $matches['value'];
+                        $references[$matches['ref']] = $value;
                     }
 
                     --$i;
@@ -549,6 +550,7 @@ class Inline
                         }
                         break;
                     default:
+                        $hasAnchorAtStart = null === $tag && isset($mapping[$i]) && '&' === $mapping[$i];
                         $value = self::parseScalar($mapping, $flags, [',', '}', "\n"], $i, null === $tag, $references, $isValueQuoted);
                         // Spec: Keys MUST be unique; first one wins.
                         // Parser cannot abort this mapping earlier, since lines
@@ -557,9 +559,9 @@ class Inline
                         if ('<<' === $key) {
                             $output += $value;
                         } elseif ($allowOverwrite || !isset($output[$key])) {
-                            if (!$isValueQuoted && \is_string($value) && '' !== $value && '&' === $value[0] && !self::isBinaryString($value) && Parser::preg_match(Parser::REFERENCE_PATTERN, $value, $matches)) {
-                                $references[$matches['ref']] = $matches['value'];
-                                $value = $matches['value'];
+                            if ($hasAnchorAtStart && !$isValueQuoted && \is_string($value) && '' !== $value && '&' === $value[0] && !self::isBinaryString($value) && Parser::preg_match(Parser::REFERENCE_PATTERN, $value, $matches)) {
+                                $value = '' === $matches['value'] ? null : $matches['value'];
+                                $references[$matches['ref']] = $value;
                             }
 
                             if (null !== $tag) {

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -1152,4 +1152,25 @@ class InlineTest extends TestCase
         $this->assertSame([null, 'foo', 'bar'], Inline::parse('[, foo, bar]'));
         $this->assertSame(['foo', 'bar'], Inline::parse('[foo, bar, ]'));
     }
+
+    public function testFlowAndBlockProduceSameOutputForAmpersandPrefixedItems()
+    {
+        $this->assertSame([null], Inline::parse('[&string4]'));
+        $this->assertSame(['foo' => null], Inline::parse('{foo: &string4}'));
+
+        $this->assertSame(['&string3'], Inline::parse('[!!str &string3]'));
+        $this->assertSame(['foo' => '&string3'], Inline::parse('{foo: !!str &string3}'));
+
+        $yaml = <<<YAML
+            block:
+                - '&string1'
+                - "&string2"
+                - !!str &string3
+                - &string4
+            flow: ['&string1', "&string2", !!str &string3, &string4 ]
+            YAML;
+        $parsed = Yaml::parse($yaml);
+        $this->assertSame(['&string1', '&string2', '&string3', null], $parsed['block']);
+        $this->assertSame($parsed['block'], $parsed['flow']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44019
| License       | MIT

In #44019, two equivalent YAML representations of the same collection
produce divergent results when items start with `&`:

```yaml
block:
    - '&string1'
    - "&string2"
    - !!str &string3
    - &string4
flow: ['&string1', "&string2", !!str &string3, &string4 ]
```

Reproduces with:

```
block: ['&string1', '&string2', '&string3', NULL]
flow:  ['&string1', '&string2', '',         '']
```

Cases 0-1 were fixed by #44034 / #44131. The two remaining cases — bare
anchor and `!!str <anchor>` inside a flow collection — are addressed
here.

The flow parser used to extract every `&xxx` value as if it were an
anchor declaration, even when the scalar had been produced by `!!str`
prefix stripping. After this patch:

* `[&string4]` yields `null` (matching block parser, where `- &string4`
  resolves to `null`).
* `[!!str &string3]` yields the literal `'&string3'` (matching block
  parser, where `- !!str &string3` does not extract an anchor inside
  the tagged value).

Anchor extraction is now skipped when the value at the parsing offset
either started with a tag (so `&` is the tagged value's content) or was
produced by `!!str`-style scalar evaluation. Existing `&ref value` /
`*ref` reference handling is unchanged.