### PR TITLE
[Serializer] Allow passing in `PropertyWriteInfoExtractorInterface` to `ObjectNormalizer`

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
  * Add the `XmlEncoder::BOOLEAN_REPR` context option to choose the strings representing booleans when encoding, e.g. `['true', 'false']`
  * Add support for denormalizing arrays of union types, e.g. `array<Foo|Bar>`
+ * Add argument `$writeInfoExtractor` to `ObjectNormalizer::__construct()`
 
 8.1
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -21,6 +21,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
+use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -48,7 +49,7 @@ final class ObjectNormalizer extends AbstractObjectNormalizer
 
     private readonly \Closure $objectClassResolver;
 
-    public function __construct(?ClassMetadataFactoryInterface $classMetadataFactory = null, ?NameConverterInterface $nameConverter = null, ?PropertyAccessorInterface $propertyAccessor = null, ?PropertyTypeExtractorInterface $propertyTypeExtractor = null, ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, ?callable $objectClassResolver = null, array $defaultContext = [], ?PropertyInfoExtractorInterface $propertyInfoExtractor = null)
+    public function __construct(?ClassMetadataFactoryInterface $classMetadataFactory = null, ?NameConverterInterface $nameConverter = null, ?PropertyAccessorInterface $propertyAccessor = null, ?PropertyTypeExtractorInterface $propertyTypeExtractor = null, ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, ?callable $objectClassResolver = null, array $defaultContext = [], ?PropertyInfoExtractorInterface $propertyInfoExtractor = null, ?PropertyWriteInfoExtractorInterface $writeInfoExtractor = null)
     {
         if (!class_exists(PropertyAccess::class)) {
             throw new LogicException('The ObjectNormalizer class requires the "PropertyAccess" component. Try running "composer require symfony/property-access".');
@@ -60,7 +61,7 @@ final class ObjectNormalizer extends AbstractObjectNormalizer
 
         $this->objectClassResolver = ($objectClassResolver ?? static fn ($class) => \is_object($class) ? $class::class : $class)(...);
         $this->propertyInfoExtractor = $propertyInfoExtractor ?: new ReflectionExtractor();
-        $this->writeInfoExtractor = new ReflectionExtractor();
+        $this->writeInfoExtractor = $writeInfoExtractor ?: new ReflectionExtractor();
     }
 
     public function getSupportedTypes(?string $format): array

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -12,12 +12,16 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
 use Symfony\Component\PropertyAccess\Exception\InvalidTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessorBuilder;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyAccess\PropertyPathInterface;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -244,7 +248,41 @@ class ObjectNormalizerTest extends TestCase
         );
     }
 
-    public function testWriteInfoExtractorCanBeInjected()
+    public function testDenormalizeWithAccessorButNoWriteInfoExtractorDoesNotApplyValue()
+    {
+        $propertyAccessor = new class implements PropertyAccessorInterface {
+            public function setValue(object|array &$objectOrArray, string|PropertyPathInterface $propertyPath, mixed $value): void
+            {
+                throw new AssertionFailedError('PropertyAccessor->setValue should not be called without injected PropertyWriteInfoExtractorInterface');
+            }
+
+            public function getValue(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): mixed
+            {
+                throw new \BadMethodCallException('Not implemented in test.');
+            }
+
+            public function isWritable(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): bool
+            {
+                return true;
+            }
+
+            public function isReadable(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): bool
+            {
+                return true;
+            }
+        };
+
+        $normalizer = new ObjectNormalizer(
+            propertyAccessor: $propertyAccessor,
+        );
+
+        $obj = $normalizer->denormalize(['foo' => 'bar'], ObjectWithUnconventionalSetter::class);
+
+        $this->assertInstanceOf(ObjectWithUnconventionalSetter::class, $obj);
+        $this->assertSame('init', $obj->getFoo());
+    }
+
+    public function testDenormalizeWithAccessorAndWriteInfoExtractorAppliesValue()
     {
         $writeInfoExtractor = new class implements PropertyWriteInfoExtractorInterface {
             public array $properties = [];
@@ -257,11 +295,41 @@ class ObjectNormalizerTest extends TestCase
             }
         };
 
