### PR TITLE
[DomCrawler] Fix `ChoiceFormField::addChoice()` clobbering values on multi-selects

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -163,7 +163,11 @@ class ChoiceFormField extends FormField
         $this->options[] = $option;
 
         if ($node->hasAttribute('checked')) {
-            $this->value = $option['value'];
+            if ($this->multiple) {
+                $this->value[] = $option['value'];
+            } else {
+                $this->value = $option['value'];
+            }
         }
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -128,6 +128,22 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $this->assertTrue($field->isDisabled(), '->isDisabled() returns true for selects with a disabled attribute');
     }
 
+    public function testAddChoiceOnMultipleSelectKeepsExistingValues()
+    {
+        $node = $this->createSelectNode(['foo' => true, 'bar' => false], ['multiple' => 'multiple']);
+        $field = new ChoiceFormField($node);
+
+        $this->assertEquals(['foo'], $field->getValue());
+
+        $document = new \DOMDocument();
+        $newOption = $document->createElement('option', 'baz');
+        $newOption->setAttribute('value', 'baz');
+        $newOption->setAttribute('checked', 'checked');
+        $field->addChoice($newOption);
+
+        $this->assertEquals(['foo', 'baz'], $field->getValue());
+    }
+
     public function testMultipleSelects()
     {
         $node = $this->createSelectNode(['foo' => false, 'bar' => false], ['multiple' => 'multiple']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backported from https://github.com/symfony/symfony/pull/64256