### PR TITLE
[Tui] Add KeyBindingWidget

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`
  * [BC BREAK] Add `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
+ * Add `KeyBindingWidget` to display the keybindings of the focused widget
 
 8.1
 ---

--- a/src/Symfony/Component/Tui/Event/FocusEvent.php
+++ b/src/Symfony/Component/Tui/Event/FocusEvent.php
@@ -29,10 +29,15 @@ use Symfony\Component\Tui\Widget\FocusableInterface;
 class FocusEvent extends AbstractEvent
 {
     public function __construct(
-        AbstractWidget&FocusableInterface $target,
+        private readonly AbstractWidget&FocusableInterface $target,
         private readonly ?FocusableInterface $previous,
     ) {
         parent::__construct($target);
+    }
+
+    public function getTarget(): AbstractWidget&FocusableInterface
+    {
+        return $this->target;
     }
 
     /**

--- a/src/Symfony/Component/Tui/Input/Key.php
+++ b/src/Symfony/Component/Tui/Input/Key.php
@@ -55,6 +55,24 @@ final class Key
     public const F11 = 'f11';
     public const F12 = 'f12';
 
+    private const LABELS = [
+        self::ESCAPE => 'Esc',
+        self::ENTER => '↵',
+        self::TAB => 'Tab',
+        self::SPACE => 'Space',
+        self::BACKSPACE => '⌫',
+        self::DELETE => 'Del',
+        self::INSERT => 'Ins',
+        self::HOME => 'Home',
+        self::END => 'End',
+        self::PAGE_UP => '⇞',
+        self::PAGE_DOWN => '⇟',
+        self::UP => '▲',
+        self::DOWN => '▼',
+        self::LEFT => '◀',
+        self::RIGHT => '▶',
+    ];
+
     public static function ctrl(string $key): string
     {
         return 'ctrl+'.strtolower($key);
@@ -88,5 +106,22 @@ final class Key
     public static function ctrlShiftAlt(string $key): string
     {
         return 'ctrl+shift+alt+'.strtolower($key);
+    }
+
+    /**
+     * Return a human-readable display label for a key identifier,
+     * e.g. "▲" for Key::UP or "Ctrl+C" for Key::ctrl('c').
+     */
+    public static function label(string $key): string
+    {
+        return self::LABELS[$key] ?? implode('+', array_map(
+            static fn (string $part) => match ($part) {
+                'ctrl' => 'Ctrl',
+                'shift' => 'Shift',
+                'alt' => 'Alt',
+                default => self::LABELS[$part] ?? mb_strtoupper($part),
+            },
+            explode('+', $key),
+        ));
     }
 }

--- a/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
+++ b/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Tui\Style;
 use Symfony\Component\Tui\Widget\CancellableLoaderWidget;
 use Symfony\Component\Tui\Widget\EditorWidget;
 use Symfony\Component\Tui\Widget\InputWidget;
+use Symfony\Component\Tui\Widget\KeyBindingWidget;
 use Symfony\Component\Tui\Widget\LoaderWidget;
 use Symfony\Component\Tui\Widget\MarkdownWidget;
 use Symfony\Component\Tui\Widget\SelectListWidget;
@@ -50,6 +51,13 @@ final class DefaultStyleSheet
             // Layout aliases (used by <columns>/<column> tag aliases)
             '.columns' => new Style(direction: Direction::Horizontal, gap: 2),
             '.column' => new Style(),
+
+            // KeyBindingWidget
+            KeyBindingWidget::class => new Style(padding: Padding::from([0, 1]), border: Border::all(1)),
+            KeyBindingWidget::class.'::key' => new Style(background: 'gray', bold: true),
+            KeyBindingWidget::class.'::action' => new Style(color: 'gray'),
+            KeyBindingWidget::class.'::global-key' => new Style(background: 'blue', bold: true),
+            KeyBindingWidget::class.'::global-action' => new Style(color: 'gray'),
 
             // CancellableLoaderWidget
             CancellableLoaderWidget::class.':focus' => new Style()->withBold(),

