### PR TITLE
[Tui] Various fixes and hardenings

### DIFF
--- a/src/Symfony/Component/Tui/Event/FocusEvent.php
+++ b/src/Symfony/Component/Tui/Event/FocusEvent.php
@@ -17,6 +17,11 @@ use Symfony\Component\Tui\Widget\FocusableInterface;
 /**
  * Event dispatched when focus changes to a new widget.
  *
+ * Not dispatched when focus is cleared to null. Listeners that need
+ * to know when focus is lost can observe widget removal directly or
+ * track the previous focus via {@see getPrevious()} on subsequent
+ * focus-change events.
+ *
  * @experimental
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Tui/Focus/FocusManager.php
+++ b/src/Symfony/Component/Tui/Focus/FocusManager.php
@@ -129,6 +129,7 @@ class FocusManager
     public function clear(): static
     {
         $this->focusables = [];
+        $this->setFocus(null);
 
         return $this;
     }

--- a/src/Symfony/Component/Tui/Input/StdinBuffer.php
+++ b/src/Symfony/Component/Tui/Input/StdinBuffer.php
@@ -25,6 +25,10 @@ namespace Symfony\Component\Tui\Input;
  */
 final class StdinBuffer
 {
+    private const int MAX_PASTE_BYTES = 16 * 1024 * 1024;
+    private const int MAX_PENDING_BYTES = 1024 * 1024;
+    private const string PASTE_OVERFLOW_MESSAGE = '[paste exceeded 16 MiB limit]';
+
     private string $buffer = '';
 
     /** @var (\Closure(string): void)|null */
@@ -96,6 +100,20 @@ final class StdinBuffer
                     // Still waiting for end marker
                     $this->pasteBuffer .= $this->buffer;
                     $this->buffer = '';
+
+                    // Cap reached without an end marker: discard the partial
+                    // paste and emit a visible overflow notice through the
+                    // paste callback so the user can see why their paste did
+                    // not land. Defense against unbounded buffering from a
+                    // missing/spoofed end marker.
+                    if (\strlen($this->pasteBuffer) > self::MAX_PASTE_BYTES) {
+                        $this->pasteBuffer = '';
+                        $this->inPaste = false;
+
+                        if (null !== $this->onPaste) {
+                            ($this->onPaste)(self::PASTE_OVERFLOW_MESSAGE);
+                        }
+                    }
                 }
                 continue;
             }
@@ -104,7 +122,13 @@ final class StdinBuffer
             $sequence = $this->extractSequence();
 
             if (null === $sequence) {
-                // Buffer might contain incomplete sequence, wait for more data
+                // Buffer might contain incomplete sequence, wait for more data.
+                // If we cross the cap without producing a complete sequence
+                // (e.g. unterminated OSC/DCS), discard the pending buffer
+                // silently to bound memory.
+                if (\strlen($this->buffer) > self::MAX_PENDING_BYTES) {
+                    $this->buffer = '';
+                }
                 break;
             }
 

--- a/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
@@ -117,7 +117,7 @@ final class VirtualTerminal implements TerminalInterface
 
     public function setTitle(string $title): void
     {
-        $safe = preg_replace("/[\x00-\x1f\x7f]/", '', $title);
+        $safe = preg_replace("/[\x00-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $title);
         $this->write("\x1b]0;{$safe}\x07");
     }
 

--- a/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
@@ -416,4 +416,39 @@ class StdinBufferTest extends TestCase
         $buffer->process('A');
         $this->assertSame([bin2hex("\x1b[1;5A")], $sequences);
     }
