### PR TITLE
 Migrate `configureSchema()` to DBAL's editor API

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -7,6 +7,26 @@ git checkout src/Symfony/Contracts/Service/ResetInterface.php
 (echo "$head" && echo && git diff -U2 src/ | grep '^index ' -v) > .github/expected-missing-return-types.diff
 git checkout composer.json src/
 
+diff --git a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
++++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+@@ -34,5 +34,5 @@ abstract class AbstractSchemaListener
+      * @return Schema The (possibly new) schema after filtering
+      */
+-    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator)
++    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator): Schema
+     {
+         $filter = $connection->getConfiguration()->getSchemaAssetsFilter();
+diff --git a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
++++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+@@ -193,5 +193,5 @@ final class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifi
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase)
++    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): Schema
+     {
+         if ($schema->hasTable('rememberme_token')) {
 diff --git a/src/Symfony/Bridge/Twig/Test/Traits/RuntimeLoaderProvider.php b/src/Symfony/Bridge/Twig/Test/Traits/RuntimeLoaderProvider.php
 --- a/src/Symfony/Bridge/Twig/Test/Traits/RuntimeLoaderProvider.php
 +++ b/src/Symfony/Bridge/Twig/Test/Traits/RuntimeLoaderProvider.php
@@ -55,6 +75,16 @@ diff --git a/src/Symfony/Component/BrowserKit/AbstractBrowser.php b/src/Symfony/
 +    protected function filterResponse(object $response): Response
      {
          return $response;
+diff --git a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
++++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+@@ -132,5 +132,5 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase)
++    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): Schema
+     {
+         if ($schema->hasTable($this->table)) {
 diff --git a/src/Symfony/Component/Console/Command/Command.php b/src/Symfony/Component/Console/Command/Command.php
 --- a/src/Symfony/Component/Console/Command/Command.php
 +++ b/src/Symfony/Component/Console/Command/Command.php
@@ -180,7 +210,7 @@ diff --git a/src/Symfony/Component/DependencyInjection/Extension/PrependExtensio
 diff --git a/src/Symfony/Component/DomCrawler/Crawler.php b/src/Symfony/Component/DomCrawler/Crawler.php
 --- a/src/Symfony/Component/DomCrawler/Crawler.php
 +++ b/src/Symfony/Component/DomCrawler/Crawler.php
-@@ -646,5 +646,5 @@ class Crawler implements \Countable, \IteratorAggregate
+@@ -645,5 +645,5 @@ class Crawler implements \Countable, \IteratorAggregate
       * @return array|static
       */
 -    public function evaluate(string $xpath): array|self
@@ -367,6 +397,16 @@ diff --git a/src/Symfony/Component/Form/Test/TypeTestCase.php b/src/Symfony/Comp
 +    public static function assertDateIntervalEquals(\DateInterval $expected, \DateInterval $actual): void
      {
          self::assertEquals($expected->format('%RP%yY%mM%dDT%hH%iM%sS'), $actual->format('%RP%yY%mM%dDT%hH%iM%sS'));
+diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
++++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+@@ -188,5 +188,5 @@ class PdoSessionHandler extends AbstractSessionHandler
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null)
++    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null): Schema
+     {
+         if ($schema->hasTable($this->table) || ($isSameDatabase && !$isSameDatabase($this->getConnection()->exec(...)))) {
 diff --git a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
 --- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
 +++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -481,6 +521,36 @@ diff --git a/src/Symfony/Component/HttpKernel/KernelInterface.php b/src/Symfony/
 +    public function shutdown(): void;
  
      /**
+diff --git a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
++++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+@@ -259,5 +259,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, \Closure $isSameDatabase)
++    public function configureSchema(Schema $schema, \Closure $isSameDatabase): Schema
+     {
+         if ($schema->hasTable($this->table)) {
+diff --git a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
++++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+@@ -355,5 +355,5 @@ class Connection implements ResetInterface
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase)
++    public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase): Schema
+     {
+         if ($schema->hasTable($this->configuration['table_name'])) {
+diff --git a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
++++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+@@ -87,5 +87,5 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, DbalConnection $forConnection, \Closure $isSameDatabase)
++    public function configureSchema(Schema $schema, DbalConnection $forConnection, \Closure $isSameDatabase): Schema
+     {
+         return $this->connection->configureSchema($schema, $forConnection, $isSameDatabase) ?? $schema;
 diff --git a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
 --- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
 +++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -28,33 +28,90 @@ abstract class AbstractSchemaListener
 {
     abstract public function postGenerateSchema(GenerateSchemaEventArgs $event): void;
 
-    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator): void
+    /**
+     * @param callable(): Schema $configurator returns the (possibly new) schema with the table added
+     *
+     * @return Schema The (possibly new) schema after filtering
+     */
+    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator)
     {
         $filter = $connection->getConfiguration()->getSchemaAssetsFilter();
+        $getName = static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName();
 
-        if (null === $filter) {
-            $configurator();
-
-            return;
+        if (null !== $filter) {
+            $previousTableNames = array_map($getName, $schema->getTables());
+            $previousSequenceNames = array_map($getName, $schema->getSequences());
         }
 
-        $getNames = static fn ($array) => array_map(static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName(), $array);
-        $previousTableNames = $getNames($schema->getTables());
-        $previousSequenceNames = $getNames($schema->getSequences());
+        $newSchema = $configurator() ?? $schema;
 
-        $configurator();
+        if (null !== $filter) {
+            $tablesToFilter = [];
+            foreach ($newSchema->getTables() as $table) {
+                $name = $getName($table);
+                if (!\in_array($name, $previousTableNames, true) && !$filter($name)) {
+                    $tablesToFilter[] = $table;
+                }
+            }
 
-        foreach (array_diff($getNames($schema->getTables()), $previousTableNames) as $addedTable) {
-            if (!$filter($addedTable)) {
-                $schema->dropTable($addedTable);
+            $sequencesToFilter = [];
+            foreach ($newSchema->getSequences() as $sequence) {
+                $name = $getName($sequence);
+                if (!\in_array($name, $previousSequenceNames, true) && !$filter($name)) {
+                    $sequencesToFilter[] = $sequence;
+                }
+            }
+
+            if ($tablesToFilter || $sequencesToFilter) {
+                // When doctrine/dbal minimum is bumped to ^4.5, the `else` branch
+                // (and the same fallback in every configureSchema() implementation)
+                // can be removed: Schema::edit() is then always available.
+                if (method_exists($newSchema, 'edit')) {
+                    $editor = $newSchema->edit();
+                    foreach ($tablesToFilter as $table) {
+                        $editor->dropTable($table->getObjectName());
+                    }
+                    foreach ($sequencesToFilter as $sequence) {
+                        $editor->dropSequence($sequence->getObjectName());
+                    }
+
+                    $newSchema = $editor->create();
+                } else {
+                    foreach ($tablesToFilter as $table) {
+                        $newSchema->dropTable($getName($table));
+                    }
+                    foreach ($sequencesToFilter as $sequence) {
+                        $newSchema->dropSequence($getName($sequence));
+                    }
+                }
             }
         }
 
-        foreach (array_diff($getNames($schema->getSequences()), $previousSequenceNames) as $addedSequence) {
-            if (!$filter($addedSequence)) {
-                $schema->dropSequence($addedSequence);
-            }
+        // Backfill the original $schema with new tables/sequences from $newSchema so that callers holding
+        // a reference to it (e.g. ORM's GenerateSchemaEventArgs prior to setSchema() being available) still
+        // see the changes. Goes through the protected _addTable/_addSequence to bypass the deprecated
+        // public createTable/createSequence.
+        //
+        // When doctrine/orm minimum is bumped to a version providing
+        // GenerateSchemaEventArgs::setSchema() (>= 3.6.8), this whole block can be dropped
+        // and the `if (method_exists($event, 'setSchema'))` guards in each *SchemaListener
+        // subclass can become unconditional `$event->setSchema($schema);` calls.
+        if ($newSchema !== $schema) {
+            \Closure::bind(static function (Schema $schema) use ($newSchema, $getName): void {
+                foreach ($newSchema->getTables() as $table) {
+                    if (!$schema->hasTable($getName($table))) {
+                        $schema->_addTable($table);
+                    }
+                }
+                foreach ($newSchema->getSequences() as $sequence) {
+                    if (!$schema->hasSequence($getName($sequence))) {
+                        $schema->_addSequence($sequence);
+                    }
+                }
+            }, null, Schema::class)($schema);
         }
+
+        return $newSchema;
     }
 
     /**
@@ -66,13 +123,8 @@ abstract class AbstractSchemaListener
             $schemaManager = method_exists($connection, 'createSchemaManager') ? $connection->createSchemaManager() : $connection->getSchemaManager();
             $key = bin2hex(random_bytes(7));
             $table = new Table('schema_subscriber_check_');
-            $table->addColumn('id', Types::INTEGER)
-                ->setAutoincrement(true)
-                ->setNotnull(true);
-            $table->addColumn('random_key', Types::STRING)
-                ->setLength(14)
-                ->setNotNull(true)
-            ;
+            $table->addColumn('id', Types::INTEGER, ['autoincrement' => true, 'notnull' => true]);
+            $table->addColumn('random_key', Types::STRING, ['length' => 14, 'notnull' => true]);
 
             if (class_exists(PrimaryKeyConstraint::class)) {
                 $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true));

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
@@ -35,9 +35,11 @@ class DoctrineDbalCacheAdapterSchemaListener extends AbstractSchemaListener
 
         foreach ($this->dbalAdapters as $dbalAdapter) {
             $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-            $this->filterSchemaChanges($schema, $connection, static function () use ($dbalAdapter, $schema, $connection, $isSameDatabaseChecker) {
-                $dbalAdapter->configureSchema($schema, $connection, $isSameDatabaseChecker);
-            });
+            $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $dbalAdapter->configureSchema($schema, $connection, $isSameDatabaseChecker)) ?? $schema;
+        }
+
+        if (method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
@@ -36,9 +36,11 @@ final class LockStoreSchemaListener extends AbstractSchemaListener
             }
 
             $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-            $this->filterSchemaChanges($schema, $connection, static function () use ($store, $schema, $isSameDatabaseChecker) {
-                $store->configureSchema($schema, $isSameDatabaseChecker);
-            });
+            $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $store->configureSchema($schema, $isSameDatabaseChecker)) ?? $schema;
+        }
+
+        if (method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
@@ -42,9 +42,11 @@ class MessengerTransportDoctrineSchemaListener extends AbstractSchemaListener
             }
 
             $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-            $this->filterSchemaChanges($schema, $connection, static function () use ($transport, $schema, $connection, $isSameDatabaseChecker) {
-                $transport->configureSchema($schema, $connection, $isSameDatabaseChecker);
-            });
+            $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $transport->configureSchema($schema, $connection, $isSameDatabaseChecker)) ?? $schema;
+        }
+
+        if (method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
@@ -36,8 +36,10 @@ final class PdoSessionHandlerSchemaListener extends AbstractSchemaListener
         $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
         $sessionHandler = $this->sessionHandler;
 
-        $this->filterSchemaChanges($schema, $connection, static function () use ($sessionHandler, $schema, $isSameDatabaseChecker) {
-            $sessionHandler->configureSchema($schema, $isSameDatabaseChecker);
-        });
+        $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $sessionHandler->configureSchema($schema, $isSameDatabaseChecker)) ?? $schema;
+
+        if (method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
+        }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
@@ -40,11 +40,12 @@ class RememberMeTokenProviderDoctrineSchemaListener extends AbstractSchemaListen
                 && ($tokenProvider = $rememberMeHandler->getTokenProvider()) instanceof DoctrineTokenProvider
             ) {
                 $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-                $this->filterSchemaChanges($schema, $connection, static function () use ($tokenProvider, $schema, $connection, $isSameDatabaseChecker) {
-                    /* @var DoctrineTokenProvider $tokenProvider */
-                    $tokenProvider->configureSchema($schema, $connection, $isSameDatabaseChecker);
-                });
+                $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $tokenProvider->configureSchema($schema, $connection, $isSameDatabaseChecker)) ?? $schema;
             }
+        }
+
+        if (method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
@@ -188,23 +189,38 @@ final class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifi
 
     /**
      * Adds the Table to the Schema if "remember me" uses this Connection.
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): void
+    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase)
     {
         if ($schema->hasTable('rememberme_token')) {
-            return;
+            return $schema;
         }
 
         if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema($schema);
     }
 
-    private function addTableToSchema(Schema $schema): void
+    private function addTableToSchema(Schema $schema): Schema
     {
-        $table = $schema->createTable('rememberme_token');
+        if (method_exists($schema, 'edit')) {
+            $table = new Table('rememberme_token');
+            $this->configureSchemaTable($table);
+
+            return $schema->edit()->addTable($table)->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable('rememberme_token'));
+
+        return $schema;
+    }
+
+    private function configureSchemaTable(Table $table): void
+    {
         $table->addColumn('series', Types::STRING, ['length' => 88]);
         $table->addColumn('value', Types::STRING, ['length' => 88]);
         $table->addColumn('lastUsed', Types::DATETIME_IMMUTABLE);

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
@@ -14,10 +14,9 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaListener;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
@@ -45,8 +44,6 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
         $subscriber->postGenerateSchema($event);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchemaRespectsSchemaFilter()
     {
         $schema = new Schema();
@@ -64,13 +61,22 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
         $dbalAdapter = $this->createStub(DoctrineDbalAdapter::class);
         $dbalAdapter->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
+                if (method_exists($schema, 'edit')) {
+                    $table = new Table('cache_items');
+                    $table->addColumn('item_id', 'string');
+
+                    return $schema->edit()->addTable($table)->create();
+                }
+
                 $table = $schema->createTable('cache_items');
                 $table->addColumn('item_id', 'string');
+
+                return $schema;
             });
 
         $listener = new DoctrineDbalCacheAdapterSchemaListener([$dbalAdapter]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('cache_items'));
+        $this->assertFalse($event->getSchema()->hasTable('cache_items'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
@@ -14,10 +14,9 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\SchemaListener\LockStoreSchemaListener;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
@@ -44,8 +43,6 @@ class LockStoreSchemaListenerTest extends TestCase
         $subscriber->postGenerateSchema($event);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchemaRespectsSchemaFilter()
     {
         $schema = new Schema();
@@ -63,13 +60,21 @@ class LockStoreSchemaListenerTest extends TestCase
         $lockStore = $this->createStub(DoctrineDbalStore::class);
         $lockStore->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('lock_keys');
-                $table->addColumn('key_id', 'string');
+                if (method_exists($schema, 'edit')) {
+                    $table = new Table('lock_keys');
+                    $table->addColumn('key_id', 'string');
+
+                    return $schema->edit()->addTable($table)->create();
+                }
+
+                $schema->createTable('lock_keys')->addColumn('key_id', 'string');
+
+                return $schema;
             });
 
         $listener = new LockStoreSchemaListener([$lockStore]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('lock_keys'));
+        $this->assertFalse($event->getSchema()->hasTable('lock_keys'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
@@ -16,11 +16,10 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaListener;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
@@ -111,8 +110,6 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
         $this->assertFalse($event->isDefaultPrevented());
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchemaRespectsSchemaFilter()
     {
         $schema = new Schema();
@@ -129,19 +126,14 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
 
         $doctrineTransport = $this->createStub(DoctrineTransport::class);
         $doctrineTransport->method('configureSchema')
-            ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('messenger_messages');
-                $table->addColumn('id', 'integer', ['autoincrement' => true]);
-            });
+            ->willReturnCallback(self::addMessengerMessages(...));
 
         $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('messenger_messages'));
+        $this->assertFalse($event->getSchema()->hasTable('messenger_messages'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchemaRespectsSchemaFilterIncludingSequences()
     {
         $schema = new Schema();
@@ -159,25 +151,23 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
 
         $doctrineTransport = $this->createStub(DoctrineTransport::class);
         $doctrineTransport->method('configureSchema')
-            ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('messenger_messages');
-                $table->addColumn('id', 'integer', ['autoincrement' => true]);
-                $schema->createSequence('messenger_messages_seq');
-            });
+            ->willReturnCallback(self::addMessengerMessagesWithSequence(...));
 
         $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('messenger_messages'));
-        $this->assertFalse($schema->hasSequence('messenger_messages_seq'));
+        $this->assertFalse($event->getSchema()->hasTable('messenger_messages'));
+        $this->assertFalse($event->getSchema()->hasSequence('messenger_messages_seq'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchemaFilterDoesNotAffectPreExistingSequences()
     {
-        $schema = new Schema();
-        $schema->createSequence('existing_seq');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addSequence(new Sequence('existing_seq'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createSequence('existing_seq');
+        }
 
         $configuration = new Configuration();
         $excluded = ['messenger_messages', 'messenger_messages_seq', 'existing_seq'];
@@ -192,17 +182,42 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
 
         $doctrineTransport = $this->createStub(DoctrineTransport::class);
         $doctrineTransport->method('configureSchema')
-            ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('messenger_messages');
-                $table->addColumn('id', 'integer', ['autoincrement' => true]);
-                $schema->createSequence('messenger_messages_seq');
-            });
+            ->willReturnCallback(self::addMessengerMessagesWithSequence(...));
 
         $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('messenger_messages'));
-        $this->assertFalse($schema->hasSequence('messenger_messages_seq'));
-        $this->assertTrue($schema->hasSequence('existing_seq'));
+        $this->assertFalse($event->getSchema()->hasTable('messenger_messages'));
+        $this->assertFalse($event->getSchema()->hasSequence('messenger_messages_seq'));
+        $this->assertTrue($event->getSchema()->hasSequence('existing_seq'));
+    }
+
+    private static function addMessengerMessages(Schema $schema): Schema
+    {
+        if (method_exists($schema, 'edit')) {
+            $table = new Table('messenger_messages');
+            $table->addColumn('id', 'integer', ['autoincrement' => true]);
+
+            return $schema->edit()->addTable($table)->create();
+        }
+
+        $schema->createTable('messenger_messages')->addColumn('id', 'integer', ['autoincrement' => true]);
+
+        return $schema;
+    }
+
+    private static function addMessengerMessagesWithSequence(Schema $schema): Schema
+    {
+        if (method_exists($schema, 'edit')) {
+            $table = new Table('messenger_messages');
+            $table->addColumn('id', 'integer', ['autoincrement' => true]);
+
+            return $schema->edit()->addTable($table)->addSequence(new Sequence('messenger_messages_seq'))->create();
+        }
+
+        $schema->createTable('messenger_messages')->addColumn('id', 'integer', ['autoincrement' => true]);
+        $schema->createSequence('messenger_messages_seq');
+
+        return $schema;
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
@@ -14,10 +14,9 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\SchemaListener\PdoSessionHandlerSchemaListener;
@@ -46,8 +45,6 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
         $subscriber->postGenerateSchema($event);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchemaRespectsSchemaFilter()
     {
         $schema = new Schema();
@@ -65,14 +62,22 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
         $pdoSessionHandler = $this->createStub(PdoSessionHandler::class);
         $pdoSessionHandler->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('sessions');
-                $table->addColumn('sess_id', 'string');
+                if (method_exists($schema, 'edit')) {
+                    $table = new Table('sessions');
+                    $table->addColumn('sess_id', 'string');
+
+                    return $schema->edit()->addTable($table)->create();
+                }
+
+                $schema->createTable('sessions')->addColumn('sess_id', 'string');
+
+                return $schema;
             });
 
         $listener = new PdoSessionHandlerSchemaListener($pdoSessionHandler);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('sessions'));
+        $this->assertFalse($event->getSchema()->hasTable('sessions'));
     }
 
     #[RequiresPhpExtension('pdo_sqlite')]

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/RememberMeTokenProviderDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/RememberMeTokenProviderDoctrineSchemaListenerTest.php
@@ -16,8 +16,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\SchemaListener\RememberMeTokenProviderDoctrineSchemaListener;
 use Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider;
@@ -34,8 +32,6 @@ class RememberMeTokenProviderDoctrineSchemaListenerTest extends TestCase
         }
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchema()
     {
         $schema = new Schema();
@@ -58,11 +54,9 @@ class RememberMeTokenProviderDoctrineSchemaListenerTest extends TestCase
         $listener = new RememberMeTokenProviderDoctrineSchemaListener([$rememberMeHandler]);
         $listener->postGenerateSchema($event);
 
-        $this->assertTrue($schema->hasTable('rememberme_token'));
+        $this->assertTrue($event->getSchema()->hasTable('rememberme_token'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testPostGenerateSchemaRespectsSchemaFilter()
     {
         $schema = new Schema();
@@ -88,6 +82,6 @@ class RememberMeTokenProviderDoctrineSchemaListenerTest extends TestCase
         $listener = new RememberMeTokenProviderDoctrineSchemaListener([$rememberMeHandler]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('rememberme_token'));
+        $this->assertFalse($event->getSchema()->hasTable('rememberme_token'));
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -27,6 +27,7 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tools\DsnParser;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
@@ -120,25 +121,27 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
      */
     public function createTable(): void
     {
-        $schema = new Schema();
-        $this->addTableToSchema($schema);
+        $schema = $this->addTableToSchema(new Schema());
 
         foreach ($schema->toSql($this->conn->getDatabasePlatform()) as $sql) {
             $this->conn->executeStatement($sql);
         }
     }
 
-    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase): void
+    /**
+     * @return Schema The (possibly new) schema with the table added
+     */
+    public function configureSchema(Schema $schema, Connection $forConnection, \Closure $isSameDatabase)
     {
         if ($schema->hasTable($this->table)) {
-            return;
+            return $schema;
         }
 
         if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema($schema);
     }
 
     public function prune(): bool
@@ -403,14 +406,27 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
         };
     }
 
