### PR TITLE
[Translation] Fix `TranslationPushCommand::getDomainsFromTranslatorBag`

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -174,7 +174,7 @@ final class TranslationPushCommand extends Command
         $domains = [];
 
         foreach ($translatorBag->getCatalogues() as $catalogue) {
-            $domains += $catalogue->getDomains();
+            $domains = array_merge($domains, $catalogue->getDomains());
         }
 
         return array_unique($domains);

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -316,7 +316,6 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         $arrayLoader = new ArrayLoader();
         $xliffLoader = new XliffFileLoader();
         $locales = ['en', 'fr'];
-        $domains = ['messages'];
 
         // Simulate existing messages on Provider
         $providerReadTranslatorBag = new TranslatorBag();
@@ -326,23 +325,28 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
         $provider = $this->createMock(FilteringProvider::class);
         $provider->expects($this->once())
             ->method('read')
-            ->with($domains, $locales)
+            ->with($this->equalToCanonicalizing(['messages', 'validators']), $locales)
             ->willReturn($providerReadTranslatorBag);
         $provider->expects($this->once())
             ->method('getDomains')
-            ->willReturn(['messages']);
+            ->willReturn([]);
 
-        $filenameEn = $this->createFile([
+        $filenameMessagesEn = $this->createFile([
             'note' => 'NOTE',
             'new.foo' => 'newFoo',
         ]);
-        $filenameFr = $this->createFile([
+        $filenameMessagesFr = $this->createFile([
             'note' => 'NOTE',
             'new.foo' => 'nouveauFoo',
         ], 'fr');
+        $filenameValidatorsFr = $this->createFile([
+            'foo.error' => 'Valeur erronée',
+            'bar.success' => 'Formulaire valide !',
+        ], 'fr', 'validators.%locale%.xlf');
         $localTranslatorBag = new TranslatorBag();
-        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameEn, 'en'));
-        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameFr, 'fr'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameMessagesEn, 'en'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameMessagesFr, 'fr'));
+        $localTranslatorBag->addCatalogue($xliffLoader->load($filenameValidatorsFr, 'fr', 'validators'));
 
         $provider->expects($this->once())
             ->method('write')
@@ -370,7 +374,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
         $tester->execute(['--locales' => ['en', 'fr']]);
 
-        $this->assertStringContainsString('[OK] New local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] New local translations has been sent to "null" (for "en, fr" locale(s), and "messages, validators" domain(s)).', trim($tester->getDisplay()));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Since `MessageCatalogue::getDomains` returns a list, using `+=` to join them could make some disappear.