+
+    public function testUnterminatedPasteAbortsAtCap()
+    {
+        $buffer = new StdinBuffer();
+        $sequences = [];
+        $pastes = [];
+
+        $buffer->onData(static function (string $data) use (&$sequences) { $sequences[] = $data; });
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+
+        $buffer->process("\x1b[200~");
+        $buffer->process(str_repeat('A', 17 * 1024 * 1024));
+
+        $this->assertSame([], $sequences);
+        $this->assertSame(['[paste exceeded 16 MiB limit]'], $pastes);
+
+        $buffer->process('B');
+        $this->assertSame(['B'], $sequences, 'Buffer should accept new input after abort');
+    }
+
+    public function testUnterminatedOscAbortsAtCap()
+    {
+        $buffer = new StdinBuffer();
+        $sequences = [];
+
+        $buffer->onData(static function (string $data) use (&$sequences) { $sequences[] = $data; });
+
+        $buffer->process("\x1b]0;");
+        $buffer->process(str_repeat('A', 2 * 1024 * 1024));
+
+        $this->assertSame([], $sequences);
+
+        $buffer->process('B');
+        $this->assertSame(['B'], $sequences, 'Buffer should accept new input after abort');
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Terminal/VirtualTerminalTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/VirtualTerminalTest.php
@@ -88,6 +88,7 @@ class VirtualTerminalTest extends TestCase
         yield 'strips BEL character' => ["evil\x07injected", "\x1b]0;evilinjected\x07"];
         yield 'strips ESC character' => ["evil\x1b[31mred", "\x1b]0;evil[31mred\x07"];
         yield 'strips all control characters' => ["a\x00b\x01c\x1fd\x7fe", "\x1b]0;abcde\x07"];
+        yield 'strips UTF-8 C1 controls' => ["evil\xc2\x9cinjected", "\x1b]0;evilinjected\x07"];
         yield 'preserves unicode' => ['✓ Complete! 🎉', "\x1b]0;✓ Complete! 🎉\x07"];
     }
 

--- a/src/Symfony/Component/Tui/Tests/Widget/BracketedPasteTraitTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/BracketedPasteTraitTest.php
@@ -73,6 +73,35 @@ class BracketedPasteTraitTest extends TestCase
         $this->assertSame('extra input', $data);
     }
 
+    public function testDataBeforeStartMarkerIsPreserved()
+    {
+        $handler = $this->createHandler();
+
+        $data = "AAA\x1b[200~pasted\x1b[201~BBB";
+        $result = $handler->processBracketedPaste($data);
+
+        $this->assertSame('pasted', $result);
+        $this->assertSame('AAABBB', $data);
+        $this->assertFalse($handler->isBufferingPaste());
+    }
+
+    public function testDataBeforeStartMarkerWithoutEndIsPreservedAsPrefix()
+    {
+        $handler = $this->createHandler();
+
+        $data = "AAA\x1b[200~partial";
+        $result = $handler->processBracketedPaste($data);
+
+        $this->assertNull($result);
+        $this->assertSame('AAA', $data);
+        $this->assertTrue($handler->isBufferingPaste());
+
+        $data = "rest\x1b[201~";
+        $result = $handler->processBracketedPaste($data);
+        $this->assertSame('partialrest', $result);
+        $this->assertSame('', $data);
+    }
+
     public function testNoPasteMarkers()
     {
         $handler = $this->createHandler();
@@ -143,6 +172,26 @@ class BracketedPasteTraitTest extends TestCase
         $data = "\x1b[200~second\x1b[201~";
         $result = $handler->processBracketedPaste($data);
         $this->assertSame('second', $result);
+    }
+
+    public function testUnterminatedPasteAbortsAtCap()
+    {
+        $handler = $this->createHandler();
+
+        $data = "\x1b[200~";
+        $handler->processBracketedPaste($data);
+        $this->assertTrue($handler->isBufferingPaste());
+
+        $data = str_repeat('A', 17 * 1024 * 1024);
+        $result = $handler->processBracketedPaste($data);
+
+        $this->assertSame('[paste exceeded 16 MiB limit]', $result);
+        $this->assertFalse($handler->isBufferingPaste());
+
+        $data = 'plain';
+        $result = $handler->processBracketedPaste($data);
+        $this->assertNull($result);
+        $this->assertSame('plain', $data);
     }
 
     private function createHandler(): BracketedPasteHandler

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
@@ -438,6 +438,23 @@ class EditorDocumentTest extends TestCase
         $this->assertFalse($doc->redo());
     }
 
