### PR TITLE
[Security] Initialize lazy users before serializing them

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Doctrine\Persistence\Proxy;
+use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -31,6 +33,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -176,6 +179,18 @@ class ContextListener extends AbstractListener
                 $session->remove($this->sessionKey);
             }
         } else {
+            if ($user = $token?->getUser()) {
+                if (\PHP_VERSION_ID >= 80400 && ($reflector = new \ReflectionClass($user))->isUninitializedLazyObject($user)) {
+                    $reflector->initializeLazyObject($user);
+                } elseif ($user instanceof Proxy && !$user->__isInitialized()) {
+                    $user->__load();
+                } elseif ($user instanceof LazyObjectInterface && !$user->isLazyObjectInitialized()) {
+                    $user->initializeLazyObject();
+                } elseif ($user instanceof LazyLoadingInterface && !$user->isProxyInitialized()) {
+                    $user->initializeProxy();
+                }
+            }
+
             $session->set($this->sessionKey, serialize($token));
 
             $this->logger?->debug('Stored the security token in the session.', ['key' => $this->sessionKey]);

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
+use Doctrine\Persistence\Proxy;
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -35,7 +37,11 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\LazyDoctrinePersistenceUser;
+use Symfony\Component\Security\Http\Tests\Fixtures\LazyProxyManagerUser;
+use Symfony\Component\Security\Http\Tests\Fixtures\LazyVarExporterUser;
 use Symfony\Component\Security\Http\Tests\Fixtures\NullUserToken;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 
 class ContextListenerTest extends TestCase
@@ -104,6 +110,67 @@ class ContextListenerTest extends TestCase
         $token = unserialize($session->get('_security_session'));
         $this->assertInstanceOf(UsernamePasswordToken::class, $token);
         $this->assertEquals('test1', $token->getUserIdentifier());
+    }
+
+    /**
+     * @requires PHP 8.4
+     */
+    public function testOnKernelResponseInitializesNativeLazyUser()
+    {
+        $initialized = false;
+        $user = (new \ReflectionClass(InMemoryUser::class))->newLazyGhost(
+            function (InMemoryUser $u) use (&$initialized) {
+                $u->__construct('test', 'pass');
+                $initialized = true;
+            },
+            \ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE,
+        );
+
+        $this->runSessionOnKernelResponse(new UsernamePasswordToken($user, 'phpunit', ['ROLE_USER']));
+
+        $this->assertTrue($initialized);
+    }
+
+    public function testOnKernelResponseInitializesDoctrinePersistenceProxyUser()
+    {
+        if (!interface_exists(Proxy::class)) {
+            $this->markTestSkipped('"doctrine/persistence" is not installed.');
+        }
+
+        $user = new LazyDoctrinePersistenceUser();
+        $this->assertFalse($user->initialized);
+
+        $this->runSessionOnKernelResponse(new UsernamePasswordToken($user, 'phpunit', ['ROLE_USER']));
+
+        $this->assertTrue($user->initialized);
+    }
+
+    public function testOnKernelResponseInitializesVarExporterLazyUser()
+    {
+        if (!interface_exists(LazyObjectInterface::class)) {
+            $this->markTestSkipped('"symfony/var-exporter" is not installed.');
+        }
+
+        $user = new LazyVarExporterUser();
+        $this->assertFalse($user->initialized);
+
+        $this->runSessionOnKernelResponse(new UsernamePasswordToken($user, 'phpunit', ['ROLE_USER']));
+
+        $this->assertTrue($user->initialized);
+    }
+
+    public function testOnKernelResponseInitializesProxyManagerLazyUser()
+    {
+        if (!interface_exists(LazyLoadingInterface::class)) {
+            $this->markTestSkipped('"friendsofphp/proxy-manager-lts" is not installed.');
+        }
+
+        $user = new LazyProxyManagerUser();
+        $this->assertFalse($user->initialized);
+
+        $this->runSessionOnKernelResponse(new UsernamePasswordToken($user, 'phpunit', ['ROLE_USER']));
+
+        $this->assertTrue($user->initialized);
     }
 
     public function testOnKernelResponseWillRemoveSession()

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/LazyDoctrinePersistenceUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/LazyDoctrinePersistenceUser.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Doctrine\Persistence\Proxy;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class LazyDoctrinePersistenceUser implements UserInterface, Proxy
+{
+    public bool $initialized = false;
+
+    public function __load(): void
+    {
+        $this->initialized = true;
+    }
+
+    public function __isInitialized(): bool
+    {
+        return $this->initialized;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return 'test';
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/LazyProxyManagerUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/LazyProxyManagerUser.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use ProxyManager\Proxy\LazyLoadingInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class LazyProxyManagerUser implements UserInterface, LazyLoadingInterface
+{
+    public bool $initialized = false;
+
+    public function setProxyInitializer(?\Closure $initializer = null): void
+    {
+    }
+
+    public function getProxyInitializer(): ?\Closure
+    {
+        return null;
+    }
+
+    public function initializeProxy(): bool
+    {
+        return $this->initialized = true;
+    }
+
+    public function isProxyInitialized(): bool
+    {
+        return $this->initialized;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return 'test';
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/LazyVarExporterUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/LazyVarExporterUser.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\VarExporter\LazyObjectInterface;
+
+class LazyVarExporterUser implements UserInterface, LazyObjectInterface
+{
+    public bool $initialized = false;
+
+    public function isLazyObjectInitialized(bool $partial = false): bool
+    {
+        return $this->initialized;
+    }
+
+    public function initializeLazyObject(): object
+    {
+        $this->initialized = true;
+
+        return $this;
+    }
+
+    public function resetLazyObject(): bool
+    {
+        $this->initialized = false;
+
+        return true;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64017
| License       | MIT

Follow-up of #64331.

No tests yet; waiting to be sure if it’s okay to depend on Doctrine and ProxyManager interfaces.