### PR TITLE
[Security] Clarify AbstractToken's role-name decoupling and simplify ContextListener

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -17,6 +17,12 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * Base class for Token instances.
  *
+ * Note that the token's role names are decoupled from the user's roles on purpose: token roles describe
+ * the authentication context (e.g. a `SwitchUserToken` adds `ROLE_PREVIOUS_ADMIN`), not the user's
+ * permanent role assignment. This is why `setUser()` only updates the user reference and leaves the
+ * role names untouched. `ContextListener` is the component responsible for comparing the stored role
+ * names against `$user->getRoles()` and deauthenticating when they diverge.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -212,11 +212,9 @@ class ContextListener extends AbstractListener
 
             try {
                 $refreshedUser = $provider->refreshUser($user);
-                $newToken = clone $token;
-                $newToken->setUser($refreshedUser, false);
 
                 // tokens can be deauthenticated if the user has been changed.
-                if ($token instanceof AbstractToken && $this->hasUserChanged($user, $newToken)) {
+                if ($token instanceof AbstractToken && self::hasUserChanged($token, $user, $refreshedUser)) {
                     $userDeauthenticated = true;
 
                     $this->logger?->debug('Cannot refresh token because user has changed.', ['username' => $refreshedUser->getUserIdentifier(), 'provider' => $provider::class]);
@@ -285,10 +283,8 @@ class ContextListener extends AbstractListener
         return $token;
     }
 
-    private static function hasUserChanged(UserInterface $originalUser, TokenInterface $refreshedToken): bool
+    private static function hasUserChanged(AbstractToken $token, UserInterface $originalUser, UserInterface $refreshedUser): bool
     {
-        $refreshedUser = $refreshedToken->getUser();
-
         if ($originalUser instanceof EquatableInterface) {
             return !$originalUser->isEqualTo($refreshedUser);
         }
@@ -309,13 +305,15 @@ class ContextListener extends AbstractListener
 
         $userRoles = array_map('strval', (array) $refreshedUser->getRoles());
 
-        if ($refreshedToken instanceof SwitchUserToken) {
+        if ($token instanceof SwitchUserToken) {
             $userRoles[] = 'ROLE_PREVIOUS_ADMIN';
         }
 
+        $tokenRoleNames = $token->getRoleNames();
+
         if (
-            \count($userRoles) !== \count($refreshedToken->getRoleNames())
-            || \count($userRoles) !== \count(array_intersect($userRoles, $refreshedToken->getRoleNames()))
+            \count($userRoles) !== \count($tokenRoleNames)
+            || \count($userRoles) !== \count(array_intersect($userRoles, $tokenRoleNames))
         ) {
             return true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

For clarification.

Somewhat related to https://github.com/symfony/symfony/pull/42050