### PR TITLE
[Runtime] Fix TypeError when resolving untyped arguments

### DIFF
--- a/src/Symfony/Component/Runtime/GenericRuntime.php
+++ b/src/Symfony/Component/Runtime/GenericRuntime.php
@@ -168,10 +168,10 @@ class GenericRuntime implements RuntimeInterface
             return $this;
         }
 
-        if (!$runtime = $this->getRuntime($type)) {
+        if (!$runtime = $this->getRuntime($type ?? 'mixed')) {
             $r = $parameter->getDeclaringFunction();
 
-            throw new \InvalidArgumentException(\sprintf('Cannot resolve argument "%s $%s" in "%s" on line "%d": "%s" supports only arguments "array $context", "array $argv" and "array $request", or a runtime named "Symfony\Runtime\%1$sRuntime".', $type, $parameter->name, $r->getFileName(), $r->getStartLine(), get_debug_type($this)));
+            throw new \InvalidArgumentException(\sprintf('Cannot resolve argument "%s $%s" in "%s" on line "%d": "%s" supports only arguments "array $context", "array $argv" and "array $request", or a runtime named "Symfony\Runtime\%1$sRuntime".', $type ?? 'mixed', $parameter->name, $r->getFileName(), $r->getStartLine(), get_debug_type($this)));
         }
 
         return $runtime->getArgument($parameter, $type);

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -222,7 +222,7 @@ class SymfonyRuntime extends GenericRuntime
 
     protected function getArgument(\ReflectionParameter $parameter, ?string $type): mixed
     {
-        return $this->resolveType($type) ?? parent::getArgument($parameter, $type);
+        return (null !== $type ? $this->resolveType($type) : null) ?? parent::getArgument($parameter, $type);
     }
 
     protected function resolveType(string $type): mixed

--- a/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
+++ b/src/Symfony/Component/Runtime/Tests/SymfonyRuntimeTest.php
@@ -50,4 +50,38 @@ class SymfonyRuntimeTest extends TestCase
 
         new SymfonyRuntime(['worker_loop_max' => false]);
     }
+
+    public function testUntypedOptionalArgumentDoesNotCrash()
+    {
+        $runtime = new SymfonyRuntime();
+        $captured = null;
+
+        try {
+            $resolver = $runtime->getResolver(static function ($untyped = 'default') use (&$captured) {
+                $captured = $untyped;
+            });
+            [$callable, $args] = $resolver->resolve();
+            $callable(...$args);
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+
+        $this->assertSame([], $args);
+        $this->assertSame('default', $captured);
+    }
+
+    public function testUntypedRequiredArgumentThrowsInvalidArgument()
+    {
+        $runtime = new SymfonyRuntime();
+
+        try {
+            $resolver = $runtime->getResolver(static fn ($untyped) => $untyped);
+            $this->expectException(\InvalidArgumentException::class);
+            $resolver->resolve();
+        } finally {
+            restore_error_handler();
+            restore_exception_handler();
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64209
| License       | MIT

`SymfonyRuntime::getArgument()` accepts `?string $type` but forwarded null straight to `resolveType(string)`, raising a `TypeError`. The parent `GenericRuntime::getArgument()` had the same hole, forwarding null to `getRuntime(string)`.

Skip `resolveType()` when `$type` is null, and let `getRuntime()` see `'mixed'` so it falls through to the standard `InvalidArgumentException` (which `getResolver()` already catches for optional params).