### PR TITLE
[FrameworkBundle][Mailer] Harden default IP allowlist for Postmark and Brevo webhook parsers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2703,24 +2703,6 @@ class FrameworkExtension extends Extension
             }
         }
 
-        if ($webhookEnabled) {
-            $webhookRequestParsers = [
-                MailerBridge\Brevo\Webhook\BrevoRequestParser::class => 'mailer.webhook.request_parser.brevo',
-                MailerBridge\Mailgun\Webhook\MailgunRequestParser::class => 'mailer.webhook.request_parser.mailgun',
-                MailerBridge\Mailjet\Webhook\MailjetRequestParser::class => 'mailer.webhook.request_parser.mailjet',
-                MailerBridge\Postmark\Webhook\PostmarkRequestParser::class => 'mailer.webhook.request_parser.postmark',
-                MailerBridge\Sendgrid\Webhook\SendgridRequestParser::class => 'mailer.webhook.request_parser.sendgrid',
-            ];
-
-            foreach ($webhookRequestParsers as $class => $service) {
-                $package = substr($service, \strlen('mailer.webhook.request_parser.'));
-
-                if (!ContainerBuilder::willBeAvailable(\sprintf('symfony/%s-mailer', 'gmail' === $package ? 'google' : $package), $class, ['symfony/framework-bundle', 'symfony/mailer'])) {
-                    $container->removeDefinition($service);
-                }
-            }
-        }
-
         $envelopeListener = $container->getDefinition('mailer.envelope_listener');
         $envelopeListener->setArgument(0, $config['envelope']['sender'] ?? null);
         $envelopeListener->setArgument(1, $config['envelope']['recipients'] ?? null);
@@ -2746,6 +2728,23 @@ class FrameworkExtension extends Extension
 
         if ($webhookEnabled) {
             $loader->load('mailer_webhook.php');
+
+            $debug = $container->getParameter('kernel.debug');
+            foreach ([
+                MailerBridge\Brevo\Webhook\BrevoRequestParser::class => 'mailer.webhook.request_parser.brevo',
+                MailerBridge\Mailgun\Webhook\MailgunRequestParser::class => 'mailer.webhook.request_parser.mailgun',
+                MailerBridge\Mailjet\Webhook\MailjetRequestParser::class => 'mailer.webhook.request_parser.mailjet',
+                MailerBridge\Postmark\Webhook\PostmarkRequestParser::class => 'mailer.webhook.request_parser.postmark',
+                MailerBridge\Sendgrid\Webhook\SendgridRequestParser::class => 'mailer.webhook.request_parser.sendgrid',
+            ] as $class => $service) {
+                $package = substr($service, \strlen('mailer.webhook.request_parser.'));
+
+                if (!ContainerBuilder::willBeAvailable(\sprintf('symfony/%s-mailer', 'gmail' === $package ? 'google' : $package), $class, ['symfony/framework-bundle', 'symfony/mailer'])) {
+                    $container->removeDefinition($service);
+                } elseif ($debug && \defined($class.'::PROVIDER_IPS')) {
+                    $container->getDefinition($service)->setArgument('$allowedIPs', [...$class::PROVIDER_IPS, '127.0.0.1']);
+                }
+            }
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\Mailer\Bridge\Brevo\Webhook\BrevoRequestParser;
+use Symfony\Component\Mailer\Bridge\Postmark\Webhook\PostmarkRequestParser;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 
@@ -273,5 +275,58 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
             yield [$mode];
         }
         yield ['loose'];
