### PR TITLE
[WebProfilerBundle] Don’t try to access `RawMessage::$headers`

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -278,24 +278,8 @@
                             {% for event in collector.events.events(transport) %}
                                 <tr class="mailer-email-summary-table-row {{ loop.first ? 'active' }}" data-target="#email-{{ loop.index }}">
                                     <td>{{ loop.index }}</td>
-                                    <td>
-                                        {% if event.message.subject is defined %}
-                                            {{ event.message.getSubject() ?? '(No subject)' }}
-                                        {% elseif event.message.headers.has('subject') %}
-                                            {{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}
-                                        {% else %}
-                                            (No subject)
-                                        {% endif %}
-                                    </td>
-                                    <td>
-                                        {% if event.message.to is defined %}
-                                            {{ event.message.getTo()|map(addr => addr.toString())|join(', ')|default('(empty)') }}
-                                        {% elseif event.message.headers.has('to') %}
-                                            {{ event.message.headers.get('to').bodyAsString()|default('(empty)') }}
-                                        {% else %}
-                                            (empty)
-                                        {% endif %}
-                                    </td>
+                                    <td>{{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}</td>
+                                    <td>{{ event.message.headers.get('to').bodyAsString()|default(event.envelope.recipients|map(addr => addr.toString())|join(', ')) }}</td>
                                     <td class="visually-hidden"><button class="mailer-email-summary-table-row-button" data-target="#email-{{ loop.index }}">View email details</button></td>
                                 </tr>
                             {% endfor %}
@@ -339,34 +323,16 @@
                     <div class="tab-content">
                         <div class="card-block">
                             <p class="mailer-message-subject">
-                                {% if message.subject is defined %}
-                                    {{ message.getSubject() ?? '(No subject)' }}
-                                {% elseif message.headers.has('subject') %}
-                                    {{ message.headers.get('subject').bodyAsString()|default('(No subject)') }}
-                                {% else %}
-                                    (No subject)
-                                {% endif %}
+                                {{ message.headers.get('subject').bodyAsString()|default('(No subject)') }}
                             </p>
                             <div class="mailer-message-headers">
                                 <p>
                                     <strong>From:</strong>
-                                    {% if message.from is defined %}
-                                        {{ message.getFrom()|map(addr => addr.toString())|join(', ')|default('(empty)') }}
-                                    {% elseif message.headers.has('from') %}
-                                        {{ message.headers.get('from').bodyAsString()|default('(empty)') }}
-                                    {% else %}
-                                        (empty)
-                                    {% endif %}
+                                    {{ message.headers.get('from').bodyAsString()|default('(empty)') }}
                                 </p>
                                 <p>
                                     <strong>To:</strong>
-                                    {% if message.to is defined %}
-                                        {{ message.getTo()|map(addr => addr.toString())|join(', ')|default('(empty)') }}
-                                    {% elseif message.headers.has('to') %}
-                                        {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
-                                    {% else %}
-                                        (empty)
-                                    {% endif %}
+                                    {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
                                 </p>
                                 {% for header in message.headers.all|filter(header => (header.name ?? '')|lower not in ['subject', 'from', 'to']) %}
                                     <p class="mailer-message-header-secondary">{{ header.toString }}</p>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64164
| License       | MIT

If the email is a `RawMessage`, we get the recipients from the envelope.

EDIT: just noticed #64165; but since this PR is a bit different I keep it open until further notice.