### PR TITLE
[HtmlSanitizer] Honor universal attribute sanitizers, apply maxInputLength to text contexts, document forceAttribute and allowAttribute caveats

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizer.php
@@ -51,6 +51,11 @@ final class HtmlSanitizer implements HtmlSanitizerInterface
 
     private function sanitizeWithContext(string $context, string $input): string
     {
+        // Prevent DOS attack induced by extremely long HTML strings
+        if (-1 !== $this->config->getMaxInputLength() && \strlen($input) > $this->config->getMaxInputLength()) {
+            $input = substr($input, 0, $this->config->getMaxInputLength());
+        }
+
         // Text context: early return with HTML encoding
         if (W3CReference::CONTEXT_TEXT === $context) {
             return StringSanitizer::encodeHtmlEntities($input);
@@ -58,11 +63,6 @@ final class HtmlSanitizer implements HtmlSanitizerInterface
 
         // Other context: build a DOM visitor
         $this->domVisitors[$context] ??= $this->createDomVisitorForContext($context);
-
-        // Prevent DOS attack induced by extremely long HTML strings
-        if (-1 !== $this->config->getMaxInputLength() && \strlen($input) > $this->config->getMaxInputLength()) {
-            $input = substr($input, 0, $this->config->getMaxInputLength());
-        }
 
         // Only operate on valid UTF-8 strings. This is necessary to prevent cross
         // site scripting issues on Internet Explorer 6. Idea from Drupal (filter_xss).

--- a/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
+++ b/src/Symfony/Component/HtmlSanitizer/HtmlSanitizerConfig.php
@@ -318,6 +318,11 @@ class HtmlSanitizerConfig
      * A list of allowed elements for this attribute can be passed as a second argument.
      * Passing "*" will allow all currently allowed elements to use this attribute.
      *
+     * Note: this method is subtractive within the currently allowed elements.
+     * It restricts the attribute to the listed elements and removes it from any
+     * other allowed element that previously had it. To add an attribute to one
+     * element without affecting others, use allowElement($element, [$attribute]).
+     *
      * @param list<string>|string $allowedElements
      */
     public function allowAttribute(string $attribute, array|string $allowedElements): static
@@ -370,7 +375,10 @@ class HtmlSanitizerConfig
     /**
      * Forcefully set the value of a given attribute on a given element.
      *
-     * The attribute will be created on the nodes if it didn't exist.
+     * The attribute will be created on the nodes if it didn't exist. The
+     * provided value is written verbatim and is NOT passed through any
+     * attribute sanitizer (in particular, URL attribute sanitization is
+     * skipped), so callers are responsible for ensuring the value is safe.
      */
     public function forceAttribute(string $element, string $attribute, string $value): static
     {

--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
@@ -531,6 +531,45 @@ class HtmlSanitizerCustomTest extends TestCase
         );
     }
 
+    public function testWildcardAttributeSanitizerIsCalled()
+    {
+        $config = (new HtmlSanitizerConfig())
+            ->allowElement('div', ['data-foo', 'data-bar'])
+            ->withAttributeSanitizer(new class implements AttributeSanitizerInterface {
+                public function getSupportedElements(): ?array
+                {
+                    return null;
+                }
+
+                public function getSupportedAttributes(): ?array
+                {
+                    return null;
+                }
+
+                public function sanitizeAttribute(string $element, string $attribute, string $value, HtmlSanitizerConfig $config): ?string
+                {
+                    return strrev($value);
+                }
+            })
+        ;
+
+        $this->assertSame(
+            '<div data-foo="cba" data-bar="zyx">Hello world</div>',
+            $this->sanitize($config, '<div data-foo="abc" data-bar="xyz">Hello world</div>')
+        );
+    }
+
+    public function testMaxInputLengthIsAppliedToTextContext()
+    {
+        $config = (new HtmlSanitizerConfig());
+
+        $input = str_repeat('A', $config->getMaxInputLength() + 100);
+        $expected = str_repeat('A', $config->getMaxInputLength());
+
+        $this->assertSame($expected, (new HtmlSanitizer($config))->sanitizeFor('textarea', $input));
+        $this->assertSame($expected, (new HtmlSanitizer($config))->sanitizeFor('title', $input));
+    }
+
     private function sanitize(HtmlSanitizerConfig $config, string $input): string
     {
         return (new HtmlSanitizer($config))->sanitize($input);

--- a/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
+++ b/src/Symfony/Component/HtmlSanitizer/Visitor/DomVisitor.php
@@ -164,6 +164,7 @@ final class DomVisitor
                     $this->attributeSanitizers[$domNodeName][$name] ?? [],
                     $this->attributeSanitizers['*'][$name] ?? [],
                     $this->attributeSanitizers[$domNodeName]['*'] ?? [],
+                    $this->attributeSanitizers['*']['*'] ?? [],
                 );
 
                 foreach ($attributeSanitizers as $sanitizer) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Hardening, not a security fix. Bundles four small improvements surfaced during a recent audit:

- `DomVisitor::setAttributes()` now honors attribute sanitizers registered with the documented `null, null` wildcard pattern from `AttributeSanitizerInterface`: the `['*']['*']` slot is added to the `array_merge` so universal sanitizers actually run.
- `HtmlSanitizer::sanitizeWithContext()` applies `maxInputLength` before the `CONTEXT_TEXT` early-return path, so text-context calls (`sanitizeFor('textarea', …)`, `sanitizeFor('title', …)`) cannot exceed the configured limit.
- `HtmlSanitizerConfig::forceAttribute()` docblock now documents that the provided value is written verbatim and is **not** routed through any attribute sanitizer (including `UrlAttributeSanitizer`). Callers are responsible for ensuring the value is safe.
- `HtmlSanitizerConfig::allowAttribute()` docblock now documents its subtractive nature: it restricts the attribute to the listed elements and removes it from any other allowed element that previously had it. Use `allowElement($element, [$attribute])` to add an attribute to one element without affecting others.