### PR TITLE
[HttpClient] Broaden cacheable response status handling

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -53,13 +53,9 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
     use HttpClientTrait;
 
     /**
-     * The status codes that are always cacheable.
+     * The status codes that are cacheable by default.
      */
-    private const CACHEABLE_STATUS_CODES = [200, 203, 204, 300, 301, 404, 410];
-    /**
-     * The status codes that are cacheable if the response carries explicit cache directives.
-     */
-    private const CONDITIONALLY_CACHEABLE_STATUS_CODES = [302, 303, 307, 308];
+    private const DEFAULT_CACHEABLE_STATUS_CODES = [200, 203, 204, 300, 301, 308, 404, 405, 410, 414, 501];
     /**
      * The HTTP methods that are always cacheable.
      */
@@ -95,6 +91,10 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
      * Maximum heuristic freshness lifetime in seconds (24 hours).
      */
     private const MAX_HEURISTIC_FRESHNESS_TTL = 86400;
+    /**
+     * RFC 9111 recommends a heuristic freshness lifetime of 10% of the time since Last-Modified.
+     */
+    private const HEURISTIC_FRESHNESS_FRACTION = 0.1;
 
     private TagAwareCacheInterface|HttpCache $cache;
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
@@ -651,24 +651,37 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
             }
         }
 
-        // Heuristic freshness fallback when no explicit directives are present
-        if (
-            !isset($cacheControl['no-cache'])
-            && !isset($cacheControl['no-store'])
-            && isset($headers['last-modified'])
-        ) {
-            foreach ($headers['last-modified'] as $lastModified) {
-                if (false === $lastModifiedTimestamp = strtotime($lastModified)) {
-                    continue;
-                }
-                if (0 < $secondsSinceLastModified = time() - $lastModifiedTimestamp) {
-                    // Heuristic: 10% of time since last modified, capped at max heuristic freshness
-                    $heuristicFreshnessSeconds = (int) ($secondsSinceLastModified * 0.1);
-                    $cappedHeuristicFreshness = min($heuristicFreshnessSeconds, self::MAX_HEURISTIC_FRESHNESS_TTL);
+        if (null !== $heuristicFreshnessLifetime = $this->determineHeuristicFreshnessLifetime($headers, $cacheControl)) {
+            return max(0, $heuristicFreshnessLifetime - $age);
+        }
 
-                    return max(0, $cappedHeuristicFreshness - $age);
-                }
+        return null;
+    }
+
+    /**
+     * @param array<string, string|string[]> $headers
+     * @param array<string, string|true>     $cacheControl
+     */
+    private function determineHeuristicFreshnessLifetime(array $headers, array $cacheControl): ?int
+    {
+        if (!$this->allowsHeuristicFreshness($headers, $cacheControl)) {
+            return null;
+        }
+
+        foreach ($headers['last-modified'] as $lastModified) {
+            if (false === $lastModifiedTimestamp = strtotime($lastModified)) {
+                continue;
             }
+
+            $secondsSinceLastModified = time() - $lastModifiedTimestamp;
+
+            if (0 >= $secondsSinceLastModified) {
+                continue;
+            }
+
+            $heuristicFreshnessLifetime = (int) ($secondsSinceLastModified * self::HEURISTIC_FRESHNESS_FRACTION);
+
+            return min($heuristicFreshnessLifetime, self::MAX_HEURISTIC_FRESHNESS_TTL);
         }
 
         return null;
@@ -737,29 +750,67 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
             }
         }
 
-        // Conditionals require an explicit expiration
-        if (\in_array($statusCode, self::CONDITIONALLY_CACHEABLE_STATUS_CODES, true)) {
-            return $this->hasExplicitExpiration($responseHeaders, $cacheControl);
+        if (self::isDefaultCacheableStatusCode($statusCode)) {
+            return true;
         }
 
-        return \in_array($statusCode, self::CACHEABLE_STATUS_CODES, true);
+        if (self::isStatusCodeExcludedFromStorage($statusCode)) {
+            return false;
+        }
+
+        if ($this->hasExplicitFreshness($responseHeaders, $cacheControl)) {
+            return true;
+        }
+
+        return $this->allowsHeuristicFreshnessForNonDefaultStatus($responseHeaders, $cacheControl);
+    }
+
+    private static function isDefaultCacheableStatusCode(int $statusCode): bool
+    {
+        return \in_array($statusCode, self::DEFAULT_CACHEABLE_STATUS_CODES, true);
+    }
+
+    private static function isStatusCodeExcludedFromStorage(int $statusCode): bool
+    {
+        // 206 is only cacheable for range requests, which this client does not store.
+        return 206 === $statusCode || 304 === $statusCode;
     }
 
     /**
-     * Checks if the response has an explicit expiration.
+     * Checks if the response has explicit freshness.
      *
-     * This function will return true if the response has an explicit expiration
-     * time specified in the headers or in the Cache-Control directives,
+     * This function will return true if the response has explicit freshness
+     * specified in the headers or in the Cache-Control directives,
      * false otherwise.
      *
      * @param array<string, string|string[]> $headers
      * @param array<string, string|true>     $cacheControl
      */
