### PR TITLE
[Tui] Add shadow support to widgets

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `Shadow`, `ShadowOrientation` and `Style::withShadow()` to draw a drop shadow around widgets
  * Add `AnsiUtils::walkCells()` to iterate the cells and escape sequences of a rendered line
  * Add `AnsiUtils::sliceToWidth()` to extract a fixed-width range of columns from a line
  * Add `AbstractWidget::postRender()` to post-process a widget's finished lines, chrome included

--- a/src/Symfony/Component/Tui/Render/ChromeApplier.php
+++ b/src/Symfony/Component/Tui/Render/ChromeApplier.php
@@ -13,16 +13,19 @@ namespace Symfony\Component\Tui\Render;
 
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Style\Border;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\Shadow;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
 use Symfony\Component\Tui\Widget\AbstractWidget;
 
 /**
- * Applies chrome (padding, border, background) around widget content.
+ * Applies chrome (padding, border, background, shadow) around widget content.
  *
  * Chrome is the visual frame around a widget's rendered lines:
- * padding adds space inside, borders draw a box, and background colors
- * fill the area. The result is cached for performance.
+ * padding adds space inside, borders draw a box, background colors
+ * fill the area, and a shadow paints shade cells next to the box.
+ * The result is cached for performance.
  *
  * @experimental
  *
@@ -38,13 +41,18 @@ final class ChromeApplier
     }
 
     /**
-     * Apply chrome (padding, border, background) to rendered lines.
+     * Apply chrome (padding, border, background, shadow) to rendered lines.
      */
     public function apply(LineBufferInterface $lines, int $width, Style $style, AbstractWidget $widget): LineBufferInterface
     {
         if ($this->isIdentity($style)) {
             return $lines;
         }
+
+        $shadow = $style->getShadow();
+        // Reserve the shadow columns next to the box, keeping at least 1 column for it
+        $shadowOffset = min($shadow->offset ?? 0, max(0, $width - 1));
+        $width -= $shadowOffset;
 
         $border = $style->getBorder();
         $padding = $style->getPadding();
@@ -136,12 +144,18 @@ final class ChromeApplier
 
         $innerLines = [...$topPadding, ...$contentLines, ...$bottomPadding];
 
-        return new ArrayLineBuffer($border?->wrapLines(
+        $boxLines = $border?->wrapLines(
             $innerLines,
             $innerWidth,
             $style,
             $outerStyle,
-        ) ?? $innerLines);
+        ) ?? $innerLines;
+
+        if ($shadowOffset && $boxLines) {
+            $boxLines = $this->applyShadow($boxLines, $shadow, $shadowOffset, $width);
+        }
+
+        return new ArrayLineBuffer($boxLines);
     }
 
     private function isIdentity(Style $style): bool
@@ -158,11 +172,12 @@ final class ChromeApplier
             && !($padding?->bottom ?? 0)
             && !($padding?->left ?? 0)
             && null === $style->getTextAlign()
+            && null === $style->getShadow()
             && $style->isPlain();
     }
 
     /**
-     * Compute inner dimensions (content area after border/padding).
+     * Compute inner dimensions (content area after border/padding/shadow).
      *
      * @return array{int, int} [innerColumns, innerRows]
      */
