### PR TITLE
[Tui] Fix invisible border with null color in BorderPattern's inverse strategies

### DIFF
--- a/src/Symfony/Component/Tui/Style/BorderPattern.php
+++ b/src/Symfony/Component/Tui/Style/BorderPattern.php
@@ -20,8 +20,8 @@ use Symfony\Component\Tui\Exception\InvalidArgumentException;
  * for block-style borders:
  * - 0: border color on inner background (standard border rendering)
  * - 1: border color on outer background (blend with outer background)
- * - 2: outer background on border color (inverse left-style border)
- * - 3: inner background on border color (inverse right-style border)
+ * - 2: reverse video border/outer — filled part shows outer bg, empty part shows border color
+ * - 3: reverse video border/inner — filled part shows inner bg, empty part shows border color
  *
  * @experimental
  *
@@ -84,8 +84,8 @@ final class BorderPattern
 
         return match ($strategy) {
             1 => $this->applyColors($segment, $borderColor, $outerBackground, $outerForeground, $outerBackground),
-            2 => $this->applyColors($segment, $outerBackground, $borderColor, $outerForeground, $outerBackground),
-            3 => $this->applyColors($segment, $innerBackground, $borderColor, $outerForeground, $outerBackground),
+            2 => $this->applyColorsReversed($segment, $borderColor, $outerBackground, $outerForeground, $outerBackground),
+            3 => $this->applyColorsReversed($segment, $borderColor, $innerBackground, $outerForeground, $outerBackground),
             default => $this->applyColors($segment, $borderColor, $innerBackground, $outerForeground, $outerBackground),
         };
     }
@@ -421,6 +421,23 @@ final class BorderPattern
         return $this->foregroundCode($foreground)
             .$this->backgroundCode($background)
             .$segment
+            .$this->foregroundCode($outerForeground)
+            .$this->backgroundCode($outerBackground);
+    }
+
+    /**
+     * Like applyColors but uses ANSI reverse video so that borderColor lands in the FG slot.
+     * This ensures null borderColor falls back to the terminal's default text color (visible)
+     * rather than the terminal's default background color (invisible on dark terminals).
+     * The block character's filled portion shows $background, the empty portion shows $foreground.
+     */
+    private function applyColorsReversed(string $segment, ?Color $foreground, ?Color $background, ?Color $outerForeground, ?Color $outerBackground): string
+    {
+        return $this->foregroundCode($foreground)
+            .$this->backgroundCode($background)
+            ."\e[7m"
+            .$segment
+            ."\e[27m"
             .$this->foregroundCode($outerForeground)
             .$this->backgroundCode($outerBackground);
     }

--- a/src/Symfony/Component/Tui/Tests/Style/BorderPatternTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/BorderPatternTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Style\BorderPattern;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\Style;
 
 class BorderPatternTest extends TestCase
 {
@@ -53,5 +55,95 @@ class BorderPatternTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         BorderPattern::fromName('unknown');
+    }
+
+    #[DataProvider('reverseVideoStrategiesProvider')]
+    public function testReverseVideoStrategiesEmitReverseVideoAnsi(int $strategy)
+    {
+        $pattern = new BorderPattern();
+        $outerStyle = new Style();
+        $innerStyle = (new Style())->withBackground('blue');
+
+        $result = $pattern->applyBorderSegment('▊', $strategy, $outerStyle, $innerStyle, Color::from('white'));
+
+        $this->assertStringContainsString("\e[7m", $result);
+        $this->assertStringContainsString("\e[27m", $result);
+    }
+
+    #[DataProvider('nonReverseVideoStrategiesProvider')]
+    public function testNonReverseVideoStrategiesDoNotEmitReverseVideoAnsi(int $strategy)
+    {
+        $pattern = new BorderPattern();
+        $outerStyle = new Style();
+        $innerStyle = (new Style())->withBackground('blue');
+
+        $result = $pattern->applyBorderSegment('│', $strategy, $outerStyle, $innerStyle, Color::from('white'));
+
+        $this->assertStringNotContainsString("\e[7m", $result);
+    }
+
+    #[DataProvider('reverseVideoStrategiesProvider')]
+    public function testNullBorderColorInStrategy2And3GoesToForegroundSlot(int $strategy)
+    {
+        $pattern = new BorderPattern();
+        $outerStyle = new Style();
+        $innerStyle = (new Style())->withBackground('blue');
+
+        $result = $pattern->applyBorderSegment('▊', $strategy, $outerStyle, $innerStyle, null);
+
+        $this->assertStringContainsString(Color::resetForeground(), $result);
+    }
+
+    public function testNullOuterBackgroundInStrategy2GoesToBackgroundSlot()
+    {
+        $pattern = new BorderPattern();
+        $outerStyle = new Style();
+        $innerStyle = new Style();
+
+        $result = $pattern->applyBorderSegment('▊', 2, $outerStyle, $innerStyle, Color::from('white'));
+
+        $this->assertStringContainsString(Color::resetBackground(), $result);
+    }
+
+    public function testStrategy2WithExplicitColorsProducesCorrectAnsiCodes()
+    {
+        $pattern = new BorderPattern();
+        $outerStyle = (new Style())->withBackground('black');
+        $innerStyle = new Style();
+        $borderColor = Color::from('white');
+
+        $result = $pattern->applyBorderSegment('▊', 2, $outerStyle, $innerStyle, $borderColor);
+
+        $this->assertStringContainsString($borderColor->toForegroundCode(), $result);
+        $this->assertStringContainsString(Color::from('black')->toBackgroundCode(), $result);
+        $this->assertStringContainsString("\e[7m", $result);
+        $this->assertStringContainsString("\e[27m", $result);
+    }
+
+    public function testStrategy3WithExplicitColorsProducesCorrectAnsiCodes()
+    {
+        $pattern = new BorderPattern();
+        $outerStyle = new Style();
+        $innerStyle = (new Style())->withBackground('blue');
+        $borderColor = Color::from('white');
+
+        $result = $pattern->applyBorderSegment('▊', 3, $outerStyle, $innerStyle, $borderColor);
+
+        $this->assertStringContainsString($borderColor->toForegroundCode(), $result);
+        $this->assertStringContainsString(Color::from('blue')->toBackgroundCode(), $result);
+        $this->assertStringContainsString("\e[7m", $result);
+        $this->assertStringContainsString("\e[27m", $result);
+    }
+
+    public static function reverseVideoStrategiesProvider(): iterable
+    {
+        yield 'strategy 2' => [2];
+        yield 'strategy 3' => [3];
+    }
+
+    public static function nonReverseVideoStrategiesProvider(): iterable
+    {
+        yield 'strategy 0 (default)' => [0];
+        yield 'strategy 1' => [1];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

fix BorderPattern issue for WIDE, WIDE_MEDIUM, TALL, TALL_MEDIUM 
Before fix, white border appears : 
<img width="449" height="210" alt="image" src="https://github.com/user-attachments/assets/cb8b107a-a233-4fed-bd77-3e5bbb875dcd" />

After fix: 
<img width="449" height="210" alt="image" src="https://github.com/user-attachments/assets/ea81df0e-f5de-46ff-a616-09f9862182a5" />
