### PR TITLE
[HttpKernel][WebProfilerBundle] Decrease response subscribers’ priority

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -213,7 +213,8 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::RESPONSE => ['onKernelResponse', -128],
+            // Run after ProfilerListener::onKernelResponse since we need the X-Debug-Token header
+            KernelEvents::RESPONSE => ['onKernelResponse', -2048],
         ];
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -142,7 +142,8 @@ class ProfilerListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::RESPONSE => ['onKernelResponse', -100],
+            // low priority to come after listeners that could change the response
+            KernelEvents::RESPONSE => ['onKernelResponse', -1024],
             KernelEvents::EXCEPTION => ['onKernelException', 0],
             KernelEvents::TERMINATE => ['onKernelTerminate', -1024],
         ];

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -59,6 +59,7 @@
         "symfony/http-client-contracts": "<2.5",
         "symfony/translation-contracts": "<2.5",
         "symfony/var-dumper": "<8.1",
+        "symfony/web-profiler-bundle": "<8.1",
         "twig/twig": "<3.21"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #36846
| License       | MIT

The issue is about the profiler not showing the session listener’s changes to the response.

#36789 already attempted to fix it by decreasing `ProfilerListener::onKernelResponse`’s priority but then caused #36836 because this subscriber triggers the `Profiler` to set the `X-Debug-Token` header the `WebDebugToolbarListener` needs to inject the toolbar, so `WebDebugToolbarListener::onKernelResponse` needs to run after that.

As such, this PR also decreases `WebDebugToolbarListener::onKernelResponse`’s priority and adds a conflict rule to `symfony/http-kernel` so that it cannot be installed with a previous version of `symfony/web-profiler-bundle`.