### PR TITLE
[Yaml] Fix parsing inline anchored values

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -383,6 +383,22 @@ class Inline
                 }
 
                 $tag = self::parseTag($sequence, $i, $flags);
+                $anchorRef = self::parseAnchor($sequence, $i);
+                if (null !== $anchorRef && null === $tag) {
+                    $tag = self::parseTag($sequence, $i, $flags);
+                }
+
+                if (null !== $anchorRef && (!isset($sequence[$i]) || ',' === $sequence[$i] || ']' === $sequence[$i])) {
+                    $value = null;
+                    $references[$anchorRef] = $value;
+                    if (null !== $tag && '' !== $tag) {
+                        $value = new TaggedValue($tag, $value);
+                    }
+                    $output[] = $value;
+                    $lastToken = 'value';
+                    continue;
+                }
+
                 switch ($sequence[$i]) {
                     case '[':
                         // nested sequence
@@ -393,7 +409,6 @@ class Inline
                         $value = self::parseMapping($state, $sequence, $flags, $i, $references);
                         break;
                     default:
-                        $hasAnchorAtStart = null === $tag && isset($sequence[$i]) && '&' === $sequence[$i];
                         $value = self::parseScalar($sequence, $flags, [',', ']'], $i, null === $tag, $references, $isQuoted, $state);
 
                         // the value can be an array if a reference has been resolved to an array var
@@ -429,12 +444,11 @@ class Inline
                             }
                         }
 
-                        if ($hasAnchorAtStart && !$isQuoted && \is_string($value) && '' !== $value && '&' === $value[0] && Parser::preg_match(Parser::REFERENCE_PATTERN, $value, $matches)) {
-                            $value = '' === $matches['value'] ? null : $matches['value'];
-                            $references[$matches['ref']] = $value;
-                        }
-
                         --$i;
+                }
+
+                if (null !== $anchorRef) {
+                    $references[$anchorRef] = $value;
                 }
 
                 if (null !== $tag && '' !== $tag) {
@@ -526,10 +540,31 @@ class Inline
                     }
 
                     $tag = self::parseTag($mapping, $i, $flags);
+                    $anchorRef = self::parseAnchor($mapping, $i);
+                    if (null !== $anchorRef && null === $tag) {
+                        $tag = self::parseTag($mapping, $i, $flags);
+                    }
+
+                    if (null !== $anchorRef && (!isset($mapping[$i]) || \in_array($mapping[$i], [',', '}', "\n"], true))) {
+                        $value = null;
+                        $references[$anchorRef] = $value;
+                        if ('<<' !== $key) {
+                            if ($allowOverwrite || !isset($output[$key])) {
+                                $output[$key] = null !== $tag ? new TaggedValue($tag, $value) : $value;
+                            } elseif (isset($output[$key])) {
+                                throw new ParseException(\sprintf('Duplicate key "%s" detected.', $key), self::$parsedLineNumber + 1, $mapping);
+                            }
+                        }
+                        continue 2;
+                    }
+
                     switch ($mapping[$i]) {
                         case '[':
                             // nested sequence
                             $value = self::parseSequence($state, $mapping, $flags, $i, $references);
+                            if (null !== $anchorRef) {
+                                $references[$anchorRef] = $value;
+                            }
                             // Spec: Keys MUST be unique; first one wins.
                             // Parser cannot abort this mapping earlier, since lines
                             // are processed sequentially.
@@ -551,6 +586,9 @@ class Inline
                         case '{':
                             // nested mapping
                             $value = self::parseMapping($state, $mapping, $flags, $i, $references);
+                            if (null !== $anchorRef) {
+                                $references[$anchorRef] = $value;
+                            }
                             // Spec: Keys MUST be unique; first one wins.
                             // Parser cannot abort this mapping earlier, since lines
                             // are processed sequentially.
@@ -568,8 +606,10 @@ class Inline
                             }
                             break;
                         default:
-                            $hasAnchorAtStart = null === $tag && isset($mapping[$i]) && '&' === $mapping[$i];
                             $value = self::parseScalar($mapping, $flags, [',', '}', "\n"], $i, null === $tag, $references, $isValueQuoted, $state);
+                            if (null !== $anchorRef) {
+                                $references[$anchorRef] = $value;
+                            }
                             // Spec: Keys MUST be unique; first one wins.
                             // Parser cannot abort this mapping earlier, since lines
                             // are processed sequentially.
@@ -577,11 +617,6 @@ class Inline
                             if ('<<' === $key) {
                                 $output += $value;
                             } elseif ($allowOverwrite || !isset($output[$key])) {
-                                if ($hasAnchorAtStart && !$isValueQuoted && \is_string($value) && '' !== $value && '&' === $value[0] && !self::isBinaryString($value) && Parser::preg_match(Parser::REFERENCE_PATTERN, $value, $matches)) {
-                                    $value = '' === $matches['value'] ? null : $matches['value'];
-                                    $references[$matches['ref']] = $value;
-                                }
-
                                 if (null !== $tag) {
                                     $output[$key] = new TaggedValue($tag, $value);
                                 } else {
@@ -804,6 +839,21 @@ class Inline
         }
 
         return (string) $scalar;
+    }
+
+    private static function parseAnchor(string $value, int &$i): ?string
+    {
+        if (!isset($value[$i]) || '&' !== $value[$i]) {
+            return null;
+        }
+
+        if (!Parser::preg_match('/^&(?P<ref>[^ \t,\[\]\{\}\n]++)\s*+/A', substr($value, $i), $matches)) {
+            return null;
+        }
+
+        $i += \strlen($matches[0]);
+
+        return $matches['ref'];
     }
 
     private static function parseTag(string $value, int &$i, int $flags): ?string

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1230,6 +1230,18 @@ class Parser
         return substr($this->currentLine, $offset, $cursor - $offset);
     }
 
