### PR TITLE
[Messenger][Amqp] Fix support for RabbitMQ v4 by adding delayed quorum queues

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.4
+---
+
+ * Add option `delay[daily_delay_queues]` in the transport definition
+
 6.0
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -546,6 +546,22 @@ class ConnectionTest extends TestCase
         $connection->publish('{}', ['x-some-headers' => 'foo'], -5000);
     }
 
+    public function testItDelaysTheMessageWithDailyDelayQueues()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $date = date('Y-m-d');
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', "delay_messages__5000_delay_$date", \AMQP_NOPARAM, [
+                'headers' => ['x-some-headers' => 'foo'],
+                'delivery_mode' => 2,
+                'timestamp' => time(),
+            ]);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, "delay_messages__5000_delay_$date", true);
+
+        $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
+    }
+
     public function testItRetriesTheMessage()
     {
         $delayExchange = $this->createMock(\AMQPExchange::class);
@@ -557,6 +573,34 @@ class ConnectionTest extends TestCase
         $amqpEnvelope = $this->createStub(\AMQPEnvelope::class);
         $amqpStamp = AmqpStamp::createFromAmqpEnvelope($amqpEnvelope, null, '');
         $connection->publish('{}', [], 5000, $amqpStamp);
+    }
+
+    public function testItRetriesTheMessageWithDailyDelayQueues()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $date = date('Y-m-d');
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', "delay_messages__5000_retry_$date", \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, '', "delay_messages__5000_retry_$date", true);
+
+        $amqpStamp = AmqpStamp::createFromAmqpEnvelope($this->createStub(\AMQPEnvelope::class), null, '');
+        $connection->publish('{}', [], 5000, $amqpStamp);
+    }
+
+    public function testDailyDelayQueuesOptionIsNormalizedToBoolean()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', 'delay_messages__5000_delay', \AMQP_NOPARAM, [
+                'headers' => ['x-some-headers' => 'foo'],
+                'delivery_mode' => 2,
+                'timestamp' => time(),
+            ]);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, 'delay_messages__5000_delay', 'false');
+
+        $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
     }
 
     public function testItDelaysTheMessageWithADifferentRoutingKeyAndTTLs()
@@ -950,7 +994,7 @@ class ConnectionTest extends TestCase
         $connection->publish('body');
     }
 
-    private function createDelayOrRetryConnection(\AMQPExchange $delayExchange, string $deadLetterExchangeName, string $delayQueueName): Connection
+    private function createDelayOrRetryConnection(\AMQPExchange $delayExchange, string $deadLetterExchangeName, string $delayQueueName, bool|string $dailyDelayQueues = false): Connection
     {
         $amqpConnection = $this->createStub(\AMQPConnection::class);
         $amqpChannel = $this->createStub(\AMQPChannel::class);
@@ -962,19 +1006,20 @@ class ConnectionTest extends TestCase
         $delayQueue = $this->createMock(\AMQPQueue::class);
         $factory->method('createQueue')->willReturn($this->createStub(\AMQPQueue::class), $delayQueue);
         $factory->method('createExchange')->willReturn($this->createStub(\AMQPExchange::class), $delayExchange);
-
+        $baseExpire = filter_var($dailyDelayQueues, \FILTER_VALIDATE_BOOL) ? 86400 * 1000 : 0;
         $delayQueue->expects($this->once())->method('setName')->with($delayQueueName);
         $delayQueue->expects($this->once())->method('setArguments')->with([
             'x-message-ttl' => 5000,
-            'x-expires' => 5000 + 10000,
+            'x-expires' => 5000 + 10000 + $baseExpire,
             'x-dead-letter-exchange' => $deadLetterExchangeName,
             'x-dead-letter-routing-key' => '',
         ]);
 
         $delayQueue->expects($this->once())->method('declareQueue');
         $delayQueue->expects($this->once())->method('bind')->with('delays', $delayQueueName);
+        $options = false === $dailyDelayQueues ? [] : ['delay' => ['daily_delay_queues' => $dailyDelayQueues]];
 
-        return Connection::fromDsn('amqp://localhost', [], $factory);
+        return Connection::fromDsn('amqp://localhost', $options, $factory);
     }
 }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -150,6 +150,10 @@ class Connection
      *   * delay:
      *     * queue_name_pattern: Pattern to use to create the queues (Default: "delay_%exchange_name%_%routing_key%_%delay%")
      *     * exchange_name: Name of the exchange to be used for the delayed/retried messages (Default: "delays")
