### PR TITLE
[JsonStreamer] Various fixes and hardenings

### DIFF
--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate `DateTimeToStringValueTransformer` and `StringToDateTimeValueTransformer`, use `DateTimeValueObjectTransformer` instead
  * Deprecate `ValueTransformerInterface`, use `PropertyValueTransformerInterface` instead
  * Add `$defaultOptions` to `JsonStreamReader` and `JsonStreamWriter`
+ * Reject JSON inputs reaching `Lexer::MAX_DEPTH` consistently with `json_decode()`
 
 8.0
 ---

--- a/src/Symfony/Component/JsonStreamer/Read/Decoder.php
+++ b/src/Symfony/Component/JsonStreamer/Read/Decoder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\JsonStreamer\Read;
 
+use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnexpectedValueException;
 
 /**
@@ -36,6 +37,10 @@ final class Decoder
      */
     public static function decodeStream($stream, int $offset = 0, ?int $length = null): mixed
     {
-        return self::decodeString(stream_get_contents($stream, $length ?? -1, $offset));
+        if (false === $contents = stream_get_contents($stream, $length ?? -1, $offset)) {
+            throw new RuntimeException('Failed to read JSON stream.');
+        }
+
+        return self::decodeString($contents);
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Read/Lexer.php
+++ b/src/Symfony/Component/JsonStreamer/Read/Lexer.php
@@ -24,6 +24,7 @@ use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 final class Lexer
 {
     private const MAX_CHUNK_LENGTH = 8192;
+    private const MAX_DEPTH = 512;
 
     private const WHITESPACE_CHARS = [' ' => true, "\r" => true, "\t" => true, "\n" => true];
     private const STRUCTURE_CHARS = [',' => true, ':' => true, '{' => true, '}' => true, '[' => true, ']' => true];
@@ -165,7 +166,9 @@ final class Lexer
                 throw new InvalidStreamException(\sprintf('Unexpected "%s" token.', $token));
             }
 
-            ++$context['pointer'];
+            if (++$context['pointer'] >= self::MAX_DEPTH - 1) {
+                throw new InvalidStreamException(\sprintf('Maximum stack depth of %d exceeded.', self::MAX_DEPTH));
+            }
             $context['structures'][$context['pointer']] = 'dict';
             $context['keys'][$context['pointer']] = [];
             $context['expected_token'] = self::TOKEN_DICT_END | self::TOKEN_KEY;
@@ -195,8 +198,11 @@ final class Lexer
                 throw new InvalidStreamException(\sprintf('Unexpected "%s" token.', $token));
             }
 
+            if (++$context['pointer'] >= self::MAX_DEPTH - 1) {
+                throw new InvalidStreamException(\sprintf('Maximum stack depth of %d exceeded.', self::MAX_DEPTH));
+            }
             $context['expected_token'] = self::TOKEN_LIST_END | self::TOKEN_VALUE;
-            $context['structures'][++$context['pointer']] = 'list';
+            $context['structures'][$context['pointer']] = 'list';
 
             return;
         }

--- a/src/Symfony/Component/JsonStreamer/Read/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/PhpGenerator.php
@@ -66,7 +66,7 @@ final class PhpGenerator
                 .$providers
                 .($this->canBeDecodedWithJsonDecode($dataModel, $decodeFromStream)
                     ? $this->line('    return \\'.Decoder::class.'::decodeStream($stream, 0, null);', $context)
-                    : $this->line('    return $providers['.$this->quote($dataModel->getIdentifier()).']($stream, 0, null);', $context))
+                    : $this->line('    return $providers['.var_export($dataModel->getIdentifier(), true).']($stream, 0, null);', $context))
                 .$this->line('};', $context);
         }
 
@@ -79,7 +79,7 @@ final class PhpGenerator
             .$providers
             .($this->canBeDecodedWithJsonDecode($dataModel, $decodeFromStream)
                 ? $this->line('    return \\'.Decoder::class.'::decodeString((string) $string);', $context)
-                : $this->line('    return $providers['.$this->quote($dataModel->getIdentifier()).'](\\'.Decoder::class.'::decodeString((string) $string));', $context))
+                : $this->line('    return $providers['.var_export($dataModel->getIdentifier(), true).'](\\'.Decoder::class.'::decodeString((string) $string));', $context))
             .$this->line('};', $context);
     }
 
@@ -102,7 +102,7 @@ final class PhpGenerator
             $accessor = $decodeFromStream ? '\\'.Decoder::class.'::decodeStream($stream, $offset, $length)' : '$data';
             $arguments = $decodeFromStream ? '$stream, $offset, $length' : '$data';
 
-            return $this->line('$providers['.$this->quote($node->getIdentifier())."] = static function ($arguments) {", $context)
+            return $this->line('$providers['.var_export($node->getIdentifier(), true)."] = static function ($arguments) {", $context)
                 .$this->line('    return '.$this->generateValueFormat($node, $accessor).';', $context)
                 .$this->line('};', $context);
         }
@@ -117,20 +117,20 @@ final class PhpGenerator
 
             $arguments = $decodeFromStream ? '$stream, $offset, $length' : '$data';
 
-            $php .= $this->line('$providers['.$this->quote($node->getIdentifier())."] = static function ($arguments) use (\$options, \$transformers, \$instantiator, &\$providers) {", $context);
+            $php .= $this->line('$providers['.var_export($node->getIdentifier(), true)."] = static function ($arguments) use (\$options, \$transformers, \$instantiator, &\$providers) {", $context);
 
             ++$context['indentation_level'];
 
             $php .= $decodeFromStream ? $this->line('$data = \\'.Decoder::class.'::decodeStream($stream, $offset, $length);', $context) : '';
 
             foreach ($node->getNodes() as $n) {
-                $value = $this->canBeDecodedWithJsonDecode($n, $decodeFromStream) ? $this->generateValueFormat($n, '$data') : '$providers['.$this->quote($n->getIdentifier())."]($arguments)";
+                $value = $this->canBeDecodedWithJsonDecode($n, $decodeFromStream) ? $this->generateValueFormat($n, '$data') : '$providers['.var_export($n->getIdentifier(), true)."]($arguments)";
                 $php .= $this->line('if ('.$this->generateCompositeNodeItemCondition($n, '$data').') {', $context)
                     .$this->line("    return $value;", $context)
                     .$this->line('}', $context);
             }
 