+    public function testUndoStackIsBoundedByMemoryBudget()
+    {
+        $doc = new EditorDocument();
+        $doc->setText(str_repeat('x', 5 * 1024 * 1024));
+
+        for ($i = 0; $i < 20; ++$i) {
+            $doc->insertText('y');
+        }
+
+        $stack = new \ReflectionProperty($doc, 'undoStack');
+        $entries = $stack->getValue($doc);
+        $this->assertLessThan(10, \count($entries), 'Undo stack should evict snapshots when memory budget is exceeded');
+        $this->assertGreaterThan(0, \count($entries), 'At least one undo snapshot should remain');
+
+        $this->assertTrue($doc->undo());
+    }
+
     // --- Kill Ring ---
 
     public function testYankAndYankPop()

--- a/src/Symfony/Component/Tui/Tests/Widget/Figlet/FigletFontTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Figlet/FigletFontTest.php
@@ -94,4 +94,21 @@ class FigletFontTest extends TestCase
 
         FigletFont::load('/nonexistent/path/to/font.flf');
     }
+
+    public function testLoadZipRejectsOversizedDecompressedEntry()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'flf_zip_').'.zip';
+        try {
+            $zip = new \ZipArchive();
+            $this->assertTrue(true === $zip->open($path, \ZipArchive::CREATE | \ZipArchive::OVERWRITE));
+            $zip->addFromString('bomb.flf', str_repeat('A', 5 * 1024 * 1024));
+            $zip->close();
+
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessageMatches('/too large/i');
+            FigletFont::load($path);
+        } finally {
+            @unlink($path);
+        }
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/LoaderTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/LoaderTest.php
@@ -25,6 +25,7 @@ class LoaderTest extends TestCase
     public function testRenderIncludesBlankLine()
     {
         $loader = new LoaderWidget(message: 'Test');
+        $loader->start();
 
         $lines = $loader->render(new RenderContext(80, 24));
 
@@ -36,6 +37,7 @@ class LoaderTest extends TestCase
     public function testRenderIncludesSpinnerAndMessage()
     {
         $loader = new LoaderWidget(message: 'Working...');
+        $loader->start();
 
         $lines = $loader->render(new RenderContext(80, 24));
         $content = implode('', $lines);
@@ -52,6 +54,7 @@ class LoaderTest extends TestCase
         // from the stylesheet when rendered with a Tui context
         $terminal = new VirtualTerminal(80, 24);
         $loader = new LoaderWidget(message: 'Test');
+        $loader->start();
 
         $stylesheet = new StyleSheet([
             LoaderWidget::class.'::spinner' => new Style()->withBold(),
@@ -72,6 +75,7 @@ class LoaderTest extends TestCase
     public function testSetSpinnerStyle()
     {
         $loader = new LoaderWidget(message: 'Test');
+        $loader->start();
         $loader->setSpinner('line');
 
         $lines = $loader->render(new RenderContext(80, 24));
@@ -95,6 +99,7 @@ class LoaderTest extends TestCase
         LoaderWidget::addSpinner('custom', ['A', 'B', 'C']);
 
         $loader = new LoaderWidget(message: 'Test');
+        $loader->start();
         $loader->setSpinner('custom');
 
         $lines = $loader->render(new RenderContext(80, 24));
@@ -155,6 +160,7 @@ class LoaderTest extends TestCase
         $loader = new LoaderWidget(message: 'Test');
         $loader->setSpinner('line');
         $loader->setIntervalMs(80);
+        $loader->start();
 
         $loader->tick(0.24);
         $this->assertSame('/', $loader->getSpinnerFrame());
@@ -174,9 +180,21 @@ class LoaderTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $tui = new Tui(terminal: $terminal);
         $loader = new LoaderWidget();
+        $loader->start();
         $tui->add($loader);
 
         $this->assertNotNull($this->getScheduledTickId($loader));
+    }
+
+    public function testNotStartedLoaderDoesNotScheduleTickOnAttach()
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+        $loader = new LoaderWidget();
+        $tui->add($loader);
+
+        $this->assertNull($this->getScheduledTickId($loader));
+        $this->assertFalse($loader->isRunning());
     }
 
     public function testDetachClearsScheduledTickId()
@@ -184,6 +202,7 @@ class LoaderTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $tui = new Tui(terminal: $terminal);
         $loader = new LoaderWidget();
+        $loader->start();
         $tui->add($loader);
         $this->assertNotNull($this->getScheduledTickId($loader));
 
@@ -196,6 +215,7 @@ class LoaderTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $tui = new Tui(terminal: $terminal);
         $loader = new LoaderWidget();
+        $loader->start();
         $tui->add($loader);
 
         $firstId = $this->getScheduledTickId($loader);
@@ -206,6 +226,21 @@ class LoaderTest extends TestCase
         $secondId = $this->getScheduledTickId($loader);
         $this->assertNotNull($secondId);
         $this->assertNotSame($firstId, $secondId);
+    }
+
+    public function testSetMessageStripsControlBytes()
+    {
+        $loader = new LoaderWidget(message: 'init');
+        $loader->setMessage("evil\x1b[31mred\x07bell");
+
+        $this->assertSame('evil[31mredbell', $loader->getMessage());
+    }
+
+    public function testConstructorStripsControlBytes()
+    {
+        $loader = new LoaderWidget(message: "evil\x1b[31mred");
+
+        $this->assertSame('evil[31mred', $loader->getMessage());
     }
 
     private function getScheduledTickId(LoaderWidget $loader): ?string

--- a/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
@@ -382,6 +382,34 @@ class ProgressBarTest extends TestCase
         $this->assertTrue($bar->tick());
     }
 
+    public function testTickAdvancesIndeterminateBar()
+    {
+        $bar = new ProgressBarWidget();
+        $bar->setBarWidth(10);
+        $bar->start();
+
+        $offsets = [$bar->getBarOffset()];
+        for ($i = 0; $i < 5; ++$i) {
+            $bar->tick();
+            $offsets[] = $bar->getBarOffset();
+        }
+
+        $this->assertSame([0, 1, 2, 3, 4, 5], $offsets);
+    }
+
+    public function testTickDoesNotAdvanceDeterminateBar()
+    {
+        $bar = new ProgressBarWidget(100);
+        $bar->setProgress(42);
+        $bar->start(startAt: 42);
+
+        $before = $bar->getProgress();
+        $bar->tick();
+        $bar->tick();
+
+        $this->assertSame($before, $bar->getProgress());
+    }
+
     public function testSubElementStylesFromStylesheet()
     {
         $terminal = new VirtualTerminal(80, 24);

--- a/src/Symfony/Component/Tui/Tui.php
+++ b/src/Symfony/Component/Tui/Tui.php
@@ -500,11 +500,13 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
 
     private function invokeTickCallback(float $deltaTime): ?bool
     {
+        $event = new TickEvent($deltaTime);
+        $this->eventDispatcher->dispatch($event);
+
         if (null === $this->onTick) {
-            return null;
+            return $event->hasBusyHint() ? $event->isBusy() : null;
         }
 
-        $event = new TickEvent($deltaTime);
         $result = ($this->onTick)($event);
 
         if (\is_bool($result)) {

--- a/src/Symfony/Component/Tui/Widget/BracketedPasteTrait.php
+++ b/src/Symfony/Component/Tui/Widget/BracketedPasteTrait.php
@@ -25,6 +25,9 @@ namespace Symfony\Component\Tui\Widget;
  */
 trait BracketedPasteTrait
 {
+    private const int MAX_PASTE_BYTES = 16 * 1024 * 1024;
+    private const string PASTE_OVERFLOW_MESSAGE = '[paste exceeded 16 MiB limit]';
+
     private bool $inPaste = false;
     private string $pasteBuffer = '';
 
@@ -37,26 +40,36 @@ trait BracketedPasteTrait
      * Process bracketed paste sequences in input data.
      *
      * Detects paste start/end markers and buffers content across
-     * multiple input chunks. Modifies $data in place to remove
-     * paste markers and consumed content.
+     * multiple input chunks. Modifies $data in place to leave the
+     * caller with the non-paste portion of the chunk: any bytes that
+     * preceded the start marker, plus any bytes after the end marker.
+     * Returns the complete pasted text when the end marker is
+     * received, or null when still buffering.
      *
-     * @param string $data Input data; modified to contain only the portion
-     *                     after the paste end marker (if any), or emptied
-     *                     if still buffering
+     * @param string $data Input data; on return contains the non-paste
+     *                     bytes (prefix and/or suffix), or '' while
+     *                     buffering or when the chunk was paste-only
      *
      * @return string|null The complete pasted text when the end marker is
-     *                     received, or null if still buffering
+     *                     received, or null if still buffering or if no
+     *                     paste is in progress. If a paste exceeds the
+     *                     internal cap, {@see PASTE_OVERFLOW_MESSAGE} is
+     *                     returned in lieu of the partial content so the
+     *                     caller can surface a visible notice.
      */
     private function processBracketedPaste(string &$data): ?string
     {
-        if (str_contains($data, "\x1b[200~")) {
-            $this->inPaste = true;
-            $this->pasteBuffer = '';
-            $data = str_replace("\x1b[200~", '', $data);
-        }
+        $prefix = '';
 
         if (!$this->inPaste) {
-            return null;
+            if (false === $start = strpos($data, "\x1b[200~")) {
+                return null;
+            }
+
+            $prefix = substr($data, 0, $start);
+            $data = substr($data, $start + 6);
+            $this->inPaste = true;
+            $this->pasteBuffer = '';
         }
 
         if (false !== $endIndex = strpos($data, "\x1b[201~")) {
@@ -64,13 +77,25 @@ trait BracketedPasteTrait
             $pastedText = $this->pasteBuffer;
             $this->inPaste = false;
             $this->pasteBuffer = '';
-            $data = substr($data, $endIndex + 6);
+            $data = $prefix.substr($data, $endIndex + 6);
 
             return $pastedText;
         }
 
         $this->pasteBuffer .= $data;
-        $data = '';
+        $data = $prefix;
+
+        // Cap reached without an end marker: discard the partial paste and
+        // exit paste mode. Returns a visible overflow notice in place of
+        // the partial content so the caller can show the user why their
+        // paste did not land. Defense against unbounded buffering from a
+        // missing/spoofed end marker.
+        if (\strlen($this->pasteBuffer) > self::MAX_PASTE_BYTES) {
+            $this->pasteBuffer = '';
+            $this->inPaste = false;
+
+            return self::PASTE_OVERFLOW_MESSAGE;
+        }
 
         return null;
     }

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
@@ -29,6 +29,8 @@ use Symfony\Component\Tui\Widget\Util\StringUtils;
  */
 final class EditorDocument
 {
+    private const int MAX_UNDO_BYTES = 32 * 1024 * 1024;
+
     /** @var string[] */
     private array $lines = [''];
     private int $cursorLine = 0;
@@ -41,6 +43,7 @@ final class EditorDocument
     private array $undoStack = [];
     /** @var array<int, array{lines: string[], cursor_line: int, cursor_col: int}> */
     private array $redoStack = [];
+    private int $undoStackBytes = 0;
 
     // Character jump mode
     private ?string $jumpMode = null; // 'forward' or 'backward'
@@ -142,6 +145,7 @@ final class EditorDocument
         $this->cursorLine = 0;
         $this->cursorCol = 0;
         $this->undoStack = [];
+        $this->undoStackBytes = 0;
         $this->redoStack = [];
         $this->pasteMarkers = [];
         $this->pasteCount = 0;
@@ -508,6 +512,7 @@ final class EditorDocument
         $this->redoStack[] = $this->createSnapshot();
 
         $snapshot = array_pop($this->undoStack);
+        $this->undoStackBytes -= self::snapshotBytes($snapshot);
         $this->restoreSnapshot($snapshot);
         $this->killRing->resetAll();
 
@@ -520,7 +525,9 @@ final class EditorDocument
             return false;
         }
 
-        $this->undoStack[] = $this->createSnapshot();
+        $snapshot = $this->createSnapshot();
+        $this->undoStack[] = $snapshot;
+        $this->undoStackBytes += self::snapshotBytes($snapshot);
 
         $snapshot = array_pop($this->redoStack);
         $this->restoreSnapshot($snapshot);
@@ -669,13 +676,32 @@ final class EditorDocument
 
     private function pushUndoSnapshot(): void
     {
-        $this->undoStack[] = $this->createSnapshot();
+        $snapshot = $this->createSnapshot();
+        $this->undoStack[] = $snapshot;
+        $this->undoStackBytes += self::snapshotBytes($snapshot);
 
         if (\count($this->undoStack) > 100) {
-            array_shift($this->undoStack);
+            $this->undoStackBytes -= self::snapshotBytes(array_shift($this->undoStack));
+        }
+
+        while ($this->undoStackBytes > self::MAX_UNDO_BYTES && \count($this->undoStack) > 1) {
+            $this->undoStackBytes -= self::snapshotBytes(array_shift($this->undoStack));
         }
 
         $this->redoStack = [];
+    }
+
+    /**
+     * @param array{lines: string[], cursor_line: int, cursor_col: int} $snapshot
+     */
+    private static function snapshotBytes(array $snapshot): int
+    {
+        $bytes = 0;
+        foreach ($snapshot['lines'] as $line) {
+            $bytes += \strlen($line);
+        }
+
+        return $bytes;
     }
 
     /**

--- a/src/Symfony/Component/Tui/Widget/EditorWidget.php
+++ b/src/Symfony/Component/Tui/Widget/EditorWidget.php
@@ -203,7 +203,7 @@ class EditorWidget extends AbstractWidget implements FocusableInterface, Vertica
             if ('' === $data) {
                 return;
             }
-        } elseif ($this->isBufferingPaste()) {
+        } elseif ('' === $data && $this->isBufferingPaste()) {
             return;
         }
 
@@ -561,9 +561,10 @@ class EditorWidget extends AbstractWidget implements FocusableInterface, Vertica
             'insert_space' => ['shift+space'],
             'new_line' => ['shift+enter'],
             'submit' => [Key::ENTER],
-            'select_cancel' => [Key::ESCAPE, 'ctrl+c'],
+            'select_cancel' => [Key::ESCAPE],
 
-            // Clipboard
+            // Clipboard (leave to parent: ctrl+c is the conventional copy / abort
+            // signal; the editor itself does not implement a selection model).
             'copy' => ['ctrl+c'],
 
             // Kill ring
@@ -573,9 +574,6 @@ class EditorWidget extends AbstractWidget implements FocusableInterface, Vertica
             // Undo/Redo
             'undo' => ['ctrl+-'],
             'redo' => ['ctrl+shift+z'],
-
-            // Tool output
-            'expand_tools' => ['ctrl+o'],
         ];
     }
 

--- a/src/Symfony/Component/Tui/Widget/Figlet/FigletFont.php
+++ b/src/Symfony/Component/Tui/Widget/Figlet/FigletFont.php
@@ -34,6 +34,8 @@ use Symfony\Component\Tui\Exception\InvalidArgumentException;
  */
 final class FigletFont
 {
+    private const int MAX_DECOMPRESSED_BYTES = 4 * 1024 * 1024;
+
     /** @var array<int, string[]> codepoint → array of lines */
     private array $characters = [];
 
@@ -190,8 +192,17 @@ final class FigletFont
             for ($i = 0; $i < $zip->numFiles; ++$i) {
                 $name = $zip->getNameIndex($i);
                 if (false !== $name && str_ends_with($name, '.flf')) {
-                    $content = $zip->getFromIndex($i);
+                    $stat = $zip->statIndex($i);
+                    if (false !== $stat && isset($stat['size']) && $stat['size'] > self::MAX_DECOMPRESSED_BYTES) {
+                        throw new InvalidArgumentException(\sprintf('FIGlet font entry "%s" inside ZIP archive "%s" is too large.', $name, $path));
+                    }
+
+                    $content = $zip->getFromIndex($i, self::MAX_DECOMPRESSED_BYTES + 1);
                     if (false !== $content) {
+                        if (\strlen($content) > self::MAX_DECOMPRESSED_BYTES) {
+                            throw new InvalidArgumentException(\sprintf('FIGlet font entry "%s" inside ZIP archive "%s" is too large.', $name, $path));
+                        }
+
                         return $content;
                     }
                 }

--- a/src/Symfony/Component/Tui/Widget/InputWidget.php
+++ b/src/Symfony/Component/Tui/Widget/InputWidget.php
@@ -92,6 +92,12 @@ class InputWidget extends AbstractWidget implements FocusableInterface
     }
 
     /**
+     * Sets the prompt text rendered before the input field.
+     *
+     * The prompt is stored verbatim and rendered as-is. See {@see TextWidget}
+     * for the raw-passthrough contract: sanitize untrusted input upstream via
+     * {@see StringUtils::stripControlBytes()}.
+     *
      * @return $this
      */
     public function setPrompt(string $prompt): static
@@ -149,7 +155,7 @@ class InputWidget extends AbstractWidget implements FocusableInterface
                 if ('' === $data) {
                     return;
                 }
-            } elseif ($this->isBufferingPaste()) {
+            } elseif ('' === $data && $this->isBufferingPaste()) {
                 return;
             }
 

--- a/src/Symfony/Component/Tui/Widget/LoaderWidget.php
+++ b/src/Symfony/Component/Tui/Widget/LoaderWidget.php
@@ -15,9 +15,14 @@ use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Loop\PeriodicStepper;
 use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Widget\Util\StringUtils;
 
 /**
  * Animated loading spinner.
+ *
+ * Newly constructed loaders are stopped; call {@see start()} to begin
+ * the animation. Attaching a stopped loader to the widget tree does not
+ * schedule any ticks until start() is called.
  *
  * @experimental
  *
@@ -50,12 +55,14 @@ class LoaderWidget extends AbstractWidget
     private bool $finished = false;
     private PeriodicStepper $frameStepper;
 
+    private string $message;
+
     public function __construct(
-        private string $message = 'Loading...',
+        string $message = 'Loading...',
     ) {
+        $this->message = StringUtils::stripControlBytes(StringUtils::sanitizeUtf8($message));
         $this->frames = self::$styles[self::DEFAULT_STYLE];
         $this->frameStepper = PeriodicStepper::everyMs(self::DEFAULT_INTERVAL_MS, 8);
-        $this->start();
     }
 
     /**
@@ -81,14 +88,13 @@ class LoaderWidget extends AbstractWidget
      */
     public function stop(): void
     {
-        if (!$this->running) {
-            return;
-        }
-
+        $wasRunning = $this->running;
         $this->running = false;
         $this->finished = true;
 
-        $this->clearScheduledTick();
+        if ($wasRunning) {
+            $this->clearScheduledTick();
+        }
 
         $this->invalidate();
         $this->getContext()?->requestRender();
@@ -107,6 +113,8 @@ class LoaderWidget extends AbstractWidget
      */
     public function setMessage(string $message): static
     {
+        $message = StringUtils::stripControlBytes(StringUtils::sanitizeUtf8($message));
+
         if ($this->message !== $message) {
             $this->message = $message;
             $this->invalidate();

--- a/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
+++ b/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
@@ -438,12 +438,22 @@ class ProgressBarWidget extends AbstractWidget
     }
 
     /**
-     * Tick the animation (for indeterminate mode bouncing).
+     * Tick the animation.
+     *
+     * In indeterminate mode (no max), advances the bar offset by one
+     * cell each tick so the bar visibly bounces. In determinate mode
+     * the offset tracks {@see setProgress()} and tick() only invalidates
+     * the render cache so dependent placeholders ({@see %elapsed%},
+     * {@see %memory%}, etc.) can refresh.
      */
     public function tick(): bool
     {
         if (!$this->running) {
             return false;
+        }
+
+        if (null === $this->max) {
+            ++$this->step;
         }
 
         $this->invalidate();

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -22,6 +22,11 @@ use Symfony\Component\Tui\Render\RenderContext;
 /**
  * Interactive selection list with keyboard navigation.
  *
+ * Item `label`, `description`, and `value` are rendered to the terminal
+ * as-is and are not sanitized. See {@see TextWidget} for the raw-passthrough
+ * contract: never pass untrusted bytes here; sanitize upstream via
+ * {@see Util\StringUtils::stripControlBytes()}.
+ *
  * @experimental
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Tui/Widget/SettingItem.php
+++ b/src/Symfony/Component/Tui/Widget/SettingItem.php
@@ -17,6 +17,11 @@ use Symfony\Component\Tui\Widget\Util\StringUtils;
 /**
  * Represents a single item in a SettingsListWidget.
  *
+ * The `$label` and `$description` constructor arguments are stored verbatim
+ * and rendered as-is. Only `$currentValue` is sanitized. See {@see TextWidget}
+ * for the raw-passthrough contract: sanitize untrusted label/description
+ * upstream via {@see StringUtils::stripControlBytes()}.
+ *
  * @experimental
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Tui/Widget/TextWidget.php
+++ b/src/Symfony/Component/Tui/Widget/TextWidget.php
@@ -46,13 +46,21 @@ use Symfony\Component\Tui\Widget\Figlet\FigletRenderer;
  * width.
  *
  * Because the content is not sanitized, **never pass untrusted input
- * directly to setText() or the constructor** — a hostile string can inject
+ * directly to setText() or the constructor**. A hostile string can inject
  * OSC sequences (terminal title, hyperlinks), CSI sequences that hide or
  * reposition surrounding output, or other escape-driven misbehavior. Sanitize
  * upstream (e.g. via {@see Util\StringUtils::stripControlBytes()})
- * before passing user-supplied data here. Other text-bearing widgets
- * (InputWidget, EditorWidget, MarkdownWidget, SettingItem, ProgressBarWidget::setMessage())
- * sanitize on input and do not have this caveat.
+ * before passing user-supplied data here.
+ *
+ * The same raw-passthrough contract applies to these other surfaces:
+ *  - SelectListWidget items (label, description, value)
+ *  - SettingItem $label and $description constructor arguments
+ *  - InputWidget::setPrompt()
+ *
+ * Sanitizing widgets (which call StringUtils::stripControlBytes on input):
+ * InputWidget::setValue, EditorWidget/EditorDocument, MarkdownWidget,
+ * SettingItem::$currentValue, ProgressBarWidget::setMessage,
+ * LoaderWidget::setMessage.
  *
  * @experimental
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Round of hardenings on the experimental Tui component:

- Bound input buffers (paste, pending control sequences, undo, FIGlet ZIP); paste overflow now surfaces a visible marker rather than a silent drop. Paste cap aligned to 16 MiB to match `FileInputHelper`.
- Strip control bytes in `LoaderWidget` messages and UTF-8 C1 in `VirtualTerminal::setTitle()` to close OSC-injection vectors.
- Fix `BracketedPasteTrait` to preserve bytes that preceded the paste start marker instead of folding them into the paste buffer.
- `FocusManager::clear()` now also clears the focused widget reference; `TickEvent` is always dispatched so listeners can hint busy state without an `onTick` callback.
- `LoaderWidget` no longer auto-starts in the constructor; call `start()` explicitly.
- `ProgressBarWidget::tick()` advances the bar offset in indeterminate mode.
- Document the raw-passthrough contract on `TextWidget`, `SelectListWidget`, `SettingItem`, and `InputWidget::setPrompt()`.
