### PR TITLE
[Tui] Add CollapsibleWidget

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `CollapsibleWidget` for collapsible detail/summary panels
  * Add `AnsiUtils::walkCells()` to iterate the cells and escape sequences of a rendered line
  * Add `AnsiUtils::sliceToWidth()` to extract a fixed-width range of columns from a line
  * Add `AbstractWidget::postRender()` to post-process a widget's finished lines, chrome included

--- a/src/Symfony/Component/Tui/Event/CollapseEvent.php
+++ b/src/Symfony/Component/Tui/Event/CollapseEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Event;
+
+/**
+ * Event dispatched when a CollapsibleWidget is collapsed.
+ *
+ * @experimental
+ *
+ * @author Sylvain Blondeau <contact@sylvainblondeau.dev>
+ */
+class CollapseEvent extends AbstractEvent
+{
+}

--- a/src/Symfony/Component/Tui/Event/ExpandEvent.php
+++ b/src/Symfony/Component/Tui/Event/ExpandEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Event;
+
+/**
+ * Event dispatched when a CollapsibleWidget is expanded.
+ *
+ * @experimental
+ *
+ * @author Sylvain Blondeau <contact@sylvainblondeau.dev>
+ */
+class ExpandEvent extends AbstractEvent
+{
+}

--- a/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
+++ b/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Style;
 
 use Symfony\Component\Tui\Widget\CancellableLoaderWidget;
+use Symfony\Component\Tui\Widget\CollapsibleWidget;
 use Symfony\Component\Tui\Widget\EditorWidget;
 use Symfony\Component\Tui\Widget\InputWidget;
 use Symfony\Component\Tui\Widget\LoaderWidget;
@@ -53,6 +54,11 @@ final class DefaultStyleSheet
 
             // CancellableLoaderWidget
             CancellableLoaderWidget::class.':focus' => new Style()->withBold(),
+
+            // CollapsibleWidget
+            CollapsibleWidget::class.'::symbol:focus' => new Style()->withReverse(),
+            CollapsibleWidget::class.'::summary:focus' => new Style()->withReverse(),
+            CollapsibleWidget::class.'::description' => new Style()->withColor('gray'),
 
             // LoaderWidget
             LoaderWidget::class.'::spinner' => new Style()->withColor('cyan'),