+    private function lexInlineAnchorOrAlias(int &$cursor): string
+    {
+        $offset = $cursor;
+        ++$cursor;
+
+        while ($cursor < \strlen($this->currentLine) && !\in_array($this->currentLine[$cursor], [' ', "\t", ',', '[', ']', '{', '}'], true)) {
+            ++$cursor;
+        }
+
+        return substr($this->currentLine, $offset, $cursor - $offset);
+    }
+
     private function lexInlineMapping(int &$cursor = 0, bool $consumeUntilEol = true): string
     {
         return $this->lexInlineStructure($cursor, '}', $consumeUntilEol);
@@ -1264,6 +1276,10 @@ class Parser
                         break;
                     case '[':
                         $value .= $this->lexInlineSequence($cursor, false);
+                        break;
+                    case '&':
+                    case '*':
+                        $value .= $this->lexInlineAnchorOrAlias($cursor);
                         break;
                     case $closingTag:
                         $value .= $this->currentLine[$cursor];

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -1137,4 +1137,62 @@ class InlineTest extends TestCase
         $this->assertSame(['&string1', '&string2', '&string3', null], $parsed['block']);
         $this->assertSame($parsed['block'], $parsed['flow']);
     }
+
+    #[DataProvider('getAnchoredInlineValues')]
+    public function testParseAnchoredInlineValues(string $yaml, array $expected)
+    {
+        $this->assertSame($expected, Inline::parse($yaml));
+    }
+
+    public static function getAnchoredInlineValues(): iterable
+    {
+        yield 'double-quoted value in mapping' => [
+            '{ foo: &a "FOO", bar: *a }',
+            ['foo' => 'FOO', 'bar' => 'FOO'],
+        ];
+        yield 'single-quoted value in mapping' => [
+            "{ foo: &a 'FOO', bar: *a }",
+            ['foo' => 'FOO', 'bar' => 'FOO'],
+        ];
+        yield 'double-quoted value with braces in mapping' => [
+            '{ foo: &a "${FOO}", bar: *a }',
+            ['foo' => '${FOO}', 'bar' => '${FOO}'],
+        ];
+        yield 'double-quoted value with comma in mapping' => [
+            '{ foo: &a "a,b", bar: *a }',
+            ['foo' => 'a,b', 'bar' => 'a,b'],
+        ];
+        yield 'sequence value in mapping' => [
+            '{ foo: &a [a, b], bar: *a }',
+            ['foo' => ['a', 'b'], 'bar' => ['a', 'b']],
+        ];
+        yield 'mapping value in mapping' => [
+            '{ foo: &a { k: v }, bar: *a }',
+            ['foo' => ['k' => 'v'], 'bar' => ['k' => 'v']],
+        ];
+        yield 'double-quoted value in sequence' => [
+            '[&a "FOO", *a]',
+            ['FOO', 'FOO'],
+        ];
+        yield 'double-quoted value with braces in sequence' => [
+            '[&a "${FOO}", *a]',
+            ['${FOO}', '${FOO}'],
+        ];
+        yield 'sequence value in sequence' => [
+            '[&a [a, b], *a]',
+            [['a', 'b'], ['a', 'b']],
+        ];
+        yield 'plain scalar value in mapping' => [
+            '{ foo: &a bar, baz: *a }',
+            ['foo' => 'bar', 'baz' => 'bar'],
+        ];
+    }
+
+    public function testParseAnchoredMergeKey()
+    {
+        $this->assertSame(
+            ['k' => 'v', 'bar' => 2],
+            Inline::parse('{ <<: &a { k: v }, bar: 2 }'),
+        );
+    }
 }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -3356,6 +3356,22 @@ YAML;
         $this->assertSame(['foo' => 'bar'], $this->parser->parse($yaml));
     }
 
+    public function testParseInlineMappingWithAnchoredQuotedValueContainingBraces()
+    {
+        $this->assertSame(
+            ['foo' => '${FOO}', 'bar' => '${FOO}'],
+            $this->parser->parse('{ foo: &a "${FOO}", bar: *a }'),
+        );
+    }
+
+    public function testParseInlineMappingWithAnchoredQuotedValue()
+    {
+        $this->assertSame(
+            ['foo' => 'FOO', 'bar' => 'FOO'],
+            $this->parser->parse('{ foo: &a "FOO", bar: *a }'),
+        );
+    }
+
     private function assertSameData($expected, $actual)
     {
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64363
| License       | MIT

Parsing inline YAML like `{ foo: &1 "FOO", bar: *1 }` returned the value with surrounding quotes (`'"FOO"'`) instead of unescaping the quoted scalar, and `{ foo: &1 "${FOO}", bar: *1 }` failed with `Malformed inline YAML string` because the `{` inside the quoted value broke the lexer.

Two issues combined:

1. The lexer's `lexUnquotedString` did not recognize `&` and `*` as anchor/alias indicators, so it greedily consumed `&NAME "value` and broke at the `{` of `\${FOO}`.
2. The inline parser treated `&NAME "value"` as a single plain scalar; `REFERENCE_PATTERN` just captured the literal substring after the anchor name, so quotes and other value types were never parsed.

This adds a dedicated `&`/`*` token in `lexInlineStructure`, and a `parseAnchor` helper in `Inline` that extracts the anchor name before dispatching to the matching value parser (sequence/mapping/scalar). The fix also covers anchored sequences, mappings, and merge keys.