### PR TITLE
[Console] Add missing `symfony/polyfill-php85` dependency

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.4.1",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/polyfill-mbstring": "^1.0",
+        "symfony/polyfill-php85": "^1.32",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/string": "^7.4.6|^8.0.6"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64168
| License       | MIT

`Output/CombinedOutput.php` (introduced in #61494) calls `array_first()` 8 times. That function was added in PHP 8.5, but the Console component requires `php: ">=8.4.1"`, and `Console/composer.json` does not declare `symfony/polyfill-php85`.

On PHP 8.4, exercising `CommandTester` in multi-stream mode reaches `CombinedOutput::getVerbosity()` (and the other accessors) via `TestOutput`, resulting in `Call to undefined function array_first()`.

This PR aligns Console with the precedent set by `ErrorHandler` (uses `get_error_handler()`) and `FrameworkBundle` (uses `array_first()` in `routing.php`), both of which already declare `symfony/polyfill-php85`.
