### PR TITLE
[Workflow] Add $disabledEvents to permanently silence events at the workflow level

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `--dispatchers` option to `debug:event-dispatcher` command
+ * Allow prefixing entries with `!` in `framework.workflows.<name>.events_to_dispatch` to permanently disable an event; e.g. `events_to_dispatch: ['!workflow.announce']` fires every event except `workflow.announce`. The GuardEvent can never be disabled; `!workflow.guard` is rejected at config compile time. Mixing allow-list and block-list entries in the same list is rejected at config compile time too.
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -515,16 +515,46 @@ class Configuration implements ConfigurationInterface
                                                 }
 
                                                 foreach ($v as $value) {
-                                                    if (!\in_array($value, WorkflowEvents::ALIASES, true)) {
+                                                    $name = str_starts_with($value, '!') ? substr($value, 1) : $value;
+                                                    if (!\in_array($name, WorkflowEvents::ALIASES, true)) {
                                                         return true;
                                                     }
                                                 }
 
                                                 return false;
                                             })
-                                            ->thenInvalid('The value must be "null" or an array of workflow events (like ["workflow.enter"]).')
+                                            ->thenInvalid('The value must be "null" or an array of workflow events (like ["workflow.enter"]). Prefix an event with "!" to disable it (e.g. ["!workflow.announce"]).')
                                         ->end()
-                                        ->info('Select which Transition events should be dispatched for this Workflow.')
+                                        ->validate()
+                                            ->ifTrue(static function ($v) {
+                                                if (!\is_array($v) || [] === $v) {
+                                                    return false;
+                                                }
+                                                $hasAllowList = false;
+                                                $hasBlockList = false;
+                                                foreach ($v as $value) {
+                                                    if (str_starts_with($value, '!')) {
+                                                        $hasBlockList = true;
+                                                    } else {
+                                                        $hasAllowList = true;
+                                                    }
+                                                }
+
+                                                return $hasAllowList && $hasBlockList;
+                                            })
+                                            ->thenInvalid('Cannot mix allow-list and block-list entries in "events_to_dispatch": every entry must start with "!" (block-list mode) or none of them must (allow-list mode).')
+                                        ->end()
+                                        ->validate()
+                                            ->ifTrue(static function ($v) {
+                                                if (!class_exists(WorkflowEvents::class) || !\is_array($v)) {
+                                                    return false;
+                                                }
+
+                                                return \in_array('!'.WorkflowEvents::GUARD, $v, true);
+                                            })
+                                            ->thenInvalid(\sprintf('The "%s" event cannot be disabled in "events_to_dispatch": it is always dispatched.', WorkflowEvents::GUARD))
+                                        ->end()
+                                        ->info('Select which Transition events should be dispatched for this Workflow. Prefix an event with "!" to disable it (e.g. ["!workflow.announce"]); future events are dispatched by default in block-list mode.')
                                         ->example(['workflow.enter', 'workflow.transition'])
                                     ->end()
                                     ->arrayNode('places', 'place')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -665,6 +665,89 @@ class ConfigurationTest extends TestCase
         $this->assertSame([['place' => 'c', 'weight' => 1]], $transitions[1]['to']);
     }
 
