### PR TITLE
[Security] Fix impersonation being deauthenticated on every request

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -18,10 +18,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * Base class for Token instances.
  *
  * Note that the token's role names are decoupled from the user's roles on purpose: token roles describe
- * the authentication context (e.g. a `SwitchUserToken` adds `ROLE_PREVIOUS_ADMIN`), not the user's
- * permanent role assignment. This is why `setUser()` only updates the user reference and leaves the
- * role names untouched. `ContextListener` is the component responsible for comparing the stored role
- * names against `$user->getRoles()` and deauthenticating when they diverge.
+ * the authentication context, not the user's permanent role assignment. This is why `setUser()` only
+ * updates the user reference and leaves the role names untouched. `ContextListener` is the component
+ * responsible for comparing the stored role names against `$user->getRoles()` and deauthenticating
+ * when they diverge.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -312,11 +312,6 @@ class ContextListener extends AbstractListener
         }
 
         $userRoles = array_map('strval', (array) $refreshedUser->getRoles());
-
-        if ($token instanceof SwitchUserToken) {
-            $userRoles[] = 'ROLE_PREVIOUS_ADMIN';
-        }
-
         $tokenRoleNames = $token->getRoleNames();
 
         if (

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -268,6 +269,49 @@ class ContextListenerTest extends TestCase
         $goodRefreshedUser = new InMemoryUser('foobar', 'bar');
         $tokenStorage = $this->handleEventWithPreviousSession([new SupportingUserProvider($badRefreshedUser), new SupportingUserProvider($goodRefreshedUser)], $goodRefreshedUser);
         $this->assertSame($goodRefreshedUser, $tokenStorage->getToken()->getUser());
+    }
+
+    public function testSwitchUserTokenIsNotDeauthenticated()
+    {
+        $impersonated = new CustomUser('user', ['ROLE_USER'], 'pass', false);
+        $impersonator = new CustomUser('admin', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'], 'pass', false);
+        $originalToken = new UsernamePasswordToken($impersonator, 'context_key', $impersonator->getRoles());
+        $token = new SwitchUserToken($impersonated, 'context_key', $impersonated->getRoles(), $originalToken);
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize($token));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $provider = new class($impersonated) implements UserProviderInterface {
+            public function __construct(private CustomUser $refreshedUser)
+            {
+            }
+
+            public function loadUserByIdentifier(string $identifier): UserInterface
+            {
+                return $this->refreshedUser;
+            }
+
+            public function refreshUser(UserInterface $user): UserInterface
+            {
+                return $this->refreshedUser;
+            }
+
+            public function supportsClass(string $class): bool
+            {
+                return CustomUser::class === $class;
+            }
+        };
+
+        $tokenStorage = new TokenStorage();
+        $listener = new ContextListener($tokenStorage, [$provider], 'context_key');
+        $listener->authenticate(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertInstanceOf(SwitchUserToken::class, $tokenStorage->getToken());
+        $this->assertSame($impersonated, $tokenStorage->getToken()->getUser());
     }
 
     public function testTryAllUserProvidersUntilASupportingUserProviderIsFound()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64211
| License       | MIT

In #64175 the `ROLE_PREVIOUS_ADMIN` role-check block was reintroduced in `ContextListener::hasUserChanged()` when merging from 6.4 up to 7.4. On 6.4 the matching half lives in `SwitchUserListener`, which appends `ROLE_PREVIOUS_ADMIN` to the token's roles; on 7.4+ that code was removed back in 2023 (#50957), so the check now sees a role-count mismatch on every refresh and deauthenticates the impersonation token.

This removes the stale half so the two halves stay consistent on 7.4+.