### PR TITLE
[Validator] Allow non-string values in ConstraintViolationBuilderInterface::setParameter()

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `Cron` constraint to validate cron expressions
+ * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`
 
 8.1
 ---

--- a/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Violation/ConstraintViolationBuilderTest.php
@@ -84,6 +84,29 @@ class ConstraintViolationBuilderTest extends TestCase
         $this->assertViolationEquals(new ConstraintViolation($this->messageTemplate, $this->messageTemplate, [], $this->root, 'data', 'foo', null, null, new Valid(), $cause));
     }
 
+    public function testNonStringParametersAreSupported()
+    {
+        $date = new \DateTimeImmutable('2024-01-01');
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())->method('trans')->willReturn('translated');
+
+        $builder = new ConstraintViolationBuilder($this->violations, new Valid(), $this->messageTemplate, [], $this->root, 'data', 'foo', $translator);
+        $builder
+            ->setParameter('%string%', 'foo')
+            ->setParameter('%int%', 42)
+            ->setParameter('%float%', 3.14)
+            ->setParameter('%date%', $date)
+            ->addViolation();
+
+        $this->assertSame([
+            '%string%' => 'foo',
+            '%int%' => 42,
+            '%float%' => 3.14,
+            '%date%' => $date,
+        ], $this->violations->get(0)->getParameters());
+    }
+
     public function testTranslationDomainFalse()
     {
         $translator = $this->createMock(TranslatorInterface::class);

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -52,7 +52,7 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
         return $this;
     }
 
-    public function setParameter(string $key, string $value): static
+    public function setParameter(string $key, string|int|float|\Stringable|\DateTimeInterface $value): static
     {
         $this->parameters[$key] = $value;
 

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -22,6 +22,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * execution context.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method $this setParameter(string $key, string|int|float|\Stringable|\DateTimeInterface $value) Sets a parameter to be inserted into the violation message. Passing a non-string value is supported as of Symfony 8.2.
  */
 interface ConstraintViolationBuilderInterface
 {
@@ -36,16 +38,6 @@ interface ConstraintViolationBuilderInterface
      * @return $this
      */
     public function atPath(string $path): static;
-
-    /**
-     * Sets a parameter to be inserted into the violation message.
-     *
-     * @param string $key   The name of the parameter
-     * @param string $value The value to be inserted in the parameter's place
-     *
-     * @return $this
-     */
-    public function setParameter(string $key, string $value): static;
 
     /**
      * Sets all parameters to be inserted into the violation message.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58948
| License       | MIT

`ConstraintViolationBuilderInterface::setParameter()` restricted `$value` to `string`, while its sibling `setParameters()` accepts an array of arbitrary values. The ICU message format — used through the translator — supports objects such as `\DateTimeInterface`, as well as `int` and `float` values, so the restriction was inconsistent and forced users to fall back to `setParameters()`.

This PR widens the accepted type to `string|int|float|\Stringable|\DateTimeInterface`.

To preserve BC, the hard-typed method declaration is removed from the public interface and documented via an `@method` annotation (as suggested by @nicolas-grekas in the issue), following the existing `findByCodes()` precedent in `ConstraintViolationListInterface`. Widening the parameter type directly on the interface would have broken any third-party implementation typed `string` (parameter contravariance). As noted by @stof, `ConstraintViolationBuilder` is the only implementation and its constructor is the sole `@internal` part.