### PR TITLE
[HttpClient] Invalidate cache for unknown unsafe methods

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -65,9 +65,9 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
      */
     private const CACHEABLE_METHODS = ['GET', 'HEAD'];
     /**
-     * The HTTP methods that will trigger a cache invalidation.
+     * The HTTP methods that are considered safe per RFC 9110.
      */
-    private const UNSAFE_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH'];
+    private const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS', 'TRACE'];
     /**
      * Headers that influence the response and may affect caching behavior.
      */
@@ -168,7 +168,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
                 }
 
                 $statusCode = $context->getStatusCode();
-                if ($statusCode >= 100 && $statusCode < 400 && \in_array($method, self::UNSAFE_METHODS, true)) {
+                if ($statusCode >= 200 && $statusCode < 400 && !\in_array($method, self::SAFE_METHODS, true)) {
                     $this->cache->invalidateTags([$fullUrlTag]);
                 }
 

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -1016,13 +1016,63 @@ class CachingHttpClientTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('initial get', $response->getContent());
 
-        // Unsafe POST with body (bypasses cache but invalidates on success)
-        $client->request('POST', 'http://example.com/unsafe-test', ['body' => 'invalidate']);
+        // Unsafe POST with body (bypasses cache but invalidates on successful responses)
+        $response = $client->request('POST', 'http://example.com/unsafe-test', ['body' => 'invalidate']);
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
 
         // Next GET should miss cache and fetch new
         $response = $client->request('GET', 'http://example.com/unsafe-test');
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('after invalidate', $response->getContent());
+    }
+
+    public function testUnknownMethodInvalidationInBypassFlow()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('initial get', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('', ['http_code' => 204]),
+            new MockResponse('after invalidate', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/unknown-method-test');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('initial get', $response->getContent());
+
+        // Deliberately unknown methods are treated as unsafe and must invalidate cache entries on successful responses.
+        $response = $client->request('FOO', 'http://example.com/unknown-method-test', ['body' => 'invalidate']);
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/unknown-method-test');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('after invalidate', $response->getContent());
+    }
+
+    public function testNoInvalidationOnInformationalResponseInBypassFlow()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('initial get', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('', ['http_code' => 103]),
+            new MockResponse('should not be fetched', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/no-invalidate-1xx-test');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('initial get', $response->getContent());
+
+        $response = $client->request('FOO', 'http://example.com/no-invalidate-1xx-test', ['body' => 'do not invalidate']);
+        $this->assertSame(103, $response->getStatusCode());
+        $this->assertSame('', $response->getContent(false));
+
+        // Informational response must not invalidate.
+        $response = $client->request('GET', 'http://example.com/no-invalidate-1xx-test');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('initial get', $response->getContent());
     }
 
     public function testNoInvalidationOnErrorInBypassFlow()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Unsafe requests now invalidate stored responses for their target URI after a non-error response. Unknown extension methods are treated conservatively as unsafe because methods are only safe when defined as safe.

Non-error responses for this invalidation rule are 2xx or 3xx responses, so informational 1xx responses do not trigger invalidation.

Sources: RFC 9111 §4, §4.4; RFC 9110 §9.2.1.