### PR TITLE
[HttpClient] Log stale-if-error fallback in CachingHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `GuzzleHttpHandler` that allows using Symfony HttpClient as a Guzzle handler
  * Change `$maxTtl` argument of `CachingHttpClient` to default to `86400` (24h) instead of `null`
  * Deprecate passing `null` as `$maxTtl` to `CachingHttpClient`, pass a positive integer instead
+ * Make `CachingHttpClient` implement `Psr\Log\LoggerAwareInterface` to log when a stale cached response is served because the upstream call failed (`stale-if-error` fallback)
 
 8.0
 ---

--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Caching\Freshness;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Exception\ChunkCacheItemNotFoundException;
@@ -40,7 +42,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @see https://www.rfc-editor.org/rfc/rfc9111
  */
-class CachingHttpClient implements HttpClientInterface, ResetInterface
+class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, ResetInterface
 {
     use AsyncDecoratorTrait {
         stream as asyncStream;
@@ -94,6 +96,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
     private bool $isInnerRequest = false;
+    private ?LoggerInterface $logger = null;
 
     /**
      * @param bool         $sharedCache Indicates whether this cache is shared or private. When true, responses
@@ -117,6 +120,11 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
         if ($defaultOptions) {
             [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);
         }
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     public function request(string $method, string $url, array $options = []): ResponseInterface
@@ -205,6 +213,11 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
                 null !== $attemptTag && $this->cache->invalidateTags([$attemptTag]);
 
                 if (Freshness::StaleButUsable === $freshness) {
+                    $this->logger?->info('Serving stale cached response for "{method} {url}" because the upstream call failed: {error}.', [
+                        'method' => $method,
+                        'url' => $url,
+                        'error' => $chunk instanceof ErrorChunk ? $chunk->getError() : 'timeout',
+                    ]);
                     // avoid throwing exception in ErrorChunk#__destruct()
                     $chunk instanceof ErrorChunk && $chunk->didThrow(true);
                     $context->passthru();
@@ -259,6 +272,11 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
                 if ($statusCode >= 500 && $statusCode < 600) {
                     if (Freshness::StaleButUsable === $freshness) {
+                        $this->logger?->info('Serving stale cached response for "{method} {url}" because the upstream returned a server error (HTTP {status}).', [
+                            'method' => $method,
+                            'url' => $url,
+                            'status' => $statusCode,
+                        ]);
                         $context->passthru();
                         $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey));
 

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\HttpClient\Tests;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
@@ -243,6 +246,100 @@ class CachingHttpClientTest extends TestCase
         $response = $client->request('GET', 'http://example.com/foo-bar');
         $this->assertSame(404, $response->getStatusCode());
         $this->assertSame('foo', $response->getContent(false));
+    }
+
+    public function testItLogsWhenStaleIfErrorFallsBackOnUpstreamServerError()
+    {
+        $logger = new class extends AbstractLogger {
+            public array $logs = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->logs[] = [$level, (string) $message, $context];
+            }
+        };
+
+        $client = new CachingHttpClient(
+            new MockHttpClient([
+                new MockResponse('foo', [
+                    'http_code' => 200,
+                    'response_headers' => [
+                        'Cache-Control' => 'max-age=1, stale-if-error=5',
+                    ],
+                ]),
+                new MockResponse('Service Unavailable', ['http_code' => 503]),
+            ]),
+            $this->cacheAdapter,
+            [],
+            false,
+        );
+        $client->setLogger($logger);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+        $this->assertSame([], $logger->logs);
+
+        sleep(5);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+
+        $this->assertCount(1, $logger->logs);
+        [$level, $message, $context] = $logger->logs[0];
+        $this->assertSame('info', $level);
+        $this->assertStringContainsString('stale cached response', $message);
+        $this->assertSame('GET', $context['method']);
+        $this->assertSame('http://example.com/foo-bar', $context['url']);
+        $this->assertSame(503, $context['status']);
+    }
+
+    public function testItLogsWhenStaleIfErrorFallsBackOnUpstreamTransportError()
+    {
+        $logger = new class extends AbstractLogger {
+            public array $logs = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->logs[] = [$level, (string) $message, $context];
+            }
+        };
+
+        $client = new CachingHttpClient(
+            new MockHttpClient([
+                new MockResponse('foo', [
+                    'http_code' => 200,
+                    'response_headers' => [
+                        'Cache-Control' => 'max-age=1, stale-if-error=5',
+                    ],
+                ]),
+                new MockResponse('', ['error' => 'Simulated transport error']),
+            ]),
+            $this->cacheAdapter,
+            [],
+            false,
+        );
+        $client->setLogger($logger);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+        $this->assertSame([], $logger->logs);
+
+        sleep(5);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+
+        $this->assertCount(1, $logger->logs);
+        [$level, $message, $context] = $logger->logs[0];
+        $this->assertSame('info', $level);
+        $this->assertStringContainsString('upstream call failed', $message);
+        $this->assertSame('GET', $context['method']);
+        $this->assertSame('http://example.com/foo-bar', $context['url']);
+        $this->assertNotEmpty($context['error']);
     }
 
     public function testPrivateCacheWithSharedCacheFalse()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #64062
| License       | MIT

`CachingHttpClient` already falls back to the cached response when the upstream call fails and the cached entry has a `stale-if-error` directive (`Freshness::StaleButUsable`). However, the failure is silent: nothing is logged, so operators cannot tell the upstream is unhealthy until the stale grace window expires.

This adds an optional `$logger` constructor argument. When set, an `info` log is emitted at the two `stale-if-error` fallback sites:

- the upstream call errored or timed out (`ErrorChunk` / timeout chunk),
- the upstream call returned a 5xx response.

The default is `null`, so existing call sites are unaffected.

This addresses the core operational concern raised in #64062. The broader question of restoring the standard `http_client.INFO: Response:` log on the failed upstream call (swallowed by `passthru()` + `replaceResponse()`) is left out of scope.
