### PR TITLE
[HttpClient] Add `extra.cache_tags` option to `CachingHttpClient` for custom cache tagging

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add options `extra.cache_tags`, `extra.cache_tags_from_headers` and `extra.cache_tags_from_response` to `CachingHttpClient` to attach custom cache tags to cached responses
+
 8.1
 ---
 

--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Caching\Freshness;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Exception\ChunkCacheItemNotFoundException;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -144,6 +145,10 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
         $fullUrlTag = self::hash($fullUrl);
         $requestCacheControl = self::parseRequestCacheControlHeader($options['normalized_headers']['cache-control'] ?? []);
 
+        $staticTags = self::parseStaticCacheTags($options['extra']['cache_tags'] ?? []);
+        $tagsFromHeadersResolver = self::parseCacheTagsResolver($options['extra']['cache_tags_from_headers'] ?? null, 'cache_tags_from_headers');
+        $tagsFromResponseResolver = self::parseCacheTagsResolver($options['extra']['cache_tags_from_response'] ?? null, 'cache_tags_from_response');
+
         if ('' !== $options['body'] || ($options['extra']['no_cache'] ?? false) || isset($options['normalized_headers']['range']) || !\in_array($method, self::CACHEABLE_METHODS, true)) {
             if (isset($requestCacheControl['only-if-cached'])) {
                 return self::createGatewayTimeoutResponse($method, $url, $options);
@@ -230,6 +235,9 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
         $passthru = function (ChunkInterface $chunk, AsyncContext $context) use (
             $expiresAt,
             $fullUrlTag,
+            $staticTags,
+            $tagsFromHeadersResolver,
+            &$tagsFromResponseResolver,
             $requestHash,
             $varyKey,
             $varyFields,
@@ -246,6 +254,9 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             static $attemptTag = null;
             static $firstChunkKey = null;
             static $chunkKey = null;
+            static $extraTags = [];
+            static $pendingChunks = [];
+            static $accumulatedContent = '';
 
             if (null !== $chunk->getError() || $chunk->isTimeout()) {
                 null !== $attemptTag && $this->cache->invalidateTags([$attemptTag]);
@@ -303,10 +314,19 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                     }
                     $correctedInitialAge = self::getCorrectedInitialAge($headers, $requestTime, $responseTime);
                     $updatedHeaders = self::filterStorableHeaders(array_merge($cachedData['headers'], $headers), self::getExcludedHeaders($headers));
+                    // The entry is shared between requests, so the tags it already carries must
+                    // survive: a revalidating request can only add to them. Tags coming from the
+                    // response cannot be re-resolved here anyway, a 304 carries no body.
+                    $tagsForRevalidation = self::mergeCacheTags(
+                        $cachedData['cache_tags'] ?? [],
+                        $staticTags,
+                        null !== $tagsFromHeadersResolver ? self::resolveCacheTagsFromHeaders($tagsFromHeadersResolver, $statusCode, $updatedHeaders) : [],
+                    );
                     $updatedCachedData = array_replace($cachedData, [
                         'stored_at' => $responseTime,
                         'initial_age' => $correctedInitialAge,
                         'headers' => $updatedHeaders,
+                        'cache_tags' => $tagsForRevalidation,
                     ]);
 
                     $updatedCacheControl = self::parseCacheControlHeader($updatedCachedData['headers']['cache-control'] ?? []);
@@ -323,14 +343,14 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                         $context->passthru();
 
                         if (!$hasClientConditionalValidator) {
-                            $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt));
+                            $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt, [$fullUrlTag, $metadataKey, ...$tagsForRevalidation]));
                         }
 
                         return;
                     }
 
