### PR TITLE
i18n(vi): fix incorrect translations and clear review markers

### DIFF
--- a/.bounty_pr.json
+++ b/.bounty_pr.json
@@ -1,0 +1,17 @@
+{
+  "status": "ready",
+  "vertical": "translation",
+  "commit_message": "i18n(vi): fix incorrect Vietnamese translations and clear review markers",
+  "pr_title": "i18n(vi): fix incorrect translations and clear review markers",
+  "pr_body": "## Summary\n\nFixes #53309 — Missing/incorrect Vietnamese (vi) translations.\n\nAll `trans-unit` IDs were already present in the `vi` files, but several had incorrect translations or stale `state=\"needs-review-translation\"` markers that needed attention.\n\n### Validator (`src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf`)\n\n- **Critical mistranslations fixed (ids 88–91):** `positive`/`negative` had been rendered as `thực hiện được` (\"executable\") and `bị từ chối` (\"rejected\"). Corrected to `số dương` / `số âm` (positive/negative number).\n- **Mistranslated \"field\" (ids 9, 10):** `Lĩnh vực` (sector/domain) → `Trường` (form field), the correct term in form-validation context.\n- **Whitespace cleanup (ids 3, 7, 68):** removed double spaces around `{{ placeholders }}`.\n- **Resolved `needs-review-translation` markers** on entries verified as already correct (ids 37, 51, 59, 81, 83, 111–142).\n\n### Security (`src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf`)\n\n- **id 20:** removed an erroneous `|` plural separator that wasn't present in the EN source; cleared the review marker.\n\n### Stats\n- 2 files changed, 46 insertions(+), 46 deletions(-)\n- ~40 strings improved or normalized\n- XML well-formedness verified via `xml.etree.ElementTree`\n\nCloses #53309",
+  "branch": "i18n-vi/issue-53309-missing-translations-for-vietnamese",
+  "files_changed": [
+    "src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf",
+    "src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf"
+  ],
+  "strings_translated": 40,
+  "target_locale": "vi",
+  "tests_run": [],
+  "tests_passed": null,
+  "notes": "No trans-unit IDs were missing across the three vi.xlf files (Validator, Form, Security) — but quality issues warranted fixes. The most critical were validator ids 88–91 where 'positive/negative' had been completely mistranslated as 'executable/rejected'. Also fixed the mistranslation of 'field' as 'Lĩnh vực' (sector) instead of 'Trường' (form field), which is the correct context-appropriate term. Cleared 'needs-review-translation' markers for entries that read as accurate after review. The Form validators.vi.xlf was already complete and accurate; no changes there. Formal Vietnamese ('bạn' form) preserved throughout. All placeholders ({{ var }}, %placeholder%, |plural|) preserved exactly."
+}

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Quá nhiều lần đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.|Quá nhiều lần đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.</target>
+                <target>Quá nhiều lần đăng nhập không thành công, vui lòng thử lại sau %minutes% phút.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="3">
                 <source>This value should be of type {{ type }}.</source>
-                <target>Giá trị này phải là kiểu  {{ type }}.</target>
+                <target>Giá trị này phải là kiểu {{ type }}.</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>This value should be blank.</source>
@@ -28,7 +28,7 @@
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-                <target>Bạn phải chọn nhiều nhất {{ limit }} lựa chọn.|Bạn phải chọn nhiều  nhất {{ limit }} lựa chọn.</target>
+                <target>Bạn phải chọn nhiều nhất {{ limit }} lựa chọn.|Bạn phải chọn nhiều nhất {{ limit }} lựa chọn.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid.</source>
@@ -36,11 +36,11 @@
             </trans-unit>
             <trans-unit id="9">
                 <source>This field was not expected.</source>
-                <target>Lĩnh vực này không được dự kiến.</target>
+                <target>Trường này không được mong đợi.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>This field is missing.</source>
-                <target>Lĩnh vực này bị thiếu.</target>
+                <target>Trường này bị thiếu.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>This value is not a valid date.</source>
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
-                <target state="needs-review-translation">Giá trị này không phải là địa chỉ IP hợp lệ.</target>
+                <target>Giá trị này không phải là địa chỉ IP hợp lệ.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target state="needs-review-translation">Không có thư mục tạm được cấu hình trong php.ini, hoặc thư mục đã cấu hình không tồn tại.</target>
+                <target>Không có thư mục tạm được cấu hình trong php.ini, hoặc thư mục đã cấu hình không tồn tại.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
-                <target state="needs-review-translation">Giá trị này không phải là Số Tài Khoản Ngân Hàng Quốc Tế (IBAN) hợp lệ.</target>
+                <target>Giá trị này không phải là Số Tài Khoản Ngân Hàng Quốc Tế (IBAN) hợp lệ.</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -260,7 +260,7 @@
             </trans-unit>
             <trans-unit id="68">
                 <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-                <target>Giá trị phải giống  {{ compared_value_type }} {{ compared_value }}.</target>