--- a/src/Symfony/Component/Tui/Tests/Widget/CollapsibleWidgetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/CollapsibleWidgetTest.php
@@ -1,0 +1,516 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Widget;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Event\ChangeEvent;
+use Symfony\Component\Tui\Event\CollapseEvent;
+use Symfony\Component\Tui\Event\ExpandEvent;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Style\Style;
+use Symfony\Component\Tui\Style\StyleSheet;
+use Symfony\Component\Tui\Terminal\VirtualTerminal;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\CollapsibleWidget;
+use Symfony\Component\Tui\Widget\EditorWidget;
+use Symfony\Component\Tui\Widget\InputWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+use Symfony\Component\Tui\Widget\WidgetContext;
+
+final class CollapsibleWidgetTest extends TestCase
+{
+    public function testDefaultStateIsCollapsed()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+
+        $this->assertFalse($widget->isExpanded());
+    }
+
+    public function testCanBeConstructedExpanded()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'), expanded: true);
+
+        $this->assertTrue($widget->isExpanded());
+    }
+
+    public function testGetSummaryReturnsString()
+    {
+        $widget = new CollapsibleWidget('My Title', new TextWidget('Content'));
+
+        $this->assertSame('My Title', $widget->getSummary());
+    }
+
+    public function testNoDescriptionByDefault()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+
+        $this->assertNull($widget->getDescription());
+    }
+
+    public function testDescriptionCanBeSetViaConstructor()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'), description: '[3]');
+
+        $this->assertSame('[3]', $widget->getDescription());
+    }
+
+    public function testAllIsEmptyWhenCollapsed()
+    {
+        $content = new TextWidget('Content');
+        $widget = new CollapsibleWidget('Title', $content);
+
+        $this->assertSame([], $widget->all());
+    }
+
+    public function testContentInAllWhenExpanded()
+    {
+        $content = new TextWidget('Content');
+        $widget = new CollapsibleWidget('Title', $content, expanded: true);
+
+        $this->assertSame([$content], $widget->all());
+    }
+
+    public function testContentParentIsSetWhenExpanded()
+    {
+        $content = new TextWidget('Content');
+        $widget = new CollapsibleWidget('Title', $content, expanded: true);
+
+        $this->assertSame($widget, $content->getParent());
+    }
+
+    public function testToggleExpandsAndCollapses()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+
+        $widget->toggle();
+        $this->assertTrue($widget->isExpanded());
+
+        $widget->toggle();
+        $this->assertFalse($widget->isExpanded());
+    }
+
+    public function testToggleWiresAndReleasesTheContent()
+    {
+        $content = new TextWidget('Content');
+        $widget = new CollapsibleWidget('Title', $content);
+
+        $widget->toggle();
+        $this->assertSame($widget, $content->getParent());
+
+        $widget->toggle();
+        $this->assertNull($content->getParent());
+    }
+
+    public function testExpandIsIdempotent()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+
+        $widget->expand();
+        $widget->expand();
+
+        $this->assertTrue($widget->isExpanded());
+    }
+
+    public function testCollapseIsIdempotent()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'), expanded: true);
+
+        $widget->collapse();
+        $widget->collapse();
+
+        $this->assertFalse($widget->isExpanded());
+    }
+
+    public function testSetSummaryIsFluentInterface()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+
+        $this->assertSame($widget, $widget->setSummary('New Title'));
+        $this->assertSame('New Title', $widget->getSummary());
+    }
+
+    public function testSetDescriptionIsFluentInterface()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+
+        $this->assertSame($widget, $widget->setDescription('[5]'));
+        $this->assertSame('[5]', $widget->getDescription());
+    }
+
+    public function testSetDescriptionCanClearIt()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'), description: '[3]');
+
+        $widget->setDescription(null);
+
+        $this->assertNull($widget->getDescription());
+    }
+
+    public function testDispatchesExpandEvent()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+        $called = false;
+
+        $widget->on(ExpandEvent::class, function (ExpandEvent $event) use (&$called, $widget) {
+            $called = true;
+            $this->assertSame($widget, $event->getTarget());
+        });
+
+        $widget->toggle();
+
+        $this->assertTrue($called);
+    }
+
+    public function testDispatchesCollapseEvent()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'), expanded: true);
+        $called = false;
+
+        $widget->on(CollapseEvent::class, static function () use (&$called) {
+            $called = true;
+        });
+
+        $widget->toggle();
+
+        $this->assertTrue($called);
+    }
+
+    public function testExpandDoesNotDispatchEventWhenAlreadyExpanded()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'), expanded: true);
+        $called = false;
+
+        $widget->on(ExpandEvent::class, static function () use (&$called) {
+            $called = true;
+        });
+
+        $widget->expand();
+
+        $this->assertFalse($called);
+    }
+
+    public function testCollapseDoesNotDispatchEventWhenAlreadyCollapsed()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+        $called = false;
+
+        $widget->on(CollapseEvent::class, static function () use (&$called) {
+            $called = true;
+        });
+
+        $widget->collapse();
+
+        $this->assertFalse($called);
+    }
+
+    public function testSetContentReplacesContent()
+    {
+        $content1 = new TextWidget('First');
+        $content2 = new TextWidget('Second');
+        $widget = new CollapsibleWidget('Title', $content1, expanded: true);
+
+        $widget->setContent($content2);
+
+        $this->assertSame([$content2], $widget->all());
+        $this->assertNull($content1->getParent());
+        $this->assertSame($widget, $content2->getParent());
+    }
+
+    public function testSetContentIsFluentInterface()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('First'));
+
+        $result = $widget->setContent(new TextWidget('Second'));
+
+        $this->assertSame($widget, $result);
+    }
+
+    public function testSetContentWhileCollapsedAppearsAfterExpand()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Old'));
+        $context = $this->attachWithTui($widget);
+
+        $widget->setContent(new TextWidget('New content'));
+        $widget->expand();
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $plain = AnsiUtils::stripAnsiCodes(implode("\n", $lines));
+
+        $this->assertStringContainsString('New content', $plain);
+        $this->assertStringNotContainsString('Old', $plain);
+    }
+
+    public function testSetContentWhileCollapsedKeepsTheReplacedContentListeners()
+    {
+        $old = new TextWidget('Old');
+        $widget = new CollapsibleWidget('Title', $old);
+        $this->attachWithTui($widget);
+        $old->on(ChangeEvent::class, static fn () => null);
+
+        $widget->setContent(new TextWidget('New'));
+
+        $this->assertTrue($old->hasListeners(ChangeEvent::class));
+    }
+
+    public function testSetSummaryUpdatesRender()
+    {
+        $widget = new CollapsibleWidget('Old Title', new TextWidget('Content'));
+        $context = $this->attachWithTui($widget);
+
+        $widget->setSummary('New Title');
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $firstLine = AnsiUtils::stripAnsiCodes($lines[0] ?? '');
+
+        $this->assertStringContainsString('New Title', $firstLine);
+        $this->assertStringNotContainsString('Old Title', $firstLine);
+    }
+
+    public function testSymbolPrefixedOnFirstSummaryLine()
+    {
+        $widget = new CollapsibleWidget('My Title', new TextWidget('Content'));
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $firstLine = AnsiUtils::stripAnsiCodes($lines[0] ?? '');
+
+        $this->assertStringStartsWith('▶ My Title', $firstLine);
+
+        $widget->toggle();
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $firstLine = AnsiUtils::stripAnsiCodes($lines[0] ?? '');
+
+        $this->assertStringStartsWith('▼ My Title', $firstLine);
+    }
+
+    public function testCustomSymbols()
+    {
+        $widget = new CollapsibleWidget(
+            summary: 'Title',
+            content: new TextWidget('Content'),
+            collapsedSymbol: '+',
+            expandedSymbol: '-',
+        );
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $this->assertStringStartsWith('+ Title', AnsiUtils::stripAnsiCodes($lines[0] ?? ''));
+
+        $widget->toggle();
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $this->assertStringStartsWith('- Title', AnsiUtils::stripAnsiCodes($lines[0] ?? ''));
+    }
+
+    public function testDescriptionIsRightAligned()
+    {
+        $widget = new CollapsibleWidget('Settings', new TextWidget('Content'), description: '[3]');
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $firstLine = AnsiUtils::stripAnsiCodes($lines[0] ?? '');
+
+        $this->assertMatchesRegularExpression('/^▶ Settings\s+\[3\]$/', $firstLine);
+        $this->assertSame(40, AnsiUtils::visibleWidth($firstLine));
+    }
+
+    public function testDescriptionWrapsToNextLineWhenNoSpace()
+    {
+        $widget = new CollapsibleWidget('VeryLongSummary', new TextWidget('Content'), description: '[desc]');
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(20, 10));
+
+        $this->assertCount(2, $lines);
+        $this->assertStringContainsString('[desc]', AnsiUtils::stripAnsiCodes($lines[1]));
+    }
+
+    public function testLongSummaryIsTruncatedToTheAvailableWidth()
+    {
+        $widget = new CollapsibleWidget(str_repeat('Long summary ', 5), new TextWidget('Content'));
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(20, 10));
+
+        $this->assertLessThanOrEqual(20, AnsiUtils::visibleWidth($lines[0]));
+    }
+
+    public function testWrappedDescriptionIsTruncatedToTheAvailableWidth()
+    {
+        $widget = new CollapsibleWidget('Summary', new TextWidget('Content'), description: str_repeat('description ', 5));
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(20, 10));
+
+        $this->assertCount(2, $lines);
+        $this->assertLessThanOrEqual(20, AnsiUtils::visibleWidth($lines[1]));
+    }
+
+    public function testContentRenderedWhenExpanded()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Hello content'));
+        $context = $this->attachWithTui($widget);
+
+        $widget->toggle();
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $plain = AnsiUtils::stripAnsiCodes(implode("\n", $lines));
+
+        $this->assertStringContainsString('Hello content', $plain);
+    }
+
+    public function testContentNotRenderedWhenCollapsed()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Hidden content'));
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+        $plain = AnsiUtils::stripAnsiCodes(implode("\n", $lines));
+
+        $this->assertStringNotContainsString('Hidden content', $plain);
+    }
+
+    public function testNestedCollapsiblesRender()
+    {
+        $inner = new CollapsibleWidget('Inner', new TextWidget('Deep content'), expanded: true);
+        $outer = new CollapsibleWidget('Outer', $inner, expanded: true);
+        $context = $this->attachWithTui($outer);
+
+        $lines = $context->renderWidget($outer, new RenderContext(40, 10));
+        $plain = AnsiUtils::stripAnsiCodes(implode("\n", $lines));
+
+        $this->assertStringContainsString('Outer', $plain);
+        $this->assertStringContainsString('Inner', $plain);
+        $this->assertStringContainsString('Deep content', $plain);
+    }
+
+    public function testExpandedContentFitsTheRowBudget()
+    {
+        $editor = (new EditorWidget())->expandVertically(true);
+        $editor->setText(implode("\n", array_map(static fn (int $i) => "line $i", range(1, 20))));
+        $widget = new CollapsibleWidget('Title', $editor, expanded: true);
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+
+        $this->assertCount(10, $lines);
+        $this->assertStringContainsString('line 1', AnsiUtils::stripAnsiCodes(implode("\n", $lines)));
+    }
+
+    public function testExpandedContentFitsTheRowBudgetWithAWrappedDescription()
+    {
+        $editor = (new EditorWidget())->expandVertically(true);
+        $editor->setText(implode("\n", array_map(static fn (int $i) => "line $i", range(1, 20))));
+        $widget = new CollapsibleWidget('VeryLongSummary', $editor, expanded: true, description: '[desc]');
+        $context = $this->attachWithTui($widget);
+
+        $lines = $context->renderWidget($widget, new RenderContext(20, 10));
+
+        $this->assertStringContainsString('[desc]', AnsiUtils::stripAnsiCodes($lines[1]));
+        $this->assertCount(10, $lines);
+    }
+
+    public function testKeybindingsToggleExpandAndCollapse()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+        $this->attachWithTui($widget);
+
+        $widget->handleInput("\r");
+        $this->assertTrue($widget->isExpanded());
+
+        $widget->handleInput("\r");
+        $this->assertFalse($widget->isExpanded());
+
+        $widget->handleInput("\e[C");
+        $this->assertTrue($widget->isExpanded());
+
+        $widget->handleInput("\e[D");
+        $this->assertFalse($widget->isExpanded());
+    }
+
+    public function testFocusedHeaderIsReversedByDefault()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+        $context = $this->attachWithTui($widget);
+
+        $widget->setFocused(true);
+        $lines = $context->renderWidget($widget, new RenderContext(40, 10));
+
+        $this->assertStringContainsString("\e[7m", $lines[0]);
+    }
+
+    public function testFocusStyleIsDrivenByTheStylesheet()
+    {
+        $widget = new CollapsibleWidget('Title', new TextWidget('Content'));
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+        $tui->addStyleSheet(new StyleSheet([
+            CollapsibleWidget::class.'::summary:focus' => new Style(underline: true),
+        ]));
+        $tui->add($widget);
+
+        $widget->setFocused(true);
+        $lines = $widget->getContext()->renderWidget($widget, new RenderContext(40, 10));
+
+        $this->assertStringContainsString("\e[4m", $lines[0]);
+    }
+
+    public function testCollapsingReturnsFocusToTheHeader()
+    {
+        $input = new InputWidget();
+        $widget = new CollapsibleWidget('Title', $input, expanded: true);
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($widget);
+
+        $tui->setFocus($input);
+        $this->assertTrue($input->isFocused());
+
+        $widget->collapse();
+
+        $this->assertSame($widget, $tui->getFocus());
+        $this->assertTrue($widget->isFocused());
+        $this->assertFalse($input->isFocused());
+    }
+
+    public function testCollapsedContentIsNotFocusReachable()
+    {
+        $input = new InputWidget();
+        $widget = new CollapsibleWidget('Title', $input, expanded: true);
+        $tui = new Tui(terminal: new VirtualTerminal(80, 24));
+        $tui->add($widget);
+        $focusManager = $tui->getFocusManager();
+
+        $this->assertContains($input, $focusManager->all());
+
+        $widget->collapse();
+
+        $this->assertNotContains($input, $focusManager->all());
+        $focusManager->focusNext();
+        $this->assertSame($widget, $tui->getFocus());
+
+        $widget->expand();
+
+        $focusManager->focusNext();
+        $this->assertSame($input, $tui->getFocus());
+    }
+
+    private function attachWithTui(CollapsibleWidget $widget): WidgetContext
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+        $tui->add($widget);
+
+        return $widget->getContext();
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/CollapsibleWidget.php
+++ b/src/Symfony/Component/Tui/Widget/CollapsibleWidget.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Event\CollapseEvent;
+use Symfony\Component\Tui\Event\ExpandEvent;
+use Symfony\Component\Tui\Input\Key;
+use Symfony\Component\Tui\Render\RenderContext;
+
+/**
+ * A collapsible panel with a summary header and expandable content.
+ *
+ * Mirrors the HTML <details>/<summary> pattern. The summary is always
+ * visible; the content is shown only when expanded.
+ *
+ * Usage:
+ *
+ *     // Basic
+ *     $collapsible = new CollapsibleWidget('Settings', new TextWidget('Content…'));
+ *
+ *     // With a description (right-aligned in the header)
+ *     $collapsible = new CollapsibleWidget('Settings', $list, description: '[3 items]');
+ *
+ *     // Listen to events
+ *     $collapsible->on(ExpandEvent::class, fn () => ...);
+ *     $collapsible->on(CollapseEvent::class, fn () => ...);
+ *
+ * Default keybindings: Enter/Space to toggle, Right to expand, Left to collapse.
+ *
+ * The header parts are styleable via the stylesheet, with an optional
+ * :focus state:
+ *
+ *     $stylesheet->addRule(CollapsibleWidget::class.'::symbol', new Style(bold: true));
+ *     $stylesheet->addRule(CollapsibleWidget::class.'::summary:focus', new Style(bold: true));
+ *     $stylesheet->addRule(CollapsibleWidget::class.'::description', new Style(color: 'gray'));
+ *
+ * @experimental
+ *
+ * @author Sylvain Blondeau <contact@sylvainblondeau.dev>
+ */
+class CollapsibleWidget extends AbstractWidget implements FocusableInterface, ParentInterface
+{
+    use FocusableTrait;
+    use KeybindingsTrait;
+
+    public function __construct(
+        private string $summary,
+        private AbstractWidget $content,
+        private bool $expanded = false,
+        private ?string $description = null,
+        private readonly string $collapsedSymbol = '▶',
+        private readonly string $expandedSymbol = '▼',
+    ) {
+        if ($expanded) {
+            $this->attachChild($content);
+        }
+    }
+
+    public function getSummary(): string
+    {
+        return $this->summary;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setSummary(string $summary): static
+    {
+        if ($this->summary !== $summary) {
+            $this->summary = $summary;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDescription(?string $description): static
+    {
+        if ($this->description !== $description) {
+            $this->description = $description;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function getContent(): AbstractWidget
+    {
+        return $this->content;
+    }
+
+    /**
+     * Replace the content widget.
+     *
+     * When expanded, the old content leaves the widget tree and the new
+     * one takes its place.
+     *
+     * @return $this
+     */
+    public function setContent(AbstractWidget $content): static
+    {
+        if ($content === $this->content) {
+            return $this;
+        }
+
+        if ($this->expanded) {
+            $this->detachChild($this->content);
+        }
+        $this->content = $content;
+        if ($this->expanded) {
+            $this->attachChild($content);
+        }
+        $this->invalidate();
+
+        return $this;
+    }
+
+    public function isExpanded(): bool
+    {
+        return $this->expanded;
+    }
+
+    public function toggle(): void
+    {
+        $this->expanded = !$this->expanded;
+        if ($this->expanded) {
+            $this->attachChild($this->content);
+            $this->dispatch(new ExpandEvent($this));
+        } else {
+            $this->detachChild($this->content);
+            $this->dispatch(new CollapseEvent($this));
+        }
+        $this->invalidate();
+    }
+
+    public function expand(): void
+    {
+        if (!$this->expanded) {
+            $this->toggle();
+        }
+    }
+
+    public function collapse(): void
+    {
+        if ($this->expanded) {
+            $this->toggle();
+        }
+    }
+
+    public function all(): array
+    {
+        return $this->expanded ? [$this->content] : [];
+    }
+
+    public function render(RenderContext $context): array
+    {
+        $columns = $context->getColumns();
+        $symbol = $this->expanded ? $this->expandedSymbol : $this->collapsedSymbol;
+        $header = $this->applyElement('symbol', $symbol).' '.$this->applyElement('summary', $this->summary);
+        $description = null !== $this->description ? $this->applyElement('description', $this->description) : null;
+
+        $lines = [];
+
+        if (null !== $description && ($spacing = $columns - AnsiUtils::visibleWidth($header) - AnsiUtils::visibleWidth($description)) >= 1) {
+            $lines[] = $header.str_repeat(' ', $spacing).$description;
+        } else {
+            $lines[] = AnsiUtils::truncateToWidth($header, $columns);
+            if (null !== $description) {
+                $indent = str_repeat(' ', AnsiUtils::visibleWidth($symbol) + 1);
+                $lines[] = AnsiUtils::truncateToWidth($indent.$description, $columns);
+            }
+        }
+
+        if ($this->expanded && null !== $widgetContext = $this->getContext()) {
+            $contentContext = $context->withRows(max(0, $context->getRows() - \count($lines)));
+            array_push($lines, ...$widgetContext->renderWidget($this->content, $contentContext));
+        }
+
+        return $lines;
+    }
+
+    public function handleInput(string $data): void
+    {
+        if (null !== $this->onInput && ($this->onInput)($data)) {
+            return;
+        }
+
+        $kb = $this->getKeybindings();
+        if ($kb->matches($data, 'expand')) {
+            $this->expand();
+        } elseif ($kb->matches($data, 'collapse')) {
+            $this->collapse();
+        } elseif ($kb->matches($data, 'toggle')) {
+            $this->toggle();
+        }
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    protected static function getDefaultKeybindings(): array
+    {
+        return [
+            'toggle' => [Key::ENTER, Key::SPACE],
+            'expand' => [Key::RIGHT],
+            'collapse' => [Key::LEFT],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT


## Description

Adds `CollapsibleWidget`, a focusable widget that mirrors the HTML `<details>`/`<summary>` pattern: a header line is always visible, and the content widget is shown only when expanded.

## Usage

```php
use Symfony\Component\Tui\Widget\CollapsibleWidget;
use Symfony\Component\Tui\Widget\TextWidget;

// Basic
$collapsible = new CollapsibleWidget(summary: 'Settings', content: new TextWidget('Content…'));

// With a description (right-aligned, wraps to next line if not enough space)
$collapsible = new CollapsibleWidget('Settings', $contentWidget, description: '[3 items]');

// Expanded by default
$collapsible = new CollapsibleWidget('Settings', $contentWidget, expanded: true);

// Custom symbols
$collapsible = new CollapsibleWidget('Settings', $contentWidget, collapsedSymbol: '+', expandedSymbol: '-');

// Update at runtime
$collapsible->setSummary('New title');
$collapsible->setDescription('5 items');
$collapsible->setContent($newWidget);

// React to state changes
$collapsible->on(ExpandEvent::class, fn(ExpandEvent $e) => ...);
$collapsible->on(CollapseEvent::class, fn(CollapseEvent $e) => ...);
```

## Examples

**Basic - Collapsed**
<img width="527" height="78" alt="image" src="https://github.com/user-attachments/assets/d356ec4f-f73e-4e2d-94d2-ab8843afb460" />

**Basic - Expanded**
<img width="527" height="78" alt="image" src="https://github.com/user-attachments/assets/e3a52b1a-2e6a-4fcd-86d9-0f02a4689f1a" />

**Alternative symbol, description - Collapsed **
<img width="542" height="52" alt="image" src="https://github.com/user-attachments/assets/9d995871-f5db-4d85-a25f-1f73460ffed2" />

**With rich content - Expanded**
<img width="542" height="275" alt="image" src="https://github.com/user-attachments/assets/8b64625c-be8c-484c-b921-dbdc5768bd1b" />

**Advanced Style**
<img width="542" height="66" alt="image" src="https://github.com/user-attachments/assets/edeb63fc-b0a9-4b8a-85ea-77049e1fa338" />
 
## Keyboard

| Key | Action |
|-----|--------|
| `Enter` / `Space` | Toggle |
| `→` | Expand |
| `←` | Collapse |

Keybindings are customizable via `setKeybindings()`.

## Styling

The three header parts are independently stylable via the stylesheet:

```php
$stylesheet->addRule(CollapsibleWidget::class.'::symbol',      new Style(bold: true));
$stylesheet->addRule(CollapsibleWidget::class.'::summary',     new Style(bold: true));
$stylesheet->addRule(CollapsibleWidget::class.'::description', new Style(foreground: Color::named('gray')));

// Focus state
$stylesheet->addRule(CollapsibleWidget::class.'::symbol:focus',  new Style(foreground: Color::named('blue')));
$stylesheet->addRule(CollapsibleWidget::class.'::summary:focus', new Style(bold: true));
```

By default (from `DefaultStyleSheet`), a focused header renders the symbol and summary reversed and the
description in gray; the screenshots above predate this and show the whole header reversed. Header lines
wider than the available columns are truncated to fit.