--- a/src/Symfony/Component/Tui/Tests/Input/KeyTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/KeyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Input;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Input\Key;
+
+class KeyTest extends TestCase
+{
+    #[DataProvider('provideLabels')]
+    public function testLabel(string $expected, string $key)
+    {
+        $this->assertSame($expected, Key::label($key));
+    }
+
+    public static function provideLabels(): iterable
+    {
+        yield ['Esc', Key::ESCAPE];
+        yield ['↵', Key::ENTER];
+        yield ['▲', Key::UP];
+        yield ['⇟', Key::PAGE_DOWN];
+        yield ['F6', Key::F6];
+        yield ['Ctrl+C', Key::ctrl('c')];
+        yield ['Ctrl+Shift+X', Key::ctrlShift('x')];
+        yield ['Ctrl+Space', Key::ctrl(Key::SPACE)];
+        yield ['Alt+⇞', Key::alt(Key::PAGE_UP)];
+        yield ['?', '?'];
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Widget/KeyBindingWidgetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/KeyBindingWidgetTest.php
@@ -1,0 +1,597 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Widget;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Input\Key;
+use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Style\Style;
+use Symfony\Component\Tui\Style\StyleSheet;
+use Symfony\Component\Tui\Terminal\VirtualTerminal;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\FocusableInterface;
+use Symfony\Component\Tui\Widget\FocusableTrait;
+use Symfony\Component\Tui\Widget\KeybindingsTrait;
+use Symfony\Component\Tui\Widget\KeyBindingWidget;
+
+class KeyBindingWidgetTest extends TestCase
+{
+    // --- Render: empty state ---
+
+    public function testRenderEmptyReturnsNoLines()
+    {
+        $widget = new KeyBindingWidget();
+
+        $this->assertSame([], $widget->render(new RenderContext(80, 1)));
+    }
+
+    public function testActionsWithoutKeysAreSkipped()
+    {
+        $widget = new KeyBindingWidget();
+        $widget->setGlobalKeybindings(new Keybindings(['quit' => []]), ['quit' => 'Quit']);
+
+        $this->assertSame([], $widget->render(new RenderContext(80, 1)));
+    }
+
+    // --- Render: globals only ---
+
+    public function testRenderGlobalItemsOnly()
+    {
+        $widget = new KeyBindingWidget();
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit']
+        );
+
+        $lines = $this->renderStripped($widget);
+        $this->assertCount(1, $lines);
+        $this->assertStringContainsString('Quit', $lines[0]);
+        $this->assertStringContainsString('Ctrl+C', $lines[0]);
+    }
+
+    public function testGlobalsOnlyLineIsRightAnchored()
+    {
+        $widget = new KeyBindingWidget();
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit']
+        );
+
+        $lines = $this->renderStripped($widget, 40);
+        $this->assertCount(1, $lines);
+        $this->assertSame(40, AnsiUtils::visibleWidth($lines[0]));
+        $this->assertStringEndsWith('Quit', $lines[0]);
+    }
+
+    // --- Render: focused items only ---
+
+    public function testRenderFocusedItemsOnly()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Move Up']
+        );
+
+        $lines = $this->renderStripped($widget);
+        $this->assertCount(1, $lines);
+        $this->assertStringContainsString('Move Up', $lines[0]);
+        $this->assertStringContainsString('▲', $lines[0]);
+    }
+
+    // --- Render: both groups on one line ---
+
+    public function testRenderBothGroupsOnOneLine()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Move Up']
+        );
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit']
+        );
+
+        $lines = $this->renderStripped($widget);
+        $this->assertCount(1, $lines);
+        $this->assertStringContainsString('Move Up', $lines[0]);
+        $this->assertStringContainsString('│', $lines[0]);
+        $this->assertStringContainsString('Quit', $lines[0]);
+    }
+
+    public function testGlobalsAreRightAligned()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Up']
+        );
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit']
+        );
+
+        $lines = $this->renderStripped($widget, 40);
+        $this->assertCount(1, $lines);
+        // Globals appear after focused items in the line
+        $this->assertGreaterThan(
+            strpos($lines[0], 'Up'),
+            strpos($lines[0], 'Quit')
+        );
+    }
+
+    // --- Render: wrapping ---
+
+    public function testFocusedItemsWrapToMultipleLines()
+    {
+        $bindings = new Keybindings([
+            'a' => ['a'], 'b' => ['b'], 'c' => ['c'], 'd' => ['d'],
+            'e' => ['e'], 'f' => ['f'], 'g' => ['g'], 'h' => ['h'],
+        ]);
+        $labels = [
+            'a' => 'Action A', 'b' => 'Action B', 'c' => 'Action C', 'd' => 'Action D',
+            'e' => 'Action E', 'f' => 'Action F', 'g' => 'Action G', 'h' => 'Action H',
+        ];
+
+        [$widget] = $this->createWithTui($bindings, $labels);
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit']
+        );
+
+        $lines = $this->renderStripped($widget, 40);
+        $this->assertGreaterThan(1, \count($lines));
+        $this->assertStringContainsString('Quit', end($lines));
+    }
+
+    public function testGlobalsOnOwnLineWhenLastLineFull()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['a' => ['a'], 'b' => ['b'], 'c' => ['c']]),
+            ['a' => 'Action A Long', 'b' => 'Action B Long', 'c' => 'Action C Long']
+        );
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c'], 'help' => ['?'], 'save' => ['ctrl+s']]),
+            ['quit' => 'Quit', 'help' => 'Help', 'save' => 'Save']
+        );
+
+        $lines = $this->renderStripped($widget, 20);
+        $lastLine = end($lines);
+        $this->assertStringContainsString('Quit', $lastLine);
+    }
+
+    // --- Width constraints ---
+
+    public function testLinesNeverExceedColumns()
+    {
+        $bindings = new Keybindings([
+            'a' => ['a'], 'b' => ['b'], 'c' => ['c'], 'd' => ['d'],
+            'e' => ['e'], 'f' => ['f'], 'g' => ['g'],
+        ]);
+        $labels = [
+            'a' => 'Action A', 'b' => 'Action B', 'c' => 'Action C', 'd' => 'Action D',
+            'e' => 'Action E', 'f' => 'Action F', 'g' => 'Action G',
+        ];
+
+        [$widget] = $this->createWithTui($bindings, $labels);
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit']
+        );
+
+        $columns = 30;
+        foreach ($widget->render(new RenderContext($columns, 10)) as $line) {
+            $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testUnicodeKeyLabelsCountedCorrectly()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Up']
+        );
+        $widget->setKeyLabels([Key::UP => '▲▲']);
+
+        $columns = 20;
+        foreach ($widget->render(new RenderContext($columns, 1)) as $line) {
+            $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testItemsWiderThanColumnsAreClamped()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'A Focused Action Label Wider Than The Terminal']
+        );
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'A Global Label Wider Than The Terminal']
+        );
+
+        $columns = 20;
+        $lines = $widget->render(new RenderContext($columns, 10));
+        $this->assertNotEmpty($lines);
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    // --- Gap ---
+
+    public function testSetGapChangesSpacingBetweenItems()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['a' => ['a'], 'b' => ['b']]),
+            ['a' => 'A', 'b' => 'B']
+        );
+        $widget->setGap(4);
+
+        $lines = $this->renderStripped($widget);
+        // The two items should have 4 spaces between them
+        $this->assertMatchesRegularExpression('/A\s{4}/', $lines[0]);
+    }
+
+    // --- Separator ---
+
+    public function testSeparatorAbsentWhenNoGlobals()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['a' => ['a']]),
+            ['a' => 'Action A']
+        );
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringNotContainsString('│', $lines[0]);
+    }
+
+    public function testSetSeparatorChangesCharacter()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['a' => ['a']]),
+            ['a' => 'Action A']
+        );
+        $widget->setGlobalKeybindings(new Keybindings(['quit' => ['q']]), ['quit' => 'Quit']);
+        $widget->setSeparator(' | ');
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('|', $lines[0]);
+        $this->assertStringNotContainsString('│', $lines[0]);
+    }
+
+    public function testSetSeparatorEmptyHidesIt()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['a' => ['a']]),
+            ['a' => 'Action A']
+        );
+        $widget->setGlobalKeybindings(new Keybindings(['quit' => ['q']]), ['quit' => 'Quit']);
+        $widget->setSeparator('');
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringNotContainsString('│', $lines[0]);
+    }
+
+    // --- setGlobalKeybindings() ---
+
+    public function testGlobalKeybindingsWithExplicitLabels()
+    {
+        $widget = new KeyBindingWidget();
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c'], 'help' => ['?']]),
+            ['quit' => 'Quit', 'help' => 'Help']
+        );
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Quit', $lines[0]);
+        $this->assertStringContainsString('Help', $lines[0]);
+    }
+
+    public function testGlobalKeybindingsWithHumanizedLabels()
+    {
+        $widget = new KeyBindingWidget();
+        $widget->setGlobalKeybindings(
+            new Keybindings(['move_up' => [Key::UP], 'page_down' => [Key::PAGE_DOWN]])
+        );
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Move Up', $lines[0]);
+        $this->assertStringContainsString('Page Down', $lines[0]);
+    }
+
+    public function testGlobalKeybindingsSkipsUnknownActions()
+    {
+        $widget = new KeyBindingWidget();
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit', 'nonexistent' => 'Ghost']
+        );
+
+        $this->assertStringNotContainsString('Ghost', implode('', $this->renderStripped($widget)));
+    }
+
+    // --- setKeyLabels() ---
+
+    public function testKeyLabelOverrideAppearsInRender()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Move Up']
+        );
+        $widget->setKeyLabels([Key::UP => 'CUSTOM-UP']);
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('CUSTOM-UP', $lines[0]);
+        $this->assertStringNotContainsString('▲', $lines[0]);
+    }
+
+    public function testSetKeyLabelsNullRevertsToDefaults()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Move Up']
+        );
+        $widget->setKeyLabels([Key::UP => 'CUSTOM-UP']);
+        $widget->setKeyLabels(null);
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('▲', $lines[0]);
+        $this->assertStringNotContainsString('CUSTOM-UP', $lines[0]);
+    }
+
+    // --- setKeybindingLabels() on focused widget ---
+
+    public function testExplicitKeybindingLabelsOnFocusedWidget()
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+
+        $stub = new StubFocusableWidget();
+        $stub->setKeybindings(new Keybindings(['move_up' => [Key::UP]]));
+        $stub->setKeybindingLabels(['move_up' => 'Monter']);
+
+        $widget = new KeyBindingWidget();
+        $tui->add($stub);
+        $tui->add($widget);
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Monter', $lines[0]);
+        $this->assertStringNotContainsString('Move Up', $lines[0]);
+    }
+
+    public function testSetKeybindingLabelsNullRevertsToDefaults()
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+
+        $stub = new StubFocusableWidget();
+        $stub->setKeybindings(new Keybindings(['move_up' => [Key::UP]]));
+        // No labels → falls back to humanize
+        $stub->setKeybindingLabels(null);
+
+        $widget = new KeyBindingWidget();
+        $tui->add($stub);
+        $tui->add($widget);
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Move Up', $lines[0]);
+    }
+
+    public function testLabelChangeOnFocusedWidgetAppearsOnNextRender()
+    {
+        [$widget, $stub] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Move Up']
+        );
+
+        $this->assertStringContainsString('Move Up', $this->renderStripped($widget)[0]);
+
+        $stub->setKeybindingLabels(['move_up' => 'Monter']);
+        $widget->beforeRender();
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Monter', $lines[0]);
+        $this->assertStringNotContainsString('Move Up', $lines[0]);
+    }
+
+    public function testLabelsChangedAfterFocusReachTheScreen()
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+
+        $stub = new class extends StubFocusableWidget {
+            public function handleInput(string $data): void
+            {
+                $this->setKeybindingLabels(['move_up' => 'Monter']);
+            }
+        };
+        $stub->setKeybindings(new Keybindings(['move_up' => [Key::UP]]));
+        $stub->setKeybindingLabels(['move_up' => 'Move Up']);
+
+        $tui->add($stub);
+        $tui->add(new KeyBindingWidget());
+        $tui->start();
+        $tui->processRender();
+        $this->assertStringContainsString('Move Up', $terminal->consumeOutput());
+
+        $tui->handleInput('r');
+        $tui->processRender();
+
+        $this->assertStringContainsString('Monter', $terminal->consumeOutput());
+    }
+
+    // --- Focus integration ---
+
+    public function testInitialFocusedWidgetPopulatesItemsOnAttach()
+    {
+        [$widget] = $this->createWithTui(
+            new Keybindings(['move_up' => [Key::UP]]),
+            ['move_up' => 'Move Up']
+        );
+
+        $this->assertNotEmpty($this->renderStripped($widget));
+    }
+
+    public function testUpdatesOnFocusChange()
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+
+        $stub1 = new StubFocusableWidget();
+        $stub1->setKeybindings(new Keybindings(['action_a' => ['a']]));
+        $stub1->setKeybindingLabels(['action_a' => 'Action A']);
+
+        $stub2 = new StubFocusableWidget();
+        $stub2->setKeybindings(new Keybindings(['action_b' => ['b']]));
+        $stub2->setKeybindingLabels(['action_b' => 'Action B']);
+
+        $widget = new KeyBindingWidget();
+
+        $tui->add($stub1);
+        $tui->add($stub2);
+        $tui->add($widget);
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Action A', implode('', $lines));
+
+        // F6 moves focus to next focusable widget
+        $tui->handleInput("\x1b[17~");
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Action B', implode('', $lines));
+        $this->assertStringNotContainsString('Action A', implode('', $lines));
+    }
+
+    public function testFocusCycleReturnsToFirstWidgetBindings()
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+
+        $stub1 = new StubFocusableWidget();
+        $stub1->setKeybindings(new Keybindings(['action_a' => ['a']]));
+        $stub1->setKeybindingLabels(['action_a' => 'Action A']);
+
+        $stub2 = new StubFocusableWidget();
+        $stub2->setKeybindings(new Keybindings(['action_b' => ['b']]));
+        $stub2->setKeybindingLabels(['action_b' => 'Action B']);
+
+        $widget = new KeyBindingWidget();
+
+        $tui->add($stub1);
+        $tui->add($stub2);
+        $tui->add($widget);
+
+        // Navigate until back to stub1
+        $tui->handleInput("\x1b[17~"); // stub2
+        $tui->handleInput("\x1b[17~"); // back to stub1
+
+        $lines = $this->renderStripped($widget);
+        $this->assertStringContainsString('Action A', implode('', $lines));
+        $this->assertStringNotContainsString('Action B', implode('', $lines));
+    }
+
+    // --- Sub-element styles ---
+
+    public function testSubElementKeyStyleApplied()
+    {
+        $stylesheet = new StyleSheet([
+            KeyBindingWidget::class.'::key' => new Style(bold: true),
+        ]);
+
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(styleSheet: $stylesheet, terminal: $terminal);
+
+        $stub = new StubFocusableWidget();
+        $stub->setKeybindings(new Keybindings(['move_up' => [Key::UP]]));
+        $stub->setKeybindingLabels(['move_up' => 'Move Up']);
+
+        $widget = new KeyBindingWidget();
+        $tui->add($stub);
+        $tui->add($widget);
+
+        $raw = implode('', $widget->render(new RenderContext(80, 1)));
+        $this->assertStringContainsString("\x1b[1m", $raw); // bold ANSI code
+    }
+
+    public function testSubElementGlobalKeyStyleApplied()
+    {
+        $stylesheet = new StyleSheet([
+            KeyBindingWidget::class.'::global-key' => new Style(bold: true),
+        ]);
+
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(styleSheet: $stylesheet, terminal: $terminal);
+
+        $widget = new KeyBindingWidget();
+        $widget->setGlobalKeybindings(
+            new Keybindings(['quit' => ['ctrl+c']]),
+            ['quit' => 'Quit']
+        );
+        $tui->add($widget);
+
+        $raw = implode('', $widget->render(new RenderContext(80, 1)));
+        $this->assertStringContainsString("\x1b[1m", $raw); // bold ANSI code
+    }
+
+    // --- Helpers ---
+
+    /**
+     * @return array{KeyBindingWidget, StubFocusableWidget}
+     */
+    private function createWithTui(Keybindings $bindings, array $labels): array
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+
+        $stub = new StubFocusableWidget();
+        $stub->setKeybindings($bindings);
+        $stub->setKeybindingLabels($labels);
+
+        $widget = new KeyBindingWidget();
+
+        $tui->add($stub);   // added first → gets focus
+        $tui->add($widget); // onAttach sees stub as focused → populates items
+
+        return [$widget, $stub];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function renderStripped(KeyBindingWidget $widget, int $columns = 80): array
+    {
+        return array_map(
+            static fn (string $line) => AnsiUtils::stripAnsiCodes($line),
+            $widget->render(new RenderContext($columns, 10))
+        );
+    }
+}
+
+/**
+ * @internal
+ */
+class StubFocusableWidget extends AbstractWidget implements FocusableInterface
+{
+    use FocusableTrait;
+    use KeybindingsTrait;
+
+    public function render(RenderContext $context): array
+    {
+        return [];
+    }
+
+    public function handleInput(string $data): void
+    {
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
@@ -447,6 +447,28 @@ class SelectListTest extends TestCase
         );
     }
 
