### PR TITLE
[Security] Allow passing extra signed parameters in the login link URL

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -142,6 +142,8 @@ Security
    extends `AuthenticationException`. The firewall no longer turns the failure into a login redirect or a 401, and
    code catching the `Security\Core` exception for this case must catch the `Security\Http` one instead
  * Add argument `$targetUri` to `ImpersonateUrlGenerator::generateImpersonationPath()` and `ImpersonateUrlGenerator::generateImpersonationUrl()`
+ * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()`
+ * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `SignatureHasher::acceptSignatureHash()` and `SignatureHasher::verifySignatureHash()`
 
 SecurityBundle
 --------------

--- a/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
@@ -38,9 +38,14 @@ class FirewallAwareLoginLinkHandler implements LoginLinkHandlerInterface
         $this->requestStack = $requestStack;
     }
 
-    public function createLoginLink(UserInterface $user, ?Request $request = null, ?int $lifetime = null): LoginLinkDetails
+    /**
+     * @param array<string, \Stringable|scalar> $parameters A list of additional query string parameters that should be part of the login link URL
+     */
+    public function createLoginLink(UserInterface $user, ?Request $request = null, ?int $lifetime = null/* , array $parameters = [] */): LoginLinkDetails
     {
-        return $this->getForFirewall()->createLoginLink($user, $request, $lifetime);
+        $parameters = 3 < \func_num_args() ? func_get_arg(3) : [];
+
+        return $this->getForFirewall()->createLoginLink($user, $request, $lifetime, $parameters);
     }
 
     public function consumeLoginLink(Request $request): UserInterface

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow using wildcards as placeholders in the keys of the `RoleHierarchy` map
+ * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `acceptSignatureHash()` and `verifySignatureHash()`
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -47,19 +47,22 @@ class SignatureHasher
      *
      * This method must be called before the user object is loaded from a provider.
      *
-     * @param int    $expires The expiry time as a unix timestamp
-     * @param string $hash    The plaintext hash provided by the request
+     * @param int                               $expires    The expiry time as a unix timestamp
+     * @param string                            $hash       The plaintext hash provided by the request
+     * @param array<string, \Stringable|scalar> $parameters Extra values covered by the signature
      *
      * @throws InvalidSignatureException If the signature does not match the provided parameters
      * @throws ExpiredSignatureException If the signature is no longer valid
      */
-    public function acceptSignatureHash(string $userIdentifier, int $expires, string $hash): void
+    public function acceptSignatureHash(string $userIdentifier, int $expires, string $hash/* , array $parameters = [] */): void
     {
+        $parameters = 3 < \func_num_args() ? func_get_arg(3) : [];
+
         if ($expires < time()) {
             throw new ExpiredSignatureException('Signature has expired.');
         }
         $hmac = substr($hash, 0, 44);
-        $payload = substr($hash, 44).':'.$expires.':'.$userIdentifier;
+        $payload = substr($hash, 44).':'.$expires.':'.$userIdentifier.self::squashParameters($parameters);
 
         if (!hash_equals($hmac, $this->generateHash($payload))) {
             throw new InvalidSignatureException('Invalid or expired signature.');
@@ -69,19 +72,22 @@ class SignatureHasher
     /**
      * Verifies the hash using the provided user and expire time.
      *
-     * @param int    $expires The expiry time as a unix timestamp
-     * @param string $hash    The plaintext hash provided by the request
+     * @param int                               $expires    The expiry time as a unix timestamp
+     * @param string                            $hash       The plaintext hash provided by the request
+     * @param array<string, \Stringable|scalar> $parameters Extra values covered by the signature
      *
      * @throws InvalidSignatureException If the signature does not match the provided parameters
      * @throws ExpiredSignatureException If the signature is no longer valid
      */
-    public function verifySignatureHash(UserInterface $user, int $expires, string $hash): void
+    public function verifySignatureHash(UserInterface $user, int $expires, string $hash/* , array $parameters = [] */): void
     {
+        $parameters = 3 < \func_num_args() ? func_get_arg(3) : [];
+
         if ($expires < time()) {
             throw new ExpiredSignatureException('Signature has expired.');
         }
 
-        if (!hash_equals($hash, $this->computeSignatureHash($user, $expires))) {
+        if (!hash_equals($hash, $this->computeSignatureHash($user, $expires, $parameters))) {
             throw new InvalidSignatureException('Invalid or expired signature.');
         }
 
@@ -97,10 +103,12 @@ class SignatureHasher
     /**
      * Computes the secure hash for the provided user and expire time.
      *
-     * @param int $expires The expiry time as a unix timestamp
+     * @param int                               $expires    The expiry time as a unix timestamp
+     * @param array<string, \Stringable|scalar> $parameters Extra values covered by the signature
      */
-    public function computeSignatureHash(UserInterface $user, int $expires): string
+    public function computeSignatureHash(UserInterface $user, int $expires/* , array $parameters = [] */): string
     {
+        $parameters = 2 < \func_num_args() ? func_get_arg(2) : [];
         $userIdentifier = $user->getUserIdentifier();
         $fieldsHash = hash_init('sha256');
 
@@ -119,9 +127,38 @@ class SignatureHasher
             hash_update($fieldsHash, ':'.$value);
         }
 
+        hash_update($fieldsHash, self::squashParameters($parameters));
+
         $fieldsHash = strtr(base64_encode(hash_final($fieldsHash, true)), '+/=', '-_~');
 
-        return $this->generateHash($fieldsHash.':'.$expires.':'.$userIdentifier).$fieldsHash;
+        return $this->generateHash($fieldsHash.':'.$expires.':'.$userIdentifier.self::squashParameters($parameters)).$fieldsHash;
+    }
+
+    /**
+     * Renders extra parameters as a single string that can take part in the signature.
+     *
+     * @param array<string, \Stringable|scalar> $parameters
+     */
+    private static function squashParameters(array $parameters): string
+    {
+        if (!$parameters) {
+            return '';
+        }
+
+        ksort($parameters);
+
+        $result = '';
+
+        foreach ($parameters as $key => $value) {
+            if (!\is_scalar($value) && !$value instanceof \Stringable) {
+                throw new \InvalidArgumentException(\sprintf('Login link parameter "%s" must be a scalar or a stringable object, "%s" given.', $key, get_debug_type($value)));
+            }
+
+            // booleans travel in the query string as "0" and "1", sign them the same way
+            $result .= ':'.base64_encode($key).'_'.base64_encode(\is_bool($value) ? (string) (int) $value : (string) $value);
+        }
+
+        return $result;
     }
 
     private function generateHash(string $tokenValue): string

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -14,6 +14,8 @@ CHANGELOG
  * Add `ImpersonateUrlGenerator::generateImpersonationForm()` and `generateExitForm()` to build a form that switches the user with a POST
  * Add `$targetUri` argument to `ImpersonateUrlGenerator::generateImpersonationPath()` and `generateImpersonationUrl()`
  * Configure the decorated handler of `CustomAuthenticationSuccessHandler` and `CustomAuthenticationFailureHandler` when they are called instead of when they are built, so that a single handler can be shared by several authenticators
+ * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()` to add extra query parameters covered by the link signature
+ * Expose the verified extra parameters via the `_login_link_parameters` request attribute when consuming a login link
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -29,6 +29,8 @@ use Symfony\Component\Security\Http\ParameterBagUtils;
  */
 final class LoginLinkHandler implements LoginLinkHandlerInterface
 {
+    private const RESERVED_PARAMETERS = ['user', 'expires', 'hash', 'hash_parameters'];
+
     private array $options;
 
     public function __construct(
@@ -43,15 +45,34 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         ], $options);
     }
 
