### PR TITLE
[Console] Format message in ConsoleSectionOutput::overwrite()

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -106,7 +106,7 @@ class ConsoleSectionOutput extends StreamOutput
         }
 
         foreach ($message as $line) {
-            $this->addContent($line, true);
+            $this->addContent($this->getFormatter()->format($line) ?? '', true);
         }
 
         $erasedContent = $this->popStreamContentUntilCurrentSection($this->maxHeight ? min($this->maxHeight, $linesCleared) : $linesCleared);

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -188,6 +188,18 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals($expected, stream_get_contents($output->getStream()));
     }
 
+    public function testOverwriteFormatsMessage()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->writeln('Foo');
+        $output->overwrite('<info>Bar</>');
+
+        rewind($output->getStream());
+        $this->assertEquals('Foo'.\PHP_EOL."\x1b[1A\x1b[0J\x1b[32mBar\x1b[39m".\PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
     public function testOverwriteMultipleLines()
     {
         $sections = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64333
| License       | MIT

Since #64176, `ConsoleSectionOutput::overwrite()` builds the content via
`addContent()` and emits it via `parent::doWrite($this->getVisibleContent(), …)`.
Unlike the previous `clear()` + `writeln()` path, this never goes through
`Output::write()`, which is where the formatter is normally applied — so
`<info>foo</>` was written verbatim instead of being colorized.

This applies the formatter to each line before storing it, matching what
`Output::write()` does for the regular path.