-    private function addTableToSchema(Schema $schema): void
+    private function addTableToSchema(Schema $schema): Schema
+    {
+        if (method_exists($schema, 'edit')) {
+            $table = new Table($this->table);
+            $this->configureSchemaTable($table);
+
+            return $schema->edit()->addTable($table)->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->table));
+
+        return $schema;
+    }
+
+    private function configureSchemaTable(Table $table): void
     {
         $types = [
             'mysql' => 'binary',
             'sqlite' => 'text',
         ];
 
-        $table = $schema->createTable($this->table);
         $table->addColumn($this->idCol, $types[$this->getPlatformName()] ?? 'string', ['length' => 255]);
         $table->addColumn($this->dataCol, 'blob', ['length' => 16777215]);
         $table->addColumn($this->lifetimeCol, 'integer', ['unsigned' => true, 'notnull' => false]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -22,15 +22,12 @@ use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 
 #[RequiresPhpExtension('pdo_sqlite')]
 #[Group('time-sensitive')]
-#[IgnoreDeprecations]
-#[Group('doctrine-dbal-workaround')]
 class DoctrineDbalAdapterTest extends AdapterTestCase
 {
     protected static string $dbFile;
@@ -86,10 +83,9 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         }
 
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile], $this->getDbalConfig());
-        $schema = new Schema();
 
         $adapter = new DoctrineDbalAdapter($connection);
