### PR TITLE
[ObjectMapper] Various fixes and hardenings

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Condition/ClassRuleList.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/ClassRuleList.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\ObjectMapper\Condition;
 
+use Symfony\Component\ObjectMapper\Exception\InvalidArgumentException;
+
 /**
  * @implements ClassRuleConditionCallableInterface<object, object>
  */
@@ -21,6 +23,9 @@ final class ClassRuleList implements ClassRuleConditionCallableInterface
      */
     public function __construct(private array $rules)
     {
+        if (!$this->rules) {
+            throw new InvalidArgumentException('A ClassRuleList needs at least one rule.');
+        }
     }
 
     public function __invoke(mixed $value, object $source, ?object $target): bool

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -149,17 +149,18 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                if (
-                    $if
-                    && ($fn = $this->getCallable($if, $this->conditionCallableLocator, ConditionCallableInterface::class))
-                    && $fn instanceof ClassRuleConditionCallableInterface
-                    && !$this->call($fn, null, $source, $mappedTarget)
-                ) {
-                    continue;
+                $fn = null;
+                $isClassRule = false;
+                if ($if) {
+                    $fn = $this->getCallable($if, $this->conditionCallableLocator, ConditionCallableInterface::class);
+                    $isClassRule = $fn instanceof ClassRuleConditionCallableInterface;
+                    if ($isClassRule && !$this->call($fn, null, $source, $mappedTarget)) {
+                        continue;
+                    }
                 }
 
                 $value = $this->getRawValue($source, $sourcePropertyName);
-                if ($if && $fn && !$this->call($fn, $value, $source, $mappedTarget)) {
+                if ($fn && !$isClassRule && !$this->call($fn, $value, $source, $mappedTarget)) {
                     unset($ctorArguments[$targetPropertyName]);
 
                     continue;
@@ -191,6 +192,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             $rawValue = $this->getRawValue($source, $propertyName);
             if (
                 \is_object($rawValue)
+                && !$objectMap->offsetExists($rawValue)
                 && ($innerMetadata = $this->metadataFactory->create($rawValue))
                 && ($mapTo = $this->getMapTarget($innerMetadata, $rawValue, $source, $mappedTarget))
                 && \is_string($mapTo->target)

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMergeRecursion/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMergeRecursion/Source.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Exception;
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMergeRecursion;
 
-/**
- * Thrown when an invalid transform or condition callable is defined.
- *
- * @author Michaël Marinetti <github@marinetti.fr>
- */
-class NoSuchCallableException extends MappingException
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Target::class)]
+class Source
 {
+    public string $name;
+    public ?Source $child = null;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMergeRecursion/Target.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMergeRecursion/Target.php
@@ -9,13 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\ObjectMapper\Exception;
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMergeRecursion;
 
-/**
- * Thrown when an invalid transform or condition callable is defined.
- *
- * @author Michaël Marinetti <github@marinetti.fr>
- */
-class NoSuchCallableException extends MappingException
+class Target
 {
+    public string $name;
 }

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\ObjectMapper\Tests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\ObjectMapper\Condition\ClassRule;
+use Symfony\Component\ObjectMapper\Condition\ClassRuleList;
+use Symfony\Component\ObjectMapper\Exception\InvalidArgumentException;
 use Symfony\Component\ObjectMapper\Exception\MappingException;
 use Symfony\Component\ObjectMapper\Exception\MappingTransformException;
 use Symfony\Component\ObjectMapper\Exception\NoSuchCallableException;
@@ -98,6 +101,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransfor
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ChildWithoutClassTransformerTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMergeRecursion\Source as NestedMergeRecursionSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMergeRecursion\Target as NestedMergeRecursionTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PromotedConstructor\Source as PromotedConstructorSource;
@@ -910,6 +915,19 @@ final class ObjectMapperTest extends TestCase
         $this->assertSame('Test Bank', $bankDataResource->bankName);
     }
 
+    public function testNestedMergeWithCyclicSource()
+    {
+        $source = new NestedMergeRecursionSource();
+        $source->name = 'root';
+        $source->child = $source;
+
+        $mapper = new ObjectMapper();
+        $mapped = $mapper->map($source);
+
+        $this->assertInstanceOf(NestedMergeRecursionTarget::class, $mapped);
+        $this->assertSame('root', $mapped->name);
+    }
+
     public function testNestedMappingWithClassTransform()
     {
         $target = (new ObjectMapper())->map(new ParentSource());
@@ -1004,5 +1022,76 @@ final class ObjectMapperTest extends TestCase
         $target = $mapper->map($source, new IsNotNullTargetMapping());
         $this->assertSame('Charlie', $target->name);
         $this->assertSame(42, $target->points);
+    }
+
+    public function testClassRuleListRejectsEmptyArray()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A ClassRuleList needs at least one rule.');
+
+        new ClassRuleList([]);
+    }
+
+    public function testClassRuleWithBothSourcesAndTargets()
+    {
+        $rule = new ClassRule(sources: [ClassRuleB::class], targets: [ClassRuleA::class]);
+
+        $this->assertTrue($rule(null, new ClassRuleB(), new ClassRuleA()));
+        $this->assertFalse($rule(null, new ClassRuleC(), new ClassRuleA()), 'wrong source rejects');
+        $this->assertFalse($rule(null, new ClassRuleB(), new ClassRuleC()), 'wrong target rejects');
+    }
+
+    public function testClassRuleConditionInvokedOnce()
+    {
+        $calls = 0;
+        $rule = new class($calls) implements \Symfony\Component\ObjectMapper\Condition\ClassRuleConditionCallableInterface {
+            public function __construct(private int &$calls)
+            {
+            }
+
+            public function __invoke(mixed $value, object $source, ?object $target): bool
+            {
+                ++$this->calls;
+
+                return true;
+            }
+        };
+
+        $source = new class {
+            public string $foo = 'bar';
+        };
+        $target = new class {
+            public string $foo = '';
+        };
+
+        $factory = $this->createStub(ObjectMapperMetadataFactoryInterface::class);
+        $factory->method('create')->willReturnCallback(static function (object $o, ?string $property = null) use ($rule, $source) {
+            if ($o === $source && 'foo' === $property) {
+                return [new Mapping(target: 'foo', if: $rule::class)];
+            }
+
+            return [];
+        });
+
+        $locator = $this->createStub(ContainerInterface::class);
+        $locator->method('has')->willReturnCallback(static fn ($id) => $id === $rule::class);
+        $locator->method('get')->willReturnCallback(static fn ($id) => $id === $rule::class ? $rule : null);
+
+        (new ObjectMapper($factory, null, null, $locator))->map($source, $target);
+
+        $this->assertSame(1, $calls);
+    }
+
+    public function testReverseClassObjectMapperMetadataFactoryWithMissingTargetClass()
+    {
+        $source = new Cost(10, 20, 'bar');
+
+        $factory = new ReverseClassObjectMapperMetadataFactory(
+            new ReflectionObjectMapperMetadataFactory(),
+            [Cost::class => 'Nonexistent\\Class\\ForReverseFactoryTest'],
+        );
+
+        $this->expectException(\ReflectionException::class);
+        $factory->create($source, 'amount');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Three independent fixes to the ObjectMapper component:

- Cyclic-source recursion: when a source object references itself (directly or transitively) through a nested-merge property, mapping now terminates instead of recursing forever. Guarded by checking the existing WeakMap of visited objects.
- Class-rule conditions invoked once: refactor of the per-property condition logic so that ClassRuleConditionCallableInterface callables are called a single time with null, and other condition callables a single time with the property value. Previously class rules were evaluated twice.
- Empty ClassRuleList rejected: constructing one with [] now throws InvalidArgumentException instead of producing a silently always-false rule.