-    public function createLoginLink(UserInterface $user, ?Request $request = null, ?int $lifetime = null): LoginLinkDetails
+    /**
+     * @param array<string, \Stringable|scalar> $parameters Extra query parameters to add to the link and cover with its signature
+     */
+    public function createLoginLink(UserInterface $user, ?Request $request = null, ?int $lifetime = null, array $parameters = []): LoginLinkDetails
     {
+        foreach ($parameters as $name => $value) {
+            if (!\is_string($name) || !preg_match('/^[A-Za-z0-9_.-]++$/', $name)) {
+                throw new \InvalidArgumentException(\sprintf('Login link parameter names must match "[A-Za-z0-9_.-]+", "%s" given.', $name));
+            }
+
+            if (\in_array($name, self::RESERVED_PARAMETERS, true)) {
+                throw new \InvalidArgumentException(\sprintf('Login link parameter name "%s" is reserved.', $name));
+            }
+        }
+
         $expires = time() + ($lifetime ?: $this->options['lifetime']);
         $expiresAt = new \DateTimeImmutable('@'.$expires);
 
+        if ($parameters) {
+            ksort($parameters);
+            $parameters['hash_parameters'] = implode(',', array_keys($parameters));
+        }
+
         $parameters = [
+            ...$parameters,
             'user' => $user->getUserIdentifier(),
             'expires' => $expires,
-            'hash' => $this->signatureHasher->computeSignatureHash($user, $expires),
+            'hash' => $this->signatureHasher->computeSignatureHash($user, $expires, $parameters),
         ];
 
         if ($request) {
@@ -96,12 +117,36 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
             throw new InvalidLoginLinkException('Invalid "expires" parameter.');
         }
 
+        $parameters = [];
+        if (null !== $names = ParameterBagUtils::getRequestParameterValue($request, 'hash_parameters')) {
+            if (!\is_string($names)) {
+                throw new InvalidLoginLinkException('Invalid "hash_parameters" parameter.');
+            }
+
+            foreach (explode(',', $names) as $name) {
+                if (!preg_match('/^[A-Za-z0-9_.-]++$/', $name)) {
+                    throw new InvalidLoginLinkException(\sprintf('Invalid "%s" parameter.', $name));
+                }
+
+                if (null === $value = ParameterBagUtils::getRequestParameterValue($request, $name)) {
+                    throw new InvalidLoginLinkException(\sprintf('Missing "%s" parameter.', $name));
+                }
+                if (!\is_string($value)) {
+                    throw new InvalidLoginLinkException(\sprintf('Invalid "%s" parameter.', $name));
+                }
+
+                $parameters[$name] = $value;
+            }
+
+            $parameters['hash_parameters'] = $names;
+        }
+
         try {
-            $this->signatureHasher->acceptSignatureHash($userIdentifier, $expires, $hash);
+            $this->signatureHasher->acceptSignatureHash($userIdentifier, $expires, $hash, $parameters);
 
             $user = $this->userProvider->loadUserByIdentifier($userIdentifier);
 
-            $this->signatureHasher->verifySignatureHash($user, $expires, $hash);
+            $this->signatureHasher->verifySignatureHash($user, $expires, $hash, $parameters);
         } catch (UserNotFoundException $e) {
             throw new InvalidLoginLinkException('User not found.', 0, $e);
         } catch (ExpiredSignatureException $e) {
@@ -109,6 +154,9 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         } catch (InvalidSignatureException $e) {
             throw new InvalidLoginLinkException(ucfirst(str_ireplace('signature', 'login link', $e->getMessage())), 0, $e);
         }
+
+        unset($parameters['hash_parameters']);
+        $request->attributes->set('_login_link_parameters', $parameters);
 
         return $user;
     }

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -24,12 +24,16 @@ interface LoginLinkHandlerInterface
     /**
      * Generate a link that can be used to authenticate as the given user.
      *
-     * @param int|null $lifetime When not null, the argument overrides any default lifetime previously set
+     * @param int|null                          $lifetime   When not null, the argument overrides any default lifetime previously set
+     * @param array<string, \Stringable|scalar> $parameters A list of additional query string parameters that should be part of the login link URL
      */
