### PR TITLE
[JsonStreamer] Add a "cache_variant" option to the generated cache file name

### DIFF
--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `BcMath\Number` value object support with `BcMathNumberValueObjectTransformer`
  * Add `GMP` value object support with `GmpNumberValueObjectTransformer`
+ * Add a `cache_variant` option that partitions the generated code cache, so a custom property metadata loader can produce several payload shapes for the same PHP type
 
 8.1
 ---

--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -40,8 +40,14 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
  *     date_time_format?: string,
  *     date_time_timezone?: string|\DateTimeZone,
  *     date_interval_format?: string,
+ *     cache_variant?: string,
  *     ...<string, mixed>,
  * }
+ *
+ * The "cache_variant" option does not change the output on its own. It is appended to the
+ * name of the generated code cache file, so that a custom property metadata loader can
+ * produce several payload shapes for one PHP type without them overwriting each other.
+ * It must match "[a-zA-Z0-9_-]+".
  *
  * @implements StreamReaderInterface<Options>
  */

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -39,8 +39,14 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
  *     date_time_timezone?: string|\DateTimeZone,
  *     date_interval_format?: string,
  *     include_null_properties?: bool,
+ *     cache_variant?: string,
  *     ...<string, mixed>,
  * }
+ *
+ * The "cache_variant" option does not change the output on its own. It is appended to the
+ * name of the generated code cache file, so that a custom property metadata loader can
+ * produce several payload shapes for one PHP type without them overwriting each other.
+ * It must match "[a-zA-Z0-9_-]+".
  *
  * @implements StreamWriterInterface<Options>
  */

--- a/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
@@ -19,6 +19,7 @@ use Symfony\Component\JsonStreamer\DataModel\Read\CompositeNode;
 use Symfony\Component\JsonStreamer\DataModel\Read\DataModelNodeInterface;
 use Symfony\Component\JsonStreamer\DataModel\Read\ObjectNode;
 use Symfony\Component\JsonStreamer\DataModel\Read\ScalarNode;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
 use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnsupportedException;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
