### PR TITLE
[Yaml] Emit `{}` instead of `{  }` when dumping an empty map

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -252,6 +252,10 @@ class Inline
             $output[] = \sprintf('%s: %s', self::dump($key, $keyFlags), self::dump($val, $flags));
         }
 
+        if (!$output) {
+            return '{}';
+        }
+
         return \sprintf('{ %s }', implode(', ', $output));
     }
 

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -62,7 +62,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": {}
             bar:
                    - 1
                    - foo
@@ -127,7 +127,7 @@ class DumperTest extends TestCase
     public function testInlineLevel()
     {
         $expected = <<<'EOF'
-            { '': bar, foo: '#bar', "foo'bar": {  }, bar: [1, foo, { a: A }], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
+            { '': bar, foo: '#bar', "foo'bar": {}, bar: [1, foo, { a: A }], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
             EOF;
         $this->assertSame($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
         $this->assertSame($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
@@ -136,7 +136,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": {}
             bar: [1, foo, { a: A }]
             foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
 
@@ -147,7 +147,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": {}
             bar:
                 - 1
                 - foo
@@ -164,7 +164,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": {}
             bar:
                 - 1
                 - foo
@@ -185,7 +185,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": {}
             bar:
                 - 1
                 - foo
@@ -419,12 +419,12 @@ class DumperTest extends TestCase
 
     public function testDumpEmptyArrayObjectInstanceAsMap()
     {
-        $this->assertSame('{  }', $this->dumper->dump(new \ArrayObject(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
+        $this->assertSame('{}', $this->dumper->dump(new \ArrayObject(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
     }
 
     public function testDumpEmptyStdClassInstanceAsMap()
     {
-        $this->assertSame('{  }', $this->dumper->dump(new \stdClass(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
+        $this->assertSame('{}', $this->dumper->dump(new \stdClass(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
     }
 
     public function testDumpingStdClassInstancesRespectsInlineLevel()
@@ -1244,7 +1244,7 @@ class DumperTest extends TestCase
                       value: 0
                     -
                      -
-                      - {  }
+                      - {}
                  - name: Jupiter
                    distance: 778500000
                    properties:
@@ -1253,7 +1253,7 @@ class DumperTest extends TestCase
                     - name: moons
                       value: 79
                     -
-                     - {  }
+                     - {}
 
                 YAML,
             1,
@@ -1272,7 +1272,7 @@ class DumperTest extends TestCase
                         value: 0
                       -
                         -
-                          - {  }
+                          - {}
                   - name: Jupiter
                     distance: 778500000
                     properties:
@@ -1281,7 +1281,7 @@ class DumperTest extends TestCase
                       - name: moons
                         value: 79
                       -
-                        - {  }
+                        - {}
 
                 YAML,
             2,
@@ -1300,7 +1300,7 @@ class DumperTest extends TestCase
                           value: 0
                         -
                            -
-                              - {  }
+                              - {}
                    - name: Jupiter
                      distance: 778500000
                      properties:
@@ -1309,7 +1309,7 @@ class DumperTest extends TestCase
                         - name: moons
                           value: 79
                         -
-                           - {  }
+                           - {}
 
                 YAML,
             3,
@@ -1328,7 +1328,7 @@ class DumperTest extends TestCase
                             value: 0
                           -
                               -
-                                  - {  }
+                                  - {}
                     - name: Jupiter
                       distance: 778500000
                       properties:
@@ -1337,7 +1337,7 @@ class DumperTest extends TestCase
                           - name: moons
                             value: 79
                           -
-                              - {  }
+                              - {}
 
                 YAML,
             4,
@@ -1352,13 +1352,13 @@ class DumperTest extends TestCase
                     properties:
                       - { name: size, value: 4879 }
                       - { name: moons, value: 0 }
-                      - [[{  }]]
+                      - [[{}]]
                   - name: Jupiter
                     distance: 778500000
                     properties:
                       - { name: size, value: 139820 }
                       - { name: moons, value: 79 }
-                      - [{  }]
+                      - [{}]
 
                 YAML,
             2,

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -540,6 +540,8 @@ class InlineTest extends TestCase
             ['[\'foo,bar\', \'foo bar\']', ['foo,bar', 'foo bar']],
 
             // mappings
+            ['{}', []],
+            ['{ foo: {} }', ['foo' => []]],
             ['{ foo: bar, bar: foo, \'false\': false, \'null\': null, integer: 12 }', ['foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12]],
             ['{ foo: bar, bar: \'foo: bar\' }', ['foo' => 'bar', 'bar' => 'foo: bar']],
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64137
| License       | MIT

`Inline::dumpHashArray()` always wrapped its body with `sprintf('{ %s }', ...)`, so an empty hash dumped as `{  }` (two spaces). Empty arrays go through `dumpArray()`, which falls through to `dumpHashArray()` when neither sequence nor populated, so they suffered from the same artefact.

Mirror the empty-sequence form (`[]`) and emit `{}` for empty maps, which is also what `Inline::parse('{}')` already produces. This removes pointless whitespace from dumped configs — tooling around YAML coding standards (e.g. Drupal config) re-formats every diff otherwise.

Targeting `8.1` rather than `6.4` per @stof: `{  }` is technically a valid YAML representation, this is a formatting cleanup, not a behavioural bug — patch versions on the LTS shouldn't move dumped output for projects asserting on it.

Coverage: existing `DumperTest` empty-map assertions are tightened from `'{  }'` to `'{}'`, and the inline-level fixtures used in `testInlineLevel`/`testIndentationInConstructor` (which all contain a `'foo\'bar' => []` slot) are updated accordingly. A new `['{}', []]` and `['{ foo: {} }', ['foo' => []]]` are added to `InlineTest::getTestsForDump` so both the bare and nested empty-map paths are covered for `dump`+`parse` round-trip.
