### PR TITLE
[Security] Deprecate storing uninitialized lazy user objects into the session

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 8.1 to 8.2
+=======================
+
+Symfony 8.2 is a minor release. According to the Symfony release process, there should be no significant
+backward compatibility breaks. Minor backward compatibility breaks are prefixed in this document with
+`[BC BREAK]`, make sure your code is compatible with these entries before upgrading.
+Read more about this in the [Symfony documentation](https://symfony.com/doc/8.1/setup/upgrade_minor.html).
+
+If you're upgrading from a version below 8.1, follow the [8.1 upgrade guide](UPGRADE-8.1.md) first.
+
+Security
+--------
+
+ * Deprecate storing uninitialized lazy user objects into the session, make sure they implement `__serialize()` and that it triggers their initialization

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Deprecate storing uninitialized lazy user objects into the session, make sure they implement `__serialize()` and that it triggers their initialization
+
 8.1
 ---
 

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -176,6 +176,11 @@ class ContextListener extends AbstractListener
         } else {
             $session->set($this->sessionKey, serialize($token));
 
+            $user = $token->getUser();
+            if ($user && new \ReflectionClass($user)->isUninitializedLazyObject($user)) {
+                trigger_deprecation('symfony/security-http', '8.2', 'Storing uninitialized lazy user objects into the session is deprecated, make sure "%s" implements "__serialize()" and that it triggers its initialization.', $user::class);
+            }
+
             $this->logger?->debug('Stored the security token in the session.', ['key' => $this->sessionKey]);
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,6 +47,8 @@ use Symfony\Contracts\Service\ServiceLocatorTrait;
 
 class ContextListenerTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     public function testItRequiresContextKey()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -434,6 +439,19 @@ class ContextListenerTest extends TestCase
 
         $this->assertInstanceOf(UsernamePasswordToken::class, $tokenStorage->getToken());
         $this->assertSame($user, $tokenStorage->getToken()->getUser());
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testStoringUninitializedLazyUserObjectIntoTheSessionIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/security-http 8.2: Storing uninitialized lazy user objects into the session is deprecated, make sure "Symfony\Component\Security\Core\User\InMemoryUser" implements "__serialize()" and that it triggers its initialization.');
+
+        $this->runSessionOnKernelResponse(new UsernamePasswordToken(
+            new \ReflectionClass(InMemoryUser::class)->newLazyGhost(function() {}, \ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE),
+            'phpunit',
+            ['ROLE_USER'],
+        ));
     }
 
     protected function runSessionOnKernelResponse($newToken, $original = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT