### PR TITLE
[Tui] Fix vertical align

### DIFF
--- a/src/Symfony/Component/Tui/Render/LayoutEngine.php
+++ b/src/Symfony/Component/Tui/Render/LayoutEngine.php
@@ -48,10 +48,10 @@ final class LayoutEngine
      *
      * @return string[]
      */
-    public function layout(array $children, int $columns, int $rows, int $gap, Direction $direction, ?string $gapLine = null): array
+    public function layout(array $children, int $columns, int $rows, int $gap, Direction $direction, ?string $gapLine = null, ?VerticalAlign $verticalAlign = null): array
     {
         if (Direction::Horizontal === $direction) {
-            return $this->layoutHorizontal($children, $columns, $rows, $gap);
+            return $this->layoutHorizontal($children, $columns, $rows, $gap, $verticalAlign);
         }
 
         return $this->layoutVertical($children, $columns, $rows, $gap, $gapLine);
@@ -76,7 +76,7 @@ final class LayoutEngine
         $availableSpace = max(0, $columns - $maxWidth);
 
         return match ($align) {
-            Align::Center => (int) floor($availableSpace / 2),
+            Align::Center => $availableSpace >> 1,
             Align::Right => $availableSpace,
             Align::Left => 0,
         };
@@ -91,7 +91,7 @@ final class LayoutEngine
 
         return match ($verticalAlign) {
             VerticalAlign::Top => 0,
-            VerticalAlign::Center => (int) floor($space / 2),
+            VerticalAlign::Center => $space >> 1,
             VerticalAlign::Bottom => $space,
         };
     }
@@ -256,7 +256,7 @@ final class LayoutEngine
      *
      * @return string[]
      */
