### PR TITLE
[Serializer] honor `csv_headers` context when `no_headers` is true

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -152,10 +152,17 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                 $nbHeaders = $nbCols;
 
                 if ($context[self::NO_HEADERS_KEY] ?? $this->defaultContext[self::NO_HEADERS_KEY]) {
+                    $userHeaders = $context[self::HEADERS_KEY] ?? $this->defaultContext[self::HEADERS_KEY];
                     for ($i = 0; $i < $nbCols; ++$i) {
-                        $headers[] = [$i];
+                        if (isset($userHeaders[$i])) {
+                            $header = explode($keySeparator, $userHeaders[$i]);
+                            $headers[] = $header;
+                            $headerCount[] = \count($header);
+                        } else {
+                            $headers[] = [$i];
+                            $headerCount[] = 1;
+                        }
                     }
-                    $headerCount = array_fill(0, $nbCols, 1);
                 } else {
                     foreach ($cols as $col) {
                         $header = explode($keySeparator, $col ?? '');

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -707,6 +707,55 @@ class CsvEncoderTest extends TestCase
             ]));
     }
 
+    public function testDecodeWithoutHeaderUsesProvidedHeadersAsKeys()
+    {
+        $csv = <<<'CSV'
+            abc
+            def
+            xyz
+
+            CSV;
+
+        $this->assertSame(
+            [['name' => 'abc'], ['name' => 'def'], ['name' => 'xyz']],
+            $this->encoder->decode($csv, 'csv', [
+                CsvEncoder::NO_HEADERS_KEY => true,
+                CsvEncoder::HEADERS_KEY => ['name'],
+            ])
+        );
+
+        $this->assertSame(
+            [['first' => 'a', 'last' => 'b'], ['first' => 'c', 'last' => 'd']],
+            $this->encoder->decode("a,b\nc,d\n", 'csv', [
+                CsvEncoder::NO_HEADERS_KEY => true,
+                CsvEncoder::HEADERS_KEY => ['first', 'last'],
+            ])
+        );
+
+        $this->assertSame(
+            [['first' => 'a', 1 => 'b'], ['first' => 'c', 1 => 'd']],
+            $this->encoder->decode("a,b\nc,d\n", 'csv', [
+                CsvEncoder::NO_HEADERS_KEY => true,
+                CsvEncoder::HEADERS_KEY => ['first'],
+            ])
+        );
+
+        $this->assertSame(
+            [['user' => ['first' => 'a', 'last' => 'b']]],
+            $this->encoder->decode('a,b', 'csv', [
+                CsvEncoder::NO_HEADERS_KEY => true,
+                CsvEncoder::HEADERS_KEY => ['user.first', 'user.last'],
+            ])
+        );
+
+        $this->assertSame(
+            [['a', 'b'], ['c', 'd']],
+            $this->encoder->decode("a,b\nc,d\n", 'csv', [
+                CsvEncoder::NO_HEADERS_KEY => true,
+            ])
+        );
+    }
+
     public function testBOMIsAddedOnDemand()
     {
         $value = ['foo' => 'hello', 'bar' => 'hey ho'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63919
| License       | MIT

When decoding a headerless CSV (`NO_HEADERS_KEY => true`), the `CsvEncoder::HEADERS_KEY`
context option was silently ignored. Row values were always indexed numerically
(`[0 => 'abc', 1 => 'def', ...]`) regardless of the names supplied by the caller.

Reproduces with:

```php
$enc->decode("abc\ndef\nxyz\n", 'csv', [
    CsvEncoder::HEADERS_KEY    => ['name'],
    CsvEncoder::NO_HEADERS_KEY => true,
]);
// got:      [[0 => 'abc'], [0 => 'def'], [0 => 'xyz']]
// expected: [['name' => 'abc'], ['name' => 'def'], ['name' => 'xyz']]
```

The user-supplied list is now used as the keys for each column. `KEY_SEPARATOR` is
honored on these entries, mirroring the headered decode path so nested names (e.g.
`'user.first'`) produce nested associative arrays.

Backward compatibility is preserved:

* When `HEADERS_KEY` is empty (the default) and `NO_HEADERS_KEY` is true, columns keep
  numeric keys exactly as before.
* When fewer names are provided than the CSV has columns, extra columns fall back to
  numeric keys.
