### PR TITLE
[TypeInfo] Add support for covariant templates

### DIFF
--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `@template-covariant` and its vendor prefixed synonyms
+
 8.1
 ---
 

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithCovariantTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithCovariantTemplates.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @template-covariant T of int|string
+ * @template-covariant U
+ */
+final class DummyWithCovariantTemplates
+{
+    private int $price;
+
+    /**
+     * @template-covariant T of int|float
+     * @template-covariant V
+     *
+     * @return T
+     */
+    public function getPrice(bool $inCents = false): int|float
+    {
+        return $inCents ? $this->price : $this->price / 100;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpstanCovariantTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPhpstanCovariantTemplates.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @phpstan-template-covariant T of int|string
+ * @phpstan-template-covariant U
+ */
+final class DummyWithPhpstanCovariantTemplates
+{
+    private int $price;
+
+    /**
+     * @phpstan-template-covariant T of int|float
+     * @phpstan-template-covariant V
+     *
+     * @return T
+     */
+    public function getPrice(bool $inCents = false): int|float
+    {
+        return $inCents ? $this->price : $this->price / 100;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPsalmCovariantTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithPsalmCovariantTemplates.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @psalm-template-covariant T of int|string
+ * @psalm-template-covariant U
+ */
+final class DummyWithPsalmCovariantTemplates
+{
+    private int $price;
+
+    /**
+     * @psalm-template-covariant T of int|float
+     * @psalm-template-covariant V
+     *
+     * @return T
+     */
+    public function getPrice(bool $inCents = false): int|float
+    {
+        return $inCents ? $this->price : $this->price / 100;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -18,10 +18,13 @@ use Symfony\Component\TypeInfo\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace\DummyInDifferentNs;
 use Symfony\Component\TypeInfo\Tests\Fixtures\AnotherNamespace\DummyWithTemplateAndParentInDifferentNs;
 use Symfony\Component\TypeInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithCovariantTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithImportedOnlyTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAliasImport;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPhpstanCovariantTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPhpstanTemplates;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPsalmCovariantTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPsalmTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithRecursiveTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplateAndParent;
@@ -165,6 +168,9 @@ class TypeContextFactoryTest extends TestCase
         yield [DummyWithTemplates::class];
         yield [DummyWithPhpstanTemplates::class];
         yield [DummyWithPsalmTemplates::class];
+        yield [DummyWithCovariantTemplates::class];
+        yield [DummyWithPsalmCovariantTemplates::class];
+        yield [DummyWithPhpstanCovariantTemplates::class];
     }
 
     public function testCollectTemplatesWithParent()

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -249,8 +249,24 @@ final class TypeContextFactory
             return [];
         }
 
+        $docNode = $this->getPhpDocNode($rawDocNode);
+
+        $templateTags = [
+            '@template',
+            '@template-covariant',
+            '@psalm-template',
+            '@psalm-template-covariant',
+            '@phpstan-template',
+            '@phpstan-template-covariant',
+        ];
+
+        $tags = [];
+        foreach ($templateTags as $tagName) {
+            $tags = [...$tags, ...$docNode->getTagsByName($tagName)];
+        }
+
         $templates = [];
-        foreach ($this->getPhpDocNode($rawDocNode)->getTagsByName('@template') + $this->getPhpDocNode($rawDocNode)->getTagsByName('@phpstan-template') + $this->getPhpDocNode($rawDocNode)->getTagsByName('@psalm-template') as $tag) {
+        foreach ($tags as $tag) {
             if (!$tag->value instanceof TemplateTagValueNode) {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | None that I can find
| License       | MIT

It appears that type resolver does not currently support `@template-covariant` and its vendor variants.

This patch adds support for that…