@@ -61,7 +62,7 @@ final class StreamReaderGenerator
      */
     public function generate(Type $type, bool $decodeFromStream, array $options = []): string
     {
-        $path = \sprintf('%s%s%s.json%s.php', $this->streamReadersDir, \DIRECTORY_SEPARATOR, hash('xxh128', (string) $type), $decodeFromStream ? '.stream' : '');
+        $path = \sprintf('%s%s%s.%s%s.php', $this->streamReadersDir, \DIRECTORY_SEPARATOR, hash('xxh128', (string) $type), self::cacheVariant($options), $decodeFromStream ? '.stream' : '');
         $generateContent = function () use ($type, $decodeFromStream, $options): string {
             $this->phpGenerator ??= new PhpGenerator($this->transformers);
 
@@ -71,6 +72,22 @@ final class StreamReaderGenerator
         $this->dumper->dump($type, $path, $generateContent);
 
         return $path;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private static function cacheVariant(array $options): string
+    {
+        $variant = $options['cache_variant'] ?? 'json';
+
+        // the value ends up in the cache file name, before the ".stream" marker,
+        // so it must neither reach the filesystem unchecked nor shadow that marker
+        if (!\is_string($variant) || !preg_match('/^[a-zA-Z0-9_-]++$/', $variant)) {
+            throw new InvalidArgumentException(\sprintf('The "cache_variant" option must match "[a-zA-Z0-9_-]+", "%s" given.', \is_string($variant) ? $variant : get_debug_type($variant)));
+        }
+
+        return $variant;
     }
 
     /**

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\JsonStreamer\Tests\Read;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
 use Symfony\Component\JsonStreamer\Exception\LogicException;
 use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnsupportedException;
@@ -264,5 +265,77 @@ class StreamReaderGeneratorTest extends TestCase
         $this->expectExceptionMessageMatches('/Cannot generate accessor for anonymous function ".*\{closure[^"]*"\./');
 
         $generator->generate($type, false);
+    }
+
+    public function testCacheVariantOptionProducesDistinctFiles()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $loader = new class implements PropertyMetadataLoaderInterface {
+            public function load(string $className, array $options = [], array $context = []): array
+            {
+                $properties = ['id' => new PropertyMetadata('id', Type::int())];
+
+                if ($options['extra'] ?? false) {
+                    $properties['name'] = new PropertyMetadata('name', Type::string());
+                }
+
+                return $properties;
+            }
+        };
+
+        $generator = new StreamReaderGenerator($loader, new ServiceContainer(), $this->streamReadersDir);
+
+        $pathDefault = $generator->generate($type, false);
+        $pathVariant = $generator->generate($type, false, ['extra' => true, 'cache_variant' => 'jsonld']);
+
+        $this->assertNotSame($pathDefault, $pathVariant);
+        $this->assertStringEndsWith('.json.php', $pathDefault);
+        $this->assertStringEndsWith('.jsonld.php', $pathVariant);
+        $this->assertFileNotEquals($pathDefault, $pathVariant);
+    }
+
+    public function testFilenameIsStableWithoutCacheVariantOption()
+    {
+        $generator = new StreamReaderGenerator(new PropertyMetadataLoader(TypeResolver::create()), new ServiceContainer(), $this->streamReadersDir);
+        $type = Type::object(ClassicDummy::class);
+
+        $this->assertSame($generator->generate($type, false), $generator->generate($type, false, ['include_null_properties' => true]));
+        $this->assertStringEndsWith('.json.php', $generator->generate($type, false));
+        $this->assertStringEndsWith('.json.stream.php', $generator->generate($type, true));
+    }
+
+    public function testCacheVariantOptionCannotShadowTheStreamMarker()
+    {
+        $generator = new StreamReaderGenerator(new PropertyMetadataLoader(TypeResolver::create()), new ServiceContainer(), $this->streamReadersDir);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $generator->generate(Type::object(ClassicDummy::class), false, ['cache_variant' => 'json.stream']);
+    }
+
+    #[DataProvider('invalidCacheVariants')]
+    public function testCacheVariantOptionRejectsInvalidValues(mixed $variant)
+    {
+        $generator = new StreamReaderGenerator(new PropertyMetadataLoader(TypeResolver::create()), new ServiceContainer(), $this->streamReadersDir);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "cache_variant" option must match "[a-zA-Z0-9_-]+"');
+
+        $generator->generate(Type::object(ClassicDummy::class), false, ['cache_variant' => $variant]);
+    }
+
+    public static function invalidCacheVariants(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'directory separator' => ['a/b'];
+        yield 'parent directory' => ['../../escaped'];
+        yield 'dot' => ['json.stream'];
+        yield 'null byte' => ["json\0evil"];
+        yield 'newline' => ["json\nld"];
+        yield 'non-ascii' => ['jsonld✓'];
+        yield 'array' => [['a']];
+        yield 'true' => [true];
+        yield 'integer' => [1];
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\JsonStreamer\Tests\Write;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
 use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnsupportedException;
 use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
@@ -216,5 +217,67 @@ class StreamWriterGeneratorTest extends TestCase
         $this->expectExceptionMessageMatches('/Cannot generate accessor for anonymous function ".*\{closure[^"]*"\./');
 
         $generator->generate($type);
+    }
+
+    public function testCacheVariantOptionProducesDistinctFiles()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $loader = new class implements PropertyMetadataLoaderInterface {
+            public function load(string $className, array $options = [], array $context = []): array
+            {
+                $properties = ['id' => new PropertyMetadata('id', Type::int())];
+
+                if ($options['extra'] ?? false) {
+                    $properties['name'] = new PropertyMetadata('name', Type::string());
+                }
+
+                return $properties;
+            }
+        };
+
+        $generator = new StreamWriterGenerator($loader, new ServiceContainer(), $this->streamWritersDir);
+
+        $pathDefault = $generator->generate($type);
+        $pathVariant = $generator->generate($type, ['extra' => true, 'cache_variant' => 'jsonld']);
+
+        $this->assertNotSame($pathDefault, $pathVariant);
+        $this->assertStringEndsWith('.json.php', $pathDefault);
+        $this->assertStringEndsWith('.jsonld.php', $pathVariant);
+        $this->assertFileNotEquals($pathDefault, $pathVariant);
+    }
+
+    public function testFilenameIsStableWithoutCacheVariantOption()
+    {
+        $generator = new StreamWriterGenerator(new PropertyMetadataLoader(TypeResolver::create()), new ServiceContainer(), $this->streamWritersDir);
+        $type = Type::object(ClassicDummy::class);
+
+        $this->assertSame($generator->generate($type), $generator->generate($type, ['include_null_properties' => true]));
+        $this->assertStringEndsWith('.json.php', $generator->generate($type));
+    }
+
+    #[DataProvider('invalidCacheVariants')]
+    public function testCacheVariantOptionRejectsInvalidValues(mixed $variant)
+    {
+        $generator = new StreamWriterGenerator(new PropertyMetadataLoader(TypeResolver::create()), new ServiceContainer(), $this->streamWritersDir);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "cache_variant" option must match "[a-zA-Z0-9_-]+"');
+
+        $generator->generate(Type::object(ClassicDummy::class), ['cache_variant' => $variant]);
+    }
+
+    public static function invalidCacheVariants(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'directory separator' => ['a/b'];
+        yield 'parent directory' => ['../../escaped'];
+        yield 'dot' => ['json.stream'];
+        yield 'null byte' => ["json\0evil"];
+        yield 'newline' => ["json\nld"];
+        yield 'non-ascii' => ['jsonld✓'];
+        yield 'array' => [['a']];
+        yield 'true' => [true];
+        yield 'integer' => [1];
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
@@ -19,6 +19,7 @@ use Symfony\Component\JsonStreamer\DataModel\Write\CompositeNode;
 use Symfony\Component\JsonStreamer\DataModel\Write\DataModelNodeInterface;
 use Symfony\Component\JsonStreamer\DataModel\Write\ObjectNode;
 use Symfony\Component\JsonStreamer\DataModel\Write\ScalarNode;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
 use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnsupportedException;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
@@ -61,7 +62,7 @@ final class StreamWriterGenerator
      */
     public function generate(Type $type, array $options = []): string
     {
-        $path = \sprintf('%s%s%s.json.php', $this->streamWritersDir, \DIRECTORY_SEPARATOR, hash('xxh128', (string) $type));
+        $path = \sprintf('%s%s%s.%s.php', $this->streamWritersDir, \DIRECTORY_SEPARATOR, hash('xxh128', (string) $type), self::cacheVariant($options));
         $generateContent = function () use ($type, $options): string {
             $this->phpGenerator ??= new PhpGenerator($this->transformers);
 
@@ -71,6 +72,21 @@ final class StreamWriterGenerator
         $this->dumper->dump($type, $path, $generateContent);
 
         return $path;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private static function cacheVariant(array $options): string
+    {
+        $variant = $options['cache_variant'] ?? 'json';
+
+        // the value ends up in the cache file name, so it must not reach the filesystem unchecked
+        if (!\is_string($variant) || !preg_match('/^[a-zA-Z0-9_-]++$/', $variant)) {
+            throw new InvalidArgumentException(\sprintf('The "cache_variant" option must match "[a-zA-Z0-9_-]+", "%s" given.', \is_string($variant) ? $variant : get_debug_type($variant)));
+        }
+
+        return $variant;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Adds a `cache_variant` option that is appended to the name of the generated code cache file, so `<hash>.json.php` becomes `<hash>.jsonld.php`.

The option changes nothing on its own: passing it alone produces two files with identical contents. It is a cache-partition key. Every other option in the `Options` typedef (`include_null_properties`, `date_time_format`, `date_interval_format`) is read by the generated code at call time, so one cache file serves every value of them. A custom `PropertyMetadataLoaderInterface` is different: it runs at compile time, so when it varies the property set by option, the two shapes need two cache files. Without this option the second shape silently overwrites the first.

The motivating case is API Platform, which serves several representations of one PHP class.

Added during review:

* the value is validated against `[a-zA-Z0-9_-]+`. It used to be spliced straight into a path, so `'a/b'` created a subdirectory, an array produced `<hash>.Array.php` after an `Array to string conversion` warning, and a null byte reached `tempnam()`. No path escape was achievable, but the stated use case is content negotiation, and a caller that forwards a negotiated format string should not be handing request data to `sprintf` on a path;
* the same check closes a collision on the reader side. The reader builds `<hash>.<variant><.stream|>.php`, so a string read with `cache_variant` set to `json.stream` resolved to the same file as a stream read with the default variant, and the mismatched closure then failed with `Argument #3 ($instantiator) must be of type LazyInstantiator, Instantiator given`;
* the CHANGELOG entry moved from the `8.1` section to `8.2`, and now says what the option does rather than implying it changes the output;
* both `JsonStreamReader` and `JsonStreamWriter` now document the option next to the typedef that declares it. It is public, and it is settable from `framework.json_streamer.default_options`, so `cache_variant?: string` on its own was not enough for a reader to tell a cache key from an output switch;
* the assertions dropped in the last commit are restored: `assertNotSame($pathDefault, $pathVariant)`, `assertStringEndsWith('.jsonld.php', ...)` and `testFilenameIsStableWithoutCacheVariantOption` on both sides. Without them the surviving test passed for the wrong reason, since the two files differ in content only because the test also sets an option its metadata loader acts on.

Default behaviour is unchanged: generated code, file names and output are byte-identical when the option is unset, and a cache warmed before the upgrade is reused untouched.

One thing for the merger.

**`StreamerCacheWarmer` ignores the option.** It always generates `.json.php`, so an application that sets `cache_variant` in `framework.json_streamer.default_options` gets warmed files that are never read, and compiles every type on the first request instead. That breaks on a read-only cache directory. Left as is here because the fix belongs in FrameworkBundle, but it should not ship unnoticed.

The option was called `format_variant` earlier in the review. It was renamed because it would have sat next to `date_time_format`, `date_interval_format` and, once #64714 lands, `uid_format`, which are all runtime output knobs, while this one is a compile-time cache discriminator that changes nothing by itself.

#64714 touches the same `@psalm-type Options` block in `JsonStreamReader`, one line apart. Keeping both lines resolves it; the two features are otherwise orthogonal, since `uid_format` is a runtime option and does not interact with the cache key.