-            $php .= $this->line('throw new \\'.UnexpectedValueException::class.'(\\sprintf(\'Unexpected "%s" value for "%s".\', \\get_debug_type($data), '.$this->quote($node->getIdentifier()).'));', $context);
+            $php .= $this->line('throw new \\'.UnexpectedValueException::class.'(\\sprintf(\'Unexpected "%s" value for "%s".\', \\get_debug_type($data), '.var_export($node->getIdentifier(), true).'));', $context);
 
             --$context['indentation_level'];
 
@@ -140,7 +140,7 @@ final class PhpGenerator
         if ($node instanceof CollectionNode) {
             $arguments = $decodeFromStream ? '$stream, $offset, $length' : '$data';
 
-            $php = $this->line('$providers['.$this->quote($node->getIdentifier())."] = static function ($arguments) use (\$options, \$transformers, \$instantiator, &\$providers) {", $context);
+            $php = $this->line('$providers['.var_export($node->getIdentifier(), true)."] = static function ($arguments) use (\$options, \$transformers, \$instantiator, &\$providers) {", $context);
 
             ++$context['indentation_level'];
 
@@ -154,11 +154,11 @@ final class PhpGenerator
             if ($decodeFromStream) {
                 $php .= $this->canBeDecodedWithJsonDecode($node->getItemNode(), $decodeFromStream)
                     ? $this->line('        yield $k => '.$this->generateValueFormat($node->getItemNode(), '\\'.Decoder::class.'::decodeStream($stream, $v[0], $v[1]);'), $context)
-                    : $this->line('        yield $k => $providers['.$this->quote($node->getItemNode()->getIdentifier()).']($stream, $v[0], $v[1]);', $context);
+                    : $this->line('        yield $k => $providers['.var_export($node->getItemNode()->getIdentifier(), true).']($stream, $v[0], $v[1]);', $context);
             } else {
                 $php .= $this->canBeDecodedWithJsonDecode($node->getItemNode(), $decodeFromStream)
                     ? $this->line('        yield $k => $v;', $context)
-                    : $this->line('        yield $k => $providers['.$this->quote($node->getItemNode()->getIdentifier()).']($v);', $context);
+                    : $this->line('        yield $k => $providers['.var_export($node->getItemNode()->getIdentifier(), true).']($v);', $context);
             }
 
             $php .= $this->line('    }', $context)
@@ -183,13 +183,13 @@ final class PhpGenerator
 
             $arguments = $decodeFromStream ? '$stream, $offset, $length' : '$data';
 
-            $php = $this->line('$providers['.$this->quote($node->getIdentifier())."] = static function ($arguments) use (\$options, \$transformers, \$instantiator, &\$providers) {", $context);
+            $php = $this->line('$providers['.var_export($node->getIdentifier(), true)."] = static function ($arguments) use (\$options, \$transformers, \$instantiator, &\$providers) {", $context);
 
             ++$context['indentation_level'];
 
             if ($valueObjectTransformerId = $this->getValueObjectTransformerId($node->getType()->getClassName())) {
                 $data = $decodeFromStream ? '\\'.Decoder::class.'::decodeStream($stream, $offset, $length)' : '$data';
-                $php .= $this->line("return \$transformers->get('$valueObjectTransformerId')->reverseTransform($data, \$options);", $context);
+                $php .= $this->line('return $transformers->get('.var_export($valueObjectTransformerId, true).")->reverseTransform($data, \$options);", $context);
 
                 --$context['indentation_level'];
 
@@ -206,9 +206,9 @@ final class PhpGenerator
                 foreach ($node->getProperties() as $streamedName => $property) {
                     $propertyValuePhp = $this->canBeDecodedWithJsonDecode($property['value'], $decodeFromStream)
                         ? $this->generateValueFormat($property['value'], '\\'.Decoder::class.'::decodeStream($stream, $v[0], $v[1])')
-                        : '$providers['.$this->quote($property['value']->getIdentifier()).']($stream, $v[0], $v[1])';
+                        : '$providers['.var_export($property['value']->getIdentifier(), true).']($stream, $v[0], $v[1])';
 
-                    $php .= $this->line("            '$streamedName' => \$object->".$property['name'].' = '.$property['accessor']($propertyValuePhp).',', $context);
+                    $php .= $this->line('            '.var_export($streamedName, true).' => $object->'.$property['name'].' = '.$property['accessor']($propertyValuePhp).',', $context);
                 }
 
                 $php .= $this->line('            default => null,', $context)
@@ -219,10 +219,11 @@ final class PhpGenerator
                 $propertiesValuePhp = '[';
                 $separator = '';
                 foreach ($node->getProperties() as $streamedName => $property) {
+                    $quotedStreamedName = var_export($streamedName, true);
                     $propertyValuePhp = $this->canBeDecodedWithJsonDecode($property['value'], $decodeFromStream)
-                        ? "\$data['$streamedName'] ?? '_symfony_missing_value'"
-                        : "\\array_key_exists('$streamedName', \$data) ? \$providers[".$this->quote($property['value']->getIdentifier())."](\$data['$streamedName']) : '_symfony_missing_value'";
-                    $propertiesValuePhp .= "$separator'".$property['name']."' => ".$property['accessor']($propertyValuePhp);
+                        ? "\$data[$quotedStreamedName] ?? '_symfony_missing_value'"
+                        : "\\array_key_exists($quotedStreamedName, \$data) ? \$providers[".var_export($property['value']->getIdentifier(), true)."](\$data[$quotedStreamedName]) : '_symfony_missing_value'";
+                    $propertiesValuePhp .= $separator.var_export($property['name'], true).' => '.$property['accessor']($propertyValuePhp);
                     $separator = ', ';
                 }
                 $propertiesValuePhp .= ']';
@@ -328,11 +329,6 @@ final class PhpGenerator
         }
 
         throw new LogicException(\sprintf('Unexpected "%s" type.', $type::class));
-    }
-
-    private function quote(string $identifier): string
-    {
-        return \sprintf("'%s'", addcslashes($identifier, "'"));
     }
 
     /**

--- a/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Read/StreamReaderGenerator.php
@@ -29,6 +29,7 @@ use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\EnumType;
 use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\IntersectionType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\UnionType;
 
@@ -80,6 +81,10 @@ final class StreamReaderGenerator
     {
         $context['original_type'] ??= $type;
 
+        if ($type instanceof IntersectionType) {
+            throw new UnsupportedException(\sprintf('Intersection types are not supported ("%s").', (string) $type));
+        }
+
         if ($type instanceof UnionType) {
             return new CompositeNode(array_map(fn (Type $t): DataModelNodeInterface => $this->createDataModel($t, $options, $context), $type->getTypes()));
         }
@@ -120,7 +125,7 @@ final class StreamReaderGenerator
                     'accessor' => static function (string $accessor) use ($propertyMetadata): string {
                         foreach ($propertyMetadata->getValueTransformers() as $valueTransformer) {
                             if (\is_string($valueTransformer)) {
-                                $accessor = "\$transformers->get('$valueTransformer')->transform($accessor, \$options)";
+                                $accessor = '$transformers->get('.var_export($valueTransformer, true).")->transform($accessor, \$options)";
 
                                 continue;
                             }
@@ -129,6 +134,10 @@ final class StreamReaderGenerator
                                 $functionReflection = new \ReflectionFunction($valueTransformer);
                             } catch (\ReflectionException $e) {
                                 throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+                            }
+
+                            if ($functionReflection->isAnonymous()) {
+                                throw new RuntimeException(\sprintf('Cannot generate accessor for anonymous function "%s".', $functionReflection->getName()));
                             }
 
                             $functionName = !$functionReflection->getClosureCalledClass()

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.php
@@ -4,8 +4,8 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($data) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($data) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from($data);
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/backed_enum.stream.php
@@ -4,8 +4,8 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.php
@@ -4,17 +4,17 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($data) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($data) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from($data);
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         if (\is_int($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($data);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($data);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_backed_enum.stream.php
@@ -4,18 +4,18 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_int($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($stream, $offset, $length);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($stream, $offset, $length);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.php
@@ -4,19 +4,19 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         if (\is_array($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($data);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($data);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy|null'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object.stream.php
@@ -4,7 +4,7 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -16,15 +16,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_array($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, $offset, $length);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, $offset, $length);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy|null'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy|null']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.php
@@ -4,27 +4,27 @@
  * @return array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($v);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($v);
             }
         };
         return \iterator_to_array($iterable($data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         if (\is_array($data)) {
-            return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($data);
+            return $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>']($data);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'));
     };
-    return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_dict.stream.php
@@ -4,16 +4,16 @@
  * @return array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, $v[0], $v[1]);
             }
         };
         return \iterator_to_array($iterable($stream, $data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -25,15 +25,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_array($data)) {
-            return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($stream, $offset, $length);
+            return $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>']($stream, $offset, $length);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'));
     };
-    return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null']($stream, 0, null);
+    return $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.php
@@ -4,27 +4,27 @@
  * @return list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($v);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($v);
             }
         };
         return \iterator_to_array($iterable($data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($data);
+            return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>']($data);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'));
     };
-    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/nullable_object_list.stream.php
@@ -4,16 +4,16 @@
  * @return list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, $v[0], $v[1]);
             }
         };
         return \iterator_to_array($iterable($stream, $data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -25,15 +25,15 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($stream, $offset, $length);
+            return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>']($stream, $offset, $length);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null'));
     };
-    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>|null']($stream, 0, null);
+    return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>|null']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.php
@@ -4,10 +4,10 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object.stream.php
@@ -4,7 +4,7 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -16,5 +16,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.php
@@ -4,18 +4,18 @@
  * @return array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($v);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($v);
             }
         };
         return \iterator_to_array($iterable($data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_dict.stream.php
@@ -4,16 +4,16 @@
  * @return array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, $v[0], $v[1]);
             }
         };
         return \iterator_to_array($iterable($stream, $data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -25,5 +25,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    return $providers['array<string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($stream, 0, null);
+    return $providers['array<string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.php
@@ -4,20 +4,20 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
-        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies::class, \array_filter(['name' => $data['name'] ?? '_symfony_missing_value', 'otherDummyOne' => \array_key_exists('otherDummyOne', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes']($data['otherDummyOne']) : '_symfony_missing_value', 'otherDummyTwo' => \array_key_exists('otherDummyTwo', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($data['otherDummyTwo']) : '_symfony_missing_value'], static function ($v) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithOtherDummies'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies::class, \array_filter(['name' => $data['name'] ?? '_symfony_missing_value', 'otherDummyOne' => \array_key_exists('otherDummyOne', $data) ? $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes']($data['otherDummyOne']) : '_symfony_missing_value', 'otherDummyTwo' => \array_key_exists('otherDummyTwo', $data) ? $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($data['otherDummyTwo']) : '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes::class, \array_filter(['id' => $data['@id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithOtherDummies'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_in_object.stream.php
@@ -4,20 +4,20 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithOtherDummies'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
                 match ($k) {
                     'name' => $object->name = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]),
-                    'otherDummyOne' => $object->otherDummyOne = $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes']($stream, $v[0], $v[1]),
-                    'otherDummyTwo' => $object->otherDummyTwo = $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]),
+                    'otherDummyOne' => $object->otherDummyOne = $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes']($stream, $v[0], $v[1]),
+                    'otherDummyTwo' => $object->otherDummyTwo = $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, $v[0], $v[1]),
                     default => null,
                 };
             }
         });
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -29,7 +29,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -41,5 +41,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithOtherDummies']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithOtherDummies']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.php
@@ -4,18 +4,18 @@
  * @return iterable<int|string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['iterable<int|string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['iterable<int|string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($v);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($v);
             }
         };
         return $iterable($data);
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['iterable<int|string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['iterable<int|string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_iterable.stream.php
@@ -4,16 +4,16 @@
  * @return iterable<int|string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['iterable<int|string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['iterable<int|string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, $v[0], $v[1]);
             }
         };
         return $iterable($stream, $data);
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -25,5 +25,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    return $providers['iterable<int|string, Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($stream, 0, null);
+    return $providers['iterable<int|string, Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.php
@@ -4,18 +4,18 @@
  * @return list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($v);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($v);
             }
         };
         return \iterator_to_array($iterable($data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, \array_filter(['id' => $data['id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_list.stream.php
@@ -4,16 +4,16 @@
  * @return list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy']($stream, $v[0], $v[1]);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy']($stream, $v[0], $v[1]);
             }
         };
         return \iterator_to_array($iterable($stream, $data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -25,5 +25,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy>']($stream, 0, null);
+    return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\ClassicDummy>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.php
@@ -4,22 +4,22 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
-        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties::class, \array_filter(['name' => $data['name'] ?? '_symfony_missing_value', 'enum' => \array_key_exists('enum', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null']($data['enum']) : '_symfony_missing_value'], static function ($v) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNullableProperties'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties::class, \array_filter(['name' => $data['name'] ?? '_symfony_missing_value', 'enum' => \array_key_exists('enum', $data) ? $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null']($data['enum']) : '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($data) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($data) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from($data);
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         if (\is_int($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($data);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($data);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNullableProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_nullable_properties.stream.php
@@ -4,30 +4,30 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNullableProperties'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
                 match ($k) {
                     'name' => $object->name = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]),
-                    'enum' => $object->enum = $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null']($stream, $v[0], $v[1]),
+                    'enum' => $object->enum = $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null']($stream, $v[0], $v[1]),
                     default => null,
                 };
             }
         });
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_int($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($stream, $offset, $length);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($stream, $offset, $length);
         }
         if (null === $data) {
             return null;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNullableProperties']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.php
@@ -4,10 +4,10 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithSyntheticProperties'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties::class, \array_filter([], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithSyntheticProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_synthetic_properties.stream.php
@@ -4,7 +4,7 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithSyntheticProperties'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -14,5 +14,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithSyntheticProperties']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.php
@@ -4,17 +4,17 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
-        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties::class, \array_filter(['value' => \array_key_exists('value', $data) ? $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string']($data['value']) : '_symfony_missing_value'], static function ($v) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithUnionProperties'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties::class, \array_filter(['value' => \array_key_exists('value', $data) ? $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null|string']($data['value']) : '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($data) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($data) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from($data);
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null|string'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         if (\is_int($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($data);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($data);
         }
         if (null === $data) {
             return null;
@@ -22,7 +22,7 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         if (\is_string($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null|string'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithUnionProperties'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_union.stream.php
@@ -4,24 +4,24 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithUnionProperties'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
                 match ($k) {
-                    'value' => $object->value = $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string']($stream, $v[0], $v[1]),
+                    'value' => $object->value = $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null|string']($stream, $v[0], $v[1]),
                     default => null,
                 };
             }
         });
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null|string'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_int($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($stream, $offset, $length);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($stream, $offset, $length);
         }
         if (null === $data) {
             return null;
@@ -29,7 +29,7 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
         if (\is_string($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum|null|string'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum|null|string'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithUnionProperties']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_object.php
@@ -4,7 +4,7 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithDateTimes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes::class, \array_filter(['interface' => \array_key_exists('interface', $data) ? $providers['DateTimeInterface']($data['interface']) : '_symfony_missing_value', 'immutable' => \array_key_exists('immutable', $data) ? $providers['DateTimeImmutable']($data['immutable']) : '_symfony_missing_value', 'union' => \array_key_exists('union', $data) ? $providers['DateTimeImmutable|int']($data['union']) : '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
@@ -24,5 +24,5 @@ return static function (string|\Stringable $string, \Psr\Container\ContainerInte
         }
         throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'DateTimeImmutable|int'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithDateTimes'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_object.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_object.stream.php
@@ -4,7 +4,7 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithDateTimes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -33,5 +33,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
         }
         throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'DateTimeImmutable|int'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithDateTimes']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.php
@@ -4,10 +4,10 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
-        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::class, \array_filter(['id' => $transformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\DivideStringAndCastToIntValueTransformer')->transform($data['id'] ?? '_symfony_missing_value', $options), 'active' => $transformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\StringToBooleanValueTransformer')->transform($data['active'] ?? '_symfony_missing_value', $options), 'name' => strtoupper($data['name'] ?? '_symfony_missing_value'), 'range' => Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::explodeRange($data['range'] ?? '_symfony_missing_value', $options)], static function ($v) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithValueTransformerAttributes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+        return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::class, \array_filter(['id' => $transformers->get('Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Transformer\\DivideStringAndCastToIntValueTransformer')->transform($data['id'] ?? '_symfony_missing_value', $options), 'active' => $transformers->get('Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Transformer\\StringToBooleanValueTransformer')->transform($data['active'] ?? '_symfony_missing_value', $options), 'name' => strtoupper($data['name'] ?? '_symfony_missing_value'), 'range' => Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::explodeRange($data['range'] ?? '_symfony_missing_value', $options)], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithValueTransformerAttributes'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/object_with_value_transformer.stream.php
@@ -4,13 +4,13 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithValueTransformerAttributes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
                 match ($k) {
-                    'id' => $object->id = $transformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\DivideStringAndCastToIntValueTransformer')->transform(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]), $options),
-                    'active' => $object->active = $transformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\StringToBooleanValueTransformer')->transform(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]), $options),
+                    'id' => $object->id = $transformers->get('Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Transformer\\DivideStringAndCastToIntValueTransformer')->transform(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]), $options),
+                    'active' => $object->active = $transformers->get('Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Transformer\\StringToBooleanValueTransformer')->transform(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]), $options),
                     'name' => $object->name = strtoupper(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1])),
                     'range' => $object->range = Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::explodeRange(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $v[0], $v[1]), $options),
                     default => null,
@@ -18,5 +18,5 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithValueTransformerAttributes']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.php
@@ -4,33 +4,33 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>
  */
 return static function (string|\Stringable $string, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\Instantiator $instantiator, array $options): mixed {
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         $iterable = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($v);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($v);
             }
         };
         return \iterator_to_array($iterable($data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($data) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($data) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from($data);
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes::class, \array_filter(['id' => $data['@id'] ?? '_symfony_missing_value', 'name' => $data['name'] ?? '_symfony_missing_value'], static function ($v) {
             return '_symfony_missing_value' !== $v;
         }));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|int|list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>'] = static function ($data) use ($options, $transformers, $instantiator, &$providers) {
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($data);
+            return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>']($data);
         }
         if (\is_array($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes']($data);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes']($data);
         }
         if (\is_int($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|int|list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|int|list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>'](\Symfony\Component\JsonStreamer\Read\Decoder::decodeString((string) $string));
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_reader/union.stream.php
@@ -4,19 +4,19 @@
  * @return Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>
  */
 return static function (mixed $stream, \Psr\Container\ContainerInterface $transformers, \Symfony\Component\JsonStreamer\Read\LazyInstantiator $instantiator, array $options): mixed {
-    $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitList($stream, $offset, $length);
         $iterable = static function ($stream, $data) use ($options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
-                yield $k => $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum']($stream, $v[0], $v[1]);
+                yield $k => $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum']($stream, $v[0], $v[1]);
             }
         };
         return \iterator_to_array($iterable($stream, $data));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum'] = static function ($stream, $offset, $length) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum'] = static function ($stream, $offset, $length) {
         return \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum::from(\Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length));
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Splitter::splitDict($stream, $offset, $length);
         return $instantiator->instantiate(\Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes::class, static function ($object) use ($stream, $data, $options, $transformers, $instantiator, &$providers) {
             foreach ($data as $k => $v) {
@@ -28,18 +28,18 @@ return static function (mixed $stream, \Psr\Container\ContainerInterface $transf
             }
         });
     };
-    $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
+    $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|int|list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>'] = static function ($stream, $offset, $length) use ($options, $transformers, $instantiator, &$providers) {
         $data = \Symfony\Component\JsonStreamer\Read\Decoder::decodeStream($stream, $offset, $length);
         if (\is_array($data) && \array_is_list($data)) {
-            return $providers['list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($stream, $offset, $length);
+            return $providers['list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>']($stream, $offset, $length);
         }
         if (\is_array($data)) {
-            return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes']($stream, $offset, $length);
+            return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes']($stream, $offset, $length);
         }
         if (\is_int($data)) {
             return $data;
         }
-        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>'));
+        throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value for "%s".', \get_debug_type($data), 'Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|int|list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>'));
     };
-    return $providers['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes|int|list<Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum>']($stream, 0, null);
+    return $providers['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNameAttributes|int|list<Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Enum\\DummyBackedEnum>']($stream, 0, null);
 };

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
@@ -4,7 +4,7 @@
  * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies $data
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $transformers, array $options): \Traversable {
-    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
+    $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedDictDummies'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
         if ($depth >= 512) {
             throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
         }
@@ -15,13 +15,13 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         foreach ($data->dummies as $key1 => $value1) {
             $key1 = \substr(\json_encode($key1), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
-            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies']($value1, $depth + 1);
+            yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedDictDummies']($value1, $depth + 1);
             $prefix2 = ',';
         }
         yield "}}";
     };
     try {
-        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies']($data, 0);
+        yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedDictDummies']($data, 0);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedDictDummies\" to JSON: {$e->getMessage()}.", 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
@@ -4,7 +4,7 @@
  * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies $data
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $transformers, array $options): \Traversable {
-    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
+    $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedListDummies'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
         if ($depth >= 512) {
             throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
         }
@@ -15,13 +15,13 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         foreach ($data->dummies as $key1 => $value1) {
             $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
-            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies']($value1, $depth + 1);
+            yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedListDummies']($value1, $depth + 1);
             $prefix2 = ',';
         }
         yield "}}";
     };
     try {
-        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies']($data, 0);
+        yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedListDummies']($data, 0);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\DummyWithNestedListDummies\" to JSON: {$e->getMessage()}.", 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
@@ -7,10 +7,10 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
     try {
         $prefix1 = '';
         yield "{{$prefix1}\"id\":";
-        yield \json_encode($transformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\DoubleIntAndCastToStringValueTransformer')->transform($data->id, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($transformers->get('Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Transformer\\DoubleIntAndCastToStringValueTransformer')->transform($data->id, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
         $prefix1 = ',';
         yield "{$prefix1}\"active\":";
-        yield \json_encode($transformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\BooleanToStringValueTransformer')->transform($data->active, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($transformers->get('Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Transformer\\BooleanToStringValueTransformer')->transform($data->active, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
         yield "{$prefix1}\"name\":";
         yield \json_encode(strtolower($data->name), \JSON_THROW_ON_ERROR, 511);
         yield "{$prefix1}\"range\":";

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object.php
@@ -4,7 +4,7 @@
  * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy $data
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $transformers, array $options): \Traversable {
-    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
+    $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummy'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
         if ($depth >= 512) {
             throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
         }
@@ -15,12 +15,12 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         }
         if (null !== $data->self) {
             yield "{$prefix1}\"@self\":";
-            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy']($data->self, $depth + 1);
+            yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummy']($data->self, $depth + 1);
         }
         yield "}";
     };
     try {
-        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummy']($data, 0);
+        yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummy']($data, 0);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummy\" to JSON: {$e->getMessage()}.", 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
@@ -4,7 +4,7 @@
  * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict $data
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $transformers, array $options): \Traversable {
-    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
+    $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyDict'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
         if ($depth >= 512) {
             throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
         }
@@ -15,13 +15,13 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         foreach ($data->items as $key1 => $value1) {
             $key1 = \substr(\json_encode($key1), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
-            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict']($value1, $depth + 1);
+            yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyDict']($value1, $depth + 1);
             $prefix2 = ',';
         }
         yield "}}";
     };
     try {
-        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict']($data, 0);
+        yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyDict']($data, 0);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyDict\" to JSON: {$e->getMessage()}.", 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
@@ -4,7 +4,7 @@
  * @param Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList $data
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $transformers, array $options): \Traversable {
-    $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
+    $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyList'] = static function ($data, $depth) use ($transformers, $options, &$generators) {
         if ($depth >= 512) {
             throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException('Maximum stack depth exceeded');
         }
@@ -15,13 +15,13 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $transfor
         foreach ($data->items as $key1 => $value1) {
             $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
-            yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList']($value1, $depth + 1);
+            yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyList']($value1, $depth + 1);
             $prefix2 = ',';
         }
         yield "}}";
     };
     try {
-        yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList']($data, 0);
+        yield from $generators['Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyList']($data, 0);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException("Cannot encode \"Symfony\\Component\\JsonStreamer\\Tests\\Fixtures\\Model\\SelfReferencingDummyList\" to JSON: {$e->getMessage()}.", 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/LazyInstantiatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\JsonStreamer\Tests\Read;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Read\LazyInstantiator;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 
@@ -32,5 +33,79 @@ class LazyInstantiatorTest extends TestCase
         });
 
         $this->assertInstanceOf(\DateTimeImmutable::class, $object);
+    }
+
+    public function testInstantiateClassWithPrivateProperties()
+    {
+        $class = new class {
+            private int $value = 0;
+
+            public function getValue(): int
+            {
+                return $this->value;
+            }
+        };
+
+        $ghost = (new LazyInstantiator())->instantiate($class::class, static function (object $object): void {
+            $reflection = new \ReflectionProperty($object, 'value');
+            $reflection->setValue($object, 42);
+        });
+
+        $this->assertSame(42, $ghost->getValue());
+    }
+
+    public function testInstantiateClassWithReadonlyProperties()
+    {
+        $ghost = (new LazyInstantiator())->instantiate(ReadonlyDummy::class, static function (ReadonlyDummy $object): void {
+            $reflection = new \ReflectionProperty($object, 'id');
+            $reflection->setValue($object, 7);
+        });
+
+        $this->assertSame(7, $ghost->id);
+    }
+
+    public function testReusesCachedReflectionAcrossCalls()
+    {
+        $instantiator = new LazyInstantiator();
+
+        $first = $instantiator->instantiate(ClassicDummy::class, static function (ClassicDummy $object): void {
+            $object->id = 1;
+        });
+        $second = $instantiator->instantiate(ClassicDummy::class, static function (ClassicDummy $object): void {
+            $object->id = 2;
+        });
+
+        $this->assertSame(1, $first->id);
+        $this->assertSame(2, $second->id);
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testInitializerErrorPropagates()
+    {
+        $instantiator = new LazyInstantiator();
+        $ghost = $instantiator->instantiate(ClassicDummy::class, static function (ClassicDummy $object): void {
+            throw new \DomainException('initializer failed');
+        });
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('initializer failed');
+
+        $ghost->id;
+    }
+
+    public function testThrowsRuntimeExceptionWhenReflectionFails()
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new LazyInstantiator())->instantiate('Symfony\\NotAClass\\Missing', static function (object $object): void {
+        });
+    }
+}
+
+final class ReadonlyDummy
+{
+    public function __construct(
+        public readonly int $id = 0,
+    ) {
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/LexerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/LexerTest.php
@@ -45,6 +45,57 @@ class LexerTest extends TestCase
         $this->assertTokens([[$veryLongString, 0]], $veryLongString);
     }
 
+    public function testRejectsDeeplyNestedInput()
+    {
+        $depth = 600;
+        $resource = fopen('php://temp', 'w');
+        fwrite($resource, str_repeat('[', $depth).str_repeat(']', $depth));
+        rewind($resource);
+
+        $this->expectException(InvalidStreamException::class);
+        $this->expectExceptionMessage('Maximum stack depth');
+
+        iterator_to_array((new Lexer())->getTokens($resource, 0, null));
+    }
+
+    public function testAcceptsDepthJustBelowMax()
+    {
+        $depth = 511;
+        $resource = fopen('php://temp', 'w');
+        fwrite($resource, str_repeat('[', $depth).'1'.str_repeat(']', $depth));
+        rewind($resource);
+
+        iterator_to_array((new Lexer())->getTokens($resource, 0, null));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsAtMaxDepthBoundary()
+    {
+        $depth = 512;
+        $resource = fopen('php://temp', 'w');
+        fwrite($resource, str_repeat('[', $depth).'1'.str_repeat(']', $depth));
+        rewind($resource);
+
+        $this->expectException(InvalidStreamException::class);
+        $this->expectExceptionMessage('Maximum stack depth');
+
+        iterator_to_array((new Lexer())->getTokens($resource, 0, null));
+    }
+
+    public function testRejectsAtMaxDepthBoundaryForDicts()
+    {
+        $depth = 512;
+        $resource = fopen('php://temp', 'w');
+        fwrite($resource, str_repeat('{"a":', $depth).'1'.str_repeat('}', $depth));
+        rewind($resource);
+
+        $this->expectException(InvalidStreamException::class);
+        $this->expectExceptionMessage('Maximum stack depth');
+
+        iterator_to_array((new Lexer())->getTokens($resource, 0, null));
+    }
+
     #[DataProvider('rfc8259ComplianceProvider')]
     public function testRfc8259Compliance(string $name, string $json, bool $valid)
     {

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/StreamReaderGeneratorTest.php
@@ -14,8 +14,10 @@ namespace Symfony\Component\JsonStreamer\Tests\Read;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\JsonStreamer\Exception\LogicException;
+use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnsupportedException;
 use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadata;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
 use Symfony\Component\JsonStreamer\Mapping\Read\AttributePropertyMetadataLoader;
@@ -143,7 +145,7 @@ class StreamReaderGeneratorTest extends TestCase
         $generator = new StreamReaderGenerator(new PropertyMetadataLoader(TypeResolver::create()), new ServiceContainer(), $this->streamReadersDir);
 
         $this->expectException(UnsupportedException::class);
-        $this->expectExceptionMessage('"Stringable&Traversable" type is not supported.');
+        $this->expectExceptionMessage('Intersection types are not supported ("Stringable&Traversable").');
 
         $generator->generate(Type::intersection(Type::object(\Traversable::class), Type::object(\Stringable::class)), false);
     }
@@ -186,6 +188,81 @@ class StreamReaderGeneratorTest extends TestCase
             ->willReturn([]);
 
         $generator = new StreamReaderGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamReadersDir);
+        $generator->generate($type, false);
+    }
+
+    public function testStreamedNameIsEscapedInGeneratedReader()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $propertyMetadataLoader = $this->createStub(PropertyMetadataLoaderInterface::class);
+        $propertyMetadataLoader->method('load')->willReturn([
+            "weird'name" => new PropertyMetadata('id', Type::int()),
+        ]);
+
+        $generator = new StreamReaderGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamReadersDir);
+
+        foreach ([false, true] as $decodeFromStream) {
+            $code = file_get_contents($generator->generate($type, $decodeFromStream));
+
+            $this->assertStringNotContainsString("'weird'name'", $code);
+            $this->assertStringContainsString("'weird\\'name'", $code);
+        }
+    }
+
+    public function testStreamedNameWithTrailingBackslashProducesValidPhp()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $propertyMetadataLoader = $this->createStub(PropertyMetadataLoaderInterface::class);
+        $propertyMetadataLoader->method('load')->willReturn([
+            'name\\' => new PropertyMetadata('id', Type::int()),
+        ]);
+
+        $generator = new StreamReaderGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamReadersDir);
+
+        foreach ([false, true] as $decodeFromStream) {
+            $path = $generator->generate($type, $decodeFromStream);
+            $callable = require $path;
+
+            $this->assertIsCallable($callable);
+        }
+    }
+
+    public function testAcceptsClosureFromNamedCallable()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $propertyMetadataLoader = $this->createStub(PropertyMetadataLoaderInterface::class);
+        $propertyMetadataLoader->method('load')->willReturn([
+            'id' => new PropertyMetadata('id', Type::int(), [\Closure::fromCallable('intval')]),
+            'range' => new PropertyMetadata('id', Type::string(), [\Closure::fromCallable(DummyWithValueTransformerAttributes::explodeRange(...))]),
+        ]);
+
+        $generator = new StreamReaderGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamReadersDir);
+
+        foreach ([false, true] as $decodeFromStream) {
+            $code = file_get_contents($generator->generate($type, $decodeFromStream));
+
+            $this->assertStringContainsString('intval(', $code);
+            $this->assertStringContainsString(DummyWithValueTransformerAttributes::class.'::explodeRange(', $code);
+        }
+    }
+
+    public function testRejectsAnonymousClosureValueTransformer()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $propertyMetadataLoader = $this->createStub(PropertyMetadataLoaderInterface::class);
+        $propertyMetadataLoader->method('load')->willReturn([
+            'id' => new PropertyMetadata('id', Type::int(), [static fn (int $v): int => $v + 1]),
+        ]);
+
+        $generator = new StreamReaderGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamReadersDir);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Cannot generate accessor for anonymous function ".*\{closure[^"]*"\./');
+
         $generator->generate($type, false);
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/StreamerDumperTest.php
@@ -68,6 +68,25 @@ class StreamerDumperTest extends TestCase
         $this->assertStringEqualsFile($path, 'CONTENT');
     }
 
