### PR TITLE
[SecurityBundle] Fix Security::login() across firewalls

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -315,7 +315,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         // load firewall map
         $mapDef = $container->getDefinition('security.firewall.map');
-        $map = $authenticationProviders = $contextRefs = $authenticators = [];
+        $map = $authenticationProviders = $contextRefs = $authenticators = $firewallConfigRefs = [];
         foreach ($firewalls as $name => $firewall) {
             if (isset($firewall['user_checker']) && 'security.user_checker' !== $firewall['user_checker']) {
                 $customUserChecker = true;
@@ -347,6 +347,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
             $contextRefs[$contextId] = new Reference($contextId);
             $map[$contextId] = $matcher;
+            $firewallConfigRefs[$name] = new Reference($configId);
         }
         $container
             ->getDefinition('security.helper')
@@ -354,6 +355,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         ;
 
         $container->setAlias('security.firewall.context_locator', (string) ServiceLocatorTagPass::register($container, $contextRefs));
+        $container->setAlias('security.firewall_config_locator', (string) ServiceLocatorTagPass::register($container, $firewallConfigRefs));
 
         $mapDef->replaceArgument(0, new Reference('security.firewall.context_locator'));
         $mapDef->replaceArgument(1, new IteratorArgument($map));

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -92,6 +92,7 @@ return static function (ContainerConfigurator $container) {
                     'security.user_checker_locator' => service('security.user_checker_locator'),
                     'security.firewall.event_dispatcher_locator' => service('security.firewall.event_dispatcher_locator'),
                     'security.csrf.token_manager' => service('security.csrf.token_manager')->ignoreOnInvalid(),
+                    'security.firewall_config_locator' => service('security.firewall_config_locator')->ignoreOnInvalid(),
                 ]),
                 abstract_arg('authenticators'),
             ])

--- a/src/Symfony/Bundle/SecurityBundle/Security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security.php
@@ -13,8 +13,10 @@ namespace Symfony\Bundle\SecurityBundle;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -119,9 +121,9 @@ class Security extends InternalSecurity implements AuthorizationCheckerInterface
             throw new LogicException('Unable to login without a request context.');
         }
 
-        $firewallName ??= $this->getFirewallConfig($request)?->getName();
+        $currentFirewallConfig = $this->getFirewallConfig($request);
 
