### PR TITLE
[Runtime] Debug is false by default

### DIFF
--- a/src/Symfony/Component/Runtime/GenericRuntime.php
+++ b/src/Symfony/Component/Runtime/GenericRuntime.php
@@ -62,7 +62,7 @@ class GenericRuntime implements RuntimeInterface
         $options['env_var_name'] ??= 'APP_ENV';
         $debugKey = $options['debug_var_name'] ??= 'APP_DEBUG';
 
-        $debug = $options['debug'] ?? $_SERVER[$debugKey] ?? $_ENV[$debugKey] ?? true;
+        $debug = $options['debug'] ?? $_SERVER[$debugKey] ?? $_ENV[$debugKey] ?? false;
 
         if (!\is_bool($debug)) {
             $debug = filter_var($debug, \FILTER_VALIDATE_BOOL);

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -105,7 +105,7 @@ class SymfonyRuntime extends GenericRuntime
             (new Dotenv($envKey, $debugKey))
                 ->setProdEnvs((array) ($options['prod_envs'] ?? ['prod']))
                 ->usePutenv($options['use_putenv'] ?? false)
-                ->bootEnv($options['project_dir'].'/'.($options['dotenv_path'] ?? '.env'), 'dev', (array) ($options['test_envs'] ?? ['test']), $options['dotenv_overload'] ?? false);
+                ->bootEnv($options['project_dir'].'/'.($options['dotenv_path'] ?? '.env'), 'prod', (array) ($options['test_envs'] ?? ['test']), $options['dotenv_overload'] ?? false);
 
             if (isset($this->input) && ($options['dotenv_overload'] ?? false)) {
                 if ($this->input->getParameterOption(['--env', '-e'], $_SERVER[$envKey], true) !== $_SERVER[$envKey]) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT


Debug must be set to false by default. Otherwise, it will cause security issues in production.

---

Well, well, well. How did I end up editing this line?

In our production environment, on a specific page, we were able to see the exception / stack trace page.

Our application was born in the Symfony 2.x era, and we have continuously updated it to the latest Symfony version. But we didn't embrace Flex, nor `.env` at that time. However, two months ago, we decided to use the Symfony Runtime, still without using `.env` yet.

In our front controller, we have:

```php
<?php

use AppBundle\Kernel;

require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';

return static function (array $context) {
    return new Kernel('prod', false);
};

```

You can notice that the `$debug` flag is set to false!

And in our `.env` file, we have nothing.

With this configuration, if something bad happens in a `kernel.request` event (like `$varNotDefined->oups()`), a visitor can see the debug page!!!

How is this possible?

1. The kernel catches the exception.
2. It triggers an `ExceptionEvent` which will eventually call our broken listener again.
3. The exception is thrown again, and the kernel gives up and lets the exception bubble up to the front controller.
4. But the Runtime component had previously registered an error handler (`SymfonyErrorHandler`).
5. This one registers an exception handler (`ErrorHandler`).
6. So it catches the exception and tries to render it properly via `Kernel::terminateWithException()`.
7. But hey, our listener is still broken. So the error handler fails again.
8. So it tries to render the exception via:
    ```php
    private function renderException(\Throwable $exception): void
    {
        $renderer = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? new CliErrorRenderer() : new HtmlErrorRenderer($this->debug);

    ```

And here we go! The debug flag is false, but the exception is rendered with the `HtmlErrorRenderer`, which will display the exception details.


<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
