### PR TITLE
[HttpFoundation] Allow creating single-use signed urls

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -12,3 +12,8 @@ FrameworkBundle
 ---------------
 
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
+
+HttpFoundation
+--------------
+
+ * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()`

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate not passing an expiry to `UriSigner::sign()`
  * Add the `$defaultExpiration` argument to `UriSigner::__construct()`
+ * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()` to bind a signed URI to a state token, folded into the signature
 
 8.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
@@ -256,6 +256,27 @@ class UriSignerTest extends TestCase
         $signer->sign('http://example.com/foo?_hash=bar', new \DateTimeImmutable('2099-01-01 00:00:00'));
     }
 
+    public function testSignWithReservedVersionParameter()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->expectException(LogicException::class);
+
+        $signer->sign('http://example.com/foo?_version=valid', new \DateTimeImmutable('2099-01-01 00:00:00'));
+    }
+
+    public function testSignDoesNotExposeVersion()
+    {
+        $signer = new UriSigner('foobar');
+        $expiration = new \DateTimeImmutable('2099-01-01 00:00:00');
+        $uri = $signer->sign('http://example.com/foo', $expiration, 'v1');
+
+        parse_str(parse_url($uri, \PHP_URL_QUERY), $params);
+
+        $this->assertArrayNotHasKey('_version', $params);
+        $this->assertNotSame($signer->sign('http://example.com/foo', $expiration), $uri);
+    }
+
     public function testSignWithExpirationAndWithReservedParameter()
     {
         $signer = new UriSigner('foobar');
@@ -310,6 +331,36 @@ class UriSignerTest extends TestCase
         $this->assertFalse($signer->check($relativeUriFromNow3));
     }
 