-        $normalizer = new ObjectNormalizer(null, null, null, null, null, null, [], null, $writeInfoExtractor);
-        new Serializer([$normalizer]);
+        $propertyAccessor = new class implements PropertyAccessorInterface {
+            public function setValue(object|array &$objectOrArray, string|PropertyPathInterface $propertyPath, mixed $value): void
+            {
+                if ($propertyPath !== 'foo') {
+                    throw new InvalidPropertyPathException(\sprintf('Can only set foo, got %s', $propertyPath));
+                }
 
-        $normalizer->denormalize(['foo' => 'bar'], ObjectWithUnconventionalSetter::class);
+                $objectOrArray->assign(\sprintf('%s_set_from_custom_accessor', $value));
+            }
 
+            public function getValue(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): mixed
+            {
+                throw new \BadMethodCallException('Not implemented in test.');
+            }
+
+            public function isWritable(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): bool
+            {
+                return true;
+            }
+
+            public function isReadable(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): bool
+            {
+                return true;
+            }
+        };
+
+        $normalizer = new ObjectNormalizer(
+            propertyAccessor: $propertyAccessor,
+            writeInfoExtractor: $writeInfoExtractor,
+        );
+
+        $obj = $normalizer->denormalize(['foo' => 'bar'], ObjectWithUnconventionalSetterWithWriteInfoExtractor::class);
+
+        $this->assertInstanceOf(ObjectWithUnconventionalSetterWithWriteInfoExtractor::class, $obj);
+        $this->assertSame('bar_set_from_custom_accessor', $obj->getFoo());
         $this->assertSame(['foo'], $writeInfoExtractor->properties);
     }
 
@@ -2508,3 +2576,5 @@ class ObjectWithUnconventionalSetter
         $this->foo = $foo;
     }
 }
+
+class ObjectWithUnconventionalSetterWithWriteInfoExtractor extends ObjectWithUnconventionalSetter {}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -25,6 +25,8 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyNameExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyWriteInfo;
+use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\Ignore;
@@ -240,6 +242,27 @@ class ObjectNormalizerTest extends TestCase
             ['bar' => 'bar'],
             $this->normalizer->normalize($obj, 'any')
         );
+    }
+
+    public function testWriteInfoExtractorCanBeInjected()
+    {
+        $writeInfoExtractor = new class implements PropertyWriteInfoExtractorInterface {
+            public array $properties = [];
+
+            public function getWriteInfo(string $class, string $property, array $context = []): ?PropertyWriteInfo
+            {
+                $this->properties[] = $property;
+
+                return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, 'assign');
+            }
+        };
+
+        $normalizer = new ObjectNormalizer(null, null, null, null, null, null, [], null, $writeInfoExtractor);
+        new Serializer([$normalizer]);
+
+        $normalizer->denormalize(['foo' => 'bar'], ObjectWithUnconventionalSetter::class);
+
+        $this->assertSame(['foo'], $writeInfoExtractor->properties);
     }
 
     public function testDenormalize()
@@ -2469,4 +2492,19 @@ class ObjectNormalizerDiscriminatorSub extends ObjectNormalizerDiscriminatorBase
     public const BAR = 'bar';
 
     public string $bar = self::BAR;
+}
+
+class ObjectWithUnconventionalSetter
+{
+    private string $foo = 'init';
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function assign(string $foo): void
+    {
+        $this->foo = $foo;
+    }
 }


### PR DESCRIPTION
Instead of always creating a new `ReflectionExtractor` for the `$writeInfoExtractor` property, add an optional constructor parameter to allow instantiating the `ObjectNormalizer` with any `PropertyWriteInfoExtractorInterface` and use that if provided. If not provided, fallback on creating the `ReflectionExtractor` to match previous behavior.

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The `ObjectNormalizer` class currently allows passing in extractors and accessors for most everything, and falls back on using the `ReflectionExtractor` for extractors and accessors when no other is explicitly provided for a certain extractor. However, this does not apply for the `$writeInfoExtractor` property. Instead, the constructor will always instantiate a new `ReflectionExtractor` for that. This limits the ability to use a custom extractor for write information. This PR changes this by adding an optional `$writeInfoExtractfor` property to the end of the `ObjectNormalizer` constructor parameters, allowing the user to pass their own `PropertyWriteInfoExtractorInterface`.

On its own a custom `PropertyWriteInfoExtractorInterface` provides little benefit over the default `ReflectionExtractor`, as the `PropertyWriteInfoExtractorInterface` is only called once `$propertyInfoExtractor->isWritable()` has already returned false, and the default `PropertyAccessorInterface` recognizes writable properties through the same mechanisms as `ReflectionExtractor`. Other properties will just silently fail. However when paired with a custom `PropertyAccessorInterface` it allows the custom accessor to be called when it otherwise wouldn't be (ie. when `$propertyInfoExtractor->isWritable()` returns false). This allows you to use an unconventional method of setting properties.
 


**Breaking changes: None**
_This does not introduce any breaking changes as the parameter is optional and at the end of the constructor parameter list._

**Documentation changes: None**
_This also does not require any documentation changes as current documentation does not outline existing constructor parameters._

**New tests: 2 new tests**
Tests are written showing changed behavior when `$writeInfoExtractor` injected
<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