+    }
+
+    public function testMailerWebhookProdExcludesLocalhost()
+    {
+        if (!\defined(BrevoRequestParser::class.'::PROVIDER_IPS') || !\defined(PostmarkRequestParser::class.'::PROVIDER_IPS')) {
+            $this->markTestSkipped('PROVIDER_IPS not available on the installed bridges.');
+        }
+
+        $container = $this->createContainerFromClosure(static function ($container) {
+            $container->loadFromExtension('framework', [
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'mailer' => ['dsn' => 'smtp://null'],
+                'webhook' => ['enabled' => true],
+                'http_client' => ['enabled' => true],
+                'serializer' => ['enabled' => true],
+            ]);
+        });
+
+        foreach (['mailer.webhook.request_parser.brevo', 'mailer.webhook.request_parser.postmark'] as $service) {
+            $this->assertArrayNotHasKey('$allowedIPs', $container->getDefinition($service)->getArguments());
+        }
+    }
+
+    public function testMailerWebhookDebugAddsLocalhost()
+    {
+        if (!\defined(BrevoRequestParser::class.'::PROVIDER_IPS') || !\defined(PostmarkRequestParser::class.'::PROVIDER_IPS')) {
+            $this->markTestSkipped('PROVIDER_IPS not available on the installed bridges.');
+        }
+
+        $container = $this->createContainerFromClosure(static function ($container) {
+            $container->loadFromExtension('framework', [
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'mailer' => ['dsn' => 'smtp://null'],
+                'webhook' => ['enabled' => true],
+                'http_client' => ['enabled' => true],
+                'serializer' => ['enabled' => true],
+            ]);
+        }, ['kernel.debug' => true]);
+
+        $this->assertSame(
+            [...BrevoRequestParser::PROVIDER_IPS, '127.0.0.1'],
+            $container->getDefinition('mailer.webhook.request_parser.brevo')->getArgument('$allowedIPs')
+        );
+        $this->assertSame(
+            [...PostmarkRequestParser::PROVIDER_IPS, '127.0.0.1'],
+            $container->getDefinition('mailer.webhook.request_parser.postmark')->getArgument('$allowedIPs')
+        );
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Webhook/BrevoRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Webhook/BrevoRequestParserTest.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Component\Mailer\Bridge\Brevo\Tests\Webhook;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Brevo\RemoteEvent\BrevoPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Brevo\Webhook\BrevoRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class BrevoRequestParserTest extends AbstractRequestParserTestCase
@@ -21,5 +23,80 @@ class BrevoRequestParserTest extends AbstractRequestParserTestCase
     protected function createRequestParser(): RequestParserInterface
     {
         return new BrevoRequestParser(new BrevoPayloadConverter());
+    }
+
+    protected function getSecret(): string
+    {
+        return ':top-secret';
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '1.179.112.5',
+            'HTTP_Authorization' => 'Basic '.base64_encode(':top-secret'),
+        ], $payload);
+    }
+
+    public function testProviderIpsExcludesLocalhost()
+    {
+        $this->assertNotContains('127.0.0.1', BrevoRequestParser::PROVIDER_IPS);
+    }
+
+    public function testDefaultRejectsLocalhost()
+    {
+        $parser = new BrevoRequestParser(new BrevoPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/hard_bounce.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '127.0.0.1',
+            'HTTP_Authorization' => 'Basic '.base64_encode(':top-secret'),
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $parser->parse($request, ':top-secret');
+    }
+
+    public function testAcceptsExplicitlyAllowedIp()
+    {
+        $parser = new BrevoRequestParser(new BrevoPayloadConverter(), ['127.0.0.1']);
+        $payload = file_get_contents(__DIR__.'/Fixtures/hard_bounce.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '127.0.0.1',
+            'HTTP_Authorization' => 'Basic '.base64_encode(':top-secret'),
+        ], $payload);
+
+        $this->assertNotNull($parser->parse($request, ':top-secret'));
+    }
+
+    public function testRejectMissingCredentials()
+    {
+        $parser = new BrevoRequestParser(new BrevoPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/hard_bounce.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '1.179.112.5',
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, ':top-secret');
+    }
+
+    public function testRejectWrongSecret()
+    {
+        $parser = new BrevoRequestParser(new BrevoPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/hard_bounce.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '1.179.112.5',
+            'HTTP_Authorization' => 'Basic '.base64_encode(':wrong-secret'),
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, ':top-secret');
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Webhook/BrevoRequestParser.php
@@ -25,8 +25,12 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class BrevoRequestParser extends AbstractRequestParser
 {
+    // https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services
+    public const PROVIDER_IPS = ['1.179.112.0/20', '172.246.240.0/20'];
+
     public function __construct(
         private readonly BrevoPayloadConverter $converter,
+        private readonly array $allowedIPs = self::PROVIDER_IPS,
     ) {
     }
 
@@ -35,14 +39,16 @@ final class BrevoRequestParser extends AbstractRequestParser
         return new ChainRequestMatcher([
             new MethodRequestMatcher('POST'),
             new IsJsonRequestMatcher(),
-            // https://help.brevo.com/hc/en-us/articles/15127404548498-Brevo-IP-ranges-List-of-publicly-exposed-services
-            // localhost is added for testing
-            new IpsRequestMatcher(['1.179.112.0/20', '172.246.240.0/20', '127.0.0.1']),
+            new IpsRequestMatcher($this->allowedIPs),
         ]);
     }
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
+        if ($secret && !hash_equals('Basic '.base64_encode($secret), $request->headers->get('Authorization', ''))) {
+            throw new RejectWebhookException(403, 'Invalid credentials.');
+        }
+
         $content = $request->toArray();
         if (
             !isset($content['event'])

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/PostmarkRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/PostmarkRequestParserTest.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Component\Mailer\Bridge\Postmark\Tests\Webhook;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Postmark\RemoteEvent\PostmarkPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Postmark\Webhook\PostmarkRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class PostmarkRequestParserTest extends AbstractRequestParserTestCase
@@ -21,5 +23,43 @@ class PostmarkRequestParserTest extends AbstractRequestParserTestCase
     protected function createRequestParser(): RequestParserInterface
     {
         return new PostmarkRequestParser(new PostmarkPayloadConverter());
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '3.134.147.250',
+        ], $payload);
+    }
+
+    public function testProviderIpsExcludesLocalhost()
+    {
+        $this->assertNotContains('127.0.0.1', PostmarkRequestParser::PROVIDER_IPS);
+    }
+
+    public function testDefaultRejectsLocalhost()
+    {
+        $parser = new PostmarkRequestParser(new PostmarkPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivery.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $parser->parse($request, '');
+    }
+
+    public function testAcceptsExplicitlyAllowedIp()
+    {
+        $parser = new PostmarkRequestParser(new PostmarkPayloadConverter(), ['127.0.0.1']);
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivery.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ], $payload);
+
+        $this->assertNotNull($parser->parse($request, ''));
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
@@ -25,12 +25,12 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class PostmarkRequestParser extends AbstractRequestParser
 {
+    // https://postmarkapp.com/support/article/800-ips-for-firewalls#webhooks
+    public const PROVIDER_IPS = ['3.134.147.250', '50.31.156.6', '50.31.156.77', '18.217.206.57'];
+
     public function __construct(
         private readonly PostmarkPayloadConverter $converter,
-
-        // https://postmarkapp.com/support/article/800-ips-for-firewalls#webhooks
-        // localhost is added for testing
-        private readonly array $allowedIPs = ['3.134.147.250', '50.31.156.6', '50.31.156.77', '18.217.206.57', '127.0.0.1'],
+        private readonly array $allowedIPs = self::PROVIDER_IPS,
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Both bridges shipped `127.0.0.1` in their default IP allowlist for testing convenience. Brevo's list was also hardcoded inside `getRequestMatcher()` with no override path, so an operator could not remove the loopback entry short of subclassing. Reaching the loopback entry from off-host requires an integrator-side trust-boundary mistake (a misconfigured trusted-proxy chain accepting `X-Forwarded-For: 127.0.0.1`, or a co-resident SSRF), so this is hardening rather than a CVE — the framework still shouldn't ship the loopback in the production-default array.

Postmark exposes `PROVIDER_IPS` as a public const and drops `127.0.0.1` from the default `$allowedIPs`. Brevo gains the same `PROVIDER_IPS` const, an `$allowedIPs` constructor argument (mirroring Postmark), and `hash_equals()` validation of the `Authorization: Basic base64($secret)` header — mirroring the Mailjet parser. An empty `$secret` skips the check, consistent with the rest of the bridges. Brevo's "Secure webhook calls" documentation currently exposes only IP allowlisting, basic-auth-in-URL, bearer-token, and custom-header options, so basic-auth is the spec-aligned signature path today.

To keep local development working out of the box, FrameworkBundle re-adds `127.0.0.1` to the allowlists of `mailer.webhook.request_parser.brevo` and `mailer.webhook.request_parser.postmark` when `kernel.debug` is true. The override is gated by `\defined($class.'::PROVIDER_IPS')` for BC with older installed bridge versions, and targets the `$allowedIPs` named argument so the two bridges can keep different ctor signatures. The webhook-parser loop also moved after `mailer_webhook.php` is loaded so `removeDefinition` for unavailable bridge packages actually takes effect.