### PR TITLE
[Mailer] Improve error message when SMTP server lacks SMTPUTF8 support

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -90,7 +90,7 @@ class EsmtpTransportTest extends TestCase
         $message->text('.');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid addresses: non-ASCII characters not supported in local-part of email.');
+        $this->expectExceptionMessage('The SMTP server does not support the SMTPUTF8 extension required to send to addresses with non-ASCII characters in their local-part.');
         $transport->send($message);
     }
 

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -247,7 +247,7 @@ class SmtpTransport extends AbstractTransport
     private function doMailFromCommand(string $address, bool $smtputf8): void
     {
         if ($smtputf8 && !$this->serverSupportsSmtpUtf8()) {
-            throw new InvalidArgumentException('Invalid addresses: non-ASCII characters not supported in local-part of email.');
+            throw new InvalidArgumentException('The SMTP server does not support the SMTPUTF8 extension required to send to addresses with non-ASCII characters in their local-part.');
         }
         $this->executeCommand(\sprintf("MAIL FROM:<%s>%s\r\n", $address, $smtputf8 ? ' SMTPUTF8' : ''), [250]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Issues        | Fix #63215
| License       | MIT

When `EsmtpTransport` connects to an SMTP server that does not advertise the `SMTPUTF8` capability (RFC 6531), sending a message whose envelope has any address with a non-ASCII local-part raises an `InvalidArgumentException` with this message:

> Invalid addresses: non-ASCII characters not supported in local-part of email.

The wording is misleading: the addresses are RFC 6531 valid, and Symfony does support non-ASCII local-parts (see [the docs](https://symfony.com/doc/current/mailer.html#email-addresses)). The real cause is server-side — the connected SMTP server has not advertised the `SMTPUTF8` extension in its EHLO response, so the transport cannot use `MAIL FROM:<…> SMTPUTF8`.

This PR improves the exception so the user can immediately see the actual limitation and search for "SMTPUTF8":

> The SMTP server does not support the SMTPUTF8 extension required to send to addresses with non-ASCII characters in their local-part.

Behaviour is unchanged: same exception class (`Symfony\Component\Mailer\Exception\InvalidArgumentException`), same throw site (`SmtpTransport::doMailFromCommand`). Only the message text changes; covered by `Tests/Transport/Smtp/EsmtpTransportTest::testMissingSmtpUtf8`.
