### PR TITLE
[WebLink] Add missing `Link::AS_*` constants for `rel=preload` / `rel=modulepreload`

### DIFF
--- a/src/Symfony/Component/WebLink/CHANGELOG.md
+++ b/src/Symfony/Component/WebLink/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add `Link::AS_*` constants for the `as` attribute of `rel=preload` / `rel=modulepreload`
+
 7.4
 ---
 

--- a/src/Symfony/Component/WebLink/Link.php
+++ b/src/Symfony/Component/WebLink/Link.php
@@ -147,16 +147,27 @@ class Link implements EvolvableLinkInterface
     // Extra relations
     public const REL_MERCURE = 'mercure';
 
-    // `as` attributes (for `REL_PRELOAD`), according to https://html.spec.whatwg.org/multipage/semantics.html#attr-link-as
+    // `as` attributes for `REL_PRELOAD` only
+    // @see https://html.spec.whatwg.org/multipage/links.html#preload-destination
     public const AS_FETCH = 'fetch';
     public const AS_FONT = 'font';
     public const AS_IMAGE = 'image';
-    public const AS_SCRIPT = 'script';
-    public const AS_STYLE = 'style';
     public const AS_TRACK = 'track';
 
-    // `as` attributes for `REL_MODULEPRELOAD` only, according to https://html.spec.whatwg.org/multipage/semantics.html#module-preload-destination
+    // `as` attributes for both `REL_PRELOAD` and `REL_MODULEPRELOAD`
+    public const AS_SCRIPT = 'script';
+    public const AS_STYLE = 'style';
+
+    // `as` attributes for `REL_MODULEPRELOAD` only
+    // @see https://html.spec.whatwg.org/multipage/links.html#module-preload-destination
+    // @see https://fetch.spec.whatwg.org/#request-destination-script-like
+    public const AS_AUDIOWORKLET = 'audioworklet';
     public const AS_JSON = 'json';
+    public const AS_PAINTWORKLET = 'paintworklet';
+    public const AS_SERVICEWORKER = 'serviceworker';
+    public const AS_SHAREDWORKER = 'sharedworker';
+    public const AS_TEXT = 'text';
+    public const AS_WORKER = 'worker';
 
     /**
      * @var string[]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We added some in https://github.com/symfony/symfony/pull/63427 but forget others.