+     *     * daily_delay_queues: When true, the current date is appended to the delay queue names
+     *       (e.g. "delay_messages__5000_delay_2025-04-28") and their "x-expires" argument is increased by 24 hours
+     *       (24 * 60 * 60 * 1000 ms), so RabbitMQ deletes them automatically once the day is over. This is useful for
+     *       quorum queues, which do not allow redeclaring a queue to renew its lease. (Default: false)
      *   * auto_setup: Enable or not the auto-setup of queues and exchanges (Default: true)
      *
      *   * Connection tuning options (see http://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.tune for details):
@@ -213,6 +217,10 @@ class Connection
         unset($amqpOptions['queues'], $amqpOptions['exchange']);
         if (isset($amqpOptions['auto_setup'])) {
             $amqpOptions['auto_setup'] = filter_var($amqpOptions['auto_setup'], \FILTER_VALIDATE_BOOL);
+        }
+
+        if (isset($amqpOptions['delay']['daily_delay_queues'])) {
+            $amqpOptions['delay']['daily_delay_queues'] = filter_var($amqpOptions['delay']['daily_delay_queues'], \FILTER_VALIDATE_BOOL);
         }
 
         $queuesOptions = array_map(static function ($queueOptions) {
@@ -396,11 +404,14 @@ class Connection
         $queue = $this->amqpFactory->createQueue($this->channel());
         $queue->setName($this->getRoutingKeyForDelay($delay, $routingKey, $isRetryAttempt));
         $queue->setFlags(\AMQP_DURABLE);
+        $queueExpirationBase = ($this->connectionOptions['delay']['daily_delay_queues'] ?? false) ? 24 * 60 * 60 * 1000 : 0;
         $queue->setArguments([
             'x-message-ttl' => $delay,
             // delete the delay queue 10 seconds after the message expires
-            // publishing another message redeclares the queue which renews the lease
-            'x-expires' => $delay + 10000,
+            // publishing another message redeclares the queue which renews the lease;
+            // quorum queues cannot be redeclared, so daily_delay_queues=true adds 24 hours (24 * 60 * 60 * 1000 ms)
+            // to the lease and uses a per-day queue name instead, letting RabbitMQ clean up old queues by itself
+            'x-expires' => $queueExpirationBase + $delay + 10000,
             // message should be broadcast to all consumers during delay, but to only one queue during retry
             // empty name is default direct exchange
             'x-dead-letter-exchange' => $isRetryAttempt ? '' : $this->exchangeOptions['name'],
@@ -415,12 +426,13 @@ class Connection
     private function getRoutingKeyForDelay(int $delay, ?string $finalRoutingKey, bool $isRetryAttempt): string
     {
         $action = $isRetryAttempt ? '_retry' : '_delay';
+        $date = ($this->connectionOptions['delay']['daily_delay_queues'] ?? false) ? '_'.date('Y-m-d') : '';
 
         return str_replace(
             ['%delay%', '%exchange_name%', '%routing_key%'],
             [$delay, $this->exchangeOptions['name'], $finalRoutingKey ?? ''],
             $this->connectionOptions['delay']['queue_name_pattern']
-        ).$action;
+        ).$action.$date;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57867
| License       | MIT

This is a backport of #60298 to the 6.4 branch, as proposed in https://github.com/symfony/symfony/issues/57867#issuecomment-4424072968