### PR TITLE
 Release v7.4.13

### DIFF
--- a/CHANGELOG-7.4.md
+++ b/CHANGELOG-7.4.md
@@ -7,6 +7,38 @@ in 7.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v7.4.0...v7.4.1
 
+* 7.4.13 (2026-05-27)
+
+ * security #cve-2026-48747 [Mailer] Pin Mailomat webhook signature algorithm to SHA-256 (nicolas-grekas)
+ * security #cve-2026-48761 [HtmlSanitizer] Sanitize URL attributes on <object>, <applet>, <iframe>, <img>, and the URL inside <meta http-equiv="refresh"> content (nicolas-grekas)
+ * security #cve-2026-48760 [HtmlSanitizer] Reject percent-encoded BiDi marks and Unicode whitespace in URLs (nicolas-grekas)
+ * security #cve-2026-48736 [HttpFoundation] Block IPv6 transition forms in IpUtils::PRIVATE_SUBNETS (nicolas-grekas)
+ * security #cve-2026-48736 [HttpClient] Block IPv6 transition forms in NoPrivateNetworkHttpClient (nicolas-grekas)
+ * security #cve-2026-48489 [Security] Don't honor user-supplied _failure_path on failure_forward (nicolas-grekas)
+ * security #cve-2026-48784 [Routing] Fix dot-segment encoding for chained "../" and "./" in generated URLs (nicolas-grekas)
+ * bug #64355 [Console] Format message in ConsoleSectionOutput::overwrite() (nicolas-grekas)
+ * bug #64349 [HttpClient] ntlm regression on authPersistNonNTLM=false connections with reset() (Dooij)
+ * bug #64348 [FrameworkBundle] Allow to pass `doctrine_open_transaction_logger`’s entity manager name positionally (MatTheCat)
+ * bug #64345 [Mime][String] Reject objects in typed-string properties during __unserialize (nicolas-grekas)
+ * bug #64344 [Mailer][Notifier] Harden Mailchimp signature comparison and Smsbox IP allowlist (nicolas-grekas)
+ * bug #64330 [Cache] Fix strlen(null) deprecation on RelayCluster path in RedisTrait::doClear() (signor-pedro)
+ * bug #64335 [Scheduler] Recover pending RecurringMessages after consumer stops midway (ousamabenyounes)
+ * bug #64338 [SecurityBundle] Fix Security::login() across firewalls (ousamabenyounes)
+ * bug #64347 [Process] Stop leaking CGI/FastCGI request-context vars to subprocesses (nicolas-grekas)
+ * bug #64343 [Mime][RateLimiter][Routing][Security] Harden __unserialize against __toString trampolines (nicolas-grekas)
+ * bug #64342 [HtmlSanitizer] Honor universal attribute sanitizers, apply maxInputLength to text contexts, document forceAttribute and allowAttribute caveats (nicolas-grekas)
+ * bug #64341 [FrameworkBundle][Mailer] Harden default IP allowlist for Postmark and Brevo webhook parsers (nicolas-grekas)
+ * bug #64337 [Security] Initialize lazy users before serializing them (MatTheCat)
+ * bug #64346 [Runtime] Trust argv on CLI-like SAPIs to fix subprocess args (nicolas-grekas)
+ * bug #64336 [Cache] Accept '_' and ':' in prefix passed to AbstractAdapter::clear() (nicolas-grekas)
+ * bug #64316 [Yaml] Allow trailing newlines after the end-of-document marker (nicolas-grekas)
+ * bug #64289 [Translation] Don’t check the error message to know if Lokalise keys are missing (MatTheCat)
+ * bug #64208 [AssetMapper] Rewrite relative paths in `export ... from` statements (ousamabenyounes)
+ * bug #64311 [DependencyInjection] Fix `service()` as invokable factory in array-based PHP config (nicolas-grekas)
+ * bug #64310 [HttpKernel][WebProfilerBundle] Check logs priority name for both `WARNING` and `warning` (MatTheCat)
+ * bug #64260 [HttpClient] Various fixes and hardenings (Lctrs)
+ * bug #64309 [FrameworkBundle] Sign transports for unrouted messages too (nicolas-grekas)
+
 * 7.4.12 (2026-05-20)
 
  * security #cve-2026-46626 [Runtime] Fix CVE-2024-50340 patch bypass by gating argv on $_SERVER['QUERY_STRING'] (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -74,12 +74,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.4.13-DEV';
