### PR TITLE
[VarDumper] Make `testNonceClosureMayReturnNullToSkipInjection` pass

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -174,7 +174,7 @@ class HtmlDumper extends CliDumper
             return $nonce;
         }
 
-        if (!\is_string($value = $nonce() ?? '')) {
+        if (!\is_string(($value = $nonce()) ?? '')) {
             throw new \LogicException(\sprintf('The nonce closure passed to "%s::setNonce()" must return a string or null, "%s" returned.', self::class, get_debug_type($value)));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

In #64087 `HtmlDumper::resolveNonce` always returned a string if passed a closure. It now returns `null` if the closure returns `null`.