### PR TITLE
[Scheduler] Show "Next Run In" column in debug:scheduler command

### DIFF
--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add a "Next Run In" column to `debug:scheduler` showing the time until the next run
+
 8.1
 ---
 

--- a/src/Symfony/Component/Scheduler/Command/DebugCommand.php
+++ b/src/Symfony/Component/Scheduler/Command/DebugCommand.php
@@ -108,15 +108,15 @@ final class DebugCommand extends Command
                 $io->comment(\sprintf('Schedule "%s" is stateful: next run dates computed from stored checkpoint %s.', $name, $effectiveDate->format('r')));
             }
 
-            $recurringMessages = array_filter(array_map(self::renderRecurringMessage(...), $messages, array_fill(0, \count($messages), $effectiveDate), array_fill(0, \count($messages), $input->getOption('all'))));
+            $recurringMessages = array_filter(array_map(self::renderRecurringMessage(...), $messages, array_fill(0, \count($messages), $effectiveDate), array_fill(0, \count($messages), $date), array_fill(0, \count($messages), $input->getOption('all'))));
 
             if ($input->getOption('sort')) {
                 usort($recurringMessages, static fn (array $a, array $b): int => $a[2] <=> $b[2]);
             }
 
             $io->table(
-                ['Trigger', 'Provider', 'Next Run'],
-                array_map(static fn (array $row): array => [$row[0], $row[1], $row[2]?->format('r') ?? '-'], $recurringMessages),
+                ['Trigger', 'Provider', 'Next Run On', 'Next Run In'],
+                array_map(static fn (array $row): array => [$row[0], $row[1], $row[2]?->format('r') ?? '-', self::formatDateInterval($row[3]) ?? '-'], $recurringMessages),
             );
         }
 
@@ -151,9 +151,9 @@ final class DebugCommand extends Command
     }
 
     /**
-     * @return array{0:string,1:string,2:\DateTimeImmutable|null}|null
+     * @return array{0:string,1:string,2:\DateTimeImmutable|null,3:\DateInterval|null}|null
      */
-    private static function renderRecurringMessage(RecurringMessage $recurringMessage, \DateTimeImmutable $date, bool $all): ?array
+    private static function renderRecurringMessage(RecurringMessage $recurringMessage, \DateTimeImmutable $date, \DateTimeImmutable $now, bool $all): ?array
     {
         $trigger = $recurringMessage->getTrigger();
 
@@ -165,6 +165,44 @@ final class DebugCommand extends Command
         $provider = $recurringMessage->getProvider();
         $description = $provider instanceof \Stringable ? (string) $provider : $provider->getId();
 
-        return [(string) $trigger, $description, $next];
+        return [(string) $trigger, $description, $next, $next ? $now->diff($next) : null];
+    }
+
+    private static function formatDateInterval(?\DateInterval $interval): ?string
+    {
+        if (null === $interval) {
+            return null;
+        }
+
+        // same unit vocabulary as Helper::formatTime(), which stops at days
+        $units = [
+            'y' => 'y',
+            'm' => 'mo',
+            'd' => 'd',
+            'h' => 'h',
+            'i' => 'min',
+            's' => 's',
+        ];
+
+        $parts = [];
+        foreach ($units as $property => $unit) {
+            if ('s' === $property || 0 === $value = $interval->$property) {
+                continue;
+            }
+
+            $parts[] = $value.' '.$unit;
+        }
+
+        // seconds carry the fraction, so that a sub-second interval is not reported as zero
+        if (0 < $seconds = round($interval->s + $interval->f, 3)) {
+            $parts[] = rtrim(rtrim(\sprintf('%.3F', $seconds), '0'), '.').' s';
+        }
+
+        if (!$parts) {
+            return '0 s';
+        }
+
+        // a next run date in the past means the schedule is overdue
+        return ($interval->invert ? '-' : '').implode(', ', $parts);
     }
 }

--- a/src/Symfony/Component/Scheduler/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Command/DebugCommandTest.php
@@ -74,9 +74,9 @@ class DebugCommandTest extends TestCase
             "schedule_name\n".
             "-------------\n".
             "\n".
-            " --------- ---------- ---------- \n".
-            "  Trigger   Provider   Next Run  \n".
-            " --------- ---------- ---------- \n".
+            " --------- ---------- ------------- ------------- \n".
+            "  Trigger   Provider   Next Run On   Next Run In  \n".
+            " --------- ---------- ------------- ------------- \n".
             "\n", $tester->getDisplay(true));
     }
 
@@ -109,11 +109,11 @@ class DebugCommandTest extends TestCase
             "schedule_name\n".
             "-------------\n".
             "\n".
-            " --------- ---------- ---------- \n".
-            "  Trigger   Provider   Next Run  \n".
-            " --------- ---------- ---------- \n".
-            "  test      stdClass   -         \n".
-            " --------- ---------- ---------- \n".
+            " --------- ---------- ------------- ------------- \n".
+            "  Trigger   Provider   Next Run On   Next Run In  \n".
+            " --------- ---------- ------------- ------------- \n".
+            "  test      stdClass   -             -            \n".
+            " --------- ---------- ------------- ------------- \n".
             "\n", $tester->getDisplay(true));
     }
 
