### PR TITLE
[HttpKernel] Preserve named-attribute override on Request/Session value resolvers

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
@@ -35,6 +35,15 @@ final class RequestValueResolver implements ArgumentValueResolverInterface, Valu
 
     public function resolve(Request $request, ArgumentMetadata $argument): array
     {
-        return Request::class === $argument->getType() || is_subclass_of($argument->getType(), Request::class) ? [$request] : [];
+        $type = $argument->getType();
+        if (Request::class !== $type && !is_subclass_of($type, Request::class)) {
+            return [];
+        }
+
+        if ($request->attributes->has($argument->getName())) {
+            return [];
+        }
+
+        return [$request];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
@@ -54,6 +54,10 @@ final class SessionValueResolver implements ArgumentValueResolverInterface, Valu
             return [];
         }
 
+        if ($request->attributes->has($argument->getName())) {
+            return [];
+        }
+
         return $request->getSession() instanceof $type ? [$request->getSession()] : [];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestValueResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\ExtendingRequest;
+
+class RequestValueResolverTest extends TestCase
+{
+    public function testResolveReturnsMainRequest()
+    {
+        $resolver = new RequestValueResolver();
+        $request = Request::create('/');
+        $metadata = new ArgumentMetadata('request', Request::class, false, false, null);
+
+        $this->assertSame([$request], $resolver->resolve($request, $metadata));
+    }
+
+    public function testResolveSkipsUnrelatedTypes()
+    {
+        $resolver = new RequestValueResolver();
+        $request = Request::create('/');
+        $metadata = new ArgumentMetadata('foo', \stdClass::class, false, false, null);
+
+        $this->assertSame([], $resolver->resolve($request, $metadata));
+    }
+
+    public function testResolveSupportsExtendingRequest()
+    {
+        $resolver = new RequestValueResolver();
+        $request = new ExtendingRequest();
+        $metadata = new ArgumentMetadata('request', ExtendingRequest::class, false, false, null);
+
+        $this->assertSame([$request], $resolver->resolve($request, $metadata));
+    }
+
+    public function testResolveDefersWhenMatchingNamedAttributeExists()
+    {
+        $resolver = new RequestValueResolver();
+        $request = Request::create('/');
+        $request->attributes->set('request', Request::create('/other'));
+
+        $metadata = new ArgumentMetadata('request', Request::class, false, false, null);
+
+        $this->assertSame([], $resolver->resolve($request, $metadata));
+    }
+
+    public function testResolveIgnoresUnrelatedAttributeName()
+    {
+        $resolver = new RequestValueResolver();
+        $request = Request::create('/');
+        $request->attributes->set('foo', Request::create('/other'));
+
+        $metadata = new ArgumentMetadata('request', Request::class, false, false, null);
+
+        $this->assertSame([$request], $resolver->resolve($request, $metadata));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/SessionValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/SessionValueResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionValueResolver;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+class SessionValueResolverTest extends TestCase
+{
+    public function testResolveReturnsSession()
+    {
+        $resolver = new SessionValueResolver();
+        $session = new Session(new MockArraySessionStorage());
+        $request = Request::create('/');
+        $request->setSession($session);
+
+        $metadata = new ArgumentMetadata('session', SessionInterface::class, false, false, null);
+
+        $this->assertSame([$session], $resolver->resolve($request, $metadata));
+    }
+
+    public function testResolveSkipsWhenNoSession()
+    {
+        $resolver = new SessionValueResolver();
+        $request = Request::create('/');
+
+        $metadata = new ArgumentMetadata('session', SessionInterface::class, false, false, null);
+
+        $this->assertSame([], $resolver->resolve($request, $metadata));
+    }
+
+    public function testResolveSkipsUnrelatedTypes()
+    {
+        $resolver = new SessionValueResolver();
+        $session = new Session(new MockArraySessionStorage());
+        $request = Request::create('/');
+        $request->setSession($session);
+
+        $metadata = new ArgumentMetadata('foo', \stdClass::class, false, false, null);
+
+        $this->assertSame([], $resolver->resolve($request, $metadata));
+    }
+
+    public function testResolveDefersWhenMatchingNamedAttributeExists()
+    {
+        $resolver = new SessionValueResolver();
+        $session = new Session(new MockArraySessionStorage());
+        $request = Request::create('/');
+        $request->setSession($session);
+        $request->attributes->set('session', new Session(new MockArraySessionStorage()));
+
+        $metadata = new ArgumentMetadata('session', SessionInterface::class, false, false, null);
+
+        $this->assertSame([], $resolver->resolve($request, $metadata));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64212
| License       | MIT

When `argument_resolver.request` was bumped to priority 120 (above `argument_resolver.request_attribute` at 100) to keep type-hinted `Request` arguments from triggering DoctrineBundle's `EntityValueResolver`, it silently broke the long-standing `$this->forward(B::class, ['request' => $modified])` pattern: the matching attribute no longer wins over the sub-request.

Have `RequestValueResolver` and `SessionValueResolver` honor a matching named attribute themselves when its value matches the argument type. Non-matching names and non-matching types still short-circuit early enough to keep `EntityValueResolver` from running for `Request` arguments.