### PR TITLE
[DoctrineBridge] Avoid deprecated Schema::dropTable() / dropSequence() on DBAL 4.5+

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -33,21 +33,43 @@ abstract class AbstractSchemaListener
             return;
         }
 
-        $getNames = static fn ($array) => array_map(static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName(), $array);
+        $getName = static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName();
+        $getNames = static fn ($array) => array_map($getName, $array);
         $previousTableNames = $getNames($schema->getTables());
         $previousSequenceNames = $getNames($schema->getSequences());
 
         $configurator();
 
+        $useEditor = method_exists($schema, 'edit');
+
         foreach (array_diff($getNames($schema->getTables()), $previousTableNames) as $addedTable) {
             if (!$filter($addedTable)) {
-                $schema->dropTable($addedTable);
+                $useEditor ? $this->removeFromSchema($schema, '_tables', $addedTable, $getName) : $schema->dropTable($addedTable);
             }
         }
 
         foreach (array_diff($getNames($schema->getSequences()), $previousSequenceNames) as $addedSequence) {
             if (!$filter($addedSequence)) {
-                $schema->dropSequence($addedSequence);
+                $useEditor ? $this->removeFromSchema($schema, '_sequences', $addedSequence, $getName) : $schema->dropSequence($addedSequence);
+            }
+        }
+    }
+
+    /**
+     * Drops a Table or Sequence from the Schema in place, avoiding the deprecated
+     * Schema::dropTable() / dropSequence() on DBAL 4.5+.
+     */
+    private function removeFromSchema(Schema $schema, string $property, string $name, callable $getName): void
+    {
+        $items = $schema->{'_tables' === $property ? 'getTables' : 'getSequences'}();
+        foreach ($items as $key => $item) {
+            if ($getName($item) === $name) {
+                $prop = new \ReflectionProperty(Schema::class, $property);
+                $values = $prop->getValue($schema);
+                unset($values[$key]);
+                $prop->setValue($schema, $values);
+
+                return;
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #64319, addressing the second deprecation source from [doctrine/dbal#7373](https://github.com/doctrine/dbal/pull/7373).

When an asset filter rejects a table or sequence added during `configureSchema()`, `AbstractSchemaListener::filterSchemaChanges()` calls `Schema::dropTable()` / `dropSequence()`, which are deprecated in DBAL 4.5. The `SchemaEditor`-based replacement produces a new `Schema` instance, which cannot be substituted back into the ORM event's `readonly` `$schema` property.

When DBAL 4.5+ is detected via `method_exists($schema, 'edit')`, unset the entry directly from `Schema`'s internal `_tables` / `_sequences` array via reflection. On older DBAL the existing `dropTable()` / `dropSequence()` path is kept.

No public API change. No test changes needed.