+    public function testCheckWithUriVersion()
+    {
+        $signer = new UriSigner('foobar');
+        $expiration = new \DateTimeImmutable('2099-01-01 00:00:00');
+
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo', $expiration, 'valid'), 'valid'));
+        $this->assertFalse($signer->check($signer->sign('http://example.com/foo', $expiration, 'valid'), 'invalid'));
+        $this->assertFalse($signer->check($signer->sign('http://example.com/foo', $expiration, 'missing-on-check')));
+    }
+
+    public function testCheckRequestWithUriVersion()
+    {
+        $signer = new UriSigner('foobar');
+        $expiration = new \DateTimeImmutable('2099-01-01 00:00:00');
+
+        $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo', $expiration, 'valid')), 'valid'));
+        $this->assertFalse($signer->checkRequest(Request::create($signer->sign('http://example.com/foo', $expiration, 'valid')), 'invalid'));
+        $this->assertFalse($signer->checkRequest(Request::create($signer->sign('http://example.com/foo', $expiration, 'missing-on-check'))));
+    }
+
+    public function testUnversionedUriFailsWhenVersionExpected()
+    {
+        $signer = new UriSigner('foobar');
+        $expiration = new \DateTimeImmutable('2099-01-01 00:00:00');
+
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo', $expiration)));
+        $this->assertFalse($signer->check($signer->sign('http://example.com/foo', $expiration), 'any'));
+        $this->assertFalse($signer->checkRequest(Request::create($signer->sign('http://example.com/foo', $expiration)), 'any'));
+    }
+
     public function testNonUrlSafeBase64()
     {
         $signer = new UriSigner('foobar');
@@ -344,5 +395,25 @@ class UriSignerTest extends TestCase
         $this->expectException(ExpiredSignedUriException::class);
 
         $signer->verify($uri);
+    }
+
+    public function testVerifyWithMatchingVersion()
+    {
+        $signer = new UriSigner('foobar');
+        $uri = $signer->sign('http://example.com/foo', new \DateTimeImmutable('2099-01-01 00:00:00'), 'valid');
+
+        $this->expectNotToPerformAssertions();
+
+        $signer->verify($uri, 'valid');
+    }
+
+    public function testVerifyWithVersionMismatch()
+    {
+        $signer = new UriSigner('foobar');
+        $uri = $signer->sign('http://example.com/foo', new \DateTimeImmutable('2099-01-01 00:00:00'), 'valid');
+
+        $this->expectException(UnverifiedSignedUriException::class);
+
+        $signer->verify($uri, 'invalid');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -33,6 +33,7 @@ class UriSigner
     /**
      * @param string                 $hashParameter       Query string parameter to use
      * @param string                 $expirationParameter Query string parameter to use for expiration
+     * @param string                 $versionParameter    Reserved parameter name folded into the signature for versioning
      * @param \DateInterval|int|null $defaultExpiration   The expiration applied when none is passed to sign(); an int is a number of seconds
      */
     public function __construct(
@@ -40,6 +41,7 @@ class UriSigner
         private string $hashParameter = '_hash',
         private string $expirationParameter = '_expiration',
         private ?ClockInterface $clock = null,
+        private string $versionParameter = '_version',
         \DateInterval|int|null $defaultExpiration = null,
     ) {
         if (!$secret) {
@@ -60,11 +62,15 @@ class UriSigner
      *                                                              If $expiration is a \DateInterval, the interval is added to "now" to get the date + time.
      *                                                              If $expiration is an int, it's expected to be a timestamp in seconds of the exact date + time.
      *                                                              If $expiration is null, the default expiration passed to the constructor is used.
+     * @param string|null                               $version    A token bound to the URI's state (e.g. a user's password hash, to invalidate a reset link
+     *                                                              when the password changes). It is folded into the signature and never exposed in the URI.
      *
      * The expiration is added as a query string parameter.
      */
-    public function sign(string $uri, \DateTimeInterface|\DateInterval|int|null $expiration = null): string
+    public function sign(string $uri, \DateTimeInterface|\DateInterval|int|null $expiration = null/* , #[\SensitiveParameter] ?string $version = null */): string
     {
+        $version = 2 < \func_num_args() ? func_get_arg(2) : null;
+
         $expiration ??= $this->defaultExpiration;
 
         if (null === $expiration) {
@@ -86,12 +92,21 @@ class UriSigner
             throw new LogicException(\sprintf('URI query parameter conflict: parameter name "%s" is reserved.', $this->expirationParameter));
         }
 
+        if (isset($params[$this->versionParameter])) {
+            throw new LogicException(\sprintf('URI query parameter conflict: parameter name "%s" is reserved.', $this->versionParameter));
+        }
+
         if (null !== $expiration) {
             $params[$this->expirationParameter] = $this->getExpirationTime($expiration);
         }
 
-        $uri = $this->buildUrl($url, $params);
-        $params[$this->hashParameter] = $this->computeHash($uri);
+        $hashParams = $params;
+
+        if (null !== $version) {
+            $hashParams[$this->versionParameter] = $version;
+        }
+
+        $params[$this->hashParameter] = $this->computeHash($this->buildUrl($url, $hashParams));
 
         return $this->buildUrl($url, $params);
     }
@@ -99,29 +114,42 @@ class UriSigner
     /**
      * Checks that a URI contains the correct hash.
      * Also checks if the URI has not expired (If you used expiration during signing).
+     *
+     * @param string|null $version Expected "state" for the given URI
      */
-    public function check(string $uri): bool
+    public function check(string $uri/* , #[\SensitiveParameter] ?string $version = null */): bool
     {
-        return self::STATUS_VALID === $this->doVerify($uri);
+        $version = 1 < \func_num_args() ? func_get_arg(1) : null;
+
+        return self::STATUS_VALID === $this->doVerify($uri, $version);
     }
 
-    public function checkRequest(Request $request): bool
+    /**
+     * @param string|null $version Expected "state" for the given URI
+     */
+    public function checkRequest(Request $request/* , #[\SensitiveParameter] ?string $version = null */): bool
     {
-        return self::STATUS_VALID === $this->doVerify(self::normalize($request));
+        $version = 1 < \func_num_args() ? func_get_arg(1) : null;
+
+        return self::STATUS_VALID === $this->doVerify(self::normalize($request), $version);
     }
 
     /**
      * Verify a Request or string URI.
+     *
+     * @param string|null $version Expected "state" for the given URI
      *
      * @throws UnsignedUriException         If the URI is not signed
      * @throws UnverifiedSignedUriException If the signature is invalid
      * @throws ExpiredSignedUriException    If the URI has expired
      * @throws SignedUriException
      */
-    public function verify(Request|string $uri): void
+    public function verify(Request|string $uri/* , #[\SensitiveParameter] ?string $version = null */): void
     {
+        $version = 1 < \func_num_args() ? func_get_arg(1) : null;
+
         $uri = self::normalize($uri);
-        $status = $this->doVerify($uri);
+        $status = $this->doVerify($uri, $version);
 
         match ($status) {
             self::STATUS_VALID => null,
@@ -175,7 +203,7 @@ class UriSigner
     /**
      * @return self::STATUS_*
      */
-    private function doVerify(string $uri): int
+    private function doVerify(string $uri, ?string $version): int
     {
         $url = parse_url($uri);
         $params = [];
@@ -191,7 +219,13 @@ class UriSigner
         $hash = $params[$this->hashParameter];
         unset($params[$this->hashParameter]);
 
-        if (!hash_equals($this->computeHash($this->buildUrl($url, $params)), strtr(rtrim($hash, '='), ['/' => '_', '+' => '-']))) {
+        $hashParams = $params;
+
+        if (null !== $version) {
+            $hashParams[$this->versionParameter] = $version;
+        }
+
+        if (!hash_equals($this->computeHash($this->buildUrl($url, $hashParams)), strtr(rtrim($hash, '='), ['/' => '_', '+' => '-']))) {
             return self::STATUS_INVALID;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

This allows creating single-use urls. You just need to pass a version that's value would change after it's first used.

Example:

```php
// 1. sign the password reset link using the user's password as the "version"
$link = $signer->sign(
    'http://password-reset-link...',
    new \DateTimeImmutable('+30 minutes'),
    $user->getPassword(),
);

// 2. in password reset controller BEFORE they reset their password
$signer->verify($request, $user->getPassword());

// all good!

// user changes their password...

// 3. in password reset controller AFTER they reset their password
$signer->verify($request, $user->getPassword()); // throws UnverifiedSignedUriException
```

This could be used for many different purposes:
- Login link: versioned on "last login timestamp"
- Verify email link: versioned on "last verified timestamp"

I'm not 100% sold on the terminology used: *version* and *stale*. Open to suggestions!
