### PR TITLE
[WebProfilerBundle] Bugfix where the profiler could not show the list of sent messages

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -281,7 +281,7 @@
                                     <td>
                                         {% if event.message.subject is defined %}
                                             {{ event.message.getSubject() ?? '(No subject)' }}
-                                        {% elseif event.message.headers.has('subject') %}
+                                        {% elseif event.message.headers is defined and event.message.headers.has('subject') %}
                                             {{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}
                                         {% else %}
                                             (No subject)
@@ -290,7 +290,7 @@
                                     <td>
                                         {% if event.message.to is defined %}
                                             {{ event.message.getTo()|map(addr => addr.toString())|join(', ')|default('(empty)') }}
-                                        {% elseif event.message.headers.has('to') %}
+                                        {% elseif event.message.headers is defined and event.message.headers.has('to') %}
                                             {{ event.message.headers.get('to').bodyAsString()|default('(empty)') }}
                                         {% else %}
                                             (empty)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Issues        | Fix #64164
| License       | MIT

This bug is present in Symfony 6.4, 7.4 and 8.0. 

--

When sending multiple emails, in a single request, the profiler "emails" page could not be openend if one (or more) of the send messages is a `Symfony\Component\Mime\RawMessage`. 
The `Symfony\Component\Mime\RawMessage` does not have a method (and property) to store headers. 

The following error occurs:
```
Neither the property "headers" nor one of the methods "headers()", "getheaders()", "isheaders()", "hasheaders()" or "__call()" exist and have public access in class "Symfony\Component\Mime\RawMessage" in @WebProfiler/Collector/mailer.html.twig at line 284.
```

In order to fix this we should check if we could read the headers before actual try to read from it.

This PR should fix the error for 6.4.
I suggest merging it to 7.4 and 8.0 (and higher) too.