### PR TITLE
[Console] Remove trailing dot in command alternative list

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -837,7 +837,7 @@ class Application implements ResetInterface
             if (\count($commands) > 1) {
                 $suggestions = $this->getAbbreviationSuggestions(array_filter($abbrevs));
 
-                throw new CommandNotFoundException(\sprintf("Command \"%s\" is ambiguous.\nDid you mean one of these?\n%s.", $name, $suggestions), array_values($commands));
+                throw new CommandNotFoundException(\sprintf("Command \"%s\" is ambiguous.\nDid you mean one of these?\n%s", $name, $suggestions), array_values($commands));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

Previously, `php bin/console secrets:` added a trailing dot which looked like it belongs to the description of the last command:

```
      secrets:decrypt-to-local   Decrypt all secrets and stores them in the local vault  
      secrets:encrypt-from-local Encrypt all local secrets to the vault                  
      secrets:generate-keys      Generate new encryption keys                            
      secrets:list               List all secrets                                        
      secrets:remove             Remove a secret from the vault                          
      secrets:reveal             Reveal the value of a secret                            
      secrets:set                Set a secret in the vault.  
```

If the description of the last command itself ends with a dot, then there were two.

Now, there is no such trailing dot from the exception message:

```
      secrets:decrypt-to-local   Decrypt all secrets and stores them in the local vault  
      secrets:encrypt-from-local Encrypt all local secrets to the vault                  
      secrets:generate-keys      Generate new encryption keys                            
      secrets:list               List all secrets                                        
      secrets:remove             Remove a secret from the vault                          
      secrets:reveal             Reveal the value of a secret                            
      secrets:set                Set a secret in the vault                               
```