### PR TITLE
[Yaml] Allow trailing newlines after the end-of-document marker

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1063,7 +1063,7 @@ class Parser
             $value = $trimmedValue;
 
             // remove end of the document marker (...)
-            $value = preg_replace('#\.\.\.[ \t]*+$#', '', $value);
+            $value = preg_replace('#\.\.\.\s*+$#', '', $value);
         }
 
         return $value;

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -3078,6 +3078,13 @@ YAML;
         $this->assertSame(['foo' => 'bar'], $this->parser->parse($yaml));
     }
 
+    public function testParseHandlesTrailingNewlinesAfterDocumentEndMarker()
+    {
+        $yaml = "---\nfoo: bar\n...\n\n";
+
+        $this->assertSame(['foo' => 'bar'], $this->parser->parse($yaml));
+    }
+
     private function assertSameData($expected, $actual)
     {
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64313
| License       | MIT

The hardened `#\.\.\.[ \t]*+$#` regex introduced in 9749cd43c5e0 only accepts horizontal whitespace after the `...` end-of-document marker, so a document ending with a blank line after `...` is no longer stripped and the parser errors on the leftover marker. Restore the previous tolerance using `\s*+$`; the possessive quantifier keeps the pattern safe from catastrophic backtracking since nothing follows it.