+    public function testDumpDoesNotOverwriteExistingFile()
+    {
+        $path = $this->cacheDir.'/streamer.php';
+
+        mkdir($this->cacheDir, 0o700, true);
+        file_put_contents($path, 'EXISTING');
+
+        $generated = false;
+        $dumper = new StreamerDumper($this->createStub(PropertyMetadataLoaderInterface::class), $this->cacheDir);
+        $dumper->dump(Type::int(), $path, static function () use (&$generated): string {
+            $generated = true;
+
+            return 'CONTENT';
+        });
+
+        $this->assertFalse($generated);
+        $this->assertStringEqualsFile($path, 'EXISTING');
+    }
+
     /**
      * @param list<class-string> $expectedClassNames
      */

--- a/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
@@ -13,8 +13,10 @@ namespace Symfony\Component\JsonStreamer\Tests\Write;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnsupportedException;
 use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadata;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
 use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader;
@@ -149,7 +151,7 @@ class StreamWriterGeneratorTest extends TestCase
         $generator = new StreamWriterGenerator(new PropertyMetadataLoader(TypeResolver::create()), new ServiceContainer(), $this->streamWritersDir);
 
         $this->expectException(UnsupportedException::class);
-        $this->expectExceptionMessage('"Stringable&Traversable" type is not supported.');
+        $this->expectExceptionMessage('Intersection types are not supported ("Stringable&Traversable").');
 
         $generator->generate(Type::intersection(Type::object(\Traversable::class), Type::object(\Stringable::class)));
     }
