### PR TITLE
[Scheduler] Recover pending RecurringMessages after consumer stops midway

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -22,6 +22,7 @@ final class MessageGenerator implements MessageGeneratorInterface
 {
     private ?Schedule $schedule = null;
     private TriggerHeap $triggerHeap;
+    private bool $heapInitialized = false;
     private ?\DateTimeImmutable $waitUntil;
 
     public function __construct(
@@ -56,7 +57,7 @@ final class MessageGenerator implements MessageGeneratorInterface
         $startTime = $checkpoint->from();
         $lastTime = $checkpoint->time();
         $lastIndex = $checkpoint->index();
-        $heap = $this->heap($lastTime, $startTime);
+        $heap = $this->heap($lastTime, $startTime, $lastIndex);
 
         while (!$heap->isEmpty() && $heap->top()[0] <= $now) {
             /** @var \DateTimeImmutable $time */
@@ -100,13 +101,24 @@ final class MessageGenerator implements MessageGeneratorInterface
         return $this->schedule ??= $this->scheduleProvider->getSchedule();
     }
 
-    private function heap(\DateTimeImmutable $time, \DateTimeImmutable $startTime): TriggerHeap
+    private function heap(\DateTimeImmutable $time, \DateTimeImmutable $startTime, int $lastIndex): TriggerHeap
     {
         if (isset($this->triggerHeap) && $this->triggerHeap->time <= $time) {
             return $this->triggerHeap;
         }
 
         $heap = new TriggerHeap($time);
+
+        // On the very first heap build of this instance — a new process picking up a
+        // checkpoint that already yielded part of the messages due at $time (lastIndex
+        // >= 0) — probe one microsecond before $time so triggers, whose getNextRunDate()
+        // is strictly-after, re-emit entries due at exactly $time. The skip logic in
+        // getMessages() then filters out already-yielded indices, letting the
+        // un-processed remainder through. Subsequent rebuilds happen after a normal
+        // yield-then-advance cycle (not after a partial yield), so re-probing $time
+        // would re-emit entries that are already advanced past.
+        $probeTime = !$this->heapInitialized && $lastIndex >= 0 ? $time->modify('-1 microsecond') : $time;
+        $this->heapInitialized = true;
 
         foreach ($this->getSchedule()->getRecurringMessages() as $index => $recurringMessage) {
             $trigger = $recurringMessage->getTrigger();
@@ -115,7 +127,7 @@ final class MessageGenerator implements MessageGeneratorInterface
                 $trigger->continue($startTime);
             }
 
-            if (!$nextTime = $trigger->getNextRunDate($time)) {
+            if (!$nextTime = $trigger->getNextRunDate($probeTime)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -204,6 +204,48 @@ class MessageGeneratorTest extends TestCase
         $this->assertEquals(self::makeDateTime('22:13:00'), $checkpoint->time());
     }
 
+    public function testCheckpointWithMultipleRecurringMessagesAtSameTriggerTime()
+    {
+        $clock = new MockClock(self::makeDateTime('22:12:00'));
+
+        $first = (object) ['id' => 'first'];
+        $second = (object) ['id' => 'second'];
+        $cache = new ArrayAdapter();
+
+        // First MessageGenerator instance: simulates the first messenger:consume process.
+        $schedule1 = (new Schedule())->add(
+            RecurringMessage::every('30 seconds', $first),
+            RecurringMessage::every('30 seconds', $second),
+        );
+        $schedule1->stateful($cache);
+        $scheduler1 = new MessageGenerator($schedule1, 'dummy', clock: $clock, checkpoint: new Checkpoint('dummy', cache: $cache));
+
+        // Warmup.
+        $this->assertSame([], iterator_to_array($scheduler1->getMessages(), false));
+
+        // Both messages are due at 22:12:30; the consumer stops after yielding only the
+        // first (mimics "messenger:consume --limit 1" or any early loop break).
+        $clock->sleep(30);
+        $yielded = [];
+        foreach ($scheduler1->getMessages() as $message) {
+            $yielded[] = $message;
+            break;
+        }
+        $this->assertSame([$first], $yielded);
+
+        // Next messenger:consume process: same checkpoint cache, fresh in-memory state.
+        $schedule2 = (new Schedule())->add(
+            RecurringMessage::every('30 seconds', $first),
+            RecurringMessage::every('30 seconds', $second),
+        );
+        $schedule2->stateful($cache);
+        $scheduler2 = new MessageGenerator($schedule2, 'dummy', clock: $clock, checkpoint: new Checkpoint('dummy', cache: $cache));
+
+        // The "second" message at 22:12:30 was never yielded. It must be picked up now
+        // instead of being silently dropped to the next interval at 22:13:00.
+        $this->assertSame([$second], iterator_to_array($scheduler2->getMessages(), false));
+    }
+
     public static function messagesProvider(): \Generator
     {
         $first = (object) ['id' => 'first'];

--- a/src/Symfony/Component/Scheduler/Trigger/TriggerInterface.php
+++ b/src/Symfony/Component/Scheduler/Trigger/TriggerInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Scheduler\Trigger;
 interface TriggerInterface extends \Stringable
 {
     /**
-     * Returns the next run date; if null is returned, this method won't be called again.
+     * Returns the next run date strictly after $run; if null is returned, this method won't be called again.
      */
     public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62496
| License       | MIT

When the consumer stops after yielding part of the messages due at one trigger time (e.g. `messenger:consume --limit 1`, SIGINT, fatal error), the next process rebuilt the heap with each trigger's run strictly after the checkpointed time, silently dropping the un-yielded messages at that time.

On the first heap build of a new instance with a non-warmup checkpoint, probe triggers one microsecond before `$lastTime` so they re-emit their entries due at `$lastTime`. The existing skip logic (`$time == $lastTime && $index <= $lastIndex`) then filters out already-yielded indices and lets the un-processed remainder through.

Reproduces with two `RecurringMessage::every('30 seconds', …)` consumed under `--limit 1`: "first" runs on every restart, "second" never runs without this patch.

## TDD verification

- **RED** (new test without prod fix):

```
F 1/1 (100%)

1) Symfony\Component\Scheduler\Tests\Generator\MessageGeneratorTest::testCheckpointWithMultipleRecurringMessagesAtSameTriggerTime
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-Array &0 (
-    0 => stdClass Object &00000000000001be0000000000000000 (
-        'id' => 'second'
-    )
-)
+Array &0 ()

FAILURES! Tests: 1, Assertions: 3, Failures: 1.
```

- **GREEN** (new test with prod fix): `OK (1 test, 3 assertions)`
- Full `MessageGeneratorTest`: `OK (18 tests, 81 assertions)`
- Full Scheduler suite: `OK (144 tests, 773 assertions)` — no regression.
