### PR TITLE
[Scheduler] Prevent forgetting of Scheduler settings when calling with()

### DIFF
--- a/src/Symfony/Component/Scheduler/Schedule.php
+++ b/src/Symfony/Component/Scheduler/Schedule.php
@@ -34,7 +34,14 @@ final class Schedule implements ScheduleProviderInterface
 
     public function with(RecurringMessage $message, RecurringMessage ...$messages): static
     {
-        return static::doAdd(new self($this->dispatcher), $message, ...$messages);
+        $newInstance = static::doAdd(new self($this->dispatcher), $message, ...$messages);
+
+        $this->lock && $newInstance->lock($this->lock);
+        $this->state && $newInstance->stateful($this->state);
+        $newInstance->processOnlyLastMissedRun($this->shouldProcessOnlyLastMissedRun());
+        $newInstance->setRestart($this->shouldRestart());
+
+        return $newInstance;
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
@@ -12,9 +12,11 @@
 namespace Symfony\Component\Scheduler\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
+use Symfony\Contracts\Cache\CacheInterface;
 
 class ScheduleTest extends TestCase
 {
@@ -26,5 +28,25 @@ class ScheduleTest extends TestCase
         $this->expectException(LogicException::class);
 
         $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+    }
+
+    public function testSettingsPersistedOnWithCall()
+    {
+        $schedule = new Schedule();
+        $schedule->lock(self::createStub(LockInterface::class));
+        $schedule->stateful(self::createStub(CacheInterface::class));
+        $schedule->setRestart(true);
+        $schedule->processOnlyLastMissedRun(true);
+        $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+
+        self::assertCount(1, $schedule->getRecurringMessages());
+
+        $nextSchedule = $schedule->with(RecurringMessage::every('1 minute', new \stdClass()));
+
+        self::assertCount(1, $nextSchedule->getRecurringMessages());
+        self::assertEquals($schedule->getLock(), $nextSchedule->getLock());
+        self::assertEquals($schedule->getState(), $nextSchedule->getState());
+        self::assertEquals($schedule->shouldRestart(), $nextSchedule->shouldRestart());
+        self::assertEquals($schedule->shouldProcessOnlyLastMissedRun(), $nextSchedule->shouldProcessOnlyLastMissedRun());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/62497
| License       | MIT

This PR addresses more of a DX issue where the `Schedule::with()` method creates a fresh Schedule instance, but forgets every setting except the dispatcher. That's not what _withers_ commonly do, IMO, they're meant to "copy the object and alter selected properties". 

A consequence of this flaw is that the order of method calls begins to matter. Taking an [example from Symfony docs](https://symfony.com/doc/current/scheduler.html#efficient-management-with-symfony-scheduler):

**This will work as expected:**

```php
// src/Scheduler/SaleTaskProvider.php
namespace App\Scheduler;

#[AsSchedule('uptoyou')]
class SaleTaskProvider implements ScheduleProviderInterface
{
    public function getSchedule(): Schedule
    {
        return $this->schedule ??= new Schedule()
            ->with(
                // ...
            )
            ->stateful($this->cache)
    }
}
```

**and this won't** - the schedule becomes stateless, because the `with()` call silently drops everything.

```php
// src/Scheduler/SaleTaskProvider.php
namespace App\Scheduler;

#[AsSchedule('uptoyou')]
class SaleTaskProvider implements ScheduleProviderInterface
{
    public function getSchedule(): Schedule
    {
        return $this->schedule ??= new Schedule()
            ->stateful($this->cache)
            ->with(
                // ...
            )
    }
}
```

A fix is trivial. It rises two questions, though:

1. Is this a bugfix, or a BC break? Beats me. It will change the behaviour of a schedule, but isn't that what a bugfix should do if the behaviour is wrong? 
2. Should the `with` be renamed to something more explicitly saying "your previous tasks will be dropped if you call this function"? 