### PR TITLE
[Serializer] Fix #[Ignore] on a getter ignoring a same-name property

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AccessorCollisionResolverTrait.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AccessorCollisionResolverTrait.php
@@ -62,6 +62,11 @@ trait AccessorCollisionResolverTrait
         return false;
     }
 
+    private function hasPublicPropertyForAccessor(\ReflectionClass $class, string $propName): bool
+    {
+        return $class->hasProperty($propName) && $class->getProperty($propName)->isPublic();
+    }
+
     private function hasAttributeNameCollision(\ReflectionClass $class, string $attributeName, string $methodName): bool
     {
         if ($this->hasPropertyForAccessor($class, $attributeName)) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -177,7 +177,7 @@ class AttributeLoader implements LoaderInterface
 
                     $attributeMetadata->setSerializedPath($annotation->getSerializedPath());
                 } elseif ($annotation instanceof Ignore) {
-                    if ($attributeMetadata) {
+                    if ($attributeMetadata && !$this->hasPublicPropertyForAccessor($reflectionClass, $attributeName)) {
                         $attributeMetadata->setIgnore(true);
                     }
                 } elseif ($annotation instanceof Context) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1226,6 +1226,15 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame(['visibleGroup' => 'visible_group'], $normalizer->normalize($object, null, ['groups' => ['group1']]));
     }
 
+    public function testIgnoreAttributeOnGetterWithSameNameAsProperty()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $object = new ObjectWithIgnoredGetterSameNameAsProperty();
+
+        $this->assertSame(['name' => 'foo'], $normalizer->normalize($object));
+    }
+
     /**
      * Priority of accessor methods is defined by the PropertyReadInfoExtractorInterface passed to the PropertyAccessor
      * component. By default ReflectionExtractor::$defaultAccessorPrefixes are used.
@@ -2070,6 +2079,17 @@ class ObjectWithIgnoredMethodSameNameAsPropertyWithGroups
     public function visibleGroup()
     {
         return $this->visibleGroup;
+    }
+}
+
+class ObjectWithIgnoredGetterSameNameAsProperty
+{
+    public string $name = 'foo';
+
+    #[Ignore]
+    public function getName(): string
+    {
+        return $this->name;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #46918
| License       | MIT

`#[Ignore]` on a getter also ignored a same-named public property. The accessor reuses the property's attribute metadata, so calling `setIgnore()` on it suppressed the property too. The method-level `#[Ignore]` is now skipped when a public property of that name backs the attribute; private or protected backing properties, and getters with no property, still get ignored as before.
