### PR TITLE
[Process] Stop leaking CGI/FastCGI request-context vars to subprocesses

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1606,7 +1606,35 @@ class Process implements \IteratorAggregate
     {
         $env = getenv();
         $env = ('\\' === \DIRECTORY_SEPARATOR ? array_intersect_ukey($env, $_SERVER, 'strcasecmp') : array_intersect_key($env, $_SERVER)) ?: $env;
+        $env = $_ENV + ('\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($env, $_ENV, 'strcasecmp') : $env);
 
-        return $_ENV + ('\\' === \DIRECTORY_SEPARATOR ? array_diff_ukey($env, $_ENV, 'strcasecmp') : $env);
+        if (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+            return $env;
+        }
+
+        // On non-CLI SAPIs (notably PHP-FPM and CGI), CGI/FastCGI request-context
+        // vars are exposed through $_SERVER, $_ENV and getenv(), and must not
+        // propagate to subprocesses.
+        foreach ($env as $k => $v) {
+            if (str_starts_with($k, 'HTTP_')
+                || str_starts_with($k, 'ORIG_')
+                || str_starts_with($k, 'REDIRECT_')
+                || \in_array($k, [
+                    'AUTH_TYPE', 'CONTENT_LENGTH', 'CONTENT_TYPE', 'DOCUMENT_ROOT',
+                    'DOCUMENT_URI', 'GATEWAY_INTERFACE', 'HTTPS', 'PATH_INFO',
+                    'PATH_TRANSLATED', 'PHP_AUTH_DIGEST', 'PHP_AUTH_PW', 'PHP_AUTH_USER',
+                    'PHP_SELF', 'QUERY_STRING', 'REMOTE_ADDR', 'REMOTE_HOST',
+                    'REMOTE_IDENT', 'REMOTE_PORT', 'REMOTE_USER', 'REQUEST_METHOD',
+                    'REQUEST_SCHEME', 'REQUEST_TIME', 'REQUEST_TIME_FLOAT', 'REQUEST_URI',
+                    'SCRIPT_FILENAME', 'SCRIPT_NAME', 'SCRIPT_URI', 'SCRIPT_URL',
+                    'SERVER_ADDR', 'SERVER_ADMIN', 'SERVER_NAME', 'SERVER_PORT',
+                    'SERVER_PROTOCOL', 'SERVER_SIGNATURE', 'SERVER_SOFTWARE',
+                ], true)
+            ) {
+                unset($env[$k]);
+            }
+        }
+
+        return $env;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64327
| License       | MIT

Some SAPIs (notably PHP-FPM and CGI, via `cgi_php_import_environment_variables`) expose request-scoped CGI/FastCGI vars (`QUERY_STRING`, `HTTP_*`, `REQUEST_*`, etc.) through `$_SERVER`, `$_ENV` and `getenv()`, even though they aren't real OS env vars. `Process::getDefaultEnv()` then propagated them to subprocesses, where they would confuse runtimes: e.g. `$_SERVER['QUERY_STRING']` leaking into a `bin/console` subprocess made `SymfonyRuntime` treat it as a web request, drop argv processing and strip the command name and options.

This PR strips the standard CGI variable names (RFC 3875 + PHP/FPM additions) and the `HTTP_`/`ORIG_`/`REDIRECT_` prefixes from the default env. Custom `fastcgi_param` entries and user-set `$_ENV` vars are unaffected.

A companion PR for `Runtime` against 5.4 (#64346) makes `SymfonyRuntime` trust argv on CLI-like SAPIs as defense in depth.