### PR TITLE
[HttpKernel][WebProfilerBundle] Add dump icon in result list

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add dump indicator to profiler list view for profiles with dumped content
+
 8.1
 ---
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/dump.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/dump.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-viewfinder" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <circle cx="12" cy="12" r="9"></circle>
+    <line x1="12" y1="3" x2="12" y2="7"></line>
+    <line x1="12" y1="21" x2="12" y2="18"></line>
+    <line x1="3" y1="12" x2="7" y2="12"></line>
+    <line x1="21" y1="12" x2="18" y2="12"></line>
+    <line x1="12" y1="12" x2="12" y2="12.01"></line>
+</svg>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -27,14 +27,18 @@
         }
         #search-results .status-with-indicator {
             position: relative;
-            display: inline-block;
-            padding-right: 20px;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        #search-results .status-with-indicator .indicators {
+            display: flex;
+            gap: 2px;
+        }
+        #search-results .status-with-indicator .indicators:empty {
+            display: none;
         }
         #search-results .error-indicator {
-            position: absolute;
-            right: -10px;
-            top: 50%;
-            transform: translateY(-50%);
             display: flex;
             padding: 3px 4px;
         }
@@ -122,12 +126,21 @@
                     {% endif %}
 
                     <tr>
-                        <td class="text-center">
+                        <td class="text-left">
                             <span class="status-with-indicator">
                                 <span class="label {{ css_class }}">{{ result.status_code|default('n/a') }}</span>
-                                {%- if has_errors -%}
-                                    <span class="label status-error error-indicator">{{ source('@WebProfiler/Icon/logger.svg') }}</span>
-                                {%- endif -%}
+                                <span class="indicators">
+                                    {%- if has_errors -%}
+                                        <a href="{{ path('_profiler', {token: result.token, panel: 'exception'}) }}">
+                                            <span class="label status-error error-indicator">{{ source('@WebProfiler/Icon/logger.svg') }}</span>
+                                        </a>
+                                    {%- endif -%}
+                                    {%- if has_dump -%}
+                                        <a href="{{ path('_profiler', {token: result.token, panel: 'dump'}) }}">
+                                            <span class="label error-indicator">{{ source('@WebProfiler/Icon/dump.svg') }}</span>
+                                        </a>
+                                    {%- endif -%}
+                                </span>
                             </span>
                         </td>
                         <td>

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `#[AsControllerAttributeListener]` attribute to declare event listeners for controller attributes
  * Add the `$expiration` argument to `FragmentUriGenerator::__construct()` and sign fragment URIs with a 5-year expiration by default
+ * Add `hasDump()` method to `Profile` to track profiles with dump
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -65,7 +65,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
-            [$csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode, $csvVirtualType, $csvHasErrors] = $values + [7 => null, 8 => null];
+            [$csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode, $csvVirtualType, $csvHasErrors, $hasDump] = $values + [7 => null, 8 => null, 9 => null];
             $csvTime = (int) $csvTime;
 
             $urlFilter = false;
@@ -95,6 +95,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 'status_code' => $csvStatusCode,
                 'virtual_type' => $csvVirtualType ?: 'request',
                 'has_errors' => (bool) $csvHasErrors,
+                'has_dump' => (bool) $hasDump,
             ];
 
             if ($filter && !$filter($profile)) {
@@ -164,6 +165,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
             'status_code' => $profile->getStatusCode(),
             'virtual_type' => $profile->getVirtualType() ?? 'request',
             'has_errors' => $profile->hasErrors(),
+            'has_dump' => $profile->hasDump(),
         ];
 
         $data = serialize($data);
@@ -192,6 +194,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 $profile->getStatusCode(),
                 $profile->getVirtualType() ?? 'request',
                 $profile->hasErrors() ? '1' : '0',
+                $profile->hasDump() ? '1' : '0',
             ], ',', '"', '\\');
             fclose($file);
 
