### PR TITLE
[Tui] Throw when ext-zip is not installed and one tries to load a zipped figlet

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/Figlet/FigletFontTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Figlet/FigletFontTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Tests\Widget\Figlet;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Widget\Figlet\FigletFont;
@@ -95,6 +96,7 @@ class FigletFontTest extends TestCase
         FigletFont::load('/nonexistent/path/to/font.flf');
     }
 
+    #[RequiresPhpExtension('zip')]
     public function testLoadZipRejectsOversizedDecompressedEntry()
     {
         $path = tempnam(sys_get_temp_dir(), 'flf_zip_').'.zip';

--- a/src/Symfony/Component/Tui/Widget/Figlet/FigletFont.php
+++ b/src/Symfony/Component/Tui/Widget/Figlet/FigletFont.php
@@ -182,6 +182,10 @@ final class FigletFont
      */
     private static function extractFromZip(string $path): string
     {
+        if (!\extension_loaded('zip')) {
+            throw new InvalidArgumentException('The ZIP extension is required to load FIGlet fonts from ZIP archives.');
+        }
+
         $zip = new \ZipArchive();
 
         if (true !== $zip->open($path)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