@@ -179,6 +181,40 @@ class StreamWriterGeneratorTest extends TestCase
             ->willReturn([]);
 
         $generator = new StreamWriterGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamWritersDir);
+        $generator->generate($type);
+    }
+
+    public function testAcceptsClosureFromNamedCallable()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $propertyMetadataLoader = $this->createStub(PropertyMetadataLoaderInterface::class);
+        $propertyMetadataLoader->method('load')->willReturn([
+            'id' => new PropertyMetadata('id', Type::int(), [\Closure::fromCallable('strval')]),
+            'range' => new PropertyMetadata('name', Type::string(), [\Closure::fromCallable(DummyWithValueTransformerAttributes::concatRange(...))]),
+        ]);
+
+        $generator = new StreamWriterGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamWritersDir);
+        $code = file_get_contents($generator->generate($type));
+
+        $this->assertStringContainsString('strval(', $code);
+        $this->assertStringContainsString(DummyWithValueTransformerAttributes::class.'::concatRange(', $code);
+    }
+
+    public function testRejectsAnonymousClosureValueTransformer()
+    {
+        $type = Type::object(ClassicDummy::class);
+
+        $propertyMetadataLoader = $this->createStub(PropertyMetadataLoaderInterface::class);
+        $propertyMetadataLoader->method('load')->willReturn([
+            'id' => new PropertyMetadata('id', Type::int(), [static fn (int $v): int => $v + 1]),
+        ]);
+
+        $generator = new StreamWriterGenerator($propertyMetadataLoader, new ServiceContainer(), $this->streamWritersDir);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Cannot generate accessor for anonymous function ".*\{closure[^"]*"\./');
+
         $generator->generate($type);
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
@@ -130,7 +130,7 @@ final class PhpGenerator
             --$context['indentation_level'];
 
             $generators = [
-                $node->getIdentifier() => $this->line('$generators[\''.$node->getIdentifier().'\'] = static function ($data, $depth) use ($transformers, $options, &$generators) {', $context)
+                $node->getIdentifier() => $this->line('$generators['.var_export($node->getIdentifier(), true).'] = static function ($data, $depth) use ($transformers, $options, &$generators) {', $context)
                     .$this->line('    if ($depth >= 512) {', $context)
                     .$this->line('        throw new \\'.NotEncodableValueException::class.'(\'Maximum stack depth exceeded\');', $context)
                     .$this->line('    }', $context)
@@ -251,7 +251,7 @@ final class PhpGenerator
 
         if ($dataModelNode instanceof ObjectNode) {
             if ($valueObjectTransformerId = $this->getValueObjectTransformerId($dataModelNode->getType()->getClassName())) {
-                $rawValue = "\$transformers->get('$valueObjectTransformerId')->transform({$dataModelNode->getAccessor()}, \$options)";
+                $rawValue = '$transformers->get('.var_export($valueObjectTransformerId, true).")->transform({$dataModelNode->getAccessor()}, \$options)";
 
                 return $this->yield($this->encode($rawValue, $context), $context);
             }
@@ -260,7 +260,7 @@ final class PhpGenerator
                 $depthArgument = ($context['generating_generator'] ?? false) ? '$depth + 1' : (string) $context['depth'];
 
                 return $this->flushYieldBuffer($context)
-                    .$this->line('yield from $generators[\''.$dataModelNode->getIdentifier().'\']('.$accessor.', '.$depthArgument.');', $context);
+                    .$this->line('yield from $generators['.var_export($dataModelNode->getIdentifier(), true).']('.$accessor.', '.$depthArgument.');', $context);
             }
 
             ++$context['depth'];
@@ -349,7 +349,7 @@ final class PhpGenerator
      */
     private function encode(string $value, array $context): string
     {
-        return "\json_encode($value, \\JSON_THROW_ON_ERROR, ". 512 - $context['depth'].')';
+        return "\json_encode($value, \\JSON_THROW_ON_ERROR, ".(512 - $context['depth']).')';
     }
 
     /**

--- a/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/StreamWriterGenerator.php
@@ -29,6 +29,7 @@ use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\EnumType;
 use Symfony\Component\TypeInfo\Type\GenericType;
+use Symfony\Component\TypeInfo\Type\IntersectionType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\UnionType;
 
@@ -81,6 +82,10 @@ final class StreamWriterGenerator
         $context['original_type'] ??= $type;
         $context['depth'] ??= 0;
 
+        if ($type instanceof IntersectionType) {
+            throw new UnsupportedException(\sprintf('Intersection types are not supported ("%s").', (string) $type));
+        }
+
         if ($type instanceof UnionType) {
             return new CompositeNode($accessor, array_map(fn (Type $t): DataModelNodeInterface => $this->createDataModel($t, $accessor, $options, $context), $type->getTypes()));
         }
@@ -121,7 +126,7 @@ final class StreamWriterGenerator
 
                 foreach ($propertyMetadata->getValueTransformers() as $valueTransformer) {
                     if (\is_string($valueTransformer)) {
-                        $valueTransformerServiceAccessor = "\$transformers->get('$valueTransformer')";
+                        $valueTransformerServiceAccessor = '$transformers->get('.var_export($valueTransformer, true).')';
 
                         $propertyAccessor = "{$valueTransformerServiceAccessor}->transform($propertyAccessor, ['_current_object' => $accessor] + \$options)";
 
@@ -132,6 +137,10 @@ final class StreamWriterGenerator
                         $functionReflection = new \ReflectionFunction($valueTransformer);
                     } catch (\ReflectionException $e) {
                         throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+                    }
+
+                    if ($functionReflection->isAnonymous()) {
+                        throw new RuntimeException(\sprintf('Cannot generate accessor for anonymous function "%s".', $functionReflection->getName()));
                     }
 
                     $functionName = !$functionReflection->getClosureCalledClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Mainly ensuring we always use var_export consistently for quoting, and adding a max depth limit (512).