### PR TITLE
[DependencyInjection] Roll back only the failing service, not its ancestors, when a nested service cannot boot

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -63,6 +63,7 @@ class Container implements ContainerInterface, ResetInterface
 
     private array $envCache = [];
     private bool $compiled = false;
+    private ?\Exception $loadingException = null;
     private \Closure $getEnv;
 
     private static \Closure $make;
@@ -231,11 +232,22 @@ class Container implements ContainerInterface, ResetInterface
                 return /* self::IGNORE_ON_UNINITIALIZED_REFERENCE */ 4 === $invalidBehavior ? null : $container->{$container->methodMap[$id]}($container);
             }
         } catch (\Exception $e) {
-            unset($container->services[$id]);
+            // Roll back only the service whose factory actually raised the
+            // exception, not the ancestor services it was being created for:
+            // the same exception unwinds through every parent make() frame,
+            // and unsetting their id would wrongly drop unrelated services.
+            if ($container->loadingException !== $e) {
+                $container->loadingException = $e;
+                unset($container->services[$id]);
+            }
 
             throw $e;
         } finally {
             unset($container->loading[$id]);
+
+            if (!$container->loading) {
+                $container->loadingException = null;
+            }
         }
 
         if (self::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
@@ -338,8 +350,6 @@ class Container implements ContainerInterface, ResetInterface
 
     /**
      * Creates a service by requiring its factory file.
-     *
-     * @return mixed
      */
     protected function load(string $file)
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -144,7 +144,7 @@ class ContainerTest extends TestCase
 
         $sc = new ProjectServiceContainer();
         $sc->set('foo', $obj = new \stdClass());
-        $this->assertEquals(['service_container', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'internal_dependency', 'alias', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by factory methods in the method map, followed by service ids defined by set()');
+        $this->assertEquals(['service_container', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'internal_dependency', 'boots_with_broken_dependency', 'broken_dependency', 'alias', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by factory methods in the method map, followed by service ids defined by set()');
     }
 
     public function testSet()
@@ -372,6 +372,23 @@ class ContainerTest extends TestCase
         $this->assertFalse($c->initialized('throws_exception_on_service_configuration'));
     }
 
+    public function testGetDoesNotUnsetAncestorWhenANestedServiceCannotBoot()
+    {
+        $c = new ProjectServiceContainer();
+
+        try {
+            $c->get('boots_with_broken_dependency');
+            $this->fail('->get() should rethrow the exception of the failing dependency.');
+        } catch (\Exception $e) {
+            $this->assertSame('Cannot boot the broken dependency!', $e->getMessage());
+        }
+
+        // The service that actually failed to boot is the one rolled back...
+        $this->assertFalse($c->initialized('broken_dependency'));
+        // ...not the ancestor service it was being created for.
+        $this->assertTrue($c->initialized('boots_with_broken_dependency'));
+    }
+
     protected function getField($obj, $field)
     {
         $reflection = new \ReflectionProperty($obj, $field);
@@ -462,6 +479,8 @@ class ProjectServiceContainer extends Container
             'throw_exception' => 'getThrowExceptionService',
             'throws_exception_on_service_configuration' => 'getThrowsExceptionOnServiceConfigurationService',
             'internal_dependency' => 'getInternalDependencyService',
+            'boots_with_broken_dependency' => 'getBootsWithBrokenDependencyService',
+            'broken_dependency' => 'getBrokenDependencyService',
         ];
     }
 
@@ -509,5 +528,19 @@ class ProjectServiceContainer extends Container
         $instance->internal = $this->privates['internal'] ?? $this->getInternalService();
 
         return $instance;
+    }
+
+    protected function getBootsWithBrokenDependencyService()
+    {
+        $this->services['boots_with_broken_dependency'] = $instance = new \stdClass();
+
+        $instance->dependency = $this->get('broken_dependency');
+
+        return $instance;
+    }
+
+    protected function getBrokenDependencyService()
+    {
+        throw new \Exception('Cannot boot the broken dependency!');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54728
| License       | MIT

`Container::make()` is recursive: building service A may trigger building
a nested service B via `$container->get('B')`. When B's factory throws,
the exception unwinds through **every** parent `make()` frame, and each
frame ran:

```php
} catch (\Exception $e) {
    unset($container->services[$id]);

    throw $e;
}
```

So an ancestor (e.g. `twig` in the reproduction of #54728) that had
already registered itself in `$container->services` was wrongly dropped,
even though it was not the service that failed to boot — exactly what
@lyrixx reported: *"Symfony unset service A but it should be service B"*.

This PR rolls back **only the service whose factory directly raised the
exception**; the ancestor services it was being created for are left
untouched. The originating frame is identified by comparing the caught
exception instance, which is then cleared once the whole `loading` chain
has unwound (so it stays correct even if a factory catches and recovers
from a nested failure before triggering another one).

**Assumption (calling it out explicitly for review):** the conservative
choice here is that an ancestor whose dependency failed keeps its
existing `services` entry rather than also being unset. This matches the
expectation stated in #54728 by @lyrixx. Happy to adjust the semantics
if a different behavior is preferred.
