### PR TITLE
[Messenger] Drop trace args from FlattenException normalization

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/Normalizer/FlattenExceptionNormalizerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/Normalizer/FlattenExceptionNormalizerTest.php
@@ -55,7 +55,12 @@ class FlattenExceptionNormalizerTest extends TestCase
         $this->assertSame($exception->getFile(), $normalized['file']);
         $this->assertSame($exception->getLine(), $normalized['line']);
         $this->assertSame($previous, $normalized['previous']);
-        $this->assertSame($exception->getTrace(), $normalized['trace']);
+        $expectedTrace = array_map(static function (array $frame): array {
+            unset($frame['args']);
+
+            return $frame;
+        }, $exception->getTrace());
+        $this->assertSame($expectedTrace, $normalized['trace']);
         $this->assertSame($exception->getTraceAsString(), $normalized['trace_as_string']);
         $this->assertSame($exception->getStatusText(), $normalized['status_text']);
     }
@@ -67,6 +72,31 @@ class FlattenExceptionNormalizerTest extends TestCase
             'instance with previous exception' => [FlattenException::createFromThrowable(new \RuntimeException('foo', 42, new \Exception()))],
             'instance with headers' => [FlattenException::createFromThrowable(new \RuntimeException('foo', 42), 404, ['Foo' => 'Bar'])],
         ];
+    }
+
+    public function testNormalizeStripsTraceArgs()
+    {
+        $exception = FlattenException::createFromThrowable(new \RuntimeException('boom'));
+
+        $trace = $exception->getTrace();
+        $trace[] = [
+            'namespace' => '', 'short_class' => '', 'class' => '', 'type' => '',
+            'function' => 'fromPdf', 'file' => 'foo.php', 'line' => 1,
+            'args' => [
+                ['string', 'valid utf8'],
+                ['string', "\x80\x81\xfe"],
+            ],
+        ];
+        $traceProperty = new \ReflectionProperty(FlattenException::class, 'trace');
+        $traceProperty->setValue($exception, $trace);
+
+        $normalized = $this->normalizer->normalize($exception, null, $this->getMessengerContext());
+
+        foreach ($normalized['trace'] as $frame) {
+            $this->assertArrayNotHasKey('args', $frame);
+        }
+
+        $this->assertNotFalse(json_encode($normalized, \JSON_THROW_ON_ERROR));
     }
 
     public function testSupportsDenormalization()

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
@@ -38,7 +38,7 @@ final class FlattenExceptionNormalizer implements DenormalizerInterface, Normali
             'previous' => null === $object->getPrevious() ? null : $this->normalize($object->getPrevious(), $format, $context),
             'status' => $object->getStatusCode(),
             'status_text' => $object->getStatusText(),
-            'trace' => $object->getTrace(),
+            'trace' => self::sanitizeTrace($object->getTrace()),
             'trace_as_string' => $object->getTraceAsString(),
         ];
 
@@ -86,5 +86,16 @@ final class FlattenExceptionNormalizer implements DenormalizerInterface, Normali
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return FlattenException::class === $type && ($context[Serializer::MESSENGER_SERIALIZATION_CONTEXT] ?? false);
+    }
+
+    private static function sanitizeTrace(array $trace): array
+    {
+        foreach ($trace as &$frame) {
+            if (isset($frame['args'])) {
+                unset($frame['args']);
+            }
+        }
+
+        return $trace;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57535
| License       | MIT

When an exception is thrown over a stack frame whose argument is non-UTF-8 binary (e.g. a PDF body passed to a handler), `FlattenException` captures the raw byte sequence in its trace. JSON-encoding the resulting `ErrorDetailsStamp` through the Messenger serializer then fails with `NotEncodableValueException: "Malformed UTF-8 characters, possibly incorrectly encoded"`, so the message never reaches the failure transport for retry or inspection.

The fix sanitises the trace inside `FlattenExceptionNormalizer::normalize()`: any non-UTF-8 string argument (recursively, including arrays of args) is replaced with the `'(binary string)'` placeholder. The denormalizer is unchanged — the round-trip is intentionally lossy for binary blobs that are only diagnostic anyway.

This implements the direction @nicolas-grekas endorsed in the issue thread (and the prior closed PR #57537):

> I'd rather fix `FlattenExceptionNormalizer`, which is a better place for this concern IMHO. `FlattenException` itself doesn't make any promise regarding UTF-8.

Reproduces with:

```
Symfony\Component\Serializer\Exception\NotEncodableValueException: Malformed UTF-8 characters, possibly incorrectly encoded
```

Verified by reverting the production change with the new test in place:

```
Failed asserting that two arrays are identical.
- 1 => '(binary string)'
+ 1 => '���'
```
