### PR TITLE
[Translation] Fix XLIFF 2 catalog metadata

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -156,10 +156,11 @@ class XliffFileDumper extends FileDumper
         }
 
         if ($catalogueMetadata = $messages->getCatalogueMetadata('', $domain) ?? []) {
-            $xliff->setAttribute('xmlns:m', 'urn:oasis:names:tc:xliff:metadata:2.0');
-            $xliffMetadata = $xliffFile->appendChild($dom->createElement('m:metadata'));
+            $xliff->setAttribute('xmlns:mda', 'urn:oasis:names:tc:xliff:metadata:2.0');
+            $xliffMetadata = $xliffFile->appendChild($dom->createElement('mda:metadata'));
+            $xliffMetaGroup = $xliffMetadata->appendChild($dom->createElement('mda:metaGroup'));
             foreach ($catalogueMetadata as $key => $value) {
-                $xliffMeta = $xliffMetadata->appendChild($dom->createElement('prop'));
+                $xliffMeta = $xliffMetaGroup->appendChild($dom->createElement('mda:meta'));
                 $xliffMeta->setAttribute('type', $key);
                 $xliffMeta->appendChild($dom->createTextNode($value));
             }

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -158,6 +158,12 @@ class XliffFileLoader implements LoaderInterface
         $xml = simplexml_import_dom($dom);
         $encoding = $dom->encoding ? strtoupper($dom->encoding) : null;
 
+        $xml->registerXPathNamespace('mda', 'urn:oasis:names:tc:xliff:metadata:2.0');
+
+        foreach ($xml->xpath('//mda:meta') as $meta) {
+            $catalogue->setCatalogueMetadata($meta->attributes()['type'] ?? '', (string) $meta, $domain);
+        }
+
         $xml->registerXPathNamespace('xliff', 'urn:oasis:names:tc:xliff:document:2.0');
 
         foreach ($xml->xpath('//xliff:unit') as $unit) {

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -39,6 +39,7 @@ class XliffFileDumperTest extends TestCase
     public function testFormatCatalogueXliff2()
     {
         $catalogue = new MessageCatalogue('en_US');
+        $catalogue->setCatalogueMetadata('key', 'value');
         $catalogue->add([
             'foo' => 'bar',
             'key' => '',

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-clean.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-2.0-clean.xlf
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US" xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0">
   <file id="messages.en_US">
+    <mda:metadata>
+      <mda:metaGroup>
+        <mda:meta type="key">value</mda:meta>
+      </mda:metaGroup>
+    </mda:metadata>
     <unit id="LCa0a2j" name="foo">
       <segment>
         <source>foo</source>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources-catalog-meta.xlf
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources-catalog-meta.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US" xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0">
+  <file id="messages.en_US">
+    <mda:metadata>
+      <mda:metaGroup>
+        <mda:meta type="key">value</mda:meta>
+      </mda:metaGroup>
+    </mda:metadata>
+    <unit id="LCa0a2j" name="foo">
+      <segment>
+        <source>foo</source>
+        <target>bar</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -261,6 +261,15 @@ class XliffFileLoaderTest extends TestCase
         $this->assertEquals(['target-attributes' => ['order' => 1]], $catalogue->getMetadata('bar', 'domain1'));
     }
 
+    public function testLoadVersion2WithCatalogMeta()
+    {
+        $loader = new XliffFileLoader();
+        $resource = __DIR__.'/../Fixtures/resources-catalog-meta.xlf';
+        $catalogue = $loader->load($resource, 'en');
+
+        $this->assertSame(['key' => 'value'], $catalogue->getCatalogueMetadata());
+    }
+
     public function testLoadVersion2WithNoteMeta()
     {
         $loader = new XliffFileLoader();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The `XliffFileDumper` didn’t comply with [the XLIFF 2 Metadata Module](https://docs.oasis-open.org/xliff/xliff-core/v2.0/xliff-core-v2.0.html#metadata_module). It wasn’t really an issue though since the `XliffFileLoader` ignored it.

This PR fixes both those issues.