### PR TITLE
[Mailer][Notifier] Harden Mailchimp signature comparison and Smsbox IP allowlist

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
@@ -86,7 +86,7 @@ final class MailchimpRequestParser extends AbstractRequestParser
             $signedData .= \is_array($value) ? $this->stringifyArray($value) : $value;
         }
 
-        if ($mandrillHeaderSignature !== base64_encode(hash_hmac('sha1', $signedData, $secret, true))) {
+        if (!hash_equals(base64_encode(hash_hmac('sha1', $signedData, $secret, true)), $mandrillHeaderSignature)) {
             throw new RejectWebhookException(400, 'Signature is wrong.');
         }
     }

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/Webhook/SmsboxRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/Tests/Webhook/SmsboxRequestParserTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Smsbox\Tests\Webhook;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Notifier\Bridge\Smsbox\Webhook\SmsboxRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class SmsboxRequestParserTest extends AbstractRequestParserTestCase
@@ -33,5 +34,31 @@ class SmsboxRequestParserTest extends AbstractRequestParserTestCase
     protected static function getFixtureExtension(): string
     {
         return 'txt';
+    }
+
+    public function testProviderIpsExposed()
+    {
+        $this->assertContains('37.59.198.135', SmsboxRequestParser::PROVIDER_IPS);
+        $this->assertNotContains('127.0.0.1', SmsboxRequestParser::PROVIDER_IPS);
+    }
+
+    public function testDefaultRejectsUnknownIp()
+    {
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivred.txt');
+        parse_str(trim($payload), $parameters);
+        $request = Request::create('/', 'GET', $parameters, [], [], ['REMOTE_ADDR' => '198.51.100.7']);
+
+        $this->expectException(RejectWebhookException::class);
+        (new SmsboxRequestParser())->parse($request, '');
+    }
+
+    public function testAllowedIpsConstructorOverride()
+    {
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivred.txt');
+        parse_str(trim($payload), $parameters);
+        $request = Request::create('/', 'GET', $parameters, [], [], ['REMOTE_ADDR' => '198.51.100.7']);
+
+        $parser = new SmsboxRequestParser(['198.51.100.7']);
+        $this->assertNotNull($parser->parse($request, ''));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/Webhook/SmsboxRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/Webhook/SmsboxRequestParser.php
@@ -22,18 +22,19 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class SmsboxRequestParser extends AbstractRequestParser
 {
+    // https://www.smsbox.net/en/tools-development#doc-sms-accusees
+    public const PROVIDER_IPS = ['37.59.198.135', '178.33.185.51', '54.36.93.79', '54.36.93.80', '62.4.31.47', '62.4.31.48'];
+
+    public function __construct(
+        private readonly array $allowedIPs = self::PROVIDER_IPS,
+    ) {
+    }
+
     protected function getRequestMatcher(): RequestMatcherInterface
     {
         return new ChainRequestMatcher([
             new MethodRequestMatcher(['GET']),
-            new IpsRequestMatcher([
-                '37.59.198.135',
-                '178.33.185.51',
-                '54.36.93.79',
-                '54.36.93.80',
-                '62.4.31.47',
-                '62.4.31.48',
-            ]),
+            new IpsRequestMatcher($this->allowedIPs),
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two small hardenings spotted while reviewing the webhook parsers.

`MailchimpRequestParser::validateSignature()` compared the HMAC with `!==`, the only parser in the cluster doing the comparison non-constant-time. Swapped for `hash_equals()` to remove the timing side-channel. Both branches reject the same inputs, so no functional change.

`SmsboxRequestParser::getRequestMatcher()` hardcoded the six provider IPs inside the method body with no override path. Added a `PROVIDER_IPS` public const and an `$allowedIPs` constructor argument so operators can extend or replace the list without subclassing, mirroring the shape already used for Postmark. The default behavior is unchanged.