### PR TITLE
[TwigBridge] Require Twig 3.25 for `EscaperRuntime` service definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-xml": "*",
         "doctrine/event-manager": "^2",
         "doctrine/persistence": "^3.1|^4",
-        "twig/twig": "^3.21",
+        "twig/twig": "^3.25",
         "psr/cache": "^2.0|^3.0",
         "psr/clock": "^1.0",
         "psr/container": "^1.1|^2.0",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/translation-contracts": "^2.5|^3",
-        "twig/twig": "^3.21"
+        "twig/twig": "^3.25"
     },
     "require-dev": {
         "egulias/email-validator": "^2.1.10|^3|^4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The feature introduced by https://github.com/symfony/symfony/pull/63929 is broken with older versions of Twig. The patch https://github.com/twigphp/Twig/pull/4795 was released in [v3.25.0](https://github.com/twigphp/Twig/releases/tag/v3.25.0)