### PR TITLE
[HttpFoundation] Remove wrong documentation about the configurability of trusted proxies

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -836,10 +836,6 @@ class Request
      * being the original client, and each successive proxy that passed the request
      * adding the IP address where it received the request from.
      *
-     * If your reverse proxy uses a different header name than "X-Forwarded-For",
-     * ("Client-Ip" for instance), configure it via the $trustedHeaderSet
-     * argument of the Request::setTrustedProxies() method instead.
-     *
      * @see getClientIps()
      * @see https://wikipedia.org/wiki/X-Forwarded-For
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Support for custom header names has been removed in Symfony 4.0. The trusted header set allows configuring trusted headers among supported ones, but does not support custom ones.
The mention of custom header names was removed from the phpdoc of most methods relying on trusted values but was forgotten in `getClientIp`, causing confusion for users.