@@ -146,11 +146,11 @@ class DebugCommandTest extends TestCase
             "schedule_name\n".
             "-------------\n".
             "\n".
-            " ------------------------------- ---------- --------------------------------- \n".
-            "  Trigger                         Provider   Next Run                         \n".
-            " ------------------------------- ---------- --------------------------------- \n".
-            "  every first day of next month   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            " ------------------------------- ---------- --------------------------------- \n".
+            " ------------------------------- ---------- --------------------------------- ------------- \n".
+            "  Trigger                         Provider   Next Run On                       Next Run In  \n".
+            " ------------------------------- ---------- --------------------------------- ------------- \n".
+            "  every first day of next month   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   [^\n]+  \n".
+            ' ------------------------------- ---------- --------------------------------- ------------- '.
             "\n/", $tester->getDisplay(true));
     }
 
@@ -195,13 +195,13 @@ class DebugCommandTest extends TestCase
             "schedule_name\n".
             "-------------\n".
             "\n".
-            " ----------------- ---------- --------------------------------- \n".
-            "  Trigger           Provider   Next Run                         \n".
-            " ----------------- ---------- --------------------------------- \n".
-            "  every 3 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            "  every 1 minute    stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            "  every 2 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            " ----------------- ---------- --------------------------------- \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
+            "  Trigger           Provider   Next Run On                       Next Run In  \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
+            "  every 3 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   3 min        \n".
+            "  every 1 minute    stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   1 min        \n".
+            "  every 2 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   2 min        \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
             "\n/",
         ];
 
@@ -214,13 +214,13 @@ class DebugCommandTest extends TestCase
             "schedule_name\n".
             "-------------\n".
             "\n".
-            " ----------------- ---------- --------------------------------- \n".
-            "  Trigger           Provider   Next Run                         \n".
-            " ----------------- ---------- --------------------------------- \n".
-            "  every 1 minute    stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            "  every 2 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            "  every 3 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            " ----------------- ---------- --------------------------------- \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
+            "  Trigger           Provider   Next Run On                       Next Run In  \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
+            "  every 1 minute    stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   1 min        \n".
+            "  every 2 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   2 min        \n".
+            "  every 3 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   3 min        \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
             "\n/",
         ];
     }
@@ -258,13 +258,13 @@ class DebugCommandTest extends TestCase
             "schedule_name\n".
             "-------------\n".
             "\n".
-            " ----------------- ---------- --------------------------------- \n".
-            "  Trigger           Provider   Next Run                         \n".
-            " ----------------- ---------- --------------------------------- \n".
-            "  terminated        stdClass   -                                \n".
-            "  every 1 minute    stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            "  every 2 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}  \n".
-            " ----------------- ---------- --------------------------------- \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
+            "  Trigger           Provider   Next Run On                       Next Run In  \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
+            "  terminated        stdClass   -                                 -            \n".
+            "  every 1 minute    stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   1 min        \n".
+            "  every 2 minutes   stdClass   \w{3}, \d{1,2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (\+|-)\d{4}   2 min        \n".
+            " ----------------- ---------- --------------------------------- ------------- \n".
             "\n/", $tester->getDisplay(true));
     }
 
@@ -336,6 +336,40 @@ class DebugCommandTest extends TestCase
         $this->assertStringContainsString('stateful', $display);
         // "every 1 hour" seeded with checkpoint 2024-01-15 10:00:00 UTC ⇒ next run 11:00:00 UTC, not "now + 1h"
         $this->assertStringContainsString('Mon, 15 Jan 2024 11:00:00 +0000', $display);