-        $adapter->configureSchema($schema, $connection, static fn () => true);
+        $schema = $adapter->configureSchema(new Schema(), $connection, static fn () => true);
         $this->assertTrue($schema->hasTable('cache_items'));
     }
 
@@ -100,10 +96,9 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         }
 
         $otherConnection = $this->createConnection();
-        $schema = new Schema();
 
         $adapter = $this->createCachePool();
-        $adapter->configureSchema($schema, $otherConnection, static fn () => false);
+        $schema = $adapter->configureSchema(new Schema(), $otherConnection, static fn () => false);
         $this->assertFalse($schema->hasTable('cache_items'));
     }
 
@@ -114,11 +109,15 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         }
 
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile], $this->getDbalConfig());
-        $schema = new Schema();
-        $schema->createTable('cache_items');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new \Doctrine\DBAL\Schema\Table('cache_items'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('cache_items');
+        }
 
         $adapter = new DoctrineDbalAdapter($connection);
-        $adapter->configureSchema($schema, $connection, static fn () => true);
+        $schema = $adapter->configureSchema($schema, $connection, static fn () => true);
         $table = $schema->getTable('cache_items');
         $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 
 /**
@@ -183,45 +184,60 @@ class PdoSessionHandler extends AbstractSessionHandler
 
     /**
      * Adds the Table to the Schema if it doesn't exist.
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null): void
+    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null)
     {
         if ($schema->hasTable($this->table) || ($isSameDatabase && !$isSameDatabase($this->getConnection()->exec(...)))) {
-            return;
+            return $schema;
         }
 
-        $table = $schema->createTable($this->table);
+        if (method_exists($schema, 'edit')) {
+            $table = new Table($this->table);
+            $this->configureSchemaTable($table);
+
+            return $schema->edit()->addTable($table)->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->table));
+
+        return $schema;
+    }
+
+    private function configureSchemaTable(Table $table): void
+    {
         switch ($this->driver) {
             case 'mysql':
-                $table->addColumn($this->idCol, Types::BINARY)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
+                $table->addColumn($this->idCol, Types::BINARY, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
                 $table->addOption('engine', 'InnoDB');
                 break;
             case 'sqlite':
-                $table->addColumn($this->idCol, Types::TEXT)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                $table->addColumn($this->idCol, Types::TEXT, ['notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['notnull' => true]);
                 break;
             case 'pgsql':
-                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BINARY)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                $table->addColumn($this->idCol, Types::STRING, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BINARY, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['notnull' => true]);
                 break;
             case 'oci':
-                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                $table->addColumn($this->idCol, Types::STRING, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['notnull' => true]);
                 break;
             case 'sqlsrv':
-                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
+                $table->addColumn($this->idCol, Types::STRING, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
                 break;
             default:
                 throw new \DomainException(\sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 use Doctrine\DBAL\Schema\Schema;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -326,33 +325,29 @@ class PdoSessionHandlerTest extends TestCase
 
     public function testConfigureSchemaDifferentDatabase()
     {
-        $schema = new Schema();
-
         $pdoSessionHandler = new PdoSessionHandler($this->getMemorySqlitePdo());
-        $pdoSessionHandler->configureSchema($schema, static fn () => false);
+        $schema = $pdoSessionHandler->configureSchema(new Schema(), static fn () => false);
         $this->assertFalse($schema->hasTable('sessions'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testConfigureSchemaSameDatabase()
     {
-        $schema = new Schema();
-
         $pdoSessionHandler = new PdoSessionHandler($this->getMemorySqlitePdo());
-        $pdoSessionHandler->configureSchema($schema, static fn () => true);
+        $schema = $pdoSessionHandler->configureSchema(new Schema(), static fn () => true);
         $this->assertTrue($schema->hasTable('sessions'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('doctrine-dbal-workaround')]
     public function testConfigureSchemaTableExistsPdo()
     {
-        $schema = new Schema();
-        $schema->createTable('sessions');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new \Doctrine\DBAL\Schema\Table('sessions'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('sessions');
+        }
 
         $pdoSessionHandler = new PdoSessionHandler($this->getMemorySqlitePdo());
-        $pdoSessionHandler->configureSchema($schema, static fn () => true);
+        $schema = $pdoSessionHandler->configureSchema($schema, static fn () => true);
         $table = $schema->getTable('sessions');
         $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -27,6 +27,7 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tools\DsnParser;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
@@ -244,8 +245,8 @@ class DoctrineDbalStore implements PersistingStoreInterface
      */
     public function createTable(): void
     {
-        $schema = new Schema();
-        $this->configureSchema($schema, static fn () => true);
+        $initialSchema = new Schema();
+        $schema = $this->configureSchema($initialSchema, static fn () => true) ?? $initialSchema;
 
         foreach ($schema->toSql($this->conn->getDatabasePlatform()) as $sql) {
             $this->conn->executeStatement($sql);
@@ -254,18 +255,33 @@ class DoctrineDbalStore implements PersistingStoreInterface
 
     /**
      * Adds the Table to the Schema if it doesn't exist.
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, \Closure $isSameDatabase): void
+    public function configureSchema(Schema $schema, \Closure $isSameDatabase)
     {
         if ($schema->hasTable($this->table)) {
-            return;
+            return $schema;
         }
 
         if (!$isSameDatabase($this->conn->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $table = $schema->createTable($this->table);
+        if (method_exists($schema, 'edit')) {
+            $table = new Table($this->table);
+            $this->configureSchemaTable($table);
+
+            return $schema->edit()->addTable($table)->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->table));
+
+        return $schema;
+    }
+
+    private function configureSchemaTable(Table $table): void
+    {
         $table->addColumn($this->idCol, 'string', ['length' => 64]);
         $table->addColumn($this->tokenCol, 'string', ['length' => 44]);
         $table->addColumn($this->expirationCol, 'integer', ['unsigned' => true]);

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -26,7 +26,6 @@ use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
@@ -38,8 +37,6 @@ use Symfony\Component\Lock\Test\AbstractStoreTestCase;
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
 #[RequiresPhpExtension('pdo_sqlite')]
-#[IgnoreDeprecations]
-#[Group('doctrine-dbal-workaround')]
 class DoctrineDbalStoreTest extends AbstractStoreTestCase
 {
     use ExpiringStoreTestTrait;
@@ -370,34 +367,31 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
     public function testConfigureSchemaDifferentDatabase()
     {
         $conn = $this->createStub(Connection::class);
-        $someFunction = static fn () => false;
-        $schema = new Schema();
-
         $dbalStore = new DoctrineDbalStore($conn);
-        $dbalStore->configureSchema($schema, $someFunction);
+        $schema = $dbalStore->configureSchema(new Schema(), static fn () => false);
         $this->assertFalse($schema->hasTable('lock_keys'));
     }
 
     public function testConfigureSchemaSameDatabase()
     {
         $conn = $this->createStub(Connection::class);
-        $someFunction = static fn () => true;
-        $schema = new Schema();
-
         $dbalStore = new DoctrineDbalStore($conn);
-        $dbalStore->configureSchema($schema, $someFunction);
+        $schema = $dbalStore->configureSchema(new Schema(), static fn () => true);
         $this->assertTrue($schema->hasTable('lock_keys'));
     }
 
     public function testConfigureSchemaTableExists()
     {
-        $conn = $this->createStub(Connection::class);
-        $schema = new Schema();
-        $schema->createTable('lock_keys');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new \Doctrine\DBAL\Schema\Table('lock_keys'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('lock_keys');
+        }
 
+        $conn = $this->createStub(Connection::class);
         $dbalStore = new DoctrineDbalStore($conn);
-        $someFunction = static fn () => true;
-        $dbalStore->configureSchema($schema, $someFunction);
+        $schema = $dbalStore->configureSchema($schema, static fn () => true);
         $table = $schema->getTable('lock_keys');
         $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -33,8 +33,6 @@ use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
@@ -42,8 +40,6 @@ use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\TransportException;
 
-#[IgnoreDeprecations]
-#[Group('doctrine-dbal-workaround')]
 class ConnectionTest extends TestCase
 {
     public function testGetAMessageWillChangeItsStatus()
@@ -796,10 +792,9 @@ class ConnectionTest extends TestCase
     public function testConfigureSchema()
     {
         $driverConnection = $this->getDBALConnection();
-        $schema = new Schema();
 
         $connection = new Connection(['table_name' => 'queue_table'], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection, static fn () => true);
+        $schema = $connection->configureSchema(new Schema(), $driverConnection, static fn () => true);
         $this->assertTrue($schema->hasTable('queue_table'));
 
         // Ensure the covering index for the SELECT query exists
@@ -823,21 +818,24 @@ class ConnectionTest extends TestCase
     {
         $driverConnection = $this->getDBALConnection();
         $driverConnection2 = $this->getDBALConnection();
-        $schema = new Schema();
 
         $connection = new Connection([], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection2, static fn () => false);
+        $schema = $connection->configureSchema(new Schema(), $driverConnection2, static fn () => false);
         $this->assertFalse($schema->hasTable('messenger_messages'));
     }
 
     public function testConfigureSchemaTableExists()
     {
         $driverConnection = $this->getDBALConnection();
-        $schema = new Schema();
-        $schema->createTable('messenger_messages');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new \Doctrine\DBAL\Schema\Table('messenger_messages'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('messenger_messages');
+        }
 
         $connection = new Connection([], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection, static fn () => true);
+        $schema = $connection->configureSchema($schema, $driverConnection, static fn () => true);
         $table = $schema->getTable('messenger_messages');
         $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
@@ -905,10 +903,8 @@ class ConnectionTest extends TestCase
         $result->method('fetchOne')->willReturn('12.1.0');
         $driverConnection->method('executeQuery')->willReturn($result);
 
-        $schema = new Schema();
-
         $connection = new Connection(['table_name' => 'messenger_messages'], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection, static fn () => true);
+        $schema = $connection->configureSchema(new Schema(), $driverConnection, static fn () => true);
 
         $expectedSuffix = '_seq';
         $sequences = $schema->getSequences();

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -15,16 +15,12 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
 
 #[RequiresPhpExtension('pdo_sqlite')]
-#[IgnoreDeprecations]
-#[Group('doctrine-dbal-workaround')]
 class DoctrineIntegrationTest extends TestCase
 {
     private \Doctrine\DBAL\Connection $driverConnection;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlFilterIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlFilterIntegrationTest.php
@@ -22,7 +22,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tools\DsnParser;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
@@ -32,8 +31,6 @@ use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
  */
 #[RequiresPhpExtension('pdo_pgsql')]
 #[Group('integration')]
-#[IgnoreDeprecations()]
-#[Group('doctrine-dbal-workaround')]
 class DoctrinePostgreSqlFilterIntegrationTest extends TestCase
 {
     private Connection $driverConnection;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlIntegrationTest.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
@@ -25,8 +24,6 @@ use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
 
 #[RequiresPhpExtension('pdo_pgsql')]
 #[Group('integration')]
-#[IgnoreDeprecations]
-#[Group('doctrine-dbal-workaround')]
 class DoctrinePostgreSqlIntegrationTest extends TestCase
 {
     private Connection $driverConnection;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlPgbouncerIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlPgbouncerIntegrationTest.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
@@ -29,8 +28,6 @@ use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
  */
 #[RequiresPhpExtension('pdo_pgsql')]
 #[Group('integration')]
-#[IgnoreDeprecations]
-#[Group('doctrine-dbal-workaround')]
 class DoctrinePostgreSqlPgbouncerIntegrationTest extends TestCase
 {
     private Connection $driverConnection;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlRegularIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlRegularIntegrationTest.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
@@ -29,8 +28,6 @@ use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
  */
 #[RequiresPhpExtension('pdo_pgsql')]
 #[Group('integration')]
-#[IgnoreDeprecations]
-#[Group('doctrine-dbal-workaround')]
 class DoctrinePostgreSqlRegularIntegrationTest extends TestCase
 {
     private \Doctrine\DBAL\Connection $driverConnection;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -27,6 +27,7 @@ use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Satag\DoctrineFirebirdDriver\Platforms\FirebirdPlatform;
@@ -350,18 +351,20 @@ class Connection implements ResetInterface
 
     /**
      * @internal
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase): void
+    public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase)
     {
         if ($schema->hasTable($this->configuration['table_name'])) {
-            return;
+            return $schema;
         }
 
         if ($forConnection !== $this->driverConnection && !$isSameDatabase($this->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema($schema);
     }
 
     /**
@@ -497,50 +500,66 @@ class Connection implements ResetInterface
 
     private function getSchema(): Schema
     {
-        $schema = new Schema([], [], $this->driverConnection->createSchemaManager()->createSchemaConfig());
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema(new Schema([], [], $this->driverConnection->createSchemaManager()->createSchemaConfig()));
+    }
+
+    private function addTableToSchema(Schema $schema): Schema
+    {
+        $oracleSequenceName = null;
+        $idOptions = ['autoincrement' => true, 'notnull' => true];
+
+        // We need to create a sequence for Oracle and set the id column to get the correct nextval
+        if ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
+            $serverVersion = $this->driverConnection->executeQuery("SELECT version FROM product_component_version WHERE product LIKE 'Oracle Database%'")->fetchOne();
+            if (version_compare($serverVersion, '12.1.0', '>=')) {
+                $oracleSequenceName = $this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX;
+                // disable the creation of SEQUENCE and TRIGGER, use the sequence's nextval as default instead
+                $idOptions = ['autoincrement' => false, 'notnull' => true, 'default' => $oracleSequenceName.'.nextval'];
+            }
+        }
+
+        if (method_exists($schema, 'edit')) {
+            $table = new Table($this->configuration['table_name']);
+            $this->configureSchemaTable($table, $idOptions);
+
+            $editor = $schema->edit()->addTable($table);
+            if (null !== $oracleSequenceName) {
+                $editor->addSequence(new Sequence($oracleSequenceName));
+            }
+
+            return $editor->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->configuration['table_name']), $idOptions);
+
+        if (null !== $oracleSequenceName) {
+            $schema->createSequence($oracleSequenceName);
+        }
 
         return $schema;
     }
 
-    private function addTableToSchema(Schema $schema): void
+    /**
+     * @param array<string, mixed> $idOptions
+     */
+    private function configureSchemaTable(Table $table, array $idOptions): void
     {
-        $table = $schema->createTable($this->configuration['table_name']);
         // add an internal option to mark that we created this & the non-namespaced table name
         $table->addOption(self::TABLE_OPTION_NAME, $this->configuration['table_name']);
-        $idColumn = $table->addColumn('id', Types::BIGINT)
-            ->setAutoincrement(true)
-            ->setNotnull(true);
-        $table->addColumn('body', Types::TEXT)
-            ->setNotnull(true);
-        $table->addColumn('headers', Types::TEXT)
-            ->setNotnull(true);
-        $table->addColumn('queue_name', Types::STRING)
-            ->setLength(190) // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
-            ->setNotnull(true);
-        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(true);
-        $table->addColumn('available_at', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(true);
-        $table->addColumn('delivered_at', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(false);
+        $table->addColumn('id', Types::BIGINT, $idOptions);
+        $table->addColumn('body', Types::TEXT, ['notnull' => true]);
+        $table->addColumn('headers', Types::TEXT, ['notnull' => true]);
+        // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
+        $table->addColumn('queue_name', Types::STRING, ['length' => 190, 'notnull' => true]);
+        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE, ['notnull' => true]);
+        $table->addColumn('available_at', Types::DATETIME_IMMUTABLE, ['notnull' => true]);
+        $table->addColumn('delivered_at', Types::DATETIME_IMMUTABLE, ['notnull' => false]);
         if (class_exists(PrimaryKeyConstraint::class)) {
             $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true));
         } else {
             $table->setPrimaryKey(['id']);
         }
         $table->addIndex(['queue_name', 'available_at', 'delivered_at', 'id']);
-
-        // We need to create a sequence for Oracle and set the id column to get the correct nextval
-        if ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
-            $serverVersion = $this->driverConnection->executeQuery("SELECT version FROM product_component_version WHERE product LIKE 'Oracle Database%'")->fetchOne();
-            if (version_compare($serverVersion, '12.1.0', '>=')) {
-                $idColumn->setAutoincrement(false); // disable the creation of SEQUENCE and TRIGGER
-                $idColumn->setDefault($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX.'.nextval');
-
-                $schema->createSequence($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX);
-            }
-        }
     }
 
     private function decodeEnvelopeHeaders(array $doctrineEnvelope): array

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -83,10 +83,12 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
 
     /**
      * Adds the Table to the Schema if this transport uses this connection.
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, DbalConnection $forConnection, \Closure $isSameDatabase): void
+    public function configureSchema(Schema $schema, DbalConnection $forConnection, \Closure $isSameDatabase)
     {
-        $this->connection->configureSchema($schema, $forConnection, $isSameDatabase);
+        return $this->connection->configureSchema($schema, $forConnection, $isSameDatabase) ?? $schema;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Follow-up of #64351
| License       | MIT

#64351 silenced the deprecations introduced by doctrine/dbal#7373 (`Schema::createTable()`, `dropTable()`, `createSequence()`, `dropSequence()`) because the replacement API (`Schema::edit()` + `SchemaEditor`) returns a new `Schema` instance instead of mutating in place, which didn't fit our `configureSchema(Schema $schema)` callbacks nor Doctrine ORM's `postGenerateSchema` event (where `$schema` was effectively read-only).

doctrine/orm#12483 unblocked the ORM side by adding `GenerateSchemaEventArgs::setSchema()` (ORM 3.6+). This PR completes the picture on the Symfony side:

* `configureSchema()` on `PdoSessionHandler`, `DoctrineDbalAdapter`, `DoctrineDbalStore`, the Messenger `Connection`/`DoctrineTransport`, and `DoctrineTokenProvider` now returns the (possibly new) `Schema`. Implementations route through `Schema::edit()` + `SchemaEditor::addTable()` when DBAL 4.5+ is available, and fall back to the legacy mutating `Schema::createTable()` path otherwise.
* Schema listeners forward the returned schema via `GenerateSchemaEventArgs::setSchema()` when ORM 3.6+ is installed, otherwise mutate the original schema in place (legacy behavior).
* `AbstractSchemaListener::filterSchemaChanges()` returns the filtered schema and uses the editor API to drop filtered tables/sequences when available.

To minimize the BC impact, no PHP return type is declared on `configureSchema()` and `filterSchemaChanges()` (only `@return Schema` in the docblock). Subclasses that override with `: void` keep working, and caller sites use `?? $schema` to fall back to the original (potentially mutated) schema when a legacy override returns nothing.

While at it, the column setter chains (`->setLength()->setNotnull()->setAutoincrement()->setUnsigned()`) are folded into `addColumn()`'s options array. This dodges doctrine/dbal#7381 (column setter deprecations) the same way: constructor-internal calls don't trigger the deprecation, so passing the options at construction time keeps the code clean for both DBAL <4.5 and 4.5+.

Most `#[IgnoreDeprecations]` / `#[Group('doctrine-dbal-workaround')]` tags introduced in #64351 (plus the follow-up Messenger PostgreSQL ones) are removed. Four tags remain on tests that exercise ORM's `SchemaTool::createSchema()`, which still calls `Schema::createTable()` internally (lines 207 and 650 of `SchemaTool.php` in ORM 3.6). Lifting these requires a follow-up on the ORM side.