+    public function testWorkflowEventsToDispatchRejectsMixedAllowListAndBlockList()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Cannot mix allow-list and block-list entries in "events_to_dispatch": every entry must start with "!" (block-list mode) or none of them must (allow-list mode).');
+
+        $processor->processConfiguration($configuration, [[
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
+            'workflows' => [
+                'workflows' => [
+                    'mixed' => [
+                        'supports' => [self::class],
+                        'places' => ['a', 'b'],
+                        'initial_marking' => 'a',
+                        'events_to_dispatch' => ['workflow.enter', '!workflow.announce'],
+                        'transitions' => [
+                            ['name' => 'go', 'from' => ['a'], 'to' => ['b']],
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+    }
+
+    public function testWorkflowEventsToDispatchAcceptsBlockListOnlyList()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+
+        $config = $processor->processConfiguration($configuration, [[
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
+            'workflows' => [
+                'workflows' => [
+                    'block_list' => [
+                        'supports' => [self::class],
+                        'places' => ['a', 'b'],
+                        'initial_marking' => 'a',
+                        'events_to_dispatch' => ['!workflow.announce'],
+                        'transitions' => [
+                            ['name' => 'go', 'from' => ['a'], 'to' => ['b']],
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+
+        $this->assertSame(['!workflow.announce'], $config['workflows']['workflows']['block_list']['events_to_dispatch']);
+    }
+
+    public function testWorkflowEventsToDispatchRejectsBlockListedGuardEvent()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "workflow.guard" event cannot be disabled in "events_to_dispatch": it is always dispatched.');
+
+        $processor->processConfiguration($configuration, [[
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'php_errors' => ['log' => true],
+            'workflows' => [
+                'workflows' => [
+                    'guard_block' => [
+                        'supports' => [self::class],
+                        'places' => ['a', 'b'],
+                        'initial_marking' => 'a',
+                        'events_to_dispatch' => ['!workflow.guard'],
+                        'transitions' => [
+                            ['name' => 'go', 'from' => ['a'], 'to' => ['b']],
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+    }
+
     public function testFormCsrfProtectionFieldAttrDoNotNormalizeKeys()
     {
         $processor = new Processor();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_disabled_events.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_disabled_events.php
@@ -1,0 +1,43 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase;
+
+$container->loadFromExtension('framework', [
+    'workflows' => [
+        'my_workflow' => [
+            'type' => 'state_machine',
+            'marking_store' => [
+                'property' => 'state',
+            ],
+            'supports' => [
+                FrameworkExtensionTestCase::class,
+            ],
+            'events_to_dispatch' => [
+                '!workflow.announce',
+            ],
+            'places' => [
+                'one',
+                'two',
+                'three',
+            ],
+            'transitions' => [
+                'count_to_two' => [
+                    'from' => [
+                        'one',
+                    ],
+                    'to' => [
+                        'two',
+                    ],
+                ],
+                'count_to_three' => [
+                    'from' => [
+                        'two',
+                    ],
+                    'to' => [
+                        'three',
+                    ],
+                ],
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_disabled_events.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_disabled_events.yml
@@ -1,0 +1,21 @@
+framework:
+    workflows:
+        my_workflow:
+            type: state_machine
+            initial_marking: one
+            events_to_dispatch: ['!workflow.announce']
+            marking_store:
+                property: state
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTestCase
+            places:
+                - one
+                - two
+                - three
+            transitions:
+                count_to_two:
+                    from: one
+                    to: two
+                count_to_three:
+                    from: two
+                    to: three

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -718,6 +718,15 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame([WorkflowEvents::LEAVE, WorkflowEvents::COMPLETED], $eventsToDispatch);
     }
 
+    public function testWorkflowsWithDisabledEvents()
+    {
+        $container = $this->createContainerFromFile('workflow_with_disabled_events');
+
+        $eventsToDispatch = $container->getDefinition('state_machine.my_workflow')->getArgument('index_4');
+
+        $this->assertSame(['!'.WorkflowEvents::ANNOUNCE], $eventsToDispatch);
+    }
+
     public function testWorkflowTransitionsPerformNoDeepMerging()
     {
         $container = $this->createContainer(['kernel.charset' => 'UTF-8', 'kernel.secret' => 'secret', 'kernel.runtime_environment' => 'test']);

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -94,7 +94,7 @@
         "symfony/mime": "<7.4.9|>=8.0,<8.0.9",
         "symfony/translation": "<7.4",
         "symfony/webhook": "<7.4",
-        "symfony/workflow": "<7.4"
+        "symfony/workflow": "<8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\FrameworkBundle\\": "" },

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Allow prefixing entries with `!` in the `$eventsToDispatch` constructor argument of `Workflow` and `StateMachine` to permanently disable an event; e.g. `new Workflow(..., eventsToDispatch: ['!workflow.announce'])` fires every event except `workflow.announce`. The GuardEvent can never be suppressed; `!workflow.guard` throws an `InvalidArgumentException`. Mixing allow-list and block-list entries also throws an `InvalidArgumentException`.
+
 8.1
 ---
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -511,6 +511,44 @@ class WorkflowTest extends TestCase
         $this->assertSame($eventNameExpected, $eventDispatcher->dispatchedEvents);
     }
 
+    public function testApplyDoesNotDispatchEventsBlockListedInEventsToDispatch()
+    {
+        $definition = $this->createComplexWorkflowDefinition();
+        $subject = new Subject();
+        $eventDispatcher = new EventDispatcherMock();
+        // `!workflow.announce` = fire every event except `workflow.announce`. Future
+        // WorkflowEvents keep being dispatched without needing this list to be updated.
+        $workflow = new Workflow($definition, new MethodMarkingStore(), $eventDispatcher, 'workflow_name', ['!'.WorkflowEvents::ANNOUNCE]);
+
+        $workflow->apply($subject, 't1');
+        $workflow->apply($subject, 't2');
+
+        // Sanity: non-block-listed events still fire (a literal-allow-list parser would
+        // suppress everything and the next foreach would pass vacuously — assertNotEmpty
+        // closes that loophole).
+        $this->assertNotEmpty($eventDispatcher->dispatchedEvents, 'Non-block-listed WorkflowEvents must still fire.');
+        $this->assertContains('workflow.workflow_name.transition', $eventDispatcher->dispatchedEvents);
+        foreach ($eventDispatcher->dispatchedEvents as $event) {
+            $this->assertStringNotContainsString('announce', $event, \sprintf('Announce event "%s" must not be dispatched when block-listed via "!" in $eventsToDispatch.', $event));
+        }
+    }
+
+    public function testBlockListingGuardEventThrows()
+    {
+        $this->expectException(\Symfony\Component\Workflow\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "workflow.guard" event cannot be disabled in $eventsToDispatch for workflow "workflow_name": it is always dispatched.');
+
+        new Workflow($this->createComplexWorkflowDefinition(), new MethodMarkingStore(), new EventDispatcherMock(), 'workflow_name', ['!'.WorkflowEvents::GUARD]);
+    }
+
+    public function testMixingAllowListAndBlockListInEventsToDispatchThrows()
+    {
+        $this->expectException(\Symfony\Component\Workflow\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot mix allow-list and block-list entries in $eventsToDispatch for workflow "mixed": every entry must start with "!" (block-list mode) or none of them must (allow-list mode).');
+
+        new Workflow($this->createComplexWorkflowDefinition(), new MethodMarkingStore(), new EventDispatcherMock(), 'mixed', [WorkflowEvents::COMPLETED, '!'.WorkflowEvents::ANNOUNCE]);
+    }
+
     public function testApplyOnlyDispatchesEventsThatHaveBeenSpecifiedByDefinition()
     {
         $transitions[] = new Transition('a-b', 'a', 'b');

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -18,6 +18,7 @@ use Symfony\Component\Workflow\Event\EnterEvent;
 use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\Event\LeaveEvent;
 use Symfony\Component\Workflow\Event\TransitionEvent;
+use Symfony\Component\Workflow\Exception\InvalidArgumentException;
 use Symfony\Component\Workflow\Exception\LogicException;
 use Symfony\Component\Workflow\Exception\NotEnabledTransitionException;
 use Symfony\Component\Workflow\Exception\UndefinedTransitionException;
@@ -52,13 +53,29 @@ class Workflow implements WorkflowInterface
         WorkflowEvents::ANNOUNCE => self::DISABLE_ANNOUNCE_EVENT,
     ];
 
+    private const DISPATCHABLE_EVENTS = [
+        WorkflowEvents::LEAVE,
+        WorkflowEvents::TRANSITION,
+        WorkflowEvents::ENTER,
+        WorkflowEvents::ENTERED,
+        WorkflowEvents::COMPLETED,
+        WorkflowEvents::ANNOUNCE,
+    ];
+
     private MarkingStoreInterface $markingStore;
 
     /**
-     * @param array|string[]|null $eventsToDispatch When `null` fire all events (the default behaviour).
-     *                                              Setting this to an empty array `[]` means no events are dispatched (except the {@see GuardEvent}).
-     *                                              Passing an array with WorkflowEvents will allow only those events to be dispatched plus
-     *                                              the {@see GuardEvent}.
+     * @param string[]|null $eventsToDispatch Controls which {@see WorkflowEvents} are dispatched:
+     *                                        - `null` (default): fire all events.
+     *                                        - `[]`: fire no event (except the {@see GuardEvent}).
+     *                                        - allow-list, e.g. `['workflow.transition', 'workflow.enter']`: fire only the listed
+     *                                        events plus the {@see GuardEvent}.
+     *                                        - block-list, e.g. `['!workflow.announce']`: fire every event except the listed ones;
+     *                                        future {@see WorkflowEvents} are dispatched by default. The {@see GuardEvent} can
+     *                                        never be suppressed; blocking it with `!workflow.guard` throws an
+     *                                        {@see InvalidArgumentException}.
+     *                                        Mixing allow-list and block-list entries in the same array is not supported and throws
+     *                                        an {@see InvalidArgumentException}.
      */
     public function __construct(
         private Definition $definition,
@@ -68,6 +85,33 @@ class Workflow implements WorkflowInterface
         private ?array $eventsToDispatch = null,
     ) {
         $this->markingStore = $markingStore ?? new MethodMarkingStore();
+
+        if (null !== $this->eventsToDispatch && [] !== $this->eventsToDispatch) {
+            $hasAllowList = false;
+            $hasBlockList = false;
+            foreach ($this->eventsToDispatch as $entry) {
+                if (str_starts_with($entry, '!')) {
+                    $hasBlockList = true;
+                } else {
+                    $hasAllowList = true;
+                }
+            }
+            if ($hasAllowList && $hasBlockList) {
+                throw new InvalidArgumentException(\sprintf('Cannot mix allow-list and block-list entries in $eventsToDispatch for workflow "%s": every entry must start with "!" (block-list mode) or none of them must (allow-list mode).', $name));
+            }
+
+            if ($hasBlockList) {
+                $blockedEvents = [];
+                foreach ($this->eventsToDispatch as $entry) {
+                    $eventName = substr($entry, 1);
+                    if (WorkflowEvents::GUARD === $eventName) {
+                        throw new InvalidArgumentException(\sprintf('The "%s" event cannot be disabled in $eventsToDispatch for workflow "%s": it is always dispatched.', WorkflowEvents::GUARD, $name));
+                    }
+                    $blockedEvents[] = $eventName;
+                }
+                $this->eventsToDispatch = array_values(array_diff(self::DISPATCHABLE_EVENTS, $blockedEvents));
+            }
+        }
     }
 
     public function getMarking(object $subject, array $context = []): Marking


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64178
| License       | MIT

`Workflow` already exposes per-call context flags (`DISABLE_LEAVE_EVENT`, `DISABLE_ANNOUNCE_EVENT`, …) to silence a single event for one `apply()` invocation, and an `events_to_dispatch` allow-list to restrict which events fire for the workflow's whole lifetime. Neither is convenient when you want to permanently turn one event off for a given workflow definition:

- the per-call flag must be passed on every `apply()`, which is error-prone (the issue reporter's main concern);
- the allow-list requires enumerating every other event, so it needs maintenance every time Symfony adds a new event.

This PR extends `events_to_dispatch` with a `!` prefix syntax (monolog-channel style) to block-list individual events:

```yaml
framework:
    workflows:
        order:
            type: state_machine
            events_to_dispatch: ['!workflow.announce']
```

```php
$workflow = new Workflow($definition, $store, $dispatcher, 'order', null, ['!workflow.announce']);
```

The block-list is **converted to an allow-list at construct time** (`array_diff(DISPATCHABLE_EVENTS, $blocked)`), so every event except the listed ones fires and newly added `WorkflowEvents` stay dispatched by default. The `GuardEvent` can never be suppressed; a `!workflow.guard` entry throws (`InvalidArgumentException` at the component, `InvalidConfigurationException` at the bundle). Mixing allow-list and block-list entries in the same array is unsupported and throws — `InvalidArgumentException` at the component, `InvalidConfigurationException` at the bundle. The existing context-flag and allow-list mechanisms are untouched.

The `symfony/workflow` conflict rule in FrameworkBundle is bumped to `<8.2`, since a block-list config produces a service definition the older component can't honor.

Test plan:

- `WorkflowTest::testApplyDoesNotDispatchEventsBlockListedInEventsToDispatch` — `announce` never fires when `!`-prefixed.
- `WorkflowTest::testBlockListingGuardEventThrows` — `!workflow.guard` throws at construct time.
- `WorkflowTest::testMixingAllowListAndBlockListInEventsToDispatchThrows` — mixed entries throw at construct time.
- `ConfigurationTest::testWorkflowEventsToDispatchRejectsMixedAllowListAndBlockList` — config-level validation.
- `ConfigurationTest::testWorkflowEventsToDispatchAcceptsBlockListOnlyList` — config accepts a pure block-list.
- `ConfigurationTest::testWorkflowEventsToDispatchRejectsBlockListedGuardEvent` — `!workflow.guard` rejected at config compile time.
- `FrameworkExtensionTestCase::testWorkflowsWithDisabledEvents` — DI wiring from the YAML/PHP fixtures.

## Test verification (RED → GREEN)

The three runtime tests, run against the **base `Workflow.php`** (prod file reverted, new tests kept) — RED:

```
1) WorkflowTest::testApplyDoesNotDispatchEventsBlockListedInEventsToDispatch
Failed asserting that an array contains 'workflow.workflow_name.transition'.

2) WorkflowTest::testBlockListingGuardEventThrows
Failed asserting that exception of type "Symfony\Component\Workflow\Exception\InvalidArgumentException" is thrown.

3) WorkflowTest::testMixingAllowListAndBlockListInEventsToDispatchThrows
Failed asserting that exception of type "Symfony\Component\Workflow\Exception\InvalidArgumentException" is thrown.

FAILURES! Tests: 3, Assertions: 5, Failures: 3.
```

With the patch applied — GREEN, whole suite, no regression:

```
WorkflowTest: OK (43 tests, 218 assertions)
```

The `ConfigurationTest` and `FrameworkExtensionTestCase` cases are exercised by the green `Unit Tests` CI jobs.