@@ -278,6 +281,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $profile->setStatusCode($data['status_code']);
         $profile->setVirtualType($data['virtual_type'] ?: 'request');
         $profile->setHasErrors($data['has_errors'] ?? false);
+        $profile->setHasDump($data['has_dump'] ?? false);
         $profile->setCollectors($data['data']);
 
         if (!$parent && $data['parent']) {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -33,6 +33,7 @@ class Profile
     private ?self $parent = null;
     private ?string $virtualType = null;
     private bool $hasErrors = false;
+    private bool $hasDump = false;
 
     /**
      * @var Profile[]
@@ -166,6 +167,16 @@ class Profile
         $this->hasErrors = $hasErrors;
     }
 
+    public function hasDump(): bool
+    {
+        return $this->hasDump;
+    }
+
+    public function setHasDump(bool $hasDump): void
+    {
+        $this->hasDump = $hasDump;
+    }
+
     /**
      * Finds children profilers.
      *
@@ -273,6 +284,7 @@ class Profile
             'statusCode' => $this->statusCode,
             'virtualType' => $this->virtualType,
             'hasErrors' => $this->hasErrors,
+            'hasDump' => $this->hasDump,
         ];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 use Symfony\Contracts\Service\ResetInterface;
@@ -102,6 +103,14 @@ class Profiler implements ResetInterface
             && $logger->countErrors() > 0
         ) {
             $profile->setHasErrors(true);
+        }
+
+        if (!$profile->hasDump()
+            && $profile->hasCollector('dump')
+            && ($logger = $profile->getCollector('dump')) instanceof DumpDataCollector
+            && $logger->getDumpsCount() > 0
+        ) {
+            $profile->setHasDump(true);
         }
 
         if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -368,6 +368,45 @@ class FileProfilerStorageTest extends TestCase
         $this->assertFalse($tokens[0]['has_errors'], '->find() returns has_errors=false for old CSV lines without the field');
     }
 
+    public function testHasDump()
+    {
+        $profile = new Profile('token_with_dump');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://example.net/');
+        $profile->setMethod('GET');
+        $profile->setStatusCode(200);
+        $profile->setHasDump(true);
+        $this->storage->write($profile);
+
+        $profile = new Profile('token_without_dump');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://example.net/');
+        $profile->setMethod('GET');
+        $profile->setStatusCode(200);
+        $profile->setHasDump(false);
+        $this->storage->write($profile);
+
+        $loadedProfile = $this->storage->read('token_with_dump');
+        $this->assertTrue($loadedProfile->hasDump());
+
+        $loadedProfile = $this->storage->read('token_without_dump');
+        $this->assertFalse($loadedProfile->hasDump());
+    }
+
+    public function testHasDumpBackwardCompatibility()
+    {
+        // Test backward compatibility with old CSV lines that don't have has_errors field
+        $file = $this->tmpDir.'/index.csv';
+        $time = time();
+
+        // Write an old-format CSV line (9 fields, no has_errors)
+        file_put_contents($file, "old_token,127.0.0.1,GET,http://foo.bar/old,{$time},,200,request,,\n");
+
+        $tokens = $this->storage->find('', '', 10, '');
+        $this->assertCount(1, $tokens);
+        $this->assertFalse($tokens[0]['has_dump'], '->find() returns has_dump=false for old CSV lines without the field');
+    }
+
     public function testMultiRowIndexFile()
     {
         $iteration = 3;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62424
| License       | MIT

Inspired by #63296 and as suggested in #62424
This PR add a new icon in profiler list if a profile contains dump

<img width="1916" height="320" alt="image" src="https://github.com/user-attachments/assets/db11c405-9c86-483f-9c85-21f42959ede5" />

A screenshot coming from my local setup for test, an exemple with error and dump icon, another one without icons (the common state) and the last one with new dump icon

I guess a next step could be do the same for mailer, notifier, messenger... but it requires a bit more changes and I wanted to work on this one and gather feedbacks as a first step. 

Update : Icons now link directly to the corresponding panel for the selected request