-    private function hasExplicitExpiration(array $headers, array $cacheControl): bool
+    private function hasExplicitFreshness(array $headers, array $cacheControl): bool
     {
         return isset($headers['expires'])
             || ($this->sharedCache && isset($cacheControl['s-maxage']))
             || isset($cacheControl['max-age']);
+    }
+
+    /**
+     * @param array<string, string|string[]> $headers
+     * @param array<string, string|true>     $cacheControl
+     */
+    private function allowsHeuristicFreshnessForNonDefaultStatus(array $headers, array $cacheControl): bool
+    {
+        return isset($cacheControl['public']) && $this->allowsHeuristicFreshness($headers, $cacheControl);
+    }
+
+    /**
+     * @param array<string, string|string[]> $headers
+     * @param array<string, string|true>     $cacheControl
+     */
+    private function allowsHeuristicFreshness(array $headers, array $cacheControl): bool
+    {
+        return !isset($cacheControl['no-cache'])
+            && !isset($cacheControl['no-store'])
+            && isset($headers['last-modified']);
     }
 
     /**

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -752,6 +752,46 @@ class CachingHttpClientTest extends TestCase
         $this->assertSame('chunk1chunk2chunk3', $content);
     }
 
+    public function testItCachesHeuristicallyCacheableStatuses()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('method not allowed', ['http_code' => 405, 'response_headers' => ['Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT']]),
+            new MockResponse('uri too long', ['http_code' => 414, 'response_headers' => ['Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT']]),
+            new MockResponse('not implemented', ['http_code' => 501, 'response_headers' => ['Last-Modified' => 'Wed, 21 Oct 2015 07:28:00 GMT']]),
+            new MockResponse('should not be served'),
+            new MockResponse('should not be served'),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $this->assertSame('method not allowed', $client->request('GET', 'http://example.com/405')->getContent(false));
+        $this->assertSame('uri too long', $client->request('GET', 'http://example.com/414')->getContent(false));
+        $this->assertSame('not implemented', $client->request('GET', 'http://example.com/501')->getContent(false));
+
+        $this->assertSame('method not allowed', $client->request('GET', 'http://example.com/405')->getContent(false));
+        $this->assertSame('uri too long', $client->request('GET', 'http://example.com/414')->getContent(false));
+        $this->assertSame('not implemented', $client->request('GET', 'http://example.com/501')->getContent(false));
+    }
+
+    public function testItStoresResponsesWithExplicitFreshnessEvenForOtherStatuses()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('legal reasons', [
+                'http_code' => 451,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=60',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $this->assertSame('legal reasons', $client->request('GET', 'http://example.com/451')->getContent(false));
+        $this->assertSame('legal reasons', $client->request('GET', 'http://example.com/451')->getContent(false));
+    }
+
     public function testConditionalCacheableStatusCodeWithoutExpiration()
     {
         $mockClient = new MockHttpClient([
@@ -789,6 +829,130 @@ class CachingHttpClientTest extends TestCase
         $response = $client->request('GET', 'http://example.com/redirect');
         $this->assertSame(302, $response->getStatusCode());
         $this->assertSame('redirected', $response->getContent(false));
+    }
+
+    public function testHeuristicDefaultCacheableStatusCode()
+    {
+        $lastModified = gmdate('D, d M Y H:i:s', time() - 1000).' GMT';
+        $mockClient = new MockHttpClient([
+            new MockResponse('permanent redirect', [
+                'http_code' => 308,
+                'response_headers' => [
+                    'Last-Modified' => $lastModified,
+                ],
+            ]),
+            new MockResponse('should not be served', ['http_code' => 308]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/redirect-308');
+        $this->assertSame(308, $response->getStatusCode());
+        $this->assertSame('permanent redirect', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/redirect-308');
+        $this->assertSame(308, $response->getStatusCode());
+        $this->assertSame('permanent redirect', $response->getContent(false));
+    }
+
+    public function testExplicitFreshnessStatusCode206IsNotStored()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('partial response one', [
+                'http_code' => 206,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=60',
+                ],
+            ]),
+            new MockResponse('partial response two', [
+                'http_code' => 206,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=60',
+                ],
+            ]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/partial');
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertSame('partial response one', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/partial');
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertSame('partial response two', $response->getContent(false));
+    }
+
+    public function testExplicitFreshnessStandaloneStatusCode304IsNotStored()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('', [
+                'http_code' => 304,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=60',
+                ],
+            ]),
+            new MockResponse('fresh payload', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/not-modified');
+        $this->assertSame(304, $response->getStatusCode());
+        $this->assertSame('', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/not-modified');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('fresh payload', $response->getContent(false));
+    }
+
+    public function testPublicNonDefaultStatusCodeUsesHeuristicFreshness()
+    {
+        $lastModified = gmdate('D, d M Y H:i:s', time() - 1000).' GMT';
+        $mockClient = new MockHttpClient([
+            new MockResponse('created once', [
+                'http_code' => 201,
+                'response_headers' => [
+                    'Cache-Control' => 'public',
+                    'Last-Modified' => $lastModified,
+                ],
+            ]),
+            new MockResponse('should not be served', ['http_code' => 201]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/created');
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('created once', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/created');
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('created once', $response->getContent(false));
+    }
+
+    public function testNonDefaultStatusCodeWithoutPublicDirectiveDoesNotUseHeuristicFreshness()
+    {
+        $lastModified = gmdate('D, d M Y H:i:s', time() - 1000).' GMT';
+        $mockClient = new MockHttpClient([
+            new MockResponse('created once', [
+                'http_code' => 201,
+                'response_headers' => [
+                    'Last-Modified' => $lastModified,
+                ],
+            ]),
+            new MockResponse('created twice', ['http_code' => 201]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/created');
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('created once', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/created');
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertSame('created twice', $response->getContent(false));
     }
 
     public function testETagRevalidation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The cache now recognizes all RFC 9111 status codes that are heuristically cacheable by default, including 308, 405, 414, and 501.

Responses with other final status codes can also be stored when explicit freshness information permits it, except for 206 and standalone 304 responses which this client does not store.

Non-default status codes only use heuristic freshness when the response is explicitly marked public.

Sources: RFC 9111 §3, §4.2.1, §4.2.2.