### PR TITLE
[DoctrineBridge] Various fixes and hardenings

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/Console/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/Console/EntityValueResolver.php
@@ -47,8 +47,12 @@ final class EntityValueResolver implements ValueResolverInterface
 
     public function resolve(string $argumentName, InputInterface $input, ReflectionMember $member): iterable
     {
-        if (!Argument::tryFrom($member->getMember()) && !Option::tryFrom($member->getMember())) {
-            return [];
+        $isOption = false;
+        if (!Argument::tryFrom($member->getMember())) {
+            if (!Option::tryFrom($member->getMember())) {
+                return [];
+            }
+            $isOption = true;
         }
 
         $type = $member->getType();
@@ -58,7 +62,11 @@ final class EntityValueResolver implements ValueResolverInterface
 
         $inputName = $member->getInputName();
 
-        if ($input->hasArgument($inputName) && \is_object($input->getArgument($inputName))) {
+        if ($isOption) {
+            if ($input->hasOption($inputName) && \is_object($input->getOption($inputName))) {
+                return [];
+            }
+        } elseif ($input->hasArgument($inputName) && \is_object($input->getArgument($inputName))) {
             return [];
         }
 
@@ -79,12 +87,12 @@ final class EntityValueResolver implements ValueResolverInterface
 
         $message = '';
         if (null !== $options->expr) {
-            $variables = array_merge($input->getArguments(), ['input' => $input]);
+            $variables = array_merge($input->getArguments(), $input->getOptions(), ['input' => $input]);
             if (null === $object = $this->findViaExpression($this->expressionLanguage, $manager, $options, $variables)) {
                 $message = \sprintf(' The expression "%s" returned null.', $options->expr);
             }
-        } elseif (false === $object = $this->findById($manager, $options, $this->getIdentifier($inputName, $input, $options, $member))) {
-            if (!$criteria = $this->getCriteria($inputName, $input, $options, $manager, $member)) {
+        } elseif (false === $object = $this->findById($manager, $options, $this->getIdentifier($inputName, $input, $options, $isOption))) {
+            if (!$criteria = $this->getCriteria($inputName, $input, $options, $manager, $isOption)) {
                 throw new NearMissValueResolverException(\sprintf('Cannot find mapping for "%s": use the #[MapEntity] attribute to configure entity resolution.', $options->class));
             }
             $object = $this->findOneByCriteria($manager, $options, $criteria);
@@ -97,22 +105,25 @@ final class EntityValueResolver implements ValueResolverInterface
         return [$object];
     }
 
-    private function getIdentifier(string $argumentName, InputInterface $input, MapEntity $options, ReflectionMember $member): mixed
+    private function getIdentifier(string $inputName, InputInterface $input, MapEntity $options, bool $isOption): mixed
     {
+        $has = $isOption ? $input->hasOption(...) : $input->hasArgument(...);
+        $get = $isOption ? $input->getOption(...) : $input->getArgument(...);
+
         if (\is_array($options->id)) {
             $id = [];
             foreach ($options->id as $field) {
                 if (str_contains($field, '%s')) {
-                    $field = \sprintf($field, $argumentName);
+                    $field = \sprintf($field, $inputName);
                 }
 
                 $fieldName = (new UnicodeString($field))->kebab()->toString();
 
-                if (!$input->hasArgument($fieldName)) {
+                if (!$has($fieldName)) {
                     return $options->stripNull ? false : null;
                 }
 
-                $id[$field] = $input->getArgument($fieldName);
+                $id[$field] = $get($fieldName);
             }
 
             return $id;
@@ -121,13 +132,11 @@ final class EntityValueResolver implements ValueResolverInterface
         if ($options->id) {
             $idName = (new UnicodeString($options->id))->kebab()->toString();
 
-            return $input->hasArgument($idName)
-                ? $input->getArgument($idName)
-                : ($options->stripNull ? false : null);
+            return $has($idName) ? $get($idName) : ($options->stripNull ? false : null);
         }
 
-        if ($input->hasArgument($argumentName)) {
-            $value = $input->getArgument($argumentName);
+        if ($has($inputName)) {
+            $value = $get($inputName);
             if (\is_array($value)) {
                 return false;
             }
@@ -135,18 +144,20 @@ final class EntityValueResolver implements ValueResolverInterface
             return $value ?? ($options->stripNull ? false : null);
         }
 
-        if ($input->hasArgument('id')) {
+        if (!$isOption && $input->hasArgument('id')) {
             return $input->getArgument('id') ?? ($options->stripNull ? false : null);
         }
 
         return false;
     }
 
-    private function getCriteria(string $argumentName, InputInterface $input, MapEntity $options, ObjectManager $manager, ReflectionMember $member): array
+    private function getCriteria(string $inputName, InputInterface $input, MapEntity $options, ObjectManager $manager, bool $isOption): array
     {
+        $has = $isOption ? $input->hasOption(...) : $input->hasArgument(...);
+        $get = $isOption ? $input->getOption(...) : $input->getArgument(...);
         $mapping = $options->mapping;
 
-        if (!$mapping && $input->hasArgument($argumentName) && \is_array($criteria = $input->getArgument($argumentName))) {
+        if (!$mapping && $has($inputName) && \is_array($criteria = $get($inputName))) {
             foreach ($options->exclude ?? [] as $exclude) {
                 unset($criteria[$exclude]);
             }
@@ -171,8 +182,8 @@ final class EntityValueResolver implements ValueResolverInterface
         $values = [];
         foreach (array_keys($mapping) as $attribute) {
             $attributeName = (new UnicodeString($attribute))->kebab()->toString();
-            if ($input->hasArgument($attributeName)) {
-                $values[$attribute] = $input->getArgument($attributeName);
+            if ($has($attributeName)) {
+                $values[$attribute] = $get($attributeName);
             }
         }
 

--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolverTrait.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolverTrait.php
@@ -129,13 +129,8 @@ trait EntityValueResolverTrait
         }
 
         $criteria = [];
-        $metadata = null === $options->mapping ? $manager->getClassMetadata($options->class) : false;
 
         foreach ($mapping as $attribute => $field) {
-            if ($metadata && !$metadata->hasField($field) && (!$metadata->hasAssociation($field) || !$metadata->isSingleValuedAssociation($field))) {
-                continue;
-            }
-
             if (!\array_key_exists($attribute, $values)) {
                 continue;
             }

--- a/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Attribute/MapEntity.php
@@ -26,11 +26,15 @@ class MapEntity extends ValueResolver
      * @param string|null                $expr          An expression to fetch the entity using the {@see https://symfony.com/doc/current/components/expression_language.html ExpressionLanguage} syntax.
      *                                                  Any request attribute are available as a variable, and your entity repository in the 'repository' variable.
      * @param array<string, string>|null $mapping       Configures the properties and values to use with the findOneBy() method
-     *                                                  The key is the route placeholder name and the value is the Doctrine property name
+     *                                                  The key is the route placeholder name and the value is the Doctrine property name.
+     *                                                  On Console commands, the placeholder name is matched against argument/option names
+     *                                                  after a kebab-case transformation (e.g. "userId" maps to "user-id")
      * @param string[]|null              $exclude       Configures the properties that should be used in the findOneBy() method by excluding
      *                                                  one or more properties so that not all are used
      * @param bool|null                  $stripNull     Whether to prevent null values from being used as parameters in the query (defaults to false)
-     * @param string[]|string|null       $id            If an id option is configured and matches a route parameter, then the resolver will find by the primary key
+     * @param string[]|string|null       $id            If an id option is configured and matches a route parameter, then the resolver will find by the primary key.
+     *                                                  On Console commands, the id name is matched against argument/option names after a kebab-case
+     *                                                  transformation (e.g. "userId" looks for "user-id")
      * @param bool|null                  $evictCache    If true, forces Doctrine to always fetch the entity from the database instead of cache (defaults to false)
      */
     public function __construct(

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -66,7 +66,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
         private readonly array $aliasMap = [],
     ) {
         if ($aliasMap) {
-            trigger_deprecation('symfony/doctrine-bridge', '8.1', 'The property RegisterMappingsPass::$aliasMap is deprecated and will be removed in 9.0. Namespace alias are no longer supported.');
+            trigger_deprecation('symfony/doctrine-bridge', '8.1', 'The property RegisterMappingsPass::$aliasMap is deprecated and will be removed in 9.0. Namespace aliases are no longer supported.');
 
             if (!$configurationPattern || !$registerAliasMethodName) {
                 throw new \InvalidArgumentException('configurationPattern and registerAliasMethodName are required to register namespace alias.');

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -165,7 +165,6 @@ abstract class DoctrineType extends AbstractType implements ResetInterface
                     'binary' => 'toBinary',
                     'hex' => 'toHex',
                     'rfc4122' => 'toRfc4122',
-                    default => throw new RuntimeException(\sprintf('Unsupported value "%s" for "uid_format" option; valid values are "base32", "base58", "binary", "hex" and "rfc4122".', $uidFormat)),
                 };
 
                 return ChoiceList::value($this, static function (?object $object = null) use ($idReader, $formatMethod): string {

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
@@ -28,8 +28,22 @@ class DoctrinePingConnectionMiddleware extends AbstractDoctrineMiddleware
     protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
     {
         if (null !== $envelope->last(ConsumedByWorkerStamp::class)) {
+            // In multi-EM mode (no explicit entityManagerName), ping every manager and let healthy ones
+            // proceed even if a secondary connection failed. The first failure is rethrown at the end.
+            $firstFailure = null;
             foreach ($this->getTargetEntityManagers($entityManager) as $name => $targetEntityManager) {
-                $this->pingConnection($targetEntityManager, $name);
+                try {
+                    $this->pingConnection($targetEntityManager, $name);
+                } catch (DBALException $e) {
+                    if (null !== $this->entityManagerName) {
+                        throw $e;
+                    }
+                    $firstFailure ??= $e;
+                }
+            }
+
+            if (null !== $firstFailure) {
+                throw $firstFailure;
             }
         }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Console/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Console/ArgumentResolver/EntityValueResolverTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class EntityValueResolverTest extends TestCase
@@ -289,19 +290,119 @@ class EntityValueResolverTest extends TestCase
         $this->assertSame([], iterator_to_array($resolver->resolve('entity', $input, $member)));
     }
 
-    private function createMember(string $name, string $type, ?MapEntity $entity = null, bool $nullable = false, bool $withArgument = true): ReflectionMember
+    public function testResolveByIdFromOption()
     {
-        $nullablePrefix = $nullable ? '?' : '';
-        $argumentAttribute = $withArgument ? '#[\\Symfony\\Component\\Console\\Attribute\\Argument]' : '';
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $input = new ArrayInput(['--entity' => 1], new InputDefinition([
+            new InputOption('entity', null, InputOption::VALUE_REQUIRED),
+        ]));
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('find')
+            ->with(1)
+            ->willReturn($object = new \stdClass());
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $member = $this->createMember('entity', \stdClass::class, new MapEntity(), asOption: true);
+
+        $this->assertSame([$object], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
+    public function testResolveByIdFromOptionWithCustomName()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $input = new ArrayInput(['--user-id' => 5], new InputDefinition([
+            new InputOption('user-id', null, InputOption::VALUE_REQUIRED),
+        ]));
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('find')
+            ->with(5)
+            ->willReturn($object = new \stdClass());
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $member = $this->createMember('entity', \stdClass::class, new MapEntity(id: 'userId'), asOption: true);
+
+        $this->assertSame([$object], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
+    public function testResolveByMappingFromOption()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $input = new ArrayInput(['--name' => 'foo'], new InputDefinition([
+            new InputOption('name', null, InputOption::VALUE_REQUIRED),
+        ]));
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['name' => 'foo'])
+            ->willReturn($object = new \stdClass());
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with(\stdClass::class)
+            ->willReturn($repository);
+
+        $member = $this->createMember('entity', \stdClass::class, new MapEntity(mapping: ['name']), asOption: true);
+
+        $this->assertSame([$object], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
+    public function testResolveOptionAlreadyResolved()
+    {
+        $manager = $this->createStub(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $object = new \stdClass();
+        $input = new ArrayInput(['--entity' => $object], new InputDefinition([
+            new InputOption('entity', null, InputOption::VALUE_REQUIRED),
+        ]));
+
+        $member = $this->createMember('entity', \stdClass::class, new MapEntity(), asOption: true);
+
+        $this->assertSame([], iterator_to_array($resolver->resolve('entity', $input, $member)));
+    }
+
+    private function createMember(string $name, string $type, ?MapEntity $entity = null, bool $nullable = false, bool $withArgument = true, bool $asOption = false): ReflectionMember
+    {
+        $nullablePrefix = $nullable || $asOption ? '?' : '';
+        if ($asOption) {
+            $inputAttribute = '#[\\Symfony\\Component\\Console\\Attribute\\Option]';
+            $defaultSuffix = ' = null';
+        } else {
+            $inputAttribute = $withArgument ? '#[\\Symfony\\Component\\Console\\Attribute\\Argument]' : '';
+            $defaultSuffix = '';
+        }
         $mapEntityAttribute = $entity ? \sprintf('#[\\Symfony\\Bridge\\Doctrine\\Attribute\\MapEntity(%s)]', $this->mapEntityToString($entity)) : '';
 
         $command = eval(\sprintf('return new class {
             public function __invoke(
                 %s
                 %s
-                %s%s $%s
+                %s%s $%s%s
             ) {}
-        };', $argumentAttribute, $mapEntityAttribute, $nullablePrefix, $type, $name));
+        };', $inputAttribute, $mapEntityAttribute, $nullablePrefix, $type, $name, $defaultSuffix));
 
         $reflection = new \ReflectionMethod($command, '__invoke');
         $parameter = $reflection->getParameters()[0];

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -152,6 +152,55 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
         $middleware->handle($envelope, $this->getStackMock());
     }
 
+    public function testMiddlewarePingsHealthyManagersWhenOneFailsInMultiEntityManagerMode()
+    {
+        $healthy = $this->connectionExpectingOnePing();
+
+        $failing = $this->createMock(Connection::class);
+        $failing->method('isConnected')->willReturn(true);
+        $failing->method('getDatabasePlatform')->willReturn($this->mockPlatform());
+        $failing->expects($this->exactly(2))
+            ->method('executeQuery')
+            ->willThrowException($this->createStub(DBALException::class));
+        $failing->expects($this->once())->method('close');
+
+        $registry = $this->createRegistryForManagers([
+            'broken' => $this->createManagerWithConnection($failing),
+            'healthy' => $this->createManagerWithConnection($healthy),
+        ]);
+
+        $middleware = new DoctrinePingConnectionMiddleware($registry);
+
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+        ]);
+
+        $this->expectException(DBALException::class);
+
+        $middleware->handle($envelope, $this->getStackMock(false));
+    }
+
+    public function testMiddlewareSkipsPingWhenConnectionIsNotConnected()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(false);
+        $connection->expects($this->never())->method('executeQuery');
+        $connection->expects($this->never())->method('close');
+
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $manager->method('getConnection')->willReturn($connection);
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+
+        $middleware = new DoctrinePingConnectionMiddleware($registry, $this->entityManagerName);
+
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+        ]);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
     public function testMiddlewareResetsClosedManagersWhenEntityManagerNameIsNull()
     {
         $registry = $this->createRegistryForManagers([

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -32,6 +32,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/cache": "^7.4|^8.0",
         "symfony/config": "^7.4|^8.0",
+        "symfony/console": "^8.1",
         "symfony/dependency-injection": "^7.4|^8.0",
         "symfony/doctrine-messenger": "^7.4|^8.0",
         "symfony/expression-language": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This commit bundles several small fixes and hardenings in the Doctrine bridge:

- **Console `EntityValueResolver`**: add support for `#[Option]` parameters (previously only `#[Argument]` was resolved). Expression-language variables now also expose `$input->getOptions()`.
- **`EntityValueResolverTrait`**: remove dead metadata-filter branch in `buildCriteriaFromMapping` — the guard `null === $options->mapping` was unreachable from both call sites.
- **`MapEntity`**: document the kebab-case transformation applied to argument/option names by the Console resolver (e.g. `userId` → `user-id`).
- **`RegisterMappingsPass`**: fix typo in deprecation message ("alias are" → "aliases are").
- **`DoctrineType` (Form)**: drop unreachable `default` branch in the `uid_format` match — already validated by `setAllowedValues`.
- **`DoctrinePingConnectionMiddleware`**: in multi-EM mode (no explicit `entityManagerName`), ping every manager so healthy ones still get reset even if a secondary connection fails. The first failure is rethrown at the end so the worker still retries the message.
