### PR TITLE
[FrameworkBundle][Validator] Add `framework.validation.property_metadata_existence_check` config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `framework.validation.property_metadata_existence_check` config option
  * Deprecate `json_streamer.value_transformer.date_time_to_string` and `json_streamer.value_transformer.string_to_date_time` services, date times are handled as value objects
  * Deprecate `json_streamer.value_transformer` tag, use `json_streamer.property_value_transformer` instead
  * Add `marshaller` option to cache pool configuration to allow per-pool marshaller services

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1170,6 +1170,10 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('disable_translation')
                             ->defaultFalse()
                         ->end()
+                        ->booleanNode('property_metadata_existence_check')
+                            ->info('When enabled, validateProperty() and validatePropertyValue() throw an exception if no metadata is found for the given property.')
+                            ->defaultFalse()
+                        ->end()
                         ->arrayNode('auto_mapping')
                             ->info('A collection of namespaces for which auto-mapping will be enabled by default, or null to opt-in with the EnableAutoMapping constraint.')
                             ->example([

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1791,6 +1791,10 @@ class FrameworkExtension extends Extension
             $validatorBuilder->addMethodCall('disableTranslation');
         }
 
+        if ($config['property_metadata_existence_check'] ?? false) {
+            $validatorBuilder->addMethodCall('enablePropertyMetadataExistenceCheck');
+        }
+
         $container->setParameter('validator.auto_mapping', $config['auto_mapping']);
         if (!$propertyInfoEnabled || !class_exists(PropertyInfoLoader::class)) {
             $container->removeDefinition('validator.property_info_loader');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -772,6 +772,7 @@ class ConfigurationTest extends TestCase
                 'static_method' => ['loadValidatorMetadata'],
                 'translation_domain' => 'validators',
                 'disable_translation' => false,
+                'property_metadata_existence_check' => false,
                 'mapping' => [
                     'paths' => [],
                 ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_property_metadata_existence_check.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_property_metadata_existence_check.php
@@ -1,0 +1,7 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'validation' => [
+        'property_metadata_existence_check' => true,
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_property_metadata_existence_check.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_property_metadata_existence_check.yml
@@ -1,0 +1,3 @@
+framework:
+    validation:
+        property_metadata_existence_check: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1709,6 +1709,16 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame('messages', $container->getParameter('validator.translation_domain'));
     }
 
+    public function testValidationPropertyMetadataExistenceCheck()
+    {
+        $container = $this->createContainerFromFile('validation_property_metadata_existence_check');
+
+        $calls = $container->getDefinition('validator.builder')->getMethodCalls();
+        $methods = array_column($calls, 0);
+
+        $this->assertContains('enablePropertyMetadataExistenceCheck', $methods);
+    }
+
     public function testValidationMapping()
     {
         $container = $this->createContainerFromFile('validation_mapping');

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `ValidatorBuilder::enablePropertyMetadataExistenceCheck()` to make `validateProperty()` and `validatePropertyValue()` throw when the given property has no metadata
  * Add `findByCodes()` to `ConstraintViolationListInterface`
  * Add clock-awareness to comparison and range validators for testable date comparisons
  * Add the `Xml` constraint for validating XML content


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Follow-up of #63355
| License       | MIT

As noted by @stof in https://github.com/symfony/symfony/pull/63355#issuecomment-4487382563, #63355 was missing the FrameworkBundle wiring to expose the new `ValidatorBuilder::enablePropertyMetadataExistenceCheck()` method.

This PR adds a `framework.validation.property_metadata_existence_check` config option (default `false` to preserve BC). When set to `true`, the option calls `enablePropertyMetadataExistenceCheck()` on the `validator.builder` service, so `validateProperty()` and `validatePropertyValue()` throw a `ValidatorException` when no metadata is found for the given property.

```yaml
framework:
    validation:
        property_metadata_existence_check: true
```

Also adds the matching CHANGELOG entry to the Validator component that was missing in the original PR.