### PR TITLE
[FrameworkBundle][Cache] Configure caches via DSN

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
  * Allow prefixing entries with `!` in `framework.workflows.<name>.events_to_dispatch` to permanently disable an event; e.g. `events_to_dispatch: ['!workflow.announce']` fires every event except `workflow.announce`. The GuardEvent can never be disabled; `!workflow.guard` is rejected at config compile time. Mixing allow-list and block-list entries in the same list is rejected at config compile time too.
  * Add support for the HttpClient `max_connect_duration` option to the `http_client` configuration
+ * Allow configuring cache pools (including `framework.cache.app` and `framework.cache.system`) with a DSN that selects the adapter from its scheme at runtime, e.g. `redis://localhost` or `%env(CACHE_DSN)%`
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -25,6 +25,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'asset_mapper.compiler',
         'assets.package',
         'auto_alias',
+        'cache.adapter_factory',
         'cache.pool',
         'cache.pool.clearer',
         'cache.taggable',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -37,6 +37,7 @@ use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
+use Symfony\Component\Cache\Adapter\LazyDsnAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -2715,7 +2716,23 @@ class FrameworkExtension extends Extension
                 if (!isset($pool['provider']) && !\is_int($provider)) {
                     $pool['provider'] = $provider;
                 }
-                $definition = new ChildDefinition($adapter);
+
+                $container->resolveEnvPlaceholders($adapter, null, $usedEnvs);
+
+                // A DSN ("redis://...") or an env var holding one selects the backend from the scheme at
+                // runtime, so the pool is built by the adapter factory instead of cloning a fixed adapter.
+                if ($usedEnvs || preg_match('#^[a-z]++:#', $adapter)) {
+                    $definition = new Definition(LazyDsnAdapter::class, [
+                        '', // namespace, set positionally by CachePoolPass
+                        0, // default lifetime, set positionally by CachePoolPass when configured
+                        new Reference('cache.adapter_factory'),
+                        $adapter,
+                        new Reference('cache.default_marshaller', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                    ]);
+                    $pool['reset'] ??= 'reset';
+                } else {
+                    $definition = new ChildDefinition($adapter);
+                }
             } else {
                 $definition = new Definition(ChainAdapter::class, [$pool['adapters'], 0]);
                 $pool['reset'] = 'reset';

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -17,11 +17,15 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
+use Symfony\Component\Cache\Adapter\DsnAdapterFactory;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapterFactory;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
+use Symfony\Component\Cache\Adapter\PdoAdapterFactory;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapterFactory;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
@@ -225,6 +229,20 @@ return static function (ContainerConfigurator $container) {
                 null, // use igbinary_serialize() when available
                 '%kernel.debug%',
             ])
