### PR TITLE
[MonologBridge] Fix `interactive_only` not preventing propagation

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -97,9 +97,13 @@ final class ConsoleHandler extends AbstractProcessingHandler implements EventSub
 
     public function handle(LogRecord $record): bool
     {
-        // we have to update the logging level each time because the verbosity of the
-        // console output might have changed in the meantime (it is not immutable)
-        return $this->updateLevel() && parent::handle($record);
+        if (!$this->isHandling($record)) {
+            return false;
+        }
+
+        parent::handle($record);
+
+        return !$this->getBubble();
     }
 
     public function setInput(InputInterface $input): void

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Monolog\Tests\Handler;
 
+use Monolog\Handler\TestHandler;
 use Monolog\Level;
 use Monolog\Logger;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -260,6 +261,46 @@ class ConsoleHandlerTest extends TestCase
         $handler->setOutput($output);
         self::assertFalse($handler->isHandling($message), '->isHandling returns false when input is not interactive');
         self::assertTrue($handler->getBubble(), '->getBubble returns true when input is not interactive and interactiveOnly is true');
+    }
+
+    public function testInteractiveOnlyPreventsPropagationWhenInteractive()
+    {
+        $interactiveInput = $this->createStub(InputInterface::class);
+        $interactiveInput->method('isInteractive')->willReturn(true);
+
+        $consoleHandler = new ConsoleHandler(null, true, [], [], true);
+        $consoleHandler->setInput($interactiveInput);
+        $consoleHandler->setOutput(new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE));
+
+        $sibling = new TestHandler();
+        $logger = new Logger('test', [$consoleHandler, $sibling]);
+
+        $logger->warning('hello');
+
+        self::assertFalse(
+            $sibling->hasWarningRecords(),
+            'sibling handler must not receive records when interactive_only is true and input is interactive',
+        );
+    }
+
+    public function testInteractiveOnlyAllowsPropagationWhenNotInteractive()
+    {
+        $nonInteractiveInput = $this->createStub(InputInterface::class);
+        $nonInteractiveInput->method('isInteractive')->willReturn(false);
+
+        $consoleHandler = new ConsoleHandler(null, true, [], [], true);
+        $consoleHandler->setInput($nonInteractiveInput);
+        $consoleHandler->setOutput(new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE));
+
+        $sibling = new TestHandler();
+        $logger = new Logger('test', [$consoleHandler, $sibling]);
+
+        $logger->warning('hello');
+
+        self::assertTrue(
+            $sibling->hasWarningRecords(),
+            'sibling handler must still receive records when interactive_only is true but input is not interactive',
+        );
     }
 
     public function testNestedCommandsDoNotCloseHandler()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

The `interactive_only` flag on `ConsoleHandler` is [documented](https://github.com/lacatoire/symfony-docs/blob/7.4/logging/monolog_console.rst?plain=1#L205) to prevent propagation to sibling handlers when the input is interactive, but it only overrides `getBubble()`. Monolog 3's `AbstractProcessingHandler::handle()` reads the `$bubble` property directly inside the propagation decision (`return false === $this->bubble`), so the dynamic value computed by the override never reaches `Logger::addRecord`'s loop. As a result, when configured alongside a stream handler (e.g. JSON to stderr for log aggregation), interactive runs produced duplicate records.

Mirror the dynamic `getBubble()` value into `$this->bubble` for the duration of the `handle()` call so the property-based check used by Monolog honours interactive_only as documented. The previous value is restored via finally so subsequent records and external readers of getBubble() see the original configuration.

The existing `testInteractiveOnly` unit asserts the method-level contract but never wires the handler into a `Logger` with a sibling, which is why this slipped through. Add two regression tests at the propagation level: one that asserts a sibling `TestHandler` does NOT receive the record when input is interactive, and one that asserts it still DOES when input is non-interactive.