### PR TITLE
[HttpFoundation] Add `ParameterBag::filterCallback()`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Deprecate not passing an expiry to `UriSigner::sign()`
  * Add the `$defaultExpiration` argument to `UriSigner::__construct()`
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()` to bind a signed URI to a state token, folded into the signature
+ * Add `ParameterBag::filterCallback()` to filter a parameter value through a callback
 
 8.1
 ---

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -206,8 +206,8 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Filter key.
      *
-     * @param int                                     $filter  FILTER_* constant
-     * @param int|array{flags?: int, options?: array} $options Flags from FILTER_* constants
+     * @param int                                              $filter  FILTER_* constant
+     * @param int|array{flags?: int, options?: array|\Closure} $options Flags from FILTER_* constants, and a Closure when using FILTER_CALLBACK
      *
      * @see https://php.net/filter-var
      *
@@ -247,6 +247,28 @@ class ParameterBag implements \IteratorAggregate, \Countable
         }
 
         throw new \UnexpectedValueException(\sprintf('Parameter value "%s" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.', $key));
+    }
+
+    /**
+     * Filters the value of a parameter through a callback.
+     *
+     * Per FILTER_CALLBACK semantics, the callback receives the value cast to a string:
+     * e.g. 42 arrives as "42", and a missing key with a null default arrives as "".
+     *
+     * An array value is mapped entry by entry, unless $flags is passed without FILTER_REQUIRE_ARRAY.
+     *
+     * @param \Closure(string): mixed                                                                               $callback
+     * @param int-mask<\FILTER_REQUIRE_SCALAR, \FILTER_REQUIRE_ARRAY, \FILTER_FORCE_ARRAY, \FILTER_NULL_ON_FAILURE> $flags
+     */
+    public function filterCallback(string $key, \Closure $callback, mixed $default = null, int $flags = 0): mixed
+    {
+        $options = ['options' => $callback];
+
+        if ($flags) {
+            $options['flags'] = $flags;
+        }
+
+        return $this->filter($key, $default, \FILTER_CALLBACK, $options);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -118,6 +118,22 @@ class InputBagTest extends TestCase
         $this->assertSame('BAR', $result);
     }
 
+    public function testFilterCallbackMethod()
+    {
+        $bag = new InputBag(['foo' => 'bar']);
+
+        $this->assertSame('BAR', $bag->filterCallback('foo', strtoupper(...)));
+    }
+
+    public function testFilterCallbackMethodThrowsBadRequestOnFailure()
+    {
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Input value "foo" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
+
+        $bag = new InputBag(['foo' => 'bar']);
+        $bag->filterCallback('foo', static fn () => null);
+    }
+
     public function testSetWithNonScalarOrArray()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -294,6 +294,84 @@ class ParameterBagTest extends TestCase
         $this->assertSame('BAR', $result);
     }
 
+    public function testFilterCallbackMethod()
+    {
+        $bag = new ParameterBag(['foo' => 'bar']);
+
+        $this->assertSame('BAR', $bag->filterCallback('foo', strtoupper(...)));
+    }
+
+    public function testFilterCallbackMethodCastsTheValueToString()
+    {
+        $bag = new ParameterBag(['foo' => 42]);
+
+        $this->assertSame('42', $bag->filterCallback('foo', static fn (string $value): string => $value));
+        $this->assertSame('', $bag->filterCallback('missing', static fn (string $value): string => $value), 'a missing key with a null default arrives as an empty string');
+    }
+
+    public function testFilterCallbackMethodAppliesTheCallbackToEachEntryOfAnArrayValue()
+    {
+        $bag = new ParameterBag(['foo' => ['a', 'b']]);
+
+        $this->assertSame(['A', 'B'], $bag->filterCallback('foo', strtoupper(...)));
+    }
+
+    public function testFilterCallbackMethodAppliesTheCallbackToAnArrayDefault()
+    {
+        $bag = new ParameterBag([]);
+
+        $this->assertSame(['A'], $bag->filterCallback('missing', strtoupper(...), ['a']));
+    }
+
+    public function testFilterCallbackMethodWithRequireArrayFlag()
+    {
+        $bag = new ParameterBag(['foo' => ['a'], 'bar' => 'scalar']);
+
+        $this->assertSame(['A'], $bag->filterCallback('foo', strtoupper(...), flags: \FILTER_REQUIRE_ARRAY));
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Parameter value "bar" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
+
+        $bag->filterCallback('bar', strtoupper(...), flags: \FILTER_REQUIRE_ARRAY);
+    }
+
+    public function testFilterCallbackMethodDoesNotMapAnArrayValueWhenFlagsOmitRequireArray()
+    {
+        $bag = new ParameterBag(['foo' => ['a', 'b']]);
+
+        $this->assertNull($bag->filterCallback('foo', strtoupper(...), flags: \FILTER_NULL_ON_FAILURE));
+        $this->assertSame(['A', 'B'], $bag->filterCallback('foo', strtoupper(...), flags: \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE));
+    }
+
+    public function testFilterCallbackMethodReturnsNullOnFailure()
+    {
+        $bag = new ParameterBag(['foo' => 'bar']);
+
+        $this->assertNull($bag->filterCallback('foo', static fn () => null, flags: \FILTER_NULL_ON_FAILURE));
+    }
+
+    public function testFilterCallbackMethodThrowsOnFailureByDefault()
+    {
+        $bag = new ParameterBag(['foo' => 'bar']);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Parameter value "foo" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set.');
+
+        $bag->filterCallback('foo', static fn () => null);
+    }
+
+    public function testFilterCallbackMethodLetsCallbackExceptionsBubble()
+    {
+        $bag = new ParameterBag(['foo' => 'bar']);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('from the callback');
+
+        $bag->filterCallback('foo', static function (): never {
+            throw new \DomainException('from the callback');
+        });
+    }
+
     public function testGetIterator()
     {
         $parameters = ['foo' => 'bar', 'hello' => 'world'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63531
| License       | MIT
| Doc PR        | TODO

Filtering a parameter through a callback goes through `FILTER_CALLBACK`, which needs the callback wrapped in an options array:

```php
$bag->filter('foo', null, \FILTER_CALLBACK, ['options' => strtoupper(...)]);
```

`filterCallback()` takes the callback where it belongs:

```php
$bag->filterCallback('foo', strtoupper(...));
```

`$default` and `$flags` follow, both optional, so the common call stays two arguments.

## Behaviour

Everything comes from `filter()`, which the method delegates to, so the semantics are the ones `filter_var()` already imposes:

- The callback receives the value **cast to a string**. `42` arrives as `"42"`, and a missing key with a null default arrives as `""`.
- A callback returning `null` counts as a failure: `UnexpectedValueException` by default, `null` with `FILTER_NULL_ON_FAILURE`. On `InputBag` the failure is a `BadRequestException`.
- Exceptions thrown by the callback bubble up untouched.
- An array value, or an array `$default` for a missing key, is mapped entry by entry.

That last point is the one worth knowing about. It works because `filter()` supplies `FILTER_REQUIRE_ARRAY` on its own when no flag is given, which means **passing any flag turns it off**:

```php
$bag->filterCallback('foo', strtoupper(...));                                  // ['A', 'B']
$bag->filterCallback('foo', strtoupper(...), flags: \FILTER_NULL_ON_FAILURE);  // null
$bag->filterCallback('foo', strtoupper(...), flags: \FILTER_REQUIRE_ARRAY | \FILTER_NULL_ON_FAILURE);
                                                                               // ['A', 'B']
```

This is exactly what `filter()` does with the same flags, so the wrapper does not paper over it. It is documented on the method and pinned by a test.

## Also

The `$options` docblock on `filter()` said `options?: array`, which does not describe the `FILTER_CALLBACK` case it has accepted since the Closure guard was added. It now reads `options?: array|\Closure`, matching what the guard enforces.
