### PR TITLE
[Mailer] Use `hash_equals()` to compare webhook signatures for AhaSend

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
@@ -50,7 +50,7 @@ final class AhaSendRequestParser extends AbstractRequestParser
             throw new RejectWebhookException(406, 'Invalid timestamp.');
         }
         $expectedSignature = $this->sign($eventID, $timestamp, $request->getContent(), $secret);
-        if ($signature !== $expectedSignature) {
+        if (!hash_equals($expectedSignature, $signature)) {
             throw new RejectWebhookException(406, 'Invalid signature');
         }
         if (!isset($payload['type']) || !isset($payload['timestamp']) || !(isset($payload['data']))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