+    public function testKeybindingLabelsOmitToggleWithoutMultiselect()
+    {
+        $labels = $this->createTestList()->getKeybindingLabels();
+
+        $this->assertArrayNotHasKey('choice_toggle', $labels);
+        $this->assertSame('Select', $labels['select_confirm']);
+    }
+
+    public function testKeybindingLabelsIncludeToggleWithMultiselect()
+    {
+        $labels = $this->createTestList(multiselect: true)->getKeybindingLabels();
+
+        $this->assertSame('Toggle', $labels['choice_toggle']);
+    }
+
+    public function testExplicitKeybindingLabelsWin()
+    {
+        $labels = $this->createTestList()->setKeybindingLabels(['select_confirm' => 'OK'])->getKeybindingLabels();
+
+        $this->assertSame(['select_confirm' => 'OK'], $labels);
+    }
+
     /**
      * @return array{SelectListWidget, Tui}
      */

--- a/src/Symfony/Component/Tui/Widget/FocusableInterface.php
+++ b/src/Symfony/Component/Tui/Widget/FocusableInterface.php
@@ -79,4 +79,28 @@ interface FocusableInterface
      * @return $this
      */
     public function setKeybindings(?Keybindings $keybindings): static;
+
+    /**
+     * Return ordered display labels for keybindings shown in KeyBindingWidget.
+     *
+     * Keys define which actions are displayed and in what order.
+     * Values are the human-readable labels.
+     * Actions absent from this array are not displayed.
+     * An empty array means "show all actions with humanized action names".
+     *
+     * @return array<string, string>
+     */
+    public function getKeybindingLabels(): array;
+
+    /**
+     * Set explicit display labels for this widget's keybindings.
+     *
+     * When set, takes priority over the widget's default labels.
+     * Pass null to revert to those defaults.
+     *
+     * @param array<string, string>|null $labels
+     *
+     * @return $this
+     */
+    public function setKeybindingLabels(?array $labels): static;
 }

