### PR TITLE
[Yaml] Avoid double space when dumping an empty inline mapping

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -250,6 +250,10 @@ class Inline
             $output[] = \sprintf('%s: %s', self::dump($key, $flags), self::dump($val, $flags));
         }
 
+        if (!$output) {
+            return '{ }';
+        }
+
         return \sprintf('{ %s }', implode(', ', $output));
     }
 

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -61,7 +61,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": { }
             bar:
                    - 1
                    - foo
@@ -114,7 +114,7 @@ class DumperTest extends TestCase
     public function testInlineLevel()
     {
         $expected = <<<'EOF'
-            { '': bar, foo: '#bar', "foo'bar": {  }, bar: [1, foo, { a: A }], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
+            { '': bar, foo: '#bar', "foo'bar": { }, bar: [1, foo, { a: A }], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
             EOF;
         $this->assertSame($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
         $this->assertSame($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
@@ -123,7 +123,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": { }
             bar: [1, foo, { a: A }]
             foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
 
@@ -134,7 +134,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": { }
             bar:
                 - 1
                 - foo
@@ -151,7 +151,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": { }
             bar:
                 - 1
                 - foo
@@ -173,7 +173,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
             '': bar
             foo: '#bar'
-            "foo'bar": {  }
+            "foo'bar": { }
             bar:
                 - 1
                 - foo
@@ -355,12 +355,12 @@ class DumperTest extends TestCase
 
     public function testDumpEmptyArrayObjectInstanceAsMap()
     {
-        $this->assertSame('{  }', $this->dumper->dump(new \ArrayObject(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
+        $this->assertSame('{ }', $this->dumper->dump(new \ArrayObject(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
     }
 
     public function testDumpEmptyStdClassInstanceAsMap()
     {
-        $this->assertSame('{  }', $this->dumper->dump(new \stdClass(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
+        $this->assertSame('{ }', $this->dumper->dump(new \stdClass(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
     }
 
     public function testDumpingStdClassInstancesRespectsInlineLevel()

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -550,6 +550,7 @@ class InlineTest extends TestCase
             // mappings
             ['{ foo: bar, bar: foo, \'false\': false, \'null\': null, integer: 12 }', ['foo' => 'bar', 'bar' => 'foo', 'false' => false, 'null' => null, 'integer' => 12]],
             ['{ foo: bar, bar: \'foo: bar\' }', ['foo' => 'bar', 'bar' => 'foo: bar']],
+            ['{ }', []],
 
             // nested sequences and mappings
             ['[foo, [bar, foo]]', ['foo', ['bar', 'foo']]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64137
| License       | MIT

`Inline::dumpHashArray()` builds the inline mapping with `sprintf('{ %s }', implode(', ', \$output))`. When the input is an empty array, `implode` returns an empty string, so the result becomes `'{  }'` (two spaces). This is valid YAML but trips most YAML formatters/linters (yamllint, Drupal coding standards, etc.) which expect either `'{}'` or `'{ }'`.

Short-circuited that path to return `'{ }'` and updated the existing `DumperTest`/`InlineTest` fixtures that asserted the old double-space output.

Verified with the Yaml suite: 806 tests / 1286 assertions, all green.