+
+        ->set('cache.adapter_factory', DsnAdapterFactory::class)
+            ->args([
+                tagged_iterator('cache.adapter_factory'),
+            ])
+
+        ->set('cache.adapter_factory.redis', RedisAdapterFactory::class)
+            ->tag('cache.adapter_factory')
+
+        ->set('cache.adapter_factory.memcached', MemcachedAdapterFactory::class)
+            ->tag('cache.adapter_factory')
+
+        ->set('cache.adapter_factory.pdo', PdoAdapterFactory::class)
+            ->tag('cache.adapter_factory')
 
         ->set('cache.early_expiration_handler', EarlyExpirationHandler::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_dsn.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_dsn.php
@@ -1,0 +1,15 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'cache' => [
+        'app' => 'redis://localhost',
+        'pools' => [
+            'cache.custom_dsn' => [
+                'adapter' => 'memcached://localhost',
+            ],
+            'cache.env_dsn' => [
+                'adapter' => '%env(CACHE_DSN)%',
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -14,12 +14,15 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use Symfony\Component\Cache\Adapter\LazyDsnAdapter;
+use Symfony\Component\Cache\DependencyInjection\CachePoolPass;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Mailer\Bridge\Brevo\Webhook\BrevoRequestParser;
 use Symfony\Component\Mailer\Bridge\Postmark\Webhook\PostmarkRequestParser;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -37,6 +40,32 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
     {
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/Fixtures/php'));
         $loader->load($file.'.php');
+    }
+
+    public function testCachePoolConfiguredWithDsn()
+    {
+        $container = $this->createContainerFromFile('cache_dsn', [], true, false);
+        $container->setParameter('cache.prefix.seed', 'test');
+        $container->addCompilerPass(new CachePoolPass());
+        $container->compile();
+
+        // "framework.cache.app" configured with a DSN is built by the adapter factory, not a fixed adapter
+        $appPool = $container->getDefinition('cache.app');
+        $this->assertSame(LazyDsnAdapter::class, $appPool->getClass());
+        $this->assertEquals(new Reference('cache.adapter_factory'), $appPool->getArgument(2));
+        $this->assertSame('redis://localhost', $appPool->getArgument(3));
+
+        // the same DSN support applies to any user-defined pool, not just cache.app/cache.system
+        $customPool = $container->getDefinition('cache.custom_dsn');
+        $this->assertSame(LazyDsnAdapter::class, $customPool->getClass());
+        $this->assertSame('memcached://localhost', $customPool->getArgument(3));
+
+        // an env-var DSN stays an unresolved placeholder: the backend is selected at runtime, not at compile time
+        $envPool = $container->getDefinition('cache.env_dsn');
+        $this->assertSame(LazyDsnAdapter::class, $envPool->getClass());
+        $this->assertEquals(new Reference('cache.adapter_factory'), $envPool->getArgument(2));
+        $container->resolveEnvPlaceholders($envPool->getArgument(3), null, $usedEnvs);
+        $this->assertArrayHasKey('CACHE_DSN', $usedEnvs);
     }
 
     public function testAssetsCannotHavePathAndUrl()

--- a/src/Symfony/Component/Cache/Adapter/AdapterFactoryInterface.php
+++ b/src/Symfony/Component/Cache/Adapter/AdapterFactoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * Creates a cache adapter from a DSN, resolving the backend from the DSN scheme at runtime.
+ *
+ * Implementations are collected by {@see DsnAdapterFactory}; registering a new one (tagged
+ * "cache.adapter_factory" in FrameworkBundle) is enough to support an extra scheme, the same
+ * way Messenger transports are discovered through {@see \Symfony\Component\Messenger\Transport\TransportFactoryInterface}.
+ *
+ * @author Ousama Ben Younes <benyounes.ousama@gmail.com>
+ */
+interface AdapterFactoryInterface
+{
+    public function createAdapter(#[\SensitiveParameter] string $dsn, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null): AdapterInterface;
+
+    public function supports(#[\SensitiveParameter] string $dsn): bool;
+}

--- a/src/Symfony/Component/Cache/Adapter/DsnAdapterFactory.php
+++ b/src/Symfony/Component/Cache/Adapter/DsnAdapterFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * Builds a cache adapter from a DSN by delegating to the first registered {@see AdapterFactoryInterface}
+ * that supports the DSN scheme.
+ *
+ * Mirrors {@see \Symfony\Component\Messenger\Transport\TransportFactory}: the scheme is resolved at runtime,
+ * so a DSN coming from an environment variable (e.g. "%env(CACHE_DSN)%") selects the backend at instantiation
+ * time rather than at container-compile time.
+ *
+ * @author Ousama Ben Younes <benyounes.ousama@gmail.com>
+ */
+class DsnAdapterFactory implements AdapterFactoryInterface
+{
+    /**
+     * @param iterable<AdapterFactoryInterface> $factories
+     */
+    public function __construct(
+        private readonly iterable $factories,
+    ) {
+    }
+
+    public function createAdapter(#[\SensitiveParameter] string $dsn, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null): AdapterInterface
+    {
+        foreach ($this->factories as $factory) {
+            if ($factory->supports($dsn)) {
+                return $factory->createAdapter($dsn, $namespace, $defaultLifetime, $marshaller);
+            }
+        }
+
+        throw new InvalidArgumentException(\sprintf('No cache adapter supports the DSN scheme "%s://".', strstr($dsn, ':', true) ?: $dsn));
+    }
+
+    public function supports(#[\SensitiveParameter] string $dsn): bool
+    {
+        foreach ($this->factories as $factory) {
+            if ($factory->supports($dsn)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/Cache/Adapter/LazyDsnAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/LazyDsnAdapter.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Psr\Cache\CacheItemInterface;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Defers building the real adapter to first use, resolving the backend from the DSN scheme at runtime.
+ *
+ * The constructor argument order (namespace, default lifetime first) matches the positional injection
+ * performed by {@see \Symfony\Component\Cache\DependencyInjection\CachePoolPass}, so a DSN-configured
+ * pool reuses the exact same wiring as any other "cache.pool".
+ *
+ * @author Ousama Ben Younes <benyounes.ousama@gmail.com>
+ *
+ * @internal
+ */
+class LazyDsnAdapter implements AdapterInterface, PruneableInterface, ResettableInterface
+{
+    private ?AdapterInterface $pool = null;
+
+    public function __construct(
+        private readonly string $namespace,
+        private readonly int $defaultLifetime,
+        private readonly AdapterFactoryInterface $factory,
+        #[\SensitiveParameter] private readonly string $dsn,
+        private readonly ?MarshallerInterface $marshaller = null,
+    ) {
+    }
+
+    public function getItem(mixed $key): CacheItem
+    {
+        return $this->getPool()->getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return $this->getPool()->getItems($keys);
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return $this->getPool()->hasItem($key);
+    }
+
+    public function clear(string $prefix = ''): bool
+    {
+        return $this->getPool()->clear($prefix);
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        return $this->getPool()->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return $this->getPool()->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return $this->getPool()->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->getPool()->saveDeferred($item);
+    }
+
+    public function commit(): bool
+    {
+        return $this->getPool()->commit();
+    }
+
+    public function prune(): bool
+    {
+        $pool = $this->getPool();
+
+        return $pool instanceof PruneableInterface && $pool->prune();
+    }
+
+    public function reset(): void
+    {
+        // Only reset an adapter that has actually been built, so an unused pool stays untouched between requests.
+        if ($this->pool instanceof ResetInterface) {
+            $this->pool->reset();
+        }
+    }
+
+    private function getPool(): AdapterInterface
+    {
+        return $this->pool ??= $this->factory->createAdapter($this->dsn, $this->namespace, $this->defaultLifetime, $this->marshaller);
+    }
+}

--- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapterFactory.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapterFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * @author Ousama Ben Younes <benyounes.ousama@gmail.com>
+ */
+class MemcachedAdapterFactory implements AdapterFactoryInterface
+{
+    private const SCHEMES = ['memcached'];
+
+    public function createAdapter(#[\SensitiveParameter] string $dsn, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null): AdapterInterface
+    {
+        return new MemcachedAdapter(MemcachedAdapter::createConnection($dsn), $namespace, $defaultLifetime, $marshaller);
+    }
+
+    public function supports(#[\SensitiveParameter] string $dsn): bool
+    {
+        return \in_array(strtolower(strstr($dsn, ':', true) ?: ''), self::SCHEMES, true);
+    }
+}

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapterFactory.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapterFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * @author Ousama Ben Younes <benyounes.ousama@gmail.com>
+ */
+class PdoAdapterFactory implements AdapterFactoryInterface
+{
+    private const SCHEMES = ['mysql', 'pgsql', 'sqlite', 'sqlsrv', 'oci'];
+
+    public function createAdapter(#[\SensitiveParameter] string $dsn, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null): AdapterInterface
+    {
+        // PdoAdapter accepts the DSN directly and opens the connection lazily on first use.
+        return new PdoAdapter($dsn, $namespace, $defaultLifetime, [], $marshaller);
+    }
+
+    public function supports(#[\SensitiveParameter] string $dsn): bool
+    {
+        return \in_array(strtolower(strstr($dsn, ':', true) ?: ''), self::SCHEMES, true);
+    }
+}

--- a/src/Symfony/Component/Cache/Adapter/RedisAdapterFactory.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisAdapterFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * @author Ousama Ben Younes <benyounes.ousama@gmail.com>
+ */
+class RedisAdapterFactory implements AdapterFactoryInterface
+{
+    private const SCHEMES = ['redis', 'rediss', 'valkey', 'valkeys'];
+
+    /**
+     * Connections are created lazily so that an unused pool never opens a socket at container build time.
+     */
+    private const CONNECTION_OPTIONS = ['lazy' => true];
+
+    public function createAdapter(#[\SensitiveParameter] string $dsn, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null): AdapterInterface
+    {
+        return new RedisAdapter(RedisAdapter::createConnection($dsn, self::CONNECTION_OPTIONS), $namespace, $defaultLifetime, $marshaller);
+    }
+
+    public function supports(#[\SensitiveParameter] string $dsn): bool
+    {
+        return \in_array(strtolower(strstr($dsn, ':', true) ?: ''), self::SCHEMES, true);
+    }
+}

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `AdapterFactoryInterface`, `DsnAdapterFactory` and per-backend factories to build a cache adapter from a DSN, resolving the backend from its scheme at runtime
+
 8.0
 ---
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/DsnAdapterFactoryTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DsnAdapterFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\AdapterFactoryInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\DsnAdapterFactory;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+class DsnAdapterFactoryTest extends TestCase
+{
+    public function testDelegatesToTheFirstSupportingFactory()
+    {
+        $expected = new ArrayAdapter();
+        $factory = new DsnAdapterFactory([
+            $this->createFactory(false),
+            $this->createFactory(true, $expected),
+            $this->createFactory(true, new ArrayAdapter()),
+        ]);
+
+        $this->assertTrue($factory->supports('redis://localhost'));
+        $this->assertSame($expected, $factory->createAdapter('redis://localhost'));
+    }
+
+    public function testThrowsWhenNoFactorySupportsTheDsn()
+    {
+        $factory = new DsnAdapterFactory([$this->createFactory(false)]);
+
+        $this->assertFalse($factory->supports('foo://bar'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No cache adapter supports the DSN scheme "foo://".');
+
+        $factory->createAdapter('foo://bar');
+    }
+
+    private function createFactory(bool $supports, ?AdapterInterface $adapter = null): AdapterFactoryInterface
+    {
+        $factory = $this->createStub(AdapterFactoryInterface::class);
+        $factory->method('supports')->willReturn($supports);
+        $factory->method('createAdapter')->willReturn($adapter ?? new ArrayAdapter());
+
+        return $factory;
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/LazyDsnAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/LazyDsnAdapterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\AdapterFactoryInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\LazyDsnAdapter;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+class LazyDsnAdapterTest extends TestCase
+{
+    public function testTheInnerAdapterIsBuiltOnceOnFirstUseAndReused()
+    {
+        $factory = $this->createCountingFactory(new ArrayAdapter());
+        $adapter = new LazyDsnAdapter('ns', 10, $factory, 'redis://localhost');
+
+        $this->assertSame(0, $factory->calls, 'the inner adapter is not built at construction time');
+
+        $adapter->save($adapter->getItem('foo')->set('bar'));
+        $this->assertSame(1, $factory->calls);
+
+        $this->assertTrue($adapter->hasItem('foo'));
+        $this->assertSame(1, $factory->calls, 'the built adapter is reused across calls');
+    }
+
+    public function testCreateAdapterReceivesTheConstructorArguments()
+    {
+        $marshaller = $this->createStub(MarshallerInterface::class);
+        $factory = $this->createMock(AdapterFactoryInterface::class);
+        $factory->expects($this->once())
+            ->method('createAdapter')
+            ->with('redis://localhost', 'ns', 10, $marshaller)
+            ->willReturn(new ArrayAdapter());
+
+        $adapter = new LazyDsnAdapter('ns', 10, $factory, 'redis://localhost', $marshaller);
+        $adapter->hasItem('foo');
+    }
+
+    public function testResetDoesNotBuildAnUnusedAdapter()
+    {
+        $factory = $this->createCountingFactory(new ArrayAdapter());
+        $adapter = new LazyDsnAdapter('ns', 0, $factory, 'redis://localhost');
+
+        $adapter->reset();
+
+        $this->assertSame(0, $factory->calls);
+    }
+
+    private function createCountingFactory(AdapterInterface $inner): AdapterFactoryInterface
+    {
+        return new class($inner) implements AdapterFactoryInterface {
+            public int $calls = 0;
+
+            public function __construct(private readonly AdapterInterface $inner)
+            {
+            }
+
+            public function createAdapter(string $dsn, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null): AdapterInterface
+            {
+                ++$this->calls;
+
+                return $this->inner;
+            }
+
+            public function supports(string $dsn): bool
+            {
+                return true;
+            }
+        };
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterFactoryTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\MemcachedAdapterFactory;
+
+class MemcachedAdapterFactoryTest extends TestCase
+{
+    #[DataProvider('provideSupportedDsn')]
+    public function testSupports(bool $expected, string $dsn)
+    {
+        $this->assertSame($expected, (new MemcachedAdapterFactory())->supports($dsn));
+    }
+
+    public static function provideSupportedDsn(): iterable
+    {
+        yield [true, 'memcached://localhost'];
+        yield [true, 'memcached://user:pass@localhost:11211'];
+        yield [true, 'MEMCACHED://localhost']; // scheme matching is case-insensitive
+        yield [false, 'redis://localhost'];
+        yield [false, 'cache.adapter.memcached'];
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterFactoryTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\PdoAdapter;
+use Symfony\Component\Cache\Adapter\PdoAdapterFactory;
+
+class PdoAdapterFactoryTest extends TestCase
+{
+    #[DataProvider('provideSupportedDsn')]
+    public function testSupports(bool $expected, string $dsn)
+    {
+        $this->assertSame($expected, (new PdoAdapterFactory())->supports($dsn));
+    }
+
+    public static function provideSupportedDsn(): iterable
+    {
+        yield [true, 'mysql:host=localhost'];
+        yield [true, 'pgsql:host=localhost'];
+        yield [true, 'sqlite::memory:'];
+        yield [true, 'sqlsrv:server=localhost'];
+        yield [true, 'oci:dbname=localhost'];
+        yield [true, 'SQLITE::memory:']; // scheme matching is case-insensitive
+        yield [false, 'redis://localhost'];
+        yield [false, 'cache.adapter.pdo'];
+    }
+
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testCreateAdapter()
+    {
+        $adapter = (new PdoAdapterFactory())->createAdapter('sqlite::memory:', 'ns', 10);
+
+        $this->assertInstanceOf(PdoAdapter::class, $adapter);
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterFactoryTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\RedisAdapterFactory;
+
+class RedisAdapterFactoryTest extends TestCase
+{
+    #[DataProvider('provideSupportedDsn')]
+    public function testSupports(bool $expected, string $dsn)
+    {
+        $this->assertSame($expected, (new RedisAdapterFactory())->supports($dsn));
+    }
+
+    public static function provideSupportedDsn(): iterable
+    {
+        yield [true, 'redis://localhost'];
+        yield [true, 'rediss://localhost'];
+        yield [true, 'valkey://localhost'];
+        yield [true, 'valkeys://localhost'];
+        yield [true, 'REDIS://localhost']; // scheme matching is case-insensitive
+        yield [false, 'memcached://localhost'];
+        yield [false, 'mysql://localhost'];
+        yield [false, 'cache.adapter.redis'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61958
| License       | MIT

Following @GromNaN's review, this reworks the feature from a compile-time compiler pass into a **runtime adapter factory**, mirroring how Messenger resolves `MESSENGER_TRANSPORT_DSN` through `TransportFactory`.

### What this addresses from the review

- **The env-variable case now works.** The scheme is resolved at runtime, so `framework.cache.app: '%env(CACHE_DSN)%'` selects the backend at instantiation time. Switching the Redis URL (or the backend itself) at deploy time no longer requires recompiling the container.
- **Any pool, not just `cache.app`/`cache.system`.** A DSN works for user-defined pools too.
- **No hardcoded scheme list.** Backends are discovered from services tagged `cache.adapter_factory`; a third-party bundle adds a scheme by registering its own factory, without touching FrameworkBundle.

### Design

- `Cache\Adapter\AdapterFactoryInterface` — `supports($dsn)` + `createAdapter($dsn, $namespace, $defaultLifetime, $marshaller)`.
- `RedisAdapterFactory`, `MemcachedAdapterFactory`, `PdoAdapterFactory` — one per backend, matched by scheme.
- `DsnAdapterFactory` — aggregates the tagged factories and delegates to the first that supports the DSN (mirrors `Messenger\Transport\TransportFactory`).
- `LazyDsnAdapter` — builds the real adapter on first use, so an unused pool never opens a connection and the env placeholder stays unresolved until runtime.

A DSN-configured pool reuses the exact same `cache.pool` wiring as any other pool (namespace, default lifetime, marshaller, tag-awareness, pruning, reset).

```yaml
framework:
    cache:
        app: '%env(CACHE_DSN)%'   # redis://…, memcached://…, pgsql://…
        pools:
            my_pool:
                adapter: 'redis://localhost'
```

### Test verification (RED → GREEN)

The functional test configures `cache.app` (Redis DSN), a custom pool (Memcached DSN) and a pool fed by `%env(CACHE_DSN)%`, then asserts each pool is built by the factory and that the env placeholder stays unresolved (runtime resolution).

**RED** — production wiring in `FrameworkExtension` reverted (the DSN falls back to the old `new ChildDefinition($adapter)`):

```
1) Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\PhpFrameworkExtensionTest::testCachePoolConfiguredWithDsn
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "redis://localhost".

…/Component/Cache/DependencyInjection/CachePoolPass.php:63
…/Tests/DependencyInjection/PhpFrameworkExtensionTest.php:50

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

**GREEN** — with the fix:

```
OK (1 test, 8 assertions)
```

Full suite across the touched files (Cache factories + `LazyDsnAdapter` + Cache DI passes + `PhpFrameworkExtensionTest` + `UnusedTagsPassTest`): **257 tests, 1206 assertions, 0 failures**.