+        // the run is long overdue, so the remaining time is negative and measured from now, not from the checkpoint
+        $this->assertMatchesRegularExpression('/Mon, 15 Jan 2024 11:00:00 \+0000\s+-\d+ y,/', $display);
+    }
+
+    public function testExecuteRendersTheTimeUntilTheNextRun()
+    {
+        $schedule = new Schedule();
+        $schedule->add(RecurringMessage::every('1 hour', new \stdClass()));
+
+        $schedules = $this->createStub(ServiceProviderInterface::class);
+        $schedules->method('getProvidedServices')->willReturn(['schedule_name' => $schedule]);
+        $schedules->method('get')->willReturn($schedule);
+
+        $tester = new CommandTester(new DebugCommand($schedules));
+        $tester->execute(['--date' => '2026-08-15 12:00:00 UTC'], ['decorated' => false]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('Next Run In', $display);
+        $this->assertMatchesRegularExpression('/Sat, 15 Aug 2026 13:00:00 \+0000\s+1 h\s/', $display);
+    }
+
+    public function testExecuteRendersSubSecondsAsFractionalSeconds()
+    {
+        $schedule = new Schedule();
+        $schedule->add(RecurringMessage::every('1 hour', new \stdClass(), from: new \DateTimeImmutable('2026-08-15 12:00:00 UTC')));
+
+        $schedules = $this->createStub(ServiceProviderInterface::class);
+        $schedules->method('getProvidedServices')->willReturn(['schedule_name' => $schedule]);
+        $schedules->method('get')->willReturn($schedule);
+
+        $tester = new CommandTester(new DebugCommand($schedules));
+        $tester->execute(['--date' => '2026-08-15 12:00:00.25 UTC'], ['decorated' => false]);
+
+        $this->assertMatchesRegularExpression('/Sat, 15 Aug 2026 13:00:00 \+0000\s+59 min, 59.75 s\s/', $tester->getDisplay(true));
     }
 
     public function testExecuteWithStatefulScheduleWithoutCheckpointFallsBackToNow()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

A tiny improvement to the Scheduler's debug command: show the time remaining untill the next run alongside of the date/time of the next run. 

I found it difficult to understand my scheduler's future at a glance when looking just at the date/times, especially when multiple timezones were involved. 

**Before:**

```

Scheduler
=========

default
-------

 ------------------------------------------ ------------ --------------------------------- 
  Trigger                                    Provider     Next Run On                      
 ------------------------------------------ ------------ --------------------------------- 
  * * * * *                                  (redacted)   Mon, 18 May 2026 16:26:00 +0930  
  every 5 minutes with 0-5 second jitter     (redacted)   Mon, 18 May 2026 07:00:08 +0000  
  30 * * * * with 0-30 second jitter         (redacted)   Mon, 18 May 2026 16:30:17 +0930  
  every 5 minutes with 0-60 second jitter    (redacted)   Mon, 18 May 2026 07:00:55 +0000  
  40 * * * * with 0-30 second jitter         (redacted)   Mon, 18 May 2026 16:40:15 +0930  
  every 30 minutes with 0-60 second jitter   (redacted)   Mon, 18 May 2026 07:25:09 +0000  
  10 * * * *                                 (redacted)   Mon, 18 May 2026 17:10:00 +0930  
  20 * * * * with 0-30 second jitter         (redacted)   Mon, 18 May 2026 17:20:25 +0930  
  every 1 hour with 0-60 second jitter       (redacted)   Mon, 18 May 2026 07:55:45 +0000  
  every 1 hour with 0-60 second jitter       (redacted)   Mon, 18 May 2026 07:56:05 +0000  
  0 15 * * * with 0-60 second jitter         (redacted)   Mon, 18 May 2026 15:00:25 +0000  
  0 3 * * *                                  (redacted)   Tue, 19 May 2026 03:00:00 +0930  
  0 4 * * *                                  (redacted)   Tue, 19 May 2026 04:00:00 +0930  
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:11 +0000  
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:40 +0000  
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:54 +0000  
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:56 +0000  
 ------------------------------------------ ------------ --------------------------------- 
```

**After:**

```

Scheduler
=========

default
-------

 ------------------------------------------ ------------ --------------------------------- ----------------------------------
  Trigger                                    Provider     Next Run On                       Next Run In                      
 ------------------------------------------ ------------ --------------------------------- ----------------------------------
  * * * * *                                  (redacted)   Mon, 18 May 2026 16:26:00 +0930   54 seconds                        
  every 5 minutes with 0-5 second jitter     (redacted)   Mon, 18 May 2026 07:00:08 +0000   5 minutes, 3 seconds              
  30 * * * * with 0-30 second jitter         (redacted)   Mon, 18 May 2026 16:30:17 +0930   5 minutes, 11 seconds             
  every 5 minutes with 0-60 second jitter    (redacted)   Mon, 18 May 2026 07:00:55 +0000   5 minutes, 50 seconds             
  40 * * * * with 0-30 second jitter         (redacted)   Mon, 18 May 2026 16:40:15 +0930   15 minutes, 9 seconds             
  every 30 minutes with 0-60 second jitter   (redacted)   Mon, 18 May 2026 07:25:09 +0000   30 minutes, 4 seconds             
  10 * * * *                                 (redacted)   Mon, 18 May 2026 17:10:00 +0930   44 minutes, 54 seconds            
  20 * * * * with 0-30 second jitter         (redacted)   Mon, 18 May 2026 17:20:25 +0930   55 minutes, 19 seconds            
  every 1 hour with 0-60 second jitter       (redacted)   Mon, 18 May 2026 07:55:45 +0000   1 hour, 40 seconds                
  every 1 hour with 0-60 second jitter       (redacted)   Mon, 18 May 2026 07:56:05 +0000   1 hour, 1 minute                  
  0 15 * * * with 0-60 second jitter         (redacted)   Mon, 18 May 2026 15:00:25 +0000   8 hours, 5 minutes, 19 seconds    
  0 3 * * *                                  (redacted)   Tue, 19 May 2026 03:00:00 +0930   10 hours, 34 minutes, 54 seconds  
  0 4 * * *                                  (redacted)   Tue, 19 May 2026 04:00:00 +0930   11 hours, 34 minutes, 54 seconds  
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:11 +0000   1 day, 6 seconds                  
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:40 +0000   1 day, 35 seconds                 
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:54 +0000   1 day, 49 seconds                 
  every 1 day with 0-60 second jitter        (redacted)   Tue, 19 May 2026 06:55:56 +0000   1 day, 51 seconds                 
 ------------------------------------------ ------------ --------------------------------- ---------------------------------