### PR TITLE
[DoctrineBridge][Messenger] Allow using `DoctrineCloseConnectionMiddleware` without the ORM

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -24,6 +24,14 @@ DoctrineBridge
  * `UniqueEntity` now throws a `ConstraintDefinitionException` when a checked field holds an array or is a to-many
    association and the default `findBy` repository method is used. Such fields were silently validated against a
    query that could not match. Use the `repositoryMethod` option to provide a method that can query them
+ * Add `$connectionName` to `DoctrineCloseConnectionMiddleware` constructor and deprecate not passing it
+    ```diff
+     'middleware' => [
+    -   'doctrine_close_connection' => ['entity_manager_name'],
+    +   'doctrine_close_connection' => ['$connectionName' => 'connection_name'],
+     ],
+    ```
+ * Deprecate overriding `DoctrineCloseConnectionMiddleware::handleForManager()`
 
 Form
 ----

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add IterableToArrayCollectionTransformer for ObjectMapper
  * Throw a `ConstraintDefinitionException` from `UniqueEntity` when a checked field holds an array or is a to-many association, instead of building a query that cannot match
  * Allow using closures with the `#[MapEntity]` attribute
+ * Add `$connectionName` to `DoctrineCloseConnectionMiddleware` constructor and deprecate not passing it
+ * Deprecate overriding `DoctrineCloseConnectionMiddleware::handleForManager()`
 
 8.1
 ---