-    private function layoutHorizontal(array $children, int $columns, int $rows, int $gap): array
+    private function layoutHorizontal(array $children, int $columns, int $rows, int $gap, ?VerticalAlign $verticalAlign = null): array
     {
         if (!$count = \count($children)) {
             return [];
@@ -329,13 +329,26 @@ final class LayoutEngine
             return [];
         }
 
-        // Track widget positions for horizontal children
+        // Compute per-child vertical offset for cross-axis alignment (align-items).
+        // This positions shorter children relative to the tallest, analogous to
+        // CSS align-items on a flex row.
+        $childOffsets = [];
+        foreach ($children as $index => $child) {
+            $childHeight = \count($childRenders[$index]);
+            $childOffsets[$index] = match ($verticalAlign) {
+                VerticalAlign::Center => ($maxRows - $childHeight) >> 1,
+                VerticalAlign::Bottom => $maxRows - $childHeight,
+                default => 0,
+            };
+        }
+
+        // Track widget positions for horizontal children, accounting for vertical offsets.
         if ($hasPositionStack) {
             [$absRow, $absCol] = $this->positionTracker->currentOffset();
             $colOffset = 0;
             foreach ($children as $index => $child) {
                 $this->positionTracker->setWidgetRect($child, new WidgetRect(
-                    $absRow,
+                    $absRow + $childOffsets[$index],
                     $absCol + $colOffset,
                     $childColumnCounts[$index],
                     \count($childRenders[$index]),
@@ -350,7 +363,8 @@ final class LayoutEngine
         for ($row = 0; $row < $maxRows; ++$row) {
             $lineParts = [];
             foreach ($children as $index => $child) {
-                $line = $childRenders[$index][$row] ?? '';
+                $childRow = $row - $childOffsets[$index];
+                $line = ($childRow >= 0 && isset($childRenders[$index][$childRow])) ? $childRenders[$index][$childRow] : '';
                 $visibleLen = AnsiUtils::visibleWidth($line);
                 $cols = $childColumnCounts[$index];
 

--- a/src/Symfony/Component/Tui/Render/RenderContext.php
+++ b/src/Symfony/Component/Tui/Render/RenderContext.php
@@ -43,6 +43,7 @@ final class RenderContext
         private readonly int $rows,
         ?Style $style = null,
         ?FontRegistry $fontRegistry = null,
+        private readonly bool $fillRows = false,
     ) {
         $this->style = $style ?? new Style();
         $this->fontRegistry = $fontRegistry ?? new FontRegistry();
@@ -69,11 +70,22 @@ final class RenderContext
     }
 
     /**
+     * Returns true when this widget should fill its allocated rows (root render or vertically-expanded).
+     *
+     * Used to gate VerticalAlign padding on vertical containers: non-expanded nested containers
+     * receive the parent's row budget as a maximum, not a target to fill.
+     */
+    public function shouldFillRows(): bool
+    {
+        return $this->fillRows;
+    }
+
+    /**
      * Create a new context with a different column count.
      */
     public function withColumns(int $columns): self
     {
-        return new self($columns, $this->rows, $this->style, $this->fontRegistry);
+        return new self($columns, $this->rows, $this->style, $this->fontRegistry, $this->fillRows);
     }
 
     /**
@@ -97,6 +109,6 @@ final class RenderContext
      */
     public function withStyle(Style $style): self
     {
-        return new self($this->columns, $this->rows, $style, $this->fontRegistry);
+        return new self($this->columns, $this->rows, $style, $this->fontRegistry, $this->fillRows);
     }
 }

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -21,7 +21,6 @@ use Symfony\Component\Tui\Style\StyleSheet;
 use Symfony\Component\Tui\Widget\AbstractWidget;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\Figlet\FontRegistry;
-use Symfony\Component\Tui\Widget\ParentInterface;
 
 /**
  * Renders the widget tree with style resolution, layout, and chrome.
@@ -104,7 +103,7 @@ final class Renderer implements WidgetRendererInterface
      */
     public function render(ContainerWidget $root, int $columns, int $rows): array
     {
-        $context = new RenderContext($columns, $rows, null, $this->fontRegistry);
+        $context = new RenderContext($columns, $rows, null, $this->fontRegistry, fillRows: true);
         $this->currentColumns = $columns;
         $this->positionTracker->reset();
 
@@ -295,7 +294,9 @@ final class Renderer implements WidgetRendererInterface
         $hasVerticalAlign = null !== $verticalAlign;
         $positionsBeforeLayout = ($hasAlign || $hasVerticalAlign) ? $this->positionTracker->snapshotKeys() : null;
 
-        // Render children using layout engine
+        // Render children using layout engine.
+        // For horizontal containers, pass verticalAlign so layoutHorizontal can
+        // offset shorter children (align-items). For vertical containers it is unused.
         $childLines = $this->layoutEngine->layout(
             $children,
             $innerColumns,
@@ -303,19 +304,35 @@ final class Renderer implements WidgetRendererInterface
             $gap,
             $direction,
             $gapLine,
+            Direction::Horizontal === $direction ? $verticalAlign : null,
         );
 
         // Pop position stack
         $this->positionTracker->pop();
 
-        // Apply vertical alignment for child widgets and adjust tracked positions
-        if ($hasVerticalAlign && \count($childLines) < $innerRows) {
+        // Apply vertical alignment offset when VerticalAlign is set and the widget owns its rows.
+        if ($hasVerticalAlign && \count($childLines) < $innerRows
+            && ($context->shouldFillRows() || $widget->isVerticallyExpanded())
+        ) {
             if (0 < $verticalOffset = $this->layoutEngine->computeVerticalAlignOffset(\count($childLines), $innerRows, $verticalAlign)) {
                 $topPad = array_fill(0, $verticalOffset, '');
                 array_unshift($childLines, ...$topPad);
                 $this->positionTracker->shiftDescendantPositions($positionsBeforeLayout, 0, $verticalOffset);
             }
-            // Pad to fill remaining height so Tui::doRender() doesn't override alignment
+        }
+
+        // Pad to fill allocated rows so that chrome (e.g. background-color) covers the full height.
+        //
+        // A fill child is detected by isVerticallyExpanded()=true AND shouldFillRows()=false:
+        // layoutVertical creates a fresh RenderContext (fillRows=false) with exactly $childFillRows,
+        // so the child must fill those rows itself before chromeApplier runs — otherwise layoutVertical
+        // pads with bare empty strings that bypass chromeApplier and leave background incomplete.
+        //
+        // Root renders (shouldFillRows=true) pad only when VerticalAlign is explicitly set;
+        // without it the root returns its natural content height.
+        $shouldPad = ($widget->isVerticallyExpanded() && !$context->shouldFillRows())
+            || ($context->shouldFillRows() && $hasVerticalAlign);
+        if ($shouldPad && \count($childLines) < $innerRows) {
             while (\count($childLines) < $innerRows) {
                 $childLines[] = '';
             }

--- a/src/Symfony/Component/Tui/Tests/Render/AlignTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/AlignTest.php
@@ -258,4 +258,68 @@ final class AlignTest extends TestCase
             $this->assertStringNotContainsString('Hi', AnsiUtils::stripAnsiCodes($lines[$i]));
         }
     }
+
+    public function testVerticalAlignCenterDoesNotExpandNonExpandedNestedContainer()
+    {
+        // A non-expanded container with VerticalAlign::Center must not fill its parent's
+        // row budget — it must use its natural content height only.
+        $renderer = new Renderer(new StyleSheet([
+            '.inner' => new Style(verticalAlign: VerticalAlign::Center),
+        ]));
+
+        $root = new ContainerWidget();
+
+        $inner = new ContainerWidget();
+        $inner->addStyleClass('inner');
+        $inner->add(new TextWidget('A'));
+        $inner->add(new TextWidget('B'));
+
+        $root->add($inner);
+        $root->add(new TextWidget('After'));
+
+        $lines = $renderer->render($root, 10, 10);
+
+        // inner renders 2 lines (A + B), After renders 1 line — total 3 lines.
+        // If inner incorrectly expands to 10 rows, After is pushed off and total is > 3.
+        $this->assertCount(3, $lines);
+        $this->assertStringContainsString('A', AnsiUtils::stripAnsiCodes($lines[0]));
+        $this->assertStringContainsString('B', AnsiUtils::stripAnsiCodes($lines[1]));
+        $this->assertStringContainsString('After', AnsiUtils::stripAnsiCodes($lines[2]));
+    }
+
+    public function testVerticalAlignCenterInHorizontalContainerCentersShortChildren()
+    {
+        // In a horizontal container, VerticalAlign::Center must behave like CSS align-items: center —
+        // shorter children are vertically centered relative to the tallest child, not pinned to the top.
+        $renderer = new Renderer(new StyleSheet([
+            '.row' => new Style(direction: \Symfony\Component\Tui\Style\Direction::Horizontal, verticalAlign: VerticalAlign::Center),
+        ]));
+
+        // tall: 3-line vertical sub-container (top/METHOD/bottom)
+        // short: 1-line text (url)
+        $root = new ContainerWidget();
+
+        $row = new ContainerWidget();
+        $row->addStyleClass('row');
+
+        $tall = new ContainerWidget();
+        $tall->add(new TextWidget('top'));
+        $tall->add(new TextWidget('METHOD'));
+        $tall->add(new TextWidget('bottom'));
+
+        $short = new TextWidget('url');
+
+        $row->add($tall);
+        $row->add($short);
+        $root->add($row);
+
+        $lines = $renderer->render($root, 30, 10);
+
+        // $row is a non-expanded nested container — it renders exactly 3 lines (tallest child height).
+        // 'url' must appear on line 1 (center of 3), not line 0 (top).
+        $this->assertCount(3, $lines);
+        $this->assertStringNotContainsString('url', AnsiUtils::stripAnsiCodes($lines[0]), 'url must not be at the top');
+        $this->assertStringContainsString('url', AnsiUtils::stripAnsiCodes($lines[1]), 'url must be centered at line 1');
+        $this->assertStringNotContainsString('url', AnsiUtils::stripAnsiCodes($lines[2]), 'url must not be at the bottom');
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Tui\Style\Direction;
 use Symfony\Component\Tui\Style\Padding;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
+use Symfony\Component\Tui\Style\VerticalAlign;
 use Symfony\Component\Tui\Widget\AbstractWidget;
 use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\ParentInterface;
@@ -828,6 +829,67 @@ class RendererTest extends TestCase
         // Right leaf: pane starts at col 20 (40/2), padding top=1, left=2
         $this->assertSame(1, $rightLeafRect->row);
         $this->assertSame(22, $rightLeafRect->col);
+    }
+
+    public function testWidgetPositionTrackingForHorizontalChildrenWithVerticalAlignCenter()
+    {
+        // Shorter children in a horizontal container with VerticalAlign::Center must have their
+        // tracked row offset by floor((maxRows - childHeight) / 2) so mouse clicks land correctly.
+        $renderer = new Renderer(new StyleSheet([
+            '.row' => new Style(direction: Direction::Horizontal, verticalAlign: VerticalAlign::Center),
+        ]));
+
+        $root = new ContainerWidget();
+        $row = new ContainerWidget();
+        $row->addStyleClass('row');
+
+        $tall = new ContainerWidget();
+        $tall->add(new TextWidget('top'));
+        $tall->add(new TextWidget('mid'));
+        $tall->add(new TextWidget('bot'));
+
+        $short = new TextWidget('url');
+
+        $row->add($tall);
+        $row->add($short);
+        $root->add($row);
+
+        $renderer->render($root, 40, 10);
+
+        $tallRect = $renderer->getWidgetRect($tall);
+        $shortRect = $renderer->getWidgetRect($short);
+
+        // tall is the tallest (3 lines) — no offset
+        $this->assertSame(0, $tallRect->row);
+
+        // short is 1 line, centered in 3: floor((3-1)/2) = 1
+        $this->assertSame(1, $shortRect->row);
+    }
+
+    public function testFillChildExpandsToAllocatedRowsWithoutVerticalAlign()
+    {
+        // A fill child must pad its output to fill its allocated rows even without VerticalAlign,
+        // so that chrome (background-color, border) covers the full height before layoutVertical
+        // can append bare empty strings that bypass the chrome applier.
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->expandVertically(true);
+
+        $fill = new ContainerWidget();
+        $fill->expandVertically(true);
+        $fill->add(new TextWidget('Content'));
+
+        $footer = new TextWidget('Footer');
+
+        $root->add($fill);
+        $root->add($footer);
+
+        $lines = $renderer->render($root, 40, 10);
+
+        // fill gets 9 rows, footer gets 1 — total must be 10
+        $this->assertCount(10, $lines);
+        $this->assertStringContainsString('Footer', AnsiUtils::stripAnsiCodes($lines[9]));
+        $this->assertStringContainsString('Content', AnsiUtils::stripAnsiCodes($lines[0]));
     }
 
     public function testVerticalLayoutDoesNotReRenderLeafChildrenInSecondPass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

### Summary

This PR fixes three related bugs in how `VerticalAlign` and `expandVertically` interact with the layout engine and renderer.

### Bug 1 — `VerticalAlign::Center` expands non-expanded nested containers

**Before:** Setting `VerticalAlign::Center` on a container that is a non-expanded child of a vertical layout caused it to fill the entire parent height (e.g. the full terminal).
The renderer padded its output to `$innerRows`, which `layoutVertical` sets to the full parent budget for all children regardless of whether they are fill children.

**After:** Padding only occurs when the widget actually owns the allocated space — i.e. when it is the root render (`RenderContext::$fillRows = true`) or a vertically-expanded fill child (`ContainerWidget::isVerticallyExpanded()`).

**Implementation:** `RenderContext` gains a `$fillRows` flag (default `false`) propagated by `withColumns()` and `withStyle()`. `Renderer::render()` creates the root context with `fillRows: true`. `Renderer::renderContainer()` gates padding on `$context->shouldFillRows() || $widget->isVerticallyExpanded()`.

---

### Bug 2 — `VerticalAlign::Center` on horizontal containers had no effect

**Before:** In a horizontal container, children of different heights were always top-aligned, regardless of the `VerticalAlign` setting on the container.

**After:** `LayoutEngine::layoutHorizontal()` now receives `?VerticalAlign $verticalAlign` and computes a per-child vertical offset before rendering rows:

    offset = floor((maxRows - childHeight) / 2)  // for Center
    offset = maxRows - childHeight                // for Bottom

Shorter children are visually shifted down relative to the tallest child in the row, matching CSS `align-items: center` / `align-items: flex-end` on a flex row.

Widget position tracking (`WidgetRect`) is updated to reflect the offset so that mouse click coordinates remain accurate.

---

### Bug 3 — Fill children without `VerticalAlign` did not apply chrome to full height

**Before:** A fill child (`expandVertically(true)`) with a `background-color` but without `VerticalAlign` rendered its natural content height through `chromeApplier`, then `layoutVertical` padded the remaining rows with bare empty strings — bypassing `chromeApplier`. The background color only covered the content lines.

**After:** `Renderer::renderContainer()` pads fill children (`isVerticallyExpanded() && !shouldFillRows()`) to `$innerRows` before `chromeApplier` runs, ensuring all rows carry the widget's chrome. `layoutVertical`'s own padding loop then finds the output already complete and adds nothing.

---

### Examples

ContainerWidget with Style `withDirection(Direction::Horizontal)`  and withVerticalAlign(VerticalAlign::Center)

**expandVertically = true** 

*Before (no vertical alignment)*
<img width="609" height="260" alt="image" src="https://github.com/user-attachments/assets/1aea060f-b386-45c5-9634-8af9351aa000" />

*After*
<img width="527" height="217" alt="image" src="https://github.com/user-attachments/assets/3c03dcfa-a474-4eaa-bebb-6271b77124a2" />

**with  expandVertically = false**

*Before (always expanded AND no vertical alignment)*
<img width="609" height="260" alt="image" src="https://github.com/user-attachments/assets/737b4904-2b10-45a8-863d-b1bcf5baaf69" />

*After*
<img width="609" height="93" alt="image" src="https://github.com/user-attachments/assets/bf80cf23-d176-4d17-aff6-8a3e03b0245f" />
