### PR TITLE
[ObjectMapper] Add MappingAwareTransformCallableInterface

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add automatic conversion between `BackedEnum` and scalar types (both ways)
+ * Add a `MappingAwareTransformCallableInterface` to pass the `Map` attribute being applied to transformers
 
 8.1
 ---

--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add `SourceClass`, `ClassRule`, and `ClassRuleList` condition callables to match mapping rules based on source/target class
  * Allow `TargetClass` and `SourceClass` to accept arrays of class FQDNs
  * Add `IsNotNull` built-in condition to skip mapping when a source property value is null
+ * Add `MappingAwareTransformCallableInterface` to give transformers access to the current `Map` metadata
 
 7.4
 ---

--- a/src/Symfony/Component/ObjectMapper/MappingAwareTransformCallableInterface.php
+++ b/src/Symfony/Component/ObjectMapper/MappingAwareTransformCallableInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * A transformer receiving the #[Map] attribute being applied.
+ *
+ * The attribute is passed to __invoke() so that the transformer stays stateless and can be used
+ * as a service. It is nullable only because an interface cannot add a required parameter to an
+ * inherited signature: the mapper always passes it. {@see Map::$target} is null when the mapping
+ * is declared on the target side with #[Map(source: ...)].
+ *
+ * @template T of object
+ * @template T2 of object
+ *
+ * @extends TransformCallableInterface<T, T2>
+ */
+interface MappingAwareTransformCallableInterface extends TransformCallableInterface
+{
+    /**
+     * @param mixed    $value   The value being mapped
+     * @param T        $source  The object we're working on
+     * @param T2|null  $target  The target we're mapping to
+     * @param Map|null $mapping The mapping being applied
+     */
+    public function __invoke(mixed $value, object $source, ?object $target, ?Map $mapping = null): mixed;
+}

--- a/src/Symfony/Component/ObjectMapper/MappingAwareTransformCallableInterface.php
+++ b/src/Symfony/Component/ObjectMapper/MappingAwareTransformCallableInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * Allows a transformer to receive the {@see Map} metadata describing the
+ * property currently being mapped (target/source name, condition, transform).
+ */
+interface MappingAwareTransformCallableInterface
+{
+    /**
+     * Returns a clone of the original instance, configured with the given mapping.
+     */
+    public function withMapping(Map $mapping): static;
+}

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -509,7 +509,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             if ($fn instanceof ObjectMapperAwareInterface) {
                 $fn = $fn->withObjectMapper($this->objectMapper ?? $this);
             }
-            $value = $this->call($fn, $value, $source, $target);
+            $value = $fn instanceof MappingAwareTransformCallableInterface
+                ? $fn($value, $source, $target, $map)
+                : $this->call($fn, $value, $source, $target);
         }
 
         return $value;

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -377,6 +377,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             if ($fn instanceof ObjectMapperAwareInterface) {
                 $fn = $fn->withObjectMapper($this->objectMapper ?? $this);
             }
+            if ($fn instanceof MappingAwareTransformCallableInterface) {
+                $fn = $fn->withMapping($map);
+            }
             $value = $this->call($fn, $value, $source, $target);
         }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/A.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/A.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(B::class)]