--- a/src/Symfony/Bridge/Doctrine/Messenger/AbstractDbalMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/AbstractDbalMiddleware.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+/**
+ * @internal
+ */
+abstract class AbstractDbalMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+        protected ?string $entityManagerName = null,
+        protected ?string $connectionName = null,
+    ) {
+        if (null === $this->connectionName) {
+            trigger_deprecation('symfony/doctrine-bridge', '8.2', 'Instantiating "%s" without a connection name is deprecated.', static::class);
+        }
+
+        if (self::class !== ($childClass = new \ReflectionMethod($this, 'handleForManager')->getDeclaringClass()->getName())) {
+            trigger_deprecation('symfony/doctrine-bridge', '8.2', 'Overriding "%s::handleForManager()" in "%s" is deprecated, override "handleForConnection()" instead.', self::class, $childClass);
+        }
+    }
+
+    final public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            if (null === $this->connectionName) {
+                if (!($entityManager = $this->managerRegistry->getManager($this->entityManagerName)) instanceof EntityManagerInterface) {
+                    throw new \InvalidArgumentException(\sprintf('Expected "%s" to be an entity manager, but got a "%s".', $this->entityManagerName ?? $this->managerRegistry->getDefaultManagerName(), $entityManager::class));
+                }
+
+                return $this->handleForManager($entityManager, $envelope, $stack);
+            }
+
+            if (!($connection = $this->managerRegistry->getConnection($this->connectionName)) instanceof Connection) {
+                throw new \InvalidArgumentException(\sprintf('Expected "%s" to be a DBAL connection, but got a "%s".', $this->connectionName, $connection::class));
+            }
+
+            return $this->handleForConnection($connection, $envelope, $stack);
+        } catch (\InvalidArgumentException $e) {
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        }
+    }
+
+    abstract protected function handleForConnection(Connection $connection, Envelope $envelope, StackInterface $stack): Envelope;
+
+    /**
+     * @deprecated since Symfony 8.2, use handleForConnection() instead
+     */
+    protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
+    {
+        return $this->handleForConnection($entityManager->getConnection(), $envelope, $stack);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/AbstractOrmMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/AbstractOrmMiddleware.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
  *
  * @internal
  */
-abstract class AbstractDoctrineMiddleware implements MiddlewareInterface
+abstract class AbstractOrmMiddleware implements MiddlewareInterface
 {
     public function __construct(
         protected ManagerRegistry $managerRegistry,
@@ -34,7 +34,9 @@ abstract class AbstractDoctrineMiddleware implements MiddlewareInterface
     final public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         try {
-            $entityManager = $this->managerRegistry->getManager($this->entityManagerName);
+            if (!($entityManager = $this->managerRegistry->getManager($this->entityManagerName)) instanceof EntityManagerInterface) {
+                throw new \InvalidArgumentException(\sprintf('Expected "%s" to be an entity manager, but got a "%s".', $this->entityManagerName ?? $this->managerRegistry->getDefaultManagerName(), $entityManager::class));
+            }
         } catch (\InvalidArgumentException $e) {
             throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
         }

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Messenger;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Connection;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
@@ -21,13 +21,11 @@ use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
  *
  * @author Fuong <insidestyles@gmail.com>
  */
-class DoctrineCloseConnectionMiddleware extends AbstractDoctrineMiddleware
+class DoctrineCloseConnectionMiddleware extends AbstractDbalMiddleware
 {
-    protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
+    protected function handleForConnection(Connection $connection, Envelope $envelope, StackInterface $stack): Envelope
     {
         try {
-            $connection = $entityManager->getConnection();
-
             return $stack->next()->handle($envelope, $stack);
         } finally {
             if (null !== $envelope->last(ConsumedByWorkerStamp::class)) {

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
@@ -22,7 +22,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-class DoctrineOpenTransactionLoggerMiddleware extends AbstractDoctrineMiddleware
+class DoctrineOpenTransactionLoggerMiddleware extends AbstractOrmMiddleware
 {
     private bool $isHandling = false;
 

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
  *
  * @author Fuong <insidestyles@gmail.com>
  */
-class DoctrinePingConnectionMiddleware extends AbstractDoctrineMiddleware
+class DoctrinePingConnectionMiddleware extends AbstractOrmMiddleware
 {
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineTransactionMiddleware.php
@@ -22,7 +22,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class DoctrineTransactionMiddleware extends AbstractDoctrineMiddleware
+class DoctrineTransactionMiddleware extends AbstractOrmMiddleware
 {
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/AbstractDbalMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/AbstractDbalMiddlewareTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use Symfony\Bridge\Doctrine\Messenger\AbstractDbalMiddleware;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class AbstractDbalMiddlewareTest extends MiddlewareTestCase
+{
+    use ExpectUserDeprecationMessageTrait;
+
+    public function testNamedConnection()
+    {
+        $connection = $this->createStub(Connection::class);
+
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getConnection')->willReturnMap([['connectionName', $connection]]);
+
+        $middleware = new DummyMiddleware($managerRegistry, connectionName: 'connectionName');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+
+        $this->assertSame($connection, $middleware->handledConnection);
+    }
+
+    public function testMissingConnection()
+    {
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getConnection')->willThrowException(new \InvalidArgumentException('Doctrine default Connection named "unknownConnectionName" does not exist.'));
+
+        $middleware = new DummyMiddleware($managerRegistry, connectionName: 'unknownConnectionName');
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Doctrine default Connection named "unknownConnectionName" does not exist.');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock(false));
+    }
+
+    public function testInvalidConnection()
+    {
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getConnection')->willReturn(new \stdClass());
+
+        $middleware = new DummyMiddleware($managerRegistry, connectionName: 'invalidConnectionName');
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Expected "invalidConnectionName" to be a DBAL connection, but got a "stdClass".');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock(false));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDefaultEntityManager()
+    {
+        $connection = $this->createStub(Connection::class);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getManager')->willReturnMap([[null, $entityManager]]);
+
+        $middleware = new DummyMiddleware($managerRegistry);
+
+        $this->expectUserDeprecationMessage('Since symfony/doctrine-bridge 8.2: Instantiating "Symfony\Bridge\Doctrine\Tests\Messenger\DummyMiddleware" without a connection name is deprecated.');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+
+        $this->assertSame($connection, $middleware->handledConnection);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testNamedEntityManager()
+    {
+        $connection = $this->createStub(Connection::class);
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getManager')->willReturnMap([['entityManagerName', $entityManager]]);
+
+        $middleware = new DummyMiddleware($managerRegistry, 'entityManagerName');
+
+        $this->expectUserDeprecationMessage('Since symfony/doctrine-bridge 8.2: Instantiating "Symfony\Bridge\Doctrine\Tests\Messenger\DummyMiddleware" without a connection name is deprecated.');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+
+        $this->assertSame($connection, $middleware->handledConnection);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testMissingEntityManager()
+    {
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getManager')->willThrowException(new \InvalidArgumentException('Doctrine default Manager named "missingEntityManagerName" does not exist.'));
+
+        $middleware = new DummyMiddleware($managerRegistry, 'missingEntityManagerName');
+
+        $this->expectUserDeprecationMessage('Since symfony/doctrine-bridge 8.2: Instantiating "Symfony\Bridge\Doctrine\Tests\Messenger\DummyMiddleware" without a connection name is deprecated.');
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Doctrine default Manager named "missingEntityManagerName" does not exist.');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock(false));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testInvalidEntityManager()
+    {
+        $manager = $this->createStub(ObjectManager::class);
+
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getManager')->willReturn($manager);
+
+        $middleware = new DummyMiddleware($managerRegistry, 'invalidEntityManagerName');
+
+        $this->expectUserDeprecationMessage('Since symfony/doctrine-bridge 8.2: Instantiating "Symfony\Bridge\Doctrine\Tests\Messenger\DummyMiddleware" without a connection name is deprecated.');
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage(\sprintf('Expected "invalidEntityManagerName" to be an entity manager, but got a "%s".', $manager::class));
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock(false));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testOverridingHandleForManagerIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/doctrine-bridge 8.2: Overriding "Symfony\Bridge\Doctrine\Messenger\AbstractDbalMiddleware::handleForManager()" in "Symfony\Bridge\Doctrine\Tests\Messenger\HandleForManagerMiddleware" is deprecated, override "handleForConnection()" instead.');
+
+        new HandleForManagerMiddleware($this->createStub(ManagerRegistry::class), connectionName: 'whatever');
+    }
+}
+
+class DummyMiddleware extends AbstractDbalMiddleware
+{
+    public ?Connection $handledConnection = null;
+
+    protected function handleForConnection(Connection $connection, Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $this->handledConnection = $connection;
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}
+
+class HandleForManagerMiddleware extends AbstractDbalMiddleware
+{
+    protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
+    {
+        return $stack->next()->handle($envelope, $stack);
+    }
+
+    protected function handleForConnection(Connection $connection, Envelope $envelope, StackInterface $stack): Envelope
+    {
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
@@ -12,75 +12,39 @@
 namespace Symfony\Bridge\Doctrine\Tests\Messenger;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineCloseConnectionMiddleware;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 
 class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
 {
-    private MockObject&Connection $connection;
-    private EntityManagerInterface $entityManager;
-    private ManagerRegistry $managerRegistry;
-    private DoctrineCloseConnectionMiddleware $middleware;
-    private string $entityManagerName = 'default';
-
-    protected function setUp(): void
+    public function testMiddlewareCloseConnection()
     {
-        $this->connection = $this->createMock(Connection::class);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('close');
 
-        $this->entityManager = $this->createStub(EntityManagerInterface::class);
-        $this->entityManager->method('getConnection')->willReturn($this->connection);
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getConnection')->willReturn($connection);
 
-        $this->managerRegistry = $this->createStub(ManagerRegistry::class);
-        $this->managerRegistry->method('getManager')->willReturn($this->entityManager);
-
-        $this->middleware = new DoctrineCloseConnectionMiddleware(
-            $this->managerRegistry,
-            $this->entityManagerName
+        new DoctrineCloseConnectionMiddleware($managerRegistry, connectionName: 'connection')->handle(
+            new Envelope(new \stdClass(), [new ConsumedByWorkerStamp()]),
+            $this->getStackMock(),
         );
     }
 
-    public function testMiddlewareCloseConnection()
+    public function testMiddlewareDoesNotCloseConnectionInNonWorkerContext()
     {
-        $this->connection->expects($this->once())
-            ->method('close')
-        ;
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('close');
 
-        $envelope = new Envelope(new \stdClass(), [
-            new ConsumedByWorkerStamp(),
-        ]);
-        $this->middleware->handle($envelope, $this->getStackMock());
-    }
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getConnection')->willReturn($connection);
 
-    public function testInvalidEntityManagerThrowsException()
-    {
-        $this->connection->expects($this->never())->method('getDatabasePlatform');
-        $managerRegistry = $this->createMock(ManagerRegistry::class);
-        $managerRegistry
-            ->expects($this->once())
-            ->method('getManager')
-            ->with('unknown_manager')
-            ->willThrowException(new \InvalidArgumentException());
-
-        $middleware = new DoctrineCloseConnectionMiddleware($managerRegistry, 'unknown_manager');
-
-        $this->expectException(UnrecoverableMessageHandlingException::class);
-
-        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock(false));
-    }
-
-    public function testMiddlewareNotCloseInNonWorkerContext()
-    {
-        $this->connection->expects($this->never())
-            ->method('close')
-        ;
-
-        $envelope = new Envelope(new \stdClass());
-        $this->middleware->handle($envelope, $this->getStackMock());
+        new DoctrineCloseConnectionMiddleware($managerRegistry, connectionName: 'connection')->handle(
+            new Envelope(new \stdClass()),
+            $this->getStackMock(),
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Prerequisite for #38988
| License       | MIT

This PR splits `AbstractDoctrineMiddleware` into `AbstractOrmMiddleware` and `AbstractDbalMiddleware`.
The latter gets an additional `$connectionName` argument, and not passing it is deprecated.

`DoctrineCloseConnectionMiddleware` was updated accordingly to showcase this change since it is the simplest to convert.