### PR TITLE
[Validator] Add findByCodes() to ConstraintViolationListInterface

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -140,16 +140,18 @@ Uid
 Validator
 ---------
 
-* Deprecate `ConstraintValidatorInterface::initialize()` and `ConstraintValidatorInterface::validate()` in
-  favor of `ConstraintValidatorInterface::validateInContext()`. The `ConstraintValidator` abstract class
-  handles the context management when extending it. When writing tests with `ConstraintValidatorTestCase`,
-  use the new `validate` method to abstract the way to use the constraint validator.
+ * Deprecate `ConstraintValidatorInterface::initialize()` and `ConstraintValidatorInterface::validate()` in
+   favor of `ConstraintValidatorInterface::validateInContext()`. The `ConstraintValidator` abstract class
+   handles the context management when extending it. When writing tests with `ConstraintValidatorTestCase`,
+   use the new `validate` method to abstract the way to use the constraint validator.
 
-  | Your code                                          | Action required
-  |----------------------------------------------------| ---------------
-  | extends `ConstraintValidator`                      | Nothing to do
-  | implements `ConstraintValidatorInterface` directly | Implement `validateInContext()`
-  | tests using `ConstraintValidatorTestCase`          | Call `$this->validate()` instead of `$this->validator->validate()`
+   | Your code                                          | Action required
+   |----------------------------------------------------| ---------------
+   | extends `ConstraintValidator`                      | Nothing to do
+   | implements `ConstraintValidatorInterface` directly | Implement `validateInContext()`
+   | tests using `ConstraintValidatorTestCase`          | Call `$this->validate()` instead of `$this->validator->validate()`
+
+ * Implementing `ConstraintViolationListInterface` without implementing `findByCodes()` is deprecated
 
 VarExporter
 -----------

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `findByCodes()` to `ConstraintViolationListInterface`
  * Add clock-awareness to comparison and range validators for testable date comparisons
  * Add the `Xml` constraint for validating XML content
  * Add `ConstraintValidatorTestCase::validate()` to encapsulate the way to call the constraint validator

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -131,11 +131,6 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
         $this->remove($offset);
     }
 
-    /**
-     * Creates iterator for errors with specific codes.
-     *
-     * @param string|string[] $codes The codes to find
-     */
     public function findByCodes(string|array $codes): static
     {
         $codes = (array) $codes;

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -20,6 +20,8 @@ use Symfony\Component\Validator\Exception\OutOfBoundsException;
  *
  * @extends \ArrayAccess<int, ConstraintViolationInterface>
  * @extends \Traversable<int, ConstraintViolationInterface>
+ *
+ * @method static findByCodes(string|string[] $codes) Returns a new instance with violations matching the given error codes. Not implementing it is deprecated since Symfony 8.1.
  */
 interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #63673
| License       | MIT

`ConstraintViolationList::findByCodes()` is missing from `ConstraintViolationListInterface`, so it cannot be called when type-hinting against the interface.

This PR exposes it via a `@method` annotation, like was done for `__toString()` in 6.1 (4cead0c8a03). It can be promoted to a real interface method in 9.0.

Replaces #63902 (closed by mistake).