### PR TITLE
[HttpClient] Improve Cache-Control parsing for shared caches

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -563,14 +563,47 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
             foreach (explode(',', $line) as $directive) {
                 if (str_contains($directive, '=')) {
                     [$name, $value] = explode('=', $directive, 2);
-                    $parsed[trim($name)] = trim($value);
+                    $normalizedName = strtolower(trim($name));
+                    $normalizedValue = self::unquoteCacheControlValue(trim($value));
                 } else {
-                    $parsed[trim($directive)] = true;
+                    $normalizedName = strtolower(trim($directive));
+                    $normalizedValue = true;
                 }
+
+                if ('' === $normalizedName) {
+                    continue;
+                }
+
+                if (\array_key_exists($normalizedName, $parsed)) {
+                    // Duplicate directive values are ambiguous; make value-based checks fail closed.
+                    $parsed[$normalizedName] = '';
+
+                    continue;
+                }
+
+                $parsed[$normalizedName] = $normalizedValue;
             }
         }
 
         return $parsed;
+    }
+
+    private static function unquoteCacheControlValue(string $value): string
+    {
+        if (2 <= \strlen($value) && '"' === $value[0] && '"' === $value[-1]) {
+            return substr($value, 1, -1);
+        }
+
+        return $value;
+    }
+
+    private static function parseDeltaSeconds(string|true|null $value): ?int
+    {
+        if (!\is_string($value) || '' === $value || !ctype_digit($value)) {
+            return null;
+        }
+
+        return (int) $value;
     }
 
     /**
@@ -598,12 +631,21 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
         if (
             isset($parseCacheControlHeader['must-revalidate'])
-            || ($this->sharedCache && isset($parseCacheControlHeader['proxy-revalidate']))
+            || (
+                $this->sharedCache
+                && (
+                    isset($parseCacheControlHeader['proxy-revalidate'])
+                    || self::hasValidSharedMaxAge($parseCacheControlHeader)
+                )
+            )
         ) {
             return Freshness::MustRevalidate;
         }
 
-        if (isset($parseCacheControlHeader['stale-if-error']) && ($now - $expires) <= (int) $parseCacheControlHeader['stale-if-error']) {
+        if (
+            null !== ($staleIfError = self::parseDeltaSeconds($parseCacheControlHeader['stale-if-error'] ?? null))
+            && ($now - $expires) <= $staleIfError
+        ) {
             return Freshness::StaleButUsable;
         }
 
@@ -632,13 +674,17 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
         $age = self::getCurrentAge($headers);
 
         if ($this->sharedCache && isset($cacheControl['s-maxage'])) {
-            $sharedMaxAge = (int) $cacheControl['s-maxage'];
+            if (null === $sharedMaxAge = self::parseDeltaSeconds($cacheControl['s-maxage'])) {
+                return null;
+            }
 
             return max(0, $sharedMaxAge - $age);
         }
 
         if (isset($cacheControl['max-age'])) {
-            $maxAge = (int) $cacheControl['max-age'];
+            if (null === $maxAge = self::parseDeltaSeconds($cacheControl['max-age'])) {
+                return null;
+            }
 
             return max(0, $maxAge - $age);
         }
@@ -722,7 +768,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
         if ($this->sharedCache) {
             if (
-                !isset($cacheControl['public']) && !isset($cacheControl['s-maxage']) && !isset($cacheControl['must-revalidate'])
+                !isset($cacheControl['public']) && !self::hasValidSharedMaxAge($cacheControl) && !isset($cacheControl['must-revalidate'])
                 && isset($requestHeaders['authorization'])
             ) {
                 return false;
@@ -758,8 +804,16 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
     private function hasExplicitExpiration(array $headers, array $cacheControl): bool
     {
         return isset($headers['expires'])
-            || ($this->sharedCache && isset($cacheControl['s-maxage']))
-            || isset($cacheControl['max-age']);
+            || ($this->sharedCache && self::hasValidSharedMaxAge($cacheControl))
+            || null !== self::parseDeltaSeconds($cacheControl['max-age'] ?? null);
+    }
+
+    /**
+     * @param array<string, string|true> $cacheControl
+     */
+    private static function hasValidSharedMaxAge(array $cacheControl): bool
+    {
+        return null !== self::parseDeltaSeconds($cacheControl['s-maxage'] ?? null);
     }
 
     /**

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -276,6 +276,85 @@ class CachingHttpClientTest extends TestCase
         $this->assertSame('foo', $response->getContent(false));
     }
 
+    public function testSharedCacheDoesNotServeStaleResponseOnErrorWhenExpiredByMixedCaseSMaxAge()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 404,
+                'response_headers' => [
+                    'Cache-Control' => 'S-MaxAge=1, max-age=100, stale-if-error=5',
+                ],
+            ]),
+            new MockResponse('Internal Server Error', ['http_code' => 500]),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent(false));
+
+        sleep(2);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(504, $response->getStatusCode());
+    }
+
+    public function testSharedCacheServesStaleResponseOnErrorWithMalformedSMaxAgeAndStaleIfError()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 404,
+                'response_headers' => [
+                    'Cache-Control' => 's-maxage=abc, stale-if-error=9999999999',
+                ],
+            ]),
+            new MockResponse('Internal Server Error', ['http_code' => 500]),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-malformed-s-maxage-stale-if-error');
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-malformed-s-maxage-stale-if-error');
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent(false));
+    }
+
+    public function testSharedCacheServesStaleResponseOnErrorWithDuplicateSMaxAgeAndStaleIfError()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 404,
+                'response_headers' => [
+                    'Cache-Control' => 's-maxage=1, s-maxage=2, stale-if-error=9999999999',
+                ],
+            ]),
+            new MockResponse('Internal Server Error', ['http_code' => 500]),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-duplicate-s-maxage-stale-if-error');
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-duplicate-s-maxage-stale-if-error');
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent(false));
+    }
+
     public function testPrivateCacheWithSharedCacheFalse()
     {
         $responses = [
@@ -310,7 +389,7 @@ class CachingHttpClientTest extends TestCase
             new MockResponse('foo', [
                 'http_code' => 200,
                 'response_headers' => [
-                    'Cache-Control' => 'no-store',
+                    'Cache-Control' => 'NO-STORE',
                 ],
             ]),
             new MockResponse('bar'),
@@ -327,6 +406,30 @@ class CachingHttpClientTest extends TestCase
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
         $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testItDoesntStoreAResponseWithUppercaseNoStoreDirectiveEvenWithMaxAge()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=300, NO-STORE',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-no-store');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-no-store');
         $this->assertSame('bar', $response->getContent());
     }
 
@@ -420,6 +523,304 @@ class CachingHttpClientTest extends TestCase
         $response = $client->request('GET', 'http://example.com/foo-bar');
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testASharedCacheDoesntStoreAResponseWithMalformedSMaxAgeDirectiveFromRequestWithAuthorization()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 's-maxage=abc',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            ['headers' => ['Authorization' => 'foo']],
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-malformed-s-maxage');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-malformed-s-maxage');
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testItStoresAResponseWithUppercaseMaxAgeDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'MAX-AGE=300',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testItStoresAResponseWithQuotedUppercaseMaxAgeDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'MAX-AGE="300"',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-quoted-max-age');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-quoted-max-age');
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testItStoresAResponseWithEmptyCacheControlDirectives()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => ',,, max-age=300,,',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-empty-cache-control-directives');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-empty-cache-control-directives');
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testItDoesntStoreAResponseWithMalformedMaxAgeDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=3x0',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-malformed-max-age');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-malformed-max-age');
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testItDoesntStoreAResponseWithQuotedCommaInMaxAgeDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age="3,0"',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-quoted-comma-max-age');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-quoted-comma-max-age');
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testCacheControlDuplicateDirectiveInvalidatesFreshness()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=0, MAX-AGE=300',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-duplicate-max-age');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-duplicate-max-age');
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testCacheControlDuplicateDirectiveAcrossHeaderLinesInvalidatesFreshness()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => ['max-age=0', 'MAX-AGE=300'],
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-duplicate-max-age-header-lines');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-duplicate-max-age-header-lines');
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testASharedCacheStoresAResponseWithUppercasePublicDirectiveFromRequestWithAuthorization()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'PUBLIC, max-age=300',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            ['headers' => ['Authorization' => 'foo']],
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-public');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-public');
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testASharedCacheStoresAResponseWithUppercaseSMaxAgeDirectiveFromRequestWithAuthorization()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'S-MAXAGE=300',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            ['headers' => ['Authorization' => 'foo']],
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-s-maxage');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-s-maxage');
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testASharedCacheDoesntStoreAResponseWithUppercasePrivateDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'PRIVATE, max-age=300',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-private');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-private');
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testASharedCacheDoesntStoreAResponseWithUppercaseNoStoreDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'NO-STORE, max-age=300',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-no-store-shared');
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar-uppercase-no-store-shared');
+        $this->assertSame('bar', $response->getContent());
     }
 
     public function testASharedCacheDoesntStoreAResponseWithPrivateDirective()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Cache-Control directive names are now parsed case-insensitively, empty directives are ignored, and quoted directive values such as max-age="300" are unquoted before validation.

Duplicate Cache-Control directives are treated as invalid freshness information so cached responses fall back to stale instead of choosing an arbitrary value.

For shared caches, a valid s-maxage delta-seconds value overrides max-age/Expires and carries proxy-revalidate semantics; malformed or duplicate values are treated as unusable freshness information.

Sources: RFC 9111 §4.2.1, §5.2, §5.2.2.8, §5.2.2.10.