-                    $updatedCachedData = $this->cache->get($metadataKey, static function (ItemInterface $item) use ($updatedCachedData, $expiresAt, $fullUrlTag, $metadataKey): array {
-                        $item->expiresAt($expiresAt)->tag([$fullUrlTag, $metadataKey]);
+                    $updatedCachedData = $this->cache->get($metadataKey, static function (ItemInterface $item) use ($updatedCachedData, $expiresAt, $fullUrlTag, $metadataKey, $tagsForRevalidation): array {
+                        $item->expiresAt($expiresAt)->tag([$fullUrlTag, $metadataKey, ...$tagsForRevalidation]);
 
                         return $updatedCachedData;
                     }, \INF);
@@ -338,7 +358,7 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                     $context->passthru();
 
                     if (!$hasClientConditionalValidator) {
-                        $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt));
+                        $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt, [$fullUrlTag, $metadataKey, ...$tagsForRevalidation]));
                     }
 
                     return;
@@ -400,6 +420,22 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                     return $newVaryFields;
                 }, \INF);
 
+                // Initialize the tag set for subsequent chunk writes. Tags depending on the
+                // response body are added at isLast(); see the "from_response" branch below.
+                $extraTags = self::mergeCacheTags(
+                    $staticTags,
+                    null !== $tagsFromHeadersResolver ? self::resolveCacheTagsFromHeaders($tagsFromHeadersResolver, $statusCode, $headers) : [],
+                );
+
+                // Resolving tags from the response requires holding its body in memory
+                // until the last chunk, so honor the caller's "buffer" option: when it
+                // disables buffering, skip the resolver instead of overriding the choice.
+                if (null !== $tagsFromResponseResolver && true !== ($options['buffer'] ?? true)) {
+                    // buffering is off, or decided by a closure the transport calls itself;
+                    // either way the body is not ours to hold, so the resolver is skipped
+                    $tagsFromResponseResolver = null;
+                }
+
                 $firstChunkKey = $chunkKey = self::generateChunkKey();
 
                 yield $chunk;
@@ -415,8 +451,30 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             }
 
             if ($chunk->isLast()) {
-                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $chunk, $attemptTag): array {
-                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+                if (null !== $tagsFromResponseResolver) {
+                    $accumulatedContent .= $chunk->getContent();
+                    $extraTags = self::mergeCacheTags(
+                        $extraTags,
+
+                        self::resolveCacheTagsFromResponse($tagsFromResponseResolver, $accumulatedContent, $context->getStatusCode(), $headers),
+                    );
+
+                    foreach ($pendingChunks as $pending) {
+                        $content = substr($accumulatedContent, $pending['offset'], $pending['length']);
+                        $writeChunk = static function (ItemInterface $item) use ($content, $pending, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $extraTags): array {
+                            $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
+
+                            return [
+                                'content' => $content,
+                                'next_chunk' => $pending['next_chunk'],
+                            ];
+                        };
+                        $this->cache->get($pending['key'], $writeChunk, \INF);
+                    }
+                }
+
+                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $chunk, $attemptTag, $extraTags): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
 
                     return [
                         'content' => $chunk->getContent(),
@@ -428,8 +486,8 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                 $responseTime = time();
                 $correctedInitialAge = self::getCorrectedInitialAge($headers, $requestTime, $responseTime);
                 $maxAge = $this->determineMaxAge($headers, self::parseCacheControlHeader($headers['cache-control'] ?? []), $correctedInitialAge, $requestTime, $responseTime);
-                $this->cache->get($metadataKey, static function (ItemInterface $item) use ($context, $headers, $maxAge, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $firstChunkKey, $responseTime, $correctedInitialAge): array {
-                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+                $this->cache->get($metadataKey, static function (ItemInterface $item) use ($context, $headers, $maxAge, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $firstChunkKey, $responseTime, $correctedInitialAge, $extraTags): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
 
                     return [
                         'status_code' => $context->getStatusCode(),
@@ -438,6 +496,7 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                         'stored_at' => $responseTime,
                         'expires_at' => self::calculateExpiresAt($maxAge),
                         'next_chunk' => $firstChunkKey,
+                        'cache_tags' => $extraTags,
                     ];
                 }, \INF);
 
@@ -447,14 +506,27 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             }
 
             $nextChunkKey = self::generateChunkKey();
-            $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $chunk, $nextChunkKey): array {
-                $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
-
-                return [
-                    'content' => $chunk->getContent(),
+            if (null !== $tagsFromResponseResolver) {
+                // chunk contents are sliced back out of $accumulatedContent at flush
+                // time, so the body is only held once in memory
+                $content = $chunk->getContent();
+                $pendingChunks[] = [
+                    'key' => $chunkKey,
+                    'offset' => \strlen($accumulatedContent),
+                    'length' => \strlen($content),
                     'next_chunk' => $nextChunkKey,
                 ];
-            }, \INF);
+                $accumulatedContent .= $content;
+            } else {
+                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $chunk, $nextChunkKey, $extraTags): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
+
+                    return [
+                        'content' => $chunk->getContent(),
+                        'next_chunk' => $nextChunkKey,
+                    ];
+                }, \INF);
+            }
             $chunkKey = $nextChunkKey;
 
             yield $chunk;
