### PR TITLE
[AssetMapper] Rewrite relative paths in `export ... from` statements

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -27,9 +27,6 @@ use Symfony\Component\Filesystem\Path;
  */
 final class JavaScriptImportPathCompiler implements AssetCompilerInterface
 {
-    /**
-     * @see https://regex101.com/r/1iBAIb/2
-     */
     private const IMPORT_PATTERN = '/
             ^(?:\/\/.*)                     # Lines that start with comments
         |
@@ -45,6 +42,10 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
                         (?:\*\s*as\s+\w+|\s+[\w\s{},*]+)
                         \s*from\s*
                     )?
+            |
+                export\s*
+                    (?:\*(?:\s*as\s+\w+)?|\{[^}]*+\})
+                    \s*from\s*
             |
                 \bimport\(
             )

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -204,6 +204,56 @@ class JavaScriptImportPathCompilerTest extends TestCase
             ],
         ];
 
+        yield 'static_export_star_from' => [
+            'input' => "export * from './other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_export_named_from' => [
+            'input' => "export { myFunction } from './other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_export_multiple_named_from' => [
+            'input' => "export { myFunction, myOtherFunction } from './other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_export_star_as_namespace_from' => [
+            'input' => "export * as myModule from './other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'export_const_without_from_is_ignored' => [
+            'input' => "export const foo = 1;\nexport { bar } from './other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'local_exports_without_from_produce_no_imports' => [
+            'input' => "export const foo = 1;\nexport default foo;\nexport { foo };",
+            'expectedJavaScriptImports' => [],
+        ];
+
+        yield 'static_export_named_from_multiline' => [
+            'input' => "export {\n    foo,\n    bar,\n} from './other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_export_named_from_minified' => [
+            'input' => "export{foo}from'./other.js';",
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'commented_export_from_is_ignored' => [
+            'input' => "// export { foo } from './other.js';",
+            'expectedJavaScriptImports' => [],
+        ];
+
+        yield 'block_commented_export_from_is_ignored' => [
+            'input' => "/* export { foo } from './other.js'; */",
+            'expectedJavaScriptImports' => [],
+        ];
+
         yield 'extra_import_word_does_not_cause_issues' => [
             'input' => "// about to do an import\nimport('./other.js');",
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => true, 'asset' => 'other.js', 'add' => true]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64183
| License       | MIT

`JavaScriptImportPathCompiler`'s `IMPORT_PATTERN` only matches `import` /
`import(...)` statements. `export * from './x.js'` and `export { foo } from './x.js'`
re-exports are not captured, so the browser receives the original relative path
(unhashed) and 404s on the asset.

### Reproduces with

Plain regex test (no PHPUnit needed) on the current 6.4 HEAD pattern:

```
input: "export * from './other.js';"
preg_match_all(IMPORT_PATTERN, input, $m)  -> 1 raw match, no capture group ($m[1] empty)
=> compile() early-returns, path stays "./other.js"
```

With the patch, `$m[1]` captures `./other.js`, the path is rewritten through
`findAssetForRelativeImport()` and emitted as the versioned public path.

### Fix

Extend the alternation block in `IMPORT_PATTERN` with an `export` branch that
**requires** a `from` clause (so plain `export const x = 1;` is correctly skipped):

```regex
export\s+
    (?:\*(?:\s*as\s+\w+)?|[\w\s{},*]+)
    \s*from\s*
```

This mirrors the existing `import\s*(...)?\s*from\s*` structure and reuses the
same trailing path-capture group.

### Tests

5 new data-provider entries in `provideCompileTests()`:

| Case | Input |
| ---- | ----- |
| `static_export_star_from` | `export * from './other.js';` |
| `static_export_named_from` | `export { myFunction } from './other.js';` |
| `static_export_multiple_named_from` | `export { myFunction, myOtherFunction } from './other.js';` |
| `static_export_star_as_namespace_from` | `export * as myModule from './other.js';` |
| `export_const_without_from_is_ignored` | `export const foo = 1;\nexport { bar } from './other.js';` (only the second matches) |

Verified locally via `docker run php:8.4-cli`: 5/5 RED on the upstream/6.4
regex, 5/5 GREEN with the patch; plain `export const x = 1;` stays 0/0 on both.

Fixes #64183.
