### PR TITLE
[Messenger] Ensure SigningSerializer won't decode before verifying the signature

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -113,6 +113,26 @@ class PhpSerializerTest extends TestCase
         $this->assertEquals($envelope, $serializer->decode($encoded));
     }
 
+    public function testGetMessageType()
+    {
+        $serializer = $this->createPhpSerializer();
+
+        $this->assertSame(DummyMessage::class, $serializer->getMessageType($serializer->encode(new Envelope(new DummyMessage('Hello')))));
+        // base64-encoded body (non-UTF8 payload)
+        $this->assertSame(DummyMessage::class, $serializer->getMessageType($serializer->encode(new Envelope(new DummyMessage("\xE9")))));
+    }
+
+    public function testGetMessageTypeReturnsNullForUndeterminableBody()
+    {
+        $serializer = $this->createPhpSerializer();
+
+        $this->assertNull($serializer->getMessageType([]));
+        $this->assertNull($serializer->getMessageType(['body' => '']));
+        $this->assertNull($serializer->getMessageType(['body' => 'definitely not serialized data']));
+        $this->assertNull($serializer->getMessageType(['body' => addslashes(serialize(123))]));
+        $this->assertNull($serializer->getMessageType(['body' => addslashes(serialize(new DummyMessage('Hello')))]));
+    }
+
     protected function createPhpSerializer(): PhpSerializer
     {
         return new PhpSerializer();

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -76,6 +76,15 @@ class SerializerTest extends TestCase
         $this->assertSame('application/json', $encoded['headers']['Content-Type']);
     }
 
+    public function testGetMessageType()
+    {
+        $serializer = new Serializer();
+
+        $this->assertSame(DummyMessage::class, $serializer->getMessageType($serializer->encode(new Envelope(new DummyMessage('Hello')))));
+        $this->assertNull($serializer->getMessageType(['body' => '{}']));
+        $this->assertNull($serializer->getMessageType(['body' => '{}', 'headers' => []]));
+    }
+
     public function testUsesTheCustomFormatAndContext()
     {
         $message = new DummyMessage('Foo');

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Exception\InvalidMessageSignatureException;
 use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
+use Symfony\Component\Messenger\Transport\Serialization\MessageTypeAwareSerializerInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SigningSerializer;
@@ -80,6 +81,162 @@ class SigningSerializerTest extends TestCase
         $serializer->decode($encoded);
     }
 