+                <target>Giá trị phải giống {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="69">
                 <source>This value should be less than {{ compared_value }}.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target state="needs-review-translation">Giá trị này không phải là Mã Định Danh Doanh Nghiệp (BIC) hợp lệ.</target>
+                <target>Giá trị này không phải là Mã Định Danh Doanh Nghiệp (BIC) hợp lệ.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83" resname="This is not a valid UUID.">
                 <source>This value is not a valid UUID.</source>
-                <target state="needs-review-translation">Giá trị này không phải là UUID hợp lệ.</target>
+                <target>Giá trị này không phải là UUID hợp lệ.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -340,19 +340,19 @@
             </trans-unit>
             <trans-unit id="88">
                 <source>This value should be positive.</source>
-                <target>Giá trị này có thể thực hiện được.</target>
+                <target>Giá trị này phải là số dương.</target>
             </trans-unit>
             <trans-unit id="89">
                 <source>This value should be either positive or zero.</source>
-                <target>Giá trị này có thể thực hiện được hoặc bằng không.</target>
+                <target>Giá trị này phải là số dương hoặc bằng không.</target>
             </trans-unit>
             <trans-unit id="90">
                 <source>This value should be negative.</source>
-                <target>Giá trị này nên bị từ chối.</target>
+                <target>Giá trị này phải là số âm.</target>
             </trans-unit>
             <trans-unit id="91">
                 <source>This value should be either negative or zero.</source>
-                <target>Giá trị này nên bị từ chối hoặc bằng không.</target>
+                <target>Giá trị này phải là số âm hoặc bằng không.</target>
             </trans-unit>
             <trans-unit id="92">
                 <source>This value is not a valid timezone.</source>
@@ -432,127 +432,127 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-review-translation">Mã hóa ký tự được phát hiện là không hợp lệ ({{ detected }}). Các mã hóa được phép là {{ encodings }}.</target>
+                <target>Mã hóa ký tự được phát hiện là không hợp lệ ({{ detected }}). Các mã hóa được phép là {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
-                <target state="needs-review-translation">Giá trị này không phải là địa chỉ MAC hợp lệ.</target>
+                <target>Giá trị này không phải là địa chỉ MAC hợp lệ.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target state="needs-review-translation">URL này thiếu miền cấp cao.</target>
+                <target>URL này thiếu miền cấp cao.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target state="needs-review-translation">Giá trị này quá ngắn. Nó phải chứa ít nhất một từ.|Giá trị này quá ngắn. Nó phải chứa ít nhất {{ min }} từ.</target>
+                <target>Giá trị này quá ngắn. Nó phải chứa ít nhất một từ.|Giá trị này quá ngắn. Nó phải chứa ít nhất {{ min }} từ.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target state="needs-review-translation">Giá trị này quá dài. Nó chỉ nên chứa một từ.|Giá trị này quá dài. Nó chỉ nên chứa {{ max }} từ hoặc ít hơn.</target>
+                <target>Giá trị này quá dài. Nó chỉ nên chứa một từ.|Giá trị này quá dài. Nó chỉ nên chứa {{ max }} từ hoặc ít hơn.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target state="needs-review-translation">Giá trị này không đại diện cho một tuần hợp lệ theo định dạng ISO 8601.</target>
+                <target>Giá trị này không đại diện cho một tuần hợp lệ theo định dạng ISO 8601.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target state="needs-review-translation">Giá trị này không phải là một tuần hợp lệ.</target>
+                <target>Giá trị này không phải là một tuần hợp lệ.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target state="needs-review-translation">Giá trị này không nên trước tuần "{{ min }}".</target>
+                <target>Giá trị này không nên trước tuần "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target state="needs-review-translation">Giá trị này không nên sau tuần "{{ max }}".</target>
+                <target>Giá trị này không nên sau tuần "{{ max }}".</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Giá trị này không phải là một mẫu Twig hợp lệ.</target>
+                <target>Giá trị này không phải là một mẫu Twig hợp lệ.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Tệp này không phải là video hợp lệ.</target>
+                <target>Tệp này không phải là video hợp lệ.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Không thể phát hiện kích thước của video.</target>
+                <target>Không thể phát hiện kích thước của video.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Chiều rộng video quá lớn ({{ width }}px). Chiều rộng tối đa cho phép là {{ max_width }}px.</target>
+                <target>Chiều rộng video quá lớn ({{ width }}px). Chiều rộng tối đa cho phép là {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Chiều rộng video quá nhỏ ({{ width }}px). Chiều rộng tối thiểu mong đợi là {{ min_width }}px.</target>
+                <target>Chiều rộng video quá nhỏ ({{ width }}px). Chiều rộng tối thiểu mong đợi là {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Chiều cao video quá lớn ({{ height }}px). Chiều cao tối đa cho phép là {{ max_height }}px.</target>
+                <target>Chiều cao video quá lớn ({{ height }}px). Chiều cao tối đa cho phép là {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Chiều cao video quá nhỏ ({{ height }}px). Chiều cao tối thiểu dự kiến là {{ min_height }}px.</target>
+                <target>Chiều cao video quá nhỏ ({{ height }}px). Chiều cao tối thiểu dự kiến là {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video có quá ít điểm ảnh ({{ pixels }}). Lượng tối thiểu mong đợi là {{ min_pixels }}.</target>
+                <target>Video có quá ít điểm ảnh ({{ pixels }}). Lượng tối thiểu mong đợi là {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video có quá nhiều điểm ảnh ({{ pixels }}). Số lượng tối đa dự kiến là {{ max_pixels }}.</target>
+                <target>Video có quá nhiều điểm ảnh ({{ pixels }}). Số lượng tối đa dự kiến là {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Tỉ lệ video quá lớn ({{ ratio }}). Tỉ lệ tối đa được phép là {{ max_ratio }}.</target>
+                <target>Tỉ lệ video quá lớn ({{ ratio }}). Tỉ lệ tối đa được phép là {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Tỉ lệ video quá nhỏ ({{ ratio }}). Tỉ lệ tối thiểu dự kiến là {{ min_ratio }}.</target>
+                <target>Tỉ lệ video quá nhỏ ({{ ratio }}). Tỉ lệ tối thiểu dự kiến là {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Video có dạng hình vuông ({{ width }}x{{ height }}px). Không cho phép video hình vuông.</target>
+                <target>Video có dạng hình vuông ({{ width }}x{{ height }}px). Không cho phép video hình vuông.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video có hướng ngang ({{ width }}x{{ height }} px). Không cho phép video ngang.</target>
+                <target>Video có hướng ngang ({{ width }}x{{ height }} px). Không cho phép video ngang.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video có hướng dọc ({{ width }}x{{ height }}px). Không cho phép video hướng dọc.</target>
+                <target>Video có hướng dọc ({{ width }}x{{ height }}px). Không cho phép video hướng dọc.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Tệp video bị hỏng.</target>
+                <target>Tệp video bị hỏng.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Video chứa nhiều luồng. Chỉ cho phép một luồng.</target>
+                <target>Video chứa nhiều luồng. Chỉ cho phép một luồng.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Bộ mã hóa video không được hỗ trợ "{{ codec }}".</target>
+                <target>Bộ mã hóa video không được hỗ trợ "{{ codec }}".</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Bộ chứa video không được hỗ trợ "{{ container }}".</target>
+                <target>Bộ chứa video không được hỗ trợ "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Tệp hình ảnh bị hỏng.</target>
+                <target>Tệp hình ảnh bị hỏng.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Hình ảnh có quá ít điểm ảnh ({{ pixels }}). Số lượng tối thiểu dự kiến là {{ min_pixels }}.</target>
+                <target>Hình ảnh có quá ít điểm ảnh ({{ pixels }}). Số lượng tối thiểu dự kiến là {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Hình ảnh có quá nhiều điểm ảnh ({{ pixels }}). Lượng tối đa dự kiến là {{ max_pixels }}.</target>
+                <target>Hình ảnh có quá nhiều điểm ảnh ({{ pixels }}). Lượng tối đa dự kiến là {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Tên tệp này không khớp với bộ ký tự mong đợi.</target>
+                <target>Tên tệp này không khớp với bộ ký tự mong đợi.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
## Summary

Fixes #53309 — Missing/incorrect Vietnamese (vi) translations.

All `trans-unit` IDs were already present in the `vi` files, but several had incorrect translations or stale `state="needs-review-translation"` markers that needed attention.

### Validator (`src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf`)

- **Critical mistranslations fixed (ids 88–91):** `positive`/`negative` had been rendered as `thực hiện được` ("executable") and `bị từ chối` ("rejected"). Corrected to `số dương` / `số âm` (positive/negative number).
- **Mistranslated "field" (ids 9, 10):** `Lĩnh vực` (sector/domain) → `Trường` (form field), the correct term in form-validation context.
- **Whitespace cleanup (ids 3, 7, 68):** removed double spaces around `{{ placeholders }}`.
- **Resolved `needs-review-translation` markers** on entries verified as already correct (ids 37, 51, 59, 81, 83, 111–142).

### Security (`src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf`)

- **id 20:** removed an erroneous `|` plural separator that wasn't present in the EN source; cleared the review marker.

### Stats
- 2 files changed, 46 insertions(+), 46 deletions(-)
- ~40 strings improved or normalized
- XML well-formedness verified via `xml.etree.ElementTree`

Closes #53309