### PR TITLE
 Fix XMLHttpRequest URL handling in toolbar JS

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -355,6 +355,7 @@
 
                     XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
                         var self = this;
+                        url = String(url);
 
                         /* prevent logging AJAX calls to static and inline files, like templates */
                         var path = url;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64393
| License       | MIT

The toolbar's `XMLHttpRequest.prototype.open` wrapper called `url.slice()` / `url.indexOf()` directly, throwing a `TypeError` when callers (e.g. `pdfjs-dist`) pass a `URL` object as allowed by the XHR spec. Coerce `url` to a string at the start of the wrapper, mirroring the existing pattern in the `fetch` wrapper (line 368) and the previous `EventSource` fix in #62858.