### PR TITLE
[HttpKernel][WebProfilerBundle] Check logs priority name for both `WARNING` and `warning`

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -455,7 +455,7 @@
             <tbody>
                 {% for log in collector.processedLogs %}
                     {% set css_class = 'error' == log.type ? 'error'
-                        : (log.priorityName == 'WARNING' or 'deprecation' == log.type) ? 'warning'
+                        : (log.priorityName in ['WARNING', 'warning'] or 'deprecation' == log.type) ? 'warning'
                         : 'silenced' == log.type ? 'silenced'
                     %}
                     <tr class="log-status-{{ css_class }}" data-type="{{ log.type }}" data-priority="{{ log.priority }}" data-channel="{{ log.channel }}" style="{{ 'event' == log.channel or 'DEBUG' == log.priorityName ? 'display: none' }}">
@@ -464,9 +464,9 @@
                                 {{ log.timestamp|date('H:i:s.v') }}
                             </time>
 
-                            {% if log.type in ['error', 'deprecation', 'silenced'] or 'WARNING' == log.priorityName %}
+                            {% if log.type in ['error', 'deprecation', 'silenced'] or log.priorityName in ['WARNING', 'warning'] %}
                                 <span class="log-type-badge badge badge-{{ css_class }}">
-                                    {% if 'error' == log.type or 'WARNING' == log.priorityName %}
+                                    {% if 'error' == log.type or log.priorityName in ['WARNING', 'warning'] %}
                                         {{ log.priorityName|lower }}
                                     {% else %}
                                         {{ log.type|lower }}

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -306,7 +306,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
                     'name' => $log['priorityName'],
                 ];
             }
-            if ('WARNING' === $log['priorityName']) {
+            if ('WARNING' === $log['priorityName'] || 'warning' === $log['priorityName']) {
                 ++$count['warning_count'];
             }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -222,4 +222,20 @@ class LoggerDataCollectorTest extends TestCase
             2,
         ];
     }
+
+    public function testWarningCount()
+    {
+        $logger = $this->createStub(DebugLoggerInterface::class);
+        $logger->method('getLogs')->willReturn([
+            ['message' => 'Monolog warning record', 'priority' => 300, 'priorityName' => 'WARNING'],
+            ['message' => 'HttpKernel logger warning record', 'priority' => 300, 'priorityName' => 'warning'],
+            ['message' => 'Monolog debug record', 'priority' => 100, 'priorityName' => 'DEBUG'],
+            ['message' => 'HttpKernel logger debug record', 'priority' => 100, 'priorityName' => 'debug'],
+        ]);
+
+        $c = new LoggerDataCollector($logger);
+        $c->lateCollect();
+
+        $this->assertSame(2, $c->countWarnings());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The `LoggerDataCollector` matches logs’ `priorityName` against `WARNING` to count them, but this value comes from `Monolog\Level::getName()`, meaning it is uppercase.

Meanwhile, the HttpKernel logger uses `Psr\Log\LogLevel` constants which are lowercased. That means the warning count is always zero when using it.

This PR checks against both cases to fix this.