### PR TITLE
[Scheduler] Use stored checkpoint as base date for debug:scheduler

### DIFF
--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -19,7 +19,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
@@ -78,28 +80,61 @@ final class DebugCommand extends Command
             return 2;
         }
 
-        $date = new \DateTimeImmutable($input->getOption('date'));
-        if ('now' !== $input->getOption('date')) {
+        $dateOption = $input->getOption('date');
+        $date = new \DateTimeImmutable($dateOption);
+        if ('now' !== $dateOption) {
             $io->comment(\sprintf('All next run dates computed from %s.', $date->format('r')));
         }
 
         foreach ($names as $name) {
             $io->section($name);
 
-            /** @var ScheduleProviderInterface $schedule */
-            $schedule = $this->schedules->get($name);
-            if (!$messages = $schedule->getSchedule()->getRecurringMessages()) {
+            /** @var Schedule $schedule */
+            $schedule = $this->schedules->get($name)->getSchedule();
+            if (!$messages = $schedule->getRecurringMessages()) {
                 $io->warning(\sprintf('No recurring messages found for schedule "%s".', $name));
 
                 continue;
             }
+            $effectiveDate = $date;
+            if ('now' === $dateOption && null !== $checkpoint = self::getStatefulCheckpointTime($schedule, $name)) {
+                $effectiveDate = $checkpoint;
+                $io->comment(\sprintf('Schedule "%s" is stateful: next run dates computed from stored checkpoint %s.', $name, $effectiveDate->format('r')));
+            }
             $io->table(
                 ['Trigger', 'Provider', 'Next Run'],
-                array_filter(array_map(self::renderRecurringMessage(...), $messages, array_fill(0, \count($messages), $date), array_fill(0, \count($messages), $input->getOption('all')))),
+                array_filter(array_map(self::renderRecurringMessage(...), $messages, array_fill(0, \count($messages), $effectiveDate), array_fill(0, \count($messages), $input->getOption('all')))),
             );
         }
 
         return 0;
+    }
+
+    /**
+     * Returns a stateful schedule's last-run time, read from its cache without populating it.
+     *
+     * This mirrors the worker's checkpoint storage (key and `[\DateTimeImmutable $time, int $index,
+     * \DateTimeImmutable $from]` tuple, owned by {@see \Symfony\Component\Scheduler\Generator\Checkpoint}).
+     * It is a best-effort base date for the displayed next runs, not an exact replay of the worker;
+     * anything unexpected falls back to `null` so `debug:scheduler` keeps using `now` instead of crashing.
+     */
+    private static function getStatefulCheckpointTime(Schedule $schedule, string $name): ?\DateTimeImmutable
+    {
+        if (!$state = $schedule->getState()) {
+            return null;
+        }
+
+        $checkpoint = $state->get('scheduler_checkpoint_'.$name, static function (ItemInterface $item, bool &$save) {
+            $save = false;
+
+            return null;
+        });
+
+        if (!\is_array($checkpoint)) {
+            return null;
+        }
+
+        return ($checkpoint[0] ?? null) instanceof \DateTimeImmutable ? $checkpoint[0] : null;
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Command/DebugCommandTest.php
@@ -12,11 +12,13 @@
 namespace Symfony\Component\Scheduler\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Scheduler\Command\DebugCommand;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\Trigger\CallbackTrigger;
+use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
@@ -149,5 +151,67 @@ class DebugCommandTest extends TestCase
             "  every first day of next month   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
             " ------------------------------- ---------- --------------------------------- \n".
             "\n/", $tester->getDisplay(true));
+    }
+
+    public function testExecuteWithStatefulScheduleUsesStoredCheckpoint()
+    {
+        $cache = new ArrayAdapter();
+        $checkpointTime = new \DateTimeImmutable('2024-01-15 10:00:00 UTC');
+        $cache->get('scheduler_checkpoint_schedule_name', static fn (ItemInterface $item) => [$checkpointTime, 0, $checkpointTime]);
+
+        $schedule = (new Schedule())->stateful($cache);
+        $schedule->add(RecurringMessage::every('1 hour', new \stdClass()));
+
+        $schedules = $this->createMock(ServiceProviderInterface::class);
+        $schedules
+            ->expects($this->once())
+            ->method('getProvidedServices')
+            ->willReturn(['schedule_name' => $schedule])
+        ;
+        $schedules
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($schedule)
+        ;
+
+        $command = new DebugCommand($schedules);
+        $tester = new CommandTester($command);
+
+        $tester->execute([], ['decorated' => false]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('stateful', $display);
+        // "every 1 hour" seeded with checkpoint 2024-01-15 10:00:00 UTC ⇒ next run 11:00:00 UTC, not "now + 1h"
+        $this->assertStringContainsString('Mon, 15 Jan 2024 11:00:00 +0000', $display);
+    }
+
+    public function testExecuteWithStatefulScheduleWithoutCheckpointFallsBackToNow()
+    {
+        // Stateful schedule but no checkpoint stored yet ⇒ command must not mention "stateful" and use "now".
+        $cache = new ArrayAdapter();
+
+        $schedule = (new Schedule())->stateful($cache);
+        $schedule->add(RecurringMessage::every('1 hour', new \stdClass()));
+
+        $schedules = $this->createMock(ServiceProviderInterface::class);
+        $schedules
+            ->expects($this->once())
+            ->method('getProvidedServices')
+            ->willReturn(['schedule_name' => $schedule])
+        ;
+        $schedules
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($schedule)
+        ;
+
+        $command = new DebugCommand($schedules);
+        $tester = new CommandTester($command);
+
+        $tester->execute([], ['decorated' => false]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringNotContainsString('stateful', $display);
+        $this->assertMatchesRegularExpression('/every 1 hour\s+stdClass\s+\w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}/', $display);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63798
| License       | MIT

When a `Schedule` is stateful (`->stateful($cache)`), the worker advances each next run from the last-fired time persisted in the `scheduler_checkpoint_<name>` cache entry. `debug:scheduler` ignored that and always computed next runs from `now`, so the command's output didn't match what the worker would actually do next. Reproduces with:

```
debug:scheduler renders next run as "Sun, 10 May 2026 09:48:30 +0000" (now + 1h)
for a stateful schedule whose stored checkpoint is "Mon, 15 Jan 2024 10:00:00 +0000"
— expected next run "Mon, 15 Jan 2024 11:00:00 +0000".
```

When `--date` is not passed and the schedule is stateful, this PR reads the stored checkpoint without populating the cache (using `$save = false` in the cache callback) and uses the stored time as the base. Stateless schedules and explicit `--date=…` keep their previous behavior.

Before:

```
schedule_name
-------------
 Trigger        Provider   Next Run
 every 1 hour   stdClass   Sun, 10 May 2026 09:48:30 +0000
```

After:

```
schedule_name
-------------

 ! [NOTE] Schedule "schedule_name" is stateful — next run dates computed from stored checkpoint
 !       Mon, 15 Jan 2024 10:00:00 +0000.

 Trigger        Provider   Next Run
 every 1 hour   stdClass   Mon, 15 Jan 2024 11:00:00 +0000
```
