### PR TITLE
[Security] Remove the legacy nested unserialize() call from token and exception classes

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -50,7 +50,6 @@ class PreAuthenticatedToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [, $this->firewallName, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -65,7 +65,6 @@ class RememberMeToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->secret, $this->firewallName, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
@@ -60,7 +60,6 @@ class SwitchUserToken extends UsernamePasswordToken
         } else {
             [$this->originalToken, $this->originatedFromUri, $parentData] = $data;
         }
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -47,7 +47,6 @@ class UsernamePasswordToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [, $this->firewallName, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -48,7 +48,6 @@ abstract class AccountStatusException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$this->user, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -64,7 +64,6 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$parentData, $this->messageKey, $this->messageData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
@@ -47,7 +47,6 @@ class TooManyLoginAttemptsAuthenticationException extends AuthenticationExceptio
     public function __unserialize(array $data): void
     {
         [$this->threshold, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
@@ -55,7 +55,6 @@ class UserNotFoundException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$this->identifier, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -38,6 +38,18 @@ class RememberMeTokenTest extends TestCase
         );
     }
 
+    public function testUnserializeRejectsLegacyStringParentData()
+    {
+        $token = new RememberMeToken($this->getUser(), 'fookey', 'foo');
+        $data = $token->__serialize();
+        $data[2] = serialize($data[2]);
+
+        $token = new RememberMeToken($this->getUser(), 'fookey', 'foo');
+
+        $this->expectException(\TypeError::class);
+        $token->__unserialize($data);
+    }
+
     protected function getUser($roles = ['ROLE_FOO'])
     {
         return new InMemoryUser('John', 'password', $roles);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This was added in https://github.com/symfony/symfony/pull/36862 to provide BC for payloads that date back to 3.4.

Ppl that upgrade from 3.4 should go through 4.4 then 5.4 before upgrading to 6.4 as that's the only supported upgrade path. That means they have plenty of opportunities to upgrade their session data. Ppl already on 4.4+ don't have legacy payloads in their storage anymore.
