### PR TITLE
[AssetMapper] Rewrite import paths in "export … from" statements

### DIFF
--- a/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
+++ b/src/Symfony/Component/AssetMapper/Compiler/JavaScriptImportPathCompiler.php
@@ -39,12 +39,16 @@ final class JavaScriptImportPathCompiler implements AssetCompilerInterface
                 "(?:[^"\\\\\n]|\\\\.)*+"      # Strings enclosed in double quotes
             )
         |
-            (?:                            # Import statements (script captured)
+            (?:                            # Import or re-export statements (script captured)
                 import\s*
                     (?:
                         (?:\*\s*as\s+\w+|\s+[\w\s{},*]+)
                         \s*from\s*
                     )?
+            |
+                export\s*                  # Re-exports always carry a "from" clause
+                    (?:\*(?:\s*as\s+\w+)?|\{[^}]*+\})
+                    \s*from\s*
             |
                 \bimport\(
             )

--- a/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Compiler/JavaScriptImportPathCompilerTest.php
@@ -196,6 +196,41 @@ class JavaScriptImportPathCompilerTest extends TestCase
             'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
         ];
 
+        yield 'static_named_reexport' => [
+            'input' => 'export { myFunction } from "./other.js";',
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_named_reexport_single_quotes' => [
+            'input' => 'export { myFunction as helper } from \'./other.js\';',
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_reexport_everything' => [
+            'input' => 'export * from "./other.js";',
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_reexport_namespace' => [
+            'input' => 'export * as myModule from "./other.js";',
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'static_multiple_named_reexports' => [
+            'input' => <<<EOF
+                export {
+                    myFunction,
+                    helperFunction
+                } from "./other.js";
+                EOF,
+            'expectedJavaScriptImports' => ['/assets/other.js' => ['lazy' => false, 'asset' => 'other.js', 'add' => true]],
+        ];
+
+        yield 'local_export_without_from_is_not_a_reexport' => [
+            'input' => "export const foo = 1;\nexport default foo;\nexport { foo };",
+            'expectedJavaScriptImports' => [],
+        ];
+
         yield 'mix_of_static_and_dynamic_imports' => [
             'input' => 'import "./other.js"; import("./subdir/foo.js");',
             'expectedJavaScriptImports' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64183
| License       | MIT

`JavaScriptImportPathCompiler` only rewrites relative paths in `import` statements (and dynamic `import()`). Re-export statements carrying a module specifier were not recognized by `IMPORT_PATTERN`, so:

```js
export { foo } from './foo.js';
export * from './bar.js';
export * as ns from './baz.js';
```

were left untouched and the browser received the source relative path (e.g. `./foo.js`) instead of the hashed public asset path.

This adds an `export … from` alternative to the pattern. The `from` clause is mandatory, so local exports (`export const`, `export default`, `export { foo }` without a specifier) are correctly left alone.