@@ -170,11 +185,14 @@ final class ChromeApplier
     {
         $border = $style->getBorder();
         $padding = $style->getPadding();
+        $shadowOffset = $style->getShadow()->offset ?? 0;
 
         $hChrome = ($border?->left ?? 0) + ($border?->right ?? 0)
-            + ($padding?->left ?? 0) + ($padding?->right ?? 0);
+            + ($padding?->left ?? 0) + ($padding?->right ?? 0)
+            + $shadowOffset;
         $vChrome = ($border?->top ?? 0) + ($border?->bottom ?? 0)
-            + ($padding?->top ?? 0) + ($padding?->bottom ?? 0);
+            + ($padding?->top ?? 0) + ($padding?->bottom ?? 0)
+            + $shadowOffset;
 
         return [
             max(1, $columns - $hChrome),
@@ -183,7 +201,7 @@ final class ChromeApplier
     }
 
     /**
-     * Compute the top-left chrome offset (border + padding) for a style.
+     * Compute the top-left chrome offset (border + padding + shadow) for a style.
      *
      * @return array{int, int} [topOffset, leftOffset]
      */
@@ -191,9 +209,12 @@ final class ChromeApplier
     {
         $border = $style->getBorder();
         $padding = $style->getPadding();
+        $shadow = $style->getShadow();
 
-        $top = ($border?->top ?? 0) + ($padding?->top ?? 0);
-        $left = ($border?->left ?? 0) + ($padding?->left ?? 0);
+        $top = ($border?->top ?? 0) + ($padding?->top ?? 0)
+            + (null !== $shadow && !$shadow->orientation->isBottom() ? $shadow->offset : 0);
+        $left = ($border?->left ?? 0) + ($padding?->left ?? 0)
+            + (null !== $shadow && !$shadow->orientation->isRight() ? $shadow->offset : 0);
 
         return [$top, $left];
     }
@@ -212,6 +233,78 @@ final class ChromeApplier
         // visual formatting (color, bold, etc.). The Renderer owns layout
         // (padding, border, gap, direction, hidden, cursorShape, textAlign, align, verticalAlign); widgets own content.
         return new RenderContext($innerColumns, $innerRows, $context->getStyle()->withoutLayoutProperties(), $context->getFontRegistry());
+    }
+
+    /**
+     * Paint the shadow cells next to the box, then add the shadow rows.
+     *
+     * Each line in $lines is $boxWidth cells wide. After this method, each
+     * line is $boxWidth + $offset cells wide and $offset rows were added.
+     *
+     * The shadow is shifted diagonally from the box: the row and column
+     * touching the opposite corner stay blank, so the box looks lifted.
+     * Moving away from that corner, the side shadow fills in one cell per
+     * row up to $offset cells, and each shadow row shifts by one more cell.
+     *
+     * @param string[] $lines
+     *
+     * @return string[]
+     */
+    private function applyShadow(array $lines, Shadow $shadow, int $offset, int $boxWidth): array
+    {
+        $count = \count($lines);
+        $isRight = $shadow->orientation->isRight();
+        $isBottom = $shadow->orientation->isBottom();
+        $paint = static fn (string $cells) => '' !== $cells ? $shadow->color->toForegroundCode().$cells.Color::resetForeground() : '';
+
+        for ($i = 0; $i < $count; ++$i) {
+            // Rows count from the blank edge: the top row for a bottom shadow,
+            // the bottom row for a top shadow
+            $distance = $isBottom ? $i : $count - 1 - $i;
+            $shadowCount = min($distance, $offset);
+            $blank = str_repeat(' ', $offset - $shadowCount);
+
+            $cells = '';
+            if ($isRight) {
+                for ($colD = 1; $colD <= $shadowCount; ++$colD) {
+                    $cells .= $shadow->getChar($colD);
+                }
+                $lines[$i] .= $paint($cells).$blank;
+            } else {
+                // Mirrored: blank cells outermost, then the cells from farthest to nearest
+                for ($colD = $shadowCount; $colD >= 1; --$colD) {
+                    $cells .= $shadow->getChar($colD);
+                }
+                $lines[$i] = $blank.$paint($cells).$lines[$i];
+            }
+        }
+
+        // Shadow rows: rowD counts from the box edge outward; each row shifts
+        // one more cell toward the orientation, leaving a growing blank gap
+        $shadowRows = [];
+        for ($rowD = 1; $rowD <= $offset; ++$rowD) {
+            $gap = str_repeat(' ', min($rowD, $boxWidth));
+            $body = str_repeat($shadow->getChar($rowD), max(0, $boxWidth - $rowD));
+
+            $corner = '';
+            if ($isRight) {
+                for ($colD = 1; $colD <= $offset; ++$colD) {
+                    $corner .= $shadow->getChar(max($rowD, $colD));
+                }
+                $shadowRows[] = $gap.$paint($body.$corner);
+            } else {
+                for ($colD = $offset; $colD >= 1; --$colD) {
+                    $corner .= $shadow->getChar(max($rowD, $colD));
+                }
+                $shadowRows[] = $paint($corner.$body).$gap;
+            }
+        }
+
+        if ($isBottom) {
+            return [...$lines, ...$shadowRows];
+        }
+
+        return [...array_reverse($shadowRows), ...$lines];
     }
 
     /**

--- a/src/Symfony/Component/Tui/Style/Shadow.php
+++ b/src/Symfony/Component/Tui/Style/Shadow.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * Drop-shadow configuration for a widget.
+ *
+ * The shadow is rendered outside the widget's box using Unicode block
+ * characters (░ ▒ ▓ █). It is always shifted 1 cell from the widget edge
+ * in the orientation direction, giving a "lifted" depth effect.
+ *
+ * @experimental
+ *
+ * @author Sylvain Blondeau <contact@sylvainblondeau.dev>
+ */
+final class Shadow
+{
+    private const CHARS = ['░', '▒', '▓', '█'];
+
+    public readonly Color $color;
+    public readonly int $density;
+    public readonly int $offset;
+
+    /**
+     * @param ShadowOrientation $orientation Corner the shadow extends toward
+     * @param Color|null        $color       Foreground color of the shade characters (null = gray)
+     * @param int               $density     Visual weight of the shadow: 1=░ 2=▒ 3=▓ 4=█ (clamped to 1-4)
+     * @param int               $offset      Thickness of the shadow in cells (clamped to 1-3)
+     * @param bool              $spread      Whether the shadow fades outward from density (default) or stays solid
+     */
+    public function __construct(
+        public readonly ShadowOrientation $orientation = ShadowOrientation::BottomRight,
+        ?Color $color = null,
+        int $density = 2,
+        int $offset = 1,
+        public readonly bool $spread = true,
+    ) {
+        $this->color = $color ?? Color::named('gray');
+        $this->density = max(1, min(4, $density));
+        $this->offset = max(1, min(3, $offset));
+    }
+
+    /**
+     * Return the shade character for a given distance from the widget edge.
+     *
+     * Distance 1 = adjacent to the widget (darkest), increasing distances
+     * fade outward when spread=true.
+     */
+    public function getChar(int $distance): string
+    {
+        return self::CHARS[$this->spread ? max(0, $this->density - $distance) : $this->density - 1];
+    }
+}

