### PR TITLE
[Mime][String] Reject objects in typed-string properties during __unserialize

### DIFF
--- a/src/Symfony/Component/Mime/Part/SMimePart.php
+++ b/src/Symfony/Component/Mime/Part/SMimePart.php
@@ -119,6 +119,12 @@ class SMimePart extends AbstractPart
 
     public function __unserialize(array $data): void
     {
+        foreach (['body', 'type', 'subtype'] as $prop) {
+            if (($data[$prop] ?? $data["\0".self::class."\0".$prop] ?? $data["\0*\0".$prop] ?? null) instanceof \Stringable) {
+                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+            }
+        }
+
         if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
             trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
         }

--- a/src/Symfony/Component/Mime/Part/TextPart.php
+++ b/src/Symfony/Component/Mime/Part/TextPart.php
@@ -276,6 +276,12 @@ class TextPart extends AbstractPart
 
     public function __unserialize(array $data): void
     {
+        foreach (['charset', 'subtype', 'disposition', 'name', 'encoding'] as $prop) {
+            if (($data[$prop] ?? $data["\0".self::class."\0".$prop] ?? $data["\0*\0".$prop] ?? null) instanceof \Stringable) {
+                throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+            }
+        }
+
         if ($wakeup = self::class !== (new \ReflectionMethod($this, '__wakeup'))->class && self::class === (new \ReflectionMethod($this, '__unserialize'))->class) {
             trigger_deprecation('symfony/mime', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
         }

--- a/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Tests\Part;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Part\SMimePart;
+
+class SMimePartTestToStringGadget
+{
+    public static bool $fired = false;
+
+    public function __toString(): string
+    {
+        self::$fired = true;
+
+        return '';
+    }
+}
+
+class SMimePartTest extends TestCase
+{
+    #[DataProvider('provideTrampolineKeys')]
+    public function testUnserializeRejectsObjectInTypedStringProperty(string $key)
+    {
+        $template = (new SMimePart('body content', 'application', 'pkcs7-mime', []))->__serialize();
+        $template[$key] = new SMimePartTestToStringGadget();
+        $payload = \sprintf('O:%d:"%s":%d:{', \strlen(SMimePart::class), SMimePart::class, \count($template));
+        foreach ($template as $k => $v) {
+            $payload .= serialize($k).serialize($v);
+        }
+        $payload .= '}';
+        SMimePartTestToStringGadget::$fired = false;
+
+        try {
+            unserialize($payload);
+            $this->fail('Expected BadMethodCallException.');
+        } catch (\BadMethodCallException $e) {
+        }
+
+        $this->assertFalse(SMimePartTestToStringGadget::$fired, '__toString gadget must not fire during unserialize');
+    }
+
+    public static function provideTrampolineKeys(): iterable
+    {
+        yield ['body'];
+        yield ['type'];
+        yield ['subtype'];
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mime\Tests\Part;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Encoder\ContentEncoderInterface;
 use Symfony\Component\Mime\Exception\InvalidArgumentException;
@@ -21,8 +22,50 @@ use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Component\Mime\Part\File;
 use Symfony\Component\Mime\Part\TextPart;
 
+class TextPartTestToStringGadget
+{
+    public static bool $fired = false;
+
+    public function __toString(): string
+    {
+        self::$fired = true;
+
+        return '';
+    }
+}
+
 class TextPartTest extends TestCase
 {
+    #[DataProvider('provideTrampolineKeys')]
+    public function testUnserializeRejectsObjectInTypedStringProperty(string $key)
+    {
+        $template = (new TextPart('body content'))->__serialize();
+        $template[$key] = new TextPartTestToStringGadget();
+        $payload = \sprintf('O:%d:"%s":%d:{', \strlen(TextPart::class), TextPart::class, \count($template));
+        foreach ($template as $k => $v) {
+            $payload .= serialize($k).serialize($v);
+        }
+        $payload .= '}';
+        TextPartTestToStringGadget::$fired = false;
+
+        try {
+            unserialize($payload);
+            $this->fail('Expected BadMethodCallException.');
+        } catch (\BadMethodCallException $e) {
+        }
+
+        $this->assertFalse(TextPartTestToStringGadget::$fired, '__toString gadget must not fire during unserialize');
+    }
+
+    public static function provideTrampolineKeys(): iterable
+    {
+        yield ['charset'];
+        yield ['subtype'];
+        yield ['disposition'];
+        yield ['name'];
+        yield ['encoding'];
+    }
+
     public function testConstructor()
     {
         $p = new TextPart('content');

--- a/src/Symfony/Component/String/Tests/UnicodeStringTest.php
+++ b/src/Symfony/Component/String/Tests/UnicodeStringTest.php
@@ -15,8 +15,38 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\String\AbstractString;
 use Symfony\Component\String\UnicodeString;
 
+class UnicodeStringTestToStringGadget
+{
+    public static bool $fired = false;
+
+    public function __toString(): string
+    {
+        self::$fired = true;
+
+        return '';
+    }
+}
+
 class UnicodeStringTest extends AbstractUnicodeTestCase
 {
+    public function testUnserializeRejectsObjectInTypedStringProperty()
+    {
+        $payload = \sprintf(
+            'O:%d:"%s":1:{s:6:"string";O:%d:"%s":0:{}}',
+            \strlen(UnicodeString::class), UnicodeString::class,
+            \strlen(UnicodeStringTestToStringGadget::class), UnicodeStringTestToStringGadget::class,
+        );
+        UnicodeStringTestToStringGadget::$fired = false;
+
+        try {
+            unserialize($payload);
+            $this->fail('Expected BadMethodCallException.');
+        } catch (\BadMethodCallException $e) {
+        }
+
+        $this->assertFalse(UnicodeStringTestToStringGadget::$fired, '__toString gadget must not fire during unserialize');
+    }
+
     #[DataProvider('provideTrimNormalization')]
     public function testTrimPrefixNormalization(string $expected, string $string, $prefix)
     {

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -414,6 +414,10 @@ class UnicodeString extends AbstractUnicodeString
             trigger_deprecation('symfony/string', '7.4', 'Implementing "%s::__wakeup()" is deprecated, use "__unserialize()" instead.', get_debug_type($this));
         }
 
+        if (($data['string'] ?? null) instanceof \Stringable || ($data["\0*\0string"] ?? null) instanceof \Stringable) {
+            throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+        }
+
         try {
             if (\in_array(array_keys($data), [['string'], ["\0*\0string"]], true)) {
                 $this->string = $data['string'] ?? $data["\0*\0string"];
@@ -438,10 +442,6 @@ class UnicodeString extends AbstractUnicodeString
             }, $this, static::class)($data);
         } finally {
             if (!$wakeup) {
-                if (!\is_string($this->string)) {
-                    throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
-                }
-
                 normalizer_is_normalized($this->string) ?: $this->string = normalizer_normalize($this->string);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Same class of issue as #64343 on 6.4: a `__unserialize(array $data)` that assigns `$data[...]` to a typed `string` (or union-with-`string`) property lets PHP's type coercion invoke `__toString()` on any attacker-supplied object before the value is stored. A post-assignment `is_string()` guard runs too late.

This PR covers the surface that exists on 7.4 and is not addressed in #64343:

| Class                  | Typed-string slots assigned from raw `$data`                                                       |
| ---------------------- | -------------------------------------------------------------------------------------------------- |
| `String\UnicodeString` | `string $string`                                                                                   |
| `Mime\Part\TextPart`   | `?string $charset`, `string $subtype`, `?string $disposition`, `?string $name`, `string $encoding` |
| `Mime\Part\SMimePart`  | `iterable\|string $body`, `string $type`, `string $subtype`                                        |

Union types that include `string` (e.g. `iterable|string`) also trigger `__toString()` coercion; for `SMimePart::$body` the guard is `instanceof \Stringable && !is_iterable($body)` since PHP prefers the iterable branch when an object satisfies both.

Each `__unserialize()` now validates the shape of the raw `$data` before any assignment, throwing `BadMethodCallException` on mismatch. `UnicodeString`'s existing post-check is moved to run before the assignment; `TextPart` and `SMimePart` gain explicit pre-checks for every typed-string slot (in every key-prefix variant: bare, `\0Class\0...`, and `\0*\0...`).

The 6.4 hardening for `Route`, `CompiledRoute`, `Window`, `SlidingWindow`, `TokenBucket`, and `Email` lands on 7.4 via the upmerge.