### PR TITLE
[ObjectMapper] Inherit #[Map] class attribute from parent classes

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add automatic conversion between `BackedEnum` and scalar types (both ways)
  * Add a `MappingAwareTransformCallableInterface` to pass the `Map` attribute being applied to transformers
+ * Add class-level Inheritance for `#[Map]` attribute
 
 8.1
 ---

--- a/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
+++ b/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
@@ -28,7 +28,7 @@ final class ReverseMappingPass implements CompilerPassInterface
         $reverseClassObjectMapperMetadataFactory = $container->getDefinition('object_mapper.metadata_factory.reverse_class');
 
         $classes = [];
-        foreach ($container->findTaggedResourceIds('object_mapper.map') as $tags) {
+        foreach ($container->findTaggedResourceIds('object_mapper.map', false) as $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['source'], $tag['target'])) {
                     continue;

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReflectionObjectMapperMetadataFactory.php
@@ -37,11 +37,17 @@ final class ReflectionObjectMapperMetadataFactory implements ObjectMapperMetadat
             }
 
             $refl = $this->reflectionClassCache[$object::class] ??= new \ReflectionClass($object);
-            $target = $refl;
-            if ($property && null === $target = $this->getPropertyFromHierarchy($refl, $property)) {
-                return $this->attributesCache[$key] = [];
+            if ($property) {
+                if (null === $target = $this->getPropertyFromHierarchy($refl, $property)) {
+                    return $this->attributesCache[$key] = [];
+                }
+                $attributes = $target->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
+            } else {
+                $attributes = [];
+                for ($parent = $refl; $parent && !$attributes; $parent = $parent->getParentClass()) {
+                    $attributes = $parent->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
+                }
             }
-            $attributes = $target->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
             $mappings = [];
             foreach ($attributes as $attribute) {
                 $map = $attribute->newInstance();

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -47,7 +47,11 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
         }
 
         $mappings = $this->objectMapperMetadataFactory->create($object, $property, $context);
-        $targetClasses = (array) ($this->classMap[$class] ?? []);
+
+        $targetClasses = [];
+        for ($refl = new \ReflectionClass($object); $refl && !$targetClasses; $refl = $refl->getParentClass()) {
+            $targetClasses = (array) ($this->classMap[$refl->getName()] ?? []);
+        }
 
         if (!$targetClasses) {
             return $mappings;

--- a/src/Symfony/Component/ObjectMapper/Tests/DependencyInjection/ReverseMappingPassTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/DependencyInjection/ReverseMappingPassTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\ObjectMapper\DependencyInjection\ReverseMappingPass;
+use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Cost;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
@@ -78,6 +79,27 @@ final class ReverseMappingPassTest extends TestCase
         (new ReverseMappingPass())->process($container);
 
         $this->assertSame([], $factory->getArgument(1));
+    }
+
+    public function testAbstractMappedClassesAreNotRejected()
+    {
+        $container = new ContainerBuilder();
+        $container->register('object_mapper.metadata_factory.reverse_class', ReverseClassObjectMapperMetadataFactory::class)
+            ->setArguments([null, []]);
+
+        // #[Map] is meant to live on an abstract parent so children inherit it;
+        // such a resource must not be rejected at compile time.
+        $container->register('source', 'Foo\AbstractSource')
+            ->setAbstract(true)
+            ->addTag('object_mapper.map', ['source' => 'Foo\AbstractSource', 'target' => 'Foo\Target'])
+            ->addResourceTag('container.excluded');
+
+        (new ReverseMappingPass())->process($container);
+
+        $this->assertSame(
+            ['Foo\AbstractSource' => ['Foo\Target']],
+            $container->getDefinition('object_mapper.metadata_factory.reverse_class')->getArgument(1),
+        );
     }
 
     private function registerReverseClassFactory(ContainerBuilder $container): Definition

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/ChildOfLineItemSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/ChildOfLineItemSource.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap;
+
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping\LineItemSource;
+
+class ChildOfLineItemSource extends LineItemSource
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/InheritedReverseChildSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/InheritedReverseChildSource.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap;
+
+class InheritedReverseChildSource extends InheritedReverseSource
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/InheritedReverseSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/InheritedReverseSource.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap;
+
+class InheritedReverseSource
+{
+    public function __construct(
+        public string $id = 'foo',
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/InheritedReverseTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/InheritedReverseTarget.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap;
+
+class InheritedReverseTarget
+{
+    public string $id;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/OverridingChildOfLineItemSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InheritedClassMap/OverridingChildOfLineItemSource.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Target;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedCollectionMapping\LineItemSource;
+
+#[Map(target: Target::class)]
+class OverridingChildOfLineItemSource extends LineItemSource
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -90,6 +90,11 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\HydrateObject\SourceOnly;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap\ChildOfLineItemSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap\InheritedReverseChildSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap\InheritedReverseSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap\InheritedReverseTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InheritedClassMap\OverridingChildOfLineItemSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\A as InitializedConstructorA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\B as InitializedConstructorB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\C as InitializedConstructorC;
@@ -980,6 +985,32 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(CostRequestView::class, $quoteRequestView->cost);
         $this->assertEquals(10, $quoteRequestView->cost->amount);
         $this->assertEquals(20, $quoteRequestView->cost->tax);
+    }
+
+    public function testInheritedClassMapFromParent()
+    {
+        $out = (new ObjectMapper())->map(new ChildOfLineItemSource());
+        $this->assertInstanceOf(LineItemTarget::class, $out);
+    }
+
+    public function testInheritedClassMapIsOverriddenByChild()
+    {
+        $out = (new ObjectMapper())->map(new OverridingChildOfLineItemSource());
+        $this->assertInstanceOf(Target::class, $out);
+    }
+
+    public function testInheritedReverseClassMapFromParent()
+    {
+        $classMap = [
+            InheritedReverseSource::class => InheritedReverseTarget::class,
+        ];
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+
+        $out = $mapper->map(new InheritedReverseChildSource());
+
+        $this->assertInstanceOf(InheritedReverseTarget::class, $out);
+        $this->assertSame('foo', $out->id);
     }
 
     public function testClassMapWithSourceAttribute()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

# What
This change adds inheritance over `#[Map]` attribute. Based on my real world need.
- If a parent has `#[Map]`, children have so,
- If any mapping property is different for a child, it takes priority.

# Why
```php
#[AsMessage] // can be promoted on parent, cool
abstract class SaveActivity
{
    abstract public ?int $id { get; set; }
    ...
}

#[Map] // can't be promoted on parent, not cool
final class SaveContest extends SaveActivity
{
    public function __construct(
        #[Map(if: false)]
        public ?int $id = null,
        public ?string $name = null,
        ...
    ) {}
}

#[Map] // same, but different, but same
final class SaveTournament extends SaveActivity
{
    public function __construct(
        #[Map(if: false)]
        public ?int $id = null,
        public ?TournamentFormat $format = null,
        ...
    ) {}
}
```

# How
- If `#[Map]` is missing on a class, `ReflectionObjectMapperMetadataFactory` will look it up by walking the parent chain and stop at the first ancestor that declares it.
- Tests with fixtures.