### PR TITLE
[DomCrawler] Various fixes and hardenings

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -34,6 +34,11 @@ DoctrineBridge
 
  * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`. Namespace aliases are no longer supported in Doctrine.
 
+DomCrawler
+----------
+
+ * Always set `LIBXML_NONET` in `Crawler::addXmlContent()` so external entities cannot trigger network requests
+
 ErrorHandler
 ------------
 

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 8.1
 ---
 
- * Allow to add choices to single select
+ * Make `ChoiceFormField::addChoice()` part of the supported public API
+ * Always set `LIBXML_NONET` in `Crawler::addXmlContent()` so external entities cannot trigger network requests
 
 8.0
 ---

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -193,7 +193,9 @@ class Crawler implements \Countable, \IteratorAggregate
      * and then, get the errors via libxml_get_errors(). Be
      * sure to clear errors with libxml_clear_errors() afterward.
      *
-     * @param int $options Bitwise OR of the libxml option constants
+     * @param int $options Bitwise OR of the libxml option constants;
+     *                     `LIBXML_NONET` is always added to the options to prevent
+     *                     network requests for external entities.
      *                     LIBXML_PARSEHUGE is dangerous, see
      *                     http://symfony.com/blog/security-release-symfony-2-0-17-released
      */
@@ -210,7 +212,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $dom->validateOnParse = true;
 
         if ('' !== trim($content)) {
-            @$dom->loadXML($content, $options);
+            @$dom->loadXML($content, $options | \LIBXML_NONET);
         }
 
         libxml_use_internal_errors($internalErrors);

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -141,19 +141,29 @@ class ChoiceFormField extends FormField
     /**
      * Adds a choice to the current ones.
      *
-     * @throws \LogicException When choice provided is neither multiple, radio nor select
+     * @throws \LogicException When choice provided is neither multiple, radio nor select,
+     *                         or when the node tag does not match the field type
      */
     final public function addChoice(\DOMElement $node): void
     {
         if (!$this->multiple && !\in_array($this->type, ['radio', 'select'], true)) {
-            throw new \LogicException(\sprintf('Unable to add a choice for "%s" as it is neither multiple, a radio button nor a select field.', $this->name));
+            throw new \LogicException(\sprintf('Unable to add a choice for "%s" as it is neither multiple, a radio button nor a select field (type is "%s").', $this->name, $this->type));
+        }
+
+        $expectedTag = 'select' === $this->type ? 'option' : 'input';
+        if ($expectedTag !== $node->nodeName) {
+            throw new \LogicException(\sprintf('Unable to add a choice for "%s": expected an "%s" tag, got "%s".', $this->name, $expectedTag, $node->nodeName));
         }
 
         $option = $this->buildOptionValue($node);
         $this->options[] = $option;
 
         if ($node->hasAttribute('select' === $this->type ? 'selected' : 'checked')) {
-            $this->value = $option['value'];
+            if ($this->multiple) {
+                $this->value[] = $option['value'];
+            } else {
+                $this->value = $option['value'];
+            }
         }
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -145,6 +145,29 @@ class CrawlerTest extends TestCase
         $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addXmlContent() adds nodes from an XML string');
     }
 
+    public function testAddXmlContentForcesNoNetEvenWhenCallerRequestsEntityExpansion()
+    {
+        // LIBXML_NOENT forces libxml to try expanding the external entity;
+        // without LIBXML_NONET this would attempt a network fetch. The crawler
+        // always adds LIBXML_NONET, so libxml must refuse with XML_IO_NETWORK_ATTEMPT (1543).
+        libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        $crawler = $this->createCrawler();
+        $crawler->addXmlContent(
+            '<?xml version="1.0"?>'
+            .'<!DOCTYPE r [<!ENTITY xxe SYSTEM "http://127.0.0.1:1/xxe.dtd">]>'
+            .'<r>&xxe;</r>',
+            'UTF-8',
+            \LIBXML_NOENT
+        );
+
+        $codes = array_map(static fn ($e) => $e->code, libxml_get_errors());
+        libxml_clear_errors();
+
+        $this->assertContains(1543, $codes, 'libxml reports XML_IO_NETWORK_ATTEMPT when an external entity is blocked by LIBXML_NONET');
+    }
+
     public function testAddXmlContentCharset()
     {
         $crawler = $this->createCrawler();

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -130,6 +130,41 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $this->assertSame('mr_robot', $field->getValue(), '->addChoice() changes the value to added choice if selected attribute is set');
     }
 
+    public function testAddChoiceToMultipleSelectAppendsSelectedValue()
+    {
+        $node = $this->createSelectNode(['foo' => true, 'bar' => false], ['multiple' => 'multiple']);
+        $field = new ChoiceFormField($node);
+
+        $this->assertSame(['foo'], $field->getValue());
+
+        $option = $this->createNode('option', '', ['value' => 'baz', 'selected' => true]);
+        $field->addChoice($option);
+
+        $this->assertSame(['foo', 'baz'], $field->getValue(), '->addChoice() appends to the value array for a multiple select');
+    }
+
+    public function testAddChoiceRejectsMismatchedTagForSelect()
+    {
+        $node = $this->createSelectNode(['foo' => false, 'bar' => false]);
+        $field = new ChoiceFormField($node);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('expected an "option" tag, got "input"');
+
+        $field->addChoice($this->createNode('input', '', ['value' => 'baz']));
+    }
+
+    public function testAddChoiceRejectsMismatchedTagForRadio()
+    {
+        $node = $this->createNode('input', '', ['type' => 'radio', 'name' => 'name', 'value' => 'foo']);
+        $field = new ChoiceFormField($node);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('expected an "input" tag, got "option"');
+
+        $field->addChoice($this->createNode('option', '', ['value' => 'bar']));
+    }
+
     public function testSelectWithEmptyBooleanAttribute()
     {
         $node = $this->createSelectNode(['foo' => false, 'bar' => true], [], '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Mainly hardening by passing `LIBXML_NONET` to `Crawler::addXmlContent()`.