@@ -522,6 +594,97 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
     private static function generateChunkKey(): string
     {
         return str_replace('/', '_', base64_encode(random_bytes(6)));
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    private static function parseStaticCacheTags(mixed $value): array
+    {
+        if (!\is_array($value)) {
+            throw new InvalidArgumentException(\sprintf('The "extra.cache_tags" option must be an array of non-empty strings, "%s" given.', get_debug_type($value)));
+        }
+
+        foreach ($value as $tag) {
+            if (!\is_string($tag) || '' === $tag) {
+                throw new InvalidArgumentException(\sprintf('The "extra.cache_tags" option must be an array of non-empty strings, found "%s".', get_debug_type($tag)));
+            }
+
+            if (false !== strpbrk($tag, ItemInterface::RESERVED_CHARACTERS)) {
+                throw new InvalidArgumentException(\sprintf('The "extra.cache_tags" option contains the tag "%s" with one of the reserved characters "%s".', $tag, ItemInterface::RESERVED_CHARACTERS));
+            }
+        }
+
+        return array_values($value);
+    }
+
+    private static function parseCacheTagsResolver(mixed $value, string $optionName): ?\Closure
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!\is_callable($value)) {
+            throw new InvalidArgumentException(\sprintf('The "extra.%s" option must be a callable returning an iterable of non-empty strings, "%s" given.', $optionName, get_debug_type($value)));
+        }
+
+        return $value(...);
+    }
+
+    /**
+     * @param array<string, string|string[]> $headers
+     *
+     * @return list<non-empty-string>
+     */
+    private static function resolveCacheTagsFromHeaders(\Closure $resolver, int $statusCode, array $headers): array
+    {
+        return self::validateResolvedCacheTags($resolver($statusCode, $headers), 'cache_tags_from_headers');
+    }
+
+    /**
+     * @param array<string, string|string[]> $headers
+     *
+     * @return list<non-empty-string>
+     */
+    private static function resolveCacheTagsFromResponse(\Closure $resolver, string $body, int $statusCode, array $headers): array
+    {
+        return self::validateResolvedCacheTags($resolver($body, $statusCode, $headers), 'cache_tags_from_response');
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    private static function validateResolvedCacheTags(mixed $resolved, string $optionName): array
+    {
+        if (!is_iterable($resolved)) {
+            throw new InvalidArgumentException(\sprintf('The callable passed to "extra.%s" must return an iterable of non-empty strings, "%s" returned.', $optionName, get_debug_type($resolved)));
+        }
+
+        $tags = [];
+        foreach ($resolved as $tag) {
+            if (!\is_string($tag) || '' === $tag) {
+                throw new InvalidArgumentException(\sprintf('The callable passed to "extra.%s" must return an iterable of non-empty strings, found "%s".', $optionName, get_debug_type($tag)));
+            }
+
+            if (false !== strpbrk($tag, ItemInterface::RESERVED_CHARACTERS)) {
+                throw new InvalidArgumentException(\sprintf('The callable passed to "extra.%s" returned the tag "%s" with one of the reserved characters "%s".', $optionName, $tag, ItemInterface::RESERVED_CHARACTERS));
+            }
+            $tags[] = $tag;
+        }
+
+        return $tags;
+    }
+
+    /**
+     * Merges multiple sets of cache tags while preserving insertion order and removing duplicates.
+     *
+     * @param list<string> ...$tagSets
+     *
+     * @return list<non-empty-string>
+     */
+    private static function mergeCacheTags(array ...$tagSets): array
+    {
+        return array_values(array_unique(array_merge(...array_values($tagSets))));
     }
 
     /**
@@ -1149,8 +1312,12 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
      * returned.
      *
      * @param array{next_chunk: string, status_code: int, initial_age: int, headers: array<string, string|string[]>, stored_at: int} $cachedData
+     * @param list<string>                                                                                                           $newTags    The tags to attach to the chunk items rewritten when extending their expiry,
+     *                                                                                                                                           as rewriting a tagged item without re-tagging it drops its tags
+     *
+     *
      */
-    private function createResponseFromCache(array $cachedData, string $method, string $url, array $options, string $metadataKey, \DateTimeImmutable|false|null $newExpiresAt = false): MockResponse
+    private function createResponseFromCache(array $cachedData, string $method, string $url, array $options, string $metadataKey, \DateTimeImmutable|false|null $newExpiresAt = false, array $newTags = []): MockResponse
     {
         $cache = $this->cache;
 
@@ -1163,12 +1330,12 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
 
         if (false !== $newExpiresAt) {
             $beta = \INF;
-            $callback = static function (ItemInterface $item) use ($callback, $newExpiresAt): array {
+            $callback = static function (ItemInterface $item) use ($callback, $newExpiresAt, $newTags): array {
                 if (!$item->isHit()) {
                     $callback($item);
                 }
 
-                $item->expiresAt($newExpiresAt);
+                $item->tag($newTags)->expiresAt($newExpiresAt);
 
                 return $item->get();
             };

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -2485,6 +2485,471 @@ class CachingHttpClientTest extends TestCase
         new CachingHttpClient(new MockHttpClient([]), $this->cacheAdapter, [], true, null);
     }
 
+    public function testCacheTagsAllowTargetedInvalidation()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300'],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/products', [
+            'extra' => ['cache_tags' => ['product-1', 'product-2']],
+        ]);
+        $this->assertSame('foo', $response->getContent());
+
+        // Sanity check: the response is cached on a second request.
+        $response = $client->request('GET', 'http://example.com/products');
+        $this->assertSame('foo', $response->getContent());
+
+        // Invalidating a custom tag must evict the cached response.
+        $this->cacheAdapter->invalidateTags(['product-1']);
+
+        $response = $client->request('GET', 'http://example.com/products');
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testCacheTagsRejectsScalar()
+    {
+        $client = $this->buildClient([new MockResponse('foo')]);
+
+        $this->expectException(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "extra.cache_tags" option must be an array of non-empty strings, "int" given.');
+
+        $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags' => 42],
+        ]);
+    }
+
+    public function testCacheTagsRejectsNonStringEntry()
+    {
+        $client = $this->buildClient([new MockResponse('foo')]);
+
+        $this->expectException(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "extra.cache_tags" option must be an array of non-empty strings, found "int".');
+
+        $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags' => ['product-1', 42]],
+        ]);
+    }
+
+    public function testCacheTagsFromHeadersResolver()
+    {
+        $client = $this->buildClient([
+            new MockResponse('large body that should not be buffered', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300', 'Content-Type' => 'application/json'],
+            ]),
+            new MockResponse('miss'),
+        ]);
+
+        $invocations = 0;
+        $tagsFromHeaders = static function (int $statusCode, array $headers) use (&$invocations): array {
+            ++$invocations;
+
+            return ['mime-'.strtr($headers['content-type'][0], ['/' => '-']), 'status-'.$statusCode];
+        };
+
+        $response = $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags_from_headers' => $tagsFromHeaders],
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('large body that should not be buffered', $response->getContent());
+        $this->assertSame(1, $invocations);
+
+        // Sanity check: cached on second request.
+        $response = $client->request('GET', 'http://example.com/foo');
+        $this->assertSame('large body that should not be buffered', $response->getContent());
+
+        // Invalidating either resolved tag must evict the cached response.
+        $this->cacheAdapter->invalidateTags(['mime-application-json']);
+
+        $response = $client->request('GET', 'http://example.com/foo');
+        $this->assertSame('miss', $response->getContent());
+    }
+
+    public function testCacheTagsFromResponseResolver()
+    {
+        $client = $this->buildClient([
+            new MockResponse(json_encode(['items' => [['id' => 1], ['id' => 2]]]), [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300', 'Content-Type' => 'application/json'],
+            ]),
+            new MockResponse('miss'),
+        ]);
+
+        $invocations = 0;
+        $tagsFromBody = static function (string $body, int $statusCode, array $headers) use (&$invocations): array {
+            ++$invocations;
+            $data = json_decode($body, true);
+
+            return array_map(static fn (array $item): string => 'product-'.$item['id'], $data['items']);
+        };
+
+        $response = $client->request('GET', 'http://example.com/products', [
+            'extra' => ['cache_tags_from_response' => $tagsFromBody],
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['items' => [['id' => 1], ['id' => 2]]], $response->toArray());
+        $this->assertSame(1, $invocations);
+
+        $response = $client->request('GET', 'http://example.com/products');
+        $this->assertSame(['items' => [['id' => 1], ['id' => 2]]], $response->toArray());
+
+        $this->cacheAdapter->invalidateTags(['product-2']);
+
+        $response = $client->request('GET', 'http://example.com/products');
+        $this->assertSame('miss', $response->getContent());
+    }
+
+    public function testCacheTagsCanBeCombined()
+    {
+        $client = $this->buildClient([
+            new MockResponse(json_encode(['items' => [['id' => 1]]]), [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300', 'Content-Type' => 'application/json'],
+            ]),
+            new MockResponse('miss'),
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/products', [
+            'extra' => [
+                'cache_tags' => ['fixed-tag'],
+                'cache_tags_from_headers' => static fn (int $statusCode, array $headers): array => ['mime-'.strtr($headers['content-type'][0], ['/' => '-'])],
+                'cache_tags_from_response' => static fn (string $body): array => array_map(
+                    static fn (array $item): string => 'product-'.$item['id'],
+                    json_decode($body, true)['items'],
+                ),
+            ],
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('{"items":[{"id":1}]}', $response->getContent());
+
+        // The cached response can be invalidated by ANY of the three tag sources.
+        $this->cacheAdapter->invalidateTags(['product-1']);
+
+        $response = $client->request('GET', 'http://example.com/products');
+        $this->assertSame('miss', $response->getContent());
+    }
+
+    public function testCacheTagsFromHeadersResolverRejectsNonCallable()
+    {
+        $client = $this->buildClient([new MockResponse('foo')]);
+
+        $this->expectException(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "extra.cache_tags_from_headers" option must be a callable returning an iterable of non-empty strings, "string" given.');
+
+        $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags_from_headers' => 'not a callable'],
+        ]);
+    }
+
+    public function testCacheTagsFromResponseResolverRejectsNonCallable()
+    {
+        $client = $this->buildClient([new MockResponse('foo')]);
+
+        $this->expectException(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "extra.cache_tags_from_response" option must be a callable returning an iterable of non-empty strings, "int" given.');
+
+        $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags_from_response' => 42],
+        ]);
+    }
+
+    public function testCacheTagsFromHeadersResolverMustReturnStrings()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300'],
+            ]),
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags_from_headers' => static fn (): array => ['ok', 42]],
+        ]);
+
+        try {
+            $response->getContent();
+            $this->fail('Expected exception was not thrown.');
+        } catch (\Symfony\Component\HttpClient\Exception\TransportException $e) {
+            $this->assertInstanceOf(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class, $e->getPrevious());
+            $this->assertSame('The callable passed to "extra.cache_tags_from_headers" must return an iterable of non-empty strings, found "int".', $e->getPrevious()->getMessage());
+        }
+    }
+
+    public function testCacheTagsFromResponseResolverMustReturnIterable()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300'],
+            ]),
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags_from_response' => static fn (): string => 'oops'],
+        ]);
+
+        try {
+            $response->getContent();
+            $this->fail('Expected exception was not thrown.');
+        } catch (\Symfony\Component\HttpClient\Exception\TransportException $e) {
+            $this->assertInstanceOf(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class, $e->getPrevious());
+            $this->assertSame('The callable passed to "extra.cache_tags_from_response" must return an iterable of non-empty strings, "string" returned.', $e->getPrevious()->getMessage());
+        }
+    }
+
+    public function testCacheTagsFromResponseResolverMustReturnStrings()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300'],
+            ]),
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags_from_response' => static fn (): array => ['ok', 42]],
+        ]);
+
+        try {
+            $response->getContent();
+            $this->fail('Expected exception was not thrown.');
+        } catch (\Symfony\Component\HttpClient\Exception\TransportException $e) {
+            $this->assertInstanceOf(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class, $e->getPrevious());
+            $this->assertSame('The callable passed to "extra.cache_tags_from_response" must return an iterable of non-empty strings, found "int".', $e->getPrevious()->getMessage());
+        }
+    }
+
+    public function testCacheTagsFromResponseIsSkippedWhenBufferingIsDisabled()
+    {
+        $client = $this->buildClient([
+            new MockResponse('large body that should not be buffered', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300', 'Content-Type' => 'application/octet-stream'],
+            ]),
+            new MockResponse('miss'),
+        ]);
+
+        $resolverInvocations = 0;
+
+        $response = $client->request('GET', 'http://example.com/file', [
+            'buffer' => false,
+            'extra' => [
+                'cache_tags' => ['static-tag'],
+                'cache_tags_from_response' => static function () use (&$resolverInvocations): array {
+                    ++$resolverInvocations;
+
+                    return ['should-not-be-applied'];
+                },
+            ],
+        ]);
+
+        $body = '';
+        foreach ($client->stream($response) as $chunk) {
+            $body .= $chunk->getContent();
+        }
+        $this->assertSame('large body that should not be buffered', $body);
+        $this->assertSame(0, $resolverInvocations, 'cache_tags_from_response must be skipped when the "buffer" option disables buffering');
+
+        // Static tags are still applied: invalidating one must evict the cached response.
+        $this->cacheAdapter->invalidateTags(['static-tag']);
+
+        $response = $client->request('GET', 'http://example.com/file');
+        $this->assertSame('miss', $response->getContent());
+    }
+
+    public function testCacheTagsFromResponseIsSkippedWhenBufferingIsNotPlainlyEnabled()
+    {
+        $resolver = static fn (string $body): array => ['from-body-'.strtolower(trim($body, '"'))];
+
+        foreach ([false, static fn (array $headers): bool => true] as $buffer) {
+            $client = $this->buildClient([
+                new MockResponse('"decoded"', [
+                    'http_code' => 200,
+                    'response_headers' => ['Cache-Control' => 'max-age=300', 'Content-Type' => 'application/json'],
+                ]),
+                new MockResponse('miss'),
+            ]);
+
+            $response = $client->request('GET', 'http://example.com/products', [
+                'buffer' => $buffer,
+                'extra' => ['cache_tags_from_response' => $resolver],
+            ]);
+            $this->assertSame('"decoded"', $response->getContent());
+
+            $this->cacheAdapter->invalidateTags(['from-body-decoded']);
+
+            $response = $client->request('GET', 'http://example.com/products');
+            $this->assertSame('"decoded"', $response->getContent(), 'no body-derived tag was attached, so the entry survives the invalidation');
+        }
+    }
+
+    public function testCacheTagsFromResponseWithChunkedBody()
+    {
+        $client = $this->buildClient([
+            new MockResponse(['{"items":', '[{"id":9}]}'], [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300', 'Content-Type' => 'application/json'],
+            ]),
+            new MockResponse('miss'),
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/products', [
+            'extra' => [
+                'cache_tags_from_response' => static fn (string $body): array => array_map(
+                    static fn (array $item): string => 'product-'.$item['id'],
+                    json_decode($body, true)['items'],
+                ),
+            ],
+        ]);
+        $this->assertSame(['items' => [['id' => 9]]], $response->toArray());
+
+        // The body served from cache is reassembled from the flushed chunk chain.
+        $response = $client->request('GET', 'http://example.com/products');
+        $this->assertSame(['items' => [['id' => 9]]], $response->toArray());
+
+        $this->cacheAdapter->invalidateTags(['product-9']);
+
+        $response = $client->request('GET', 'http://example.com/products');
+        $this->assertSame('miss', $response->getContent());
+    }
+
+    public function testAnUntaggedRevalidationKeepsTheTagsOfTheEntry()
+    {
+        $inner = new ArrayAdapter();
+        $this->cacheAdapter = new TagAwareAdapter($inner);
+
+        $client = $this->buildClient([
+            new MockResponse('body-v1', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=0', 'ETag' => '"v1"'],
+            ]),
+            new MockResponse('', [
+                'http_code' => 304,
+                'response_headers' => ['ETag' => '"v1"'],
+            ]),
+        ]);
+
+        $this->assertSame('body-v1', $client->request('GET', 'http://example.com/products', [
+            'extra' => ['cache_tags' => ['product-1']],
+        ])->getContent());
+
+        // the entry is shared, so a request declaring no tag must not strip the stored ones
+        $this->assertSame('body-v1', $client->request('GET', 'http://example.com/products')->getContent());
+
+        $this->cacheAdapter->invalidateTags(['product-1']);
+
+        foreach (array_keys($inner->getValues()) as $key) {
+            if (str_starts_with($key, 'vary_')) {
+                continue;
+            }
+
+            $this->assertFalse($this->cacheAdapter->getItem($key)->isHit(), \sprintf('"%s" must still be invalidatable by the tags stored before the revalidation.', $key));
+        }
+    }
+
+    public function testCacheTagsSurviveRevalidation()
+    {
+        $inner = new ArrayAdapter();
+        $this->cacheAdapter = new TagAwareAdapter($inner);
+
+        $client = $this->buildClient([
+            new MockResponse('body-v1', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=0', 'ETag' => '"v1"'],
+            ]),
+            new MockResponse('', [
+                'http_code' => 304,
+                'response_headers' => ['ETag' => '"v1"'],
+            ]),
+        ]);
+        $options = ['extra' => ['cache_tags' => ['product-1']]];
+
+        $this->assertSame('body-v1', $client->request('GET', 'http://example.com/products', $options)->getContent());
+
+        // The 304 revalidation refreshes the metadata and rewrites the chunk items with a new expiry.
+        $this->assertSame('body-v1', $client->request('GET', 'http://example.com/products', $options)->getContent());
+
+        $chunkKeys = [];
+        foreach ($inner->getValues() as $key => $value) {
+            if (\is_string($value) && str_contains($value, 'next_chunk') && !str_contains($value, 'status_code')) {
+                $chunkKeys[] = $key;
+                $this->assertTrue($this->cacheAdapter->getItem($key)->isHit());
+            }
+        }
+        $this->assertNotEmpty($chunkKeys);
+
+        $this->cacheAdapter->invalidateTags(['product-1']);
+
+        foreach ($chunkKeys as $key) {
+            $this->assertFalse($this->cacheAdapter->getItem($key)->isHit(), 'chunk items rewritten during a 304 revalidation must remain invalidatable by the custom tags');
+        }
+    }
+
+    public function testCacheTagsFromResponseDoesNotReplayOnProgress()
+    {
+        $mockResponse = static fn (): MockResponse => new MockResponse('{"id":1}', [
+            'http_code' => 200,
+            'response_headers' => ['Cache-Control' => 'max-age=300', 'Content-Type' => 'application/json'],
+        ]);
+        $client = $this->buildClient([$mockResponse(), $mockResponse()]);
+
+        $baselineCalls = 0;
+        $client->request('GET', 'http://example.com/without-resolver', [
+            'on_progress' => static function () use (&$baselineCalls): void {
+                ++$baselineCalls;
+            },
+        ])->getContent();
+
+        $resolverCalls = 0;
+        $client->request('GET', 'http://example.com/with-resolver', [
+            'on_progress' => static function () use (&$resolverCalls): void {
+                ++$resolverCalls;
+            },
+            'extra' => ['cache_tags_from_response' => static fn (): array => ['some-tag']],
+        ])->getContent();
+
+        $this->assertSame($baselineCalls, $resolverCalls, 'resolving tags from the response must not replay the caller\'s "on_progress" callback');
+    }
+
+    public function testCacheTagsRejectsReservedCharacters()
+    {
+        $client = $this->buildClient([new MockResponse('foo')]);
+
+        $this->expectException(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "extra.cache_tags" option contains the tag "product/1" with one of the reserved characters "{}()/\@:".');
+
+        $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags' => ['product/1']],
+        ]);
+    }
+
+    public function testCacheTagsFromHeadersResolverRejectsReservedCharacters()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=300'],
+            ]),
+        ]);
+
+        $response = $client->request('GET', 'http://example.com/foo', [
+            'extra' => ['cache_tags_from_headers' => static fn (): array => ['status:200']],
+        ]);
+
+        try {
+            $response->getContent();
+            $this->fail('Expected exception was not thrown.');
+        } catch (\Symfony\Component\HttpClient\Exception\TransportException $e) {
+            $this->assertInstanceOf(\Symfony\Component\HttpClient\Exception\InvalidArgumentException::class, $e->getPrevious());
+            $this->assertSame('The callable passed to "extra.cache_tags_from_headers" returned the tag "status:200" with one of the reserved characters "{}()/\@:".', $e->getPrevious()->getMessage());
+        }
+    }
+
     /**
      * @param iterable<MockResponse> $responses
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Refs #63790
| License       | MIT

Following the discussion in #63790, this PR brings back the custom cache tagging extension point that used to be possible via `StoreInterface` (deprecated in 7.4) but disappeared with the `TagAwareCacheInterface`-based implementation in 8.0.

Three `extra` options, all combinable (resolved tag sets are merged):

* `cache_tags`: `list<string>`, static tags known at request time
* `cache_tags_from_headers`: `callable(int $statusCode, array $headers): iterable<string>`, resolved as soon as the response headers arrive
* `cache_tags_from_response`: `callable(string $body, int $statusCode, array $headers): iterable<string>`, resolved once the full body is available

## Usage

```php
$client->request('GET', 'https://api.example.com/products?q=foo', [
    'extra' => [
        'cache_tags_from_response' => static fn (string $body): array => array_map(
            static fn (array $item): string => 'product-'.$item['id'],
            json_decode($body, true)['items'],
        ),
    ],
]);

// Later, when a webhook informs us that product 1 has changed:
$cache->invalidateTags(['product-1']);
// the cached list response above is evicted, the next request re-fetches
```

## Implementation notes

* Tags are attached to the metadata and chunk items at store time, alongside the internal `[$fullUrlTag, $metadataKey, $attemptTag]` set. They are also persisted in the metadata so a 304 revalidation re-attaches them (chunk items rewritten during revalidation are re-tagged too, fixing a pre-existing tag loss on that path for the internal tags).
* `cache_tags_from_response` needs the body, so it only runs when the response is being stored and the `buffer` option does not disable buffering (`false`, a resource, or a closure returning anything but `true` skips the resolver; static and header-derived tags still apply). The body is held once in memory until the last chunk, then the chunk chain is flushed.
* Tags are validated up front (non-empty strings without the `symfony/cache` reserved characters `{}()/\@:`), so misuse fails fast with an actionable message instead of surfacing at content-read time.

## Limitations, stated on purpose

* Tags are request-scoped while the cache entry is shared: they are attached when the entry is stored. A request that hits an already-stored entry does not add its tags to it.
* The `from_response` resolver receives the raw body string; decoding it (JSON or otherwise) is up to the caller.

## Tests

19 tag-related tests in `CachingHttpClientTest`, covering the three options, their combination, validation failures, reserved characters, buffering opt-out (`buffer: false` and a per-response closure), a chunked body flush, tag survival across a 304 revalidation, and a guard proving the resolver does not replay the caller's `on_progress` callback.
