### PR TITLE
 Add additional exclude paths for tests

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -9,6 +9,7 @@ parameters:
     paths:
         - src
     excludePaths:
+        - src/Symfony/*/Tests/*
         - src/Symfony/*/*/Tests/*
         - src/Symfony/*/*/*/Tests/*
         - src/Symfony/*/*/*/*/Tests/*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The added pattern ensures that `src/Symfony/Contracts/Tests` is excluded from analysis.