### PR TITLE
[Console] Make `ConsoleSectionOutput::overwrite()` atomic to fix sections + ProgressIndicator clear

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -88,8 +88,31 @@ class ConsoleSectionOutput extends StreamOutput
      */
     public function overwrite(string|iterable $message)
     {
-        $this->clear();
-        $this->writeln($message);
+        if (!$this->content || !$this->isDecorated()) {
+            $this->writeln($message);
+
+            return;
+        }
+
+        // Replace own content and write everything in a single cursor-up + erase
+        // pass, to avoid the flicker (and the line-eating artifacts on some
+        // terminals) caused by calling clear() then writeln() back-to-back.
+        $linesCleared = $this->lines;
+        $this->content = [];
+        $this->lines = 0;
+
+        if (!is_iterable($message)) {
+            $message = [$message];
+        }
+
+        foreach ($message as $line) {
+            $this->addContent($line, true);
+        }
+
+        $erasedContent = $this->popStreamContentUntilCurrentSection($this->maxHeight ? min($this->maxHeight, $linesCleared) : $linesCleared);
+
+        parent::doWrite($this->getVisibleContent(), false);
+        parent::doWrite($erasedContent, false);
     }
 
     public function getContent(): string

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -200,6 +200,20 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals('Foo'.\PHP_EOL.'Bar'.\PHP_EOL.'Baz'.\PHP_EOL.\sprintf("\x1b[%dA", 3)."\x1b[0J".'Bar'.\PHP_EOL, stream_get_contents($output->getStream()));
     }
 
+    public function testOverwriteWithMaxHeightOverflow()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $output->setMaxHeight(2);
+
+        $output->writeln(['One', 'Two']);
+        // overwrite with more lines than the max height: only the last lines stay visible
+        $output->overwrite('A'.\PHP_EOL.'B'.\PHP_EOL.'C');
+
+        rewind($output->getStream());
+        $this->assertEquals('One'.\PHP_EOL.'Two'.\PHP_EOL."\x1b[2A\x1b[0J".'B'.\PHP_EOL.'C'.\PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
     public function testAddingMultipleSections()
     {
         $sections = [];
@@ -223,7 +237,7 @@ class ConsoleSectionOutputTest extends TestCase
         $output2->overwrite('Foobar');
 
         rewind($output->getStream());
-        $this->assertEquals('Foo'.\PHP_EOL.'Bar'.\PHP_EOL."\x1b[2A\x1b[0JBar".\PHP_EOL."\x1b[1A\x1b[0JBaz".\PHP_EOL.'Bar'.\PHP_EOL."\x1b[1A\x1b[0JFoobar".\PHP_EOL, stream_get_contents($output->getStream()));
+        $this->assertEquals('Foo'.\PHP_EOL.'Bar'.\PHP_EOL."\x1b[2A\x1b[0JBaz".\PHP_EOL.'Bar'.\PHP_EOL."\x1b[1A\x1b[0JFoobar".\PHP_EOL, stream_get_contents($output->getStream()));
     }
 
     public function testMultipleSectionsOutputWithoutNewline()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Refs #54262
| License       | MIT

`ConsoleSectionOutput::overwrite()` chained `clear()` then `writeln()`. Both
call `popStreamContentUntilCurrentSection()` internally, so a single overwrite
emitted **two** "cursor up + erase to end of screen" sequences, re-printing the
sections below in between.

When the section sits near the top of the viewport, the second cursor-up reaches
the top of the visible area and the following `\x1b[0J` erases lines *above* the
section — the "previously printed output being eaten line by line" symptom from
#54262 when concurrent `ProgressIndicator` instances run across sections. This
complements #63438, which fixed the `ProgressIndicator` side.

This makes `overwrite()` a single atomic operation: replace the section content,
do one combined cursor-up + erase covering the old lines *and* the sections
below, then write everything back. It also emits fewer bytes per overwrite, and
fixes rendering when the new content exceeds `setMaxHeight()` (the old path went
through `doWrite()`, which wrote the whole message past the limit) — covered by
the new `testOverwriteWithMaxHeightOverflow`.
