### PR TITLE
 Release v7.4.10

### DIFF
--- a/CHANGELOG-7.4.md
+++ b/CHANGELOG-7.4.md
@@ -7,6 +7,24 @@ in 7.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.4.0...v7.4.1
 
+* 7.4.10 (2026-05-06)
+
+ * bug #63761 [Scheduler] Fix checkpoint state expiring when cache has default TTL (Amoifr)
+ * bug #64141 [DependencyInjection] Fix lazy-autowiring an already-lazy service (nicolas-grekas)
+ * bug #64138 [Translation] Fix `TranslationPushCommand::getDomainsFromTranslatorBag` (MatTheCat)
+ * bug #63744 [Validator] Fix Compound constraint with nested Composite and validation groups (Amoifr)
+ * bug #63757 [Messenger][AmazonSqs] Do not override queue-level DelaySeconds when no DelayStamp is set (psantus)
+ * bug #64122 [Cache] Ensure compatibility with Relay extension 0.22.0 (nicolas-grekas)
+ * bug #64119 [Yaml] fix flow collection drops `&anchor` and `!!str &anchor` items (ousamabenyounes)
+ * bug #64016 [Mailer][AzureMailer] Fix inline attachments (kohlerdominik)
+ * bug #64086 [Messenger] Move `--time-limit` handling to Worker for proper capping with `--sleep` (Toflar)
+ * bug #64103 [AssetMapper] Stop baking CSP nonce into the importmap polyfill body (ousamabenyounes)
+ * bug #64106 [Config] Normalize `backed-enum` in array shapes (MatTheCat)
+ * bug #64100 [Translation] URL-encode tmp path in XliffUtils::shouldEnableEntityLoader (ousamabenyounes)
+ * bug #64095 [RateLimiter] Carry over reserved tokens past fixed window resets (ousamabenyounes)
+ * bug #64111 [Serializer] Fix low deps (nicolas-grekas)
+ * bug #64099 [Ldap] Cast `default_socket_timeout` to `int` (ousamabenyounes)
+
 * 7.4.9 (2026-05-01)
 
  * bug #64090 [DependencyInjection] Reject circular references through a factory builder's setup (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -74,12 +74,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.4.10-DEV';
+    public const VERSION = '7.4.10';
     public const VERSION_ID = 70410;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 10;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2028';
     public const END_OF_LIFE = '11/2029';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.4.9...v7.4.10)

 * bug #63761 [Scheduler] Fix checkpoint state expiring when cache has default TTL (@Amoifr)
 * bug #64141 [DependencyInjection] Fix lazy-autowiring an already-lazy service (@nicolas-grekas)
 * bug #64138 [Translation] Fix `TranslationPushCommand::getDomainsFromTranslatorBag` (@MatTheCat)
 * bug #63744 [Validator] Fix Compound constraint with nested Composite and validation groups (@Amoifr)
 * bug #63757 [Messenger][AmazonSqs] Do not override queue-level DelaySeconds when no DelayStamp is set (@psantus)
 * bug #64122 [Cache] Ensure compatibility with Relay extension 0.22.0 (@nicolas-grekas)
 * bug #64119 [Yaml] fix flow collection drops `&anchor` and `!!str &anchor` items (@ousamabenyounes)
 * bug #64016 [Mailer][AzureMailer] Fix inline attachments (@kohlerdominik)
 * bug #64086 [Messenger] Move `--time-limit` handling to Worker for proper capping with `--sleep` (@Toflar)
 * bug #64103 [AssetMapper] Stop baking CSP nonce into the importmap polyfill body (@ousamabenyounes)
 * bug #64106 [Config] Normalize `backed-enum` in array shapes (@MatTheCat)
 * bug #64100 [Translation] URL-encode tmp path in XliffUtils::shouldEnableEntityLoader (@ousamabenyounes)
 * bug #64095 [RateLimiter] Carry over reserved tokens past fixed window resets (@ousamabenyounes)
 * bug #64111 [Serializer] Fix low deps (@nicolas-grekas)
 * bug #64099 [Ldap] Cast `default_socket_timeout` to `int` (@ousamabenyounes)
