### PR TITLE
[FrameworkBundle] Make BrowserKit assertions non-verbose by default

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -40,6 +40,7 @@ FrameworkBundle
 ---------------
 
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
+ * BrowserKit assertions are no longer verbose by default. Failed response assertions no longer include the response body unless `setBrowserKitAssertionsAsVerbose(true)` is called or `verbose: true` is passed to the assertion.
 
 HttpClient
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Report `.env` variables that the container never uses in `debug:container --env-vars`
  * Add `service_id` and `advisory` options to lock stores to use advisory locks on an existing `\PDO` or Doctrine DBAL connection service
  * Add `framework.webhook.signature_format`, `framework.webhook.timestamp_header_name` and `framework.webhook.timestamp_tolerance` options
+ * Make BrowserKit assertions non-verbose by default
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Honor the `SYMFONY_BROWSERKIT_ASSERTIONS_VERBOSE` env var as the default for response-body inclusion in `BrowserKitAssertionsTrait` failure messages (set in `phpunit.xml`; `setBrowserKitAssertionsAsVerbose()` still wins)
  * Deprecate `json_streamer.value_transformer.date_time_to_string` and `json_streamer.value_transformer.string_to_date_time` services, date times are handled as value objects
  * Deprecate `json_streamer.value_transformer` tag, use `json_streamer.property_value_transformer` instead
  * Add `marshaller` option to cache pool configuration to allow per-pool marshaller services