-    public function createLoginLink(UserInterface $user, ?Request $request = null, ?int $lifetime = null): LoginLinkDetails;
+    public function createLoginLink(UserInterface $user, ?Request $request = null, ?int $lifetime = null/* , array $parameters = [] */): LoginLinkDetails;
 
     /**
      * Validates if this request contains a login link and returns the associated User.
+     *
+     * Implementations should expose the extra parameters covered by the link signature
+     * via the "_login_link_parameters" request attribute.
      *
      * Throw InvalidLoginLinkExceptionInterface if the link is invalid.
      */

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -263,12 +263,221 @@ class LoginLinkHandlerTest extends TestCase
         $linker->consumeLoginLink($request);
     }
 
-    private function createSignatureHash(string $username, int $expires, array $extraFields = ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash']): string
+    public function testCreateLoginLinkWithExtraParameters()
+    {
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'app_check_login_link_route',
+                $this->callback(function ($parameters) {
+                    $signed = ['hash_parameters' => 'foo,ref', 'foo' => 'bar', 'ref' => '42'];
+
+                    return 'weaverryan' === $parameters['user']
+                        && 'bar' === $parameters['foo']
+                        && '42' === $parameters['ref']
+                        && 'foo,ref' === $parameters['hash_parameters']
+                        && $parameters['hash'] === $this->createSignatureHash('weaverryan', $parameters['expires'], ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'], $signed);
+                }),
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('https://example.com/login/verify');
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+
+        $this->createLinker()->createLoginLink($user, null, null, ['ref' => '42', 'foo' => 'bar']);
+    }
+
+    /**
+     * @param scalar $value
+     */
+    #[DataProvider('provideExtraParameterValues')]
+    public function testConsumeLoginLinkWithExtraParameters($value, string $expected)
+    {
+        $expires = time() + 500;
+        $signed = ['hash_parameters' => 'ref', 'ref' => $value];
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'], $signed);
+
+        $request = Request::create('/login/verify?'.http_build_query([
+            'ref' => $value,
+            'hash_parameters' => 'ref',
+            'user' => 'weaverryan',
+            'expires' => $expires,
+            'hash' => $signature,
+        ]));
+
+        $this->assertSame($expected, $request->query->get('ref'));
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->createUser($user);
+
+        $this->assertEquals($user, $this->createLinker()->consumeLoginLink($request));
+    }
+
+    public static function provideExtraParameterValues(): iterable
+    {
+        yield 'string' => ['bar', 'bar'];
+        yield 'zero int' => [0, '0'];
+        yield 'zero string' => ['0', '0'];
+        yield 'empty string' => ['', ''];
+        yield 'false' => [false, '0'];
+        yield 'true' => [true, '1'];
+    }
+
+    public function testConsumeLoginLinkRejectsATamperedExtraParameter()
+    {
+        $expires = time() + 500;
+        $signed = ['hash_parameters' => 'ref', 'ref' => 'good'];
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'], $signed);
+
+        $request = Request::create('/login/verify?'.http_build_query([
+            'ref' => 'tampered',
+            'hash_parameters' => 'ref',
+            'user' => 'weaverryan',
+            'expires' => $expires,
+            'hash' => $signature,
+        ]));
+
+        $this->userProvider->createUser(new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'));
+
+        $this->expectException(InvalidLoginLinkException::class);
+
+        $this->createLinker()->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkRejectsAStrippedExtraParameter()
+    {
+        $expires = time() + 500;
+        $signed = ['hash_parameters' => 'ref', 'ref' => 'good'];
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'], $signed);
+
+        $request = Request::create('/login/verify?'.http_build_query([
+            'hash_parameters' => 'ref',
+            'user' => 'weaverryan',
+            'expires' => $expires,
+            'hash' => $signature,
+        ]));
+
+        $this->userProvider->createUser(new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'));
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Missing "ref" parameter.');
+
+        $this->createLinker()->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkRejectsAnAppendedParameterWithAnArrayValue()
+    {
+        $expires = time() + 500;
+        $signature = $this->createSignatureHash('weaverryan', $expires);
+
+        $request = Request::create(\sprintf('/login/verify?user=weaverryan&expires=%d&hash=%s&hash_parameters=x&x[]=1', $expires, $signature));
+
+        $this->userProvider->createUser(new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'));
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Invalid "x" parameter.');
+
+        $this->createLinker()->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkRejectsASignedParameterSentAsAnArray()
+    {
+        $expires = time() + 500;
+        $signed = ['hash_parameters' => 'ref', 'ref' => 'good'];
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'], $signed);
+
+        $request = Request::create(\sprintf('/login/verify?ref[]=evil&hash_parameters=ref&user=weaverryan&expires=%d&hash=%s', $expires, $signature));
+
+        $this->userProvider->createUser(new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'));
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Invalid "ref" parameter.');
+
+        $this->createLinker()->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkRejectsAMalformedParameterName()
+    {
+        $expires = time() + 500;
+        $signature = $this->createSignatureHash('weaverryan', $expires);
+
+        $request = Request::create(\sprintf('/login/verify?user=weaverryan&expires=%d&hash=%s&hash_parameters=a[b&a[x]=1', $expires, $signature));
+
+        $this->userProvider->createUser(new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'));
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Invalid "a[b" parameter.');
+
+        $this->createLinker()->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkExposesTheVerifiedParameters()
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->createUser($user);
+        $linker = $this->createLinker();
+
+        $expires = time() + 500;
+        $signed = ['hash_parameters' => 'foo,ref', 'foo' => 'bar', 'ref' => '42'];
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'], $signed);
+
+        $request = Request::create('/login/verify?'.http_build_query([
+            'foo' => 'bar',
+            'ref' => '42',
+            'hash_parameters' => 'foo,ref',
+            'user' => 'weaverryan',
+            'expires' => $expires,
+            'hash' => $signature,
+        ]));
+
+        $linker->consumeLoginLink($request);
+        $this->assertSame(['foo' => 'bar', 'ref' => '42'], $request->attributes->get('_login_link_parameters'));
+
+        $signature = $this->createSignatureHash('weaverryan', $expires);
+        $request = Request::create(\sprintf('/login/verify?user=weaverryan&expires=%d&hash=%s', $expires, $signature));
+
+        $linker->consumeLoginLink($request);
+        $this->assertSame([], $request->attributes->get('_login_link_parameters'));
+    }
+
+    #[DataProvider('provideRejectedParameterNames')]
+    public function testCreateLoginLinkRejectsReservedAndMalformedParameterNames(string $name, string $expectedMessage)
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->createLinker()->createLoginLink($user, null, null, [$name => 'value']);
+    }
+
+    public static function provideRejectedParameterNames(): iterable
+    {
+        yield 'user' => ['user', 'Login link parameter name "user" is reserved.'];
+        yield 'expires' => ['expires', 'Login link parameter name "expires" is reserved.'];
+        yield 'hash' => ['hash', 'Login link parameter name "hash" is reserved.'];
+        yield 'listing' => ['hash_parameters', 'Login link parameter name "hash_parameters" is reserved.'];
+        yield 'comma' => ['a,b', 'Login link parameter names must match "[A-Za-z0-9_.-]+", "a,b" given.'];
+        yield 'brackets' => ['a[b]', 'Login link parameter names must match "[A-Za-z0-9_.-]+", "a[b]" given.'];
+    }
+
+    public function testCreateLoginLinkRejectsAnUnstringableParameterValue()
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Login link parameter "ref" must be a scalar or a stringable object, "stdClass" given.');
+
+        $this->createLinker()->createLoginLink($user, null, null, ['ref' => new \stdClass()]);
+    }
+
+    private function createSignatureHash(string $username, int $expires, array $extraFields = ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'], array $parameters = []): string
     {
         $hasher = new SignatureHasher($this->propertyAccessor, array_keys($extraFields), 's3cret');
         $user = new TestLoginLinkHandlerUser($username, $extraFields['emailProperty'] ?? '', $extraFields['passwordProperty'] ?? '', $extraFields['lastAuthenticatedAt'] ?? null);
 
-        return $hasher->computeSignatureHash($user, $expires);
+        return $hasher->computeSignatureHash($user, $expires, $parameters);
     }
 
     private function createLinker(array $options = [], array $extraProperties = ['emailProperty', 'passwordProperty']): LoginLinkHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`LoginLinkHandlerInterface::createLoginLink()` gains an `array $parameters = []` argument to add extra query parameters to the generated link and cover them with its signature:

```php
$loginLink = $loginLinkHandler->createLoginLink($user, parameters: ['_return_to' => '/account/settings']);
```

The link then contains `_return_to=...&hash_parameters=_return_to` in addition to `user`, `expires` and `hash`. The names listed in `hash_parameters` are covered by the signature, together with the listing itself: tampering with a value, stripping a listed parameter or altering the listing makes the link invalid.

Parameters that are not listed are tolerated and ignored, on purpose: mail security products and clients routinely append tracking parameters to links, and a signature over the whole query string would break every such link. The boundary is: declared parameters are protected against tampering in transit, anything else on the URL is not.

When `consumeLoginLink()` validates a link, it exposes the verified extra parameters via the `_login_link_parameters` request attribute, so success handlers and controllers can read the values with the guarantee that they were part of the signed link:

```php
$returnTo = $request->attributes->get('_login_link_parameters')['_return_to'] ?? null;
```

Parameter names must match `[A-Za-z0-9_.-]+`, and `user`, `expires`, `hash` and `hash_parameters` are reserved. Values must be scalar or stringable; booleans are signed as `0`/`1`, matching how they travel in a query string.

Points the documentation should carry:

- Reading a parameter straight from the query string does not prove it was signed: unlisted parameters are tolerated, so anyone can append them. Read values from the `_login_link_parameters` attribute instead.
- Do not use `_target_path` as the example: `DefaultAuthenticationSuccessHandler` reads it from the raw request for every authenticator, so a `_target_path` appended to a link that never signed one is honored regardless of this feature. Apps that worry about this should set `always_use_default_target_path: true` or use a success handler that reads `_login_link_parameters`.
- Redirecting to the originally requested page after a same-browser login needs no extra parameter: the target path saved in the session when the anonymous visitor hit the protected page is used automatically. In-link parameters are for cross-device clicks and stateless firewalls.
- When using the recommended confirmation page (GET shows a form that POSTs to `check_route`), the form must forward all query parameters. Forgetting one fails closed: the link is rejected as invalid.