+    public function testDecodeDoesNotInvokeInnerSerializerWhenSignatureIsInvalid()
+    {
+        $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {
+            public bool $decoded = false;
+
+            public function getMessageType(array $encodedEnvelope): ?string
+            {
+                return DummyMessage::class;
+            }
+
+            public function decode(array $encodedEnvelope): Envelope
+            {
+                $this->decoded = true;
+
+                return new Envelope(new DummyMessage('hello'));
+            }
+
+            public function encode(Envelope $envelope): array
+            {
+                return ['body' => 'irrelevant'];
+            }
+        };
+
+        $serializer = new SigningSerializer($inner, 'secret-key', [DummyMessage::class]);
+
+        try {
+            $serializer->decode(['body' => 'irrelevant', 'headers' => ['Body-Sign' => 'tampered', 'Sign-Algo' => 'sha256']]);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', InvalidMessageSignatureException::class));
+        } catch (InvalidMessageSignatureException) {
+        }
+
+        $this->assertFalse($inner->decoded, 'The inner serializer must not be invoked when a signed message has an invalid signature.');
+    }
+
+    public function testDecodeRejectsMissingSignatureBeforeInvokingTypeAwareInnerSerializer()
+    {
+        $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {
+            public bool $decoded = false;
+
+            public function getMessageType(array $encodedEnvelope): ?string
+            {
+                return $encodedEnvelope['headers']['type'] ?? null;
+            }
+
+            public function decode(array $encodedEnvelope): Envelope
+            {
+                $this->decoded = true;
+
+                return new Envelope(new DummyMessage('hello'));
+            }
+
+            public function encode(Envelope $envelope): array
+            {
+                return ['body' => 'irrelevant', 'headers' => ['type' => $envelope->getMessage()::class]];
+            }
+        };
+
+        $serializer = new SigningSerializer($inner, 'secret-key', [DummyMessage::class]);
+
+        try {
+            $serializer->decode(['body' => 'irrelevant', 'headers' => ['type' => DummyMessage::class]]);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', InvalidMessageSignatureException::class));
+        } catch (InvalidMessageSignatureException) {
+        }
+
+        $this->assertFalse($inner->decoded, 'A signed message arriving without a signature must be rejected before the inner serializer is invoked.');
+    }
+
+    public function testDecodeDoesNotRejectUnsignedTypeReportedByTypeAwareInnerSerializer()
+    {
+        $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {
+            public function getMessageType(array $encodedEnvelope): ?string
+            {
+                return $encodedEnvelope['headers']['type'] ?? null;
+            }
+
+            public function decode(array $encodedEnvelope): Envelope
+            {
+                return new Envelope(new DummyMessage('hello'));
+            }
+
+            public function encode(Envelope $envelope): array
+            {
+                return ['body' => 'irrelevant', 'headers' => ['type' => $envelope->getMessage()::class]];
+            }
+        };
+
+        $serializer = new SigningSerializer($inner, 'secret-key', []);
+
+        // a stray (and here invalid) signature on a type that is not configured for signing is ignored
+        $decoded = $serializer->decode(['body' => 'irrelevant', 'headers' => ['type' => DummyMessage::class, 'Body-Sign' => 'not-a-valid-signature', 'Sign-Algo' => 'sha256']]);
+        $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
+    }
+
+    public function testDecodeRejectsMessageWithoutSignatureWhenTypeAwareInnerSerializerCannotDetermineType()
+    {
+        $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {
+            public bool $decoded = false;
+
+            public function getMessageType(array $encodedEnvelope): ?string
+            {
+                return null;
+            }
+
+            public function decode(array $encodedEnvelope): Envelope
+            {
+                $this->decoded = true;
+
+                return new Envelope(new DummyMessage('hello'));
+            }
+
+            public function encode(Envelope $envelope): array
+            {
+                return ['body' => 'irrelevant'];
+            }
+        };
+
+        $serializer = new SigningSerializer($inner, 'secret-key', [DummyMessage::class]);
+
+        try {
+            $serializer->decode(['body' => 'irrelevant']);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', InvalidMessageSignatureException::class));
+        } catch (InvalidMessageSignatureException) {
+        }
+
+        $this->assertFalse($inner->decoded, 'A message whose type cannot be determined and that carries no signature must not be decoded.');
+    }
+
+    public function testDecodeAcceptsValidSignatureRegardlessOfReportedType()
+    {
+        $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {
+            public function getMessageType(array $encodedEnvelope): ?string
+            {
+                return null; // not consulted: a valid signature is enough
+            }
+
+            public function decode(array $encodedEnvelope): Envelope
+            {
+                return new Envelope(new DummyMessage('hello'));
+            }
+
+            public function encode(Envelope $envelope): array
+            {
+                return ['body' => 'the-body'];
+            }
+        };
+
+        $serializer = new SigningSerializer($inner, 'secret-key', [DummyMessage::class]);
+
+        $decoded = $serializer->decode([
+            'body' => 'the-body',
+            'headers' => ['Body-Sign' => hash_hmac('sha256', 'the-body', 'secret-key'), 'Sign-Algo' => 'sha256'],
+        ]);
+        $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
+    }
+
     public function testEncodeSignsWhenSignedTypeIsInterfaceImplementedByMessage()
     {
         $serializer = $this->createSerializer([DummyMessageInterface::class]);
@@ -95,7 +252,6 @@ class SigningSerializerTest extends TestCase
     public function testDecodeVerifiesWhenSignedTypeIsParentClassOfMessage()
     {
         $serializer = $this->createSerializer([DummyMessage::class]);
-        $inner = new PhpSerializer();
 
         // Encode with signature by using the SigningSerializer against a child instance
         $encoded = $serializer->encode(new Envelope(new ChildDummyMessage('child')));

--- a/src/Symfony/Component/Messenger/Transport/Serialization/MessageTypeAwareSerializerInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/MessageTypeAwareSerializerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization;
+
+/**
+ * Implemented by serializers that can tell the class of the carried message
+ * from the encoded envelope, without instantiating the payload.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface MessageTypeAwareSerializerInterface
+{
+    /**
+     * Returns the FQCN of the message carried by the encoded envelope.
+     *
+     * Implementations MUST determine the class from the encoded metadata only:
+     * they MUST NOT unserialize or otherwise instantiate the payload, and MUST
+     * be side-effect free.
+     *
+     * Returning null signals that the envelope is not recognizable under these
+     * constraints; consumers may treat such an envelope as untrusted (e.g. refuse
+     * to decode it unless it carries a valid signature). Implementations SHOULD
+     * therefore return the actual class for every well-formed envelope they can
+     * produce, reserving null for malformed or unrecognized input.
+     *
+     * @param array{body: string, headers?: array<string, string>} $encodedEnvelope
+     *
+     * @return class-string|null
+     */
+    public function getMessageType(array $encodedEnvelope): ?string;
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -19,7 +19,7 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 /**
  * @author Ryan Weaver<ryan@symfonycasts.com>
  */
-class PhpSerializer implements SerializerInterface
+class PhpSerializer implements SerializerInterface, MessageTypeAwareSerializerInterface
 {
     private bool $acceptPhpIncompleteClass = false;
 
@@ -52,6 +52,33 @@ class PhpSerializer implements SerializerInterface
         $serializeEnvelope = stripslashes($encodedEnvelope['body']);
 
         return $this->safelyUnserialize($serializeEnvelope);
+    }
+
+    public function getMessageType(array $encodedEnvelope): ?string
+    {
+        if (!\is_string($body = $encodedEnvelope['body'] ?? null) || '' === $body) {
+            return null;
+        }
+
+        if (!str_ends_with($body, '}') && false === $body = base64_decode($body, true)) {
+            return null;
+        }
+
+        try {
+            // Allowing only Envelope means the carried message (and any stamp) becomes a
+            // \__PHP_Incomplete_Class, so no constructor/__wakeup/__unserialize runs.
+            $envelope = @unserialize(stripslashes($body), ['allowed_classes' => [Envelope::class]]);
+
+            if (!$envelope instanceof Envelope) {
+                return null;
+            }
+
+            $message = $envelope->getMessage();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $message instanceof \__PHP_Incomplete_Class ? ((array) $message)['__PHP_Incomplete_Class_Name'] : $message::class;
     }
 
     public function encode(Envelope $envelope): array

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -32,7 +32,7 @@ use Symfony\Component\Serializer\SerializerInterface as SymfonySerializerInterfa
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class Serializer implements SerializerInterface
+class Serializer implements SerializerInterface, MessageTypeAwareSerializerInterface
 {
     public const MESSENGER_SERIALIZATION_CONTEXT = 'messenger_serialization';
     private const STAMP_HEADER_PREFIX = 'X-Message-Stamp-';
@@ -96,6 +96,11 @@ class Serializer implements SerializerInterface
         }
 
         return new Envelope($message, $stamps);
+    }
+
+    public function getMessageType(array $encodedEnvelope): ?string
+    {
+        return $encodedEnvelope['headers']['type'] ?? null;
     }
 
     public function encode(Envelope $envelope): array

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
@@ -45,16 +45,31 @@ final class SigningSerializer implements SerializerInterface
 
     public function decode(array $encodedEnvelope): Envelope
     {
-        $envelope = $this->inner->decode($encodedEnvelope);
-        $type = $envelope->getMessage()::class;
+        $headers = $encodedEnvelope['headers'] ?? [];
+        $sign = $headers['Body-Sign'] ?? null;
 
-        if (!$this->shouldSign($type)) {
-            return $envelope;
+        if ($sign && hash_equals(hash_hmac($this->algorithm, $encodedEnvelope['body'] ?? '', $this->signingKey), $sign)) {
+            // A valid signature authenticates the message whatever its type: decode it without peeking.
+            // The algorithm is implied by the HMAC itself, so the "Sign-Algo" header isn't consulted here.
+            unset($encodedEnvelope['headers']['Body-Sign'], $encodedEnvelope['headers']['Sign-Algo']);
+
+            return $this->inner->decode($encodedEnvelope);
         }
 
-        $headers = $encodedEnvelope['headers'] ?? [];
+        $envelope = null;
 
-        if (!$sign = $headers['Body-Sign'] ?? null) {
+        if (!$this->inner instanceof MessageTypeAwareSerializerInterface) {
+            $envelope = $this->inner->decode($encodedEnvelope);
+            $type = $envelope->getMessage()::class;
+        } elseif (null === $type = $this->inner->getMessageType($encodedEnvelope)) {
+            throw new InvalidMessageSignatureException('The message could not be verified and its type could not be determined; refusing to decode it.');
+        }
+
+        if (!$this->shouldSign($type)) {
+            return $envelope ?? $this->inner->decode($encodedEnvelope);
+        }
+
+        if (!$sign) {
             throw new InvalidMessageSignatureException(\sprintf('Message "%s" requires a signature but none was found.', $type));
         }
 
@@ -62,15 +77,7 @@ final class SigningSerializer implements SerializerInterface
             throw new InvalidMessageSignatureException(\sprintf('Expected "%s" signature algorithm for message "%s", "%s" given.', $this->algorithm, $type, $algo));
         }
 
-        $expected = hash_hmac($algo, $encodedEnvelope['body'] ?? '', $this->signingKey);
-        if (!hash_equals($sign, $expected)) {
-            throw new InvalidMessageSignatureException(\sprintf('Invalid signature for message "%s".', $type));
-        }
-
-        unset($headers['Body-Sign'], $headers['Sign-Algo']);
-        $encodedEnvelope['headers'] = $headers;
-
-        return $envelope;
+        throw new InvalidMessageSignatureException(\sprintf('Invalid signature for message "%s".', $type));
     }
 
     private function shouldSign(string $type): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SigningSerializer::decode()` currently calls the inner serializer first and only then checks the HMAC, so a payload for a signed message type that carries a bad or missing signature is deserialized *before* being rejected. With `PhpSerializer` that means `unserialize()` runs regardless of the failed signature check.

This reworks `decode()` so the signature decides what happens *before* the payload is instantiated:

* a valid `Body-Sign` over the raw body → the message is authentic whatever its type → decode it;
* otherwise the message class is determined *without* deserializing.

Getting the class without deserializing is done through a new `MessageTypeAwareSerializerInterface::getMessageType(array $encodedEnvelope): ?string` method, now implemented by both `Serializer`  and `PhpSerializer`.

A serializer that doesn't implement the interface keeps today's behavior (decode, then enforce), so no BC break.

Submitted as a bugfix despite the new interface because this is a hardening missing from https://github.com/symfony/symfony/pull/62230.

We might deprecate using `SigningSerializer` with a serializer that doesn't implement `MessageTypeAwareSerializerInterface` in the next 8.x.