### PR TITLE
[HttpKernel] Deserialize a JSON query parameter with #[MapQueryString(key:)]

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `hasDump()` method to `Profile` to track profiles with dump
  * Dispatch `RateLimitExceededEvent` from `RateLimitAttributeListener` when the `#[RateLimit]` attribute rejects a request
  * Seed the query bag from the `_query` route default when a route is matched
+ * Deserialize the query parameter named by `#[MapQueryString(key:)]` as JSON when it holds a string, e.g. `?filter={"page":1}`
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -218,6 +218,21 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     private function mapQueryString(Request $request, ArgumentMetadata $argument, MapQueryString $attribute): ?object
     {
+        // a named parameter holding a JSON document, e.g. ?filter={"page":1}
+        if (null !== $attribute->key && \is_string($data = $request->query->all()[$attribute->key] ?? null)) {
+            if ('' === $data && !$attribute->mapWhenEmpty) {
+                return null;
+            }
+
+            try {
+                return $this->serializer->deserialize($data, $argument->getType(), 'json', self::CONTEXT_DESERIALIZE + $attribute->serializationContext);
+            } catch (NotEncodableValueException $e) {
+                throw new BadRequestHttpException(\sprintf('Query parameter "%s" contains invalid "json" data.', $attribute->key), $e);
+            } catch (UnexpectedPropertyException $e) {
+                throw new BadRequestHttpException(\sprintf('Query parameter "%s" contains invalid "%s" property.', $attribute->key, $e->property), $e);
+            }
+        }
+
         if (!($data = $request->query->all($attribute->key)) && ($argument->isNullable() || $argument->hasDefaultValue()) && !$attribute->mapWhenEmpty) {
             return null;
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -597,6 +598,91 @@ class RequestPayloadValueResolverTest extends TestCase
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertSame('This value should be of type float.', $validationFailedException->getViolations()[0]->getMessage());
         }
+    }
+
+    public function testQueryStringKeyDeserializesJsonPayload()
+    {
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new ReflectionExtractor())], ['json' => new JsonEncoder()]);
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('valid', NestedQueryPayload::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(key: 'foo'),
+        ]);
+
+        $request = Request::create('/', 'GET', ['foo' => '{"poo":1}']);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $resolved = $event->getArguments()[0];
+        $this->assertInstanceOf(NestedQueryPayload::class, $resolved);
+        $this->assertSame(1, $resolved->poo);
+    }
+
+    public function testQueryStringKeyJsonAndBracketNotationAreEquivalent()
+    {
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new ReflectionExtractor())], ['json' => new JsonEncoder()]);
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('valid', NestedQueryPayload::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(key: 'foo'),
+        ]);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $resolve = static function (array $query) use ($resolver, $argument, $kernel) {
+            $request = Request::create('/', 'GET', $query);
+            $event = new ControllerArgumentsEvent($kernel, static fn () => null, $resolver->resolve($request, $argument), $request, HttpKernelInterface::MAIN_REQUEST);
+            $resolver->onKernelControllerArguments($event);
+
+            return $event->getArguments();
+        };
+
+        $this->assertEquals($resolve(['foo' => ['poo' => '1']]), $resolve(['foo' => '{"poo":1}']));
+    }
+
+    public function testQueryStringKeyWithInvalidJson()
+    {
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new ReflectionExtractor())], ['json' => new JsonEncoder()]);
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('valid', NestedQueryPayload::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(key: 'foo'),
+        ]);
+
+        $request = Request::create('/', 'GET', ['foo' => '{"poo":1']);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('Query parameter "foo" contains invalid "json" data.');
+
+        $resolver->onKernelControllerArguments($event);
+    }
+
+    public function testQueryStringWithoutKeyIgnoresJsonLookingValues()
+    {
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new ReflectionExtractor())], ['json' => new JsonEncoder()]);
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('valid', QueryPayloadWithStringProperty::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(),
+        ]);
+
+        $request = Request::create('/', 'GET', ['foo' => '{"poo":1}']);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static fn () => null, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $this->assertSame('{"poo":1}', $event->getArguments()[0]->foo);
     }
 
     public function testRequestInputValidationPassed()
@@ -1526,6 +1612,20 @@ interface SerializerDenormalizer extends SerializerInterface, DenormalizerInterf
 class QueryPayload
 {
     public function __construct(public readonly float $page)
+    {
+    }
+}
+
+class NestedQueryPayload
+{
+    public function __construct(public readonly int $poo)
+    {
+    }
+}
+
+class QueryPayloadWithStringProperty
+{
+    public function __construct(public readonly string $foo)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64366
| License       | MIT

`#[MapQueryString]` has taken a `key` argument since #59157, naming the query parameter to map:

```php
// ?search[term]=foo&search[category]=bar
public function list(#[MapQueryString(key: 'search')] SearchDto $search) { ... }
```

That only works when the parameter is an array. When it holds a JSON document, it fails with `BadRequestException: Unexpected value for parameter "search": expecting "array", got "string"`.

This PR deserializes it instead, with the serializer, the same way `#[MapRequestPayload]` handles the request body:

```php
// ?search={"term":"foo","category":"bar"}
public function list(#[MapQueryString(key: 'search')] SearchDto $search) { ... }
```

Both notations now map to the same object, so callers can use whichever the infrastructure allows, which is what #64366 asks for.

`serializationContext`, `validationGroups`, `validationFailedStatusCode` and the validator work as before. Malformed JSON returns a 400 naming the parameter rather than a type mismatch further down.

Nothing changes without `key`: the whole query string keeps mapping through `denormalize()` and a value that merely looks like JSON stays a string.
