### PR TITLE
[HttpKernel] Use backend-handled request for terminate listeners in HttpCache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -39,6 +39,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     private ?ResponseCacheStrategyInterface $surrogateCacheStrategy = null;
     private array $options = [];
     private array $traces = [];
+    private ?Request $forwardedRequest = null;
+    private ?Request $backendRequest = null;
 
     /**
      * Constructor.
@@ -195,6 +197,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         // FIXME: catch exceptions and implement a 500 error page here? -> in Varnish, there is a built-in error page mechanism
         if (HttpKernelInterface::MAIN_REQUEST === $type) {
             $this->traces = [];
+            $this->forwardedRequest = null;
+            $this->backendRequest = null;
             // Keep a clone of the original request for surrogates so they can access it.
             // We must clone here to get a separate instance because the application will modify the request during
             // the application flow (we know it always does because we do ourselves by setting REMOTE_ADDR to 127.0.0.1
@@ -226,6 +230,12 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
                 } catch (CacheWasLockedException) {
                 }
             } while (null === $response);
+        }
+
+        if (HttpKernelInterface::MAIN_REQUEST === $type) {
+            // Expose the request actually handled by the backend (a sub-request on a cache miss)
+            // to kernel.terminate listeners, as would happen behind a real reverse proxy.
+            $this->backendRequest = $this->forwardedRequest ?? $request;
         }
 
         $this->restoreResponseBody($request, $response);
@@ -266,7 +276,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         }
 
         if ($this->getKernel() instanceof TerminableInterface) {
-            $this->getKernel()->terminate($request, $response);
+            $this->getKernel()->terminate($this->backendRequest ?? $request, $response);
         }
     }
 
@@ -480,6 +490,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
         // always a "master" request (as the real master request can be in cache)
         $response = SubRequestHandler::handle($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $catch);
+        $this->forwardedRequest = $request;
 
         /*
          * Support stale-if-error given on Responses or as a config option.

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -100,6 +100,49 @@ class HttpCacheTest extends HttpCacheTestCase
     }
 
     /**
+     * @dataProvider provideTerminateBackendRequestCases
+     */
+    public function testTerminateUsesBackendRequestOnCacheMiss(string $method, string $expectedMethod)
+    {
+        $terminateEvents = [];
+
+        $eventDispatcher = $this->createStub(EventDispatcher::class);
+        $eventDispatcher
+            ->method('dispatch')
+            ->with($this->callback(static function ($event) use (&$terminateEvents) {
+                if ($event instanceof TerminateEvent) {
+                    $terminateEvents[] = $event;
+                }
+
+                return true;
+            }));
+
+        $this->setNextResponse(
+            200,
+            ['Cache-Control' => 'public, s-maxage=60'],
+            'Hello World',
+            static function (Request $request): void {
+                $request->attributes->set('terminate_attribute', 'present');
+            },
+            $eventDispatcher
+        );
+
+        $this->request($method, '/');
+        $this->cache->terminate($this->request, $this->response);
+
+        $this->assertCount(1, $terminateEvents);
+        $this->assertSame($expectedMethod, $terminateEvents[0]->getRequest()->getMethod());
+        $this->assertSame('present', $terminateEvents[0]->getRequest()->attributes->get('terminate_attribute'));
+    }
+
+    public static function provideTerminateBackendRequestCases(): iterable
+    {
+        yield 'GET is forwarded as-is' => ['GET', 'GET'];
+        // HEAD requests are forwarded to the backend as GET sub-requests
+        yield 'HEAD is forwarded as GET' => ['HEAD', 'GET'];
+    }
+
+    /**
      * @group legacy
      */
     public function testDoesCallTerminateOnFreshResponseIfConfigured()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

There's currently a mismatch in the `Request` object that `TerminateEvent` listeners are presented with depending on whether `HttpCache` is in use or not:

* No `HttpCache` used: Request is handled by the router and controller and thus, the request attributes set to the request during the request flow are available to the `kernel.terminate` listener, when calling `$event->getRequest()->attributes`.
* `HttpCache` used and cache miss: The request is duplicated and forwarded to the app. The same router and controller process happens but the `kernel.terminate` listener does not get the attributes because the original request is forwarded to `->terminate()` instead of the one processed by the app 🐞 

This PR fixes that by correctly forwarding the request that was handled by the backend on cache-miss to `kernel.terminate`. Exactly what would happen if you did not have `HttpCache` but instead would use a proxy like Varnish, Cloudflare etc.

This is about making the event listeners being constantly presented with the same data no matter what proxy is used. Related discussion: https://github.com/symfony/symfony/pull/46763