### PR TITLE
[Dotenv] Don't truncate external env vars containing $ when referenced via ${...} indirection

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -616,6 +616,10 @@ final class Dotenv
                 $value = (string) getenv($name);
             }
 
+            if ('' !== $value && !isset($loadedVars[$name])) {
+                $value = str_replace('$', "\x00", $value);
+            }
+
             if ('' === $value && isset($matches['default_value']) && '' !== $matches['default_value']) {
                 $unsupportedChars = strpbrk($matches['default_value'], '\'"{$');
                 if (false !== $unsupportedChars) {
@@ -746,92 +750,95 @@ final class Dotenv
         $this->cursor = 0;
         $this->end = 0;
 
-        // Detect variables that were originally defined as self-referencing
-        // (e.g. MY_VAR="${MY_VAR:-default}") so their own raw value is hidden
-        // during resolution, allowing the default to trigger correctly.
-        $selfReferencingVars = [];
-        foreach ($rawVars as $name => $_) {
-            $value = $_ENV[$name] ?? '';
-            if (str_contains($value, '$') && preg_match('/\$\{?'.preg_quote($name, '/').'(?![A-Za-z0-9_])/', $value)) {
-                $selfReferencingVars[$name] = true;
-            }
-        }
-
-        for ($pass = 0; $pass < 5; ++$pass) {
-            $resolved = [];
+        try {
+            // Detect variables that were originally defined as self-referencing
+            // (e.g. MY_VAR="${MY_VAR:-default}") so their own raw value is hidden
+            // during resolution, allowing the default to trigger correctly.
+            $selfReferencingVars = [];
             foreach ($rawVars as $name => $_) {
-                if (!str_contains($value = $_ENV[$name] ?? '', '$')) {
-                    continue;
+                $value = $_ENV[$name] ?? '';
+                if (str_contains($value, '$') && preg_match('/\$\{?'.preg_quote($name, '/').'(?![A-Za-z0-9_])/', $value)) {
+                    $selfReferencingVars[$name] = true;
                 }
+            }
 
-                if (isset($selfReferencingVars[$name])) {
-                    $envBackup = $_ENV[$name] ?? null;
-                    $serverBackup = $_SERVER[$name] ?? null;
-                    if (isset($this->overriddenValues[$name])) {
-                        $_ENV[$name] = $this->overriddenValues[$name];
-                        $_SERVER[$name] = $this->overriddenValues[$name];
-                    } else {
-                        unset($_ENV[$name], $_SERVER[$name]);
+            for ($pass = 0; $pass < 5; ++$pass) {
+                $resolved = [];
+                foreach ($rawVars as $name => $_) {
+                    if (!str_contains($value = $_ENV[$name] ?? '', '$')) {
+                        continue;
                     }
-                    if ($this->usePutenv) {
-                        $getenvBackup = (string) getenv($name);
+
+                    if (isset($selfReferencingVars[$name])) {
+                        $envBackup = $_ENV[$name] ?? null;
+                        $serverBackup = $_SERVER[$name] ?? null;
                         if (isset($this->overriddenValues[$name])) {
-                            putenv("$name={$this->overriddenValues[$name]}");
+                            $_ENV[$name] = str_replace('$', "\x00", $this->overriddenValues[$name]);
+                            $_SERVER[$name] = $_ENV[$name];
                         } else {
-                            putenv($name);
+                            unset($_ENV[$name], $_SERVER[$name]);
+                        }
+                        if ($this->usePutenv) {
+                            $getenvBackup = (string) getenv($name);
+                            if (isset($this->overriddenValues[$name])) {
+                                putenv("$name={$this->overriddenValues[$name]}");
+                            } else {
+                                putenv($name);
+                            }
                         }
                     }
-                }
 
-                $resolvedValue = $this->resolveCommands($value, $loadedVars);
-                $resolvedValue = $this->resolveVariables($resolvedValue, $loadedVars);
+                    $resolvedValue = $this->resolveCommands($value, $loadedVars);
+                    $resolvedValue = $this->resolveVariables($resolvedValue, $loadedVars);
 
-                if (isset($selfReferencingVars[$name])) {
-                    if (null !== $envBackup) {
-                        $_ENV[$name] = $envBackup;
+                    if (isset($selfReferencingVars[$name])) {
+                        if (null !== $envBackup) {
+                            $_ENV[$name] = $envBackup;
+                        }
+                        if (null !== $serverBackup) {
+                            $_SERVER[$name] = $serverBackup;
+                        }
+                        if ($this->usePutenv) {
+                            putenv("$name=$getenvBackup");
+                        }
                     }
-                    if (null !== $serverBackup) {
-                        $_SERVER[$name] = $serverBackup;
-                    }
-                    if ($this->usePutenv) {
-                        putenv("$name=$getenvBackup");
+
+                    if ($value !== $resolvedValue) {
+                        $resolved[$name] = $resolvedValue;
                     }
                 }
+                if (!$resolved) {
+                    break;
+                }
+                $this->populate($resolved, true);
+            }
+            if (5 === $pass && $resolved) {
+                throw new VariableCircularReferenceException('Too many levels of variable indirection in env vars: '.implode(', ', array_keys($resolved)).'.');
+            }
 
-                if ($value !== $resolvedValue) {
-                    $resolved[$name] = $resolvedValue;
+            // Restore literal $ signs and unescape backslashes
+            $restored = [];
+            foreach ($rawVars as $name => $_) {
+                $value = $_ENV[$name] ?? '';
+                if ($value !== $newValue = str_replace(["\x00", '\\\\'], ['$', '\\'], $value)) {
+                    $restored[$name] = $newValue;
                 }
             }
-            if (!$resolved) {
-                break;
+            if ($restored) {
+                $this->populate($restored, true);
             }
-            $this->populate($resolved, true);
-        }
-        if (5 === $pass && $resolved) {
-            throw new VariableCircularReferenceException('Too many levels of variable indirection in env vars: '.implode(', ', array_keys($resolved)).'.');
-        }
 
-        // Restore literal $ signs and unescape backslashes
-        $restored = [];
-        foreach ($rawVars as $name => $_) {
-            $value = $_ENV[$name] ?? '';
-            if ($value !== $newValue = str_replace(["\x00", '\\\\'], ['$', '\\'], $value)) {
-                $restored[$name] = $newValue;
+            if ($this->usePutenv && $this->pendingPutenv) {
+                foreach ($this->pendingPutenv as $name => $_) {
+                    putenv($name.'='.($_ENV[$name] ?? ''));
+                }
+                $this->pendingPutenv = [];
             }
-        }
-        if ($restored) {
-            $this->populate($restored, true);
-        }
-
-        if ($this->usePutenv && $this->pendingPutenv) {
-            foreach ($this->pendingPutenv as $name => $_) {
-                putenv($name.'='.($_ENV[$name] ?? ''));
-            }
+        } finally {
+            $this->values = [];
+            $this->overriddenValues = [];
             $this->pendingPutenv = [];
+            unset($this->path, $this->data, $this->lineno, $this->cursor, $this->end);
         }
-
-        $this->values = [];
-        $this->overriddenValues = [];
-        unset($this->path, $this->data, $this->lineno, $this->cursor, $this->end);
     }
 }

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -275,11 +275,6 @@ class DotenvTest extends TestCase
 
     public function testLoadDoesNotResolveExternalEnvVarsOnlyPresentInServer()
     {
-        // Mimics PHP's default `variables_order = "GPCS"` (no `E`) where
-        // OS-provided environment variables (e.g. from Kubernetes envFrom or
-        // Docker) are placed in $_SERVER but not in $_ENV when PHP starts.
-        // Such values must be left untouched by Dotenv even when the same key
-        // has a default value in the loaded .env file.
         unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
         putenv('FOO');
         putenv('SYMFONY_DOTENV_VARS');
@@ -299,6 +294,107 @@ class DotenvTest extends TestCase
             putenv('FOO');
             putenv('SYMFONY_DOTENV_VARS');
             unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
+    public function testLoadDoesNotTruncateExternalEnvVarReferencedFromDotenv()
+    {
+        foreach ([['env' => true, 'server' => true], ['env' => false, 'server' => true]] as $where) {
+            unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['INDIRECT'], $_SERVER['INDIRECT'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('EXT_VAR');
+            putenv('INDIRECT');
+            putenv('SYMFONY_DOTENV_VARS');
+
+            if ($where['env']) {
+                $_ENV['EXT_VAR'] = 'secret$word';
+            }
+            if ($where['server']) {
+                $_SERVER['EXT_VAR'] = 'secret$word';
+            }
+
+            @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+            $path = tempnam($tmpdir, 'sf-');
+            file_put_contents($path, "INDIRECT=\${EXT_VAR}\n");
+
+            try {
+                (new Dotenv())->load($path);
+                $this->assertSame('secret$word', $_ENV['INDIRECT']);
+                $this->assertSame('secret$word', $_SERVER['INDIRECT']);
+            } finally {
+                unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['INDIRECT'], $_SERVER['INDIRECT'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+                putenv('EXT_VAR');
+                putenv('INDIRECT');
+                putenv('SYMFONY_DOTENV_VARS');
+                unlink($path);
+                @rmdir($tmpdir);
+            }
+        }
+    }
+
+    public function testOverloadDoesNotExecuteShellSyntaxFromExternalEnvOnSelfReference()
+    {
+        unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('FOO');
+        putenv('SYMFONY_DOTENV_VARS');
+
+        $_ENV['FOO'] = $_SERVER['FOO'] = 'value$(id)';
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $path = tempnam($tmpdir, 'sf-');
+        file_put_contents($path, "FOO=\${FOO:-default}\n");
+
+        try {
+            (new Dotenv())->overload($path);
+            $this->assertSame('value$(id)', $_ENV['FOO']);
+            $this->assertSame('value$(id)', $_SERVER['FOO']);
+        } finally {
+            unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('FOO');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
+    public function testResolveLoadedVarsClearsStateOnCircularReferenceException()
+    {
+        unset($_ENV['A'], $_SERVER['A'], $_ENV['B'], $_SERVER['B'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('A');
+        putenv('B');
+        putenv('SYMFONY_DOTENV_VARS');
+
+        $_ENV['A'] = $_SERVER['A'] = 'external';
+
+        $dotenv = new Dotenv();
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $circular = tempnam($tmpdir, 'sf-');
+        file_put_contents($circular, "A=\${B}\nB=\${A}x\n");
+        $selfRef = tempnam($tmpdir, 'sf-');
+        file_put_contents($selfRef, "A=\${A:-default}\n");
+
+        try {
+            try {
+                $dotenv->overload($circular);
+                $this->fail('A VariableCircularReferenceException should have been thrown.');
+            } catch (VariableCircularReferenceException) {
+            }
+
+            unset($_ENV['A'], $_SERVER['A'], $_ENV['B'], $_SERVER['B'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('A');
+            putenv('B');
+            putenv('SYMFONY_DOTENV_VARS');
+
+            $dotenv->load($selfRef);
+            $this->assertSame('default', $_ENV['A']);
+        } finally {
+            unset($_ENV['A'], $_SERVER['A'], $_ENV['B'], $_SERVER['B'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('A');
+            putenv('B');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($circular);
+            unlink($selfRef);
             @rmdir($tmpdir);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64385
| License       | MIT

Follow-up to #64148, covering the indirect-propagation variant of the same regression family.

When a Dotenv-loaded var references an OS-provided var via `${VAR}` indirection (e.g. `LOCK_DSN=${REDIS_DSN}` with `REDIS_DSN=secret$word` in the OS environment), the substituted value is silently truncated at the first literal `$`. `resolveLoadedVars()` is a multi-pass loop: pass 1 substitutes `${REDIS_DSN}` and writes `secret$word` back to `$_ENV[LOCK_DSN]`; pass 2 re-scans the value, treats `$word` as an undefined reference, substitutes the empty string, and the final value becomes `secret`.

#64148 prevented externally-present host vars from being added to `loadedRawVars` (so they are not themselves re-scanned). It did not protect external values pulled in via substitution. This patch closes that gap in `resolveVariables()`: when the looked-up name is not in `$loadedVars`, the substituted value's `$` chars are converted to the existing `\x00` literal marker before being spliced in. The terminal `str_replace` at the end of `resolveLoadedVars()` (and the equivalents in `resolveValue()` and `resolveEnvKey()`) turns them back into `$`. The gate on `!isset($loadedVars[$name])` preserves the multi-pass design for chained Dotenv refs like `A=${B}`, `B=${C}`, `C=literal`.

Two adjacent issues on the same code path are fixed in the same patch rather than as follow-ups.

The first: with `.env` containing `FOO=${FOO:-default}`, OS-provided `FOO='value$(id)'`, and the user calling `Dotenv::overload()` (or `loadEnv(..., overrideExistingVars: true)`), the self-referencing branch of `resolveLoadedVars()` temporarily restores the OS value back into `$_ENV[FOO]` so the `:-default` lookup can see it. Pass 1 substitutes it into `FOO`; pass 2 reads `$_ENV[FOO]='value$(id)'`, `resolveCommands()` matches `$(id)` and runs it through `Process::fromShellCommandline()`. The regression test below demonstrates this concretely: pre-fix, `id` is actually invoked and its real output ends up in `$_ENV[FOO]`. The fix applies the same `\x00` protection to the OS value when exposing it back to `$_ENV` / `$_SERVER`.

The second: `$this->overriddenValues = []` (and the parser cursor properties) is reset only in the success path of `resolveLoadedVars()`. On a `VariableCircularReferenceException`, the stale `overriddenValues` carries into the next `load()` call on the same Dotenv instance and can resurrect a value the OS no longer provides (concretely, when the next `.env` uses a self-referencing default for the same name). The fix moves the cleanup into a `finally`, and also resets `$this->pendingPutenv` for symmetry.

Best reviewed [ignoring whitespaces](https://github.com/symfony/symfony/pull/64386/files?w=1).