### PR TITLE
[Notifier] Use `hash_equals()` to compare webhook signatures for Vonage

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Vonage/Webhook/VonageRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/Webhook/VonageRequestParser.php
@@ -83,7 +83,8 @@ final class VonageRequestParser extends AbstractRequestParser
         }
 
         [$header, $payload, $signature] = $tokenParts;
-        if ($signature !== $this->base64EncodeUrl(hash_hmac('sha256', $header.'.'.$payload, $secret, true))) {
+        $expected = $this->base64EncodeUrl(hash_hmac('sha256', $header.'.'.$payload, $secret, true));
+        if (!hash_equals($expected, $signature)) {
             throw new RejectWebhookException(406, 'Signature is wrong.');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