+    public const VERSION = '7.4.13';
     public const VERSION_ID = 70413;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 13;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2028';
     public const END_OF_LIFE = '11/2029';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v7.4.12...v7.4.13)

 * security #cve-2026-48747 [Mailer] Pin Mailomat webhook signature algorithm to SHA-256 (@nicolas-grekas)
 * security #cve-2026-48761 [HtmlSanitizer] Sanitize URL attributes on <object>, <applet>, <iframe>, <img>, and the URL inside <meta http-equiv="refresh"> content (@nicolas-grekas)
 * security #cve-2026-48760 [HtmlSanitizer] Reject percent-encoded BiDi marks and Unicode whitespace in URLs (@nicolas-grekas)
 * security #cve-2026-48736 [HttpFoundation] Block IPv6 transition forms in IpUtils::PRIVATE_SUBNETS (@nicolas-grekas)
 * security #cve-2026-48736 [HttpClient] Block IPv6 transition forms in NoPrivateNetworkHttpClient (@nicolas-grekas)
 * security #cve-2026-48489 [Security] Don't honor user-supplied _failure_path on failure_forward (@nicolas-grekas)
 * security #cve-2026-48784 [Routing] Fix dot-segment encoding for chained "../" and "./" in generated URLs (@nicolas-grekas)
 * bug #64355 [Console] Format message in ConsoleSectionOutput::overwrite() (@nicolas-grekas)
 * bug #64349 [HttpClient] ntlm regression on authPersistNonNTLM=false connections with reset() (Dooij)
 * bug #64348 [FrameworkBundle] Allow to pass `doctrine_open_transaction_logger`’s entity manager name positionally (@MatTheCat)
 * bug #64345 [Mime][String] Reject objects in typed-string properties during __unserialize (@nicolas-grekas)
 * bug #64344 [Mailer][Notifier] Harden Mailchimp signature comparison and Smsbox IP allowlist (@nicolas-grekas)
 * bug #64330 [Cache] Fix strlen(null) deprecation on RelayCluster path in RedisTrait::doClear() (@signor-pedro)
 * bug #64335 [Scheduler] Recover pending RecurringMessages after consumer stops midway (@ousamabenyounes)
 * bug #64338 [SecurityBundle] Fix Security::login() across firewalls (@ousamabenyounes)
 * bug #64347 [Process] Stop leaking CGI/FastCGI request-context vars to subprocesses (@nicolas-grekas)
 * bug #64343 [Mime][RateLimiter][Routing][Security] Harden __unserialize against __toString trampolines (@nicolas-grekas)
 * bug #64342 [HtmlSanitizer] Honor universal attribute sanitizers, apply maxInputLength to text contexts, document forceAttribute and allowAttribute caveats (@nicolas-grekas)
 * bug #64341 [FrameworkBundle][Mailer] Harden default IP allowlist for Postmark and Brevo webhook parsers (@nicolas-grekas)
 * bug #64337 [Security] Initialize lazy users before serializing them (@MatTheCat)
 * bug #64346 [Runtime] Trust argv on CLI-like SAPIs to fix subprocess args (@nicolas-grekas)
 * bug #64336 [Cache] Accept '_' and ':' in prefix passed to AbstractAdapter::clear() (@nicolas-grekas)
 * bug #64316 [Yaml] Allow trailing newlines after the end-of-document marker (@nicolas-grekas)
 * bug #64289 [Translation] Don’t check the error message to know if Lokalise keys are missing (@MatTheCat)
 * bug #64208 [AssetMapper] Rewrite relative paths in `export ... from` statements (@ousamabenyounes)
 * bug #64311 [DependencyInjection] Fix `service()` as invokable factory in array-based PHP config (@nicolas-grekas)
 * bug #64310 [HttpKernel][WebProfilerBundle] Check logs priority name for both `WARNING` and `warning` (@MatTheCat)
 * bug #64260 [HttpClient] Various fixes and hardenings (@Lctrs)
 * bug #64309 [FrameworkBundle] Sign transports for unrouted messages too (@nicolas-grekas)