--- a/src/Symfony/Component/Tui/Style/ShadowOrientation.php
+++ b/src/Symfony/Component/Tui/Style/ShadowOrientation.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * Direction in which a drop-shadow is projected from a widget.
+ *
+ * The shadow is always offset by 1 cell relative to the widget edge,
+ * creating a "lifted" depth effect. The orientation controls which
+ * corner the shadow extends toward.
+ *
+ * @experimental
+ *
+ * @author Sylvain Blondeau <contact@sylvainblondeau.dev>
+ */
+enum ShadowOrientation
+{
+    case BottomRight;
+    case BottomLeft;
+    case TopRight;
+    case TopLeft;
+
+    public function isBottom(): bool
+    {
+        return self::BottomRight === $this || self::BottomLeft === $this;
+    }
+
+    public function isRight(): bool
+    {
+        return self::BottomRight === $this || self::TopRight === $this;
+    }
+}

--- a/src/Symfony/Component/Tui/Style/Style.php
+++ b/src/Symfony/Component/Tui/Style/Style.php
@@ -86,6 +86,7 @@ final class Style
      * @param Align|null            $align         Horizontal alignment of child widgets (null = not set, defaults to left)
      * @param VerticalAlign|null    $verticalAlign Vertical alignment of child widgets (null = not set, defaults to top)
      * @param int|null              $flex          Flex grow weight for horizontal layouts (null = not set, 0 = intrinsic width, 1+ = proportional)
