### PR TITLE
[FrameworkBundle] Rethrow command registration errors instead of swallowing them

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Console;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\Command\TraceableCommand;
 use Symfony\Component\Console\Debug\CliRequest;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,7 +32,6 @@ use Symfony\Contracts\Service\ContainerAwareInterface;
 class Application extends BaseApplication implements ContainerAwareInterface
 {
     private bool $commandsRegistered = false;
-    private array $registrationErrors = [];
 
     public function __construct(
         private KernelInterface $kernel,
@@ -77,10 +75,6 @@ class Application extends BaseApplication implements ContainerAwareInterface
     {
         $this->registerCommands();
 
-        if ($this->registrationErrors) {
-            $this->renderRegistrationErrors($input, $output);
-        }
-
         $container = $this->kernel->getContainer();
         $this->setDispatcher($container->get('event_dispatcher'));
 
@@ -94,15 +88,6 @@ class Application extends BaseApplication implements ContainerAwareInterface
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
     {
         $requestStack = null;
-        $renderRegistrationErrors = true;
-
-        if (!$command instanceof ListCommand) {
-            if ($this->registrationErrors) {
-                $this->renderRegistrationErrors($input, $output);
-                $this->registrationErrors = [];
-                $renderRegistrationErrors = false;
-            }
-        }
 
         if ($input->hasParameterOption('--profile')) {
             $container = $this->kernel->getContainer();
@@ -137,11 +122,6 @@ class Application extends BaseApplication implements ContainerAwareInterface
             $returnCode = parent::doRunCommand($command, $input, $output);
         } finally {
             $requestStack?->pop();
-        }
-
-        if ($renderRegistrationErrors && $this->registrationErrors) {
-            $this->renderRegistrationErrors($input, $output);
-            $this->registrationErrors = [];
         }
 
         return $returnCode;
@@ -202,7 +182,7 @@ class Application extends BaseApplication implements ContainerAwareInterface
                 try {
                     $bundle->registerCommands($this);
                 } catch (\Throwable $e) {
-                    $this->registrationErrors[] = $e;
+                    throw new \RuntimeException(\sprintf('"%s::registerCommands()" failed: register your commands as services tagged "console.command" (or with the #[AsCommand] attribute) instead of overriding this method.', $bundle::class), 0, $e);
                 }
             }
         }
@@ -218,23 +198,10 @@ class Application extends BaseApplication implements ContainerAwareInterface
                     try {
                         $this->addCommand($container->get($id));
                     } catch (\Throwable $e) {
-                        $this->registrationErrors[] = $e;
+                        throw new \RuntimeException(\sprintf('Eagerly loading command "%s" failed: declare its name at compile time with the #[AsCommand] attribute (or the "command" attribute of the "console.command" tag) so it can be loaded lazily.', $id), 0, $e);
                     }
                 }
             }
