### PR TITLE
[ObjectMapper] Fix TargetClass generic type in ConditionCallableInterface

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Condition/TargetClass.php
+++ b/src/Symfony/Component/ObjectMapper/Condition/TargetClass.php
@@ -16,7 +16,7 @@ use Symfony\Component\ObjectMapper\ConditionCallableInterface;
 /**
  * @template T of object
  *
- * @implements ConditionCallableInterface<object, T>
+ * @implements ConditionCallableInterface<object, object>
  */
 final class TargetClass implements ConditionCallableInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64340
| License       | MIT

`TargetClass` declared `@implements ConditionCallableInterface<object, T>`, which narrows the target generic to the `className` type. However, `__invoke` accepts any `?object` at runtime (it only checks `instanceof` internally), so this generic binding was over-specified.

The mismatch caused a PHPStan error when using `TargetClass` as the `if` condition of `#[Map]`:

```php
#[Map(if: new TargetClass(self::class))]
```

PHPStan inferred the callable as `callable(mixed, object, ?Foo): bool`, which is not contravariantly compatible with the `callable(mixed, object, ?object): bool` type expected by `Map::$if`.

Fixing the `@implements` binding to `<object, object>` aligns the generic annotation with the actual runtime behavior, with no BC break — `@template T of object` is preserved so `$className` keeps its `class-string<T>` constraint.