### PR TITLE
[Security] Remove protectedHeaderOnly from claim checkers

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -237,9 +237,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
     {
         // Verify the claims
         $checkers = [
-            new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-            new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-            new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+            new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0),
+            new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0),
+            new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0),
             new Checker\AudienceChecker($this->audience),
             new Checker\IssuerChecker($this->issuers),
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      |no
| New feature?  | no 
| Deprecations? | no
| Issues        | 
| License       | MIT

When looking through the code changes in the CWE https://symfony.com/blog/cve-2026-45069-oidctokenhandler-accepts-jwts-missing-aud-iss-exp-claims I noticed `protectedHeaderOnly`.

I have also implemented `web-token/jwt-checker` library in my own non-symfony application but didn't set this parameter. To check if I have missed setting this (maybe important) parameter I checked the `web-token/jwt-checker` code and noticed that parameter is never used when using `ClaimCheckerManager`.

The `HeaderCheckerManager` is calling `protectedHeaderOnly` but not `ClaimCheckerManager`.
Therefore I suggest removing this named argument to avoid confusion.