### PR TITLE
[Form] Don't submit absent forms even when they have false_values children

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -61,13 +61,13 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             } else {
                 $queryData = $request->query->all()[$name] ?? $missingData;
 
-                $data = $this->missingDataHandler->handle($form, $queryData);
-
-                if ($missingData === $data) {
+                if ($missingData === $queryData) {
                     // Don't submit GET requests if the form's name does not exist
                     // in the request
                     return;
                 }
+
+                $data = $this->missingDataHandler->handle($form, $queryData);
             }
         } else {
             // Mark the form with an error if the uploaded size was too large
@@ -98,13 +98,13 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                 $files = null;
             }
 
-            if ('PATCH' !== $method) {
-                $params = $this->missingDataHandler->handle($form, $params);
-            }
-
             if ($missingData === $params) {
                 // Don't submit the form if it is not present in the request
                 return;
+            }
+
+            if ('PATCH' !== $method) {
+                $params = $this->missingDataHandler->handle($form, $params);
             }
 
             if (\is_array($params) && \is_array($files)) {

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -67,13 +67,14 @@ class NativeRequestHandler implements RequestHandlerInterface
                 $data = $_GET;
             } else {
                 $queryData = $_GET[$name] ?? $missingData;
-                $data = $this->missingDataHandler->handle($form, $queryData);
 
-                if ($missingData === $data) {
+                if ($missingData === $queryData) {
                     // Don't submit GET requests if the form's name does not exist
                     // in the request
                     return;
                 }
+
+                $data = $this->missingDataHandler->handle($form, $queryData);
             }
         } else {
             // Mark the form with an error if the uploaded size was too large
@@ -109,13 +110,13 @@ class NativeRequestHandler implements RequestHandlerInterface
                 $files = null;
             }
 
-            if ('PATCH' !== $method) {
-                $params = $this->missingDataHandler->handle($form, $params);
-            }
-
             if ($missingData === $params) {
                 // Don't submit the form if it is not present in the request
                 return;
+            }
+
+            if ('PATCH' !== $method) {
+                $params = $this->missingDataHandler->handle($form, $params);
             }
 
             if (\is_array($params) && \is_array($files)) {

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -71,7 +71,7 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
             'method' => $method,
         ]);
 
-        $this->setRequestData($method, []);
+        $this->setRequestData($method, ['collection' => []]);
 
         $this->requestHandler->handleRequest($form, $this->request);
 
@@ -110,7 +110,7 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $form->get('subform')
             ->add('checkbox', CheckboxType::class);
 
-        $this->setRequestData($method, []);
+        $this->setRequestData($method, ['form' => []]);
 
         $this->requestHandler->handleRequest($form, $this->request);
 
@@ -156,18 +156,39 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $this->assertSame(['ROLE_USER'], $form->getData());
     }
 
-    #[DataProvider('methodExceptPatchProvider')]
-    public function testSubmitSimpleCheckboxFormWithEmptyData($method)
+    #[DataProvider('methodProvider')]
+    public function testDoNotSubmitAbsentNamedFormWithCheckboxesWhenRequestBodyContainsOtherData($method)
     {
-        $form = $this->factory->createNamed('checkbox', CheckboxType::class, true, [
-            'method' => $method,
-        ]);
+        $form = $this->factory->createNamed('form', FormType::class, null, ['method' => $method])
+            ->add('displayedColumns', ChoiceType::class, [
+                'choices' => ['foo' => 'foo', 'bar' => 'bar'],
+                'expanded' => true,
+                'multiple' => true,
+            ]);
 
-        $this->setRequestData($method, []);
+        $this->setRequestData($method, ['other_field' => 'value']);
 
         $this->requestHandler->handleRequest($form, $this->request);
 
-        $this->assertFalse($form->getData());
+        $this->assertFalse($form->isSubmitted());
+    }
+
+    #[DataProvider('methodExceptPatchProvider')]
+    public function testSubmitNamedFormWithMissingCheckboxesWhenFormKeyIsPresentInRequest($method)
+    {
+        $form = $this->factory->createNamed('form', FormType::class, null, ['method' => $method])
+            ->add('displayedColumns', ChoiceType::class, [
+                'choices' => ['foo' => 'foo', 'bar' => 'bar'],
+                'expanded' => true,
+                'multiple' => true,
+            ]);
+
+        $this->setRequestData($method, ['form' => []]);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $this->assertTrue($form->isSubmitted());
+        $this->assertSame([], $form->get('displayedColumns')->getData());
     }
 
     public static function methodExceptPatchProvider(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64315
| License       | MIT

Fix a regression introduced in #45081 (8.1): `MissingDataHandler` was called before the "form absent from request" guard, so for compound forms with `false_values`-aware children (expanded multiple `ChoiceType`, `CheckboxType`, ...) the handler synthesised values for the missing children, masking the "form absent" condition and causing the form to be submitted on any unrelated POST to the same endpoint.

The fix moves the early-return guard before `MissingDataHandler::handle()` in both the GET and request-body branches of `HttpFoundationRequestHandler` and `NativeRequestHandler`, so an entirely absent form is never processed. The legitimate `false_values` synthesis for missing children of a *submitted* form (e.g. all-unchecked checkboxes inside a form whose key is in the request body) is preserved.