### PR TITLE
[Security] Fix SwitchUserToken being deauthenticated on every request

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -18,10 +18,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * Base class for Token instances.
  *
  * Note that the token's role names are decoupled from the user's roles on purpose: token roles describe
- * the authentication context (e.g. a `SwitchUserToken` adds `ROLE_PREVIOUS_ADMIN`), not the user's
- * permanent role assignment. This is why `setUser()` only updates the user reference and leaves the
- * role names untouched. `ContextListener` is the component responsible for comparing the stored role
- * names against `$user->getRoles()` and deauthenticating when they diverge.
+ * the authentication context, not the user's permanent role assignment. This is why `setUser()` only
+ * updates the user reference and leaves the role names untouched. `ContextListener` is the component
+ * responsible for comparing the stored role names against `$user->getRoles()` and deauthenticating
+ * when they diverge.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -312,11 +312,6 @@ class ContextListener extends AbstractListener
         }
 
         $userRoles = array_map('strval', (array) $refreshedUser->getRoles());
-
-        if ($token instanceof SwitchUserToken) {
-            $userRoles[] = 'ROLE_PREVIOUS_ADMIN';
-        }
-
         $tokenRoleNames = $token->getRoleNames();
 
         if (

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -237,6 +238,49 @@ class ContextListenerTest extends TestCase
     {
         $refreshedUser = new InMemoryUser('foobar', 'baz');
         $tokenStorage = $this->handleEventWithPreviousSession([new NotSupportingUserProvider(true), new NotSupportingUserProvider(false), new SupportingUserProvider($refreshedUser)]);
+
+        $this->assertNull($tokenStorage->getToken());
+    }
+
+    public function testSwitchUserTokenIsNotDeauthenticatedWhenRolesAreUnchanged()
+    {
+        $impersonated = new InMemoryUser('foo', 'bar', ['ROLE_USER']);
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('admin', 'pass', ['ROLE_ADMIN']), 'context_key', ['ROLE_ADMIN']);
+        $token = new SwitchUserToken($impersonated, 'context_key', $impersonated->getRoles(), $originalToken);
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize($token));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $tokenStorage = new TokenStorage();
+        $listener = new ContextListener($tokenStorage, [new SupportingUserProvider($impersonated)], 'context_key');
+        $listener->authenticate(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertInstanceOf(SwitchUserToken::class, $tokenStorage->getToken());
+        $this->assertSame('foo', $tokenStorage->getToken()->getUserIdentifier());
+        $this->assertSame('admin', $tokenStorage->getToken()->getOriginalToken()->getUserIdentifier());
+    }
+
+    public function testSwitchUserTokenIsDeauthenticatedWhenRolesChange()
+    {
+        $impersonated = new InMemoryUser('foo', 'bar', ['ROLE_USER']);
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('admin', 'pass', ['ROLE_ADMIN']), 'context_key', ['ROLE_ADMIN']);
+        $token = new SwitchUserToken($impersonated, 'context_key', ['ROLE_USER'], $originalToken);
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize($token));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $refreshed = new InMemoryUser('foo', 'bar', ['ROLE_USER', 'ROLE_ADMIN']);
+        $tokenStorage = new TokenStorage();
+        $listener = new ContextListener($tokenStorage, [new SupportingUserProvider($refreshed)], 'context_key');
+        $listener->authenticate(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
 
         $this->assertNull($tokenStorage->getToken());
     }


### PR DESCRIPTION
ContextListener::hasUserChanged() was appending ROLE_PREVIOUS_ADMIN to the refreshed user's roles before comparing them with the token's role names, but SwitchUserListener does not store ROLE_PREVIOUS_ADMIN in the token. The role counts always diverged, so any user impersonation was dropped on the next request.

This branch was reintroduced by mistake; the same code had already been removed in 2023 as unused code. Drop it again, and align AbstractToken's docblock with the actual behavior.

| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #64245  
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
