### PR TITLE
[Finder] Fix recursion into stream wrapper subdirectories on Windows

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -835,7 +835,7 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Normalizes given directory names by removing trailing slashes.
      *
-     * Excluding: (s)ftp:// or ssh2.(s)ftp:// wrapper
+     * Excluding: stream wrapper schemes such as ftp:// or s3://
      */
     private function normalizeDir(string $dir): string
     {
@@ -845,7 +845,7 @@ class Finder implements \IteratorAggregate, \Countable
 
         $dir = rtrim($dir, '/'.\DIRECTORY_SEPARATOR);
 
-        if (preg_match('#^(ssh2\.)?s?ftp://#', $dir)) {
+        if (preg_match('#^[a-zA-Z][a-zA-Z0-9.+-]*://#', $dir)) {
             $dir .= '/';
         }
 

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1883,4 +1883,14 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         return $data;
     }
+
+    public function testNormalizeDirKeepsTrailingSlashForStreamWrappers()
+    {
+        $normalize = new \ReflectionMethod(Finder::class, 'normalizeDir');
+        $finder = new Finder();
+
+        $this->assertSame('s3://bucket/test_dir/', $normalize->invoke($finder, 's3://bucket/test_dir'));
+        $this->assertSame('sftp://host/test_dir/', $normalize->invoke($finder, 'sftp://host/test_dir'));
+        $this->assertSame(__DIR__, $normalize->invoke($finder, __DIR__.'/'));
+    }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/VfsIteratorTestTrait.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/VfsIteratorTestTrait.php
@@ -52,7 +52,7 @@ trait VfsIteratorTestTrait
 
                 $this->scheme = $urlArr['scheme'];
 
-                return str_replace(\DIRECTORY_SEPARATOR, '/', $urlArr['host'].($urlArr['path'] ?? ''));
+                return rtrim(str_replace(\DIRECTORY_SEPARATOR, '/', $urlArr['host'].($urlArr['path'] ?? '')), '/');
             }
 
             public function processListDir(bool $fromRewind): bool
@@ -163,7 +163,7 @@ trait VfsIteratorTestTrait
         \assert($urlArr['scheme'] === $this->vfsScheme);
         \assert(isset($urlArr['host']));
 
-        return str_replace(\DIRECTORY_SEPARATOR, '/', $urlArr['host'].($urlArr['path'] ?? ''));
+        return rtrim(str_replace(\DIRECTORY_SEPARATOR, '/', $urlArr['host'].($urlArr['path'] ?? '')), '/');
     }
 
     protected function assertSameVfsIterator(array $expected, \Traversable $iterator)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #57900
| License       | MIT

`normalizeDir()` only kept the trailing slash for `sftp`/`ftp`, so `s3://` and other wrappers lost it and Finder stopped recursing into their subdirectories on Windows. The scheme check now matches any wrapper. The VFS test double trims it to match real wrappers.
