### PR TITLE
[Cache][DoctrineBridge][HttpFoundation][Lock][Messenger] Avoid deprecated Schema mutators on DBAL 4.5+

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -33,21 +33,43 @@ abstract class AbstractSchemaListener
             return;
         }
 
-        $getNames = static fn ($array) => array_map(static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName(), $array);
+        $getName = static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName();
+        $getNames = static fn ($array) => array_map($getName, $array);
         $previousTableNames = $getNames($schema->getTables());
         $previousSequenceNames = $getNames($schema->getSequences());
 
         $configurator();
 
+        $useEditor = method_exists($schema, 'edit');
+
         foreach (array_diff($getNames($schema->getTables()), $previousTableNames) as $addedTable) {
             if (!$filter($addedTable)) {
-                $schema->dropTable($addedTable);
+                $useEditor ? $this->removeFromSchema($schema, '_tables', $addedTable, $getName) : $schema->dropTable($addedTable);
             }
         }
 
         foreach (array_diff($getNames($schema->getSequences()), $previousSequenceNames) as $addedSequence) {
             if (!$filter($addedSequence)) {
-                $schema->dropSequence($addedSequence);
+                $useEditor ? $this->removeFromSchema($schema, '_sequences', $addedSequence, $getName) : $schema->dropSequence($addedSequence);
+            }
+        }
+    }
+
+    /**
+     * Drops a Table or Sequence from the Schema in place, avoiding the deprecated
+     * Schema::dropTable() / dropSequence() on DBAL 4.5+.
+     */
+    private function removeFromSchema(Schema $schema, string $property, string $name, callable $getName): void
+    {
+        $items = $schema->{'_tables' === $property ? 'getTables' : 'getSequences'}();
+        foreach ($items as $key => $item) {
+            if ($getName($item) === $name) {
+                $prop = new \ReflectionProperty(Schema::class, $property);
+                $values = $prop->getValue($schema);
+                unset($values[$key]);
+                $prop->setValue($schema, $values);
+
+                return;
             }
         }
     }

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
@@ -206,12 +207,17 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
 
     private function addTableToSchema(Schema $schema): void
     {
-        $table = $schema->createTable('rememberme_token');
+        $useEditor = method_exists($schema, 'edit');
+        $table = $useEditor ? new Table('rememberme_token') : $schema->createTable('rememberme_token');
         $table->addColumn('series', Types::STRING, ['length' => 88]);
         $table->addColumn('value', Types::STRING, ['length' => 88]);
         $table->addColumn('lastUsed', Types::DATETIME_IMMUTABLE);
         $table->addColumn('class', Types::STRING, ['length' => 100]);
         $table->addColumn('username', Types::STRING, ['length' => 200]);
         $table->setPrimaryKey(['series']);
+
+        if ($useEditor) {
+            (new \ReflectionMethod(Schema::class, '_addTable'))->invoke($schema, $table);
+        }
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\ServerVersionProvider;
 use Doctrine\DBAL\Tools\DsnParser;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
@@ -425,11 +426,16 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
             'sqlite' => 'text',
         ];
 
-        $table = $schema->createTable($this->table);
+        $useEditor = method_exists($schema, 'edit');
+        $table = $useEditor ? new Table($this->table) : $schema->createTable($this->table);
         $table->addColumn($this->idCol, $types[$this->getPlatformName()] ?? 'string', ['length' => 255]);
         $table->addColumn($this->dataCol, 'blob', ['length' => 16777215]);
         $table->addColumn($this->lifetimeCol, 'integer', ['unsigned' => true, 'notnull' => false]);
         $table->addColumn($this->timeCol, 'integer', ['unsigned' => true]);
         $table->setPrimaryKey([$this->idCol]);