+     * @param Shadow|null           $shadow        Drop-shadow configuration (null = not set)
      */
     public function __construct(
         private ?Padding $padding = null,
@@ -108,6 +109,7 @@ final class Style
         private ?Align $align = null,
         private ?VerticalAlign $verticalAlign = null,
         private ?int $flex = null,
+        private ?Shadow $shadow = null,
     ) {
         $this->backgroundColor = null !== $background ? Color::from($background) : null;
         $this->foregroundColor = null !== $color ? Color::from($color) : null;
@@ -287,6 +289,14 @@ final class Style
     }
 
     /**
+     * Get the drop-shadow configuration.
+     */
+    public function getShadow(): ?Shadow
+    {
+        return $this->shadow;
+    }
+
+    /**
      * Check whether the style applies no visual formatting.
      *
      * @internal
@@ -326,6 +336,14 @@ final class Style
     }
 
     /**
+     * Create a style with shadow only.
+     */
+    public static function shadow(Shadow $shadow): self
+    {
+        return new self(shadow: $shadow);
+    }
+
+    /**
      * Merge multiple styles into one in a single pass.
      *
      * Later styles override earlier ones for non-null properties.
@@ -355,6 +373,7 @@ final class Style
         $align = null;
         $verticalAlign = null;
         $flex = null;
+        $shadow = null;
 
         foreach ($styles as $style) {
             $padding = $style->padding ?? $padding;
@@ -377,6 +396,7 @@ final class Style
             $align = $style->align ?? $align;
             $verticalAlign = $style->verticalAlign ?? $verticalAlign;
             $flex = $style->flex ?? $flex;
+            $shadow = $style->shadow ?? $shadow;
         }
 
         return new self(
@@ -400,6 +420,7 @@ final class Style
             $align,
             $verticalAlign,
             $flex,
+            $shadow,
         );
     }
 
@@ -673,6 +694,19 @@ final class Style
     }
 
     /**
+     * Create new style with a drop-shadow.
+     *
+     * @param Shadow|null $shadow Shadow configuration, or null to clear
+     */
+    public function withShadow(?Shadow $shadow): self
+    {
+        $clone = clone $this;
+        $clone->shadow = $shadow;
+
+        return $clone;
+    }
+
+    /**
      * Create a copy with only visual formatting and content properties.
      *
      * Strips layout properties that the Renderer owns: padding, border,
@@ -694,7 +728,7 @@ final class Style
             && null === $this->hidden && null === $this->cursorShape
             && null === $this->textAlign && null === $this->maxColumns
             && null === $this->align && null === $this->verticalAlign
-            && null === $this->flex) {
+            && null === $this->flex && null === $this->shadow) {
             return $this;
         }
 
@@ -710,6 +744,7 @@ final class Style
         $clone->align = null;
         $clone->verticalAlign = null;
         $clone->flex = null;
+        $clone->shadow = null;
 
         return $clone;
     }

--- a/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
@@ -19,7 +19,10 @@ use Symfony\Component\Tui\Render\ChromeApplier;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Render\WidgetRendererInterface;
 use Symfony\Component\Tui\Style\Border;
+use Symfony\Component\Tui\Style\Color;
 use Symfony\Component\Tui\Style\Padding;
+use Symfony\Component\Tui\Style\Shadow;
+use Symfony\Component\Tui\Style\ShadowOrientation;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
 use Symfony\Component\Tui\Widget\TextWidget;
@@ -55,6 +58,9 @@ final class ChromeApplierTest extends TestCase
         yield 'border and padding' => [40, 10, new Style(padding: Padding::all(1), border: Border::all(1, 'none')), [36, 6]];
         yield 'asymmetric padding' => [40, 10, new Style(padding: new Padding(2, 3, 1, 5)), [32, 7]];
         yield 'clamps to 1' => [4, 4, new Style(padding: Padding::all(3)), [1, 1]];
+        yield 'shadow only offset=1' => [40, 10, (new Style())->withShadow(new Shadow(offset: 1)), [39, 9]];
+        yield 'shadow only offset=2' => [40, 10, (new Style())->withShadow(new Shadow(offset: 2)), [38, 8]];
+        yield 'shadow and border' => [40, 10, (new Style())->withShadow(new Shadow(offset: 1))->withBorder([1]), [37, 7]];
     }
 
     // ---------------------------------------------------------------
@@ -81,6 +87,10 @@ final class ChromeApplierTest extends TestCase
         yield 'padding only' => [new Style(padding: new Padding(2, 0, 0, 3)), [2, 3]];
         yield 'border only' => [new Style(border: Border::all(1, 'none')), [1, 1]];
         yield 'border and padding' => [new Style(padding: new Padding(1, 0, 0, 2), border: Border::all(1, 'none')), [2, 3]];
+        yield 'bottom-right shadow shifts nothing' => [(new Style())->withShadow(new Shadow(offset: 2)), [0, 0]];
+        yield 'top-left shadow shifts both' => [(new Style())->withShadow(new Shadow(orientation: ShadowOrientation::TopLeft, offset: 2)), [2, 2]];
+        yield 'top-right shadow shifts down' => [(new Style())->withShadow(new Shadow(orientation: ShadowOrientation::TopRight, offset: 1)), [1, 0]];
+        yield 'bottom-left shadow shifts right' => [(new Style())->withShadow(new Shadow(orientation: ShadowOrientation::BottomLeft, offset: 1)), [0, 1]];
     }
 
     // ---------------------------------------------------------------
@@ -358,6 +368,206 @@ final class ChromeApplierTest extends TestCase
         }
         // Content should be on line 2 (index 2)
         $this->assertStringContainsString('Text', $result[2]);
+    }
+
+    // ---------------------------------------------------------------
+    // apply: shadow
+    // ---------------------------------------------------------------
+
+    public function testApplyShadowClampedInNarrowBox()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())->withShadow(new Shadow(offset: 3));
+
+        $result = $applier->apply(new ArrayLineBuffer(['AB']), 2, $style, $widget)->toArray();
+
+        // The shadow shrinks to 1 column so the box keeps 1
+        $this->assertCount(2, $result);
+        foreach ($result as $line) {
+            $this->assertSame(2, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testApplyShadowUsesItsColorOnce()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())->withShadow(new Shadow(color: Color::named('red'), offset: 2));
+
+        $result = $applier->apply(new ArrayLineBuffer(['AAAA', 'BBBB', 'CCCC']), 20, $style, $widget)->toArray();
+
+        $red = Color::named('red')->toForegroundCode();
+        // A full side run is painted with a single color prefix
+        $this->assertSame(1, substr_count($result[2], $red));
+        $this->assertStringContainsString($red, $result[3]);
+        $this->assertStringContainsString($red, $result[4]);
+        // The skipped first row carries no shadow color
+        $this->assertStringNotContainsString($red, $result[0]);
+    }
+
+    public function testApplyShadowBottomRightAddsRowsAndColumns()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        // offset=1: 1 extra row (bottom), 1 extra col (right)
+        $style = (new Style())->withShadow(new Shadow(offset: 1));
+
+        $result = $applier->apply(new ArrayLineBuffer(['Hello']), 20, $style, $widget)->toArray();
+
+        // 1 content row + 1 shadow row = 2 lines
+        $this->assertCount(2, $result);
+        // All lines must be exactly $width wide (19 content + 1 shadow col)
+        foreach ($result as $line) {
+            $this->assertSame(20, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testApplyShadowBottomRightVerticalStaircase()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        // offset=2: side shadow builds up over 2 rows
+        $style = (new Style())->withShadow(new Shadow(offset: 2));
+        $lines = new ArrayLineBuffer(['AAAA', 'BBBB', 'CCCC']);
+
+        $result = $applier->apply($lines, 20, $style, $widget)->toArray();
+
+        // 3 content rows + 2 shadow rows = 5
+        $this->assertCount(5, $result);
+
+        // Row 0 (distance=0 from top/skipped edge): trailing spaces only, no shadow chars
+        $plain0 = AnsiUtils::stripAnsiCodes($result[0]);
+        $this->assertSame(' ', mb_substr($plain0, -1, 1)); // trailing space
+        $this->assertSame(' ', mb_substr($plain0, -2, 1)); // second-to-last also space
+
+        // Row 1 (distance=1): 1 shadow col + 1 trailing space
+        $plain1 = AnsiUtils::stripAnsiCodes($result[1]);
+        $this->assertSame(' ', mb_substr($plain1, -1, 1)); // trailing space
+        $this->assertNotSame(' ', mb_substr($plain1, -2, 1)); // shadow char before trailing space
+
+        // Row 2 (distance=2 ≥ offset): 2 shadow cols, no trailing space
+        $plain2 = AnsiUtils::stripAnsiCodes($result[2]);
+        $this->assertNotSame(' ', mb_substr($plain2, -1, 1)); // no trailing space
+        $this->assertNotSame(' ', mb_substr($plain2, -2, 1)); // shadow char at -2 too
+
+        // All lines same total width
+        foreach ($result as $line) {
+            $this->assertSame(20, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testApplyShadowBottomRightHorizontalStaircase()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        // offset=2: 2 shadow rows below
+        $style = (new Style())->withShadow(new Shadow(offset: 2));
+
+        $result = $applier->apply(new ArrayLineBuffer(['AAAA']), 20, $style, $widget)->toArray();
+
+        // 1 content + 2 shadow rows = 3
+        $this->assertCount(3, $result);
+
+        // Shadow row rowD=1 (index 1): starts with 1 space (gap=1), then shadow body
+        $plain1 = AnsiUtils::stripAnsiCodes($result[1]);
+        $this->assertSame(' ', $plain1[0]);
+
+        // Shadow row rowD=2 (index 2): starts with 2 spaces (gap=2), then shorter body
+        $plain2 = AnsiUtils::stripAnsiCodes($result[2]);
+        $this->assertSame(' ', $plain2[0]);
+        $this->assertSame(' ', $plain2[1]);
+
+        // All lines same total width
+        foreach ($result as $line) {
+            $this->assertSame(20, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testApplyShadowTopRightAddsRowAboveAndColumnRight()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())->withShadow(new Shadow(orientation: ShadowOrientation::TopRight, offset: 1));
+
+        $result = $applier->apply(new ArrayLineBuffer(['Hello']), 20, $style, $widget)->toArray();
+
+        // 1 shadow row (top) + 1 content = 2 lines
+        $this->assertCount(2, $result);
+        foreach ($result as $line) {
+            $this->assertSame(20, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testApplyShadowBottomLeftAddsRowBelowAndColumnLeft()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())->withShadow(new Shadow(orientation: ShadowOrientation::BottomLeft, offset: 1));
+
+        $result = $applier->apply(new ArrayLineBuffer(['Hello']), 20, $style, $widget)->toArray();
+
+        // 1 content + 1 shadow row = 2 lines
+        $this->assertCount(2, $result);
+        foreach ($result as $line) {
+            $this->assertSame(20, AnsiUtils::visibleWidth($line));
+        }
+
+        // Content line: shadow column prepended (left side)
+        $plain0 = AnsiUtils::stripAnsiCodes($result[0]);
+        // First row from top edge = skipped (no shadow chars), only leading space
+        $this->assertSame(' ', $plain0[0]);
+    }
+
+    public function testApplyShadowTopLeftAddsRowAboveAndColumnLeft()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())->withShadow(new Shadow(orientation: ShadowOrientation::TopLeft, offset: 1));
+
+        $result = $applier->apply(new ArrayLineBuffer(['Hello']), 20, $style, $widget)->toArray();
+
+        // 1 shadow row (top) + 1 content = 2 lines
+        $this->assertCount(2, $result);
+        foreach ($result as $line) {
+            $this->assertSame(20, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testApplyShadowWithSpreadFalseUsesUniformChar()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        // density=3 (▓), spread=false → all shadow cells use ▓
+        $style = (new Style())->withShadow(new Shadow(density: 3, spread: false, offset: 2));
+
+        $result = $applier->apply(new ArrayLineBuffer(['AAAA', 'BBBB', 'CCCC']), 20, $style, $widget)->toArray();
+
+        // Row 1: 1 shadow col + 1 trailing space (staircase)
+        $plain1 = AnsiUtils::stripAnsiCodes($result[1]);
+        $this->assertSame('▓', mb_substr($plain1, -2, 1));
+        $this->assertSame(' ', mb_substr($plain1, -1, 1));
+
+        // Row 2: 2 shadow cols, no trailing space
+        $plain2 = AnsiUtils::stripAnsiCodes($result[2]);
+        $this->assertSame('▓▓', mb_substr($plain2, -2));
+    }
+
+    public function testApplyShadowCombinedWithBorder()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())
+            ->withBorder([1])
+            ->withShadow(new Shadow(offset: 1));
+
+        $result = $applier->apply(new ArrayLineBuffer(['Hello']), 20, $style, $widget)->toArray();
+
+        // 1 border-top + 1 content + 1 border-bottom + 1 shadow row = 4 lines
+        $this->assertCount(4, $result);
+        foreach ($result as $line) {
+            $this->assertSame(20, AnsiUtils::visibleWidth($line));
+        }
     }
 
     // ---------------------------------------------------------------

--- a/src/Symfony/Component/Tui/Tests/Style/ShadowTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/ShadowTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\Shadow;
+use Symfony\Component\Tui\Style\ShadowOrientation;
+
+final class ShadowTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // getChar, spread=true (gradient)
+    // ---------------------------------------------------------------
+
+    /**
+     * @param array{int, string} $cases [distance => expectedChar]
+     */
+    #[DataProvider('getCharSpreadProvider')]
+    public function testGetCharWithSpread(int $density, array $cases)
+    {
+        $shadow = new Shadow(density: $density, spread: true);
+
+        foreach ($cases as [$distance, $expectedChar]) {
+            $this->assertSame($expectedChar, $shadow->getChar($distance), "density=$density, distance=$distance");
+        }
+    }
+
+    /**
+     * @return iterable<string, array{int, array<array{int, string}>}>
+     */
+    public static function getCharSpreadProvider(): iterable
+    {
+        yield 'density 4 fades outward' => [4, [
+            [1, '█'],
+            [2, '▓'],
+            [3, '▒'],
+            [4, '░'],
+        ]];
+        yield 'density 3 fades outward' => [3, [
+            [1, '▓'],
+            [2, '▒'],
+            [3, '░'],
+            [4, '░'], // clamped at ░
+        ]];
+        yield 'density 2 fades outward' => [2, [
+            [1, '▒'],
+            [2, '░'],
+            [3, '░'], // clamped
+        ]];
+        yield 'density 1 always lightest' => [1, [
+            [1, '░'],
+            [2, '░'],
+            [3, '░'],
+        ]];
+    }
+
+    // ---------------------------------------------------------------
+    // getChar, spread=false (solid)
+    // ---------------------------------------------------------------
+
+    #[DataProvider('getCharSolidProvider')]
+    public function testGetCharWithoutSpreadReturnsSameCharAtAllDistances(int $density, string $expectedChar)
+    {
+        $shadow = new Shadow(density: $density, spread: false);
+
+        $this->assertSame($expectedChar, $shadow->getChar(1));
+        $this->assertSame($expectedChar, $shadow->getChar(2));
+        $this->assertSame($expectedChar, $shadow->getChar(3));
+    }
+
+    /**
+     * @return iterable<string, array{int, string}>
+     */
+    public static function getCharSolidProvider(): iterable
+    {
+        yield 'density 1' => [1, '░'];
+        yield 'density 2' => [2, '▒'];
+        yield 'density 3' => [3, '▓'];
+        yield 'density 4' => [4, '█'];
+    }
+
+    // ---------------------------------------------------------------
+    // color
+    // ---------------------------------------------------------------
+
+    public function testColorDefaultsToGray()
+    {
+        $shadow = new Shadow();
+
+        $this->assertSame(Color::named('gray')->toForegroundCode(), $shadow->color->toForegroundCode());
+    }
+
+    public function testCustomColorIsKept()
+    {
+        $shadow = new Shadow(color: Color::named('red'));
+
+        $this->assertSame(Color::named('red')->toForegroundCode(), $shadow->color->toForegroundCode());
+    }
+
+    // ---------------------------------------------------------------
+    // clamping
+    // ---------------------------------------------------------------
+
+    public function testDensityClampedToMin()
+    {
+        $this->assertSame(1, (new Shadow(density: 0))->density);
+    }
+
+    public function testDensityClampedToMax()
+    {
+        $this->assertSame(4, (new Shadow(density: 5))->density);
+    }
+
+    public function testOffsetClampedToMin()
+    {
+        $this->assertSame(1, (new Shadow(offset: 0))->offset);
+    }
+
+    public function testOffsetClampedToMax()
+    {
+        $this->assertSame(3, (new Shadow(offset: 4))->offset);
+    }
+
+    // ---------------------------------------------------------------
+    // defaults
+    // ---------------------------------------------------------------
+
+    public function testDefaultOrientationIsBottomRight()
+    {
+        $shadow = new Shadow();
+
+        $this->assertSame(ShadowOrientation::BottomRight, $shadow->orientation);
+    }
+
+    public function testDefaultParameterValues()
+    {
+        $shadow = new Shadow();
+
+        $this->assertSame(2, $shadow->density);
+        $this->assertSame(1, $shadow->offset);
+        $this->assertTrue($shadow->spread);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/StyleTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/StyleTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\Tui\Style\Color;
 use Symfony\Component\Tui\Style\CursorShape;
 use Symfony\Component\Tui\Style\Direction;
 use Symfony\Component\Tui\Style\Padding;
+use Symfony\Component\Tui\Style\Shadow;
+use Symfony\Component\Tui\Style\ShadowOrientation;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
 use Symfony\Component\Tui\Style\VerticalAlign;
@@ -237,6 +239,93 @@ class StyleTest extends TestCase
         $this->assertStringContainsString("\x1b[36m", $result);
     }
 
