### PR TITLE
[Form] Add MonthType and corresponding tests for min, max, and step attributes

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/MonthType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MonthType.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MonthType extends AbstractType
+{
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['type'] = 'month';
+
+        if (null !== $options['min']) {
+            $view->vars['attr']['min'] = $options['min'];
+        }
+
+        if (null !== $options['max']) {
+            $view->vars['attr']['max'] = $options['max'];
+        }
+
+        if (null !== $options['step']) {
+            $view->vars['attr']['step'] = $options['step'];
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'min' => null,
+            'max' => null,
+            'step' => null,
+        ]);
+
+        $resolver->setAllowedTypes('min', ['null', 'string']);
+        $resolver->setAllowedTypes('max', ['null', 'string']);
+        $resolver->setAllowedTypes('step', ['null', 'int', 'string']);
+    }
+
+    public function getParent(): string
+    {
+        return TextType::class;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'month';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MonthTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MonthTypeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\MonthType;
+
+class MonthTypeTest extends BaseTypeTestCase
+{
+    public const TESTED_TYPE = MonthType::class;
+
+    public function testPassTypeToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->createView();
+
+        $this->assertSame('month', $view->vars['type']);
+    }
+
+    public function testPassMinAttrToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'min' => '2018-03',
+        ])
+            ->createView();
+
+        $this->assertSame('2018-03', $view->vars['attr']['min']);
+    }
+
+    public function testPassMaxAttrToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'max' => '2025-12',
+        ])
+            ->createView();
+
+        $this->assertSame('2025-12', $view->vars['attr']['max']);
+    }
+
+    public function testPassMinAndMaxAttrsToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'min' => '2018-03',
+            'max' => '2025-12',
+        ])
+            ->createView();
+
+        $this->assertSame('2018-03', $view->vars['attr']['min']);
+        $this->assertSame('2025-12', $view->vars['attr']['max']);
+    }
+
+    public function testPassStepAttrToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'step' => 3,
+        ])
+            ->createView();
+
+        $this->assertSame(3, $view->vars['attr']['step']);
+    }
+
+    public function testUserAttrsAreNotOverridden()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, [
+            'min' => '2018-03',
+            'attr' => [
+                'min' => '2017-01',
+            ],
+        ])
+            ->createView();
+
+        $this->assertSame('2017-01', $view->vars['attr']['min']);
+    }
+
+    public function testSubmit()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit('2018-05');
+
+        $this->assertSame('2018-05', $form->getData());
+        $this->assertSame('2018-05', $form->getViewData());
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 for features
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Source        | [MDN Input Month](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/month)

This pull request introduces a new `MonthType` form field to the Symfony Form component, allowing users to select months with optional constraints for minimum, maximum, and step values.

New form type implementation:

* Added `MonthType` class, supporting `min`, `max`, and `step` options, and mapping them to HTML attributes for month input fields. (`src/Symfony/Component/Form/Extension/Core/Type/MonthType.php`)

Testing and validation:

* Added `MonthTypeTest` with tests for the correct propagation of `type`, `min`, `max`, and `step` attributes, user attribute overrides, and form submission handling. (`src/Symfony/Component/Form/Tests/Extension/Core/Type/MonthTypeTest.php`)