### PR TITLE
[Form] Fix array_flip() warning in expanded+multiple ChoiceType on partial submit

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -123,7 +123,8 @@ class ChoiceType extends AbstractType
                 }
 
                 // A map from submitted values to integers
-                $valueMap = array_flip($data);
+		// `null` entries are produced by MissingDataHandler for unchecked checkbox children
+                $valueMap = array_flip(array_filter($data, static fn ($v) => null !== $v));
 
                 // Make a copy of the value map to determine whether any unknown
                 // values were submitted

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataMapper\DataMapper;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -114,6 +115,43 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $this->requestHandler->handleRequest($form, $this->request);
 
         $this->assertEquals(['subform' => ['checkbox' => false]], $form->getData());
+    }
+
+    #[DataProvider('methodExceptPatchProvider')]
+    public function testSubmitExpandedMultipleChoiceWithPartialDataDoesNotEmitArrayFlipWarning($method)
+    {
+        $form = $this->factory->createNamed('roles', ChoiceType::class, null, [
+            'method' => $method,
+            'multiple' => true,
+            'expanded' => true,
+            'choices' => [
+                'User' => 'ROLE_USER',
+                'Admin' => 'ROLE_ADMIN',
+                'Super Admin' => 'ROLE_SUPER_ADMIN',
+            ],
+        ]);
+
+        $this->setRequestData($method, [
+            'roles' => ['ROLE_USER'],
+        ]);
+
+        $warnings = [];
+        set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+            if (str_contains($message, 'array_flip')) {
+                $warnings[] = $message;
+            }
+
+            return true;
+        });
+
+        try {
+            $this->requestHandler->handleRequest($form, $this->request);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $warnings, 'No array_flip() warnings should be emitted when only some checkboxes are checked.');
+        $this->assertSame(['ROLE_USER'], $form->getData());
     }
 
     #[DataProvider('methodExceptPatchProvider')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64157
| License       | MIT

When `MissingDataHandler` pads submitted data with `null` entries for unchecked checkbox children of an expanded+multiple `ChoiceType`, those nulls reach `array_flip()` in the `PRE_SUBMIT` listener and trigger one PHP warning per unchecked box. In `kernel.debug = true` they are promoted to `ErrorException` and the response becomes HTTP 500.

This filters `null` out of the value map. The `expanded` branch right below already maps children whose value is not in `$valueMap` to `null`, so removing those entries upstream changes nothing semantically — it only suppresses the `array_flip()` warnings.

Reproducer (from the issue) now runs without warnings and returns the same data.

The regression test added in `AbstractRequestHandlerTestCase` covers both `NativeRequestHandler` and `HttpFoundationRequestHandler` across POST/PUT/DELETE/GET; reverting the fix makes all 8 variants fail with the expected `array_flip()` warnings, applying it makes them pass.