+    // ---------------------------------------------------------------
+    // Shadow constructor / factory
+    // ---------------------------------------------------------------
+
+    public function testShadowCanBePassedToConstructor()
+    {
+        $shadow = new Shadow(density: 3);
+        $style = new Style(shadow: $shadow);
+
+        $this->assertSame($shadow, $style->getShadow());
+    }
+
+    public function testShadowStaticFactory()
+    {
+        $shadow = new Shadow(offset: 2);
+        $style = Style::shadow($shadow);
+
+        $this->assertSame($shadow, $style->getShadow());
+    }
+
+    // ---------------------------------------------------------------
+    // withShadow / getShadow
+    // ---------------------------------------------------------------
+
+    public function testWithShadowStoresShadow()
+    {
+        $shadow = new Shadow(orientation: ShadowOrientation::BottomLeft, density: 3, offset: 2);
+        $style = (new Style())->withShadow($shadow);
+
+        $this->assertSame($shadow, $style->getShadow());
+    }
+
+    public function testWithShadowNullClearsShadow()
+    {
+        $style = (new Style())
+            ->withShadow(new Shadow())
+            ->withShadow(null);
+
+        $this->assertNull($style->getShadow());
+    }
+
+    public function testWithShadowIsImmutable()
+    {
+        $original = new Style();
+        $withShadow = $original->withShadow(new Shadow());
+
+        $this->assertNull($original->getShadow());
+        $this->assertNotNull($withShadow->getShadow());
+    }
+
+    public function testMergeAllIncludesShadow()
+    {
+        $shadow = new Shadow(density: 4);
+        $a = new Style(bold: true);
+        $b = (new Style())->withShadow($shadow);
+
+        $result = Style::mergeAll([$a, $b]);
+
+        $this->assertSame($shadow, $result->getShadow());
+        $this->assertTrue($result->getBold());
+    }
+
+    public function testMergeAllLaterShadowOverridesEarlier()
+    {
+        $shadow1 = new Shadow(density: 1);
+        $shadow2 = new Shadow(density: 4);
+
+        $result = Style::mergeAll([
+            (new Style())->withShadow($shadow1),
+            (new Style())->withShadow($shadow2),
+        ]);
+
+        $this->assertSame($shadow2, $result->getShadow());
+    }
+
+    public function testMergeAllShadowSurvivesEmptyOverride()
+    {
+        $shadow = new Shadow();
+
+        $result = Style::mergeAll([
+            (new Style())->withShadow($shadow),
+            new Style(),
+        ]);
+
+        $this->assertSame($shadow, $result->getShadow());
+    }
+
     public function testWithoutLayoutPropertiesStripsAllLayoutProperties()
     {
         $style = new Style()
@@ -252,7 +341,8 @@ class StyleTest extends TestCase
             ->withFlex(1)
             ->withFont('big')
             ->withColor('red')
-            ->withBold();
+            ->withBold()
+            ->withShadow(new Shadow());
         $stripped = $style->withoutLayoutProperties();
 
         // Layout properties stripped
@@ -266,6 +356,7 @@ class StyleTest extends TestCase
         $this->assertNull($stripped->getAlign());
         $this->assertNull($stripped->getVerticalAlign());
         $this->assertNull($stripped->getFlex());
+        $this->assertNull($stripped->getShadow());
 
         // Content and visual properties preserved
         $this->assertSame(Color::named('red')->toForegroundCode(), $stripped->getColor()->toForegroundCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a drop-shadow system to the Tui component. Shadows are rendered outside the widget's border
using Unicode block characters (`░▒▓█`) and are configured through the `Style` API, consistent with
`Border` and `Padding`.

## Usage

```php
use Symfony\Component\Tui\Style\Shadow;
use Symfony\Component\Tui\Style\ShadowOrientation;
use Symfony\Component\Tui\Style\Style;

// Default shadow (BottomRight, gray, density 2, offset 1)
$style = new Style(shadow: new Shadow());

// Fluent API
$style = (new Style())->withShadow(new Shadow(
    orientation: ShadowOrientation::BottomRight, // BottomRight|BottomLeft|TopRight|TopLeft
    color:       null,                           // ?Color, null defaults to gray
    density:     3,                              // 1=░  2=▒  3=▓  4=█  (clamped 1–4)
    offset:      2,                              // thickness in columns (clamped 1–3)
    spread:      true,                           // true=gradient outward, false=solid
));

// Static factory
$style = Style::shadow(new Shadow(density: 4));

// Remove shadow
$style = $style->withShadow(null);
```

The shadow reserves its cells inside the widget's box during layout, so widget positions and focus
tracking account for it in all four orientations. When the box is too narrow to fit the shadow, it is
clamped the same way borders are, and the content keeps at least one column. Shadow cells carry only a
foreground color, so they stay transparent to the compositor and to backgrounds underneath.

Points for the documentation: the `Shadow` options and their defaults (orientation, color, density,
offset, spread), configuring it through `Style` like `Border` and `Padding`, and the clamping on narrow
boxes.

## Visual output

**Orientation**
<img width="795" height="141" alt="image" src="https://github.com/user-attachments/assets/ab63955a-82bf-42b8-aebc-fb6308072d04" />


**Density**
<img width="795" height="141" alt="image" src="https://github.com/user-attachments/assets/86c4c4cd-d439-4617-ac8a-fe7bbd94cd87" />

**Offset**
<img width="795" height="154" alt="image" src="https://github.com/user-attachments/assets/14b0c65b-9432-4582-adcd-c078dd32b319" />

**Spread**
<img width="795" height="154" alt="image" src="https://github.com/user-attachments/assets/b682e7c3-ca37-4153-9046-19998f9e8441" />

**With color**
<img width="795" height="154" alt="image" src="https://github.com/user-attachments/assets/289ae330-231f-4369-9757-f23bc5bc192f" />

