### PR TITLE
[HttpClient] Add $allowList argument to NoPrivateNetworkHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add support for the `max_connect_duration` option
  * Add option `extra.use_persistent_connections` to `CurlHttpClient` to control the use of persistent connections introduced in PHP 8.5
  * Add `GuzzleHttpHandler` that allows using Symfony HttpClient as a Guzzle handler
+ * Add `$allowList` argument to `NoPrivateNetworkHttpClient` to allow specific hosts (e.g. a local proxy) to bypass the private-network filter
  * Change `$maxTtl` argument of `CachingHttpClient` to default to `86400` (24h) instead of `null`
  * Deprecate passing `null` as `$maxTtl` to `CachingHttpClient`, pass a positive integer instead
 

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -34,14 +34,19 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
     private HttpClientInterface $client;
     private ?array $subnets;
+    private array $allowList;
     private int $ipFlags;
     private \ArrayObject $dnsCache;
 
     /**
-     * @param string|array|null $subnets String or array of subnets using CIDR notation that should be considered private.
-     *                                   If null is passed, the standard private subnets will be used.
+     * @param string|array|null $subnets   String or array of subnets using CIDR notation that should be considered private.
+     *                                     If null is passed, the standard private subnets will be used.
+     * @param string|array      $allowList String or array of IPs/subnets using CIDR notation that should be allowed
+     *                                     even when they would otherwise match the private subnets. Useful e.g. to allow
+     *                                     reaching a local proxy or a known internal host while still blocking the rest
+     *                                     of the private network.
      */
-    public function __construct(HttpClientInterface $client, string|array|null $subnets = null)
+    public function __construct(HttpClientInterface $client, string|array|null $subnets = null, string|array $allowList = [])
     {
         if (!class_exists(IpUtils::class)) {
             throw new \LogicException(\sprintf('You cannot use "%s" if the HttpFoundation component is not installed. Try running "composer require symfony/http-foundation".', __CLASS__));
@@ -56,12 +61,17 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
             }
         }
 
+        foreach ((array) $allowList as $allowed) {
+            $ipFlags |= str_contains($allowed, ':') ? \FILTER_FLAG_IPV6 : \FILTER_FLAG_IPV4;
+        }
+
         if (!\defined('STREAM_PF_INET6')) {
             $ipFlags &= ~\FILTER_FLAG_IPV6;
         }
 
         $this->client = $client;
         $this->subnets = null !== $subnets ? (array) $subnets : null;
+        $this->allowList = (array) $allowList;
         $this->ipFlags = $ipFlags;
         $this->dnsCache = new \ArrayObject();
     }
@@ -76,17 +86,18 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
         $dnsCache = $this->dnsCache;
 
         $ip = self::dnsResolve($dnsCache, $host, $this->ipFlags, $options);
-        self::ipCheck($ip, $this->subnets, $this->ipFlags, $host, $url);
+        self::ipCheck($ip, $this->subnets, $this->allowList, $this->ipFlags, $host, $url);
 
         $onProgress = $options['on_progress'] ?? null;
         $subnets = $this->subnets;
+        $allowList = $this->allowList;
         $ipFlags = $this->ipFlags;
 
-        $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, $ipFlags): void {
+        $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, $allowList, $ipFlags): void {
             static $lastPrimaryIp = '';
 
             if (!\in_array($info['primary_ip'] ?? '', ['', $lastPrimaryIp], true)) {
-                self::ipCheck($info['primary_ip'], $subnets, $ipFlags, null, $info['url']);
+                self::ipCheck($info['primary_ip'], $subnets, $allowList, $ipFlags, null, $info['url']);
                 $lastPrimaryIp = $info['primary_ip'];
             }
 
@@ -104,7 +115,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
             $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
         }
 
