### PR TITLE
[Tui] Fix unattached widget element styles

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -54,7 +54,7 @@ class MarkdownTest extends TestCase
     public static function markdownElementProvider(): iterable
     {
         yield 'plain text' => ['Hello World', 40, ['Hello World']];
-        yield 'heading' => ['# Heading', 40, ['# Heading']];
+        yield 'heading' => ['# Heading', 40, ['Heading']];
         yield 'bold (ANSI code)' => ['This is **bold** text', 60, ["\x1b[1m", 'bold']];
         yield 'italic (ANSI code)' => ['This is *italic* text', 60, ["\x1b[3m"]];
         yield 'inline code' => ['Use `code` here', 60, ['code']];
@@ -64,6 +64,18 @@ class MarkdownTest extends TestCase
         yield 'horizontal rule' => ['---', 40, ['─']];
         yield 'table' => ["| A | B |\n| - | - |\n| 1 | 2 |", 40, ['A', '1', '┌']];
         yield 'link' => ['[Click here](https://example.com)', 60, ['Click here', 'example.com']];
+    }
+
+    public function testRenderUnattachedUsesDefaultElementStyles()
+    {
+        $md = new MarkdownWidget("# Hello\n\nsome **bold** and *italic* text");
+        $lines = $md->render(new RenderContext(60, 24));
+        $content = implode("\n", $lines);
+
+        $this->assertStringContainsString("\x1b[1m", $content);
+        $this->assertStringContainsString("\x1b[3m", $content);
+        $this->assertStringContainsString('Hello', $content);
+        $this->assertStringNotContainsString('# Hello', AnsiUtils::stripAnsiCodes($content));
     }
 
     public function testRenderWithPadding()

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Tui\Widget;
 use Symfony\Component\Tui\Event\AbstractEvent;
 use Symfony\Component\Tui\Exception\RenderException;
 use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Style\DefaultStyleSheet;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
 use Symfony\Component\Tui\Tui;
@@ -33,6 +34,7 @@ abstract class AbstractWidget
     private ?AbstractWidget $parent = null;
     private ?WidgetContext $context = null;
     private ?Style $internalStyle = null;
+    private static ?StyleSheet $defaultStyleSheet = null;
 
     /** @var string[] */
     private array $styleClasses = [];
@@ -421,7 +423,7 @@ abstract class AbstractWidget
     {
         $context = $this->getContext();
         if (null === $context) {
-            return new Style();
+            return (self::$defaultStyleSheet ??= DefaultStyleSheet::create())->resolveElement($this, $element);
         }
 
         return $context->resolveElement($this, $element);

--- a/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
+++ b/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
@@ -197,11 +197,9 @@ class MarkdownWidget extends AbstractWidget
      */
     private function renderHeading(Heading $heading, int $columns): array
     {
-        $level = $heading->getLevel();
         $text = $this->renderInlineNodes($heading);
-        $prefix = str_repeat('#', $level).' ';
 
-        $styledText = $this->resolveElement('heading')->apply($prefix.$text);
+        $styledText = $this->resolveElement('heading')->apply($text);
 
         return TextWrapper::wrapTextWithAnsi($styledText, $columns);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64217
| License       | MIT

`MarkdownWidget::render()` can be used directly with a standalone `RenderContext`, but sub-element styles were only resolved when the widget was attached to a TUI tree. In that standalone case, `AbstractWidget::resolveElement()` returned an empty style, so Markdown headings, bold text, italic text, links, and other styled inline elements silently rendered without their default styling.

This changes the fallback at the widget level: when a widget is not attached to a context, sub-element styles are resolved from the default TUI stylesheet. That keeps standalone rendering consistent with attached rendering for core widgets.

For example:

```php
$markdown = new MarkdownWidget("# Hello\n\nsome **bold** and *italic* text");
$lines = $markdown->render(new RenderContext(60, 20));
```

Before, the heading kept the raw Markdown marker and inline formatting lost its ANSI styling:

```text
# Hello

some bold and italic text
```

After, the heading content is rendered without the Markdown syntax marker and default ANSI styles are applied to the heading, bold, and italic spans.

A regression test covers rendering an unattached `MarkdownWidget` directly with `RenderContext`.
