### PR TITLE
[Messenger] Fix "--fetch-size" option rejecting valid values

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -313,7 +313,7 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             $options['queues'] = $queues;
         }
 
-        if (1 < $fetchSize = (int) $input->getOption('fetch-size')) {
+        if (1 > $fetchSize = (int) $input->getOption('fetch-size')) {
             throw new \InvalidArgumentException(\sprintf('The "--fetch-size" option must be a positive integer, "%s" given.', $input->getOption('fetch-size')));
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyReceiver;
 use Symfony\Component\Messenger\Tests\Fixtures\ResettableDummyReceiver;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
@@ -174,6 +175,52 @@ class ConsumeMessagesCommandTest extends TestCase
         yield 'Zero second time limit' => ['--time-limit', '0', 'Option "time-limit" must be a positive integer, "0" passed.'];
         yield 'Non-numeric time limit' => ['--time-limit', 'whatever', 'Option "time-limit" must be a positive integer, "whatever" passed.'];
         yield 'Negative reset interval' => ['--no-reset', '-1', 'Option "no-reset" must be a positive integer, "-1" passed.'];
+    }
+
+    public function testRunWithFetchSizeOption()
+    {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
+
+        $receiver = new DummyReceiver([[$envelope]]);
+
+        $receiverLocator = new Container();
+        $receiverLocator->set('dummy-receiver', $receiver);
+
+        $busLocator = new Container();
+        $busLocator->set('dummy-bus', new MessageBus());
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        $application->addCommand($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--fetch-size' => '8',
+            '--limit' => 1,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertSame([8], $receiver->getFetchSizes());
+    }
+
+    public function testRunWithInvalidFetchSizeOption()
+    {
+        $receiverLocator = new Container();
+        $receiverLocator->set('dummy-receiver', new \stdClass());
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus(new Container()), $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        $application->addCommand($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "--fetch-size" option must be a positive integer, "0" given.');
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--fetch-size' => '0',
+        ]);
     }
 
     public function testRunWithTimeLimit()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `--fetch-size` option, added in 8.1 (#63662), is currently unusable for its intended purpose: any value greater than 1 throws an `InvalidArgumentException`.

In `ConsumeMessagesCommand::execute()` the validation reads:

```php
if (1 < $fetchSize = (int) $input->getOption('fetch-size')) {
    throw new \InvalidArgumentException(\sprintf('The "--fetch-size" option must be a positive integer, "%s" given.', ...));
}
```

The condition is inverted. It triggers on the valid range (`> 1`) and silently accepts `0` and negative values. The error message ("must be a positive integer") confirms the intent was the opposite: reject values `< 1`.

Since `Worker::run()` caps `fetch_size` with `max(1, ...)`, the bug is purely in the command layer, but it makes `messenger:consume --fetch-size=8` unusable from the CLI.

Before:

```console
$ bin/console messenger:consume async --fetch-size=8

In ConsumeMessagesCommand.php line 317:
  The "--fetch-size" option must be a positive integer, "8" given.
```

After: the command runs and the receiver is asked for batches of 8.

This PR flips the comparison to `1 > $fetchSize` and adds two tests in `ConsumeMessagesCommandTest`:

- `testRunWithFetchSizeOption` runs the command with `--fetch-size=8` and asserts the receiver actually saw the fetch size (regression test; fails on 8.1 without this patch).
- `testRunWithInvalidFetchSizeOption` keeps the existing rejection behaviour for `--fetch-size=0`.
