### PR TITLE
[CssSelector] Various fixes and hardenings

### DIFF
--- a/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
+++ b/src/Symfony/Component/CssSelector/Exception/SyntaxErrorException.php
@@ -40,7 +40,12 @@ class SyntaxErrorException extends ParseException
 
     public static function nestedNot(): self
     {
-        return new self('Got nested ::not().');
+        return new self('Got nested :not().');
+    }
+
+    public static function nestedHas(): self
+    {
+        return new self('Got too deeply nested :has().');
     }
 
     public static function notAtTheStartOfASelector(string $pseudoElement): self

--- a/src/Symfony/Component/CssSelector/Node/RelationNode.php
+++ b/src/Symfony/Component/CssSelector/Node/RelationNode.php
@@ -23,10 +23,12 @@ namespace Symfony\Component\CssSelector\Node;
  */
 class RelationNode extends AbstractNode
 {
+    /**
+     * @param list<array{0: string, 1: NodeInterface}> $arguments
+     */
     public function __construct(
         private NodeInterface $selector,
-        private string $combinator,
-        private NodeInterface $subSelector,
+        private array $arguments,
     ) {
     }
 
@@ -35,23 +37,32 @@ class RelationNode extends AbstractNode
         return $this->selector;
     }
 
-    public function getCombinator(): string
+    /**
+     * @return list<array{0: string, 1: NodeInterface}>
+     */
+    public function getArguments(): array
     {
-        return $this->combinator;
-    }
-
-    public function getSubSelector(): NodeInterface
-    {
-        return $this->subSelector;
+        return $this->arguments;
     }
 
     public function getSpecificity(): Specificity
     {
-        return $this->selector->getSpecificity()->plus($this->subSelector->getSpecificity());
+        $argumentsSpecificity = array_reduce(
+            $this->arguments,
+            static fn (Specificity $c, array $a) => 1 === $a[1]->getSpecificity()->compareTo($c) ? $a[1]->getSpecificity() : $c,
+            new Specificity(0, 0, 0),
+        );
+
+        return $this->selector->getSpecificity()->plus($argumentsSpecificity);
     }
 
     public function __toString(): string
     {
-        return \sprintf('%s[%s:has(%s)]', $this->getNodeName(), $this->selector, $this->subSelector);
+        $parts = array_map(
+            static fn (array $a): string => (' ' === $a[0] ? '' : $a[0].' ').$a[1],
+            $this->arguments,
+        );
+
+        return \sprintf('%s[%s:has(%s)]', $this->getNodeName(), $this->selector, implode(', ', $parts));
     }
 }

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -28,7 +28,10 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\Tokenizer;
  */
 class Parser implements ParserInterface
 {
+    private const HAS_NESTING_LIMIT = 16;
+
     private Tokenizer $tokenizer;
+    private int $hasNestingDepth = 0;
 
     public function __construct(?Tokenizer $tokenizer = null)
     {
@@ -111,9 +114,9 @@ class Parser implements ParserInterface
         return $selectors;
     }
 
-    private function parserSelectorNode(TokenStream $stream, bool $isArgument = false): Node\SelectorNode
+    private function parserSelectorNode(TokenStream $stream, bool $isArgument = false, bool $insideRelativeSelector = false): Node\SelectorNode
     {
-        [$result, $pseudoElement] = $this->parseSimpleSelector($stream, false, $isArgument);
+        [$result, $pseudoElement] = $this->parseSimpleSelector($stream, false, $isArgument, $insideRelativeSelector);
 
         while (true) {
             $stream->skipWhitespace();
@@ -138,7 +141,7 @@ class Parser implements ParserInterface
                 $combinator = ' ';
             }
 
-            [$nextSelector, $pseudoElement] = $this->parseSimpleSelector($stream, false, $isArgument);
+            [$nextSelector, $pseudoElement] = $this->parseSimpleSelector($stream, false, $isArgument, $insideRelativeSelector);
             $result = new Node\CombinedSelectorNode($result, $combinator, $nextSelector);
         }
 
@@ -146,37 +149,61 @@ class Parser implements ParserInterface
     }
 
     /**
+     * @return list<array{0: string, 1: Node\SelectorNode}>
+     *
      * @throws SyntaxErrorException
      * @throws InternalErrorException
      */
     private function parseRelativeSelector(TokenStream $stream): array
     {
-        $stream->skipWhitespace();
-        $subSelector = '';
-        $next = $stream->getNext();
-
-        if ($next->isDelimiter(['+', '>', '~'])) {
-            $combinator = $next->getValue();
-            $stream->skipWhitespace();
-            $next = $stream->getNext();
-        } else {
-            $combinator = ' ';
+        if ($this->hasNestingDepth >= self::HAS_NESTING_LIMIT) {
+            throw SyntaxErrorException::nestedHas();
         }
 
-        while (true) {
-            if ($next->isString() || $next->isIdentifier() || $next->isNumber() || $next->isDelimiter(['.', '*'])) {
-                $subSelector .= $next->getValue();
-            } elseif ($next->isHash()) {
-                $subSelector .= '#'.$next->getValue();
-            } elseif ($next->isDelimiter([')'])) {
-                $result = $this->parse($subSelector);
+        ++$this->hasNestingDepth;
 
-                return [$combinator, $result[0]];
-            } else {
-                throw SyntaxErrorException::unexpectedToken('an argument', $next);
+        try {
+            $arguments = [];
+            while (true) {
+                $stream->skipWhitespace();
+                $peek = $stream->getPeek();
+
+                if ($peek->isDelimiter(['+', '>', '~'])) {
+                    $combinator = $stream->getNext()->getValue();
+                    $stream->skipWhitespace();
+                    $peek = $stream->getPeek();
+                } else {
+                    $combinator = ' ';
+                }
+
+                if ($peek->isString() || $peek->isNumber()) {
+                    throw SyntaxErrorException::unexpectedToken('an argument', $stream->getNext());
+                }
+
+                $selector = $this->parserSelectorNode($stream, true, true);
+
+                if (null !== $pseudoElement = $selector->getPseudoElement()) {
+                    throw SyntaxErrorException::pseudoElementFound($pseudoElement, 'inside :has()');
+                }
+
+                $arguments[] = [$combinator, $selector];
+
+                if ($stream->getPeek()->isDelimiter([','])) {
+                    $stream->getNext();
+                    continue;
+                }
+
+                break;
             }
 
             $next = $stream->getNext();
+            if (!$next->isDelimiter([')'])) {
+                throw SyntaxErrorException::unexpectedToken('")"', $next);
+            }
+
+            return $arguments;
+        } finally {
+            --$this->hasNestingDepth;
         }
     }
 
@@ -186,7 +213,7 @@ class Parser implements ParserInterface
      * @throws SyntaxErrorException
      * @throws InternalErrorException
      */
-    private function parseSimpleSelector(TokenStream $stream, bool $insideNegation = false, bool $isArgument = false): array
+    private function parseSimpleSelector(TokenStream $stream, bool $insideNegation = false, bool $isArgument = false, bool $insideRelativeSelector = false): array
     {
         $stream->skipWhitespace();
 
@@ -239,12 +266,16 @@ class Parser implements ParserInterface
                     $result = new Node\PseudoNode($result, $identifier);
                     if ('Pseudo[Element[*]:scope]' === $result->__toString()) {
                         $used = \count($stream->getUsed());
+                        $prevSeparators = [','];
+                        if ($insideRelativeSelector) {
+                            $prevSeparators = [',', '(', '>', '+', '~'];
+                        }
                         if (!(2 === $used
                            || 3 === $used && $stream->getUsed()[0]->isWhiteSpace()
-                           || $used >= 3 && $stream->getUsed()[$used - 3]->isDelimiter([','])
+                           || $used >= 3 && $stream->getUsed()[$used - 3]->isDelimiter($prevSeparators)
                            || $used >= 4
                                 && $stream->getUsed()[$used - 3]->isWhiteSpace()
-                                && $stream->getUsed()[$used - 4]->isDelimiter([','])
+                                && $stream->getUsed()[$used - 4]->isDelimiter($prevSeparators)
                         )) {
                             throw SyntaxErrorException::notAtTheStartOfASelector('scope');
                         }
@@ -264,7 +295,7 @@ class Parser implements ParserInterface
                     $next = $stream->getNext();
 
                     if (null !== $argumentPseudoElement) {
-                        throw SyntaxErrorException::pseudoElementFound($argumentPseudoElement, 'inside ::not()');
+                        throw SyntaxErrorException::pseudoElementFound($argumentPseudoElement, 'inside :not()');
                     }
 
                     if (!$next->isDelimiter([')'])) {
@@ -291,8 +322,7 @@ class Parser implements ParserInterface
 
                     $result = new Node\SpecificityAdjustmentNode($result, $selectors);
                 } elseif ('has' === strtolower($identifier)) {
-                    [$combinator, $arguments] = $this->parseRelativeSelector($stream);
-                    $result = new Node\RelationNode($result, $combinator, $arguments);
+                    $result = new Node\RelationNode($result, $this->parseRelativeSelector($stream));
                 } else {
                     $arguments = [];
                     $next = null;

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -136,6 +136,15 @@ class ParserTest extends TestCase
             ['div#foobar', ['Hash[Element[div]#foobar]']],
             ['div:not(div.foo)', ['Negation[Element[div]:not(Class[Element[div].foo])]']],
             ['div:has(div.foo)', ['Relation[Element[div]:has(Selector[Class[Element[div].foo]])]']],
+            ['div:has([type=text])', ["Relation[Element[div]:has(Selector[Attribute[Element[*][type = 'text']]])]"]],
+            ['div:has(div span)', ['Relation[Element[div]:has(Selector[CombinedSelector[Element[div] <followed> Element[span]]])]']],
+            ['div:has(div > span)', ['Relation[Element[div]:has(Selector[CombinedSelector[Element[div] > Element[span]]])]']],
+            ['div:has(:hover)', ['Relation[Element[div]:has(Selector[Pseudo[Element[*]:hover]])]']],
+            ['div:has(div + p > a)', ['Relation[Element[div]:has(Selector[CombinedSelector[CombinedSelector[Element[div] + Element[p]] > Element[a]]])]']],
+            ['div:has(.a, .b)', ['Relation[Element[div]:has(Selector[Class[Element[*].a]], Selector[Class[Element[*].b]])]']],
+            ['div:has(> .a, + .b)', ['Relation[Element[div]:has(> Selector[Class[Element[*].a]], + Selector[Class[Element[*].b]])]']],
+            ['div:has(:scope > a)', ['Relation[Element[div]:has(Selector[CombinedSelector[Pseudo[Element[*]:scope] > Element[a]]])]']],
+            ['div:has(> :scope a)', ['Relation[Element[div]:has(> Selector[CombinedSelector[Pseudo[Element[*]:scope] <followed> Element[a]]])]']],
             ['td ~ th', ['CombinedSelector[Element[td] ~ Element[th]]']],
             ['.foo[data-bar][data-baz=0]', ["Attribute[Attribute[Class[Element[*].foo][data-bar]][data-baz = '0']]"]],
             ['div#foo\.bar', ['Hash[Element[div]#foo.bar]']],
@@ -190,7 +199,34 @@ class ParserTest extends TestCase
             ['foo!', SyntaxErrorException::unexpectedToken('selector', new Token(Token::TYPE_DELIMITER, '!', 3))->getMessage()],
             [':scope > div :scope header', SyntaxErrorException::notAtTheStartOfASelector('scope')->getMessage()],
             [':not(:not(a))', SyntaxErrorException::nestedNot()->getMessage()],
+            ['div:has("foo")', SyntaxErrorException::unexpectedToken('an argument', new Token(Token::TYPE_STRING, 'foo', 9))->getMessage()],
+            ['div:has(123)', SyntaxErrorException::unexpectedToken('an argument', new Token(Token::TYPE_NUMBER, '123', 8))->getMessage()],
+            ['div:has(::before)', SyntaxErrorException::pseudoElementFound('before', 'inside :has()')->getMessage()],
+            ['div:has(a::after)', SyntaxErrorException::pseudoElementFound('after', 'inside :has()')->getMessage()],
+            ['div:has(> ::before)', SyntaxErrorException::pseudoElementFound('before', 'inside :has()')->getMessage()],
         ];
+    }
+
+    public function testHasNestingDepthLimit()
+    {
+        $parser = new Parser();
+        $property = new \ReflectionProperty(Parser::class, 'hasNestingDepth');
+        $property->setValue($parser, 16);
+
+        $this->expectException(SyntaxErrorException::class);
+        $this->expectExceptionMessage(SyntaxErrorException::nestedHas()->getMessage());
+
+        $parser->parse(':has(a)');
+    }
+
+    public function testHasNestingWithinLimitIsAccepted()
+    {
+        $parser = new Parser();
+        $property = new \ReflectionProperty(Parser::class, 'hasNestingDepth');
+        $property->setValue($parser, 15);
+
+        $this->assertCount(1, $parser->parse(':has(a)'));
+        $this->assertSame(15, $property->getValue($parser));
     }
 
     public static function getPseudoElementsTestData()
@@ -252,6 +288,12 @@ class ParserTest extends TestCase
             [':where(#foo)', 0],
             [':where(#foo, :empty, foo)', 0],
             ['#foo:where(#bar:empty)', 100],
+            [':has(*)', 0],
+            [':has(.foo)', 10],
+            [':has(#foo)', 100],
+            [':has(.foo, #foo)', 100],
+            [':has(#foo, :empty, foo)', 100],
+            ['#foo:has(#bar:empty)', 210],
         ];
     }
 

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -51,11 +51,7 @@ class TranslatorTest extends TestCase
 
     public static function getUnsupportedHasSelectorTestData(): iterable
     {
-        yield 'attribute selector' => ['div:has([data-x])'];
-        yield 'descendant combinator' => ['div:has(.foo .bar)'];
-        yield 'selector list' => ['div:has(.foo, .bar)'];
-        yield 'nested pseudo-class' => ['div:has(:not(.foo))'];
-        yield 'chained combinator' => ['div:has(> .foo > .bar)'];
+        yield 'pseudo-element inside :has()' => ['div:has(::before)'];
     }
 
     public function testCssToXPathPseudoElement()
@@ -266,6 +262,13 @@ class TranslatorTest extends TestCase
             ['div:has(+ .foo)', "div[following-sibling::*[(@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')) and (position() = 1)]]"],
             ['div:has(.foo)', "div[descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]]"],
             ['div:has(#bar)', "div[descendant-or-self::*[@id = 'bar']]"],
+            ['div:has([data-x])', 'div[descendant-or-self::*[@data-x]]'],
+            ['div:has(.foo .bar)', "div[descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]/descendant-or-self::*/*[@class and contains(concat(' ', normalize-space(@class), ' '), ' bar ')]]"],
+            ['div:has(:not(.foo))', "div[descendant-or-self::*[not(@class and contains(concat(' ', normalize-space(@class), ' '), ' foo '))]]"],
+            ['div:has(> .foo > .bar)', "div[./*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]/*[@class and contains(concat(' ', normalize-space(@class), ' '), ' bar ')]]"],
+            ['div:has(.foo, .bar)', "div[(descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]) or (descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), ' bar ')])]"],
+            ['div:has(> .foo, + .bar)', "div[(./*[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]) or (following-sibling::*[(@class and contains(concat(' ', normalize-space(@class), ' '), ' bar ')) and (position() = 1)])]"],
+            ['div:has(:scope > a)', 'div[descendant-or-self::*[1]/a]'],
         ];
     }
 