-        return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use (&$method, &$options, $maxRedirects, &$redirectHeaders, $subnets, $ipFlags, $dnsCache): \Generator {
+        return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use (&$method, &$options, $maxRedirects, &$redirectHeaders, $subnets, $allowList, $ipFlags, $dnsCache): \Generator {
             if (null !== $chunk->getError() || $chunk->isTimeout() || !$chunk->isFirst()) {
                 yield $chunk;
 
@@ -123,7 +134,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
 
             $host = parse_url($url, \PHP_URL_HOST);
             $ip = self::dnsResolve($dnsCache, $host, $ipFlags, $options);
-            self::ipCheck($ip, $subnets, $ipFlags, $host, $url);
+            self::ipCheck($ip, $subnets, $allowList, $ipFlags, $host, $url);
 
             // Do like curl and browsers: turn POST to GET on 301, 302 and 303
             if (303 === $statusCode || 'POST' === $method && \in_array($statusCode, [301, 302], true)) {
@@ -206,7 +217,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
         return $options['resolve'][$host] = $dnsCache[$host] = $ip;
     }
 
-    private static function ipCheck(string $ip, ?array $subnets, int $ipFlags, ?string $host, string $url): void
+    private static function ipCheck(string $ip, ?array $subnets, array $allowList, int $ipFlags, ?string $host, string $url): void
     {
         if (null === $subnets) {
             // Quick check, but not reliable enough, see https://github.com/php/php-src/issues/16944
@@ -214,6 +225,10 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, ResetInte
         }
 
         if (false !== filter_var($ip, \FILTER_VALIDATE_IP, $ipFlags) && !IpUtils::checkIp($ip, $subnets ?? IpUtils::PRIVATE_SUBNETS)) {
+            return;
+        }
+
+        if ($allowList && false !== filter_var($ip, \FILTER_VALIDATE_IP) && IpUtils::checkIp($ip, $allowList)) {
             return;
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
@@ -138,6 +138,59 @@ class NoPrivateNetworkHttpClientTest extends TestCase
         }
     }
 
+    public static function getAllowListData(): iterable
+    {
+        // private IPs that match the allow-list -> request is allowed
+        yield 'private IPv4 explicitly allowed (single IP)' => ['10.0.0.1', null,                  '10.0.0.1',         false];
+        yield 'private IPv4 explicitly allowed (CIDR)' => ['10.0.0.42', null,                 '10.0.0.0/24',      false];
+        yield 'private IPv4 explicitly allowed (array)' => ['10.0.0.1', null,                  ['10.0.0.1'],       false];
+        yield 'private IPv6 explicitly allowed (single IP)' => ['fc00::1',  null,                  'fc00::1',          false];
+        yield 'private IPv6 explicitly allowed (CIDR)' => ['fc00::1',  null,                  'fc00::/7',         false];
+
+        // private IPs that don't match the allow-list -> request is still blocked
+        yield 'private IPv4 not in allow-list still blocked' => ['10.0.0.1', null,                  '192.168.0.0/24',   true];
+        yield 'private IPv6 not in allow-list still blocked' => ['fc00::1',  null,                  'fd00::/8',         true];
+
+        // allow-list combined with a custom $subnets list
+        yield 'private IPv4 allowed via allow-list against custom subnets' => ['10.0.0.1', '10.0.0.0/8',          '10.0.0.1',         false];
+        yield 'public IPv4 keeps being allowed regardless of allow-list' => ['104.26.14.6', null,               '10.0.0.0/8',       false];
+    }
+
+    #[DataProvider('getAllowListData')]
+    #[Group('dns-sensitive')]
+    public function testAllowList(string $ipAddr, string|array|null $subnets, string|array $allowList, bool $mustThrow)
+    {
+        $host = strtr($ipAddr, '.:', '--');
+        DnsMock::withMockedHosts([
+            $host => [
+                str_contains($ipAddr, ':') ? [
+                    'type' => 'AAAA',
+                    'ipv6' => $ipAddr,
+                ] : [
+                    'type' => 'A',
+                    'ip' => $ipAddr,
+                ],
+            ],
+        ]);
+
+        $content = 'foo';
+        $url = \sprintf('http://%s/', $host);
+
+        if ($mustThrow) {
+            $this->expectException(TransportException::class);
+            $this->expectExceptionMessage(\sprintf('Host "%s" is blocked for "%s".', $host, $url));
+        }
+
+        $previousHttpClient = $this->getMockHttpClient($ipAddr, $content);
+        $client = new NoPrivateNetworkHttpClient($previousHttpClient, $subnets, $allowList);
+        $response = $client->request('GET', $url);
+
+        if (!$mustThrow) {
+            $this->assertEquals($content, $response->getContent());
+            $this->assertEquals(200, $response->getStatusCode());
+        }
+    }
+
     public function testCustomOnProgressCallback()
     {
         $ipAddr = '104.26.14.6';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47387
| License       | MIT

This PR adds a third constructor argument `$allowList` to `NoPrivateNetworkHttpClient`, allowing specific hosts (IPs or CIDR subnets) to bypass the private-network filter. The original use case in #47387 is reaching a local HTTP proxy whose IP is in a private range, while still blocking the rest of the private network.

Approach validated by @nicolas-grekas in https://github.com/symfony/symfony/issues/47387#issuecomment-1243678684 ("We can add an allow-list yes. It'd be up to users to properly configure this, but that's OK to me.").

```php
use Symfony\Component\HttpClient\HttpClient;
use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;

// Block private networks but explicitly allow the local proxy
$client = new NoPrivateNetworkHttpClient(
    HttpClient::create(),
    subnets: null,            // default private subnets
    allowList: '10.0.0.42',   // or ['10.0.0.0/24', 'fc00::/7']
);
```

The allow-list reuses the same CIDR/IP format as the existing `$subnets` argument (powered by `IpUtils::checkIp`). When the list is empty (default), behavior is unchanged.