### PR TITLE
[Cache] skip tests for adapters that cannot clear by prefix

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
@@ -28,6 +28,7 @@ class CouchbaseBucketAdapterTest extends AdapterTestCase
 {
     protected $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
+        'testClearPrefixWithUnderscore' => 'Couchbase cannot clear by prefix',
         'testClearWithInvalidPrefix' => 'Couchbase cannot clear by prefix',
     ];
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
@@ -28,6 +28,7 @@ class CouchbaseCollectionAdapterTest extends AdapterTestCase
 {
     protected $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
+        'testClearPrefixWithUnderscore' => 'Couchbase cannot clear by prefix',
         'testClearWithInvalidPrefix' => 'Couchbase cannot clear by prefix',
     ];
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -26,6 +26,7 @@ class MemcachedAdapterTest extends AdapterTestCase
         'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
         'testClearPrefix' => 'Memcached cannot clear by prefix',
+        'testClearPrefixWithUnderscore' => 'Memcached cannot clear by prefix',
         'testClearWithInvalidPrefix' => 'Memcached cannot clear by prefix',
     ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Something I forgot in https://github.com/symfony/symfony/pull/64336