### PR TITLE
[PasswordHasher] Support stdin input and refine warning in security:hash-password

### DIFF
--- a/src/Symfony/Component/PasswordHasher/CHANGELOG.md
+++ b/src/Symfony/Component/PasswordHasher/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Emit a warning on stderr in `security:hash-password` when the password is passed as a command argument (suppressed under `--no-interaction`), listing the leakage channels: shell history, `ps`, container audit logs
+ * Support reading the password from standard input by passing `-` as the password argument in `security:hash-password`
+
 6.2
 ---
 

--- a/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
+++ b/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
@@ -68,25 +69,32 @@ class UserPasswordHashCommand extends Command
                         App\Entity\User: auto
                 </comment>
 
-                If you execute the command non-interactively, the first available configured
-                user class under the <comment>security.password_hashers</comment> key is used and a random salt is
-                generated to hash the password:
+                Executing the command interactively prompts for the password and uses
+                the first available configured user class under the
+                <comment>security.password_hashers</comment> key:
 
-                  <info>php %command.full_name% --no-interaction [password]</info>
+                  <info>php %command.full_name%</info>
 
                 Pass the full user class path as the second argument to hash passwords for
-                your own entities:
+                your own entities (pass <comment>''</comment> as the first argument to keep the interactive prompt):
+
+                  <info>php %command.full_name% '' 'App\Entity\User'</info>
+
+                Passing the password on the command line is supported for non-interactive
+                use, but exposes the plaintext to shell history and the process list
+                (<comment>ps</comment>, <comment>/proc/&lt;pid&gt;/cmdline</comment>, container audit logs); prefer the
+                interactive form when a terminal is available:
 
                   <info>php %command.full_name% --no-interaction [password] 'App\Entity\User'</info>
 
-                Executing the command interactively allows you to generate a random salt for
-                hashing the password:
+                Read the password from standard input by passing <comment>-</comment> as the password
+                argument; this avoids exposing it to shell history or the process list:
 
-                  <info>php %command.full_name% [password] 'App\Entity\User'</info>
+                  <info>echo \$PASSWORD | php %command.full_name% --no-interaction -</info>
 
                 In case your hasher doesn't require a salt, add the <comment>empty-salt</comment> option:
 
-                  <info>php %command.full_name% --empty-salt [password] 'App\Entity\User'</info>
+                  <info>php %command.full_name% --empty-salt</info>
 
                 EOF
             )
@@ -102,8 +110,11 @@ class UserPasswordHashCommand extends Command
 
         $password = $input->getArgument('password');
 
-        if ($password) {
-            $errorIo->warning('Using a password as a command argument is insecure. Use the interactive mode instead.');
+        if ('-' === $password) {
+            $stream = $input instanceof StreamableInputInterface ? $input->getStream() : null;
+            $password = rtrim(fgets($stream ?? \STDIN) ?: '', "\r\n");
+        } elseif ($password && $input->isInteractive()) {
+            $errorIo->warning('Passing the password as a command argument exposes it to shell history and the process list (ps, /proc/<pid>/cmdline, container audit logs); prefer the interactive prompt or pass "-" to read it from stdin.');
         }
 
         $userClass = $this->getUserClass($input, $io);

--- a/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
@@ -276,6 +276,74 @@ class UserPasswordHashCommandTest extends TestCase
         $this->assertStringContainsString('Hasher used      Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher', $this->passwordHasherCommandTester->getDisplay());
     }
 
+    public function testWarningWhenPasswordPassedAsArgumentInInteractiveMode()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Symfony\Component\Security\Core\User\InMemoryUser',
+            '--empty-salt' => true,
+        ], ['interactive' => true, 'capture_stderr_separately' => true]);
+
+        $errorOutput = $this->passwordHasherCommandTester->getErrorOutput();
+        $this->assertStringContainsString('[WARNING]', $errorOutput);
+        $this->assertStringContainsString('shell history', $errorOutput);
+        $this->assertStringContainsString('process list', $errorOutput);
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testNoWarningWhenPasswordPassedAsArgumentInNonInteractiveMode()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Symfony\Component\Security\Core\User\InMemoryUser',
+            '--empty-salt' => true,
+        ], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getErrorOutput());
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getDisplay());
+        $this->assertStringContainsString('Password hashing succeeded', $this->passwordHasherCommandTester->getErrorOutput());
+    }
+
+    public function testNoWarningWhenPasswordReadInteractively()
+    {
+        $this->passwordHasherCommandTester->setInputs(['p@ssw0rd']);
+        $this->passwordHasherCommandTester->execute([
+            'user-class' => 'Symfony\Component\Security\Core\User\InMemoryUser',
+            '--empty-salt' => true,
+        ], ['interactive' => true, 'capture_stderr_separately' => true]);
+
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getErrorOutput());
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testReadsPasswordFromStdinWhenPasswordIsDashNonInteractive()
+    {
+        $this->passwordHasherCommandTester->setInputs(['p@ssw0rd']);
+        $this->passwordHasherCommandTester->execute([
+            'password' => '-',
+            'user-class' => 'Symfony\Component\Security\Core\User\InMemoryUser',
+            '--empty-salt' => true,
+        ], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getErrorOutput());
+        $this->assertStringContainsString('Password hashing succeeded', $this->passwordHasherCommandTester->getErrorOutput());
+        $this->assertStringContainsString(' Password hash   p@ssw0rd', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testReadsPasswordFromStdinWhenPasswordIsDashInteractive()
+    {
+        $this->passwordHasherCommandTester->setInputs(['p@ssw0rd']);
+        $this->passwordHasherCommandTester->execute([
+            'password' => '-',
+            'user-class' => 'Symfony\Component\Security\Core\User\InMemoryUser',
+            '--empty-salt' => true,
+        ], ['interactive' => true, 'capture_stderr_separately' => true]);
+
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getErrorOutput());
+        $this->assertStringNotContainsString('[WARNING]', $this->passwordHasherCommandTester->getDisplay());
+        $this->assertStringContainsString(' Password hash   p@ssw0rd', $this->passwordHasherCommandTester->getDisplay());
+    }
+
     public function testThrowsExceptionOnNoConfiguredHashers()
     {
         $tester = new CommandTester(new UserPasswordHashCommand(new PasswordHasherFactory([]), []));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR finishes the story started in #64105

It's great to tell about not listing passwords as command line arguments, but interactive mode can't be the only answer - scripts need a way too.

This PR makes `symfony console security:hash-password --no-interaction -` read the password from STDIN.