### PR TITLE
[Messenger] Fix PhpSerializer::getMessageType() when getting payload with Serializable instances

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyLegacySerializable.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyLegacySerializable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyLegacySerializable implements \Serializable
+{
+    public function __construct(private string $value = '')
+    {
+    }
+
+    public function serialize(): string
+    {
+        return $this->value;
+    }
+
+    public function unserialize($data): void
+    {
+        $this->value = $data;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageEnum.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+enum DummyMessageEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithLegacySerializable.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithLegacySerializable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyMessageWithLegacySerializable
+{
+    public function __construct(public DummyLegacySerializable $value)
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -11,12 +11,32 @@
 
 namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyLegacySerializable;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageEnum;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageWithLegacySerializable;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+
+// Force-load the deprecated-Serializable fixture under an error handler that swallows
+// the PHP deprecation it triggers at class-declaration time.
+$errorHandler = set_error_handler(static function (int $errno, string $errstr) use (&$errorHandler) {
+    if (\E_DEPRECATED === $errno && str_contains($errstr, 'Serializable interface')) {
+        return true;
+    }
+
+    return $errorHandler ? $errorHandler(...\func_get_args()) : false;
+});
+
+try {
+    class_exists(DummyLegacySerializable::class);
+} finally {
+    restore_error_handler();
+}
 
 class PhpSerializerTest extends TestCase
 {
@@ -122,6 +142,30 @@ class PhpSerializerTest extends TestCase
         $this->assertSame(DummyMessage::class, $serializer->getMessageType($serializer->encode(new Envelope(new DummyMessage("\xE9")))));
     }
 
+    public function testGetMessageTypeWithLegacySerializableProperty()
+    {
+        $serializer = $this->createPhpSerializer();
+
+        $envelope = new Envelope(new DummyMessageWithLegacySerializable(new DummyLegacySerializable('15.98')));
+        $encoded = $serializer->encode($envelope);
+
+        $errors = [];
+        set_error_handler(static function ($_, $msg) use (&$errors) {
+            $errors[] = $msg;
+
+            return true;
+        });
+
+        try {
+            $type = $serializer->getMessageType($encoded);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(DummyMessageWithLegacySerializable::class, $type);
+        $this->assertSame([], $errors, 'getMessageType() should not emit PHP warnings.');
+    }
+
     public function testGetMessageTypeReturnsNullForUndeterminableBody()
     {
         $serializer = $this->createPhpSerializer();
@@ -131,6 +175,120 @@ class PhpSerializerTest extends TestCase
         $this->assertNull($serializer->getMessageType(['body' => 'definitely not serialized data']));
         $this->assertNull($serializer->getMessageType(['body' => addslashes(serialize(123))]));
         $this->assertNull($serializer->getMessageType(['body' => addslashes(serialize(new DummyMessage('Hello')))]));
+    }
+
+    #[DataProvider('provideAdversarialBodies')]
+    public function testGetMessageTypeRejectsOrMatchesPhpForAdversarialBody(string $body, ?string $expected)
+    {
+        $this->assertSame($expected, $this->createPhpSerializer()->getMessageType(['body' => addslashes($body)]));
+    }
+
+    public static function provideAdversarialBodies(): iterable
+    {
+        $stampsKey = 's:44:"'."\0".'Symfony\\Component\\Messenger\\Envelope'."\0".'stamps";';
+        $messageKey = 's:45:"'."\0".'Symfony\\Component\\Messenger\\Envelope'."\0".'message";';
+        $envelopePrefix = 'O:36:"Symfony\\Component\\Messenger\\Envelope"';
+
+        yield 'reversed property order: still finds message by key' => [
+            $envelopePrefix.':2:{'.$messageKey.'O:8:"stdClass":0:{}'.$stampsKey.'a:0:{}}',
+            'stdClass',
+        ];
+
+        yield 'duplicate message keys: returns last value (PHP semantics)' => [
+            $envelopePrefix.':3:{'.$stampsKey.'a:0:{}'.$messageKey.'O:5:"First":0:{}'.$messageKey.'O:6:"Second":0:{}}',
+            'Second',
+        ];
+
+        $enumClass = DummyMessageEnum::class;
+        $enumPayload = $enumClass.':A';
+        yield 'enum message: returns class name without case suffix' => [
+            $envelopePrefix.':2:{'.$stampsKey.'a:0:{}'.$messageKey.'E:'.\strlen($enumPayload).':"'.$enumPayload.'";}',
+            $enumClass,
+        ];
+
+        yield 'stamp string value containing message-key bytes: ignored' => (static function () use ($stampsKey, $messageKey, $envelopePrefix) {
+            $decoy = $messageKey.'O:5:"PWNED":0:{}';
+            $stamps = 'a:1:{i:0;s:'.\strlen($decoy).':"'.$decoy.'";}';
+
+            return [
+                $envelopePrefix.':2:{'.$stampsKey.$stamps.$messageKey.'O:6:"Honest":0:{}}',
+                'Honest',
+            ];
+        })();
+
+        yield 'C: opaque payload containing message-key bytes: ignored' => (static function () use ($stampsKey, $messageKey, $envelopePrefix) {
+            $opaque = $messageKey.'O:8:"PWNED999":0:{}';
+            $stamps = 'a:1:{i:0;C:6:"FakeOp":'.\strlen($opaque).':{'.$opaque.'}}';
+
+            return [
+                $envelopePrefix.':2:{'.$stampsKey.$stamps.$messageKey.'O:7:"Honest1":0:{}}',
+                'Honest1',
+            ];
+        })();
+
+        yield 'trailing garbage after envelope: rejected' => [
+            $envelopePrefix.':2:{'.$stampsKey.'a:0:{}'.$messageKey.'O:8:"stdClass":0:{}}garbage',
+            null,
+        ];
+
+        yield 'wrong declared property count vs actual pairs: rejected' => [
+            $envelopePrefix.':3:{'.$stampsKey.'a:0:{}'.$messageKey.'O:8:"stdClass":0:{}}',
+            null,
+        ];
+
+        yield 'message value is a reference to the envelope itself: safely resolves to Envelope' => [
+            // PHP unserialize() resolves r:1; to the envelope itself; the resulting class
+            // name (Envelope) is harmless when fed back to SigningSerializer because
+            // Envelope is virtually never registered as a signed message type.
+            $envelopePrefix.':2:{'.$stampsKey.'a:0:{}'.$messageKey.'r:1;}',
+            Envelope::class,
+        ];
+
+        yield 'capital-S binary-string format (not produced by serialize()): rejected' => [
+            $envelopePrefix.':2:{'.$stampsKey.'a:0:{}S:45:"\\00Symfony\\\\Component\\\\Messenger\\\\Envelope\\00message";O:6:"Signed":0:{}}',
+            null,
+        ];
+
+        yield 'no message key in envelope: returns null' => [
+            $envelopePrefix.':1:{'.$stampsKey.'a:0:{}}',
+            null,
+        ];
+
+        $protectedMessageKey = 's:10:"'."\0*\0".'message";';
+        $publicMessageKey = 's:7:"message";';
+
+        yield 'protected-form message key: scanner recognizes it (PHP routes it to $message)' => [
+            $envelopePrefix.':2:{'.$stampsKey.'a:0:{}'.$protectedMessageKey.'O:8:"stdClass":0:{}}',
+            'stdClass',
+        ];
+
+        yield 'public-form message key: scanner recognizes it (PHP routes it to $message)' => [
+            $envelopePrefix.':2:{'.$stampsKey.'a:0:{}'.$publicMessageKey.'O:8:"stdClass":0:{}}',
+            'stdClass',
+        ];
+
+        yield 'private-form message key with unrelated class name: not recognized' => [
+            // PHP only routes "\0<ClassName>\0prop" to Envelope::$prop when <ClassName>
+            // matches the declaring class. So "\0Unrelated\0message" is just a stray
+            // dynamic-like property; Envelope::$message stays uninitialized.
+            $envelopePrefix.':2:{'.$stampsKey.'a:0:{}s:17:"'."\0".'Unrelated'."\0".'message";O:8:"stdClass":0:{}}',
+            null,
+        ];
+
+        yield 'signature bypass attempt: scanner must catch the public-form last-wins override' => [
+            // PHP last-wins → $message = Signed; scanner that ignored public-form key
+            // would return "Unsigned" and let SigningSerializer fall through.
+            $envelopePrefix.':3:{'.$stampsKey.'a:0:{}'.$messageKey.'O:8:"Unsigned":0:{}'.$publicMessageKey.'O:6:"Signed":0:{}}',
+            'Signed',
+        ];
+
+        // Deeply nested stamps: PHP unserialize() refuses past unserialize_max_depth (4096
+        // by default). The scanner must refuse rather than burning CPU descending recursively.
+        $deepNesting = str_repeat('a:1:{i:0;', 10_000).'s:0:"";'.str_repeat('}', 10_000);
+        yield 'deeply nested stamps (DoS guard)' => [
+            $envelopePrefix.':2:{'.$stampsKey.$deepNesting.$messageKey.'O:8:"stdClass":0:{}}',
+            null,
+        ];
     }
 
     protected function createPhpSerializer(): PhpSerializer

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -64,21 +64,96 @@ class PhpSerializer implements SerializerInterface, MessageTypeAwareSerializerIn
             return null;
         }
 
-        try {
-            // Allowing only Envelope means the carried message (and any stamp) becomes a
-            // \__PHP_Incomplete_Class, so no constructor/__wakeup/__unserialize runs.
-            $envelope = @unserialize(stripslashes($body), ['allowed_classes' => [Envelope::class]]);
+        $body = stripslashes($body);
 
-            if (!$envelope instanceof Envelope) {
+        // Fast path: when the body carries no Serializable (`C:`) payload, native
+        // unserialize() with allowed_classes restricted to Envelope is safe and fast.
+        // The carried message becomes a __PHP_Incomplete_Class with no constructor /
+        // __wakeup / __unserialize executed. This skips the in-PHP tokenizer below.
+        if (!str_contains($body, 'C:')) {
+            try {
+                $envelope = @unserialize($body, ['allowed_classes' => [Envelope::class]]);
+
+                if (!$envelope instanceof Envelope) {
+                    return null;
+                }
+                $message = $envelope->getMessage();
+            } catch (\Throwable) {
                 return null;
             }
 
-            $message = $envelope->getMessage();
-        } catch (\Throwable) {
+            return $message instanceof \__PHP_Incomplete_Class ? ((array) $message)['__PHP_Incomplete_Class_Name'] : $message::class;
+        }
+
+        // Slow path: parse the serialized envelope without invoking unserialize() so that
+        // no Serializable payload is mis-decoded as a __PHP_Incomplete_Class (which has no
+        // unserializer for the `C:` format and would trigger a PHP warning, sometimes
+        // returning false).
+        if (!preg_match('/^O:36:"Symfony\\\\Component\\\\Messenger\\\\Envelope":(\d+):\{/', $body, $m)) {
+            return null;
+        }
+        $offset = \strlen($m[0]);
+        $count = (int) $m[1];
+
+        // PHP unserialize() accepts all three property-name encodings and routes any of
+        // them to Envelope::$message, so the scanner must recognize all three forms too,
+        // otherwise an attacker can hide the real message behind a non-canonical key.
+        $messageKeys = [
+            's:45:"'."\0".Envelope::class."\0".'message";',
+            's:10:"'."\0*\0".'message";',
+            's:7:"message";',
+        ];
+        $messageType = null;
+
+        for ($i = 0; $i < $count; ++$i) {
+            $isMessageKey = false;
+            foreach ($messageKeys as $key) {
+                if (0 === substr_compare($body, $key, $offset, \strlen($key))) {
+                    $isMessageKey = true;
+                    break;
+                }
+            }
+
+            if (!self::skipSerializedValue($body, $offset)) {
+                return null;
+            }
+
+            if ($isMessageKey) {
+                if (!preg_match('/\G[OCE]:(\d+):"/A', $body, $m, 0, $offset)) {
+                    return null;
+                }
+                $kind = $body[$offset];
+                $nameLen = (int) $m[1];
+                $nameOffset = $offset + \strlen($m[0]);
+
+                if ($nameLen <= 0 || \strlen($body) < $nameOffset + $nameLen + 1 || '"' !== $body[$nameOffset + $nameLen]) {
+                    return null;
+                }
+
+                $name = substr($body, $nameOffset, $nameLen);
+
+                if ('E' === $kind) {
+                    // Enum: name has the form "FQCN:CaseName"; only the class part matters here.
+                    if (!$colon = strpos($name, ':')) {
+                        return null;
+                    }
+                    $name = substr($name, 0, $colon);
+                }
+
+                // PHP unserialize() uses last-wins for duplicate keys; mirror that semantics.
+                $messageType = $name;
+            }
+
+            if (!self::skipSerializedValue($body, $offset)) {
+                return null;
+            }
+        }
+
+        if (($body[$offset] ?? '') !== '}' || isset($body[$offset + 1])) {
             return null;
         }
 
-        return $message instanceof \__PHP_Incomplete_Class ? ((array) $message)['__PHP_Incomplete_Class_Name'] : $message::class;
+        return $messageType;
     }
 
     public function encode(Envelope $envelope): array
@@ -146,5 +221,122 @@ class PhpSerializer implements SerializerInterface, MessageTypeAwareSerializerIn
     public static function handleUnserializeCallback(string $class): never
     {
         throw new MessageDecodingFailedException(\sprintf('Message class "%s" not found during decoding.', $class));
+    }
+
+    /**
+     * Advances $offset past one PHP-serialized value, without instantiating any object.
+     *
+     * Iterative (manual stack) to avoid PHP function-call overhead on deep payloads.
+     * $maxDepth mirrors PHP's `unserialize_max_depth` so an adversarial deeply-nested
+     * payload can't burn CPU or blow the stack here when native unserialize() would
+     * have rejected it.
+     */
+    private static function skipSerializedValue(string $body, int &$offset, int $maxDepth = 4096): bool
+    {
+        // $remaining[$d] = number of values still to parse at nesting level $d
+        // (one $count pair contributes 2 values: a key and a value).
+        $depth = 0;
+        $remaining = [0 => 1]; // one value to read at the top level
+
+        while (true) {
+            // Close completed nesting levels (`}` per level).
+            while (0 === $remaining[$depth]) {
+                if (0 === $depth) {
+                    return true;
+                }
+                if (($body[$offset] ?? '') !== '}') {
+                    return false;
+                }
+                ++$offset;
+                unset($remaining[$depth--]);
+            }
+
+            --$remaining[$depth];
+
+            if (!isset($body[$offset])) {
+                return false;
+            }
+            $sep = null;
+
+            switch ($kind = $body[$offset]) {
+                case 'N': // N;
+                case 'b': // b:0; or b:1;
+                case 'i': // i:NN;
+                case 'd': // d:NN[.NN][E±NN]; or d:INF; / d:NAN;
+                case 'r': // r:NN;
+                case 'R': // R:NN;
+                    $end = $offset + strspn($body, '0123456789+-.:;NbidrRIFAE', $offset);
+                    while (';' !== $body[$end - 1]) {
+                        if (--$end === $offset) {
+                            return false;
+                        }
+                    }
+                    $remaining[$depth] -= substr_count($body, ';', $offset, $end - $offset) - 1;
+                    $offset = $end;
+                    break;
+
+                case 'a': // a:NN:{<key>;<value>; ...}
+                    if (':' !== ($body[$offset + 1] ?? '')) {
+                        return false;
+                    }
+                    $d = strspn($body, '0123456789', $offset + 2);
+                    if (0 === $d || '{' !== ($body[$offset + 3 + $d] ?? '') || ':' !== $body[$offset + 2 + $d]) {
+                        return false;
+                    }
+                    if (++$depth > $maxDepth) {
+                        return false;
+                    }
+                    $remaining[$depth] = (int) substr($body, $offset + 2, $d) << 1;
+                    $offset += 4 + $d;
+                    break;
+
+                case 's': // s:NN:"...";
+                case 'E': // E:NN:"<FQCN>:<case>";
+                    $sep = ';';
+                    // no break;
+                case 'O': // O:NN:"FQCN":NN:{<key>;<value>; ...}
+                case 'C': // C:NN:"FQCN":NN:{<opaque payload>}
+                    $sep ??= ':';
+                    if (':' !== ($body[$offset + 1] ?? '')) {
+                        return false;
+                    }
+                    $d = strspn($body, '0123456789', $offset + 2);
+                    if (0 === $d || '"' !== ($body[$offset + 3 + $d] ?? '') || ':' !== $body[$offset + 2 + $d]) {
+                        return false;
+                    }
+                    $offset += 4 + $d + (int) substr($body, $offset + 2, $d);
+                    if (($body[$offset + 1] ?? '') !== $sep || '"' !== $body[$offset]) {
+                        return false;
+                    }
+                    $offset += 2;
+                    if (';' === $sep) {
+                        break;
+                    }
+
+                    $d = strspn($body, '0123456789', $offset);
+                    if (0 === $d || '{' !== ($body[$offset + 1 + $d] ?? '') || ':' !== $body[$offset + $d]) {
+                        return false;
+                    }
+                    $count = (int) substr($body, $offset, $d);
+                    $offset += 2 + $d;
+                    if ('O' === $kind) {
+                        if (++$depth > $maxDepth) {
+                            return false;
+                        }
+                        $remaining[$depth] = $count << 1;
+                    } else {
+                        // C: opaque payload of $count bytes followed by `}`.
+                        $offset += $count;
+                        if (($body[$offset] ?? '') !== '}') {
+                            return false;
+                        }
+                        ++$offset;
+                    }
+                    break;
+
+                default:
+                    return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64257
| License       | MIT
