### PR TITLE
[Security] Preserve webserver base URL in HttpUtils::createRequest()

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -74,9 +74,17 @@ class HttpUtils
             Request::setTrustedProxies([], Request::getTrustedHeaderSet());
         }
 
+        // Trusted proxies are disabled above, so getBaseUrl() now returns only the
+        // webserver-derived portion of the base URL (e.g. an Apache "Alias /myapp …"
+        // sub-directory install). That portion must remain in the generated sub-request
+        // URI so it can re-detect its own base URL from SCRIPT_NAME/REQUEST_URI; only
+        // the trusted-proxy prefix is dropped from the URL generator's context here,
+        // otherwise it would be doubled once the sub-request is processed.
         $context = $this->urlGenerator?->getContext();
-        if ($baseUrl = $context?->getBaseUrl()) {
-            $context->setBaseUrl('');
+        $contextBaseUrl = $context?->getBaseUrl();
+        $realBaseUrl = null !== $context ? $request->getBaseUrl() : null;
+        if ($resetBaseUrl = $contextBaseUrl !== $realBaseUrl) {
+            $context->setBaseUrl($realBaseUrl);
         }
 
         try {
@@ -85,8 +93,8 @@ class HttpUtils
             if ($trustedProxies) {
                 Request::setTrustedProxies($trustedProxies, Request::getTrustedHeaderSet());
             }
-            if ($baseUrl) {
-                $context->setBaseUrl($baseUrl);
+            if ($resetBaseUrl) {
+                $context->setBaseUrl($contextBaseUrl);
             }
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -262,6 +262,66 @@ class HttpUtilsTest extends TestCase
         );
     }
 
+    public function testCreateRequestFromRoutePreservesScriptNameBaseUrl()
+    {
+        // Sub-directory install (Apache "Alias /myapp /var/www/myapp/public" + mod_rewrite).
+        // The master request's base URL comes from SCRIPT_NAME, NOT from X-Forwarded-Prefix.
+        // The sub-request created for a `form_login.use_forward` login MUST inherit that base
+        // URL so the URL generator (re-initialized from the sub-request via
+        // RouterListener::onKernelRequest) emits form action URLs prefixed with `/myapp`.
+        $server = [
+            'REQUEST_URI' => '/myapp/',
+            'SCRIPT_NAME' => '/myapp/index.php',
+            'PHP_SELF' => '/myapp/index.php',
+            'SCRIPT_FILENAME' => '/var/www/myapp/public/index.php',
+        ];
+        $request = new Request([], [], [], [], [], $server);
+        $this->assertSame('/myapp', $request->getBaseUrl());
+
+        $urlGenerator = new UrlGenerator(
+            $routeCollection = new RouteCollection(),
+            (new RequestContext())->fromRequest($request),
+        );
+        $routeCollection->add('app_login', new Route('/login'));
+
+        $subRequest = (new HttpUtils($urlGenerator))->createRequest($request, 'app_login');
+
+        $this->assertSame('/myapp', $subRequest->getBaseUrl());
+        $this->assertSame('http://localhost/myapp/login', $subRequest->getUri());
+    }
+
+    public function testCreateRequestFromRouteBehindProxyPreservesScriptNameBaseUrl()
+    {
+        // Sub-directory install (Apache "Alias /myapp …") behind a trusted proxy adding
+        // an extra prefix: getBaseUrl() === "/proxy-prefix" + "/myapp". Only the
+        // "/proxy-prefix" part may be dropped from the generated sub-request URI; the
+        // "/myapp" part stays so the sub-request re-detects it from SCRIPT_NAME, and the
+        // proxy prefix is re-added (not doubled) once the sub-request is processed.
+        Request::setTrustedProxies(['127.0.0.1'], Request::HEADER_X_FORWARDED_PREFIX);
+
+        $server = [
+            'REQUEST_URI' => '/myapp/',
+            'SCRIPT_NAME' => '/myapp/index.php',
+            'PHP_SELF' => '/myapp/index.php',
+            'SCRIPT_FILENAME' => '/var/www/myapp/public/index.php',
+            'REMOTE_ADDR' => '127.0.0.1',
+            'HTTP_X_FORWARDED_PREFIX' => '/proxy-prefix',
+        ];
+        $request = new Request([], [], [], [], [], $server);
+        $this->assertSame('/proxy-prefix/myapp', $request->getBaseUrl());
+
+        $urlGenerator = new UrlGenerator(
+            $routeCollection = new RouteCollection(),
+            (new RequestContext())->fromRequest($request),
+        );
+        $routeCollection->add('app_login', new Route('/login'));
+
+        $subRequest = (new HttpUtils($urlGenerator))->createRequest($request, 'app_login');
+
+        $this->assertSame('/proxy-prefix/myapp', $subRequest->getBaseUrl());
+        $this->assertSame('http://localhost/proxy-prefix/myapp/login', $subRequest->getUri());
+    }
+
     public function testCheckRequestPath()
     {
         $utils = new HttpUtils($this->getUrlGenerator());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63939
| License       | MIT

`HttpUtils::createRequest()` is used by `FormLoginAuthenticator::start()` when `use_forward: true` is configured. It builds a sub-request that the kernel then dispatches to render the login form.

#62965 added an unconditional `setBaseUrl('')` on the URL generator's context to fix an X-Forwarded-Prefix double-application bug. The reset is needed when the master base URL comes from `X-Forwarded-Prefix` (trusted-proxy), because `Request::getBaseUrl()` re-adds the trusted prefix on top of the sub-request's own `getBaseUrlReal()`. But the reset also silently drops the **SCRIPT_NAME-derived** portion of the base URL — the prefix used by Apache `Alias /myapp …`, sub-directory installs, or any setup where Symfony lives under a webserver path.

Effect on issue #63939:

- User visits `http://localhost/myapp/`.
- Firewall throws → `FormLoginAuthenticator::start()` (with `use_forward: true`) → `HttpUtils::createRequest($request, 'app_login')`.
- `setBaseUrl('')` strips `/myapp` from the URL generator's context → the generated URI is `http://localhost/login`, not `http://localhost/myapp/login`.
- The sub-request's `prepareBaseUrl()` cannot recover `/myapp`: `REQUEST_URI='/login'` shares no prefix with `SCRIPT_NAME='/myapp/index.php'`, so `getBaseUrlReal()` returns `''`.
- `RouterListener::onKernelRequest` then sets `context.baseUrl = ''` from the sub-request, and the form action emitted in the rendered login HTML is `/login` instead of `/myapp/login`.

Reproduces with the failing test added in `HttpUtilsTest::testCreateRequestFromRoutePreservesScriptNameBaseUrl`. Before the patch: sub-request `getBaseUrl()` returns `''` (expected `/myapp`).

This PR keeps #62965's behaviour for the X-Forwarded-Prefix case (the trusted-proxy portion is still removed from the URL generator's context) and restores the pre-#62965 behaviour for sub-directory installs (the SCRIPT_NAME-derived portion stays in the generated URI so the sub-request can re-detect its own base URL). The existing `testCreateRequestFromRouteHandlesTrustedHeaders` continues to pass unchanged.
