### PR TITLE
[Tui] Add tab widget

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Reuse unchanged rendered line segments during differential updates
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`
+ * Add the tab widget
  * [BC BREAK] Add `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
  * Add `KeyBindingWidget` to display the keybindings of the focused widget
 

--- a/src/Symfony/Component/Tui/Event/TabChangeEvent.php
+++ b/src/Symfony/Component/Tui/Event/TabChangeEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Event;
+
+use Symfony\Component\Tui\Widget\TabsWidget;
+
+/**
+ * Event dispatched when the active tab changes in TabsWidget.
+ *
+ * @experimental
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TabChangeEvent extends AbstractEvent
+{
+    public function __construct(
+        TabsWidget $target,
+        private readonly int $previousIndex,
+        private readonly int $index,
+        private readonly string $previousId,
+        private readonly string $id,
+    ) {
+        parent::__construct($target);
+    }
+
+    public function getPreviousIndex(): int
+    {
+        return $this->previousIndex;
+    }
+
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
+    public function getPreviousId(): string
+    {
+        return $this->previousId;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
+++ b/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
@@ -20,6 +20,7 @@ use Symfony\Component\Tui\Widget\LoaderWidget;
 use Symfony\Component\Tui\Widget\MarkdownWidget;
 use Symfony\Component\Tui\Widget\SelectListWidget;
 use Symfony\Component\Tui\Widget\SettingsListWidget;
+use Symfony\Component\Tui\Widget\TabsWidget;
 
 /**
  * Default TUI stylesheet with base styling rules.
@@ -94,6 +95,13 @@ final class DefaultStyleSheet
             SettingsListWidget::class.'::value-selected:focus' => new Style()->withColor('cyan'),
             SettingsListWidget::class.'::description' => new Style()->withColor('gray'),
             SettingsListWidget::class.'::hint' => new Style()->withColor('gray'),
+
+            // TabsWidget
+            TabsWidget::class.'::tab' => new Style()->withColor('gray'),
+            TabsWidget::class.'::tab-active' => new Style()->withBold()->withColor('cyan'),
+            TabsWidget::class.'::tab:focus' => new Style(background: '#253041'),
+            TabsWidget::class.'::tab-active:focus' => new Style()->withBold()->withColor('cyan')->withBackground('#253041'),
+            TabsWidget::class.'::separator' => new Style()->withColor('gray'),
 
             // MarkdownWidget
             MarkdownWidget::class.'::heading' => new Style()->withColor('cyan')->withBold(),

--- a/src/Symfony/Component/Tui/Tests/Widget/TabsWidgetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/TabsWidgetTest.php
@@ -1,0 +1,686 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Widget;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Event\TabChangeEvent;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Style\Direction;
+use Symfony\Component\Tui\Terminal\VirtualTerminal;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\InputWidget;
+use Symfony\Component\Tui\Widget\TabItem;
+use Symfony\Component\Tui\Widget\TabsWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+class TabsWidgetTest extends TestCase
+{
+    public function testOnlyActiveTabContentIsAttached()
+    {
+        $first = new InputWidget();
+        $second = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+        ]);
+
+        $this->assertSame($tabs, $first->getParent());
+        $this->assertNull($second->getParent());
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $focusables = $tui->getFocusManager()->all();
+        $this->assertContains($tabs, $focusables);
+        $this->assertContains($first, $focusables);
+        $this->assertNotContains($second, $focusables);
+
+        $tabs->setActiveTab(1);
+
+        $focusables = $tui->getFocusManager()->all();
+        $this->assertContains($tabs, $focusables);
+        $this->assertContains($second, $focusables);
+        $this->assertNotContains($first, $focusables);
+    }
+
+    public function testFocusMovesBackToTabsWhenSwitchingAwayFromFocusedContent()
+    {
+        $first = new InputWidget();
+        $second = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tui->setFocus($first);
+        $this->assertSame($first, $tui->getFocus());
+
+        $tabs->setActiveTab(1);
+
+        $this->assertSame($tabs, $tui->getFocus());
+    }
+
+    public function testFocusContentOnSwitchFocusesNewActiveContent()
+    {
+        $first = new InputWidget();
+        $second = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+        ]);
+        $tabs->setFocusContentOnSwitch(true);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tui->setFocus($first);
+
+        $tabs->setActiveTab(1);
+
+        $this->assertSame($second, $tui->getFocus());
+    }
+
+    public function testCanFocusActiveTabContentOnConfirm()
+    {
+        $first = new InputWidget();
+        $second = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tui->setFocus($tabs);
+        $this->assertSame($tabs, $tui->getFocus());
+
+        $tabs->handleInput("\r");
+
+        $this->assertSame($first, $tui->getFocus());
+    }
+
+    public function testTabChangeEventIsDispatched()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('A')),
+            new TabItem('second', 'Second', new TextWidget('B')),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $previous = null;
+        $current = null;
+
+        $tui->addListener(static function (TabChangeEvent $event) use (&$previous, &$current): void {
+            $previous = $event->getPreviousId();
+            $current = $event->getId();
+        });
+
+        $tabs->setActiveTab(1);
+
+        $this->assertSame('first', $previous);
+        $this->assertSame('second', $current);
+    }
+
+    public function testRemoveActiveTabDispatchesTabChangeEvent()
+    {
+        $first = new TextWidget('a');
+        $second = new TextWidget('b');
+        $third = new TextWidget('c');
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+            new TabItem('third', 'Third', $third),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $events = [];
+        $tabs->onTabChange(static function (TabChangeEvent $event) use (&$events): void {
+            $events[] = [$event->getPreviousId(), $event->getId()];
+        });
+
+        $tabs->remove($third);
+        $this->assertSame([], $events);
+
+        $tabs->remove($first);
+        $this->assertSame([['first', 'second']], $events);
+
+        $tabs->remove($second);
+        $this->assertSame([['first', 'second']], $events);
+    }
+
+    public function testTabAndShiftTabSwitchTabsByDefault()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('A')),
+            new TabItem('second', 'Second', new TextWidget('B')),
+            new TabItem('third', 'Third', new TextWidget('C')),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tabs->handleInput("\t");
+        $this->assertSame('second', $tabs->getActiveTabId());
+
+        $tabs->handleInput("\x1b[Z");
+        $this->assertSame('first', $tabs->getActiveTabId());
+
+        $tabs->handleInput("\x1b[Z");
+        $this->assertSame('third', $tabs->getActiveTabId());
+    }
+
+    public function testHorizontalRenderDoesNotPadToContextHeight()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('one line')),
+            new TabItem('second', 'Second', new TextWidget('other line')),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $lines = $tabs->render(new RenderContext(40, 20));
+
+        $this->assertCount(4, $lines);
+        $this->assertStringContainsString('First', $lines[1]);
+        $this->assertStringContainsString('one line', $lines[3]);
+    }
+
+    public function testVerticalRenderDoesNotPadToContextHeight()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('one line')),
+            new TabItem('second', 'Second', new TextWidget('other line')),
+        ], Direction::Vertical);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $lines = $tabs->render(new RenderContext(40, 20));
+
+        // 2 tabs × 3 rows each = 6 lines
+        $this->assertCount(6, $lines);
+        // Tab 0: rows 0 (top), 1 (label), 2 (bottom); Tab 1: rows 3 (top), 4 (label), 5 (bottom)
+        $this->assertStringContainsString('one line', $lines[1]);
+        $this->assertStringContainsString('First', $lines[1]);
+        $this->assertStringContainsString('Second', $lines[4]);
+    }
+
+    public function testVerticalRenderUsesHeaderDecorationAndEnclosedLabels()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('one line')),
+            new TabItem('second', 'Second', new TextWidget('other line')),
+        ], Direction::Vertical);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $lines = $tabs->render(new RenderContext(40, 20));
+
+        // 2 tabs × 3 rows = 6 lines:
+        // [0] top of tab 0 (top separator), [1] label tab 0 (active),
+        // [2] bottom of tab 0, [3] top of tab 1,
+        // [4] label tab 1 (inactive), [5] bottom of tab 1 (bottom separator)
+        $this->assertCount(6, $lines);
+
+        $plainTop = AnsiUtils::stripAnsiCodes($lines[0]);
+        $plainActive = AnsiUtils::stripAnsiCodes($lines[1]);
+        $plainActiveBottom = AnsiUtils::stripAnsiCodes($lines[2]);
+        $plainInactiveTop = AnsiUtils::stripAnsiCodes($lines[3]);
+        $plainInactive = AnsiUtils::stripAnsiCodes($lines[4]);
+        $plainBottom = AnsiUtils::stripAnsiCodes($lines[5]);
+
+        $headerWidth = mb_strpos($plainActive, 'one line', 0, 'UTF-8');
+        $this->assertNotFalse($headerWidth);
+        $this->assertGreaterThanOrEqual(3, $headerWidth);
+
+        $headerWidth = (int) $headerWidth;
+
+        // Top separator (first tab top): ╭──── extended with ─ fill (active at edge, no vertical line)
+        $this->assertSame('╭', mb_substr($plainTop, 0, 1, 'UTF-8'));
+        $this->assertSame('─', mb_substr($plainTop, $headerWidth - 1, 1, 'UTF-8'));
+        $this->assertSame('─', mb_substr($plainTop, $headerWidth, 1, 'UTF-8'));
+
+        // Active tab label: open right (space)
+        $this->assertSame('│', mb_substr($plainActive, 0, 1, 'UTF-8'));
+        $this->assertSame(' ', mb_substr($plainActive, $headerWidth - 1, 1, 'UTF-8'));
+
+        // Active tab bottom: ╰──┐ (┐ starts the vertical line below)
+        $this->assertSame('╰', mb_substr($plainActiveBottom, 0, 1, 'UTF-8'));
+        $this->assertSame('┐', mb_substr($plainActiveBottom, $headerWidth - 1, 1, 'UTF-8'));
+
+        // Inactive tab top: ╭──┤ (┤ continues the vertical line)
+        $this->assertSame('╭', mb_substr($plainInactiveTop, 0, 1, 'UTF-8'));
+        $this->assertSame('┤', mb_substr($plainInactiveTop, $headerWidth - 1, 1, 'UTF-8'));
+
+        // Inactive tab label: closed right (│)
+        $this->assertSame('│', mb_substr($plainInactive, 0, 1, 'UTF-8'));
+        $this->assertSame('│', mb_substr($plainInactive, $headerWidth - 1, 1, 'UTF-8'));
+
+        // Bottom separator (last tab bottom): ╰──┴ extended with ─ fill (┴ connects vertical line)
+        $this->assertSame('╰', mb_substr($plainBottom, 0, 1, 'UTF-8'));
+        $this->assertSame('┴', mb_substr($plainBottom, $headerWidth - 1, 1, 'UTF-8'));
+        $this->assertSame('─', mb_substr($plainBottom, $headerWidth, 1, 'UTF-8'));
+    }
+
+    public function testVerticalTabBoxStructureVariesByActiveTab()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('a', 'A', new TextWidget('x')),
+            new TabItem('b', 'B', new TextWidget('y')),
+            new TabItem('c', 'C', new TextWidget('z')),
+        ], Direction::Vertical);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        // Header width for 1-char labels is 5 (│ A │), right char at position 4
+        $extractRightChars = static function (TabsWidget $tabs): array {
+            $lines = $tabs->render(new RenderContext(40, 20));
+            $chars = [];
+            foreach ($lines as $line) {
+                $plain = AnsiUtils::stripAnsiCodes($line);
+                $chars[] = mb_substr($plain, 4, 1, 'UTF-8');
+            }
+
+            return $chars;
+        };
+
+        // 3 tabs × 3 rows = 9 lines:
+        // [0] tab0 top, [1] tab0 label, [2] tab0 bottom,
+        // [3] tab1 top, [4] tab1 label, [5] tab1 bottom,
+        // [6] tab2 top, [7] tab2 label, [8] tab2 bottom
+
+        // Active tab 0: vertical line starts at ┐ on active bottom, runs down
+        $tabs->setActiveTab(0);
+        $chars = $extractRightChars($tabs);
+        $this->assertSame('─', $chars[0], 'Tab 0 top: ─ (no line, active at edge)');
+        $this->assertSame(' ', $chars[1], 'Tab 0 label: active (open)');
+        $this->assertSame('┐', $chars[2], 'Tab 0 bottom: ┐ (line starts)');
+        $this->assertSame('┤', $chars[3], 'Tab 1 top: ┤ (line continues)');
+        $this->assertSame('│', $chars[4], 'Tab 1 label: │ (inactive)');
+        $this->assertSame('┤', $chars[5], 'Tab 1 bottom: ┤ (line continues)');
+        $this->assertSame('┤', $chars[6], 'Tab 2 top: ┤ (line continues)');
+        $this->assertSame('│', $chars[7], 'Tab 2 label: │ (inactive)');
+        $this->assertSame('┴', $chars[8], 'Tab 2 bottom: ┴ (bottom separator)');
+
+        // Active tab 1: line breaks at tab 1 label
+        $tabs->setActiveTab(1);
+        $chars = $extractRightChars($tabs);
+        $this->assertSame('┬', $chars[0], 'Tab 0 top: ┬ (top separator)');
+        $this->assertSame('│', $chars[1], 'Tab 0 label: │ (inactive)');
+        $this->assertSame('┤', $chars[2], 'Tab 0 bottom: ┤ (line continues)');
+        $this->assertSame('┘', $chars[3], 'Tab 1 top: ┘ (line ends)');
+        $this->assertSame(' ', $chars[4], 'Tab 1 label: active (open)');
+        $this->assertSame('┐', $chars[5], 'Tab 1 bottom: ┐ (line starts)');
+        $this->assertSame('┤', $chars[6], 'Tab 2 top: ┤ (line continues)');
+        $this->assertSame('│', $chars[7], 'Tab 2 label: │ (inactive)');
+        $this->assertSame('┴', $chars[8], 'Tab 2 bottom: ┴ (bottom separator)');
+
+        // Active tab 2: line ends at ┘ on active top
+        $tabs->setActiveTab(2);
+        $chars = $extractRightChars($tabs);
+        $this->assertSame('┬', $chars[0], 'Tab 0 top: ┬ (top separator)');
+        $this->assertSame('│', $chars[1], 'Tab 0 label: │ (inactive)');
+        $this->assertSame('┤', $chars[2], 'Tab 0 bottom: ┤ (line continues)');
+        $this->assertSame('┤', $chars[3], 'Tab 1 top: ┤ (line continues)');
+        $this->assertSame('│', $chars[4], 'Tab 1 label: │ (inactive)');
+        $this->assertSame('┤', $chars[5], 'Tab 1 bottom: ┤ (line continues)');
+        $this->assertSame('┘', $chars[6], 'Tab 2 top: ┘ (line ends)');
+        $this->assertSame(' ', $chars[7], 'Tab 2 label: active (open)');
+        $this->assertSame('─', $chars[8], 'Tab 2 bottom: ─ (no line, active at edge)');
+    }
+
+    public function testVerticalTopAndBottomSeparatorsFillToRightEdge()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'A', new TextWidget('content')),
+            new TabItem('second', 'B', new TextWidget('other')),
+        ], Direction::Vertical);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $lines = $tabs->render(new RenderContext(30, 10));
+
+        // 2 tabs × 3 rows = 6 total lines
+        $this->assertCount(6, $lines);
+
+        // Top separator (first tab top, line 0) should fill to full width with ─
+        $this->assertSame(30, AnsiUtils::visibleWidth($lines[0]));
+        $plainTop = AnsiUtils::stripAnsiCodes($lines[0]);
+        $this->assertSame('╭', mb_substr($plainTop, 0, 1, 'UTF-8'));
+        $this->assertSame('─', mb_substr($plainTop, 29, 1, 'UTF-8'));
+
+        // Bottom separator (last tab bottom, line 5) should fill to full width with ─
+        $this->assertSame(30, AnsiUtils::visibleWidth($lines[5]));
+        $plainBottom = AnsiUtils::stripAnsiCodes($lines[5]);
+        $this->assertSame('╰', mb_substr($plainBottom, 0, 1, 'UTF-8'));
+        $this->assertSame('─', mb_substr($plainBottom, 29, 1, 'UTF-8'));
+    }
+
+    public function testHorizontalBottomLineFillsToRightEdge()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('content')),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $lines = $tabs->render(new RenderContext(30, 10));
+
+        $this->assertCount(4, $lines);
+        $this->assertSame(30, AnsiUtils::visibleWidth($lines[2]));
+
+        $plainBottom = AnsiUtils::stripAnsiCodes($lines[2]);
+        $this->assertSame('─', mb_substr($plainBottom, 29, 1, 'UTF-8'));
+    }
+
+    public function testHorizontalHeaderKeepsActiveTabVisible()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'AAAA', new TextWidget('a')),
+            new TabItem('second', 'BBBB', new TextWidget('b')),
+            new TabItem('third', 'CCCC', new TextWidget('c')),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+        $tabs->setActiveTab(2);
+
+        $lines = $tabs->render(new RenderContext(10, 10));
+        $header = AnsiUtils::stripAnsiCodes($lines[1]);
+
+        $this->assertStringContainsString('CCCC', $header);
+        $this->assertStringNotContainsString('AAAA', $header);
+        $this->assertStringContainsString('c', $lines[3]);
+    }
+
+    public function testVerticalHeaderKeepsActiveTabVisible()
+    {
+        $items = [];
+        foreach (range(0, 5) as $i) {
+            $items[] = new TabItem((string) $i, 'T'.$i, new TextWidget('content'.$i));
+        }
+
+        $tabs = new TabsWidget($items, Direction::Vertical);
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+        $tabs->setActiveTab(5);
+
+        $lines = array_map(AnsiUtils::stripAnsiCodes(...), $tabs->render(new RenderContext(20, 6)));
+        $output = implode("\n", $lines);
+
+        $this->assertStringContainsString('T5', $output);
+        $this->assertStringNotContainsString('T0', $output);
+        $this->assertStringContainsString('content5', $output);
+    }
+
+    public function testVerticalScrolledHeaderUsesEdgeJunctions()
+    {
+        $items = [];
+        foreach (range(0, 5) as $i) {
+            $items[] = new TabItem((string) $i, 'T'.$i, new TextWidget('content'.$i));
+        }
+
+        $tabs = new TabsWidget($items, Direction::Vertical);
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        // Header width for 2-char labels is 6 (│ T0 │), right char at position 5
+        $extractRightChars = static function (TabsWidget $tabs): array {
+            $chars = [];
+            foreach ($tabs->render(new RenderContext(20, 9)) as $line) {
+                $chars[] = mb_substr(AnsiUtils::stripAnsiCodes($line), 5, 1, 'UTF-8');
+            }
+
+            return $chars;
+        };
+
+        // 9 rows show 3 of the 6 tab boxes; the first and last visible rows are
+        // the full-width separators and must use edge junctions (┬, ┴ or ─)
+
+        // Active tab 0: window shows tabs 0-2, active at the window top
+        $chars = $extractRightChars($tabs);
+        $this->assertSame(['─', ' ', '┐', '┤', '│', '┤', '┤', '│', '┴'], $chars);
+
+        // Active tab 3: window shows tabs 1-3, active at the window bottom
+        $tabs->setActiveTab(3);
+        $chars = $extractRightChars($tabs);
+        $this->assertSame(['┬', '│', '┤', '┤', '│', '┤', '┘', ' ', '─'], $chars);
+
+        // Active tab 5: window shows tabs 3-5, active at the window bottom
+        $tabs->setActiveTab(5);
+        $chars = $extractRightChars($tabs);
+        $this->assertSame(['┬', '│', '┤', '┤', '│', '┤', '┘', ' ', '─'], $chars);
+    }
+
+    public function testVerticalRenderFitsNarrowContexts()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('content')),
+        ], Direction::Vertical);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        foreach ([1, 2, 3] as $columns) {
+            foreach ($tabs->render(new RenderContext($columns, 5)) as $line) {
+                $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line));
+            }
+        }
+    }
+
+    public function testHeaderDirectionCanBeChanged()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('A')),
+            new TabItem('second', 'Second', new TextWidget('B')),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tabs->setHeaderDirection(Direction::Vertical);
+        $tabs->handleInput("\x1b[B");
+
+        $this->assertSame('second', $tabs->getActiveTabId());
+        $this->assertStringContainsString('Second', $tabs->render(new RenderContext(40, 20))[4]);
+    }
+
+    public function testAddAttachesFirstTabContentWhenAlreadyAttached()
+    {
+        $tabs = new TabsWidget();
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $first = new InputWidget();
+        $tabs->add($first);
+
+        $this->assertContains($first, $tui->getFocusManager()->all());
+    }
+
+    public function testRemoveActiveTabDetachesContentAndAttachesNewActive()
+    {
+        $first = new InputWidget();
+        $second = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tabs->remove($first);
+
+        $focusables = $tui->getFocusManager()->all();
+        $this->assertNotContains($first, $focusables);
+        $this->assertContains($second, $focusables);
+    }
+
+    public function testRemoveInactiveTabBeforeActiveTabPreservesActiveContent()
+    {
+        $first = new InputWidget();
+        $second = new InputWidget();
+        $third = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+            new TabItem('third', 'Third', $third),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+        $tabs->setActiveTab(1);
+
+        $tabs->remove($first);
+
+        $this->assertSame('second', $tabs->getActiveTabId());
+        $focusables = $tui->getFocusManager()->all();
+        $this->assertContains($second, $focusables);
+        $this->assertNotContains($third, $focusables);
+    }
+
+    public function testRemoveActiveTabKeepsFocusOnTabsWhenContentWasFocused()
+    {
+        $other = new InputWidget();
+        $first = new InputWidget();
+        $second = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+            new TabItem('second', 'Second', $second),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($other);
+        $tui->add($tabs);
+
+        $tui->setFocus($first);
+
+        $tabs->remove($first);
+
+        $this->assertSame($tabs, $tui->getFocus());
+    }
+
+    public function testClearKeepsFocusOnTabsWhenContentWasFocused()
+    {
+        $other = new InputWidget();
+        $first = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($other);
+        $tui->add($tabs);
+
+        $tui->setFocus($first);
+
+        $tabs->clear();
+
+        $this->assertSame($tabs, $tui->getFocus());
+    }
+
+    public function testAutoGeneratedTabIdsStayUniqueAfterRemoval()
+    {
+        $tabs = new TabsWidget();
+        $first = new TextWidget('a');
+
+        $tabs->add($first);
+        $tabs->add(new TextWidget('b'));
+        $tabs->remove($first);
+        $tabs->add(new TextWidget('c'));
+
+        $ids = array_map(static fn (TabItem $tab) => $tab->getId(), $tabs->getTabs());
+
+        $this->assertSame(['tab_1', 'tab_2'], $ids);
+    }
+
+    public function testClearDetachesActiveContent()
+    {
+        $first = new InputWidget();
+
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', $first),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $this->assertContains($first, $tui->getFocusManager()->all());
+
+        $tabs->clear();
+
+        $this->assertNotContains($first, $tui->getFocusManager()->all());
+    }
+
+    public function testEmptyTabsCanBeAttachedRenderedAndNavigated()
+    {
+        $tabs = new TabsWidget();
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tabs->handleInput("\x1b[C");
+
+        $this->assertNull($tabs->getActiveTabId());
+        $this->assertSame([], $tabs->render(new RenderContext(40, 10)));
+
+        $tabs->add(new TextWidget('content'));
+        $tabs->clear();
+        $tabs->handleInput("\x1b[D");
+
+        $this->assertNull($tabs->getActiveTabId());
+    }
+
+    public function testFocusedTabsRenderBackgroundOnHeaderLabels()
+    {
+        $tabs = new TabsWidget([
+            new TabItem('first', 'First', new TextWidget('A')),
+            new TabItem('second', 'Second', new TextWidget('B')),
+        ]);
+
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($tabs);
+
+        $tui->setFocus(null);
+        $unfocused = $tabs->render(new RenderContext(40, 10));
+        $this->assertStringNotContainsString("\x1b[48;", $unfocused[1]);
+
+        $tui->setFocus($tabs);
+
+        $focused = $tabs->render(new RenderContext(40, 10));
+        $this->assertStringContainsString("\x1b[48;", $focused[1]);
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/TabItem.php
+++ b/src/Symfony/Component/Tui/Widget/TabItem.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+/**
+ * Represents a single tab entry for TabsWidget.
+ *
+ * @experimental
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class TabItem
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly string $label,
+        private readonly AbstractWidget $content,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getContent(): AbstractWidget
+    {
+        return $this->content;
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/TabsWidget.php
+++ b/src/Symfony/Component/Tui/Widget/TabsWidget.php
@@ -1,0 +1,729 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Event\TabChangeEvent;
+use Symfony\Component\Tui\Focus\FocusManager;
+use Symfony\Component\Tui\Input\Key;
+use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Style\Direction;
+
+/**
+ * Tab container widget with horizontal/vertical headers.
+ *
+ * Only the active tab content is attached to the widget tree; inactive tabs
+ * are detached so they are fully disabled (focus, input hit-testing).
+ *
+ * @experimental
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TabsWidget extends AbstractWidget implements FocusableInterface, WidgetContainerInterface
+{
+    use FocusableTrait;
+    use KeybindingsTrait;
+
+    /** @var list<TabItem> */
+    private array $tabs;
+
+    private int $activeIndex = 0;
+
+    private (FocusableInterface&AbstractWidget)|null $activeFocusableContent = null;
+
+    private bool $focusContentOnSwitch = false;
+
+    /**
+     * @param list<TabItem> $tabs
+     */
+    public function __construct(
+        array $tabs = [],
+        private Direction $headerDirection = Direction::Horizontal,
+        ?Keybindings $keybindings = null,
+    ) {
+        $this->tabs = $tabs;
+
+        if ($this->tabs) {
+            $this->attachChild($this->tabs[0]->getContent());
+        }
+
+        if (null !== $keybindings) {
+            $this->setKeybindings($keybindings);
+        }
+    }
+
+    /**
+     * Add a child widget as a new tab.
+     *
+     * The tab ID is taken from the widget's ID and the tab label from the
+     * widget's label; both fall back to a generated "tab_N" identifier.
+     *
+     * @return $this
+     */
+    public function add(AbstractWidget $widget): static
+    {
+        $id = $widget->getId();
+        if (null === $id) {
+            $existingIds = array_map(static fn (TabItem $tab) => $tab->getId(), $this->tabs);
+            $n = \count($this->tabs);
+            while (\in_array($id = 'tab_'.$n, $existingIds, true)) {
+                ++$n;
+            }
+        }
+        $label = $widget->getLabel() ?? $id;
+
+        $isFirst = !$this->tabs;
+        $this->tabs[] = new TabItem($id, $label, $widget);
+
+        if ($isFirst) {
+            $this->attachChild($widget);
+            $this->activeFocusableContent = $this->findFirstFocusable($widget);
+        }
+
+        $this->invalidate();
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function remove(AbstractWidget $widget): static
+    {
+        foreach ($this->tabs as $i => $tab) {
+            if ($tab->getContent() !== $widget) {
+                continue;
+            }
+
+            $wasActive = $i === $this->activeIndex;
+            $focusManager = $this->getContext()?->getFocusManager();
+            $focusWasInside = $wasActive && null !== $focusManager && $this->isWidgetContainedIn($focusManager->getFocus(), $widget);
+
+            if ($wasActive) {
+                $this->detachChild($widget);
+            }
+
+            array_splice($this->tabs, $i, 1);
+
+            if (!$wasActive && $i < $this->activeIndex) {
+                --$this->activeIndex;
+            } elseif ($this->activeIndex >= \count($this->tabs)) {
+                $this->activeIndex = max(0, \count($this->tabs) - 1);
+            }
+
+            if ($wasActive && $this->tabs) {
+                $newActive = $this->tabs[$this->activeIndex]->getContent();
+                $this->attachChild($newActive);
+                $this->activeFocusableContent = $this->findFirstFocusable($newActive);
+            } elseif (!$this->tabs) {
+                $this->activeFocusableContent = null;
+            }
+
+            if ($focusWasInside) {
+                $this->refocusAfterSwitch($focusManager);
+            }
+
+            if ($wasActive && $this->tabs) {
+                $this->dispatch(new TabChangeEvent(
+                    $this,
+                    $i,
+                    $this->activeIndex,
+                    $tab->getId(),
+                    $this->tabs[$this->activeIndex]->getId(),
+                ));
+            }
+
+            $this->invalidate();
+            break;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function clear(): static
+    {
+        $focusManager = null;
+        $focusWasInside = false;
+
+        if ($this->tabs) {
+            $activeContent = $this->tabs[$this->activeIndex]->getContent();
+            $focusManager = $this->getContext()?->getFocusManager();
+            $focusWasInside = null !== $focusManager && $this->isWidgetContainedIn($focusManager->getFocus(), $activeContent);
+
+            $this->detachChild($activeContent);
+        }
+
+        $this->tabs = [];
+        $this->activeIndex = 0;
+        $this->activeFocusableContent = null;
+
+        if ($focusWasInside) {
+            $this->refocusAfterSwitch($focusManager);
+        }
+
+        $this->invalidate();
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHeaderDirection(Direction $headerDirection): static
+    {
+        if ($this->headerDirection !== $headerDirection) {
+            $this->headerDirection = $headerDirection;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setFocusContentOnSwitch(bool $focusContentOnSwitch): static
+    {
+        if ($this->focusContentOnSwitch !== $focusContentOnSwitch) {
+            $this->focusContentOnSwitch = $focusContentOnSwitch;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function getActiveTabIndex(): int
+    {
+        return $this->activeIndex;
+    }
+
+    public function getActiveTabId(): ?string
+    {
+        return ($this->tabs[$this->activeIndex] ?? null)?->getId();
+    }
+
+    /**
+     * @return list<TabItem>
+     */
+    public function getTabs(): array
+    {
+        return $this->tabs;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setActiveTab(int $index): static
+    {
+        if (!$this->tabs) {
+            return $this;
+        }
+
+        $index = max(0, min($index, \count($this->tabs) - 1));
+
+        if ($index === $this->activeIndex) {
+            return $this;
+        }
+
+        $previousIndex = $this->activeIndex;
+        $previousTab = $this->tabs[$previousIndex];
+        $previousContent = $previousTab->getContent();
+
+        $context = $this->getContext();
+        $focusManager = $context?->getFocusManager();
+        $focusedBefore = $focusManager?->getFocus();
+
+        $this->detachChild($previousContent);
+
+        $this->activeIndex = $index;
+        $activeContent = $this->tabs[$this->activeIndex]->getContent();
+
+        $this->attachChild($activeContent);
+
+        $this->activeFocusableContent = $this->findFirstFocusable($activeContent);
+
+        if (null !== $focusManager && $this->isWidgetContainedIn($focusedBefore, $previousContent)) {
+            $this->refocusAfterSwitch($focusManager);
+        }
+
+        $this->dispatch(new TabChangeEvent(
+            $this,
+            $previousIndex,
+            $this->activeIndex,
+            $previousTab->getId(),
+            $this->tabs[$this->activeIndex]->getId(),
+        ));
+
+        $this->invalidate();
+
+        return $this;
+    }
+
+    /**
+     * @param callable(TabChangeEvent): void $callback
+     *
+     * @return $this
+     */
+    public function onTabChange(callable $callback): static
+    {
+        return $this->on(TabChangeEvent::class, $callback);
+    }
+
+    public function all(): array
+    {
+        if (!$this->tabs) {
+            return [];
+        }
+
+        return [$this->tabs[$this->activeIndex]->getContent()];
+    }
+
+    public function handleInput(string $data): void
+    {
+        if (null !== $this->onInput && ($this->onInput)($data)) {
+            return;
+        }
+
+        if (!$count = \count($this->tabs)) {
+            return;
+        }
+
+        $kb = $this->getKeybindings();
+
+        if ($kb->matches($data, 'tab_next')) {
+            $this->setActiveTab(($this->activeIndex + 1) % $count);
+
+            return;
+        }
+
+        if ($kb->matches($data, 'tab_previous')) {
+            $this->setActiveTab(($this->activeIndex - 1 + $count) % $count);
+
+            return;
+        }
+
+        if (Direction::Horizontal === $this->headerDirection) {
+            if ($kb->matches($data, 'cursor_left')) {
+                $this->setActiveTab(($this->activeIndex - 1 + $count) % $count);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'cursor_right')) {
+                $this->setActiveTab(($this->activeIndex + 1) % $count);
+
+                return;
+            }
+        } else {
+            if ($kb->matches($data, 'select_up')) {
+                $this->setActiveTab(($this->activeIndex - 1 + $count) % $count);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'select_down')) {
+                $this->setActiveTab(($this->activeIndex + 1) % $count);
+
+                return;
+            }
+        }
+
+        if ($kb->matches($data, 'select_confirm') && null !== $this->activeFocusableContent) {
+            $this->getContext()?->getFocusManager()->setFocus($this->activeFocusableContent);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function render(RenderContext $context): array
+    {
+        $columns = $context->getColumns();
+        $rows = $context->getRows();
+
+        if ($columns <= 0 || $rows <= 0 || !$this->tabs) {
+            return [];
+        }
+
+        if (Direction::Horizontal === $this->headerDirection) {
+            return $this->renderHorizontal($columns, $rows, $context);
+        }
+
+        return $this->renderVertical($columns, $rows, $context);
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    protected static function getDefaultKeybindings(): array
+    {
+        return [
+            'tab_next' => [Key::TAB],
+            'tab_previous' => ['shift+tab'],
+            'select_up' => [Key::UP],
+            'select_down' => [Key::DOWN],
+            'cursor_left' => [Key::LEFT],
+            'cursor_right' => [Key::RIGHT],
+            'select_confirm' => [Key::ENTER],
+        ];
+    }
+
+    protected function onAttach(WidgetContext $context): void
+    {
+        if (!$this->tabs) {
+            return;
+        }
+
+        $activeContent = $this->tabs[$this->activeIndex]->getContent();
+        $this->activeFocusableContent = $this->findFirstFocusable($activeContent);
+    }
+
+    protected function onDetach(): void
+    {
+        $this->activeFocusableContent = null;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function renderHorizontal(int $columns, int $rows, RenderContext $context): array
+    {
+        $segments = [];
+        foreach ($this->tabs as $i => $tab) {
+            $segments[] = $this->buildHorizontalTabSegment($tab, $i === $this->activeIndex);
+        }
+
+        $start = $end = $this->activeIndex;
+        $width = AnsiUtils::visibleWidth($segments[$this->activeIndex]['middle']);
+
+        while ($start > 0) {
+            $candidateWidth = AnsiUtils::visibleWidth($segments[$start - 1]['middle']);
+            if ($width + $candidateWidth > $columns) {
+                break;
+            }
+            --$start;
+            $width += $candidateWidth;
+        }
+
+        while ($end + 1 < \count($segments)) {
+            $candidateWidth = AnsiUtils::visibleWidth($segments[$end + 1]['middle']);
+            if ($width + $candidateWidth > $columns) {
+                break;
+            }
+            ++$end;
+            $width += $candidateWidth;
+        }
+
+        $top = '';
+        $middle = '';
+        $bottom = '';
+        for ($i = $start; $i <= $end; ++$i) {
+            $top .= $segments[$i]['top'];
+            $middle .= $segments[$i]['middle'];
+            $bottom .= $segments[$i]['bottom'];
+        }
+
+        $top = $this->padLine(AnsiUtils::truncateToWidth($top, $columns, ''), $columns);
+        $middle = $this->padLine(AnsiUtils::truncateToWidth($middle, $columns, ''), $columns);
+        $bottom = $this->padLineWithFill(AnsiUtils::truncateToWidth($bottom, $columns, ''), $columns, '─');
+
+        $contentRows = max(0, $rows - 3);
+        $contentLines = $contentRows > 0 ? $this->renderActiveContent($context->withRows($contentRows)) : [];
+
+        $lines = [$top, $middle, $bottom];
+        foreach (\array_slice($contentLines, 0, $contentRows) as $line) {
+            $lines[] = $this->padLine(AnsiUtils::truncateToWidth($line, $columns, ''), $columns);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function renderVertical(int $columns, int $rows, RenderContext $context): array
+    {
+        $headerWidth = $this->computeVerticalHeaderWidth($columns);
+        $contentColumns = max(0, $columns - $headerWidth);
+        $tabCount = \count($this->tabs);
+
+        $visibleTabCount = min($tabCount, max(1, intdiv($rows, 3)));
+        $startTab = max(0, min($this->activeIndex - $visibleTabCount + 1, $tabCount - $visibleTabCount));
+        $visibleHeaderCount = $rows < 3 ? $rows : 3 * $visibleTabCount;
+
+        // Compute the right-side character for each visible header row.
+        // A continuous │ line runs on the right, broken only at the active label row.
+        // Tab box borders (top/bottom) connect to this line with junction characters,
+        // just like horizontal tabs connect their side borders to the bottom ─ line.
+        $activeLabelRow = 3 * $this->activeIndex + 1;
+        $firstRow = 3 * $startTab;
+        $lastRow = $firstRow + $visibleHeaderCount - 1;
+        $rightChars = $this->computeVerticalRightChars($activeLabelRow, $firstRow, $lastRow);
+
+        // Each tab is a 3-row box: top border, label, bottom border.
+        $headerLines = [];
+
+        for ($r = $firstRow; $r <= $lastRow; ++$r) {
+            $i = intdiv($r, 3);
+            $headerLines[] = match ($r % 3) {
+                0 => $this->buildVerticalHeaderBorderLine($headerWidth, '╭', $rightChars[$r]),
+                1 => $this->buildVerticalHeaderLabelLine($this->tabs[$i], $i === $this->activeIndex, $headerWidth),
+                2 => $this->buildVerticalHeaderBorderLine($headerWidth, '╰', $rightChars[$r]),
+            };
+        }
+        $headerCount = \count($headerLines);
+        $lastHeaderLine = array_pop($headerLines);
+        if (null === $lastHeaderLine) {
+            return [];
+        }
+        $firstHeaderLine = $headerLines[0] ?? $lastHeaderLine;
+
+        // Reserve 2 rows for first/last full-width separators
+        $innerRows = max(0, $rows - 2);
+        $contentLines = $contentColumns > 0 && $innerRows > 0 ? $this->renderActiveContent($context->withSize($contentColumns, $innerRows)) : [];
+
+        $firstLine = $this->padLineWithFill($firstHeaderLine, $columns, '─');
+        $lastLine = $this->padLineWithFill($lastHeaderLine, $columns, '─');
+
+        $innerCount = min($innerRows, max($headerCount - 2, \count($contentLines)));
+
+        $lines = [$firstLine];
+        for ($i = 0; $i < $innerCount; ++$i) {
+            $left = $headerLines[$i + 1] ?? str_repeat(' ', $headerWidth);
+            $right = $contentLines[$i] ?? '';
+            $right = $this->padLine(AnsiUtils::truncateToWidth($right, $contentColumns, ''), $contentColumns);
+            $lines[] = $left.$right;
+        }
+
+        if (\count($lines) < $rows) {
+            $lines[] = $lastLine;
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Compute the right-side character for each visible header row,
+     * keyed by absolute row number.
+     *
+     * A continuous │ line runs on the right edge of the tab header, broken
+     * at the active tab's label row. Border rows (top/bottom of each tab box)
+     * connect to this line with junction characters:
+     *  - ┬ top separator with line going down
+     *  - ┴ bottom separator with line going up
+     *  - ┤ border crossing a continuous line
+     *  - ┘ line ending (above active opening)
+     *  - ┐ line starting (below active opening)
+     *  - ─ separator continuation when the active tab sits at the edge
+     *
+     * @return array<int, string>
+     */
+    private function computeVerticalRightChars(int $activeLabelRow, int $firstRow, int $lastRow): array
+    {
+        $chars = [];
+
+        for ($r = $firstRow; $r <= $lastRow; ++$r) {
+            if ($r === $activeLabelRow) {
+                $chars[$r] = ' ';
+
+                continue;
+            }
+
+            if (1 === $r % 3) {
+                // Inactive label row
+                $chars[$r] = '│';
+
+                continue;
+            }
+
+            // Border row: determine vertical line connections
+            $connectUp = $r > $firstRow && ($r - 1) !== $activeLabelRow;
+            $connectDown = $r < $lastRow && ($r + 1) !== $activeLabelRow;
+            $isSeparator = $r === $firstRow || $r === $lastRow;
+
+            if ($isSeparator) {
+                // First/last visible row: also connects right (─ fill)
+                if ($connectDown) {
+                    $chars[$r] = '┬';
+                } elseif ($connectUp) {
+                    $chars[$r] = '┴';
+                } else {
+                    // Active tab at edge: no vertical connection, line just continues
+                    $chars[$r] = '─';
+                }
+            } else {
+                // Inner border row: the rows around the active label row can
+                // never both miss, so one of the three junctions always applies
+                if ($connectUp && $connectDown) {
+                    $chars[$r] = '┤';
+                } elseif ($connectUp) {
+                    $chars[$r] = '┘';
+                } else {
+                    $chars[$r] = '┐';
+                }
+            }
+        }
+
+        return $chars;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function renderActiveContent(RenderContext $context): array
+    {
+        $content = $this->tabs[$this->activeIndex]->getContent();
+
+        return $this->getContext()?->renderWidget($content, $context) ?? [];
+    }
+
+    /**
+     * @return array{top: string, middle: string, bottom: string}
+     */
+    private function buildHorizontalTabSegment(TabItem $tab, bool $active): array
+    {
+        $label = ' '.$tab->getLabel().' ';
+        $contentWidth = max(1, AnsiUtils::visibleWidth($label));
+
+        $top = $this->applyElement('separator', '╭').$this->applyElement('separator', str_repeat('─', $contentWidth)).$this->applyElement('separator', '╮');
+        $middleLabel = $this->padLine(AnsiUtils::truncateToWidth($active ? $this->applyElement('tab-active', $label) : $this->applyElement('tab', $label), $contentWidth, ''), $contentWidth);
+        $middle = $this->applyElement('separator', '│').$middleLabel.$this->applyElement('separator', '│');
+
+        if ($active) {
+            $bottom = $this->applyElement('separator', '┘').$this->applyElement('separator', str_repeat(' ', $contentWidth)).$this->applyElement('separator', '└');
+        } else {
+            $bottom = $this->applyElement('separator', '┴').$this->applyElement('separator', str_repeat('─', $contentWidth)).$this->applyElement('separator', '┴');
+        }
+
+        return [
+            'top' => $top,
+            'middle' => $middle,
+            'bottom' => $bottom,
+        ];
+    }
+
+    private function buildVerticalHeaderBorderLine(int $width, string $leftChar, string $rightChar): string
+    {
+        if ($width <= 0) {
+            return '';
+        }
+
+        if (1 === $width) {
+            return $this->applyElement('separator', $leftChar);
+        }
+
+        return $this->applyElement('separator', $leftChar).$this->applyElement('separator', str_repeat('─', $width - 2)).$this->applyElement('separator', $rightChar);
+    }
+
+    private function buildVerticalHeaderLabelLine(TabItem $tab, bool $active, int $width): string
+    {
+        if ($width <= 0) {
+            return '';
+        }
+
+        if (1 === $width) {
+            return $this->applyElement('separator', '│');
+        }
+
+        $innerWidth = $width - 2;
+        $left = $this->applyElement('separator', '│');
+        $right = $active ? ' ' : $this->applyElement('separator', '│');
+        if (0 === $innerWidth) {
+            return $left.$right;
+        }
+
+        $label = ' '.$tab->getLabel().' ';
+        $styled = $active ? $this->applyElement('tab-active', $label) : $this->applyElement('tab', $label);
+        $inner = $this->padLine(AnsiUtils::truncateToWidth($styled, $innerWidth, ''), $innerWidth);
+
+        return $left.$inner.$right;
+    }
+
+    private function computeVerticalHeaderWidth(int $columns): int
+    {
+        $maxInner = 1;
+        foreach ($this->tabs as $tab) {
+            $maxInner = max($maxInner, AnsiUtils::visibleWidth(' '.$tab->getLabel().' '));
+        }
+
+        $maxAllowed = max(1, min($columns, max(3, (int) floor($columns * 0.4))));
+
+        return min($maxInner + 2, $maxAllowed);
+    }
+
+    private function refocusAfterSwitch(FocusManager $focusManager): void
+    {
+        if ($this->focusContentOnSwitch && null !== $this->activeFocusableContent) {
+            $focusManager->setFocus($this->activeFocusableContent);
+        } else {
+            $focusManager->setFocus($this);
+        }
+    }
+
+    private function findFirstFocusable(AbstractWidget $widget): (FocusableInterface&AbstractWidget)|null
+    {
+        if ($widget instanceof FocusableInterface) {
+            return $widget;
+        }
+
+        if ($widget instanceof ParentInterface) {
+            foreach ($widget->all() as $child) {
+                $found = $this->findFirstFocusable($child);
+                if (null !== $found) {
+                    return $found;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function isWidgetContainedIn(?AbstractWidget $needle, AbstractWidget $haystack): bool
+    {
+        if (null === $needle) {
+            return false;
+        }
+
+        if ($needle === $haystack) {
+            return true;
+        }
+
+        if ($haystack instanceof ParentInterface) {
+            foreach ($haystack->all() as $child) {
+                if ($this->isWidgetContainedIn($needle, $child)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function padLine(string $line, int $width): string
+    {
+        return $line.str_repeat(' ', max(0, $width - AnsiUtils::visibleWidth($line)));
+    }
+
+    private function padLineWithFill(string $line, int $width, string $fill): string
+    {
+        $fillCount = max(0, $width - AnsiUtils::visibleWidth($line));
+        if (0 === $fillCount) {
+            return $line;
+        }
+
+        return $line.$this->applyElement('separator', str_repeat($fill, $fillCount));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This PR adds a tab container widget to the Tui component.

`TabsWidget` displays a set of tabs with a horizontal header (boxes above the content) or a vertical one (boxes on the left, chosen with the `Direction` constructor argument or `setHeaderDirection()`). Only the active tab's content is attached to the widget tree; inactive tabs are detached, so they receive no focus and no input.

Public API:

- `TabsWidget(array $tabs = [], Direction $headerDirection = Direction::Horizontal, ?Keybindings $keybindings = null)` where `$tabs` is a list of `TabItem` instances (id, label, content widget)
- `add(AbstractWidget $widget)` creates a tab from a widget, using its id and label with a generated `tab_N` fallback
- `remove()`, `clear()`, `setActiveTab(int $index)`, `getActiveTabIndex()`, `getActiveTabId()`, `getTabs()`
- `onTabChange(callable $callback)` registers a listener for the new `TabChangeEvent` (previous/new index and id), dispatched on every active-tab change, including when the active tab is removed
- `setFocusContentOnSwitch(bool)` moves focus into the new tab's first focusable content on switch (default: focus stays on the tab bar; Enter dives into the content)

Default keybindings: Tab / Shift+Tab cycle tabs, plus Left/Right (horizontal header) or Up/Down (vertical header), Enter focuses the active content. Focus navigation between widgets stays on F6 / Shift+F6, so there is no conflict.

Styling goes through the new `tab`, `tab-active` and `separator` stylesheet elements, with `:focus` variants. When the header does not fit, it scrolls to keep the active tab visible.
