### PR TITLE
[SecurityBundle] Support decorating custom authentication result handlers

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `path`, `enable_csrf`, `csrf_token_id`, `csrf_parameter` and `csrf_token_manager` options to the `switch_user` firewall configuration to restrict user switching to a dedicated (POST-only) route protected by a CSRF token
  * Deprecate configuring an access control rule with many `roles`, use `allow_if` or role hierarchy instead
  * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
+ * Add support for decorating custom authentication failure and success handlers
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/UnshareAuthenticationResultHandlersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/UnshareAuthenticationResultHandlersPass.php
@@ -11,21 +11,81 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
-use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
-class UnshareAuthenticationResultHandlersPass implements CompilerPassInterface
+/**
+ * Unshares the handlers wired into authenticators, since each of them configures
+ * its own with its options, together with the services decorating them.
+ */
+final class UnshareAuthenticationResultHandlersPass implements CompilerPassInterface
 {
+    private const HANDLER_PARENTS = [
+        'security.authentication.custom_success_handler',
+        'security.authentication.custom_failure_handler',
+    ];
+
     public function process(ContainerBuilder $container): void
     {
+        $decorators = [];
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if ($decorated = $definition->getDecoratedService()) {
+                $decorators[$decorated[0]][] = $id;
+            }
+        }
+
+        $unshared = [];
+
         foreach ($container->getDefinitions() as $definition) {
-            if (
-                is_a($definition->getClass(), AuthenticationFailureHandlerInterface::class, true)
-                || is_a($definition->getClass(), AuthenticationSuccessHandlerInterface::class, true)
-            ) {
-                $definition->setShared(false);
+            if (!$definition instanceof ChildDefinition || !\in_array($definition->getParent(), self::HANDLER_PARENTS, true)) {
+                continue;
+            }
+
+            if (($handler = $definition->getArguments()['index_0'] ?? null) instanceof Reference) {
+                $this->unshare($container, (string) $handler, $decorators, $unshared);
+            }
+        }
+    }
+
+    private function unshare(ContainerBuilder $container, string $id, array $decorators, array &$unshared): void
+    {
+        if ($unshared[$id] ?? false) {
+            return;
+        }
+        $unshared[$id] = true;
+
+        foreach ($decorators[$id] ?? [] as $decoratorId) {
+            $this->unshare($container, $decoratorId, $decorators, $unshared);
+        }
+
+        if ($container->hasAlias($id)) {
+            $this->unshare($container, (string) $container->getAlias($id), $decorators, $unshared);
+
+            return;
+        }
+
+        if (!$container->hasDefinition($id)) {
+            return;
+        }
+
+        $definition = $container->getDefinition($id);
+        $definition->setShared(false);
+
+        if (!$definition->hasTag('container.stack')) {
+            return;
+        }
+
+        // the stack is turned into a chain of decorators later on, unshare each of its layers
+        foreach ($definition->getArguments() as $argument) {
+            if ($argument instanceof Definition) {
+                $argument->setShared(false);
+            } elseif ($argument instanceof Reference || $argument instanceof Alias) {
+                $this->unshare($container, (string) $argument, $decorators, $unshared);
             }
         }
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/UnshareAuthenticationResultHandlersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/UnshareAuthenticationResultHandlersPass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+class UnshareAuthenticationResultHandlersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            if (
+                is_a($definition->getClass(), AuthenticationFailureHandlerInterface::class, true)
+                || is_a($definition->getClass(), AuthenticationSuccessHandlerInterface::class, true)
+            ) {
+                $definition->setShared(false);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -78,7 +79,7 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
 
         if (isset($config['success_handler'])) {
             $successHandler = $container->setDefinition($successHandlerId, new ChildDefinition('security.authentication.custom_success_handler'));
-            $successHandler->replaceArgument(0, new ChildDefinition($config['success_handler']));
+            $successHandler->replaceArgument(0, new Reference($config['success_handler']));
             $successHandler->replaceArgument(1, $options);
             $successHandler->replaceArgument(2, $id);
         } else {
@@ -97,7 +98,7 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
 
         if (isset($config['failure_handler'])) {
             $failureHandler = $container->setDefinition($id, new ChildDefinition('security.authentication.custom_failure_handler'));
-            $failureHandler->replaceArgument(0, new ChildDefinition($config['failure_handler']));
+            $failureHandler->replaceArgument(0, new Reference($config['failure_handler']));
             $failureHandler->replaceArgument(1, $options);
         } else {
             $failureHandler = $container->setDefinition($id, new ChildDefinition('security.authentication.failure_handler'));

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -24,6 +24,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterTokenUsag
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RemoveSecurityDataCollectorListenerPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\ReplaceDecoratedRememberMeHandlerPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\SortFirewallListenersPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\UnshareAuthenticationResultHandlersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\CasTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OAuth2TokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OidcTokenHandlerFactory;
@@ -109,5 +110,7 @@ class SecurityBundle extends Bundle
 
         // must be registered before DecoratorServicePass
         $container->addCompilerPass(new MakeFirewallsEventDispatcherTraceablePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
+
+        $container->addCompilerPass(new UnshareAuthenticationResultHandlersPass());
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/UnshareAuthenticationResultHandlersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/UnshareAuthenticationResultHandlersPassTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\UnshareAuthenticationResultHandlersPass;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+
+class UnshareAuthenticationResultHandlersPassTest extends TestCase
+{
+    public function testHandlersWiredIntoAuthenticatorsAreUnshared()
+    {
+        $container = new ContainerBuilder();
+        $container->register('success_handler', DefaultAuthenticationSuccessHandler::class);
+        $container->register('failure_handler', DefaultAuthenticationFailureHandler::class);
+        $this->wireSuccessHandler($container, 'success_handler');
+        $this->wireFailureHandler($container, 'failure_handler');
+
+        (new UnshareAuthenticationResultHandlersPass())->process($container);
+
+        $this->assertFalse($container->getDefinition('success_handler')->isShared());
+        $this->assertFalse($container->getDefinition('failure_handler')->isShared());
+    }
+
+    public function testHandlersWithoutResolvedClassAreUnshared()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('success_handler.class', DefaultAuthenticationSuccessHandler::class);
+        $container->register('parameterized_handler', '%success_handler.class%');
+        $container->register('abstract_handler', DefaultAuthenticationSuccessHandler::class)->setAbstract(true);
+        $container->setDefinition('child_handler', new ChildDefinition('abstract_handler'));
+        $this->wireSuccessHandler($container, 'parameterized_handler');
+        $this->wireSuccessHandler($container, 'child_handler', 'json_login');
+
+        (new UnshareAuthenticationResultHandlersPass())->process($container);
+
+        $this->assertFalse($container->getDefinition('parameterized_handler')->isShared());
+        $this->assertFalse($container->getDefinition('child_handler')->isShared());
+    }
+
+    public function testDecoratorsAreUnshared()
+    {
+        $container = new ContainerBuilder();
+        $container->register('success_handler', DefaultAuthenticationSuccessHandler::class);
+        $container->register('decorating_handler', DefaultAuthenticationSuccessHandler::class)->setDecoratedService('success_handler');
+        $container->register('outer_decorating_handler', DefaultAuthenticationSuccessHandler::class)->setDecoratedService('decorating_handler');
+        $this->wireSuccessHandler($container, 'success_handler');
+
+        (new UnshareAuthenticationResultHandlersPass())->process($container);
+
+        $this->assertFalse($container->getDefinition('success_handler')->isShared());
+        $this->assertFalse($container->getDefinition('decorating_handler')->isShared());
+        $this->assertFalse($container->getDefinition('outer_decorating_handler')->isShared());
+    }
+
+    public function testStackLayersAreUnshared()
+    {
+        $container = new ContainerBuilder();
+        $stack = new ChildDefinition('');
+        $stack->addTag('container.stack');
+        $stack->setArguments($layers = [
+            new Definition(DefaultAuthenticationSuccessHandler::class),
+            new Definition(DefaultAuthenticationSuccessHandler::class),
+        ]);
+        $container->setDefinition('success_handler', $stack);
+        $this->wireSuccessHandler($container, 'success_handler');
+
+        (new UnshareAuthenticationResultHandlersPass())->process($container);
+
+        $this->assertFalse($layers[0]->isShared());
+        $this->assertFalse($layers[1]->isShared());
+    }
+
+    public function testHandlersNotWiredIntoAuthenticatorsAreLeftShared()
+    {
+        $container = new ContainerBuilder();
+        $container->register('success_handler', DefaultAuthenticationSuccessHandler::class);
+        $container->register('unrelated_handler', DefaultAuthenticationSuccessHandler::class);
+        $this->wireSuccessHandler($container, 'success_handler');
+
+        (new UnshareAuthenticationResultHandlersPass())->process($container);
+
+        $this->assertTrue($container->getDefinition('unrelated_handler')->isShared());
+    }
+
+    private function wireSuccessHandler(ContainerBuilder $container, string $handlerId, string $key = 'form_login'): void
+    {
+        $definition = new ChildDefinition('security.authentication.custom_success_handler');
+        $definition->replaceArgument(0, new Reference($handlerId));
+
+        $container->setDefinition('security.authentication.success_handler.main.'.$key, $definition);
+    }
+
+    private function wireFailureHandler(ContainerBuilder $container, string $handlerId, string $key = 'form_login'): void
+    {
+        $definition = new ChildDefinition('security.authentication.custom_failure_handler');
+        $definition->replaceArgument(0, new Reference($handlerId));
+
+        $container->setDefinition('security.authentication.failure_handler.main.'.$key, $definition);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 class AbstractFactoryTest extends TestCase
 {
@@ -53,8 +54,8 @@ class AbstractFactoryTest extends TestCase
             $this->assertInstanceOf(ChildDefinition::class, $failureHandler);
             $this->assertEquals('security.authentication.custom_failure_handler', $failureHandler->getParent());
             $failureHandlerArguments = $failureHandler->getArguments();
-            $this->assertInstanceOf(ChildDefinition::class, $failureHandlerArguments['index_0']);
-            $this->assertEquals($serviceId, $failureHandlerArguments['index_0']->getParent());
+            $this->assertInstanceOf(Reference::class, $failureHandlerArguments['index_0']);
+            $this->assertEquals($serviceId, (string) $failureHandlerArguments['index_0']);
             $this->assertEquals($expectedFailureHandlerOptions, $failureHandlerArguments['index_1']);
         }
     }
@@ -97,8 +98,8 @@ class AbstractFactoryTest extends TestCase
             $this->assertInstanceOf(ChildDefinition::class, $successHandler);
             $this->assertEquals('security.authentication.custom_success_handler', $successHandler->getParent());
             $successHandlerArguments = $successHandler->getArguments();
-            $this->assertInstanceOf(ChildDefinition::class, $successHandlerArguments['index_0']);
-            $this->assertEquals($serviceId, $successHandlerArguments['index_0']->getParent());
+            $this->assertInstanceOf(Reference::class, $successHandlerArguments['index_0']);
+            $this->assertEquals($serviceId, (string) $successHandlerArguments['index_0']);
             $this->assertEquals($expectedSuccessHandlerOptions, $successHandlerArguments['index_1']);
             $this->assertEquals($expectedFirewallName, $successHandlerArguments['index_2']);
         }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationFailureHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationFailureHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bundle\SecurityBundle\Tests\Fixtures;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationFailureHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationFailureHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+
+class DecoratingAuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
+{
+    public function __construct(private AuthenticationFailureHandlerInterface $handler)
+    {
+    }
+
+    public function setOptions(array $options): void
+    {
+        if (method_exists($this->handler, 'setOptions')) {
+            $this->handler->setOptions($options);
+        }
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        $response = $this->handler->onAuthenticationFailure($request, $exception);
+        $response->headers->add([
+            'X-Decorated-Handler' => $this->handler::class,
+            'X-Decorating-Handler' => __CLASS__,
+        ]);
+
+        return $response;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationSuccessHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationSuccessHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+class DecoratingAuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+    public function __construct(private AuthenticationSuccessHandlerInterface $handler)
+    {
+    }
+
+    public function setOptions(array $options): void
+    {
+        if (method_exists($this->handler, 'setOptions')) {
+            $this->handler->setOptions($options);
+        }
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response
+    {
+        $response = $this->handler->onAuthenticationSuccess($request, $token);
+        $response?->headers->add([
+            'X-Decorated-Handler' => $this->handler::class,
+            'X-Decorating-Handler' => __CLASS__,
+        ]);
+
+        return $response;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationSuccessHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationSuccessHandler.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bundle\SecurityBundle\Tests\Fixtures;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -20,12 +29,20 @@ class DecoratingAuthenticationSuccessHandler implements AuthenticationSuccessHan
         }
     }
 
+    public function setFirewallName(string $firewallName): void
+    {
+        if (method_exists($this->handler, 'setFirewallName')) {
+            $this->handler->setFirewallName($firewallName);
+        }
+    }
+
     public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response
     {
         $response = $this->handler->onAuthenticationSuccess($request, $token);
         $response?->headers->add([
             'X-Decorated-Handler' => $this->handler::class,
             'X-Decorating-Handler' => __CLASS__,
+            'X-Firewall-Name' => method_exists($this->handler, 'getFirewallName') ? $this->handler->getFirewallName() : null,
         ]);
 
         return $response;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
@@ -99,6 +99,7 @@ class AuthenticatorTest extends AbstractWebTestCase
         $this->assertResponseRedirects('http://localhost/firewall1/test');
         $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationSuccessHandler::class);
         $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Firewall-Name', 'firewall1');
 
         $client->request('POST', '/firewall1/dummy_login', [
             '_username' => 'jane@example.org',
@@ -107,6 +108,7 @@ class AuthenticatorTest extends AbstractWebTestCase
         $this->assertResponseRedirects('http://localhost/firewall1/dummy');
         $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationSuccessHandler::class);
         $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Firewall-Name', 'firewall1');
     }
 
     public function testCustomFailureHandler()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
@@ -12,6 +12,10 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationFailureHandler;
+use Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationSuccessHandler;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 
 class AuthenticatorTest extends AbstractWebTestCase
 {
@@ -93,12 +97,16 @@ class AuthenticatorTest extends AbstractWebTestCase
             '_password' => 'test',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/test');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationSuccessHandler::class);
 
         $client->request('POST', '/firewall1/dummy_login', [
             '_username' => 'jane@example.org',
             '_password' => 'test',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/dummy');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationSuccessHandler::class);
     }
 
     public function testCustomFailureHandler()
@@ -110,11 +118,15 @@ class AuthenticatorTest extends AbstractWebTestCase
             '_password' => 'wrong',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/login');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationFailureHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationFailureHandler::class);
 
         $client->request('POST', '/firewall1/dummy_login', [
             '_username' => 'jane@example.org',
             '_password' => 'wrong',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/dummy_login');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationFailureHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationFailureHandler::class);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/custom_handlers.yml
@@ -26,8 +26,16 @@ services:
     class: Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler
     arguments:
       - '@security.http_utils'
+  decorating_success_handler:
+    class: Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationSuccessHandler
+    decorates: success_handler
+    arguments: ['@.inner']
   failure_handler:
     class: Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler
     arguments:
       - '@http_kernel'
       - '@security.http_utils'
+  decorating_failure_handler:
+    class: Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationFailureHandler
+    decorates: failure_handler
+    arguments: ['@.inner']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49457
| License       | MIT

A firewall's `success_handler` and `failure_handler` options name a service, but the authenticator's own options (`default_target_path`, `login_path`, `failure_path`...) are pushed into that service through `setOptions()` and `setFirewallName()`. Wiring the same handler into two authenticators therefore made the last one win, so #48937 wired it as a `ChildDefinition` to give each authenticator its own copy. As a side effect, `decorates:` on the handler was silently ignored: a copy inherits the original definition, never the decorator.

The handler is now wired as a plain reference, and a compiler pass makes it non-shared together with everything decorating it. Each authenticator still gets its own instance to configure, and decoration applies:

```yaml
services:
    App\Security\SuccessHandlerDecorator:
        decorates: app.success_handler
        arguments: ['@.inner']

security:
    firewalls:
        main:
            form_login:
                success_handler: app.success_handler
                default_target_path: /dashboard
```

Only handlers referenced by an authenticator are unshared, so handlers used elsewhere in the application keep their usual sharing. `decorates:`, `#[AsDecorator]` and `stack:` are all covered.

For the docs: decorating a `success_handler` or a `failure_handler` now works. A decorator must forward `setOptions()`, and `setFirewallName()` for success handlers, to the service it decorates whenever that service relies on them, as `DefaultAuthenticationSuccessHandler` and `DefaultAuthenticationFailureHandler` do. Without forwarding, the authenticator options and the session target path are silently lost.
