### PR TITLE
[VarExporter] Various fixes and hardenings

### DIFF
--- a/src/Symfony/Component/VarExporter/DeepCloner.php
+++ b/src/Symfony/Component/VarExporter/DeepCloner.php
@@ -31,6 +31,22 @@ use Symfony\Component\VarExporter\Exception\NotInstantiableTypeException;
  * come from either the native `deepclone` PHP extension (for a 4-5x speedup) or the
  * `symfony/polyfill-deepclone` package when the extension is not loaded.
  *
+ * Security:
+ * A DeepCloner instance is itself safe to serialize and unserialize (its serialized form is
+ * a pure array of scalars and nested arrays, no objects), so it can be round-tripped via
+ * unserialize($data, ['allowed_classes' => [DeepCloner::class]]) without instantiating any
+ * other class at unserialize() time. However, the $allowedClasses discipline that applies
+ * to PHP's native unserialize() extends to clone(), cloneAs(), deepClone() and to the cloner
+ * returned by fromArray(): these are what actually instantiate the inner objects (running
+ * __wakeup() / __unserialize() on them). $allowedClasses = null (the default) lets the cloner
+ * instantiate any class loaded in the process, including classes with side effects in
+ * __wakeup() / __unserialize(), which reproduces the full unserialize-gadget surface.
+ * Callers that obtain a DeepCloner (or its array payload) from an untrusted source MUST pass
+ * an explicit allow-list to the clone methods; pass [] to forbid all classes. Allow-list
+ * violations surface as \ValueError (matching PHP's unserialize() contract), not as
+ * {@see Exception\ExceptionInterface}; callers that want to catch every DeepCloner failure
+ * must catch both.
+ *
  * @template T
  *
  * @author Nicolas Grekas <p@tchwork.com>
@@ -43,6 +59,9 @@ final class DeepCloner
      * @param T                 $value
      * @param list<string>|null $allowedClasses Classes that may be serialized.
      *                                          null (default) allows all classes. An empty array allows none.
+     *
+     * @throws NotInstantiableTypeException When $value (or a nested value) cannot be serialized
+     * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
     public function __construct(mixed $value, ?array $allowedClasses = null)
     {
@@ -56,12 +75,20 @@ final class DeepCloner
     /**
      * Deep-clones a PHP value.
      *
+     * When the input may come from an untrusted source, pass an explicit allow-list:
+     * $allowedClasses = null (default) allows every loaded class to be instantiated,
+     * which runs __wakeup() / __unserialize() on them. Pass [] to forbid all classes.
+     *
      * @template U
      *
      * @param U                 $value
      * @param list<string>|null $allowedClasses classes that may be serialized/deserialized
      *
      * @return U
+     *
+     * @throws ClassNotFoundException       When a class in the graph cannot be loaded
+     * @throws NotInstantiableTypeException When $value (or a nested value) cannot be serialized/instantiated
+     * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
     public static function deepClone(mixed $value, ?array $allowedClasses = null): mixed
     {
@@ -79,10 +106,20 @@ final class DeepCloner
     /**
      * Creates a deep clone of the value.
      *
+     * When this DeepCloner was obtained from an untrusted source (e.g. unserialize() of
+     * attacker-controlled data, or fromArray() on an attacker-controlled payload), the
+     * $allowedClasses argument is the security boundary: $allowedClasses = null (default)
+     * lets any loaded class be instantiated and runs __wakeup() / __unserialize() on it,
+     * reproducing the unserialize-gadget surface. Pass an explicit list (or [] for none).
+     *
      * @param list<string>|null $allowedClasses Classes that may be instantiated.
      *                                          null (default) allows all classes. An empty array allows none.
      *
      * @return T
+     *
+     * @throws ClassNotFoundException       When a class in the graph cannot be loaded
+     * @throws NotInstantiableTypeException When a class in the graph cannot be instantiated
+     * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
     public function clone(?array $allowedClasses = null): mixed
     {
@@ -104,6 +141,12 @@ final class DeepCloner
      *
      * The target class must be compatible with the original (typically in the same hierarchy).
      *
+     * When this DeepCloner was obtained from an untrusted source, the $allowedClasses argument
+     * is the security boundary: $allowedClasses = null (default) lets any loaded class be
+     * instantiated and runs __wakeup() / __unserialize() on it. Pass an explicit list (or []
+     * for none). $class itself is not implicitly allow-listed; include it in $allowedClasses
+     * when restricting.
+     *
      * @template U of object
      *
      * @param class-string<U>   $class
@@ -111,6 +154,11 @@ final class DeepCloner
      *                                          null (default) allows all classes. An empty array allows none.
      *
      * @return U
+     *
+     * @throws LogicException               When the cloned value is not an object
+     * @throws ClassNotFoundException       When $class or another class in the graph cannot be loaded
+     * @throws NotInstantiableTypeException When $class or another class in the graph cannot be instantiated
+     * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
     public function cloneAs(string $class, ?array $allowedClasses = null): object
     {
@@ -165,9 +213,12 @@ final class DeepCloner
     /**
      * Restores a DeepCloner from an array previously created by {@see toArray()}.
      *
-     * @template U
+     * The payload is stored as-is and validated lazily on the first clone() / cloneAs() call.
+     * When $data comes from an untrusted source, the returned cloner must be used with an
+     * explicit $allowedClasses allow-list on clone() / cloneAs(); otherwise any loaded class
+     * referenced in the payload can be instantiated, running its __wakeup() / __unserialize().
      *
-     * @return self<U>
+     * @return self<mixed>
      */
     public static function fromArray(array $data): self
     {

--- a/src/Symfony/Component/VarExporter/README.md
+++ b/src/Symfony/Component/VarExporter/README.md
@@ -11,7 +11,9 @@ of objects:
 - `DeepCloner` deep-clones PHP values while preserving copy-on-write benefits
   for strings and arrays, making it faster and more memory efficient than
   `unserialize(serialize())`;
-- `Lazy*Trait` can make a class behave as a lazy-loading ghost or virtual proxy.
+- `ProxyHelper::generateLazyProxy()` generates lazy-loading decorators for
+  abstract or internal classes and for interfaces (use native lazy objects
+  for regular concrete classes).
 
 The component depends on the native [`ext-deepclone`](https://github.com/symfony/php-ext-deepclone)
 extension for maximum performance, or on [its polyfill](https://github.com/symfony/polyfill/tree/main/src/DeepClone)

--- a/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
@@ -17,10 +17,13 @@ use Symfony\Component\VarExporter\DeepCloner;
 use Symfony\Component\VarExporter\Exception\ClassNotFoundException;
 use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\Exception\NotInstantiableTypeException;
+use Symfony\Component\VarExporter\LazyObjectInterface;
+use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\Tests\Fixtures\FooReadonly;
 use Symfony\Component\VarExporter\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\VarExporter\Tests\Fixtures\GoodNight;
 use Symfony\Component\VarExporter\Tests\Fixtures\MyWakeup;
+use Symfony\Component\VarExporter\Tests\Fixtures\SimpleObject;
 
 class DeepCloneTest extends TestCase
 {
@@ -965,6 +968,55 @@ class DeepCloneTest extends TestCase
         $this->expectException(\ValueError::class);
         $this->expectExceptionMessage('"stdClass" is not allowed');
         DeepCloner::deepClone(new \stdClass(), ['DateTime']);
+    }
+
+    public function testDeepCloneOfLazyProxyMaterializesAndClones()
+    {
+        $initCounter = 0;
+        $proxy = $this->createLazyProxy(SimpleObject::class, static function () use (&$initCounter) {
+            ++$initCounter;
+
+            return new SimpleObject();
+        });
+
+        $this->assertInstanceOf(LazyObjectInterface::class, $proxy);
+        $this->assertFalse($proxy->isLazyObjectInitialized());
+        $this->assertSame(0, $initCounter);
+
+        $clone = DeepCloner::deepClone($proxy);
+
+        $this->assertSame(1, $initCounter, 'DeepCloner triggers initialization via __serialize().');
+        $this->assertNotSame($proxy, $clone);
+        $this->assertInstanceOf(SimpleObject::class, $clone);
+        $this->assertSame('method', $clone->getMethod());
+
+        $alreadyInitialized = $this->createLazyProxy(SimpleObject::class, static fn () => new SimpleObject());
+        $this->assertSame('method', $alreadyInitialized->getMethod());
+        $this->assertTrue($alreadyInitialized->isLazyObjectInitialized());
+
+        $clone = DeepCloner::deepClone($alreadyInitialized);
+        $this->assertInstanceOf(SimpleObject::class, $clone);
+        $this->assertSame('method', $clone->getMethod());
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return T
+     */
+    private function createLazyProxy(string $class, \Closure $initializer): object
+    {
+        $r = new \ReflectionClass($class);
+        $proxyCode = ProxyHelper::generateLazyProxy($r);
+        $proxyClass = str_replace('\\', '_', $class).'_DeepCloneLazy_'.md5($proxyCode);
+
+        if (!class_exists($proxyClass, false)) {
+            eval(($r->isReadOnly() ? 'readonly ' : '').'class '.$proxyClass.' '.$proxyCode);
+        }
+
+        return $proxyClass::createLazyProxy($initializer);
     }
 
     private static function assertPureArray(array $data, string $path = '', bool $root = true): void

--- a/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/HydratorTest.php
@@ -65,6 +65,39 @@ class HydratorTest extends TestCase
 
         $this->assertSame(456, $object->getValue());
     }
+
+    public function testHydrateSplObjectStorageMagicNullKey()
+    {
+        $key1 = new \stdClass();
+        $key2 = new \stdClass();
+        $storage = new \SplObjectStorage();
+
+        Hydrator::hydrate($storage, ["\0" => [$key1, 'info1', $key2, 'info2']]);
+
+        $this->assertCount(2, $storage);
+        $this->assertTrue($storage->contains($key1));
+        $this->assertTrue($storage->contains($key2));
+        $this->assertSame('info1', $storage[$key1]);
+        $this->assertSame('info2', $storage[$key2]);
+    }
+
+    public function testHydrateArrayObjectMagicNullKey()
+    {
+        $arrayObject = new \ArrayObject();
+
+        Hydrator::hydrate($arrayObject, ["\0" => [['a' => 1, 'b' => 2]]]);
+
+        $this->assertSame(['a' => 1, 'b' => 2], $arrayObject->getArrayCopy());
+    }
+
+    public function testHydrateArrayIteratorMagicNullKey()
+    {
+        $iterator = new \ArrayIterator();
+
+        Hydrator::hydrate($iterator, ["\0" => [['x' => 10, 'y' => 20]]]);
+
+        $this->assertSame(['x' => 10, 'y' => 20], $iterator->getArrayCopy());
+    }
 }
 
 class HydratorTestClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

And document the `$allowedClasses` discipline on `DeepCloner::clone()`, `cloneAs()`, `deepClone()` and `fromArray()`.