### PR TITLE
[HttpClient] Use `retry-after` header to get delay in `GenericRetryStrategy`

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `GuzzleHttpHandler` that allows using Symfony HttpClient as a Guzzle handler
  * Change `$maxTtl` argument of `CachingHttpClient` to default to `86400` (24h) instead of `null`
  * Deprecate passing `null` as `$maxTtl` to `CachingHttpClient`, pass a positive integer instead
+ * Use `retry-after` header if present to calculate delay in `GenericRetryStrategy`
 
 8.0
 ---

--- a/src/Symfony/Component/HttpClient/Retry/GenericRetryStrategy.php
+++ b/src/Symfony/Component/HttpClient/Retry/GenericRetryStrategy.php
@@ -92,7 +92,7 @@ class GenericRetryStrategy implements RetryStrategyInterface
 
     public function getDelay(AsyncContext $context, ?string $responseContent, ?TransportExceptionInterface $exception): int
     {
-        $delay = $this->delayMs * $this->multiplier ** $context->getInfo('retry_count');
+        $delay = $this->getDelayFromHeader($context->getHeaders()) ?? $this->delayMs * $this->multiplier ** $context->getInfo('retry_count');
 
         if ($this->jitter > 0) {
             $randomness = (int) ($delay * $this->jitter);
@@ -105,4 +105,19 @@ class GenericRetryStrategy implements RetryStrategyInterface
 
         return (int) $delay;
     }
+
+    private function getDelayFromHeader(array $headers): ?int
+    {
+        if (null !== $after = $headers['retry-after'][0] ?? null) {
+            if (is_numeric($after)) {
+                return (int) ($after * 1000);
+            }
+
+            if (false !== $time = strtotime($after)) {
+                return max(0, $time - time()) * 1000;
+            }
+        }
+
+        return null;
+    }   
 }

--- a/src/Symfony/Component/HttpClient/Tests/Retry/GenericRetryStrategyTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Retry/GenericRetryStrategyTest.php
@@ -123,7 +123,7 @@ class GenericRetryStrategyTest extends TestCase
     }
 
     #[DataProvider('provideDelayWithRetryAfter')]
-    public function testGetDelayWithRetryAfterInSeconds(int $retryAfter, int $maxDelay, int $expectedDelay): void
+    public function testGetDelayWithRetryAfterInSeconds(int $retryAfter, int $maxDelay, int $expectedDelay)
     {
         $strategy = new GenericRetryStrategy([], 1000, 2, $maxDelay, 0);
         $context = $this->getContextWithHeaders(0, 'GET', 'http://example.com/', 200, ['retry-after' => [$retryAfter]]);

--- a/src/Symfony/Component/HttpClient/Tests/Retry/GenericRetryStrategyTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Retry/GenericRetryStrategyTest.php
@@ -121,4 +121,37 @@ class GenericRetryStrategyTest extends TestCase
 
         return new AsyncContext($passthru, new MockHttpClient(), $response, $info, null, 0);
     }
+
+    #[DataProvider('provideDelayWithRetryAfter')]
+    public function testGetDelayWithRetryAfterInSeconds(int $retryAfter, int $maxDelay, int $expectedDelay): void
+    {
+        $strategy = new GenericRetryStrategy([], 1000, 2, $maxDelay, 0);
+        $context = $this->getContextWithHeaders(0, 'GET', 'http://example.com/', 200, ['retry-after' => [$retryAfter]]);
+ 
+        $this->assertSame($expectedDelay, $strategy->getDelay($context, null, null));
+    }
+
+    public static function provideDelayWithRetryAfter(): iterable
+    {
+        // retryAfter in seconds, maxDelay in milliseconds, expected delay in milliseconds
+        yield [1, 50000, 1000];
+        yield [12, 50000, 12000];
+        yield [120, 5000, 5000];
+        yield [120, 0, 120000];
+    }
+
+    private function getContextWithHeaders($retryCount, $method, $url, $statusCode, array $headers): AsyncContext
+    {
+        $passthru = null;
+        $info = [
+            'retry_count' => $retryCount,
+            'http_method' => $method,
+            'url' => $url,
+            'http_code' => $statusCode,
+            'response_headers' => $headers,
+        ];
+        $response = new MockResponse('', $info);
+
+        return new AsyncContext($passthru, new MockHttpClient(), $response, $info, null, 0);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63652
| License       | MIT

Take `retry-after` header in consideration to get delay in `GenericRetryStrategy`