@@ -411,6 +414,8 @@ class TranslatorTest extends TestCase
             ['a:where(:not(#name-anchor))', ['tag-anchor', 'nofollow-anchor']],
             ['a:not(:where(#name-anchor))', ['tag-anchor', 'nofollow-anchor']],
             ['a:where(:is(#name-anchor), :where(#tag-anchor))', ['name-anchor', 'tag-anchor']],
+            ['li:has(div, [foobar])', ['second-li']],
+            ['ol:has(> li[lang], > .nonexistent)', ['first-ol']],
             // HTML-specific
             [':link', ['link-href', 'tag-anchor', 'nofollow-anchor', 'area-href']],
             [':visited', []],

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -215,9 +215,23 @@ class NodeExtension extends AbstractExtension
 
     public function translateRelation(Node\RelationNode $node, Translator $translator): XPathExpr
     {
-        $combinator = $node->getCombinator();
+        $arguments = $node->getArguments();
+        if (1 === \count($arguments)) {
+            [$combinator, $subSelector] = $arguments[0];
 
-        return $translator->addRelativeCombination($combinator, $node->getSelector(), $node->getSubSelector());
+            return $translator->addRelativeCombination($combinator, $node->getSelector(), $subSelector);
+        }
+
+        $conditions = [];
+        foreach ($arguments as [$combinator, $subSelector]) {
+            $relativeXpath = (string) $translator->addRelativeCombination($combinator, new Node\ElementNode(), $subSelector);
+            $conditions[] = substr($relativeXpath, 2, -1);
+        }
+
+        $xpath = $translator->nodeToXPath($node->getSelector());
+        $xpath->addCondition('('.implode(') or (', $conditions).')');
+
+        return $xpath;
     }
 
     public function getName(): string

--- a/src/Symfony/Component/CssSelector/XPath/Extension/RelationExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/RelationExtension.php
@@ -47,6 +47,7 @@ class RelationExtension extends AbstractExtension
 
     public function translateRelationDirectAdjacent(XPathExpr $xpath, XPathExpr $combinedXpath): XPathExpr
     {
+        // position() = 1 must apply to the sibling, not the outer element, so it goes on $combinedXpath before the join
         $combinedXpath
             ->addNameTest()
             ->addCondition('position() = 1');

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -80,6 +80,10 @@ class XPathExpr
     /**
      * Joins another XPathExpr with a combiner.
      *
+     * When $hasInnerConditions is true, $expr->condition is folded into $expr->element as a
+     * "[...]" predicate rather than onto $this->condition, so subsequent addCondition() calls
+     * on $this are not AND'd with it. Needed for relative selectors inside :has().
+     *
      * @return $this
      */
     public function join(string $combiner, self $expr, ?string $closingCombiner = null, bool $hasInnerConditions = false): static


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`:has()` is new to 8.1. This harden the logic.