### PR TITLE
[FrameworkBundle] Bump Request/Session value resolver priority above EntityValueResolver

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.php
@@ -80,10 +80,13 @@ return static function (ContainerConfigurator $container) {
             ->tag('controller.argument_value_resolver', ['priority' => 100, 'name' => RequestAttributeValueResolver::class])
 
         ->set('argument_resolver.request', RequestValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 50, 'name' => RequestValueResolver::class])
+            // Run before EntityValueResolver (DoctrineBundle, priority 110) so type-hinted
+            // Request arguments do not trigger entity-manager bootstrap. Keep this above
+            // DoctrineBundle's EntityValueResolver priority if it ever changes.
+            ->tag('controller.argument_value_resolver', ['priority' => 120, 'name' => RequestValueResolver::class])
 
         ->set('argument_resolver.session', SessionValueResolver::class)
-            ->tag('controller.argument_value_resolver', ['priority' => 50, 'name' => SessionValueResolver::class])
+            ->tag('controller.argument_value_resolver', ['priority' => 120, 'name' => SessionValueResolver::class])
 
         ->set('argument_resolver.service', ServiceValueResolver::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -172,6 +172,22 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame(ArrayAdapter::class, $cache->getClass(), 'ArrayAdapter should be used in debug mode');
     }
 
+    public function testRequestAndSessionValueResolversRunBeforeEntityValueResolver()
+    {
+        $container = $this->createContainerFromFile('full');
+
+        // DoctrineBundle ships EntityValueResolver at priority 110. Lower priorities trigger an
+        // entity-manager bootstrap on every Request/Session controller argument before the
+        // dedicated resolver is asked, costing tens of ms per request.
+        $entityValueResolverPriority = 110;
+
+        $requestTag = $container->getDefinition('argument_resolver.request')->getTag('controller.argument_value_resolver');
+        $this->assertGreaterThan($entityValueResolverPriority, $requestTag[0]['priority']);
+
+        $sessionTag = $container->getDefinition('argument_resolver.session')->getTag('controller.argument_value_resolver');
+        $this->assertGreaterThan($entityValueResolverPriority, $sessionTag[0]['priority']);
+    }
+
     public function testCsrfProtectionNeedsSessionToBeEnabled()
     {
         $this->expectException(\LogicException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54337
| License       | MIT

`argument_resolver.request` and `argument_resolver.session` ship with priority `50` in `FrameworkBundle/Resources/config/web.php`. DoctrineBundle's `EntityValueResolver` is registered at priority `110`, so for every controller argument — including the very common `Request` and `Session` ones — `EntityValueResolver::supports()` is invoked first and triggers an entity-manager bootstrap before the dedicated resolver is asked.

The reporter measures a 40-50 ms latency hit per request on a fresh `symfony/skeleton` + `symfony/webapp-pack`. Bumping the priority of both resolvers to `120` puts them above `EntityValueResolver`, so they short-circuit for `Request`/`Session` arguments without touching Doctrine.

Behavior outside of `Request`/`Session` is unchanged: `EntityValueResolver` remains the first responder for entity-typed arguments.

This re-opens the same fix proposed in #54374 (closed by its author with no maintainer objection); @stof had asked for `SessionValueResolver` to be bumped too — already done here.

Test asserts `argument_resolver.request` and `argument_resolver.session` are tagged with a priority strictly greater than `EntityValueResolver`'s `110` in all three extension test variants (php / xml / yaml). Verified locally: reverting the priority bump makes the test fail 3/3.
