### PR TITLE
[DoctrineBridge] Introduce AttributesBasedUserLoaderInterface

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+* Add `AttributesBasedUserLoaderInterface`
+
+
 8.1
 ---
 

--- a/src/Symfony/Bridge/Doctrine/Security/User/AttributesBasedUserLoaderInterface.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/AttributesBasedUserLoaderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Security\User;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @see \Symfony\Component\Security\Core\User\AttributesBasedUserProviderInterface
+ */
+interface AttributesBasedUserLoaderInterface extends UserLoaderInterface
+{
+    /**
+     * Loads the user for the given user identifier (e.g. username or email) and attributes.
+     *
+     * This method must return null if the user is not found.
+     */
+    public function loadUserByIdentifier(string $identifier, array $attributes = []): ?UserInterface;
+}

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -63,6 +63,18 @@ class EntityUserProvider implements AttributesBasedUserProviderInterface, Passwo
             } elseif (null === $attributes) {
                 $user = $repository->loadUserByIdentifier($identifier);
             } else {
+                $method = new \ReflectionMethod($repository, 'loadUserByIdentifier');
+                if ($method->getNumberOfParameters() > 1) {
+                    trigger_deprecation(
+                        'symfony/security-core',
+                        '8.2',
+                        'Implementing "%s::loadUserByIdentifier()" with a second argument without implementing "%s" is deprecated. Implement "%s" instead.',
+                        $repository::class,
+                        AttributesBasedUserProviderInterface::class,
+                        AttributesBasedUserProviderInterface::class,
+                    );
+                }
+
                 $user = $repository->loadUserByIdentifier($identifier, $attributes);
             }
         }

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -58,7 +58,9 @@ class EntityUserProvider implements AttributesBasedUserProviderInterface, Passwo
                 throw new \InvalidArgumentException(\sprintf('You must either make the "%s" entity Doctrine Repository ("%s") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.', $this->classOrAlias, get_debug_type($repository)));
             }
 
-            if (null === $attributes) {
+            if ($repository instanceof AttributesBasedUserProviderInterface) {
+                $user = $repository->loadUserByIdentifier($identifier, $attributes ?? []);
+            } elseif (null === $attributes) {
                 $user = $repository->loadUserByIdentifier($identifier);
             } else {
                 $user = $repository->loadUserByIdentifier($identifier, $attributes);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #... 
| License       | MIT

I discovered today that 
- AttributesBasedUserProviderInterface exisys https://github.com/symfony/symfony/blob/9f30c2bb7f560974f408b6b1aae8e8da2000b3a8/src/Symfony/Component/Security/Core/User/AttributesBasedUserProviderInterface.php#L24
- The chain provider supports it https://github.com/symfony/symfony/blob/9f30c2bb7f560974f408b6b1aae8e8da2000b3a8/src/Symfony/Component/Security/Core/User/ChainUserProvider.php#L53-L55
- the EntityUserProvider too https://github.com/symfony/symfony/blob/9f30c2bb7f560974f408b6b1aae8e8da2000b3a8/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php#L61-L65

BUT we only have one interface `UserLoaderInterface` which means that nothing enforce the type of the second parameters. I feel the current implementation is partially wrong since we passing the second param (or not) according to the value of the param and not the implementation of the repository.

Technically the implementation should be
```
if ($repository instanceof AttributesBasedUserProviderInterface) {
     $user = $repository->loadUserByIdentifier($identifier, $attributes ?? []);
} else {
     $user = $repository->loadUserByIdentifier($identifier);
}
```
but this would be a BC break.

At least we could introduce the interface AttributesBasedUserProviderInterface