### PR TITLE
[HttpClient] ntlm regression on authPersistNonNTLM=false connections with reset()

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -136,6 +136,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2_0;
         }
 
+        $ntlmOriginKey = null;
         if (isset($options['auth_ntlm'])) {
             $curlopts[\CURLOPT_HTTPAUTH] = \CURLAUTH_NTLM;
             $curlopts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_1_1;
@@ -154,6 +155,13 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
 
             $curlopts[\CURLOPT_USERPWD] = $options['auth_ntlm'];
+
+            $ntlmOriginKey = CurlClientState::originKey($scheme, $host, $port);
+
+            if (isset($this->multi->ntlmRequiresFreshConnection[$ntlmOriginKey])) {
+                $curlopts[\CURLOPT_FRESH_CONNECT] = true;
+                $curlopts[\CURLOPT_FORBID_REUSE] = true;
+            }
         }
 
         if (!\ZEND_THREAD_SAFE) {
@@ -316,7 +324,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return $pushedResponse ?? new CurlResponse($this->multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $authority), CurlClientState::$curlVersion['version_number'], $url);
+        return $pushedResponse ?? new CurlResponse($this->multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $authority), CurlClientState::$curlVersion['version_number'], $url, $ntlmOriginKey);
     }
 
     public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -35,6 +35,9 @@ final class CurlClientState extends ClientState
     public int $execCounter = \PHP_INT_MIN;
     public ?LoggerInterface $logger = null;
 
+    /** @var array<string, true> Indexed by self::originKey() */
+    public array $ntlmRequiresFreshConnection = [];
+
     public static array $curlVersion;
 
     public function __construct(
@@ -48,6 +51,14 @@ final class CurlClientState extends ClientState
         unset($this->handle, $this->share);
     }
 
