### PR TITLE
[ErrorHandler][Runtime] Remove usage of Kernel::VERSION when rendering exceptions

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
@@ -42,7 +42,7 @@ class EmptyAppTest extends TestCase
 
     private function deleteTempDir()
     {
-        if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel')) {
+        if (!file_exists($dir = sys_get_temp_dir().'/EmptyAppKernel')) {
             return;
         }
 
@@ -69,11 +69,11 @@ class EmptyAppKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/cache/'.$this->environment;
+        return sys_get_temp_dir().'/EmptyAppKernel/cache/'.$this->environment;
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/logs';
+        return sys_get_temp_dir().'/EmptyAppKernel/logs';
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -44,7 +44,7 @@ class NoTemplatingEntryTest extends TestCase
 
     protected function deleteTempDir()
     {
-        if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel')) {
+        if (!file_exists($dir = sys_get_temp_dir().'/NoTemplatingEntryKernel')) {
             return;
         }
 
@@ -86,11 +86,11 @@ class NoTemplatingEntryKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/cache/'.$this->environment;
+        return sys_get_temp_dir().'/NoTemplatingEntryKernel/cache/'.$this->environment;
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/NoTemplatingEntryKernel/logs';
+        return sys_get_temp_dir().'/NoTemplatingEntryKernel/logs';
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
@@ -43,7 +43,7 @@
                         </dd>
                     </dl>
 
-                    <a class="doc-link" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open this file in your IDE?</a>
+                    <a class="doc-link" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::MAJOR_VERSION') }}.{{ constant('Symfony\\Component\\HttpKernel\\Kernel::MINOR_VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open this file in your IDE?</a>
                 </div>
             </div>
         </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -52,16 +52,13 @@ class WebProfilerBundleKernel extends Kernel
     {
         $config = [
             'http_method_override' => false,
+            'handle_all_throwables' => true,
             'php_errors' => ['log' => true],
             'secret' => 'foo-secret',
             'profiler' => ['only_exceptions' => false, 'collect_serializer_data' => true],
             'session' => ['handler_id' => null, 'storage_factory_id' => 'session.storage.factory.mock_file', 'cookie-secure' => 'auto', 'cookie-samesite' => 'lax'],
             'router' => ['utf8' => true],
         ];
-
-        if (Kernel::VERSION_ID >= 60400) {
-            $config['handle_all_throwables'] = true;
-        }
 
         $container->loadFromExtension('framework', $config);
 

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
@@ -17,13 +17,13 @@
             );
         </script>
 
-        <?php if (class_exists(\Symfony\Component\HttpKernel\Kernel::class)) { ?>
+        <?php if (class_exists(\Composer\InstalledVersions::class) && \Composer\InstalledVersions::isInstalled('symfony/http-kernel')) { ?>
             <header>
                 <div class="container">
                     <h1 class="logo"><?= $this->include('assets/images/symfony-logo.svg'); ?> Symfony Exception</h1>
 
                     <div class="help-link">
-                        <a href="https://symfony.com/doc/<?= Symfony\Component\HttpKernel\Kernel::VERSION; ?>/index.html">
+                        <a href="https://symfony.com/doc/<?= preg_match('/^v?(\d+\.\d+)/', \Composer\InstalledVersions::getPrettyVersion('symfony/http-kernel'), $m) ? $m[1] : 'current'; ?>/index.html">
                             <span class="icon"><?= $this->include('assets/images/icon-book.svg'); ?></span>
                             <span class="hidden-xs-down">Symfony</span> Docs
                         </a>

--- a/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/Symfony/HttpKernelRunner.php
@@ -34,19 +34,15 @@ class HttpKernelRunner implements RunnerInterface
     {
         $response = $this->kernel->handle($this->request);
 
-        if (Kernel::VERSION_ID >= 60400) {
-            $response->send(false);
+        $response->send(false);
 
-            if (\function_exists('fastcgi_finish_request') && !$this->debug) {
-                fastcgi_finish_request();
-            } elseif (\function_exists('litespeed_finish_request') && !$this->debug) {
-                litespeed_finish_request();
-            } else {
-                Response::closeOutputBuffers(0, true);
-                flush();
-            }
+        if (\function_exists('fastcgi_finish_request') && !$this->debug) {
+            fastcgi_finish_request();
+        } elseif (\function_exists('litespeed_finish_request') && !$this->debug) {
+            litespeed_finish_request();
         } else {
-            $response->send();
+            Response::closeOutputBuffers(0, true);
+            flush();
         }
 
         if ($this->kernel instanceof TerminableInterface) {

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -28,7 +28,8 @@
         "symfony/http-kernel": "^6.4|^7.0|^8.0"
     },
     "conflict": {
-        "symfony/dotenv": "<6.4"
+        "symfony/dotenv": "<6.4",
+        "symfony/http-foundation": "<6.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64382
| License       | MIT

On 7.4 to preserve the compat between 7.4 and 8.1 on this aspect.