### PR TITLE
[AssetMapper] Warn on missing bare CSS and JSON imports

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -83,7 +83,7 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
             $isRelativeImport = str_starts_with($importedModule, '.');
             if (!$isRelativeImport) {
                 // URL or /absolute imports will also go here, but will be ignored
-                $dependentAsset = $this->findAssetForBareImport($importedModule, $assetMapper);
+                $dependentAsset = $this->findAssetForBareImport($importedModule, $asset, $assetMapper);
             } else {
                 $dependentAsset = $this->findAssetForRelativeImport($importedModule, $asset, $assetMapper);
             }
@@ -173,17 +173,26 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
         return false;
     }
 
-    private function findAssetForBareImport(string $importedModule, AssetMapperInterface $assetMapper): ?MappedAsset
+    private function findAssetForBareImport(string $importedModule, MappedAsset $asset, AssetMapperInterface $assetMapper): ?MappedAsset
     {
         if (!$importMapEntry = $this->importMapConfigReader->findRootImportMapEntry($importedModule)) {
-            // don't warn on missing non-relative (bare) imports: these could be valid URLs
+            // Bare names may resolve to a valid URL at runtime, so we don't warn about them in general.
+            // But the browser can only load a CSS or JSON module by bare name through an importmap entry
+            // (the experimental import-attributes `with { type: '...' }` syntax aside), so a missing bare
+            // `.css`/`.json` import silently does nothing - warn the user at compile time.
+            if (!$asset->isVendor
+                && !str_contains($importedModule, '://')
+                && (str_ends_with($lowerModule = strtolower($importedModule), '.css') || str_ends_with($lowerModule, '.json'))
+            ) {
+                $this->handleMissingImport(\sprintf('Unable to find asset "%s" imported from "%s". Add it to "importmap.php", e.g. via the "importmap:require" command.', $importedModule, $asset->sourcePath));
+            }
 
             return null;
         }
 
         try {
-            if ($asset = $assetMapper->getAsset($importMapEntry->path)) {
-                return $asset;
+            if ($dependentAsset = $assetMapper->getAsset($importMapEntry->path)) {
+                return $dependentAsset;
             }
 
             return $assetMapper->getAssetFromSourcePath($this->importMapConfigReader->convertPathToFilesystemPath($importMapEntry->path));

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -587,6 +587,34 @@ class JavaScriptImportPathCompilerTest extends TestCase
         $this->assertCount(0, $bootstrapAsset->getJavaScriptImports());
     }
 
+    public function testCompileDoesNotWarnOnBareCssImportPresentInImportmap()
+    {
+        $appAsset = new MappedAsset('app.js', '/path/to/app.js');
+        $cssAsset = new MappedAsset('some-package/styles.css', '/path/to/vendor/some-package/styles.css', publicPathWithoutDigest: '/assets/some-package/styles.css');
+
+        $importMapConfigReader = $this->createMock(ImportMapConfigReader::class);
+        $importMapConfigReader->expects($this->once())
+            ->method('findRootImportMapEntry')
+            ->with('some-package/styles.css')
+            ->willReturn(ImportMapEntry::createRemote('some-package/styles.css', ImportMapType::CSS, './vendor/some-package/styles.css', '1.2.3', 'could_be_anything', false));
+        $importMapConfigReader
+            ->method('convertPathToFilesystemPath')
+            ->willReturnMap([
+                ['./vendor/some-package/styles.css', '/path/to/vendor/some-package/styles.css'],
+            ]);
+
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper->expects($this->once())
+            ->method('getAssetFromSourcePath')
+            ->with('/path/to/vendor/some-package/styles.css')
+            ->willReturn($cssAsset);
+
+        $compiler = new JavaScriptImportPathCompiler($importMapConfigReader, AssetCompilerInterface::MISSING_IMPORT_STRICT, new NullLogger());
+        $input = "import 'some-package/styles.css';";
+        $this->assertSame($input, $compiler->compile($input, $appAsset, $assetMapper));
+        $this->assertCount(1, $appAsset->getJavaScriptImports());
+    }
+
     /**
      * @dataProvider provideMissingImportModeTests
      */
@@ -641,6 +669,60 @@ class JavaScriptImportPathCompilerTest extends TestCase
         yield 'importing_a_url_is_ignored' => [
             'sourceLogicalName' => 'app.js',
             'input' => "import 'https://example.com/other.js';",
+            'expectedExceptionMessage' => null,
+        ];
+
+        yield 'importing_a_bare_module_is_ignored_because_it_could_be_a_url' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "import 'lodash';",
+            'expectedExceptionMessage' => null,
+        ];
+
+        yield 'importing_a_bare_js_package_whose_name_ends_in_dot_js_is_ignored' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "import 'chart.js';",
+            'expectedExceptionMessage' => null,
+        ];
+
+        yield 'importing_a_missing_bare_css_file_throws_exception' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "import 'some-package/styles.css';",
+            'expectedExceptionMessage' => 'Unable to find asset "some-package/styles.css" imported from "/path/to/app.js". Add it to "importmap.php", e.g. via the "importmap:require" command.',
+        ];
+
+        yield 'dynamic_importing_a_missing_bare_css_file_throws_exception' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "await import('some-package/styles.css');",
+            'expectedExceptionMessage' => 'Unable to find asset "some-package/styles.css" imported from "/path/to/app.js". Add it to "importmap.php", e.g. via the "importmap:require" command.',
+        ];
+
+        yield 'importing_a_css_file_from_a_url_is_ignored' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "import 'https://example.com/styles.css';",
+            'expectedExceptionMessage' => null,
+        ];
+
+        yield 'importing_a_missing_bare_css_file_with_uppercase_extension_throws_exception' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "import 'some-package/styles.CSS';",
+            'expectedExceptionMessage' => 'Unable to find asset "some-package/styles.CSS" imported from "/path/to/app.js". Add it to "importmap.php", e.g. via the "importmap:require" command.',
+        ];
+
+        yield 'importing_a_missing_bare_json_file_throws_exception' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "import data from 'some-package/data.json';",
+            'expectedExceptionMessage' => 'Unable to find asset "some-package/data.json" imported from "/path/to/app.js". Add it to "importmap.php", e.g. via the "importmap:require" command.',
+        ];
+
+        yield 'dynamic_importing_a_missing_bare_json_file_throws_exception' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "await import('some-package/data.json');",
+            'expectedExceptionMessage' => 'Unable to find asset "some-package/data.json" imported from "/path/to/app.js". Add it to "importmap.php", e.g. via the "importmap:require" command.',
+        ];
+
+        yield 'importing_a_json_file_from_a_url_is_ignored' => [
+            'sourceLogicalName' => 'app.js',
+            'input' => "import data from 'https://example.com/data.json';",
             'expectedExceptionMessage' => null,
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64051
| License       | MIT

A bare specifier that isn't in `importmap.php` can't be resolved by the browser at all, yet `JavaScriptImportPathCompiler` skips warning for *any* bare import — the historical rationale being that a bare name *could* still be a valid URL at runtime. For CSS and JSON that exception hides a real bug: the browser can only load a CSS or JSON module by bare name through an importmap entry, so a missing one produces no network request, no error, no warning — just missing styles / undefined data at runtime. That's what #64051 reports:

```js
// works — present in importmap.php
import 'some-package/css/styles.min.css';

// silently dropped — NOT in importmap.php
try {
  await import('some-optional-package/css/styles.min.css');
} catch {}
```

This PR narrows the "could be a URL" exception: when a bare import ends in `.css` or `.json` (case-insensitive) and contains no `://`, it's routed through `handleMissingImport()` like relative-import misses already are — so `MISSING_IMPORT_WARN` (the default) logs the missing entry at compile time and `MISSING_IMPORT_STRICT` throws. Behavior is unchanged for `import 'lodash'`, `import 'chart.js'` (a package whose name merely ends in `.js`), `import 'https://cdn.example.com/foo.css'`, and for imports inside vendor assets.

Repro from the linked issue (fresh project): the CSS module is registered in the bundle's importmap but the sub-path is not — `await import('foo/bar.css')` resolves successfully without loading the stylesheet, page renders without styles. With this patch the missing sub-path is reported at compile time.

Limitations: detection is by `.css`/`.json` suffix only — query strings (`foo.css?v=2`) and `.scss`/`.sass` (not natively supported by AssetMapper, and typically compiled out-of-band by symfonycasts/sass-bundle) are unchanged. The import-attributes syntax (`with { type: 'css' | 'json' }`) is the eventual browser-native answer but isn't yet broadly available.
