### PR TITLE
[Dotenv] Don't truncate OS env vars containing $ when $_ENV is unpopulated

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -673,10 +673,11 @@ final class Dotenv
             unset($loadedVars['']);
 
             foreach ($values as $name => $_) {
-                if (!isset($this->overriddenValues[$name]) && isset($_ENV[$name])) {
-                    $this->overriddenValues[$name] = $_ENV[$name];
+                $alreadyExternal = isset($_ENV[$name]) || isset($_SERVER[$name]) && !str_starts_with($name, 'HTTP_');
+                if (!isset($this->overriddenValues[$name]) && $alreadyExternal) {
+                    $this->overriddenValues[$name] = $_ENV[$name] ?? $_SERVER[$name];
                 }
-                if (isset($loadedVars[$name]) || $overrideExistingVars || !isset($_ENV[$name])) {
+                if (isset($loadedVars[$name]) || $overrideExistingVars || !$alreadyExternal) {
                     $this->loadedRawVars[$name] = true;
                 }
             }

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -273,6 +273,36 @@ class DotenvTest extends TestCase
         }
     }
 
+    public function testLoadDoesNotResolveExternalEnvVarsOnlyPresentInServer()
+    {
+        // Mimics PHP's default `variables_order = "GPCS"` (no `E`) where
+        // OS-provided environment variables (e.g. from Kubernetes envFrom or
+        // Docker) are placed in $_SERVER but not in $_ENV when PHP starts.
+        // Such values must be left untouched by Dotenv even when the same key
+        // has a default value in the loaded .env file.
+        unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('FOO');
+        putenv('SYMFONY_DOTENV_VARS');
+
+        $_SERVER['FOO'] = 'abc$def';
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $path = tempnam($tmpdir, 'sf-');
+        file_put_contents($path, "FOO=default\n");
+
+        try {
+            (new Dotenv())->loadEnv($path, defaultEnv: 'prod');
+            $this->assertSame('abc$def', $_ENV['FOO']);
+            $this->assertSame('abc$def', $_SERVER['FOO']);
+        } finally {
+            unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('FOO');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
     public function testLoadEnv()
     {
         $resetContext = static function (): void {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64147 (regression introduced by #63955)
| License       | MIT

#63955 introduced `loadedRawVars` tracking in `doLoad()` to prevent `resolveLoadedVars()` from re-processing values from earlier `load()` calls (#63954). Its membership check uses `!isset($_ENV[$name])` to decide whether a key is host-provided and should be skipped. Without `E` in `variables_order`, OS-provided env vars are placed in `$_SERVER` but not in `$_ENV` at PHP start, so the check misclassifies them as not-yet-set and adds them to `loadedRawVars`.

Note: the PHP manual lists the compile-time default as `"EGPCS"`, but the bundled `php.ini-development` and `php.ini-production` both ship `"GPCS"` and most distributions / Docker images use one of those — so the absence of `E` is the common case in practice. The bug applies to every SAPI: per the [manual](https://www.php.net/manual/en/ini.core.php#ini.variables-order), in CGI/FastCGI `$_SERVER` is always populated from the environment ("S is always equivalent to ES"), and in CLI/FPM `$_SERVER` is populated when `S` is present, but `$_ENV` only ever gets populated when `E` is explicitly there.

`resolveLoadedVars()` then runs variable resolution over values that never went through `lexValue()` — i.e. values where literal `$` is not protected by the `\x00` placeholder mechanism added in #63496 / #63620. A value like `abc$def` provided via `docker run -e`, `envFrom:` or similar is interpreted as having a `$def` reference and gets truncated to `abc`.

`populate()` already considers both `$_SERVER` and `$_ENV` when deciding whether a key is host-provided. This change mirrors that logic in `doLoad()` so externally provided values are correctly recognized regardless of `variables_order`.

A regression test is included that fails on 6.4 HEAD without the fix and passes with it. Full Dotenv test suite (155 tests, was 154) stays green.
