### PR TITLE
[HttpKernel] Prefix the property path to `RequestPayloadValueResolver` violation messages

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Dispatch `RateLimitExceededEvent` from `RateLimitAttributeListener` when the `#[RateLimit]` attribute rejects a request
  * Seed the query bag from the `_query` route default when a route is matched
  * Deserialize the query parameter named by `#[MapQueryString(key:)]` as JSON when it holds a string, e.g. `?filter={"page":1}`
+ * Prefix the property path to each violation message reported by `RequestPayloadValueResolver`
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -37,6 +37,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -175,7 +176,7 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
                 }
 
                 if (\count($violations)) {
-                    throw HttpException::fromStatusCode($validationFailedCode, implode("\n", array_map(static fn ($e) => $e->getMessage(), iterator_to_array($violations))), new ValidationFailedException($payload, $violations));
+                    throw HttpException::fromStatusCode($validationFailedCode, implode("\n", array_map(static fn (ConstraintViolationInterface $e) => ('' !== $path = $e->getPropertyPath()) ? \sprintf('%s: %s', $path, $e->getMessage()) : $e->getMessage(), iterator_to_array($violations))), new ValidationFailedException($payload, $violations));
                 }
             } else {
                 try {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -333,6 +333,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
+            $this->assertSame('title: This value should be of type string.', $e->getMessage());
             $validationFailedException = $e->getPrevious();
             $this->assertSame(422, $e->getStatusCode());
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
@@ -430,6 +431,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
+            $this->assertSame('email: This value should be of type string.', $e->getMessage());
             $validationFailedException = $e->getPrevious();
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertSame('This value should be of type string.', $validationFailedException->getViolations()[0]->getMessage());
@@ -594,6 +596,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
+            $this->assertSame('price: This value should be of type float.', $e->getMessage());
             $validationFailedException = $e->getPrevious();
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertSame('This value should be of type float.', $validationFailedException->getViolations()[0]->getMessage());
@@ -773,6 +776,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
+            $this->assertSame('price: This value should be of type float.', $e->getMessage());
             $validationFailedException = $e->getPrevious();
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertSame('This value should be of type float.', $validationFailedException->getViolations()[0]->getMessage());
@@ -1004,6 +1008,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
+            $this->assertSame('title: This value is too short. It should have 10 characters or more.', $e->getMessage());
             $validationFailedException = $e->getPrevious();
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertSame('title', $validationFailedException->getViolations()[0]->getPropertyPath());
@@ -1069,6 +1074,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
+            $this->assertSame('Page is invalid', $e->getMessage());
             $validationFailedException = $e->getPrevious();
             $this->assertSame(400, $e->getStatusCode());
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
@@ -1100,6 +1106,7 @@ class RequestPayloadValueResolverTest extends TestCase
             $resolver->onKernelControllerArguments($event);
             $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
         } catch (HttpException $e) {
+            $this->assertSame('title: This value should be of type string.', $e->getMessage());
             $validationFailedException = $e->getPrevious();
             $this->assertSame(400, $e->getStatusCode());
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/UploadedFileValueResolverTest.php
@@ -233,7 +233,7 @@ class UploadedFileValueResolverTest extends TestCase
         );
 
         $this->expectException(HttpException::class);
-        $this->expectExceptionMessageMatches('/^The file is too large/');
+        $this->expectExceptionMessageMatches('/^bar: The file is too large/');
 
         $resolver->onKernelControllerArguments($event);
     }
@@ -323,7 +323,7 @@ class UploadedFileValueResolverTest extends TestCase
         );
 
         $this->expectException(HttpException::class);
-        $this->expectExceptionMessageMatches('/^The file is too large/');
+        $this->expectExceptionMessageMatches('/^baz\[1\]: The file is too large/');
 
         $resolver->onKernelControllerArguments($event);
     }
@@ -412,7 +412,7 @@ class UploadedFileValueResolverTest extends TestCase
         );
 
         $this->expectException(HttpException::class);
-        $this->expectExceptionMessageMatches('/^The file is too large/');
+        $this->expectExceptionMessageMatches('/^baz\[1\]: The file is too large/');
 
         $resolver->onKernelControllerArguments($event);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

When `RequestPayloadValueResolver` reports validation errors, the messages do not say which field they refer to.

```php
final readonly class TestDTO
{
    public function __construct(
        public string $name,
        public int $age,
        public bool $active,
    ) {
    }
}
```

```json
{ "name": "Name", "age": "23", "active": "false" }
```

Before:

> This value should be of type int.
> This value should be of type bool.

After:

> age: This value should be of type int.
> active: This value should be of type bool.

The property path is prefixed only when there is one, so class-level violations and custom messages without a path are unchanged.

It matters most for collections, where the current message cannot say which element failed:

> baz[1]: The file is too large (2 MiB). Allowed maximum size is 1 MiB.

Note that the messages are already clear when the Validator component is not installed, since the resolver then reports the denormalization error itself:

> The type of the "age" attribute for class "App\DTO\TestDTO" must be one of "int" ("string" given).

This also affects logs, and any setup that does not render errors through `ProblemNormalizer`; the normalizer composes its own `propertyPath: title` string from the violation list, so RFC 7807 output is unchanged.