+    public static function originKey(string $scheme, string $host, ?int $port = null): string
+    {
+        $scheme = strtolower(rtrim($scheme, ':'));
+        $port ??= 'https' === $scheme ? 443 : 80;
+
+        return $scheme.'://'.strtolower($host).':'.$port;
+    }
+
     public function reset(): void
     {
         foreach ($this->pushedResponses as $url => $response) {
@@ -59,6 +70,7 @@ final class CurlClientState extends ClientState
         $this->pushedResponses = [];
         $this->dnsCache->evictions = $this->dnsCache->evictions ?: $this->dnsCache->removals;
         $this->dnsCache->removals = $this->dnsCache->hostnames = [];
+        $this->ntlmRequiresFreshConnection = [];
 
         unset($this->share);
     }

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -33,6 +33,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
     use TransportResponseTrait;
 
     private CurlClientState $multi;
+    private ?string $ntlmOriginKey;
 
     /**
      * @var resource
@@ -42,9 +43,10 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
     /**
      * @internal
      */
-    public function __construct(CurlClientState $multi, \CurlHandle|string $ch, ?array $options = null, ?LoggerInterface $logger = null, string $method = 'GET', ?callable $resolveRedirect = null, ?int $curlVersion = null, ?string $originalUrl = null)
+    public function __construct(CurlClientState $multi, \CurlHandle|string $ch, ?array $options = null, ?LoggerInterface $logger = null, string $method = 'GET', ?callable $resolveRedirect = null, ?int $curlVersion = null, ?string $originalUrl = null, ?string $ntlmOriginKey = null)
     {
         $this->multi = $multi;
+        $this->ntlmOriginKey = $ntlmOriginKey;
 
         if ($ch instanceof \CurlHandle) {
             $this->handle = $ch;
@@ -296,6 +298,10 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
                 $id = (int) $ch = $info['handle'];
                 $waitFor = @curl_getinfo($ch, \CURLINFO_PRIVATE) ?: '_0';
 
+                if (isset($responses[$id]) && self::retryNtlmOnFreshConnection($multi, $ch, $responses[$id]->ntlmOriginKey, $result)) {
+                    continue;
+                }
+
                 if (\in_array($result, [\CURLE_SEND_ERROR, \CURLE_RECV_ERROR, /* CURLE_HTTP2 */ 16, /* CURLE_HTTP2_STREAM */ 92], true) && $waitFor[1] && 'C' !== $waitFor[0]) {
                     curl_multi_remove_handle($multi->handle, $ch);
                     $waitFor[1] = (string) ((int) $waitFor[1] - 1); // decrement the retry counter
@@ -454,5 +460,42 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
         $location = null;
 
         return \strlen($data);
+    }
+
+    /**
+     * Handles servers that do not persist NTLM authentication across requests on a reused
+     * TCP connection (e.g. IIS with authPersistNonNTLM=false). On such servers, libcurl
+     * still considers the pooled socket authenticated client-side and skips the handshake,
+     * but the server returns a fresh 401 + NTLM challenge that libcurl cannot pick up on
+     * the same request, so the caller sees an unauthenticated 401.
+     *
+     * The discriminator is CURLINFO_NUM_CONNECTS == 0: no new connection was opened for
+     * this request, so the socket came from the pool. A 401 + NTLM challenge on a brand
+     * new socket is the legitimate first leg of libcurl's in-request 3-way handshake and
+     * must NOT trigger this path.
+     *
+     * When detected, the deauthenticated socket is closed, the request is retried once on
+     * a fresh one, and the origin is recorded so subsequent requests to it skip the pool
+     * from the start.
+     */
+    private static function retryNtlmOnFreshConnection(CurlClientState $multi, \CurlHandle $ch, ?string $originKey, int $result): bool
+    {
+        if (null === $originKey
+            || \CURLE_OK !== $result
+            || 401 !== curl_getinfo($ch, \CURLINFO_RESPONSE_CODE)
+            || 0 === (curl_getinfo($ch, \CURLINFO_HTTPAUTH_AVAIL) & \CURLAUTH_NTLM)
+            || 0 !== curl_getinfo($ch, \CURLINFO_NUM_CONNECTS)
+            || isset($multi->ntlmRequiresFreshConnection[$originKey])
+        ) {
+            return false;
+        }
+
+        $multi->ntlmRequiresFreshConnection[$originKey] = true;
+        $multi->logger?->info(\sprintf('Discarding NTLM-deauthenticated connection to "%s" and retrying on a fresh one', $originKey));
+        curl_setopt($ch, \CURLOPT_FORBID_REUSE, true);
+        curl_multi_remove_handle($multi->handle, $ch);
+        curl_setopt($ch, \CURLOPT_FRESH_CONNECT, true);
+
+        return 0 === curl_multi_add_handle($multi->handle, $ch);
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -155,6 +155,94 @@ class CurlHttpClientTest extends HttpClientTestCase
         $this->assertSame('/302', $response->toArray()['REQUEST_URI'] ?? null);
     }
 
+    public function testNtlmRequiresFreshConnectionStateIsEmptyByDefault()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $r = new \ReflectionProperty($client, 'multi');
+        $state = $r->getValue($client);
+
+        self::assertSame([], $state->ntlmRequiresFreshConnection);
+    }
+
+    public function testNtlmFreshConnectionForcedWhenOriginKnown()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $client->request('GET', 'http://127.0.0.1:8057/')->getContent();
+
+        $r = new \ReflectionProperty($client, 'multi');
+        $state = $r->getValue($client);
+        $state->ntlmRequiresFreshConnection['http://127.0.0.1:8057'] = true;
+
+        $response = $client->request('GET', 'http://127.0.0.1:8057/', [
+            'auth_ntlm' => 'user:pass',
+        ]);
+        $response->getStatusCode();
+
+        self::assertStringNotContainsString('Re-using existing connection', $response->getInfo('debug'));
+    }
+
+    public function testNtlmStateNotMutatedByNonNtlmRequest()
+    {
+        // A plain (non-NTLM) request must not touch the NTLM origin map. This guards against
+        // a regression where the detection logic fires on every CURLMSG_DONE event (e.g. an
+        // inverted condition guard) — which would silently mark every origin as needing a
+        // fresh NTLM connection.
+        $client = $this->getHttpClient(__FUNCTION__);
+        $client->request('GET', 'http://127.0.0.1:8057/json')->getContent();
+
+        $r = new \ReflectionProperty($client, 'multi');
+        $state = $r->getValue($client);
+
+        self::assertSame([], $state->ntlmRequiresFreshConnection);
+    }
+
+    public function testNtlmStateNotMutatedByFreshConnectionNtlm401()
+    {
+        // A 401 + NTLM challenge that arrives on a fresh connection (NUM_CONNECTS != 0) is
+        // the legitimate first leg of libcurl's in-request handshake — not the cross-request
+        // de-auth case. Detection must NOT fire, and the origin must NOT be marked.
+        $client = $this->getHttpClient(__FUNCTION__);
+        $client->request('GET', 'http://127.0.0.1:8057/ntlm-always-401', [
+            'auth_ntlm' => 'user:pass',
+        ])->getStatusCode();
+
+        $r = new \ReflectionProperty($client, 'multi');
+        $state = $r->getValue($client);
+
+        self::assertSame([], $state->ntlmRequiresFreshConnection);
+    }
+
+    public function testNoNtlmLogMessagesForNonNtlmRequest()
+    {
+        // The observable signal for "we discarded a connection" is a specific log line.
+        // A plain request must not produce that line — protects against bugs that cause
+        // the retry/discovery path to fire unconditionally.
+        $client = $this->getHttpClient(__FUNCTION__);
+        $logger = new TestLogger();
+        $client->setLogger($logger);
+
+        $client->request('GET', 'http://127.0.0.1:8057/json')->getContent();
+
+        $ntlmLogs = array_filter($logger->logs, static fn ($msg) => str_contains($msg, 'NTLM'));
+        self::assertSame([], $ntlmLogs);
+    }
+
+    public function testNtlmLoopGuardDoesNotRetryWhenOriginAlreadyKnown()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $r = new \ReflectionProperty($client, 'multi');
+        $state = $r->getValue($client);
+        $state->ntlmRequiresFreshConnection['http://127.0.0.1:8057'] = true;
+
+        $response = $client->request('GET', 'http://127.0.0.1:8057/ntlm-always-401', [
+            'auth_ntlm' => 'user:pass',
+        ]);
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
     /**
      * @group integration
      */

--- a/src/Symfony/Component/HttpClient/Tests/Internal/CurlClientStateTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Internal/CurlClientStateTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Internal;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Internal\CurlClientState;
+
+/**
+ * @requires extension curl
+ */
+class CurlClientStateTest extends TestCase
+{
+    public function testOriginKeyFormat()
+    {
+        self::assertSame('http://127.0.0.1:8057', CurlClientState::originKey('http', '127.0.0.1', 8057));
+        self::assertSame('http://127.0.0.1:8057', CurlClientState::originKey('http:', '127.0.0.1', 8057));
+        self::assertSame('https://example.com:443', CurlClientState::originKey('https', 'example.com', 443));
+        self::assertSame('http://example.com:80', CurlClientState::originKey('http', 'example.com', 80));
+        self::assertSame('http://example.com:80', CurlClientState::originKey('http', 'EXAMPLE.com', 80));
+        self::assertSame('http://example.com:80', CurlClientState::originKey('HTTP', 'example.com', 80));
+        self::assertSame('http://example.com:80', CurlClientState::originKey('http', 'example.com'));
+        self::assertSame('https://example.com:443', CurlClientState::originKey('https', 'example.com'));
+    }
+
+    public function testResetClearsNtlmRequiresFreshConnection()
+    {
+        $state = new CurlClientState(6, 0);
+        $state->ntlmRequiresFreshConnection['http://example.com:80'] = true;
+
+        $state->reset();
+
+        self::assertSame([], $state->ntlmRequiresFreshConnection);
+    }
+}

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -209,6 +209,13 @@ switch (parse_url($vars['REQUEST_URI'], \PHP_URL_PATH)) {
                 header($header);
             }
         }
