### PR TITLE
[SecurityBundle] Fix state leak in LogoutUrlGenerator in async environments

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -233,6 +233,7 @@ return static function (ContainerConfigurator $container) {
                 service('router')->nullOnInvalid(),
                 service('security.token_storage')->nullOnInvalid(),
             ])
+            ->tag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore'])
 
         ->set('security.route_loader.logout', LogoutRouteLoader::class)
             ->args([

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Provides generator functions for the logout URL.
@@ -22,7 +23,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jeremy Mikola <jmikola@gmail.com>
  */
-class LogoutUrlGenerator
+class LogoutUrlGenerator implements ResetInterface
 {
     private ?RequestStack $requestStack;
     private ?UrlGeneratorInterface $router;
@@ -161,5 +162,11 @@ class LogoutUrlGenerator
         }
 
         throw new \InvalidArgumentException('Unable to find logout in the current firewall, pass the firewall name manually to generate a logout URL.');
+    }
+
+    public function reset(): void
+    {
+        $this->currentFirewallName = null;
+        $this->currentFirewallContext = null;
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -104,4 +104,18 @@ class LogoutUrlGeneratorTest extends TestCase
 
         $this->generator->getLogoutPath();
     }
+
+    public function testStateLeakWhenCalledTwiceWithoutReset()
+    {
+        $this->generator->registerListener('secured_area', '/logout', null, null);
+
+        $this->generator->setCurrentFirewall('secured_area');
+        $this->assertSame('/logout', $this->generator->getLogoutPath());
+
+        $this->generator->reset();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('This request is not behind a firewall, pass the firewall name manually to generate a logout URL.');
+        $this->generator->getLogoutPath();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

In long-running worker environments (like FrankenPHP, Swoole, or RoadRunner), the `LogoutUrlGenerator` can leak state between requests. This potential state leakage was identified using the [igor-php ](https://github.com/igor-php/igor-php)static analysis tool.

When `setCurrentFirewall()` is called during a request, it mutates the `$currentFirewallName` and `$currentFirewallContext` properties. If a request is interrupted (e.g., by a fatal exception) and the normal lifecycle is bypassed, these properties are never cleared. 

As a result, subsequent requests hitting the same worker might read this leaked state. For example, a user browsing a public section (no firewall) might generate a logout URL associated with the firewall of the previous user's request.

This PR implements `ResetInterface` to explicitly reset `$currentFirewallName` and `$currentFirewallContext` back to `null` between requests, ensuring deterministic behavior in asynchronous environments.