### PR TITLE
[Console] Fix signal handler scoping

### DIFF
--- a/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
@@ -81,6 +81,14 @@ final class SignalRegistry
      */
     public function pushCurrentHandlers(): void
     {
+        // Restore the original OS-level disposition while the active map is empty,
+        // so signals are not routed through handle() without a registered handler.
+        foreach ($this->signalHandlers as $signal => $handlers) {
+            if (isset($this->originalHandlers[$signal])) {
+                pcntl_signal($signal, $this->originalHandlers[$signal]);
+            }
+        }
+
         $this->stack[] = $this->signalHandlers;
         $this->signalHandlers = [];
     }
@@ -96,13 +104,24 @@ final class SignalRegistry
     public function popPreviousHandlers(): void
     {
         $popped = $this->signalHandlers;
-        $this->signalHandlers = array_pop($this->stack) ?? [];
+        $previous = array_pop($this->stack) ?? [];
 
-        // Restore OS handler if no more Symfony handlers for this signal
+        // Expose a transitional superset so handle() never reads a missing key
+        // if a signal lands while the OS-level handlers below are being swapped.
+        $this->signalHandlers = $previous + $popped;
+
+        // Reinstall the registry handler for signals owned by the restored scope.
+        foreach ($previous as $signal => $handlers) {
+            pcntl_signal($signal, [$this, 'handle']);
+        }
+
+        // Restore the original OS-level handler for signals no scope owns anymore.
         foreach ($popped as $signal => $handlers) {
-            if (!($this->signalHandlers[$signal] ?? false) && isset($this->originalHandlers[$signal])) {
+            if (!isset($previous[$signal]) && isset($this->originalHandlers[$signal])) {
                 pcntl_signal($signal, $this->originalHandlers[$signal]);
             }
         }
+
+        $this->signalHandlers = $previous;
     }
 }

--- a/src/Symfony/Component/Console/Tests/SignalRegistry/SignalRegistryTest.php
+++ b/src/Symfony/Component/Console/Tests/SignalRegistry/SignalRegistryTest.php
@@ -160,6 +160,76 @@ class SignalRegistryTest extends TestCase
         $this->assertCount(0, $this->getHandlersForSignal($registry, $signal));
     }
 
+    public function testPushCurrentHandlersRestoresOriginalHandler()
+    {
+        $registry = new SignalRegistry();
+
+        $previousHandlerCalled = false;
+        pcntl_signal(\SIGUSR1, static function () use (&$previousHandlerCalled) {
+            $previousHandlerCalled = true;
+        });
+
+        $registeredHandlerCalled = false;
+        $registry->register(\SIGUSR1, static function () use (&$registeredHandlerCalled) {
+            $registeredHandlerCalled = true;
+        });
+
+        $registry->pushCurrentHandlers();
+
+        posix_kill(posix_getpid(), \SIGUSR1);
+
+        $this->assertTrue($previousHandlerCalled);
+        $this->assertFalse($registeredHandlerCalled);
+    }
+
+    public function testPopPreviousHandlersRestoresPreviousOsHandler()
+    {
+        $registry = new SignalRegistry();
+
+        $outerHandlerCalled = false;
+        $registry->register(\SIGUSR1, static function () use (&$outerHandlerCalled) {
+            $outerHandlerCalled = true;
+        });
+
+        $registry->pushCurrentHandlers();
+
+        $innerHandlerCalled = false;
+        $registry->register(\SIGUSR2, static function () use (&$innerHandlerCalled) {
+            $innerHandlerCalled = true;
+        });
+
+        $registry->popPreviousHandlers();
+
+        posix_kill(posix_getpid(), \SIGUSR1);
+
+        $this->assertTrue($outerHandlerCalled);
+        $this->assertFalse($innerHandlerCalled);
+    }
+
+    public function testPopPreviousHandlersRestoresPreviousOsHandlerForSameSignal()
+    {
+        $registry = new SignalRegistry();
+
+        $outerHandlerCalled = false;
+        $registry->register(\SIGUSR1, static function () use (&$outerHandlerCalled) {
+            $outerHandlerCalled = true;
+        });
+
+        $registry->pushCurrentHandlers();
+
+        $innerHandlerCalled = false;
+        $registry->register(\SIGUSR1, static function () use (&$innerHandlerCalled) {
+            $innerHandlerCalled = true;
+        });
+
+        $registry->popPreviousHandlers();
+
+        posix_kill(posix_getpid(), \SIGUSR1);
+
+        $this->assertTrue($outerHandlerCalled);
+        $this->assertFalse($innerHandlerCalled);
+    }
+
     public function testRestoreOriginalOnEmptyAfterPop()
     {
         if (!\extension_loaded('pcntl')) {


### PR DESCRIPTION
| Q             | A |
|---------------|---|
| Branch?       | 6.4 |
| Bug fix?      | yes |
| New feature?  | no |
| Deprecations? | no |
| Issues        | - |
| License       | MIT |

`SignalRegistry::pushCurrentHandlers()` clears the active handler map while OS-level pcntl handlers can still route signals to `SignalRegistry::handle()`. With async signals enabled, a signal arriving after the map is cleared currently triggers an undefined array key and then `count(null)`.

This keeps OS-level handlers and the active registry map in sync when pushing/popping scoped handlers. It restores original OS-level handlers before clearing the active map, then reinstalls the registry handler for restored outer-scope handlers when popping.

During the short interval after a scope is pushed and before the next scope registers its signals, the original OS-level disposition is used for those signals. This is intentional: signals should not be routed through the registry while the active map has no handler for them.

Tests cover restoring the original handler after `pushCurrentHandlers()`, restoring previous OS-level handlers after `popPreviousHandlers()`, and restoring a previous handler when the same signal is registered in nested scopes.