--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint as ResponseConstraint;
  */
 trait BrowserKitAssertionsTrait
 {
-    private static bool $defaultVerboseMode = true;
+    private static bool $defaultVerboseMode = false;
 
     public static function setBrowserKitAssertionsAsVerbose(bool $verbose): void
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -70,14 +70,15 @@ trait BrowserKitAssertionsTrait
 
     public static function assertResponseRedirects(?string $expectedLocation = null, ?int $expectedCode = null, string $message = '', ?bool $verbose = null): void
     {
-        $constraint = new ResponseConstraint\ResponseIsRedirected($verbose ?? self::getDefaultVerboseMode());
+        $resolvedVerbose = $verbose ?? self::getDefaultVerboseMode();
+        $constraint = new ResponseConstraint\ResponseIsRedirected($resolvedVerbose);
         if ($expectedLocation) {
             $locationConstraint = new ResponseConstraint\ResponseHeaderLocationSame(self::getRequest(), $expectedLocation);
 
             $constraint = LogicalAnd::fromConstraints($constraint, $locationConstraint);
         }
         if ($expectedCode) {
-            $constraint = LogicalAnd::fromConstraints($constraint, new ResponseConstraint\ResponseStatusCodeSame($expectedCode));
+            $constraint = LogicalAnd::fromConstraints($constraint, new ResponseConstraint\ResponseStatusCodeSame($expectedCode, $resolvedVerbose));
         }
 
         self::assertThatForResponse($constraint, $message);

--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -31,31 +31,46 @@ use Symfony\Component\HttpFoundation\Test\Constraint as ResponseConstraint;
  */
 trait BrowserKitAssertionsTrait
 {
-    private static bool $defaultVerboseMode = true;
+    /**
+     * When null, the trait falls back to the SYMFONY_BROWSERKIT_ASSERTIONS_VERBOSE
+     * env var, then to verbose=true. Set explicitly via setBrowserKitAssertionsAsVerbose().
+     */
+    private static ?bool $defaultVerboseMode = null;
 
     public static function setBrowserKitAssertionsAsVerbose(bool $verbose): void
     {
         self::$defaultVerboseMode = $verbose;
     }
 
+    private static function getDefaultVerboseMode(): bool
+    {
+        if (null !== self::$defaultVerboseMode) {
+            return self::$defaultVerboseMode;
+        }
+
+        $env = $_SERVER['SYMFONY_BROWSERKIT_ASSERTIONS_VERBOSE'] ?? $_ENV['SYMFONY_BROWSERKIT_ASSERTIONS_VERBOSE'] ?? null;
+
+        return null !== $env ? filter_var($env, \FILTER_VALIDATE_BOOLEAN) : true;
+    }
+
     public static function assertResponseIsSuccessful(string $message = '', ?bool $verbose = null): void
     {
-        self::assertThatForResponse(new ResponseConstraint\ResponseIsSuccessful($verbose ?? self::$defaultVerboseMode), $message);
+        self::assertThatForResponse(new ResponseConstraint\ResponseIsSuccessful($verbose ?? self::getDefaultVerboseMode()), $message);
     }
 
     public static function assertResponseStatusCodeSame(int $expectedCode, string $message = '', ?bool $verbose = null): void
     {
-        self::assertThatForResponse(new ResponseConstraint\ResponseStatusCodeSame($expectedCode, $verbose ?? self::$defaultVerboseMode), $message);
+        self::assertThatForResponse(new ResponseConstraint\ResponseStatusCodeSame($expectedCode, $verbose ?? self::getDefaultVerboseMode()), $message);
     }
 
     public static function assertResponseFormatSame(?string $expectedFormat, string $message = '', ?bool $verbose = null): void
     {
-        self::assertThatForResponse(new ResponseConstraint\ResponseFormatSame(self::getRequest(), $expectedFormat, $verbose ?? self::$defaultVerboseMode), $message);
+        self::assertThatForResponse(new ResponseConstraint\ResponseFormatSame(self::getRequest(), $expectedFormat, $verbose ?? self::getDefaultVerboseMode()), $message);
     }
 
     public static function assertResponseRedirects(?string $expectedLocation = null, ?int $expectedCode = null, string $message = '', ?bool $verbose = null): void
     {
-        $constraint = new ResponseConstraint\ResponseIsRedirected($verbose ?? self::$defaultVerboseMode);
+        $constraint = new ResponseConstraint\ResponseIsRedirected($verbose ?? self::getDefaultVerboseMode());
         if ($expectedLocation) {
             $locationConstraint = new ResponseConstraint\ResponseHeaderLocationSame(self::getRequest(), $expectedLocation);
 
@@ -108,7 +123,7 @@ trait BrowserKitAssertionsTrait
 
     public static function assertResponseIsUnprocessable(string $message = '', ?bool $verbose = null): void
     {
-        self::assertThatForResponse(new ResponseConstraint\ResponseIsUnprocessable($verbose ?? self::$defaultVerboseMode), $message);
+        self::assertThatForResponse(new ResponseConstraint\ResponseIsUnprocessable($verbose ?? self::getDefaultVerboseMode()), $message);
     }
 
     public static function assertBrowserHasCookie(string $name, string $path = '/', ?string $domain = null, string $message = ''): void

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/BrowserKitAssertionsTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/BrowserKitAssertionsTraitTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Test;
+
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\BrowserKitAssertionsTrait;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
+
+class BrowserKitAssertionsTraitTest extends TestCase
+{
+    use BrowserKitAssertionsTrait;
+
+    private const RESPONSE_BODY_MARKER = 'verbose-body-marker';
+
+    #[RunInSeparateProcess]
+    public function testFailureMessageIsNotVerboseByDefault()
+    {
+        self::getClient($this->createDummyBrowser());
+
+        $message = $this->captureFailureMessage();
+
+        $this->assertStringNotContainsString(self::RESPONSE_BODY_MARKER, $message);
+    }
+
+    #[RunInSeparateProcess]
+    public function testPerAssertionVerboseArgumentOptsIntoVerboseFailureMessage()
+    {
+        self::getClient($this->createDummyBrowser());
+
+        $message = $this->captureFailureMessage(true);
+
+        $this->assertStringContainsString(self::RESPONSE_BODY_MARKER, $message);
+    }
+
+    #[RunInSeparateProcess]
+    public function testExplicitSetterOptsIntoVerboseFailureMessage()
+    {
+        self::setBrowserKitAssertionsAsVerbose(true);
+        self::getClient($this->createDummyBrowser());
+
+        $message = $this->captureFailureMessage();
+
+        $this->assertStringContainsString(self::RESPONSE_BODY_MARKER, $message);
+    }
+
+    private function captureFailureMessage(?bool $verbose = null): string
+    {
+        try {
+            self::assertResponseStatusCodeSame(500, verbose: $verbose);
+        } catch (ExpectationFailedException $e) {
+            return $e->getMessage();
+        }
+
+        $this->fail('Expected assertion to fail (response status is 200, asserted 500).');
+    }
+
+    private function createDummyBrowser(): AbstractBrowser
+    {
+        $browser = new class('<html><body>'.self::RESPONSE_BODY_MARKER.'</body></html>') extends AbstractBrowser {
+            public function __construct(private string $body)
+            {
+                parent::__construct();
+            }
+
+            protected function doRequest(object $request): BrowserKitResponse
+            {
+                return new BrowserKitResponse($this->body, 200, ['Content-Type' => 'text/html']);
+            }
+        };
+
+        $browser->request('GET', '/');
+
+        return $browser;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/BrowserKitAssertionsTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/BrowserKitAssertionsTraitTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Test;
+
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\BrowserKitAssertionsTrait;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
+
+/**
+ * Default-verbose-mode resolution for BrowserKit assertion failure messages:
+ * - explicit setBrowserKitAssertionsAsVerbose() value wins,
+ * - else the SYMFONY_BROWSERKIT_ASSERTIONS_VERBOSE env var (filter_var bool),
+ * - else true (BC default).
+ *
+ * Each test runs in a separate process so the trait's static $defaultVerboseMode
+ * starts fresh — otherwise an earlier setBrowserKitAssertionsAsVerbose() call
+ * would leak across tests.
+ */
+class BrowserKitAssertionsTraitTest extends TestCase
+{
+    use BrowserKitAssertionsTrait;
+
+    private const ENV_KEY = 'SYMFONY_BROWSERKIT_ASSERTIONS_VERBOSE';
+    private const RESPONSE_BODY_MARKER = 'verbose-body-marker';
+
+    #[RunInSeparateProcess]
+    public function testFailureMessageIsVerboseByDefault()
+    {
+        self::getClient($this->createDummyBrowser());
+
+        $message = $this->captureFailureMessage();
+
+        $this->assertStringContainsString(self::RESPONSE_BODY_MARKER, $message);
+    }
+
+    #[RunInSeparateProcess]
+    public function testEnvVarOptsOutOfVerboseFailureMessage()
+    {
+        $_SERVER[self::ENV_KEY] = '0';
+        self::getClient($this->createDummyBrowser());
+
+        $message = $this->captureFailureMessage();
+
+        $this->assertStringNotContainsString(self::RESPONSE_BODY_MARKER, $message);
+    }
+
+    #[RunInSeparateProcess]
+    public function testExplicitSetterWinsOverEnvVar()
+    {
+        $_SERVER[self::ENV_KEY] = '0';
+        self::setBrowserKitAssertionsAsVerbose(true);
+        self::getClient($this->createDummyBrowser());
+
+        $message = $this->captureFailureMessage();
+
+        $this->assertStringContainsString(self::RESPONSE_BODY_MARKER, $message);
+    }
+
+    private function captureFailureMessage(): string
+    {
+        try {
+            self::assertResponseStatusCodeSame(500);
+        } catch (ExpectationFailedException $e) {
+            return $e->getMessage();
+        }
+
+        $this->fail('Expected assertion to fail (response status is 200, asserted 500).');
+    }
+
+    private function createDummyBrowser(): AbstractBrowser
+    {
+        $browser = new class('<html><body>'.self::RESPONSE_BODY_MARKER.'</body></html>') extends AbstractBrowser {
+            public function __construct(private string $body)
+            {
+                parent::__construct();
+            }
+
+            protected function doRequest(object $request): BrowserKitResponse
+            {
+                return new BrowserKitResponse($this->body, 200, ['Content-Type' => 'text/html']);
+            }
+        };
+
+        $browser->request('GET', '/');
+
+        return $browser;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #62433
| License       | MIT

This PR follows the maintainer direction from #62433 and flips the default verbosity of BrowserKit response assertions to `false`.

Projects that want the response body in assertion failures can still opt in for a whole suite with `setBrowserKitAssertionsAsVerbose(true)`, or per assertion with `verbose: true`.

The previous env-var approach has been removed. The `assertResponseRedirects()` body leak through `LogicalAnd` is also left out of this PR, as discussed in review, because that is a separate bugfix path.

## Changes

- Change `BrowserKitAssertionsTrait` default verbose mode from `true` to `false`.
- Add tests covering the new default plus both opt-in paths.
- Add `CHANGELOG.md` and `UPGRADE-8.2.md` entries.

## Test verification (RED -> GREEN)

RED, before flipping the default:

```text
1) Symfony\Bundle\FrameworkBundle\Tests\Test\BrowserKitAssertionsTraitTest::testFailureMessageIsNotVerboseByDefault
Failed asserting that ... <html><body>verbose-body-marker</body></html> does not contain "verbose-body-marker".

FAILURES!
Tests: 3, Assertions: 6, Failures: 1.
```

GREEN, after the fix:

```text
OK (3 tests, 6 assertions)
```

Local `./run-ci.sh` also passes syntax checks for the touched PHP files and the focused test on PHP 8.4.