### PR TITLE
[DependencyInjection] Remove unused variables from ContainerTest.php file

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -135,12 +135,12 @@ class ContainerTest extends TestCase
     public function testGetServiceIds()
     {
         $sc = new Container();
-        $sc->set('foo', $obj = new \stdClass());
-        $sc->set('bar', $obj = new \stdClass());
+        $sc->set('foo', new \stdClass());
+        $sc->set('bar', new \stdClass());
         $this->assertEquals(['service_container', 'foo', 'bar'], $sc->getServiceIds(), '->getServiceIds() returns all defined service ids');
 
         $sc = new ProjectServiceContainer();
-        $sc->set('foo', $obj = new \stdClass());
+        $sc->set('foo', new \stdClass());
         $this->assertEquals(['service_container', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'internal_dependency', 'alias', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by factory methods in the method map, followed by service ids defined by set()');
     }
 
@@ -227,8 +227,8 @@ class ContainerTest extends TestCase
     public function testGetThrowServiceNotFoundException()
     {
         $sc = new ProjectServiceContainer();
-        $sc->set('foo', $foo = new \stdClass());
-        $sc->set('baz', $foo = new \stdClass());
+        $sc->set('foo', new \stdClass());
+        $sc->set('baz', new \stdClass());
 
         try {
             $sc->get('foo1');
@@ -340,7 +340,7 @@ class ContainerTest extends TestCase
 
         try {
             $c->get('throw_exception');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Do nothing.
         }
 
@@ -354,7 +354,7 @@ class ContainerTest extends TestCase
 
         try {
             $c->get('throws_exception_on_service_configuration');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Do nothing.
         }
 
@@ -363,7 +363,7 @@ class ContainerTest extends TestCase
         // Retry, to make sure that get*Service() will be called.
         try {
             $c->get('throws_exception_on_service_configuration');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Do nothing.
         }
         $this->assertFalse($c->initialized('throws_exception_on_service_configuration'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

There are some unsed variables in ContainerTest.php file. Therefore, I remove them.