+class A
+{
+    #[Map(target: 'bar', transform: MappingAwareTransformer::class)]
+    public string $foo = 'value';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/B.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/B.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware;
+
+class B
+{
+    public string $bar = 'unset';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/C.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(D::class)]
+class C
+{
+    public string $foo = 'value';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/D.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/D.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class D
+{
+    #[Map(source: 'foo', transform: MappingAwareTransformer::class)]
+    public string $foo = 'unset';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/MappingAwareTransformer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/MappingAwareTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\MappingAwareTransformCallableInterface;
+
+/**
+ * @implements MappingAwareTransformCallableInterface<object, object>
+ */
+class MappingAwareTransformer implements MappingAwareTransformCallableInterface
+{
+    public function __invoke(mixed $value, object $source, ?object $target, ?Map $mapping = null): mixed
+    {
+        if (!$mapping) {
+            return $value;
+        }
+
+        return $mapping->target ?? 'source:'.$mapping->source;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/MappingAwareTransformer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MappingAware/MappingAwareTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\MappingAwareTransformCallableInterface;
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+/**
+ * @implements TransformCallableInterface<A>
+ */
+class MappingAwareTransformer implements TransformCallableInterface, MappingAwareTransformCallableInterface
+{
+    private ?Map $mapping = null;
+
+    public function withMapping(Map $mapping): static
+    {
+        $clone = clone $this;
+        $clone->mapping = $mapping;
+
+        return $clone;
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        if (null === $this->mapping) {
+            return $value;
+        }
+
+        return $this->mapping->target;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -27,12 +27,6 @@ use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactor
 use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\Lead as SourceCarriesMetadataLead;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\LeadDto as SourceCarriesMetadataLeadDto;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\TypeDto as SourceCarriesMetadataTypeDto;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\OtherView as TargetInClassMapOtherView;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Source as TargetInClassMapSource;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Target as TargetInClassMapTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
@@ -118,6 +112,11 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\NestedExisti
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\Post as MapExistingObjectPost;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\PostDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\Tag;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\A as MappingAwareA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\B as MappingAwareB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\C as MappingAwareC;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\D as MappingAwareD;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\MappingAwareTransformer;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -194,9 +193,15 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\A as ServiceLoc
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\B as ServiceLocatorB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\ConditionCallable;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\TransformCallable;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\Lead as SourceCarriesMetadataLead;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\LeadDto as SourceCarriesMetadataLeadDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\TypeDto as SourceCarriesMetadataTypeDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ChildTarget as SubclassTargetWithTransformChildTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ParentTarget as SubclassTargetWithTransformParentTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\Source as SubclassTargetWithTransformSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\OtherView as TargetInClassMapOtherView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Source as TargetInClassMapSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Target as TargetInClassMapTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\SourceEntity;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\TargetDto as TargetTransformTargetDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Transform\TransformToStdClass;
@@ -740,6 +745,28 @@ final class ObjectMapperTest extends TestCase
 
         $b = $myMapper->map($a);
         $this->assertSame('got decorated', $b->relation->baz);
+    }
+
+    public function testMappingAwareTransformCallable()
+    {
+        $mapper = new ObjectMapper(
+            transformCallableLocator: $this->getServiceLocator([MappingAwareTransformer::class => new MappingAwareTransformer()]),
+        );
+        $b = $mapper->map(new MappingAwareA());
+
+        $this->assertInstanceOf(MappingAwareB::class, $b);
+        $this->assertSame('bar', $b->bar);
+    }
+
+    public function testMappingAwareTransformCallableWithTargetSideMapping()
+    {
+        $mapper = new ObjectMapper(
+            transformCallableLocator: $this->getServiceLocator([MappingAwareTransformer::class => new MappingAwareTransformer()]),
+        );
+        $d = $mapper->map(new MappingAwareC());
+
+        $this->assertInstanceOf(MappingAwareD::class, $d);
+        $this->assertSame('source:foo', $d->foo);
     }
 
     #[DataProvider('validPartialInputProvider')]

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -72,6 +72,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\IsNotNullCondition\IsNotNullSo
 use Symfony\Component\ObjectMapper\Tests\Fixtures\IsNotNullCondition\IsNotNullTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\IsNotNullCondition\IsNotNullTargetMapping;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\LazyFoo;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\A as MappingAwareA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\B as MappingAwareB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MappingAware\MappingAwareTransformer;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -602,6 +605,17 @@ final class ObjectMapperTest extends TestCase
 
         $b = $myMapper->map($a);
         $this->assertSame('got decorated', $b->relation->baz);
+    }
+
+    public function testMappingAwareTransformCallable()
+    {
+        $mapper = new ObjectMapper(
+            transformCallableLocator: $this->getServiceLocator([MappingAwareTransformer::class => new MappingAwareTransformer()]),
+        );
+        $b = $mapper->map(new MappingAwareA());
+
+        $this->assertInstanceOf(MappingAwareB::class, $b);
+        $this->assertSame('bar', $b->bar);
     }
 
     #[DataProvider('validPartialInputProvider')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64161
| License       | MIT

A `#[Map(transform: ...)]` transformer is called with the value, the source and the target, but not with the mapping it is running for. A transformer that is shared by several properties cannot tell which one it is transforming, so it has to be duplicated per property or configured out of band.

This adds an optional interface a transformer can implement to receive that mapping:

```php
namespace Symfony\Component\ObjectMapper;

use Symfony\Component\ObjectMapper\Attribute\Map;

interface MappingAwareTransformCallableInterface extends TransformCallableInterface
{
    public function __invoke(mixed $value, object $source, ?object $target, ?Map $mapping = null): mixed;
}
```

Usage:

```php
class PrefixWithTargetName implements MappingAwareTransformCallableInterface
{
    public function __invoke(mixed $value, object $source, ?object $target, ?Map $mapping = null): mixed
    {
        return $mapping?->target.': '.$value;
    }
}

class Source
{
    #[Map(target: 'label', transform: PrefixWithTargetName::class)]
    public string $name = 'Alice';
}
```

Points worth knowing:

* The interface extends `TransformCallableInterface`, so a transformer implements a single interface and stays stateless. It can be registered as a service and shared between mappings.
* The fourth argument is typed `Attribute\Map`, not `Metadata\Mapping`. `Mapping` is `@internal` and cannot appear in a public contract. Since `Mapping` extends `Map`, implementers still read `target`, `source`, `if` and `transform` from the object they receive, while `targetClass` stays internal.
* The argument is optional because PHP rejects an interface that adds a required parameter to an inherited signature. `ObjectMapper` always passes it, so it is never null in practice.
* `Map::$target` is null when the mapping is declared on the target side with `#[Map(source: ...)]`. For a class-level transform it holds the target class name.
* Transformers that do not implement the interface keep being called with three arguments.

The documentation should cover the interface and its signature, the fact that the fourth argument is always provided even though the signature allows null, and the cases where `Map::$target` is null.
