### PR TITLE
[Translation] Don’t check the error message to know if Lokalise keys are missing

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -144,9 +144,6 @@ final class LokaliseProvider implements ProviderInterface
         }
     }
 
-    /**
-     * @see https://app.lokalise.com/api2docs/curl/#transition-download-files-post
-     */
     private function exportFiles(array $locales, array $domains): array
     {
         $response = $this->client->request('POST', 'files/export', [
@@ -160,18 +157,11 @@ final class LokaliseProvider implements ProviderInterface
             ],
         ]);
 
-        $responseContent = $response->toArray(false);
-
-        if (406 === $response->getStatusCode()
-            && 'No keys found with specified filenames.' === $responseContent['error']['message']
-        ) {
+        if (406 === $response->getStatusCode()) {
             return [];
         }
 
-        if (200 !== $response->getStatusCode()) {
-            if (self::PROJECT_TOO_BIG_STATUS_CODE !== ($responseContent['error']['code'] ?? null)) {
-                throw new ProviderException(\sprintf('Unable to export translations from Lokalise: "%s".', $response->getContent(false)), $response);
-            }
+        if (self::PROJECT_TOO_BIG_STATUS_CODE === $response->getStatusCode()) {
             if (!\extension_loaded('zip')) {
                 throw new ProviderException(\sprintf('Unable to export translations from Lokalise: "%s". Make sure that the "zip" extension is enabled.', $response->getContent(false)), $response);
             }
@@ -179,10 +169,16 @@ final class LokaliseProvider implements ProviderInterface
             return $this->exportFilesAsync($locales, $domains);
         }
 
-        // Lokalise returns languages with "-" separator, we need to reformat them to "_" separator.
-        $reformattedLanguages = array_map(static fn ($language) => str_replace('-', '_', $language), array_keys($responseContent['files']));
+        if (200 !== $response->getStatusCode()) {
+            throw new ProviderException(\sprintf('Unable to export translations from Lokalise: "%s".', $response->getContent(false)), $response);
+        }
 
-        return array_combine($reformattedLanguages, $responseContent['files']);
+        $files = $response->toArray(false)['files'];
+
+        // Lokalise returns languages with "-" separator, we need to reformat them to "_" separator.
+        $reformattedLanguages = array_map(static fn ($language) => str_replace('-', '_', $language), array_keys($files));
+
+        return array_combine($reformattedLanguages, $files);
     }
 
     /**

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -697,6 +697,23 @@ class LokaliseProviderTest extends ProviderTestCase
         }
     }
 
+    public function testReadReturnsEmptyBagWhenLokaliseHasNoKeys()
+    {
+        $response = static fn (): ResponseInterface => new JsonMockResponse(
+            ['error' => ['code' => 406, 'message' => 'No keys for export with current export settings']],
+            ['http_code' => 406],
+        );
+
+        $provider = self::createProvider((new MockHttpClient($response))->withOptions([
+            'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
+            'headers' => ['X-Api-Token' => 'API_KEY'],
+        ]), new XliffFileLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
+
+        $translatorBag = $provider->read(['messages'], ['en']);
+
+        $this->assertSame([], $translatorBag->getCatalogues());
+    }
+
     /**
      * @requires extension zip
      */
@@ -705,7 +722,7 @@ class LokaliseProviderTest extends ProviderTestCase
         $zipLocation = __DIR__.\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR.'Symfony-locale.zip';
         $firstResponse = static fn (): ResponseInterface => new JsonMockResponse(
             ['error' => ['code' => 413, 'message' => 'test']],
-            ['http_code' => 406],
+            ['http_code' => 413],
         );
         $secondResponse = static fn (): ResponseInterface => new JsonMockResponse(
             ['process_id' => 123],
@@ -761,7 +778,7 @@ class LokaliseProviderTest extends ProviderTestCase
     {
         $firstResponse = static fn (): ResponseInterface => new JsonMockResponse(
             ['error' => ['code' => 413, 'message' => 'test']],
-            ['http_code' => 406],
+            ['http_code' => 413],
         );
         $secondResponse = static fn (): ResponseInterface => new JsonMockResponse(
             ['process_id' => 123],


### PR DESCRIPTION
 Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Pushing translations to an empty Lokalise project failed with

> Unable to export translations from Lokalise: "{"error":{"message":"No keys for export with current export settings","code":406}}".

because the provider checks for the following message:

> No keys found with specified filenames.

Since error responses aren’t documented anywhere and the message can change it probably is better not to take it into account.