+        break;
+
+    case '/ntlm-always-401':
+        header('HTTP/1.1 401 Unauthorized');
+        header('WWW-Authenticate: NTLM TlRMTVNTUAACAAAAAwADADgAAAAGgokCB7m5ksVjjAsAAAAAAAAAAHYAdgA7AAAACgB8TwAAAA9QUkQ=');
+        header('Content-Length: 0');
+        exit;
 }
 
 header('Content-Type: application/json', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This fixes a regression introduced by #64046.

#64046 moved the connection cache off the curl share handle. That makes max_host_connections actually work, which was the goal, but it also breaks auth_ntlm against servers that don't persist NTLM authentication across requests on the same TCP connection. I ran into the issue calling a service configured as authPersistNonNTLM=false.

The first request succeeds: libcurl does the Type 1/2/3 handshake and gets a 201. 
The second request reuses that TCP connection, libcurl's NTLM state machine considers it already authenticated and skips the handshake, IIS treats each request independently and returns 401 with a fresh WWW-Authenticate: NTLM challenge, which isnt picked up as a new handshare by libcurl anymore.

My example: 
```
  Request 1 (~1.5s, success):
    > Authorization: NTLM <Type 1>
    < HTTP/1.1 401 + WWW-Authenticate: NTLM <Type 2>
    > Authorization: NTLM <Type 3>
    < HTTP/1.1 201 Created
    * Connection #0 left intact

  Request 2 (~18ms, 401):
    > (reuses connection #0, no handshake)
    < HTTP/1.1 401 + WWW-Authenticate: NTLM <Type 2>
    (no retry)
```

The underlying NTLM-on-reused-connection problem predates #64046: any consumer making two or more NTLM requests against an authPersistNonNTLM=false server has been silently broken since well before v7.4.9. The way to make them work was by calling `$connection->reset()` before a request. This broke due to reset() unset the share handle and the share owned the connection cache via CURL_LOCK_DATA_CONNECT. #64046 correctly removed that share to honour max_host_connections, but as a side-effect it removed the resetting of the connection needed for the NTLM requests.

Fix: in CurlResponse::perform(), detect a 401 with an NTLM WWW-Authenticate arriving on a reused connection (CURLINFO_NUM_CONNECTS == 0), close the deauthenticated socket, retry on a fresh connection, and record the origin. Subsequent requests to a recorded origin set CURLOPT_FRESH_CONNECT and CURLOPT_FORBID_REUSE at setup time so they skip the pool. 

Tests for the setup-time and negative cases. Cannot cover the full reused-connection because the cli-server forces connection: close, which doesnt allow me to recreate the issue in the test.   

Considered alternative: making CurlClientState::reset() close NTLM-authenticated connections, which would restore the pre-#64046 side-effect for consumers that call reset() between requests, but this seemed like a sturdier fix.

My current local fix to get it working again in 7.4.9 (which I can remove again after this PR) is adding the CURLOPT_FORBID_REUSE to my framework.yml config.

```
  framework:
      http_client:
          scoped_clients:
              my_ntlm.client:
                  base_uri: '%env(NTLM_BASE_URI)%'
                  auth_ntlm: '%env(NTLM_AUTH_KEY)%'
                  extra:
                      curl:
                          !php/const CURLOPT_FORBID_REUSE: true
```
