### PR TITLE
[SecurityBundle] Allow defining security provider factories without config

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -848,7 +848,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         foreach ($this->userProviderFactories as $factory) {
             $key = str_replace('-', '_', $factory->getKey());
 
-            if (!empty($provider[$key])) {
+            if (\array_key_exists($key, $provider)) {
                 $factory->create($container, $name, $provider[$key]);
 
                 return $name;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProvider/DummyProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProvider/DummyProvider.php
@@ -2,22 +2,27 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider;
 
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 
-class DummyProvider implements UserProviderFactoryInterface
+class DummyProvider implements UserProviderInterface
 {
-    public function create(ContainerBuilder $container, $id, $config): void
+    public function __construct(string $foo)
     {
     }
 
-    public function getKey(): string
+    public function refreshUser(UserInterface $user): UserInterface
     {
-        return 'foo';
+        throw new \Exception('Not implemented');
     }
 
-    public function addConfiguration(NodeDefinition $node): void
+    public function supportsClass(string $class): bool
     {
+        throw new \Exception('Not implemented');
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        throw new \Exception('Not implemented');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProviderFactory/CustomProviderFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProviderFactory/CustomProviderFactory.php
@@ -1,15 +1,19 @@
 <?php
 
-namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider;
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProviderFactory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\DummyProvider;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
-class CustomProvider implements UserProviderFactoryInterface
+class CustomProviderFactory implements UserProviderFactoryInterface
 {
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
+        $definition = $container->setDefinition($id, new Definition(DummyProvider::class));
+        $definition->setArgument('$foo', $config['foo']);
     }
 
     public function getKey(): string
@@ -21,7 +25,9 @@ class CustomProvider implements UserProviderFactoryInterface
     {
         $builder
             ->children()
-                ->scalarNode('foo')->defaultValue('bar')->end()
+                ->scalarNode('foo')
+                    ->defaultValue('bar')
+                ->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProviderFactory/DummyProviderFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/UserProviderFactory/DummyProviderFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProviderFactory;
+
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\DummyProvider;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DummyProviderFactory implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, $id, $config): void
+    {
+        $container->setDefinition($id, new Definition(DummyProvider::class));
+    }
+
+    public function getKey(): string
+    {
+        return 'foo';
+    }
+
+    public function addConfiguration(NodeDefinition $node): void
+    {
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -17,7 +17,8 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\Authentic
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
-use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\DummyProvider;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProviderFactory\CustomProviderFactory;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProviderFactory\DummyProviderFactory;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -68,16 +69,50 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
     }
 
+    public function testFirewallWithCustomUserProvider()
+    {
+        $container = $this->getRawContainer();
+
+        $extension = $container->getExtension('security');
+        $extension->addUserProviderFactory(new CustomProviderFactory());
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'my_app_provider' => [
+                    'custom' => [
+                        'foo' => 'baz',
+                    ],
+                ],
+            ],
+
+            'firewalls' => [
+                'some_firewall' => [
+                    'pattern' => '/.*',
+                    'http_basic' => [],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertTrue($container->hasDefinition('security.user.provider.concrete.my_app_provider'));
+        $this->assertEquals('baz', $container->getDefinition('security.user.provider.concrete.my_app_provider')->getArgument('$foo'));
+    }
+
     public function testFirewallWithInvalidUserProvider()
     {
         $container = $this->getRawContainer();
 
         $extension = $container->getExtension('security');
-        $extension->addUserProviderFactory(new DummyProvider());
+        $extension->addUserProviderFactory(new CustomProviderFactory());
 
         $container->loadFromExtension('security', [
             'providers' => [
-                'my_foo' => ['foo' => []],
+                'my_app_provider' => [
+                    'some_other' => [
+                        'bar' => 'baz',
+                    ],
+                ],
             ],
 
             'firewalls' => [
@@ -89,9 +124,72 @@ class SecurityExtensionTest extends TestCase
         ]);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Unable to create definition for "security.user.provider.concrete.my_foo" user provider');
+        $this->expectExceptionMessage('Unrecognized option "some_other" under "security.providers.my_app_provider". Available options are "chain", "custom", "id", "ldap", "memory".');
 
         $container->compile();
+    }
+
+    public function testFirewallWithInvalidUserProviderConfig()
+    {
+        $container = $this->getRawContainer();
+
+        $extension = $container->getExtension('security');
+        $extension->addUserProviderFactory(new CustomProviderFactory());
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'my_app_provider' => [
+                    'custom' => [
+                        'bar' => 'baz',
+                    ],
+                ],
+            ],
+
+            'firewalls' => [
+                'some_firewall' => [
+                    'pattern' => '/.*',
+                    'http_basic' => [],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Unrecognized option "bar" under "security.providers.my_app_provider.custom". Available option is "foo".');
+
+        $container->compile();
+    }
+
+    public function testFirewallWithUserProviderWithoutConfig()
+    {
+        $container = $this->getRawContainer();
+
+        $extension = $container->getExtension('security');
+        $extension->addUserProviderFactory(new DummyProviderFactory());
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'my_app_provider' => [
+                    'foo' => null,
+                ],
+                'my_other_app_provider' => [
+                    'foo' => [],
+                ],
+            ],
+
+            'firewalls' => [
+                'some_firewall' => [
+                    'pattern' => '/.*',
+                    'http_basic' => [
+                        'provider' => 'my_app_provider',
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertTrue($container->hasDefinition('security.user.provider.concrete.my_app_provider'));
+        $this->assertTrue($container->hasDefinition('security.user.provider.concrete.my_other_app_provider'));
     }
 
     public function testDisableRoleHierarchyVoter()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCustomProviderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCustomProviderTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
-use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\CustomProvider;
+use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProviderFactory\CustomProviderFactory;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -30,7 +30,7 @@ class XmlCustomProviderTest extends TestCase
         $container->register('cache.system', \stdClass::class);
 
         $security = new SecurityExtension();
-        $security->addUserProviderFactory(new CustomProvider());
+        $security->addUserProviderFactory(new CustomProviderFactory());
         $container->registerExtension($security);
 
         (new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml')))->load($configurationFile);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

At the moment, user provider factories require a custom config, even if the factory doesn't actually require any. This PR fixes that.

Example:

```yaml
security:
    providers:
        # Platform provider name, can be anything
        app_user_provider:
            # Factory name
            custom_provider: ~
```
