### PR TITLE
[Cache] Accept '_' and ':' in prefix passed to AbstractAdapter::clear()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -234,7 +234,8 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
                 $sql = "TRUNCATE TABLE $this->table";
             }
         } else {
-            $sql = "DELETE FROM $this->table WHERE $this->idCol LIKE '$namespace%'";
+            $namespace = str_replace('_', '!_', $namespace);
+            $sql = "DELETE FROM $this->table WHERE $this->idCol LIKE '$namespace%' ESCAPE '!'";
         }
 
         try {

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -432,7 +432,8 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
                 $sql = "TRUNCATE TABLE $this->table";
             }
         } else {
-            $sql = "DELETE FROM $this->table WHERE $this->idCol LIKE '$namespace%'";
+            $namespace = str_replace('_', '!_', $namespace);
+            $sql = "DELETE FROM $this->table WHERE $this->idCol LIKE '$namespace%' ESCAPE '!'";
         }
 
         try {

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -309,6 +309,23 @@ abstract class AdapterTestCase extends CachePoolTest
         $this->assertTrue($cache->hasItem('barfoo'));
     }
 
+    public function testClearPrefixWithUnderscore()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $cache = $this->createCachePool(0, __FUNCTION__);
+        $cache->clear();
+
+        $cache->save($cache->getItem('DC2_REGION_product_region_key')->set(1));
+        $cache->save($cache->getItem('other_key')->set(2));
+
+        $this->assertTrue($cache->clear('DC2_REGION_'));
+        $this->assertFalse($cache->hasItem('DC2_REGION_product_region_key'));
+        $this->assertTrue($cache->hasItem('other_key'));
+    }
+
     /**
      * @dataProvider provideInvalidPrefixes
      */

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
@@ -26,6 +26,7 @@ class DoctrineAdapterTest extends AdapterTestCase
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayCache is not.',
         'testNotUnserializable' => 'ArrayCache does not use serialize/unserialize',
         'testClearPrefix' => 'Doctrine cannot clear by prefix',
+        'testClearPrefixWithUnderscore' => 'Doctrine cannot clear by prefix',
     ];
 
     public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -78,7 +78,7 @@ class PhpArrayAdapterTest extends AdapterTestCase
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface
     {
-        if ('testGetMetadata' === $testMethod || 'testClearPrefix' === $testMethod) {
+        if ('testGetMetadata' === $testMethod || 'testClearPrefix' === $testMethod || 'testClearPrefixWithUnderscore' === $testMethod) {
             return new PhpArrayAdapter(self::$file, new FilesystemAdapter());
         }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
@@ -25,6 +25,7 @@ class Psr16AdapterTest extends AdapterTestCase
     protected $skippedTests = [
         'testPrune' => 'Psr16adapter just proxies',
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',
+        'testClearPrefixWithUnderscore' => 'SimpleCache cannot clear by prefix',
     ];
 
     public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -143,7 +143,7 @@ trait AbstractAdapterTrait
                 $this->namespaceVersion = $namespaceVersion;
                 $this->ids = [];
             }
-        } elseif (preg_match('#[^-+.A-Za-z0-9]#', $prefix)) {
+        } elseif (preg_match('#[^-+.:_A-Za-z0-9]#', $prefix)) {
             CacheItem::log($this->logger, 'Failed to clear the cache: Namespace-prefix contains invalid characters.', ['cache-adapter' => get_debug_type($this)]);
 
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64328
| License       | MIT

The prefix-validation regex added to `AbstractAdapter::clear()` rejected `_`, which broke Doctrine ORM second-level cache region invalidation (regions are passed as `DC2_REGION_<name>`). It also rejected `:`, which is the conventional Redis namespace separator.

This PR extends the allowed character class to include `_` and `:`. To keep SQL-backed adapters safe, `_` (a SQL LIKE single-character wildcard) is now escaped via `ESCAPE '!'` in `PdoAdapter::doClear()` and `DoctrineDbalAdapter::doClear()`. The `!` escape character is itself rejected by the validation regex, so collisions are not possible.