### PR TITLE
[DependencyInjection] Fix `service()` as invokable factory in array-based PHP config

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -724,6 +724,10 @@ class YamlFileLoader extends FileLoader
      */
     private function parseCallable(mixed $callable, string $parameter, string $id, string $file): string|array|Reference
     {
+        if ($callable instanceof Reference) {
+            return [$callable, '__invoke'];
+        }
+
         if (\is_string($callable)) {
             if (str_starts_with($callable, '@=')) {
                 if ('factory' !== $parameter) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_factory.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_factory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory;
+
+return App::config([
+    'services' => [
+        '_defaults' => [
+            'public' => true,
+        ],
+        BarFactory::class => [
+            'arguments' => [[]],
+        ],
+        'invokable_factory' => [
+            'class' => Bar::class,
+            'factory' => service(BarFactory::class),
+        ],
+        'array_factory' => [
+            'class' => Bar::class,
+            'factory' => [service(BarFactory::class), 'getDefaultBar'],
+        ],
+        'invokable_configurator' => [
+            'class' => Bar::class,
+            'configurator' => service(BarFactory::class),
+        ],
+    ],
+]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -180,6 +180,20 @@ class PhpFileLoaderTest extends TestCase
         $this->assertTrue($container->getDefinition('child_service')->isAutoconfigured());
     }
 
+    public function testArrayConfigInvokableFactoryAndConfigurator()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator());
+        $loader->load($fixtures.'/config/array_config_factory.php');
+
+        $barFactoryRef = new Reference('Symfony\Component\DependencyInjection\Tests\Fixtures\BarFactory');
+
+        $this->assertEquals([$barFactoryRef, '__invoke'], $container->getDefinition('invokable_factory')->getFactory());
+        $this->assertEquals([$barFactoryRef, 'getDefaultBar'], $container->getDefinition('array_factory')->getFactory());
+        $this->assertEquals([$barFactoryRef, '__invoke'], $container->getDefinition('invokable_configurator')->getConfigurator());
+    }
+
     public function testFactoryShortNotationNotAllowed()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64277
| License       | MIT

`ContainerConfigurator::processValue()` turns `ReferenceConfigurator` instances into `Reference` objects when forwarding array-based PHP config to `YamlFileLoader::parseCallable()`, which only accepted strings and arrays as input and threw on a bare `Reference`. Since `Reference` is already part of `parseCallable()`'s return type and mirrors the post-processed form of `'@id'` strings, accept it as input and treat it as an invokable, like the `'@id'` branch does.
