### PR TITLE
[Security] Add BeforeAuthenticateEvent

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -32,6 +32,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
+use Symfony\Component\Security\Http\Event\BeforeAuthenticateEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
@@ -174,6 +175,9 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         $previousToken = $this->tokenStorage->getToken();
 
         try {
+            // announce the upcoming authentication attempt
+            $this->eventDispatcher->dispatch(new BeforeAuthenticateEvent($authenticator, $request));
+
             // get the passport from the Authenticator
             $passport = $authenticator->authenticate($request);
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add `ImpersonateUrlGenerator::generateImpersonationForm()` and `generateExitForm()` to build a form that switches the user with a POST
  * Add `$targetUri` argument to `ImpersonateUrlGenerator::generateImpersonationPath()` and `generateImpersonationUrl()`
  * Configure the decorated handler of `CustomAuthenticationSuccessHandler` and `CustomAuthenticationFailureHandler` when they are called instead of when they are built, so that a single handler can be shared by several authenticators
+ * Add `BeforeAuthenticateEvent`, dispatched before invoking an authenticator (useful for auditing/logging authentication attempts)
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Event/BeforeAuthenticateEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/BeforeAuthenticateEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * This event is dispatched right before an authenticator's authenticate() method is called.
+ *
+ * Listeners may use it to observe authentication attempts, e.g. to audit
+ * login attempts (including ones targeting an unknown user). Throwing an
+ * AuthenticationException from a listener triggers the regular failure
+ * flow (LoginFailureEvent is dispatched with a null passport).
+ *
+ * @author Michael Thieulin <michael.thieulin@gmail.com>
+ */
+class BeforeAuthenticateEvent extends Event
+{
+    public function __construct(
+        private AuthenticatorInterface $authenticator,
+        private Request $request,
+    ) {
+    }
+
+    public function getAuthenticator(): AuthenticatorInterface
+    {
+        return $this->authenticator instanceof TraceableAuthenticator ? $this->authenticator->getAuthenticator() : $this->authenticator;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -38,7 +38,9 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordC
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
+use Symfony\Component\Security\Http\Event\BeforeAuthenticateEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Tests\Fixtures\DummySupportsAuthenticator;
 
 class AuthenticatorManagerTest extends TestCase
@@ -148,6 +150,87 @@ class AuthenticatorManagerTest extends TestCase
     {
         yield [0];
         yield [1];
+    }
+
+    public function testBeforeAuthenticateEvent()
+    {
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
+        $authenticator->method('supports')->willReturn(true);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
+        $this->request->attributes->set('_security_authenticators', [$authenticator]);
+
+        $listenerCalled = false;
+        $this->eventDispatcher->addListener(BeforeAuthenticateEvent::class, function (BeforeAuthenticateEvent $event) use (&$listenerCalled, $authenticator) {
+            if ($event->getAuthenticator() === $authenticator && $event->getRequest() === $this->request) {
+                $listenerCalled = true;
+            }
+        });
+
+        $manager = $this->createManager([$authenticator], exposeSecurityErrors: ExposeSecurityLevel::None);
+        $this->assertNull($manager->authenticateRequest($this->request));
+        $this->assertTrue($listenerCalled, 'The BeforeAuthenticateEvent listener is not called');
+    }
+
+    public function testBeforeAuthenticateEventIsDispatchedEvenWhenAuthenticateThrows()
+    {
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
+        $authenticator->method('supports')->willReturn(true);
+        $authenticator->method('authenticate')->willThrowException(new UserNotFoundException());
+        $this->request->attributes->set('_security_authenticators', [$authenticator]);
+
+        $listenerCalled = false;
+        $this->eventDispatcher->addListener(BeforeAuthenticateEvent::class, static function () use (&$listenerCalled) {
+            $listenerCalled = true;
+        });
+
+        $manager = $this->createManager([$authenticator], exposeSecurityErrors: ExposeSecurityLevel::None);
+        $manager->authenticateRequest($this->request);
+
+        $this->assertTrue($listenerCalled, 'The BeforeAuthenticateEvent listener is called before authenticate() throws');
+    }
+
+    public function testBeforeAuthenticateEventUnwrapsTraceableAuthenticator()
+    {
+        $authenticator = $this->createStub(TestInteractiveAuthenticator::class);
+        $authenticator->method('supports')->willReturn(true);
+        $authenticator->method('authenticate')->willReturn(new SelfValidatingPassport(new UserBadge('wouter', fn () => $this->user)));
+        $authenticator->method('createToken')->willReturn($this->token);
+
+        $traceable = new TraceableAuthenticator($authenticator);
+        $this->request->attributes->set('_security_authenticators', [$traceable]);
+
+        $seenAuthenticator = null;
+        $this->eventDispatcher->addListener(BeforeAuthenticateEvent::class, static function (BeforeAuthenticateEvent $event) use (&$seenAuthenticator) {
+            $seenAuthenticator = $event->getAuthenticator();
+        });
+
+        $manager = $this->createManager([$traceable], exposeSecurityErrors: ExposeSecurityLevel::None);
+        $manager->authenticateRequest($this->request);
+
+        $this->assertSame($authenticator, $seenAuthenticator, 'getAuthenticator() should unwrap the TraceableAuthenticator');
+    }
+
+    public function testBeforeAuthenticateEventCanVetoAuthentication()
+    {
+        $authenticator = $this->createMock(TestInteractiveAuthenticator::class);
+        $authenticator->method('supports')->willReturn(true);
+        $authenticator->expects($this->never())->method('authenticate');
+        $this->request->attributes->set('_security_authenticators', [$authenticator]);
+
+        $this->eventDispatcher->addListener(BeforeAuthenticateEvent::class, static function (): void {
+            throw new BadCredentialsException('vetoed by listener');
+        });
+
+        $failurePassport = 'not-dispatched';
+        $this->eventDispatcher->addListener(LoginFailureEvent::class, static function (LoginFailureEvent $event) use (&$failurePassport) {
+            $failurePassport = $event->getPassport();
+        });
+
+        $manager = $this->createManager([$authenticator], exposeSecurityErrors: ExposeSecurityLevel::None);
+        $manager->authenticateRequest($this->request);
+
+        $this->assertNull($failurePassport, 'LoginFailureEvent is dispatched with a null passport when a listener vetoes before authenticate()');
     }
 
     public function testNoCredentialsValidated()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63147
| License       | MIT
| Doc PR        | symfony/symfony-docs#22354

This adds a `BeforeAuthenticateEvent` dispatched by `AuthenticatorManager` right before an authenticator's `authenticate()` method is called.

The primary use case is auditing/logging authentication attempts, including those targeting an unknown user. `CheckPassportEvent` only fires once a passport has been created (so it cannot observe unknown-user attempts) and `LoginFailureEvent` is dispatched after `authenticate()` has already returned or thrown (which `SelfValidatingPassport`-style authenticators can do in opaque ways).

The event is dispatched inside the `try {}` block, so a listener that throws `AuthenticationException` still goes through the regular failure flow (`LoginFailureEvent` with a null passport). Following the convention of the other in-flow events in this namespace, the class is not `final` and `getAuthenticator()` unwraps `TraceableAuthenticator`.

The name avoids the existing `PreAuthenticated*` family (`PreAuthenticatedToken`, `AbstractPreAuthenticatedAuthenticator`), which models users authenticated upstream (X.509, SSO, ...).

The programmatic login path (`authenticateUser()`) intentionally does not dispatch this event: there is no `Request` to introspect and the attempt is, by definition, already authenticated.