+
+        if ($useEditor) {
+            (new \ReflectionMethod(Schema::class, '_addTable'))->invoke($schema, $table);
+        }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 
 /**
@@ -187,7 +188,9 @@ class PdoSessionHandler extends AbstractSessionHandler
             return;
         }
 
-        $table = $schema->createTable($this->table);
+        $useEditor = method_exists($schema, 'edit');
+        $table = $useEditor ? new Table($this->table) : $schema->createTable($this->table);
+
         switch ($this->driver) {
             case 'mysql':
                 $table->addColumn($this->idCol, Types::BINARY)->setLength(128)->setNotnull(true);
@@ -225,6 +228,10 @@ class PdoSessionHandler extends AbstractSessionHandler
         }
         $table->setPrimaryKey([$this->idCol]);
         $table->addIndex([$this->lifetimeCol], $this->lifetimeCol.'_idx');
+
+        if ($useEditor) {
+            (new \ReflectionMethod(Schema::class, '_addTable'))->invoke($schema, $table);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tools\DsnParser;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
@@ -276,11 +277,16 @@ class DoctrineDbalStore implements PersistingStoreInterface
             return;
         }
 
-        $table = $schema->createTable($this->table);
+        $useEditor = method_exists($schema, 'edit');
+        $table = $useEditor ? new Table($this->table) : $schema->createTable($this->table);
         $table->addColumn($this->idCol, 'string', ['length' => 64]);
         $table->addColumn($this->tokenCol, 'string', ['length' => 44]);
         $table->addColumn($this->expirationCol, 'integer', ['unsigned' => true]);
         $table->setPrimaryKey([$this->idCol]);
+
+        if ($useEditor) {
+            (new \ReflectionMethod(Schema::class, '_addTable'))->invoke($schema, $table);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -28,6 +28,7 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
+use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
@@ -486,7 +487,11 @@ class Connection implements ResetInterface
 
     private function getSchema(): Schema
     {
-        $schema = new Schema([], [], $this->createSchemaManager()->createSchemaConfig());
+        $schemaConfig = $this->createSchemaManager()->createSchemaConfig();
+        $schema = method_exists(Schema::class, 'editor')
+            ? Schema::editor()->setSchemaConfig($schemaConfig)->create()
+            : new Schema([], [], $schemaConfig);
+
         $this->addTableToSchema($schema);
 
         return $schema;
@@ -494,9 +499,12 @@ class Connection implements ResetInterface
 
     private function addTableToSchema(Schema $schema): void
     {
-        $table = $schema->createTable($this->configuration['table_name']);
+        $useEditor = method_exists($schema, 'edit');
+        $tableName = $this->configuration['table_name'];
+        $table = $useEditor ? new Table($tableName) : $schema->createTable($tableName);
+
         // add an internal option to mark that we created this & the non-namespaced table name
-        $table->addOption(self::TABLE_OPTION_NAME, $this->configuration['table_name']);
+        $table->addOption(self::TABLE_OPTION_NAME, $tableName);
         $idColumn = $table->addColumn('id', Types::BIGINT)
             ->setAutoincrement(true)
             ->setNotnull(true);
@@ -517,10 +525,26 @@ class Connection implements ResetInterface
         $table->addIndex(['queue_name', 'available_at', 'delivered_at', 'id']);
 
         // We need to create a sequence for Oracle and set the id column to get the correct nextval
-        if ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
-            $idColumn->setDefault($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX.'.nextval');
+        $sequenceName = $this->driverConnection->getDatabasePlatform() instanceof OraclePlatform
+            ? $tableName.self::ORACLE_SEQUENCES_SUFFIX
+            : null;
 
-            $schema->createSequence($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX);
+        if (null !== $sequenceName) {
+            $idColumn->setDefault($sequenceName.'.nextval');
+        }
+
+        if ($useEditor) {
+            (new \ReflectionMethod(Schema::class, '_addTable'))->invoke($schema, $table);
+
+            if (null !== $sequenceName) {
+                (new \ReflectionMethod(Schema::class, '_addSequence'))->invoke($schema, new Sequence($sequenceName));
+            }
+
+            return;
+        }
+
+        if (null !== $sequenceName) {
+            $schema->createSequence($sequenceName);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

[doctrine/dbal#7373](https://github.com/doctrine/dbal/pull/7373) (merged, shipping in DBAL 4.5) deprecates `Schema::createTable()`, `createSequence()`, `dropTable()`, `dropSequence()` and `renameTable()` in favor of a new `SchemaEditor` API. The new editor returns a new `Schema` from `SchemaEditor::create()` rather than mutating in place, which doesn't fit our `configureSchema(Schema $schema)` callback contract nor Doctrine ORM's `postGenerateSchema` event flow (the event's `$schema` is `readonly`, no setter).

When DBAL 4.5+ is detected via `method_exists($schema, 'edit')`:

 * `configureSchema()` implementations build the `Table` standalone and push it into the passed `$schema` via reflection on the protected `Schema::_addTable()` (and `_addSequence()` for the Messenger Oracle sequence case).

 * `AbstractSchemaListener::filterSchemaChanges()` unsets the asset from `Schema`'s internal `_tables` / `_sequences` array via reflection instead of calling the deprecated `Schema::dropTable()` / `dropSequence()`.

On older DBAL the existing paths are kept. No public API change.

The reflection trick is needed until Doctrine ORM exposes a way to substitute the schema on `GenerateSchemaEventArgs`.