--- a/src/Symfony/Component/Tui/Widget/KeyBindingWidget.php
+++ b/src/Symfony/Component/Tui/Widget/KeyBindingWidget.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Event\FocusEvent;
+use Symfony\Component\Tui\Input\Key;
+use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Render\RenderContext;
+
+/**
+ * Displays the keybindings of the currently focused widget.
+ *
+ * Renders a styled key badge followed by the action label per keybinding.
+ * Updates automatically when focus changes or when the bindings or labels
+ * of the focused widget change.
+ *
+ * Styleable sub-elements via stylesheet:
+ * - ::key: the key badge for focused-widget bindings
+ * - ::action: the action label for focused-widget bindings
+ * - ::global-key: the key badge for global bindings
+ * - ::global-action: the action label for global bindings
+ *
+ * @experimental
+ *
+ * @author Sylvain Blondeau <contact@sylvainblondeau.dev>
+ */
+class KeyBindingWidget extends AbstractWidget
+{
+    /** @var list<array{label: string, keys: string[]}> */
+    private array $currentItems = [];
+
+    /** @var list<array{label: string, keys: string[]}> */
+    private array $globalItems = [];
+
+    /** @var array<string, string> */
+    private array $keyLabels = [];
+
+    private ?\Closure $focusListener = null;
+    private int $gap = 2;
+    private string $separator = ' │ ';
+
+    public function setGap(int $gap): static
+    {
+        if ($this->gap !== $gap) {
+            $this->gap = max(0, $gap);
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function setSeparator(string $separator): static
+    {
+        if ($this->separator !== $separator) {
+            $this->separator = $separator;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Override the display label of individual keys, e.g. to use
+     * platform-specific symbols or plain text.
+     *
+     * @param array<string, string>|null $labels map of key identifier => display string; null reverts to the defaults from Key::label()
+     *
+     * @return $this
+     */
+    public function setKeyLabels(?array $labels): static
+    {
+        $labels ??= [];
+
+        if ($this->keyLabels !== $labels) {
+            $this->keyLabels = $labels;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, string>|null $labels map of action => display label; null falls back to humanized action names
+     *
+     * @return $this
+     */
+    public function setGlobalKeybindings(Keybindings $bindings, ?array $labels = null): static
+    {
+        $items = self::buildItems($bindings->all(), $labels);
+
+        if ($this->globalItems !== $items) {
+            $this->globalItems = $items;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function beforeRender(): void
+    {
+        $focused = $this->getContext()?->getFocusManager()->getFocus();
+
+        if ($focused instanceof FocusableInterface) {
+            $this->updateBindings($focused);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function render(RenderContext $context): array
+    {
+        $columns = $context->getColumns();
+        $gapStr = str_repeat(' ', $this->gap);
+
+        // Right group (global), anchored to the end of the last line
+        $rightParts = [];
+        $rightWidth = 0;
+        $separatorWidth = AnsiUtils::visibleWidth($this->separator);
+        foreach ($this->globalItems as ['label' => $label, 'keys' => $keys]) {
+            $badge = ' '.$this->keyLabel($keys[0]).' ';
+            $width = AnsiUtils::visibleWidth($badge) + 1 + AnsiUtils::visibleWidth($label) + ($rightParts ? $this->gap : 0);
+            $rightParts[] = $this->applyElement('global-key', $badge).' '.$this->applyElement('global-action', $label);
+            $rightWidth += $width;
+        }
+        $right = $rightParts ? implode($gapStr, $rightParts) : '';
+        if ($right) {
+            $rightWidth += $separatorWidth;
+        }
+
+        // Left group (focused widget) wraps onto multiple lines;
+        // the last line must leave room for globals
+        $lines = [];
+        $lineParts = [];
+        $lineWidth = 0;
+
+        foreach ($this->currentItems as ['label' => $label, 'keys' => $keys]) {
+            $badge = ' '.$this->keyLabel($keys[0]).' ';
+            $itemWidth = AnsiUtils::visibleWidth($badge) + 1 + AnsiUtils::visibleWidth($label);
+            $width = $itemWidth + ($lineParts ? $this->gap : 0);
+
+            if ($lineParts && $lineWidth + $width > $columns) {
+                $lines[] = ['content' => implode($gapStr, $lineParts), 'width' => $lineWidth];
+                $lineParts = [];
+                $lineWidth = 0;
+                $width = $itemWidth;
+            }
+
+            $lineParts[] = $this->applyElement('key', $badge).' '.$this->applyElement('action', $label);
+            $lineWidth += $width;
+        }
+
+        if ($lineParts) {
+            $lines[] = ['content' => implode($gapStr, $lineParts), 'width' => $lineWidth];
+        }
+
+        if (!$lines && !$right) {
+            return [];
+        }
+
+        if (!$lines) {
+            $rightWidth -= $separatorWidth;
+
+            return [self::clamp(str_repeat(' ', max(0, $columns - $rightWidth)).$right, max($rightWidth, $columns), $columns)];
+        }
+
+        // Build result: all lines except the last are full-width left content
+        $result = [];
+        foreach (\array_slice($lines, 0, -1) as ['content' => $content, 'width' => $width]) {
+            $result[] = self::clamp($content, $width, $columns);
+        }
+
+        // Last line: combine left remainder with globals (flex space between)
+        ['content' => $lastContent, 'width' => $lastWidth] = end($lines);
+
+        if (!$right) {
+            $result[] = self::clamp($lastContent, $lastWidth, $columns);
+        } elseif ($lastWidth + $rightWidth <= $columns) {
+            $result[] = $lastContent.str_repeat(' ', $columns - $lastWidth - $rightWidth).$this->separator.$right;
+        } else {
+            $result[] = self::clamp($lastContent, $lastWidth, $columns);
+            $result[] = self::clamp(str_repeat(' ', max(0, $columns - $rightWidth)).$this->separator.$right, max($rightWidth, $columns), $columns);
+        }
+
+        return $result;
+    }
+
+    protected function onAttach(WidgetContext $context): void
+    {
+        $this->focusListener = function (FocusEvent $event): void {
+            $this->updateBindings($event->getTarget());
+        };
+        $context->getEventDispatcher()->addListener(FocusEvent::class, $this->focusListener);
+
+        $focused = $context->getFocusManager()->getFocus();
+        if ($focused instanceof FocusableInterface) {
+            $this->updateBindings($focused);
+        }
+    }
+
+    protected function onDetach(): void
+    {
+        if (null !== $this->focusListener) {
+            $this->getContext()?->getEventDispatcher()
+                ->removeListener(FocusEvent::class, $this->focusListener);
+            $this->focusListener = null;
+        }
+    }
+
+    /**
+     * @param array<string, string[]>    $bindings
+     * @param array<string, string>|null $labels
+     *
+     * @return list<array{label: string, keys: string[]}>
+     */
+    private static function buildItems(array $bindings, ?array $labels): array
+    {
+        $items = [];
+
+        if (null !== $labels) {
+            foreach ($labels as $action => $label) {
+                if ($bindings[$action] ?? false) {
+                    $items[] = ['label' => $label, 'keys' => $bindings[$action]];
+                }
+            }
+        } else {
+            foreach ($bindings as $action => $keys) {
+                if ($keys) {
+                    $items[] = ['label' => ucwords(str_replace('_', ' ', $action)), 'keys' => $keys];
+                }
+            }
+        }
+
+        return $items;
+    }
+
+    private static function clamp(string $line, int $width, int $columns): string
+    {
+        return $width > $columns ? AnsiUtils::truncateToWidth($line, $columns) : $line;
+    }
+
+    private function keyLabel(string $key): string
+    {
+        return $this->keyLabels[$key] ?? Key::label($key);
+    }
+
+    private function updateBindings(AbstractWidget&FocusableInterface $target): void
+    {
+        $items = self::buildItems($target->getKeybindings()->all(), $target->getKeybindingLabels() ?: null);
+
+        if ($this->currentItems !== $items) {
+            $this->currentItems = $items;
+            $this->invalidate();
+        }
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/KeybindingsTrait.php
+++ b/src/Symfony/Component/Tui/Widget/KeybindingsTrait.php
@@ -29,6 +29,9 @@ trait KeybindingsTrait
 {
     private ?Keybindings $keybindings = null;
 
+    /** @var array<string, string>|null */
+    private ?array $keybindingLabels = null;
+
     /** @var (\Closure(string): bool)|null */
     private ?\Closure $onInput = null;
 
@@ -57,7 +60,33 @@ trait KeybindingsTrait
      */
     public function setKeybindings(?Keybindings $keybindings): static
     {
-        $this->keybindings = $keybindings;
+        if ($this->keybindings !== $keybindings) {
+            $this->keybindings = $keybindings;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getKeybindingLabels(): array
+    {
+        return $this->keybindingLabels ?? static::getDefaultKeybindingLabels();
+    }
+
+    /**
+     * @param array<string, string>|null $labels
+     *
+     * @return $this
+     */
+    public function setKeybindingLabels(?array $labels): static
+    {
+        if ($this->keybindingLabels !== $labels) {
+            $this->keybindingLabels = $labels;
+            $this->invalidate();
+        }
 
         return $this;
     }
@@ -77,9 +106,27 @@ trait KeybindingsTrait
      *
      * Override in widgets that define their own actions.
      *
+     * The first key in each action's array is the primary binding and is
+     * the one displayed by KeyBindingWidget. Additional keys are functional
+     * aliases (e.g. Emacs-style alternatives) and are not shown by default.
+     *
      * @return array<string, string[]>
      */
     protected static function getDefaultKeybindings(): array
+    {
+        return [];
+    }
+
+    /**
+     * Return the default display labels for this widget's keybindings.
+     *
+     * Override to define which actions are shown in KeyBindingWidget,
+     * in what order, and with what human-readable labels.
+     * Actions absent from the returned array are not displayed.
+     *
+     * @return array<string, string>
+     */
+    protected static function getDefaultKeybindingLabels(): array
     {
         return [];
     }

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -329,6 +329,40 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
     }
 
     /**
+     * @return array<string, string>
+     */
+    public function getKeybindingLabels(): array
+    {
+        if (null !== $this->keybindingLabels) {
+            return $this->keybindingLabels;
+        }
+
+        $labels = static::getDefaultKeybindingLabels();
+
+        if (!$this->multiselect) {
+            unset($labels['choice_toggle']);
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function getDefaultKeybindingLabels(): array
+    {
+        return [
+            'select_down' => 'Down',
+            'select_up' => 'Up',
+            'select_page_down' => 'Page Down',
+            'select_page_up' => 'Page Up',
+            'choice_toggle' => 'Toggle',
+            'select_confirm' => 'Select',
+            'select_cancel' => 'Cancel',
+        ];
+    }
+
+    /**
      * @param array{value: string, label: string, description?: string, checked?: bool} $item
      */
     private function renderItem(array $item, bool $isSelected, ?string $description, int $columns, int $labelColumnWidth): string


### PR DESCRIPTION
 | Q             | A
 | ------------- | ---
 | Branch?       | 8.2
 | Bug fix?      | no
 | New feature?  | yes
 | Deprecations? | no
 | Issues        | -
 | License       | MIT

## Description

Adds a `KeyBindingWidget` to the (experimental) Tui component.

This widget displays the keybindings of the currently focused widget.
It listens to `FocusEvent` and automatically updates its content when focus changes between widgets.
Equivalent in other TUI libraries: https://textual.textualize.io/widgets/footer/

### Features

- Renders a styled key badge followed by the action label per keybinding
- Supports two groups:
  - **Focused widget bindings** (left-aligned, wraps onto multiple lines)
  - **Global bindings** (right-aligned, anchored to the last line) e.g. for quit
- Intelligent line wrapping respecting the available terminal width
- Fully styleable via CSS-like sub-element selectors:
  - `::key` / `::action` — focused-widget binding styles
  - `::global-key` / `::global-action` — global binding styles
- Configurable gap and separator between items
- Supports custom label overrides per action via `setGlobalKeybindings($bindings, $labels)`

<img width="749" height="287" alt="image" 
src="https://github.com/user-attachments/assets/c94f26e2-c25e-4551-8f0a-bf75f818cf79" />

### Usage example

```php
$app->addWidget(
    (new KeyBindingWidget())
        ->setGlobalKeybindings($globalBindings, [
            'quit' => 'Quit',
            'help' => 'Help',
        ])
);
```
When a FocusableInterface widget gains focus, its keybindings are automatically reflected in the
KeyBindingWidget.

### Key display labels and symbol overrides

Key::label() converts key identifiers into human-readable symbols by default:
e.g 
```
Key::ENTER  as ↵             
Key::BACKSPACE as  ⌫             
Key::UP  as ▲             
Key::DOWN  as ▼             
Key::PAGE_UP   as ⇞             
Key::PAGE_DOWN as ⇟             
Key::ctrl('c') as Ctrl+C        
```

These defaults can be overridden per widget instance via `KeyBindingWidget::setKeyLabels()`, for example
to use platform-specific symbols (⌘, ⌥…) or plain text:

```php
$footer->setKeyLabels([
    Key::ENTER => '⏎',
    Key::UP => '↑',
]);

$footer->setKeyLabels(null); // revert to the defaults
```

Combo keys resolve each part through the same map, so `ctrl+space` renders as `Ctrl+Space`. Actions
without any bound key are skipped, and items are clamped to the terminal width so an over-wide label
cannot break the render.
### Per-widget display control via KeybindingsTrait

`KeybindingsTrait` (used by all `FocusableInterface` widgets) exposes two levels of label control, which
determine what KeyBindingWidget displays when that widget is focused.

### Class level — `getDefaultKeybindingLabels()`

Widgets override this static method to declare which actions are shown, in what order, and with what
human-readable label. Actions absent from the returned array are not displayed.

```php
// SelectListWidget (already implemented as example)
protected static function getDefaultKeybindingLabels(): array
{
    return [
        'select_down'      => 'Down',
        'select_up'        => 'Up',
        'select_page_down' => 'Page Down',
        'select_page_up'   => 'Page Up',
        'choice_toggle'    => 'Toggle',
        'select_confirm'   => 'Select',
        'select_cancel'    => 'Cancel',
        // 'cursor_left' and 'cursor_right' are intentionally omitted
    ];
}
```

The `choice_toggle` entry is only displayed in multiselect mode, through an instance-level
`getKeybindingLabels()` override.
Only `SelectListWidget` implements `getDefaultKeybindingLabels()` in this PR. Other built-in widgets will
add their own implementation as needed in follow-up PRs.

#### Instance level — setKeybindingLabels()

Any widget instance can override the class defaults at runtime — useful to reorder, filter, or relabel
actions without subclassing:

// Show only the confirm action, with a custom label
```php
$list->setKeybindingLabels([
    'select_confirm' => 'OK',
]);

// Revert to class defaults
$list->setKeybindingLabels(null);
```
 ---