-        }
-    }
-
-    private function renderRegistrationErrors(InputInterface $input, OutputInterface $output): void
-    {
-        if ($output instanceof ConsoleOutputInterface) {
-            $output = $output->getErrorOutput();
-        }
-
-        (new SymfonyStyle($input, $output))->warning('Some commands could not be registered:');
-
-        foreach ($this->registrationErrors as $error) {
-            $this->doRenderThrowable($error, $output);
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -21,9 +21,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -163,9 +161,7 @@ class ApplicationTest extends TestCase
         $this->assertSame($newCommand, $application->get('example'));
     }
 
-    #[Group('legacy')]
-    #[IgnoreDeprecations]
-    public function testRunOnlyWarnsOnUnregistrableCommand()
+    public function testEagerCommandRegistrationFailureIsRethrown()
     {
         $container = new ContainerBuilder();
         $container->register('event_dispatcher', EventDispatcher::class);
@@ -173,99 +169,45 @@ class ApplicationTest extends TestCase
         $container->setParameter('console.command.ids', [ThrowingCommand::class => ThrowingCommand::class]);
 
         $kernel = $this->createStub(KernelInterface::class);
-        $kernel
-            ->method('getBundles')
-            ->willReturn([$this->createBundleMock(
-                [(new Command('fine'))->setCode(static function (InputInterface $input, OutputInterface $output): int {
-                    $output->write('fine');
-
-                    return 0;
-                })]
-            )]);
-        $kernel
-            ->method('getContainer')
-            ->willReturn($container);
+        $kernel->method('getBundles')->willReturn([]);
+        $kernel->method('getContainer')->willReturn($container);
 
         $application = new Application($kernel);
         $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
 
-        $tester = new ApplicationTester($application);
-        $tester->run(['command' => 'fine']);
-        $output = $tester->getDisplay();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Eagerly loading command "%s" failed', ThrowingCommand::class));
 
-        $tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('Some commands could not be registered:', $output);
-        $this->assertStringContainsString('throwing', $output);
-        $this->assertStringContainsString('fine', $output);
+        (new ApplicationTester($application))->run(['command' => 'fine']);
     }
 
     #[Group('legacy')]
     #[IgnoreDeprecations]
-    public function testRegistrationErrorsAreDisplayedOnCommandNotFound()
+    public function testBundleCommandRegistrationFailureIsRethrown()
     {
         $container = new ContainerBuilder();
         $container->register('event_dispatcher', EventDispatcher::class);
+
+        $bundle = new class extends Bundle {
+            public function registerCommands(\Symfony\Component\Console\Application $application): void
+            {
+                throw new \LogicException('bundle boom');
+            }
+        };
 
         $kernel = $this->createStub(KernelInterface::class);
-        $kernel
-            ->method('getBundles')
-            ->willReturn([$this->createBundleMock(
-                [(new Command(null))->setCode(static function (InputInterface $input, OutputInterface $output): int {
-                    $output->write('fine');
-
-                    return 0;
-                })]
-            )]);
-        $kernel
-            ->method('getContainer')
-            ->willReturn($container);
+        $kernel->method('getBundles')->willReturn([$bundle]);
+        $kernel->method('getContainer')->willReturn($container);
 
         $application = new Application($kernel);
         $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
 
-        $tester = new ApplicationTester($application);
-        $tester->run(['command' => 'fine']);
-        $output = $tester->getDisplay();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('"%s::registerCommands()" failed', $bundle::class));
 
-        $this->assertSame(1, $tester->getStatusCode());
-        $this->assertStringContainsString('Some commands could not be registered:', $output);
-        $this->assertStringContainsString('Command "fine" is not defined.', $output);
-    }
-
-    #[Group('legacy')]
-    #[IgnoreDeprecations]
-    public function testRunOnlyWarnsOnUnregistrableCommandAtTheEnd()
-    {
-        $container = new ContainerBuilder();
-        $container->register('event_dispatcher', EventDispatcher::class);
-        $container->register(ThrowingCommand::class, ThrowingCommand::class);
-        $container->setParameter('console.command.ids', [ThrowingCommand::class => ThrowingCommand::class]);
-
-        $kernel = $this->createMock(KernelInterface::class);
-        $kernel->expects($this->once())->method('boot');
-        $kernel
-            ->method('getBundles')
-            ->willReturn([$this->createBundleMock(
-                [(new Command('fine'))->setCode(static function (InputInterface $input, OutputInterface $output): int {
-                    $output->write('fine');
-
-                    return 0;
-                })]
-            )]);
-        $kernel
-            ->method('getContainer')
-            ->willReturn($container);
-
-        $application = new Application($kernel);
-        $application->setAutoExit(false);
-
-        $tester = new ApplicationTester($application);
-        $tester->run(['command' => 'list']);
-
-        $tester->assertCommandIsSuccessful();
-        $display = explode('List commands', $tester->getDisplay());
-
-        $this->assertStringContainsString(trim('[WARNING] Some commands could not be registered:'), trim($display[1]));
+        (new ApplicationTester($application))->run(['command' => 'fine']);
     }
 
     public function testSuggestingPackagesWithExactMatch()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54728
| License       | MIT

The protection added in #23836 (2017) addressed a world where the console eagerly discovered commands from bundle `Command/` directories — a single fatal error there would crash the whole console, so swallowing the throw and showing "Some commands could not be registered:" kept the rest usable.

Today commands are services tagged `console.command`, wrapped in `LazyCommand` by `AddConsoleCommandPass` and reached through the command loader. The eager loop in `Application::registerCommands()` only fires for two legacy paths:

- `Bundle::registerCommands()` overrides (already deprecated on 8.1, see e28b3711c47)
- commands whose name is only known via `setName()` inside `configure()` (no `#[AsCommand]`, no `static $defaultName`)

Swallowing exceptions on those paths is what makes #54728 observable: a broken eager command can leave a partially-built service (e.g. `twig` with a half-registered extension set) in `$container->services`, and the next command that resolves twig via the inline shortcut `$container->services['twig'] ?? self::getTwigService(...)` gets the partial instance.

This PR replaces both `try { ... } catch (\Throwable) { $this->registrationErrors[] = $e; }` blocks with a rethrow that names the failing command/bundle and points at `#[AsCommand]` / the `console.command` tag. The `$registrationErrors` plumbing (property, `renderRegistrationErrors()`, conditional flushes in `doRun()`/`doRunCommand()`) becomes unused and is removed.

The original #23836 use case (one broken command shouldn't block the whole console) is preserved naturally for any command that's already migrated to a lazy registration: lazy commands aren't constructed until invoked, so a broken `MyCommand` no longer affects `bin/console cache:clear`. Code still on the eager path gets a clear migration message instead of silent partial-state leaks.