-        if (!$firewallName) {
+        if (!$firewallName ??= $currentFirewallConfig?->getName()) {
             throw new LogicException('Unable to login as the current route is not covered by any firewall.');
         }
 
@@ -130,7 +132,59 @@ class Security extends InternalSecurity implements AuthorizationCheckerInterface
         $userCheckerLocator = $this->container->get('security.user_checker_locator');
         $userCheckerLocator->get($firewallName)->checkPreAuth($user);
 
-        return $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges);
+        $response = $this->container->get('security.authenticator.managers_locator')->get($firewallName)->authenticateUser($user, $authenticator, $request, $badges);
+
+        if ($currentFirewallConfig && $firewallName !== $currentFirewallConfig->getName()) {
+            $this->persistTokenInTargetFirewall($request, $firewallName);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Persists the freshly minted token under the target firewall's session key
+     * and prevents the current firewall's ContextListener from overwriting its
+     * own session bucket with a token that belongs to another firewall.
+     */
+    private function persistTokenInTargetFirewall(Request $request, string $firewallName): void
+    {
+        $token = $this->container->get('security.token_storage')->getToken();
+        if (null === $token) {
+            return;
+        }
+
+        $targetConfig = $this->getNamedFirewallConfig($firewallName);
+        if (null === $targetConfig || $targetConfig->isStateless()) {
+            return;
+        }
+
+        if (null === $session = $this->getSessionForWrite($request)) {
+            return;
+        }
+
+        $session->set('_security_'.$targetConfig->getContext(), serialize($token));
+
+        $request->attributes->remove('_security_firewall_run');
+    }
+
+    private function getNamedFirewallConfig(string $firewallName): ?FirewallConfig
+    {
+        if (!$this->container->has('security.firewall_config_locator')) {
+            return null;
+        }
+
+        $locator = $this->container->get('security.firewall_config_locator');
+
+        return $locator->has($firewallName) ? $locator->get($firewallName) : null;
+    }
+
+    private function getSessionForWrite(Request $request): ?SessionInterface
+    {
+        try {
+            return $request->getSession();
+        } catch (SessionNotFoundException) {
+            return null;
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityTest.php
@@ -107,6 +107,21 @@ class SecurityTest extends AbstractWebTestCase
         $this->assertSame('chalasr', static::getContainer()->get('security.helper')->getUser()->getUserIdentifier());
     }
 
+    public function testLoginBetweenStatefulFirewalls()
+    {
+        $client = $this->createClient(['test_case' => 'SecurityHelper', 'root_config' => 'config.yml']);
+        $client->loginUser(new InMemoryUser('no-role-username', 'the-password'), 'main');
+
+        static::getContainer()->get(ForceLoginController::class)->firewallName = 'second';
+        $client->request('GET', '/main/force-login');
+
+        $client->request('GET', '/second/logged-in');
+        $this->assertSame(['message' => 'Welcome back @chalasr'], json_decode($client->getResponse()->getContent(), true));
+
+        $client->request('GET', '/main/logged-in');
+        $this->assertSame(['message' => 'Welcome back @no-role-username'], json_decode($client->getResponse()->getContent(), true));
+    }
+
     public function testLogout()
     {
         $client = $this->createClient(['test_case' => 'SecurityHelper', 'root_config' => 'config.yml', 'debug' => true]);
@@ -245,6 +260,7 @@ final class UserWithoutEquatable implements UserInterface, PasswordAuthenticated
 class ForceLoginController
 {
     public string $authenticator = 'form_login';
+    public ?string $firewallName = null;
 
     public function __construct(private Security $security)
     {
@@ -253,7 +269,7 @@ class ForceLoginController
     public function welcome()
     {
         $user = new InMemoryUser('chalasr', 'the-password', ['ROLE_FOO']);
-        $this->security->login($user, $this->authenticator);
+        $this->security->login($user, $this->authenticator, $this->firewallName);
 
         return new JsonResponse(['message' => \sprintf('Welcome @%s!', $this->security->getUser()->getUserIdentifier())]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53499 
| License       | MIT

`Security::login()` is supposed to authenticate a user into the firewall passed as the third argument, but when that firewall differs from the one currently handling the request the new token ends up persisted under the current firewall's session key (`_security_<currentFirewall>`) instead of the target firewall's (`_security_<targetFirewall>`).

Root cause: `ContextListener::onKernelResponse()` keys its session write off `$request->attributes->get('_security_firewall_run')`, which is the *current* firewall's session key. After `Security::login()` minted a token for a different firewall, that listener writes the foreign token to the current firewall's bucket — so the user looks logged in to the wrong firewall.

Fix: when the target firewall differs from the current one, write the new token directly to the target firewall's session key (`_security_<context>`, mirroring what `KernelBrowser::loginUser()` does) and remove the `_security_firewall_run` request attribute so the current firewall's `ContextListener` does not overwrite its own bucket with the foreign token. The current firewall's existing token is therefore untouched.

The fix is a no-op when `Security::login()` is called for the firewall already handling the request, when the target firewall is stateless, or when the target firewall config cannot be resolved (e.g. on legacy setups without the new `security.firewall_config_locator` locator) — preserving full BC.

A new `security.firewall_config_locator` ServiceLocator (keyed by firewall name) is wired in `SecurityExtension` and injected into `security.helper`, alongside the existing `security.user_checker_locator` pattern.

Reproduces with `Tests/Functional/SecurityTest::testLoginBetweenStatefulFirewalls`.

## TDD verification

- **RED** (new test on `6.4` with `Security.php`/`SecurityExtension.php`/`security.php` reverted):

```
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

There was 1 failure:

1) Symfony\Bundle\SecurityBundle\Tests\Functional\SecurityTest::testLoginBetweenStatefulFirewalls
Failed asserting that null is identical to Array &0 (
    'message' => 'Welcome back @chalasr'
).

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

- **GREEN** (new test with the fix applied):

```
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

OK (1 test, 1 assertion)
```
