### PR TITLE
[Tui] Add gradient support (linear, radial, color stops)

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`
  * [BC BREAK] Add `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
+ * Add `LinearGradient`, `RadialGradient`, `ColorStop` and `Angle`, with `Style::withLinearGradient()` and
+   `Style::withRadialGradient()`, to paint gradient backgrounds on a truecolor terminal
 
 8.1
 ---

--- a/src/Symfony/Component/Tui/Render/ChromeApplier.php
+++ b/src/Symfony/Component/Tui/Render/ChromeApplier.php
@@ -107,9 +107,6 @@ final class ChromeApplier
             return new ArrayLineBuffer([]);
         }
 
-        $styledEmptyLine = $style->apply(str_repeat(' ', $innerWidth));
-        $topPadding = $paddingTop > 0 ? array_fill(0, $paddingTop, $styledEmptyLine) : [];
-        $bottomPadding = $paddingBottom > 0 ? array_fill(0, $paddingBottom, $styledEmptyLine) : [];
         $textAlign = $style->getTextAlign() ?? TextAlign::Left;
 
         // For center/right alignment, compute offset from the widest line
@@ -125,13 +122,49 @@ final class ChromeApplier
             };
         }
 
-        $contentLines = [];
+        $gradient = $style->getGradient();
         $padLen = $paddingLeft + $alignPadLeft;
         $leftPad = str_repeat(' ', $padLen);
-        foreach ($processedLines as $i => $line) {
-            $lineWithPad = $leftPad.$line;
-            $rightPad = str_repeat(' ', max(0, $innerWidth - $padLen - $processedWidths[$i]));
-            $contentLines[] = $style->apply($lineWithPad.$rightPad);
+
+        if (null !== $gradient) {
+            $totalRows = $paddingTop + \count($processedLines) + $paddingBottom;
+            $fullHeight = $borderTop + $totalRows + $borderBottom;
+            // Resolve over innerWidth so the gradient spans the content area only.
+            // Borders echo the endpoint colors; content always starts at offset=0 and ends at offset=1.
+            $fullCodes = $gradient->resolve($innerWidth, $fullHeight);
+            $codes = [];
+            for ($r = 0; $r < $totalRows; ++$r) {
+                $codes[$r] = $fullCodes[$borderTop + $r];
+            }
+
+            $topPadding = [];
+            for ($r = 0; $r < $paddingTop; ++$r) {
+                $topPadding[] = $this->buildGradientLine('', $codes[$r], $innerWidth);
+            }
+
+            $contentLines = [];
+            foreach ($processedLines as $i => $line) {
+                $lineWithPad = $leftPad.$line;
+                $rightPad = str_repeat(' ', max(0, $innerWidth - $padLen - $processedWidths[$i]));
+                $contentLines[] = $this->buildGradientLine($lineWithPad.$rightPad, $codes[$paddingTop + $i], $innerWidth);
+            }
+
+            $bottomPadding = [];
+            for ($r = 0; $r < $paddingBottom; ++$r) {
+                $row = $paddingTop + \count($processedLines) + $r;
+                $bottomPadding[] = $this->buildGradientLine('', $codes[$row], $innerWidth);
+            }
+        } else {
+            $styledEmptyLine = $style->apply(str_repeat(' ', $innerWidth));
+            $topPadding = $paddingTop > 0 ? array_fill(0, $paddingTop, $styledEmptyLine) : [];
+            $bottomPadding = $paddingBottom > 0 ? array_fill(0, $paddingBottom, $styledEmptyLine) : [];
+
+            $contentLines = [];
+            foreach ($processedLines as $i => $line) {
+                $lineWithPad = $leftPad.$line;
+                $rightPad = str_repeat(' ', max(0, $innerWidth - $padLen - $processedWidths[$i]));
+                $contentLines[] = $style->apply($lineWithPad.$rightPad);
+            }
         }
 
         $innerLines = [...$topPadding, ...$contentLines, ...$bottomPadding];
@@ -212,6 +245,179 @@ final class ChromeApplier
         // visual formatting (color, bold, etc.). The Renderer owns layout
         // (padding, border, gap, direction, hidden, cursorShape, textAlign, align, verticalAlign); widgets own content.
         return new RenderContext($innerColumns, $innerRows, $context->getStyle()->withoutLayoutProperties(), $context->getFontRegistry());
+    }
+
+    /**
+     * Build a line applying per-column gradient background codes.
+     *
+     * Walks the ANSI string in a single O(n) pass, injecting a gradient bg code
+     * before each visible character only when no child widget has set an explicit
+     * background color. This implements CSS-style cascade: child bg takes
+     * precedence over the parent gradient.
+     *
+     * @param array<int, string> $rowCodes Per-column ANSI bg codes indexed by column
+     */
+    private function buildGradientLine(string $content, array $rowCodes, int $width): string
+    {
+        $result = '';
+        $col = 0;
+        $i = 0;
+        $len = \strlen($content);
+        $childBgActive = false;
+        // Last gradient code written to the line, so a run of cells sharing a color
+        // states it once. Reset to null whenever a sequence of the child goes
+        // through, since it may have changed the background behind our back.
+        $lastCode = null;
+
+        while ($i < $len && $col < $width) {
+            $ord = \ord($content[$i]);
+
+            // ANSI escape sequence (CSI: ESC [): pass through, track bg state
+            if (0x1B === $ord && '[' === ($content[$i + 1] ?? '')) {
+                $j = self::endOfCsi($content, $i, $len);
+                $seq = substr($content, $i, $j - $i);
+                $childBgActive = $this->parseBgState($seq, $childBgActive);
+                $result .= $seq;
+                $lastCode = null;
+                $i = $j;
+                continue;
+            }
+
+            // Printable ASCII: inject gradient code only when child has no active bg
+            if ($ord >= 0x20 && $ord <= 0x7E) {
+                if (!$childBgActive && ($rowCodes[$col] ?? '') !== $lastCode) {
+                    $result .= $lastCode = $rowCodes[$col] ?? '';
+                }
+                $result .= $content[$i];
+                ++$col;
+                ++$i;
+                continue;
+            }
+
+            // Multi-byte UTF-8: same logic
+            if ($ord >= 0x80) {
+                $seqLen = match (true) {
+                    ($ord & 0xE0) === 0xC0 => 2,
+                    ($ord & 0xF0) === 0xE0 => 3,
+                    ($ord & 0xF8) === 0xF0 => 4,
+                    default => 1,
+                };
+                $char = substr($content, $i, $seqLen);
+                $charWidth = AnsiUtils::graphemeWidth($char);
+                if (!$childBgActive && ($rowCodes[$col] ?? '') !== $lastCode) {
+                    $result .= $lastCode = $rowCodes[$col] ?? '';
+                }
+                $result .= $char;
+                $col += $charWidth;
+                $i += $seqLen;
+                continue;
+            }
+
+            ++$i;
+        }
+
+        // Fill remaining width with gradient-colored spaces
+        while ($col < $width) {
+            if (($rowCodes[$col] ?? '') !== $lastCode) {
+                $result .= $lastCode = $rowCodes[$col] ?? '';
+            }
+            $result .= ' ';
+            ++$col;
+        }
+
+        // Re-emit the escape sequences left after the last visible cell. When the
+        // content fills the line exactly, the loop above stops on $col and would
+        // otherwise drop the resets a child appended past its last character
+        // (ESC[22m, ESC[39m, ...), leaking its style onto the next line.
+        while ($i < $len) {
+            if (0x1B !== \ord($content[$i]) || '[' !== ($content[$i + 1] ?? '')) {
+                ++$i;
+                continue;
+            }
+
+            $j = self::endOfCsi($content, $i, $len);
+            $result .= substr($content, $i, $j - $i);
+            $i = $j;
+        }
+
+        return $result."\x1b[49m";
+    }
+
+    /**
+     * Return the offset just past the CSI sequence starting at $start.
+     */
+    private static function endOfCsi(string $content, int $start, int $len): int
+    {
+        $j = $start + 2;
+        // Parameter bytes (0x30–0x3F)
+        while ($j < $len && \ord($content[$j]) >= 0x30 && \ord($content[$j]) <= 0x3F) {
+            ++$j;
+        }
+        // Intermediate bytes (0x20–0x2F)
+        while ($j < $len && \ord($content[$j]) >= 0x20 && \ord($content[$j]) <= 0x2F) {
+            ++$j;
+        }
+        // Final byte (0x40–0x7E)
+        if ($j < $len && \ord($content[$j]) >= 0x40 && \ord($content[$j]) <= 0x7E) {
+            ++$j;
+        }
+
+        return $j;
+    }
+
+    /**
+     * Parse a CSI escape sequence to determine the new bg-active state.
+     *
+     * Returns true if the sequence sets a background color (child bg takes
+     * precedence over parent gradient), false if it resets the background.
+     * Returns $current unchanged if the sequence doesn't affect bg.
+     */
+    private function parseBgState(string $seq, bool $current): bool
+    {
+        // Only process CSI sequences (ESC [)
+        if (\strlen($seq) < 3 || "\x1b[" !== substr($seq, 0, 2)) {
+            return $current;
+        }
+
+        // Parameter string is between [ and the final byte
+        if ('' === $params = substr($seq, 2, -1)) {
+            return false; // bare ESC [ m = SGR 0 = full reset
+        }
+
+        $state = $current;
+        $parts = explode(';', $params);
+        $count = \count($parts);
+        $idx = 0;
+
+        while ($idx < $count) {
+            $n = (int) $parts[$idx];
+
+            if (38 === $n || 48 === $n || 58 === $n) {
+                // Extended color: N;5;I (256-color) or N;2;R;G;B (RGB). Only 48
+                // sets a background, but the payload of 38 (foreground) and 58
+                // (underline) has to be skipped just the same: a zero channel
+                // would otherwise be read as SGR 0 and clear the child bg.
+                if (48 === $n) {
+                    $state = true;
+                }
+                if ($idx + 1 < $count) {
+                    if ('5' === $parts[$idx + 1]) {
+                        $idx += 2; // skip N + 5; ++$idx at end advances past I
+                    } elseif ('2' === $parts[$idx + 1]) {
+                        $idx += 4; // skip N + 2 + R + G; ++$idx at end advances past B
+                    }
+                }
+            } elseif (0 === $n || 49 === $n) {
+                // SGR 0 (full reset) or SGR 49 (bg-default): clear child bg
+                $state = false;
+            } elseif (($n >= 40 && $n <= 47) || ($n >= 100 && $n <= 107)) {
+                // Standard (40-47) and bright (100-107) bg colors
+                $state = true;
+            }
+            ++$idx;
+        }
+
+        return $state;
     }
 
     /**

--- a/src/Symfony/Component/Tui/Style/Angle.php
+++ b/src/Symfony/Component/Tui/Style/Angle.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+
+/**
+ * An angle value, expressible in degrees or radians.
+ *
+ * Used to specify the direction of a linear gradient.
+ * Convention: 0° points right, 90° points down (screen coordinates).
+ *
+ * @experimental
+ */
+final class Angle
+{
+    private function __construct(private readonly float $radians)
+    {
+    }
+
+    public static function degrees(float $degrees): self
+    {
+        if (!is_finite($degrees)) {
+            throw new InvalidArgumentException(\sprintf('An angle must be a finite number of degrees, got "%s".', var_export($degrees, true)));
+        }
+
+        return new self($degrees * \M_PI / 180.0);
+    }
+
+    public static function radians(float $radians): self
+    {
+        if (!is_finite($radians)) {
+            throw new InvalidArgumentException(\sprintf('An angle must be a finite number of radians, got "%s".', var_export($radians, true)));
+        }
+
+        return new self($radians);
+    }
+
+    public function toRadians(): float
+    {
+        return $this->radians;
+    }
+
+    public function toDegrees(): float
+    {
+        return $this->radians * 180.0 / \M_PI;
+    }
+}

--- a/src/Symfony/Component/Tui/Style/Border.php
+++ b/src/Symfony/Component/Tui/Style/Border.php
@@ -150,24 +150,69 @@ final class Border
         $outerStyle ??= new Style();
         $borderColor = $this->color ?? $innerStyle->getColor();
 
+        $gradient = $innerStyle->getGradient();
+        $totalRows = $this->top + \count($innerLines) + $this->bottom;
+        $gradientCodes = $gradient?->resolve($innerWidth, $totalRows);
+
         $lines = [];
 
         if ($this->top > 0) {
             for ($row = 0; $row < $this->top; ++$row) {
-                $lines[] = $this->buildBorderRow($pattern, $chars[0], $strategies[0], $innerWidth, $this->left, $this->right, $outerStyle, $innerStyle, $borderColor);
+                if (null !== $gradientCodes) {
+                    $lines[] = $pattern->buildGradientBorderRow($chars[0], $strategies[0], $innerWidth, $this->left, $this->right, $outerStyle, $borderColor, $gradientCodes[$row]);
+                } else {
+                    $lines[] = $this->buildBorderRow($pattern, $chars[0], $strategies[0], $innerWidth, $this->left, $this->right, $outerStyle, $innerStyle, $borderColor);
+                }
             }
         }
 
         $leftSegment = $this->left > 0 ? $pattern->applyBorderSegment(str_repeat('' !== $chars[1][0] ? $chars[1][0] : ' ', $this->left), $strategies[1][0], $outerStyle, $innerStyle, $borderColor) : '';
         $rightSegment = $this->right > 0 ? $pattern->applyBorderSegment(str_repeat('' !== $chars[1][2] ? $chars[1][2] : ' ', $this->right), $strategies[1][2], $outerStyle, $innerStyle, $borderColor) : '';
 
-        foreach ($innerLines as $line) {
-            $lines[] = $leftSegment.$line.$rightSegment;
+        $leftBorderChar = '' !== $chars[1][0] ? $chars[1][0] : ' ';
+        $rightBorderChar = '' !== $chars[1][2] ? $chars[1][2] : ' ';
+
+        if (null !== $gradientCodes) {
+            foreach ($innerLines as $idx => $line) {
+                $contentRow = $this->top + $idx;
+                $rowCodes = $gradientCodes[$contentRow];
+                $lastCol = \count($rowCodes) - 1;
+
+                $leftBgCode = $rowCodes[0] ?? '';
+                $rightBgCode = $rowCodes[$lastCol] ?? '';
+
+                $leftSeg = $this->left > 0
+                    ? $pattern->buildGradientSideSegment(
+                        str_repeat($leftBorderChar, $this->left),
+                        $strategies[1][0], $outerStyle, $borderColor,
+                        $leftBgCode,
+                    )
+                    : '';
+
+                $rightSeg = $this->right > 0
+                    ? $pattern->buildGradientSideSegment(
+                        str_repeat($rightBorderChar, $this->right),
+                        $strategies[1][2], $outerStyle, $borderColor,
+                        $rightBgCode,
+                    )."\x1b[49m"
+                    : '';
+
+                $lines[] = $leftSeg.$line.$rightSeg;
+            }
+        } else {
+            foreach ($innerLines as $line) {
+                $lines[] = $leftSegment.$line.$rightSegment;
+            }
         }
 
         if ($this->bottom > 0) {
-            for ($row = 0; $row < $this->bottom; ++$row) {
-                $lines[] = $this->buildBorderRow($pattern, $chars[2], $strategies[2], $innerWidth, $this->left, $this->right, $outerStyle, $innerStyle, $borderColor);
+            for ($r = 0; $r < $this->bottom; ++$r) {
+                if (null !== $gradientCodes) {
+                    $bottomRowIndex = $this->top + \count($innerLines) + $r;
+                    $lines[] = $pattern->buildGradientBorderRow($chars[2], $strategies[2], $innerWidth, $this->left, $this->right, $outerStyle, $borderColor, $gradientCodes[$bottomRowIndex]);
+                } else {
+                    $lines[] = $this->buildBorderRow($pattern, $chars[2], $strategies[2], $innerWidth, $this->left, $this->right, $outerStyle, $innerStyle, $borderColor);
+                }
             }
         }
 

--- a/src/Symfony/Component/Tui/Style/BorderPattern.php
+++ b/src/Symfony/Component/Tui/Style/BorderPattern.php
@@ -416,6 +416,96 @@ final class BorderPattern
         );
     }
 
+    /**
+     * Paint a left or right border segment over one cell of a gradient.
+     *
+     * @internal
+     */
+    public function buildGradientSideSegment(string $segment, int $strategy, Style $outerStyle, ?Color $borderColor, string $bgCode): string
+    {
+        return $bgCode.$this->applyFgOnly($segment, $strategy, $outerStyle, $borderColor);
+    }
+
+    /**
+     * Paint a full top or bottom border row over one row of a gradient.
+     *
+     * The corners echo the endpoints of the row: the left one takes the first code,
+     * the right one the last.
+     *
+     * @param array<int, string> $chars         The three characters of the row: left corner, fill, right corner
+     * @param array<int, int>    $strategies    Their color strategies (see the class docblock)
+     * @param array<int, string> $gradientCodes ANSI background codes of the row, indexed by column
+     *
+     * @internal
+     */
+    public function buildGradientBorderRow(array $chars, array $strategies, int $innerWidth, int $leftWidth, int $rightWidth, Style $outerStyle, ?Color $borderColor, array $gradientCodes): string
+    {
+        $result = '';
+        // Last background code written to the row. The colors of a border row often
+        // repeat from one cell to the next, and re-stating one the terminal already
+        // holds costs up to 19 bytes per cell.
+        $lastCode = null;
+
+        if ($leftWidth > 0) {
+            $cornerChar = '' !== $chars[0] ? $chars[0] : ' ';
+            $result .= $lastCode = $gradientCodes[0] ?? '';
+            for ($i = 0; $i < $leftWidth; ++$i) {
+                $result .= $this->applyFgOnly($cornerChar, $strategies[0], $outerStyle, $borderColor);
+            }
+        }
+
+        if ($innerWidth > 0) {
+            // The foreground of the fill is constant across the row, so it is stated
+            // once around the run instead of before and after every character.
+            $fillChar = '' !== $chars[1] ? $chars[1] : ' ';
+            $reversed = 2 === $strategies[1] || 3 === $strategies[1];
+
+            $result .= $this->foregroundCode($borderColor);
+            if ($reversed) {
+                $result .= "\e[7m";
+            }
+
+            for ($i = 0; $i < $innerWidth; ++$i) {
+                $code = $gradientCodes[$i] ?? '';
+                if ($code !== $lastCode) {
+                    $result .= $lastCode = $code;
+                }
+                $result .= $fillChar;
+            }
+
+            if ($reversed) {
+                $result .= "\e[27m";
+            }
+            $result .= $this->foregroundCode($outerStyle->getColor());
+        }
+
+        if ($rightWidth > 0) {
+            $cornerChar = '' !== $chars[2] ? $chars[2] : ' ';
+            $code = $gradientCodes[\count($gradientCodes) - 1] ?? '';
+            if ($code !== $lastCode) {
+                $result .= $code;
+            }
+            for ($i = 0; $i < $rightWidth; ++$i) {
+                $result .= $this->applyFgOnly($cornerChar, $strategies[2], $outerStyle, $borderColor);
+            }
+        }
+
+        $result .= "\x1b[49m";
+
+        return $result;
+    }
+
+    private function applyFgOnly(string $char, int $strategy, Style $outerStyle, ?Color $borderColor): string
+    {
+        $outerForeground = $outerStyle->getColor();
+
+        // Strategies 2 and 3 use reverse video: apply fg then reverse video, then reset reverse
+        return match ($strategy) {
+            2, 3 => $this->foregroundCode($borderColor)."\e[7m".$char."\e[27m".$this->foregroundCode($outerForeground),
+            default => $this->foregroundCode($borderColor).$char.$this->foregroundCode($outerForeground),
+        };
+    }
+
     private function applyColors(string $segment, ?Color $foreground, ?Color $background, ?Color $outerForeground, ?Color $outerBackground): string
     {
         return $this->foregroundCode($foreground)

--- a/src/Symfony/Component/Tui/Style/ColorStop.php
+++ b/src/Symfony/Component/Tui/Style/ColorStop.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+
+/**
+ * A color stop: a color with an explicit position (0–100) along a gradient.
+ *
+ * When passed to a gradient, stops with no explicit position are automatically
+ * distributed between their neighbours (CSS-compatible algorithm):
+ *   - first stop without position → 0
+ *   - last stop without position → 100
+ *   - intermediate stops without position → evenly interpolated between neighbours
+ *
+ * Stops are never reordered: a position lower than the one before it is clamped up
+ * to it, which makes the two colors meet at a hard stop, as CSS does.
+ *
+ * @experimental
+ */
+final class ColorStop
+{
+    public readonly Color $color;
+
+    private function __construct(Color $color, public readonly int $position)
+    {
+        $this->color = $color;
+    }
+
+    public static function at(Color|string|int $color, int $position): self
+    {
+        if ($position < 0 || $position > 100) {
+            throw new InvalidArgumentException(\sprintf('Color stop position must be between 0 and 100, got %d.', $position));
+        }
+
+        return new self(Color::from($color), $position);
+    }
+
+    /**
+     * Normalizes a mixed array of plain colors and ColorStops into an array of
+     * [color => Color, offset => float] entries where offset ∈ [0.0, 1.0].
+     *
+     * Plain colors (Color|string|int) without an explicit position receive one
+     * automatically using the CSS interpolation algorithm.
+     *
+     * @param array<Color|string|int|ColorStop> $input
+     *
+     * @return array<array{color: Color, offset: float}>
+     */
+    public static function normalize(array $input): array
+    {
+        // Convert to [color, pos: float|null] pairs preserving order
+        /** @var array<array{color: Color, pos: float|null}> $pairs */
+        $pairs = [];
+        foreach ($input as $item) {
+            if ($item instanceof self) {
+                $pairs[] = ['color' => $item->color, 'pos' => (float) $item->position];
+            } else {
+                $pairs[] = ['color' => Color::from($item), 'pos' => null];
+            }
+        }
+
+        $n = \count($pairs);
+
+        if ($n < 2) {
+            throw new InvalidArgumentException('A gradient requires at least 2 colors.');
+        }
+
+        // First and last plain stops default to 0 and 100
+        if (null === $pairs[0]['pos']) {
+            $pairs[0]['pos'] = 0.0;
+        }
+        if (null === $pairs[$n - 1]['pos']) {
+            $pairs[$n - 1]['pos'] = 100.0;
+        }
+
+        // Fill each run of un-positioned stops by linear interpolation between neighbours
+        $i = 0;
+        while ($i < $n) {
+            if (null !== $pairs[$i]['pos']) {
+                ++$i;
+                continue;
+            }
+            $prev = $i - 1;
+            $j = $i;
+            while ($j < $n && null === $pairs[$j]['pos']) {
+                ++$j;
+            }
+            $intervals = $j - $prev;
+            for ($k = $i; $k < $j; ++$k) {
+                $pairs[$k]['pos'] = $pairs[$prev]['pos']
+                    + ($pairs[$j]['pos'] - $pairs[$prev]['pos']) * ($k - $prev) / $intervals;
+            }
+            $i = $j;
+        }
+
+        // Clamp each position up to the highest one seen so far. A stop that goes
+        // backwards becomes a hard stop instead of being moved earlier in the
+        // gradient, which is what CSS does.
+        $stops = [];
+        $highest = 0.0;
+        foreach ($pairs as $pair) {
+            $highest = max($highest, $pair['pos']);
+            $stops[] = ['color' => $pair['color'], 'offset' => $highest / 100.0];
+        }
+
+        return $stops;
+    }
+}

--- a/src/Symfony/Component/Tui/Style/GradientDirection.php
+++ b/src/Symfony/Component/Tui/Style/GradientDirection.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * @experimental
+ */
+enum GradientDirection
+{
+    case LeftToRight;
+    case RightToLeft;
+    case TopToBottom;
+    case BottomToTop;
+
+    public function toAngle(): Angle
+    {
+        return match ($this) {
+            self::LeftToRight => Angle::degrees(0),
+            self::TopToBottom => Angle::degrees(90),
+            self::RightToLeft => Angle::degrees(180),
+            self::BottomToTop => Angle::degrees(270),
+        };
+    }
+}

--- a/src/Symfony/Component/Tui/Style/GradientInterface.php
+++ b/src/Symfony/Component/Tui/Style/GradientInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * Contract shared by the gradient backgrounds a Style can carry.
+ *
+ * No method accepts this interface: Style::withLinearGradient() and
+ * Style::withRadialGradient() are typed against the concrete classes, so a
+ * third-party implementation has nowhere to go. It stays internal until the
+ * component settles on the shape a public extension point should have.
+ *
+ * @experimental
+ *
+ * @internal
+ */
+interface GradientInterface
+{
+    /**
+     * Resolve the background of every cell of a $width x $height area.
+     *
+     * @return array<int, array<int, string>> ANSI background codes indexed by row, then by column
+     */
+    public function resolve(int $width, int $height): array;
+}

--- a/src/Symfony/Component/Tui/Style/LinearGradient.php
+++ b/src/Symfony/Component/Tui/Style/LinearGradient.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * Linear gradient background: colors distributed along a directional axis.
+ *
+ * Requires a truecolor terminal. Interpolating between two stops yields an
+ * arbitrary color, so every cell is emitted as 48;2;R;G;B, including the ones
+ * sitting exactly on a named or palette stop. The component detects no
+ * capability, so on a 256-color terminal the area shows no background at all,
+ * where Style::withBackground() would still render.
+ *
+ * @experimental
+ */
+final class LinearGradient implements GradientInterface
+{
+    /** @var array<array{color: Color, offset: float}> Normalized stops, in declaration order */
+    private readonly array $stops;
+
+    /**
+     * Codes of the last resolved size only. An app renders one size at a time, and
+     * keeping every size ever asked for made these otherwise immutable value objects
+     * grow without bound: 300 widths at height 24 cost around 91 MB.
+     *
+     * @var array<int, array<int, string>>|null
+     */
+    private ?array $cache = null;
+
+    private string $cacheKey = '';
+
+    /**
+     * @param array<array{color: Color, offset: float}> $stops
+     */
+    private function __construct(array $stops, private readonly Angle $angle)
+    {
+        $this->stops = $stops;
+    }
+
+    /**
+     * Create a LinearGradient from colors, or derive one from an existing gradient.
+     *
+     * @param self|array<Color|string|int|ColorStop> $colors    Gradient specification:
+     *                                                          - LinearGradient instance: returned as-is, or re-angled when $direction is given
+     *                                                          - array: at least 2 colors, color stops, or a mix of both
+     * @param GradientDirection|Angle|null           $direction Gradient axis. Null keeps the direction of an existing
+     *                                                          gradient, and defaults to left-to-right for an array.
+     */
+    public static function from(self|array $colors, GradientDirection|Angle|null $direction = null): self
+    {
+        if ($colors instanceof self) {
+            if (null === $direction) {
+                return $colors;
+            }
+
+            return new self($colors->stops, self::toAngle($direction));
+        }
+
+        // ColorStop::normalize() rejects a list of fewer than 2 colors
+        return new self(ColorStop::normalize($colors), self::toAngle($direction ?? GradientDirection::LeftToRight));
+    }
+
+    private static function toAngle(GradientDirection|Angle $direction): Angle
+    {
+        return $direction instanceof Angle ? $direction : $direction->toAngle();
+    }
+
+    public static function leftToRight(Color|string|int|ColorStop ...$colors): self
+    {
+        return self::from($colors, Angle::degrees(0));
+    }
+
+    public static function rightToLeft(Color|string|int|ColorStop ...$colors): self
+    {
+        return self::from($colors, Angle::degrees(180));
+    }
+
+    public static function topToBottom(Color|string|int|ColorStop ...$colors): self
+    {
+        return self::from($colors, Angle::degrees(90));
+    }
+
+    public static function bottomToTop(Color|string|int|ColorStop ...$colors): self
+    {
+        return self::from($colors, Angle::degrees(270));
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function resolve(int $width, int $height): array
+    {
+        $key = $width.':'.$height;
+        if ($key === $this->cacheKey && null !== $this->cache) {
+            return $this->cache;
+        }
+
+        $this->cacheKey = $key;
+
+        return $this->cache = $this->compute($width, $height);
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function compute(int $width, int $height): array
+    {
+        $angleRad = $this->angle->toRadians();
+        $dx = cos($angleRad);
+        $dy = sin($angleRad);
+
+        $xHalf = $width > 1 ? 0.5 : 0.0;
+        $yHalf = $height > 1 ? 0.5 : 0.0;
+
+        $pxMin = $dx >= 0 ? -$xHalf * $dx : $xHalf * $dx;
+        $pxMax = $dx >= 0 ? $xHalf * $dx : -$xHalf * $dx;
+        $pyMin = $dy >= 0 ? -$yHalf * $dy : $yHalf * $dy;
+        $pyMax = $dy >= 0 ? $yHalf * $dy : -$yHalf * $dy;
+
+        $minProj = $pxMin + $pyMin;
+        $range = ($pxMax + $pyMax) - $minProj;
+
+        $codes = [];
+        for ($row = 0; $row < $height; ++$row) {
+            $yNorm = $height > 1 ? $row / ($height - 1) - 0.5 : 0.0;
+            $pyContrib = $yNorm * $dy;
+
+            $rowCodes = [];
+            for ($col = 0; $col < $width; ++$col) {
+                $xNorm = $width > 1 ? $col / ($width - 1) - 0.5 : 0.0;
+                $proj = $xNorm * $dx + $pyContrib;
+                $offset = $range > 1e-10 ? ($proj - $minProj) / $range : 0.0;
+                $offset = max(0.0, min(1.0, $offset));
+
+                $rowCodes[$col] = $this->interpolate($offset);
+            }
+            $codes[$row] = $rowCodes;
+        }
+
+        return $codes;
+    }
+
+    private function interpolate(float $offset): string
+    {
+        $stops = $this->stops;
+        $n = \count($stops);
+
+        if ($offset <= $stops[0]['offset']) {
+            return self::backgroundCode($stops[0]['color'], $stops[0]['color'], 0.0);
+        }
+        if ($offset >= $stops[$n - 1]['offset']) {
+            return self::backgroundCode($stops[$n - 1]['color'], $stops[$n - 1]['color'], 0.0);
+        }
+
+        for ($i = 0; $i < $n - 1; ++$i) {
+            if ($offset >= $stops[$i]['offset'] && $offset <= $stops[$i + 1]['offset']) {
+                $segmentRange = $stops[$i + 1]['offset'] - $stops[$i]['offset'];
+                $localOffset = $segmentRange > 1e-10 ? ($offset - $stops[$i]['offset']) / $segmentRange : 0.0;
+
+                return self::backgroundCode($stops[$i]['color'], $stops[$i + 1]['color'], $localOffset);
+            }
+        }
+
+        return self::backgroundCode($stops[$n - 1]['color'], $stops[$n - 1]['color'], 0.0);
+    }
+
+    /**
+     * Mix two stop colors channel by channel and return the resulting bg code.
+     *
+     * Color::mix() rounds the ratio to an integer percentage, which caps a
+     * segment at 101 distinct colors: a two-stop gradient bands from about 100
+     * columns on. Keeping the ratio in float removes that ceiling.
+     *
+     * Both endpoints go through the same path, so a named or palette color is
+     * emitted as truecolor there too, instead of showing as a band of its own
+     * SGR code next to the interpolated cells.
+     */
+    private static function backgroundCode(Color $from, Color $to, float $ratio): string
+    {
+        $a = $from->toRgb();
+        $b = $to->toRgb();
+
+        return Color::rgb(
+            (int) round($a['r'] + ($b['r'] - $a['r']) * $ratio),
+            (int) round($a['g'] + ($b['g'] - $a['g']) * $ratio),
+            (int) round($a['b'] + ($b['b'] - $a['b']) * $ratio),
+        )->toBackgroundCode();
+    }
+}

--- a/src/Symfony/Component/Tui/Style/RadialGradient.php
+++ b/src/Symfony/Component/Tui/Style/RadialGradient.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+
+/**
+ * Radial gradient background: colors radiate outward from a center point.
+ *
+ * The center is expressed in normalized coordinates: (0, 0) = top-left,
+ * (0.5, 0.5) = center, (1, 1) = bottom-right. The farthest corner always
+ * reaches offset=1 (last color stop). A center outside [0, 1] is allowed, as
+ * in CSS.
+ *
+ * Requires a truecolor terminal. Interpolating between two stops yields an
+ * arbitrary color, so every cell is emitted as 48;2;R;G;B, including the ones
+ * sitting exactly on a named or palette stop. The component detects no
+ * capability, so on a 256-color terminal the area shows no background at all,
+ * where Style::withBackground() would still render.
+ *
+ * @experimental
+ */
+final class RadialGradient implements GradientInterface
+{
+    /** @var array<array{color: Color, offset: float}> Normalized stops, in declaration order */
+    private readonly array $stops;
+
+    /**
+     * Codes of the last resolved size only. An app renders one size at a time, and
+     * keeping every size ever asked for made these otherwise immutable value objects
+     * grow without bound: 300 widths at height 24 cost around 91 MB.
+     *
+     * @var array<int, array<int, string>>|null
+     */
+    private ?array $cache = null;
+
+    private string $cacheKey = '';
+
+    /**
+     * @param array<array{color: Color, offset: float}> $stops
+     */
+    private function __construct(
+        array $stops,
+        private readonly float $cx,
+        private readonly float $cy,
+        private readonly float $aspectRatio,
+    ) {
+        if (!is_finite($cx) || !is_finite($cy)) {
+            throw new InvalidArgumentException(\sprintf('The center of a radial gradient must be finite, got "%s" and "%s".', var_export($cx, true), var_export($cy, true)));
+        }
+        if (!is_finite($aspectRatio) || $aspectRatio <= 0) {
+            throw new InvalidArgumentException(\sprintf('The aspect ratio of a radial gradient must be a finite number greater than 0, got "%s".', var_export($aspectRatio, true)));
+        }
+
+        $this->stops = $stops;
+    }
+
+    /**
+     * Create a RadialGradient from colors, or derive one from an existing gradient.
+     *
+     * Each geometry argument is optional: null keeps the value of an existing gradient, and falls back to the
+     * default (center, 2.0) for an array. A non-null value always overrides the one of an existing gradient.
+     *
+     * @param self|array<Color|string|int|ColorStop> $colors      Gradient specification:
+     *                                                            - RadialGradient instance: returned as-is, or re-centered when a geometry argument is given
+     *                                                            - array: at least 2 colors, color stops, or a mix of both
+     * @param float|null                             $cx          Horizontal center in normalized coordinates [0, 1] (0=left, 0.5=center, 1=right)
+     * @param float|null                             $cy          Vertical center in normalized coordinates [0, 1] (0=top, 0.5=center, 1=bottom)
+     * @param float|null                             $aspectRatio Cell height / cell width ratio. Standard terminals use ~2.0 (cells are
+     *                                                            roughly twice as tall as wide). Set to 1.0 for square-pixel rendering.
+     */
+    public static function from(self|array $colors, ?float $cx = null, ?float $cy = null, ?float $aspectRatio = null): self
+    {
+        if ($colors instanceof self) {
+            if (null === $cx && null === $cy && null === $aspectRatio) {
+                return $colors;
+            }
+
+            return new self($colors->stops, $cx ?? $colors->cx, $cy ?? $colors->cy, $aspectRatio ?? $colors->aspectRatio);
+        }
+
+        // ColorStop::normalize() rejects a list of fewer than 2 colors
+        return new self(ColorStop::normalize($colors), $cx ?? 0.5, $cy ?? 0.5, $aspectRatio ?? 2.0);
+    }
+
+    public static function centered(Color|string|int|ColorStop ...$colors): self
+    {
+        return self::from($colors);
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function resolve(int $width, int $height): array
+    {
+        $key = $width.':'.$height;
+        if ($key === $this->cacheKey && null !== $this->cache) {
+            return $this->cache;
+        }
+
+        $this->cacheKey = $key;
+
+        return $this->cache = $this->compute($width, $height);
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function compute(int $width, int $height): array
+    {
+        // Convert normalized center to pixel coordinates
+        $cxPx = $this->cx * ($width > 1 ? $width - 1 : 0);
+        $cyPx = $this->cy * ($height > 1 ? $height - 1 : 0);
+
+        // Aspect-ratio-corrected distance: dy is scaled so 1 row == $aspectRatio columns
+        // in visual distance, matching the physical pixel dimensions of terminal cells.
+        $ar = $this->aspectRatio;
+
+        $maxDist = max(
+            sqrt($cxPx ** 2 + ($cyPx * $ar) ** 2),
+            sqrt(($width - 1 - $cxPx) ** 2 + ($cyPx * $ar) ** 2),
+            sqrt($cxPx ** 2 + (($height - 1 - $cyPx) * $ar) ** 2),
+            sqrt(($width - 1 - $cxPx) ** 2 + (($height - 1 - $cyPx) * $ar) ** 2),
+        );
+
+        $codes = [];
+        for ($row = 0; $row < $height; ++$row) {
+            $dy = ($row - $cyPx) * $ar;
+            $rowCodes = [];
+            for ($col = 0; $col < $width; ++$col) {
+                $dx = $col - $cxPx;
+                $dist = sqrt($dx ** 2 + $dy ** 2);
+                $offset = $maxDist > 1e-10 ? min(1.0, $dist / $maxDist) : 0.0;
+                $rowCodes[$col] = $this->interpolate($offset);
+            }
+            $codes[$row] = $rowCodes;
+        }
+
+        return $codes;
+    }
+
+    private function interpolate(float $offset): string
+    {
+        $stops = $this->stops;
+        $n = \count($stops);
+
+        if ($offset <= $stops[0]['offset']) {
+            return self::backgroundCode($stops[0]['color'], $stops[0]['color'], 0.0);
+        }
+        if ($offset >= $stops[$n - 1]['offset']) {
+            return self::backgroundCode($stops[$n - 1]['color'], $stops[$n - 1]['color'], 0.0);
+        }
+
+        for ($i = 0; $i < $n - 1; ++$i) {
+            if ($offset >= $stops[$i]['offset'] && $offset <= $stops[$i + 1]['offset']) {
+                $segmentRange = $stops[$i + 1]['offset'] - $stops[$i]['offset'];
+                $localOffset = $segmentRange > 1e-10 ? ($offset - $stops[$i]['offset']) / $segmentRange : 0.0;
+
+                return self::backgroundCode($stops[$i]['color'], $stops[$i + 1]['color'], $localOffset);
+            }
+        }
+
+        return self::backgroundCode($stops[$n - 1]['color'], $stops[$n - 1]['color'], 0.0);
+    }
+
+    /**
+     * Mix two stop colors channel by channel and return the resulting bg code.
+     *
+     * Color::mix() rounds the ratio to an integer percentage, which caps a
+     * segment at 101 distinct colors: a two-stop gradient bands from about 100
+     * columns on. Keeping the ratio in float removes that ceiling.
+     *
+     * Both endpoints go through the same path, so a named or palette color is
+     * emitted as truecolor there too, instead of showing as a band of its own
+     * SGR code next to the interpolated cells.
+     */
+    private static function backgroundCode(Color $from, Color $to, float $ratio): string
+    {
+        $a = $from->toRgb();
+        $b = $to->toRgb();
+
+        return Color::rgb(
+            (int) round($a['r'] + ($b['r'] - $a['r']) * $ratio),
+            (int) round($a['g'] + ($b['g'] - $a['g']) * $ratio),
+            (int) round($a['b'] + ($b['b'] - $a['b']) * $ratio),
+        )->toBackgroundCode();
+    }
+}

--- a/src/Symfony/Component/Tui/Style/Style.php
+++ b/src/Symfony/Component/Tui/Style/Style.php
@@ -64,6 +64,7 @@ final class Style
     private ?string $ansiPrefix = null;
     private ?string $ansiSuffix = null;
     private ?string $bgCode = null;
+    private ?GradientInterface $gradient = null;
 
     /**
      * @param Padding|null          $padding       Padding specification (null = not set, see Padding::from())
@@ -122,153 +123,101 @@ final class Style
         $this->bgCode = null;
     }
 
-    /**
-     * Get the background color.
-     */
     public function getBackground(): ?Color
     {
         return $this->backgroundColor;
     }
 
-    /**
-     * Get the foreground color.
-     */
+    public function getGradient(): ?GradientInterface
+    {
+        return $this->gradient;
+    }
+
     public function getColor(): ?Color
     {
         return $this->foregroundColor;
     }
 
-    /**
-     * Get the padding.
-     */
     public function getPadding(): ?Padding
     {
         return $this->padding;
     }
 
-    /**
-     * Get the border.
-     */
     public function getBorder(): ?Border
     {
         return $this->border;
     }
 
-    /**
-     * Get the bold flag.
-     */
     public function getBold(): ?bool
     {
         return $this->bold;
     }
 
-    /**
-     * Get the dim flag.
-     */
     public function getDim(): ?bool
     {
         return $this->dim;
     }
 
-    /**
-     * Get the italic flag.
-     */
     public function getItalic(): ?bool
     {
         return $this->italic;
     }
 
-    /**
-     * Get the strikethrough flag.
-     */
     public function getStrikethrough(): ?bool
     {
         return $this->strikethrough;
     }
 
-    /**
-     * Get the underline flag.
-     */
     public function getUnderline(): ?bool
     {
         return $this->underline;
     }
 
-    /**
-     * Get the reverse flag.
-     */
     public function getReverse(): ?bool
     {
         return $this->reverse;
     }
 
-    /**
-     * Get the layout direction.
-     */
     public function getDirection(): ?Direction
     {
         return $this->direction;
     }
 
-    /**
-     * Get the gap between children.
-     */
     public function getGap(): ?int
     {
         return $this->gap;
     }
 
-    /**
-     * Get the hidden flag.
-     */
     public function getHidden(): ?bool
     {
         return $this->hidden;
     }
 
-    /**
-     * Get the cursor shape.
-     */
     public function getCursorShape(): ?CursorShape
     {
         return $this->cursorShape;
     }
 
-    /**
-     * Get the text alignment.
-     */
     public function getTextAlign(): ?TextAlign
     {
         return $this->textAlign;
     }
 
-    /**
-     * Get the FIGlet font name or path.
-     */
     public function getFont(): ?string
     {
         return $this->font;
     }
 
-    /**
-     * Get the maximum width in columns.
-     */
     public function getMaxColumns(): ?int
     {
         return $this->maxColumns;
     }
 
-    /**
-     * Get the horizontal alignment of child widgets.
-     */
     public function getAlign(): ?Align
     {
         return $this->align;
     }
 
-    /**
-     * Get the vertical alignment of child widgets.
-     */
     public function getVerticalAlign(): ?VerticalAlign
     {
         return $this->verticalAlign;
@@ -300,11 +249,12 @@ final class Style
             && null === $this->italic
             && null === $this->strikethrough
             && null === $this->underline
-            && null === $this->reverse;
+            && null === $this->reverse
+            && null === $this->gradient;
     }
 
     /**
-     * Create a style with padding only.
+     * Creates a style with padding only.
      *
      * @param Padding|array<int> $padding Padding specification (see Padding::from())
      */
@@ -314,7 +264,7 @@ final class Style
     }
 
     /**
-     * Create a style with border only.
+     * Creates a style with border only.
      *
      * @param Border|array<int>         $border  Border specification (see Border::from())
      * @param BorderPattern|string|null $pattern Border pattern (see BorderPattern::fromName())
@@ -355,11 +305,11 @@ final class Style
         $align = null;
         $verticalAlign = null;
         $flex = null;
+        $gradient = null;
 
         foreach ($styles as $style) {
             $padding = $style->padding ?? $padding;
             $border = $style->border ?? $border;
-            $background = $style->backgroundColor ?? $background;
             $color = $style->foregroundColor ?? $color;
             $bold = $style->bold ?? $bold;
             $dim = $style->dim ?? $dim;
@@ -377,9 +327,19 @@ final class Style
             $align = $style->align ?? $align;
             $verticalAlign = $style->verticalAlign ?? $verticalAlign;
             $flex = $style->flex ?? $flex;
+            // Background and gradient share a single slot: they are mutually
+            // exclusive on a Style (see withBackground()/withLinearGradient()),
+            // so the last style setting either one wins over the other.
+            if (null !== $style->gradient) {
+                $gradient = $style->gradient;
+                $background = null;
+            } elseif (null !== $style->backgroundColor) {
+                $background = $style->backgroundColor;
+                $gradient = null;
+            }
         }
 
-        return new self(
+        $result = new self(
             $padding,
             $border,
             $background,
@@ -401,10 +361,13 @@ final class Style
             $verticalAlign,
             $flex,
         );
+        $result->gradient = $gradient;
+
+        return $result;
     }
 
     /**
-     * Create new style with different padding.
+     * Creates new style with different padding.
      *
      * @param Padding|array<int> $padding Padding specification (see Padding::from())
      */
@@ -417,7 +380,7 @@ final class Style
     }
 
     /**
-     * Create new style with different border.
+     * Creates new style with different border.
      *
      * @param Border|array<int>         $border  Border specification (see Border::from())
      * @param BorderPattern|string|null $pattern Border pattern (see BorderPattern::fromName())
@@ -432,7 +395,7 @@ final class Style
     }
 
     /**
-     * Create new style with a different border pattern.
+     * Creates new style with a different border pattern.
      */
     public function withBorderPattern(BorderPattern|string|null $pattern): self
     {
@@ -442,7 +405,7 @@ final class Style
     }
 
     /**
-     * Create new style with a different border color.
+     * Creates new style with a different border color.
      */
     public function withBorderColor(Color|string|int|null $color): self
     {
@@ -452,7 +415,7 @@ final class Style
     }
 
     /**
-     * Create new style with background color.
+     * Creates new style with background color.
      *
      * @param Color|string|int|null $background Color specification:
      *                                          - Color instance
@@ -464,13 +427,53 @@ final class Style
     public function withBackground(Color|string|int|null $background): self
     {
         $clone = clone $this;
+        $clone->gradient = null;
         $clone->backgroundColor = null !== $background ? Color::from($background) : null;
 
         return $clone;
     }
 
     /**
-     * Create new style with foreground color.
+     * Creates new style with a linear gradient.
+     *
+     * Clears any background color: the two are mutually exclusive. Requires a
+     * truecolor terminal, see LinearGradient.
+     *
+     * @param LinearGradient|array<Color|string|int> $gradient  Colors array or pre-built gradient object (see LinearGradient::from())
+     * @param GradientDirection|Angle|null           $direction Gradient axis. Null keeps the direction of a pre-built
+     *                                                          gradient, and defaults to left-to-right for an array.
+     */
+    public function withLinearGradient(LinearGradient|array $gradient, GradientDirection|Angle|null $direction = null): self
+    {
+        $clone = clone $this;
+        $clone->gradient = LinearGradient::from($gradient, $direction);
+        $clone->backgroundColor = null;
+
+        return $clone;
+    }
+
+    /**
+     * Creates new style with a radial gradient.
+     *
+     * Clears any background color: the two are mutually exclusive. Requires a
+     * truecolor terminal, see RadialGradient.
+     *
+     * @param RadialGradient|array<Color|string|int> $gradient    Colors array or pre-built gradient object (see RadialGradient::from())
+     * @param float|null                             $cx          Horizontal center in normalized coordinates [0, 1] (0=left, 0.5=center, 1=right)
+     * @param float|null                             $cy          Vertical center in normalized coordinates [0, 1] (0=top, 0.5=center, 1=bottom)
+     * @param float|null                             $aspectRatio Cell height / cell width ratio. Standard terminals use ~2.0. Set to 1.0 for square-pixel rendering.
+     */
+    public function withRadialGradient(RadialGradient|array $gradient, ?float $cx = null, ?float $cy = null, ?float $aspectRatio = null): self
+    {
+        $clone = clone $this;
+        $clone->gradient = RadialGradient::from($gradient, $cx, $cy, $aspectRatio);
+        $clone->backgroundColor = null;
+
+        return $clone;
+    }
+
+    /**
+     * Creates new style with foreground color.
      *
      * @param Color|string|int|null $color Color specification:
      *                                     - Color instance
@@ -488,7 +491,7 @@ final class Style
     }
 
     /**
-     * Create new style with bold enabled.
+     * Creates new style with bold enabled.
      */
     public function withBold(bool $bold = true): self
     {
@@ -499,7 +502,7 @@ final class Style
     }
 
     /**
-     * Create new style with dim/faint enabled.
+     * Creates new style with dim/faint enabled.
      */
     public function withDim(bool $dim = true): self
     {
@@ -510,7 +513,7 @@ final class Style
     }
 
     /**
-     * Create new style with italic enabled.
+     * Creates new style with italic enabled.
      */
     public function withItalic(bool $italic = true): self
     {
@@ -521,7 +524,7 @@ final class Style
     }
 
     /**
-     * Create new style with strikethrough enabled.
+     * Creates new style with strikethrough enabled.
      */
     public function withStrikethrough(bool $strikethrough = true): self
     {
@@ -532,7 +535,7 @@ final class Style
     }
 
     /**
-     * Create new style with underline enabled.
+     * Creates new style with underline enabled.
      */
     public function withUnderline(bool $underline = true): self
     {
@@ -543,7 +546,7 @@ final class Style
     }
 
     /**
-     * Create new style with reverse video enabled.
+     * Creates new style with reverse video enabled.
      */
     public function withReverse(bool $reverse = true): self
     {
@@ -554,7 +557,7 @@ final class Style
     }
 
     /**
-     * Create new style with layout direction.
+     * Creates new style with layout direction.
      */
     public function withDirection(Direction $direction): self
     {
@@ -565,7 +568,7 @@ final class Style
     }
 
     /**
-     * Create new style with gap between children.
+     * Creates new style with gap between children.
      */
     public function withGap(int $gap): self
     {
@@ -576,7 +579,7 @@ final class Style
     }
 
     /**
-     * Create new style with hidden flag.
+     * Creates new style with hidden flag.
      *
      * Hidden widgets are skipped during rendering; they produce no output
      * and take no space, similar to CSS `display: none`.
@@ -590,7 +593,7 @@ final class Style
     }
 
     /**
-     * Create new style with a cursor shape.
+     * Creates new style with a cursor shape.
      */
     public function withCursorShape(CursorShape $cursorShape): self
     {
@@ -601,7 +604,7 @@ final class Style
     }
 
     /**
-     * Create new style with text alignment.
+     * Creates new style with text alignment.
      */
     public function withTextAlign(TextAlign $textAlign): self
     {
@@ -612,7 +615,7 @@ final class Style
     }
 
     /**
-     * Create new style with a FIGlet font.
+     * Creates new style with a FIGlet font.
      *
      * @param string|null $font Bundled font name (big, small, slant, standard, mini) or path to a .flf file, or null to clear
      */
@@ -625,7 +628,7 @@ final class Style
     }
 
     /**
-     * Create new style with a maximum column width.
+     * Creates new style with a maximum column width.
      *
      * @param int|null $maxColumns Maximum width in columns, or null to clear
      */
@@ -638,7 +641,7 @@ final class Style
     }
 
     /**
-     * Create new style with horizontal alignment for child widgets.
+     * Creates new style with horizontal alignment for child widgets.
      */
     public function withAlign(Align $align): self
     {
@@ -649,7 +652,7 @@ final class Style
     }
 
     /**
-     * Create new style with vertical alignment for child widgets.
+     * Creates new style with vertical alignment for child widgets.
      */
     public function withVerticalAlign(VerticalAlign $verticalAlign): self
     {
@@ -660,7 +663,7 @@ final class Style
     }
 
     /**
-     * Create new style with a flex grow weight for horizontal layouts.
+     * Creates new style with a flex grow weight for horizontal layouts.
      *
      * @param int|null $flex 0 = intrinsic width, 1+ = proportional weight, null = clear
      */
@@ -673,7 +676,7 @@ final class Style
     }
 
     /**
-     * Create a copy with only visual formatting and content properties.
+     * Creates a copy with only visual formatting and content properties.
      *
      * Strips layout properties that the Renderer owns: padding, border,
      * gap, direction, hidden, cursorShape, textAlign, maxColumns, align,

--- a/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Tui\Render\ChromeApplier;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Render\WidgetRendererInterface;
 use Symfony\Component\Tui\Style\Border;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\GradientDirection;
 use Symfony\Component\Tui\Style\Padding;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
@@ -361,8 +363,305 @@ final class ChromeApplierTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // apply: gradient
+    // ---------------------------------------------------------------
+
+    public function testGradientAppliedColumnByColumnOnPaddingLine()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withPadding(new Padding(1, 0, 0, 0));
+
+        $lines = $applier->apply(new ArrayLineBuffer([]), 4, $style, $widget)->toArray();
+
+        // First line is top-padding: 4 spaces each with different gradient bg code
+        $this->assertCount(1, $lines);
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+
+        $this->assertStringContainsString($black, $lines[0]);
+        $this->assertStringContainsString($white, $lines[0]);
+    }
+
+    public function testGradientContentLineHasPerColumnCodes()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $applier->apply(new ArrayLineBuffer(['ab']), 2, $style, $widget)->toArray();
+
+        $this->assertCount(1, $lines);
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+
+        $this->assertStringContainsString($black, $lines[0]);
+        $this->assertStringContainsString($white, $lines[0]);
+    }
+
+    public function testGradientVerticalDifferentRowsHaveDifferentCodes()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        // Both rows hold the same character, so any difference between them can only
+        // come from the gradient.
+        $lines = $applier->apply(new ArrayLineBuffer(['a', 'a']), 1, $style, $widget)->toArray();
+
+        $this->assertCount(2, $lines);
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), self::backgroundAtColumn($lines[0], 0), 'row 0 is the first stop');
+        $this->assertSame(Color::from('#ffffff')->toBackgroundCode(), self::backgroundAtColumn($lines[1], 0), 'row 1 is the last stop');
+    }
+
+    public function testGradientVerticalContentUsesOffsetWhenBorderPresent()
+    {
+        // Top+bottom borders only (no left/right sides, to isolate content bg from │ segments).
+        // fullHeight = 3: 1(top) + 1(content) + 1(bottom).
+        // TopToBottom gradient [black→white] over fullHeight=3:
+        //   row 0 (top border): offset=0   → black
+        //   row 1 (content):    offset=0.5 → 50% gray  ← 'a' character must use this, not pure black
+        //   row 2 (bot border): offset=1   → white
+        $applier = $this->createApplier();
+        $widget = new TextWidget('a');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom)
+            ->withBorder(Border::xy(0, 1)); // top=1, right=0, bottom=1, left=0
+
+        // lines[0]=top border, lines[1]=content row (no │ side segs), lines[2]=bottom border
+        $lines = $applier->apply(new ArrayLineBuffer(['a']), 1, $style, $widget)->toArray();
+
+        $gray = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+
+        $this->assertStringContainsString($gray, $lines[1], 'content char should use offset=0.5 (row 1 of fullHeight=3), not pure black');
+    }
+
+    public function testGradientContentStartsAtGradientOriginWhenBorderPresent()
+    {
+        // width=5: 1(left border) + 3(inner) + 1(right border)
+        // Gradient spans innerWidth=3 only:
+        //   content[0]: offset=0   → pure black  ← first content char (same as left border)
+        //   content[1]: offset=0.5 → mix 50%
+        //   content[2]: offset=1   → pure white  ← last content char (same as right border)
+        // The 25%-interpolated color (from old totalWidth=5 offset) must NOT appear.
+        $applier = $this->createApplier();
+        $widget = new TextWidget('abc');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withBorder(Border::all(1));
+
+        // lines[0]=top border, lines[1]=content row, lines[2]=bottom border
+        $lines = $applier->apply(new ArrayLineBuffer(['abc']), 5, $style, $widget)->toArray();
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $gray = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $quarter = Color::from('#000000')->mix(Color::from('#ffffff'), 25)->toBackgroundCode();
+
+        // The 5 columns are: left border, 3 content cells, right border. The strip
+        // spans the 3 inner columns, and the borders echo its endpoints.
+        $this->assertSame($black, self::backgroundAtColumn($lines[1], 0), 'left border');
+        $this->assertSame($black, self::backgroundAtColumn($lines[1], 1), 'first content cell is offset=0');
+        $this->assertSame($gray, self::backgroundAtColumn($lines[1], 2), 'middle content cell is offset=0.5');
+        $this->assertSame($white, self::backgroundAtColumn($lines[1], 3), 'last content cell is offset=1');
+        $this->assertSame($white, self::backgroundAtColumn($lines[1], 4), 'right border');
+
+        // Spanning totalWidth instead of innerWidth would put 25% gray on a cell.
+        $this->assertStringNotContainsString($quarter, $lines[1], 'the strip must span innerWidth, not totalWidth');
+    }
+
+    public function testGradientRightBorderHasEndpointColor()
+    {
+        // width=29: 1(left border) + 27(inner) + 1(right border)
+        $applier = $this->createApplier();
+        $widget = new TextWidget(str_repeat('a', 27));
+        // The child paints its own background, so no content cell carries a gradient
+        // code: the endpoint color can then only come from the border itself.
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withBorder(Border::all(1));
+
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[48;2;255;0;0m".str_repeat('a', 27)."\x1b[49m"]), 29, $style, $widget)->toArray();
+
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $black = Color::from('#000000')->toBackgroundCode();
+        $childBg = "\x1b[48;2;255;0;0m";
+
+        $this->assertSame($black, self::backgroundAtColumn($lines[1], 0), 'left border takes the first stop');
+        $this->assertSame($childBg, self::backgroundAtColumn($lines[1], 14), 'content keeps its own background');
+        $this->assertSame($white, self::backgroundAtColumn($lines[1], 28), 'right border takes the last stop');
+    }
+
+    public function testGradientDoesNotOverrideChildBgWithZeroBlueComponent()
+    {
+        // ESC[48;2;255;0;0m sets red background (R=255, G=0, B=0). The blue component
+        // "0" must NOT be misread as SGR 0 (full reset) inside parseBgState, which
+        // would let the parent gradient overwrite the child's red background.
+        $applier = $this->createApplier();
+        $widget = new TextWidget('X');
+        $style = (new Style())
+            ->withLinearGradient(['#0000ff', '#ffffff'], GradientDirection::LeftToRight);
+
+        // Content with red background active: gradient must not be injected before 'X'
+        $redBg = "\x1b[48;2;255;0;0m";
+        $lines = $applier->apply(new ArrayLineBuffer([$redBg.'X']), 2, $style, $widget)->toArray();
+
+        // 'X' must be directly after the red bg code: no parent gradient injected between them
+        $this->assertStringContainsString($redBg.'X', $lines[0],
+            'parseBgState must return true for red bg (48;2;255;0;0), not mistake blue=0 for SGR 0');
+    }
+
+    /**
+     * A foreground (38) or underline (58) color never changes the background state,
+     * but its payload has to be skipped: a zero channel would otherwise be read as
+     * SGR 0 and let the parent gradient paint over the child's background.
+     */
+    #[DataProvider('zeroComponentForegroundSequenceProvider')]
+    public function testGradientDoesNotOverrideChildBgOnForegroundWithZeroComponent(string $foregroundSequence)
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('X');
+        $style = (new Style())
+            ->withLinearGradient(['#0000ff', '#ffffff'], GradientDirection::LeftToRight);
+
+        $redBg = "\x1b[48;2;255;0;0m";
+        $lines = $applier->apply(new ArrayLineBuffer([$redBg.$foregroundSequence.'X']), 2, $style, $widget)->toArray();
+
+        $this->assertStringContainsString($redBg.$foregroundSequence.'X', $lines[0],
+            'the child background must survive a foreground color holding a zero component');
+    }
+
+    public static function zeroComponentForegroundSequenceProvider(): iterable
+    {
+        yield 'rgb foreground, zero red' => ["\x1b[38;2;0;255;255m"];
+        yield 'rgb foreground, zero green' => ["\x1b[38;2;255;0;255m"];
+        yield 'rgb foreground, zero blue' => ["\x1b[38;2;255;255;0m"];
+        yield 'palette foreground, index 0' => ["\x1b[38;5;0m"];
+        yield 'rgb underline, zero red' => ["\x1b[58;2;0;255;0m"];
+        yield 'palette underline, index 0' => ["\x1b[58;5;0m"];
+        // 49 as an RGB channel is the bg-default code; it must not be read as one
+        yield 'rgb foreground, channel 49' => ["\x1b[38;2;49;49;49m"];
+    }
+
+    public function testGradientStillYieldsToBackgroundResetAfterAForegroundColor()
+    {
+        // The payload skipping must not swallow a genuine SGR 49 that follows.
+        $applier = $this->createApplier();
+        $widget = new TextWidget('X');
+        $style = (new Style())
+            ->withLinearGradient(['#0000ff', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[48;2;255;0;0m\x1b[38;2;0;255;0m\x1b[49mX"]), 2, $style, $widget)->toArray();
+
+        $blue = Color::from('#0000ff')->toBackgroundCode();
+        $this->assertStringContainsString($blue.'X', $lines[0],
+            'once the child resets its background, the gradient must paint again');
+    }
+
+    public function testGradientLineKeepsTheTrailingResetsOfTheChild()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('AB');
+        $style = (new Style())
+            ->withLinearGradient(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+
+        // 'AB' fills the two columns exactly, so the resets of the child sit past
+        // the last visible cell and used to be dropped along with the rest.
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[1m\x1b[38;2;0;255;0mAB\x1b[22m\x1b[39m"]), 2, $style, $widget)->toArray();
+
+        $this->assertStringContainsString("\x1b[22m", $lines[0], 'the bold reset of the child must survive');
+        $this->assertStringContainsString("\x1b[39m", $lines[0], 'the foreground reset of the child must survive');
+        $this->assertStringEndsWith("\x1b[22m\x1b[39m\x1b[49m", $lines[0]);
+    }
+
+    public function testGradientLineDoesNotLeakChildStyleOntoTheNextRow()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('ABCD');
+        $style = (new Style())
+            ->withLinearGradient(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+
+        // Both rows fill the four columns exactly; only the first one is styled.
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[38;2;0;255;0m\x1b[1mABCD\x1b[22m\x1b[39m", 'efgh']), 4, $style, $widget)->toArray();
+
+        $this->assertStringEndsWith("\x1b[22m\x1b[39m\x1b[49m", $lines[0],
+            'row 0 must close the bold and the foreground it opened');
+        $this->assertStringNotContainsString("\x1b[1m", $lines[1],
+            'row 1 carries no style of its own and must not re-open one');
+    }
+
+    public function testGradientLineStatesARepeatedBackgroundOnlyOnce()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('aaaa');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        // A vertical gradient gives every cell of a row the same color.
+        $lines = $applier->apply(new ArrayLineBuffer(['aaaa']), 4, $style, $widget)->toArray();
+
+        $this->assertSame(1, substr_count($lines[0], "\x1b[48;2;"), 'a row of one color states it once');
+    }
+
+    public function testGradientLineRestatesTheBackgroundAfterAChildSequence()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('abcd');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        // The child sets then drops its own background in the middle of the row: the
+        // gradient has to be restated afterwards even though its color has not changed.
+        $lines = $applier->apply(new ArrayLineBuffer(["ab\x1b[48;2;255;0;0mc\x1b[49md"]), 4, $style, $widget)->toArray();
+
+        $gradientCode = $style->getGradient()->resolve(4, 1)[0][0];
+        $this->assertSame(2, substr_count($lines[0], $gradientCode),
+            'the gradient is stated once before the child, then once after it');
+        $this->assertStringContainsString("\x1b[48;2;255;0;0mc", $lines[0], "the child's own background survives");
+    }
+
+    // ---------------------------------------------------------------
     // helpers
     // ---------------------------------------------------------------
+
+    /**
+     * Return the background code in effect at a given visible column of a line.
+     *
+     * Asserting on the state of a column rather than on the presence of a code
+     * somewhere in the line keeps the test honest: a color that repeats is not
+     * restated, and the same code may legitimately appear at another column.
+     */
+    private static function backgroundAtColumn(string $line, int $column): string
+    {
+        $background = '';
+        $col = 0;
+
+        foreach (preg_split('/(\x1b\[[0-9;]*[a-zA-Z])/', $line, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY) as $part) {
+            if (str_starts_with($part, "\x1b[")) {
+                if (preg_match('/^\x1b\[(?:4[0-7]|10[0-7]|48;[25];[0-9;]+)m$/', $part)) {
+                    $background = $part;
+                } elseif ("\x1b[49m" === $part || "\x1b[0m" === $part) {
+                    $background = '';
+                }
+
+                continue;
+            }
+
+            foreach (preg_split('//u', $part, -1, \PREG_SPLIT_NO_EMPTY) as $ignored) {
+                if ($col === $column) {
+                    return $background;
+                }
+                ++$col;
+            }
+        }
+
+        return $background;
+    }
 
     private function createApplier(): ChromeApplier
     {

--- a/src/Symfony/Component/Tui/Tests/Style/AngleTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/AngleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Style\Angle;
+
+final class AngleTest extends TestCase
+{
+    public function testDegrees()
+    {
+        $this->assertEqualsWithDelta(0.0, Angle::degrees(0)->toRadians(), 1e-10);
+        $this->assertEqualsWithDelta(\M_PI / 2, Angle::degrees(90)->toRadians(), 1e-10);
+        $this->assertEqualsWithDelta(\M_PI, Angle::degrees(180)->toRadians(), 1e-10);
+        $this->assertEqualsWithDelta(3 * \M_PI / 2, Angle::degrees(270)->toRadians(), 1e-10);
+    }
+
+    public function testRadians()
+    {
+        $this->assertEqualsWithDelta(0.0, Angle::radians(0.0)->toDegrees(), 1e-10);
+        $this->assertEqualsWithDelta(90.0, Angle::radians(\M_PI / 2)->toDegrees(), 1e-10);
+        $this->assertEqualsWithDelta(180.0, Angle::radians(\M_PI)->toDegrees(), 1e-10);
+        $this->assertEqualsWithDelta(45.0, Angle::radians(\M_PI / 4)->toDegrees(), 1e-10);
+    }
+
+    public function testDegreesAndRadiansAreEquivalent()
+    {
+        $this->assertEqualsWithDelta(
+            Angle::degrees(45)->toRadians(),
+            Angle::radians(\M_PI / 4)->toRadians(),
+            1e-10
+        );
+    }
+
+    #[DataProvider('nonFiniteProvider')]
+    public function testDegreesRejectsNonFiniteValues(float $value)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('An angle must be a finite number of degrees');
+
+        Angle::degrees($value);
+    }
+
+    #[DataProvider('nonFiniteProvider')]
+    public function testRadiansRejectsNonFiniteValues(float $value)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('An angle must be a finite number of radians');
+
+        Angle::radians($value);
+    }
+
+    public static function nonFiniteProvider(): iterable
+    {
+        yield 'NAN' => [\NAN];
+        yield 'INF' => [\INF];
+        yield '-INF' => [-\INF];
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/BorderTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/BorderTest.php
@@ -13,10 +13,12 @@ namespace Symfony\Component\Tui\Tests\Style;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Style\Border;
 use Symfony\Component\Tui\Style\BorderPattern;
 use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\GradientDirection;
 use Symfony\Component\Tui\Style\Style;
 
 class BorderTest extends TestCase
@@ -298,5 +300,184 @@ class BorderTest extends TestCase
 
         $this->assertSame(BorderPattern::rounded()->getChars(), $border->pattern->getChars());
         $this->assertSame(Color::from('#ff0000')->toRgb(), $border->color->toRgb());
+    }
+
+    public function testWrapLinesWithGradientAppliesPerColumnCodesToTopRow()
+    {
+        $border = Border::all(1, 'normal');
+        $style = (new Style())->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $border->wrapLines(['abc'], 3, $style);
+
+        // Top border row should contain both the black code (col 0) and white code (col last)
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+
+        // lines[0] is top border row (with corners + 3 fill chars = 5 columns total)
+        $this->assertStringContainsString($black, $lines[0]);
+        $this->assertStringContainsString($white, $lines[0]);
+
+        // lines[2] is bottom border row: should also have gradient
+        $this->assertStringContainsString($black, $lines[2]);
+        $this->assertStringContainsString($white, $lines[2]);
+    }
+
+    public function testWrapLinesWithGradientAppliesGradientToCorners()
+    {
+        $border = Border::all(1, 'normal');
+        $style = (new Style())->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $border->wrapLines(['abc'], 3, $style);
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+
+        // A row is 5 columns: left corner, 3 fill cells, right corner. Assert on the
+        // background actually in effect at each corner rather than on the presence of
+        // a code somewhere in the row, which a repeated color need not restate.
+        foreach ([0, 2] as $row) {
+            $this->assertSame($black, self::backgroundAtColumn($lines[$row], 0), "row $row: left corner takes the first gradient color");
+            $this->assertSame($white, self::backgroundAtColumn($lines[$row], 4), "row $row: right corner takes the last gradient color");
+        }
+    }
+
+    public function testWrapLinesWithGradientStatesARepeatedBorderColorOnlyOnce()
+    {
+        // A vertical gradient gives every cell of a row the same color, so the row
+        // must state it once instead of before each of its 5 cells.
+        $border = Border::all(1, 'normal');
+        $style = (new Style())->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        $lines = $border->wrapLines(['abc'], 3, $style);
+
+        $this->assertSame(1, substr_count($lines[0], "\x1b[48;2;"), 'top border row');
+        $this->assertSame(1, substr_count($lines[2], "\x1b[48;2;"), 'bottom border row');
+    }
+
+    public function testWrapLinesWithGradientKeepsReverseVideoOnPatternsUsingIt()
+    {
+        // tall-medium drives its top fill with strategy 3, which is reverse video.
+        // Hoisting the constant foreground out of the run must not unbalance it.
+        $border = Border::all(1, 'tall-medium');
+        $style = (new Style())->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $border->wrapLines(['abc'], 3, $style);
+
+        $this->assertStringContainsString("\e[7m", $lines[0]);
+        $this->assertSame(
+            substr_count($lines[0], "\e[7m"),
+            substr_count($lines[0], "\e[27m"),
+            'reverse video must be closed as many times as it is opened'
+        );
+        $this->assertSame('▌▆▆▆▌', AnsiUtils::stripAnsiCodes($lines[0]));
+    }
+
+    /**
+     * Return the background code in effect at a given visible column of a line.
+     */
+    private static function backgroundAtColumn(string $line, int $column): string
+    {
+        $background = '';
+        $col = 0;
+
+        foreach (preg_split('/(\x1b\[[0-9;]*[a-zA-Z])/', $line, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY) as $part) {
+            if (str_starts_with($part, "\x1b[")) {
+                if (preg_match('/^\x1b\[(?:4[0-7]|10[0-7]|48;[25];[0-9;]+)m$/', $part)) {
+                    $background = $part;
+                } elseif ("\x1b[49m" === $part || "\x1b[0m" === $part) {
+                    $background = '';
+                }
+
+                continue;
+            }
+
+            foreach (preg_split('//u', $part, -1, \PREG_SPLIT_NO_EMPTY) as $ignored) {
+                if ($col === $column) {
+                    return $background;
+                }
+                ++$col;
+            }
+        }
+
+        return $background;
+    }
+
+    public function testWrapLinesWithGradientAppliesBackgroundToSideSegments()
+    {
+        // Standalone gradient container (no outer background): side segments use inner gradient edge colors
+        $border = Border::all(1, 'normal');
+        $style = (new Style())->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $gradient = $style->getGradient();
+        $innerWidth = 3;
+        $codes = $gradient->resolve($innerWidth, 1);
+        $innerLine = $codes[0][0].' '.$codes[0][1].' '.$codes[0][2].' '."\x1b[49m]";
+
+        $lines = $border->wrapLines([$innerLine], $innerWidth, $style);
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+
+        $this->assertStringStartsWith($black, $lines[1]);
+        $this->assertStringContainsString($white, substr($lines[1], -50));
+    }
+
+    public function testWrapLinesWithGradientAlwaysUsesChildGradientRegardlessOfOuterStyle()
+    {
+        // Border chars (side segs, corners, fill) must always show the child's own gradient,
+        // whether outer has a gradient, a solid bg, or nothing.
+        $border = Border::all(1, 'normal');
+        $innerStyle = (new Style())->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $fill50 = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+
+        foreach ([
+            'no outer' => new Style(),
+            'outer gradient' => (new Style())->withLinearGradient(['#ff0000', '#0000ff'], GradientDirection::TopToBottom),
+            'outer solid bg' => (new Style())->withBackground('#ff0000'),
+        ] as $label => $outerStyle) {
+            $lines = $border->wrapLines(['abc'], 3, $innerStyle, $outerStyle);
+
+            // innerWidth=3 gradient: strip=[black, 50%gray, white]
+            // Left side seg (content row) = strip[0] of child gradient = black
+            $this->assertStringStartsWith($black, $lines[1], "$label: left side seg must use child gradient");
+            // Top/bottom border rows must contain the 50% fill color (col 2 of child gradient)
+            $this->assertStringContainsString($fill50, $lines[0], "$label: top fill must use child gradient");
+            $this->assertStringContainsString($fill50, $lines[2], "$label: bottom fill must use child gradient");
+        }
+    }
+
+    public function testWrapLinesGradientSpansInnerWidthOnly()
+    {
+        // Gradient spans innerWidth=3 only (not totalWidth=5).
+        // strip for width=3: [offset=0 → black, offset=0.5 → 50%gray, offset=1 → white]
+        // Corners use same endpoints as the fill:
+        //   left corner  = strip[0] = black
+        //   fill[0]      = strip[0] = black  ← pure black, NOT 25% gray
+        //   fill[1]      = strip[1] = 50% gray
+        //   fill[2]      = strip[2] = white
+        //   right corner = strip[2] = white
+        $border = Border::all(1, 'normal');
+        $style = (new Style())->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $border->wrapLines(['abc'], 3, $style);
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $gray = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $quarter = Color::from('#000000')->mix(Color::from('#ffffff'), 25)->toBackgroundCode();
+
+        foreach ([0, 2] as $row) {
+            $this->assertSame($black, self::backgroundAtColumn($lines[$row], 0), "row $row: left corner");
+            $this->assertSame($black, self::backgroundAtColumn($lines[$row], 1), "row $row: fill[0] is offset=0");
+            $this->assertSame($gray, self::backgroundAtColumn($lines[$row], 2), "row $row: fill[1] is offset=0.5");
+            $this->assertSame($white, self::backgroundAtColumn($lines[$row], 3), "row $row: fill[2] is offset=1");
+            $this->assertSame($white, self::backgroundAtColumn($lines[$row], 4), "row $row: right corner");
+
+            // Spanning totalWidth=5 instead of innerWidth=3 would put 25% gray on a cell.
+            $this->assertStringNotContainsString($quarter, $lines[$row], "row $row: the strip must span innerWidth");
+        }
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Style/ColorStopTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/ColorStopTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\ColorStop;
+
+final class ColorStopTest extends TestCase
+{
+    public function testAtAcceptsString()
+    {
+        $stop = ColorStop::at('red', 30);
+        $this->assertSame(Color::named('red')->toBackgroundCode(), $stop->color->toBackgroundCode());
+        $this->assertSame(30, $stop->position);
+    }
+
+    public function testAtAcceptsColorObject()
+    {
+        $color = Color::rgb(255, 128, 0);
+        $stop = ColorStop::at($color, 50);
+        $this->assertSame($color->toBackgroundCode(), $stop->color->toBackgroundCode());
+    }
+
+    public function testAtAcceptsPaletteInt()
+    {
+        $stop = ColorStop::at(196, 100);
+        $this->assertSame(Color::palette(196)->toBackgroundCode(), $stop->color->toBackgroundCode());
+    }
+
+    public function testAtRejectsPositionBelow0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ColorStop::at('red', -1);
+    }
+
+    public function testAtRejectsPositionAbove100()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ColorStop::at('red', 101);
+    }
+
+    public function testNormalizeAllExplicit()
+    {
+        $stops = ColorStop::normalize([
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#00ff00', 30),
+            ColorStop::at('#0000ff', 100),
+        ]);
+
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.3, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizePlainColorsDistributedUniformly()
+    {
+        // No positions: first=0, last=1, middle=0.5
+        $stops = ColorStop::normalize(['#ff0000', '#00ff00', '#0000ff']);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.5, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizeMixedImplicitPositionsInterpolated()
+    {
+        // Only the middle stop has an explicit position
+        $stops = ColorStop::normalize([
+            '#ff0000',                     // → 0
+            ColorStop::at('#00ff00', 30),  // → 0.3
+            '#0000ff',                     // → 1.0
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.3, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizeRunOfImplicitsBetweenTwoPositioned()
+    {
+        // Two plain colors between 0 and 60 → 20 and 40
+        $stops = ColorStop::normalize([
+            ColorStop::at('#ff0000', 0),
+            '#aaaaaa',   // → 20
+            '#bbbbbb',   // → 40
+            ColorStop::at('#0000ff', 60),
+            '#ffffff',   // → 100 (last)
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.2, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.4, $stops[2]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.6, $stops[3]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[4]['offset'], 1e-9);
+    }
+
+    public function testNormalizeClampsOutOfOrderStopsInsteadOfSortingThem()
+    {
+        $stops = ColorStop::normalize([
+            ColorStop::at('#0000ff', 100),
+            ColorStop::at('#00ff00', 50),
+            ColorStop::at('#ff0000', 0),
+        ]);
+
+        // The declaration order is kept: blue stays first, and the two positions
+        // that go backwards are both clamped up to 100.
+        $this->assertSame(Color::from('#0000ff')->toBackgroundCode(), $stops[0]['color']->toBackgroundCode());
+        $this->assertSame(Color::from('#00ff00')->toBackgroundCode(), $stops[1]['color']->toBackgroundCode());
+        $this->assertSame(Color::from('#ff0000')->toBackgroundCode(), $stops[2]['color']->toBackgroundCode());
+
+        $this->assertEqualsWithDelta(1.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizeClampsASingleBackwardsStopToAHardStop()
+    {
+        // CSS: blue runs from 0 to 80%, then red takes over at a hard stop.
+        $stops = ColorStop::normalize([
+            ColorStop::at('#0000ff', 80),
+            ColorStop::at('#ff0000', 20),
+        ]);
+
+        $this->assertSame(Color::from('#0000ff')->toBackgroundCode(), $stops[0]['color']->toBackgroundCode());
+        $this->assertEqualsWithDelta(0.8, $stops[0]['offset'], 1e-9);
+
+        $this->assertSame(Color::from('#ff0000')->toBackgroundCode(), $stops[1]['color']->toBackgroundCode());
+        $this->assertEqualsWithDelta(0.8, $stops[1]['offset'], 1e-9);
+    }
+
+    public function testNormalizeKeepsAlreadyOrderedStopsUntouched()
+    {
+        $stops = ColorStop::normalize([
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#00ff00', 50),
+            ColorStop::at('#0000ff', 100),
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.5, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/LinearGradientTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/LinearGradientTest.php
@@ -1,0 +1,391 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Style\Angle;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\ColorStop;
+use Symfony\Component\Tui\Style\GradientDirection;
+use Symfony\Component\Tui\Style\LinearGradient;
+
+final class LinearGradientTest extends TestCase
+{
+    public function testResolveTwoColorsHorizontal()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+        $codes = $g->resolve(3, 1);
+
+        // col 0 = black, col 2 = white, col 1 = mid-grey
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), $codes[0][0]);
+        $this->assertSame(Color::from('#ffffff')->toBackgroundCode(), $codes[0][2]);
+
+        // Mid color is grey (128,128,128)
+        $mid = Color::rgb(128, 128, 128)->toBackgroundCode();
+        $this->assertSame($mid, $codes[0][1]);
+    }
+
+    public function testResolveAllRowsIdenticalForHorizontal()
+    {
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+        $codes = $g->resolve(4, 3);
+
+        $this->assertSame($codes[0], $codes[1]);
+        $this->assertSame($codes[0], $codes[2]);
+    }
+
+    public function testResolveAllColsIdenticalForVertical()
+    {
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::TopToBottom);
+        $codes = $g->resolve(4, 3);
+
+        $this->assertSame($codes[0][0], $codes[0][1]);
+        $this->assertSame($codes[0][0], $codes[0][2]);
+        $this->assertSame($codes[0][0], $codes[0][3]);
+
+        // Vertical: different rows must have different codes
+        $this->assertNotSame($codes[0][0], $codes[1][0]);
+        $this->assertNotSame($codes[1][0], $codes[2][0]);
+    }
+
+    public function testResolveRightToLeftIsReversedLeftToRight()
+    {
+        $g1 = LinearGradient::from(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+        $g2 = LinearGradient::from(['#000000', '#ffffff'], GradientDirection::RightToLeft);
+
+        $c1 = $g1->resolve(4, 1);
+        $c2 = $g2->resolve(4, 1);
+
+        $this->assertSame($c1[0][0], $c2[0][3]);
+        $this->assertSame($c1[0][3], $c2[0][0]);
+
+        $this->assertSame($c1[0][1], $c2[0][2]);
+        $this->assertSame($c1[0][2], $c2[0][1]);
+    }
+
+    public function testResolveThreeColorsEvenlyDistributed()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff', '#000000'], GradientDirection::LeftToRight);
+        $codes = $g->resolve(5, 1);
+
+        // col 0 = black, col 2 = white, col 4 = black
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), $codes[0][0]);
+        $this->assertSame(Color::from('#ffffff')->toBackgroundCode(), $codes[0][2]);
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), $codes[0][4]);
+    }
+
+    public function testResolveIsStableForAGivenSize()
+    {
+        // PHP arrays compare by value, so this asserts the result is stable, not that
+        // the cache was hit. testResolveKeepsOnlyTheLastSize covers the cache itself.
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+
+        $a = $g->resolve(10, 5);
+        $b = $g->resolve(10, 5);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function testResolveKeepsOnlyTheLastSize()
+    {
+        $g = LinearGradient::leftToRight('#000000', '#ffffff');
+        $g->resolve(1, 24);
+
+        $before = memory_get_usage();
+        for ($width = 2; $width <= 300; ++$width) {
+            $g->resolve($width, 24);
+        }
+        $retained = memory_get_usage() - $before;
+
+        // Keeping every size cost around 91 MB here; one strip is well under 5.
+        $this->assertLessThan(5 * 1024 * 1024, $retained,
+            \sprintf('the cache must not grow with every size, %.1f MB retained', $retained / 1048576));
+    }
+
+    public function testResolveRecomputesASizeItHasEvicted()
+    {
+        $g = LinearGradient::leftToRight('#000000', '#ffffff');
+
+        $first = $g->resolve(10, 5);
+        $g->resolve(20, 5);
+
+        $this->assertSame($first, $g->resolve(10, 5), 'an evicted size must be recomputed identically');
+    }
+
+    public function testFromAcceptsColorObjects()
+    {
+        $g = LinearGradient::from([Color::named('red'), Color::named('blue')], GradientDirection::LeftToRight);
+        $codes = $g->resolve(2, 1);
+
+        // Named colors are normalized to RGB so all gradient steps produce consistent \x1b[48;2;...] codes
+        $this->assertSame(Color::named('red')->mix(Color::named('blue'), 0)->toBackgroundCode(), $codes[0][0]);
+        $this->assertSame(Color::named('red')->mix(Color::named('blue'), 100)->toBackgroundCode(), $codes[0][1]);
+    }
+
+    public function testFromAcceptsMixedInput()
+    {
+        // string, Color object, palette int: all accepted as gradient stops
+        $g = LinearGradient::from(['red', Color::named('blue'), 196], GradientDirection::LeftToRight);
+        $codes = $g->resolve(3, 1);
+
+        // All codes must be RGB format: named/palette stops are normalized via mix()
+        foreach ($codes[0] as $col => $code) {
+            $this->assertStringStartsWith("\x1b[48;2;", $code,
+                "Column $col must produce an RGB bg code");
+        }
+    }
+
+    public function testNamedConstructors()
+    {
+        $lr = LinearGradient::leftToRight('red', 'blue');
+        $rl = LinearGradient::rightToLeft('red', 'blue');
+        $tb = LinearGradient::topToBottom('red', 'blue');
+        $bt = LinearGradient::bottomToTop('red', 'blue');
+
+        $codesLr = $lr->resolve(3, 1);
+        $codesRl = $rl->resolve(3, 1);
+        $codesTb = $tb->resolve(1, 3);
+        $codesBt = $bt->resolve(1, 3);
+
+        $this->assertSame($codesLr[0][0], $codesRl[0][2]);
+        $this->assertSame($codesTb[0][0], $codesBt[2][0]);
+    }
+
+    public function testFromAcceptsAngleDegrees()
+    {
+        // Angle::degrees(0) = left-to-right: first column gets first color, last column gets last color
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(0));
+        $ref = LinearGradient::leftToRight('#ff0000', '#0000ff');
+        $this->assertSame($ref->resolve(5, 1)[0][0], $g->resolve(5, 1)[0][0]);
+        $this->assertSame($ref->resolve(5, 1)[0][4], $g->resolve(5, 1)[0][4]);
+
+        // Angle::degrees(90) = top-to-bottom
+        $g90 = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(90));
+        $ref90 = LinearGradient::topToBottom('#ff0000', '#0000ff');
+        $this->assertSame($ref90->resolve(1, 5)[0][0], $g90->resolve(1, 5)[0][0]);
+        $this->assertSame($ref90->resolve(1, 5)[4][0], $g90->resolve(1, 5)[4][0]);
+    }
+
+    public function testFromAcceptsAngleRadians()
+    {
+        // radians(π/2) == degrees(90) == top-to-bottom
+        $gDeg = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(90));
+        $gRad = LinearGradient::from(['#ff0000', '#0000ff'], Angle::radians(\M_PI / 2));
+        $this->assertSame($gDeg->resolve(3, 4), $gRad->resolve(3, 4));
+    }
+
+    public function testAngle45ProducesDiagonalGradient()
+    {
+        // At 45°, the gradient runs diagonally: top-left = first color, bottom-right = last color
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(45));
+        $codes = $g->resolve(3, 3);
+
+        $firstColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+        $lastColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 100)->toBackgroundCode();
+
+        $this->assertSame($firstColor, $codes[0][0], 'top-left must be first color at 45°');
+        $this->assertSame($lastColor, $codes[2][2], 'bottom-right must be last color at 45°');
+
+        // Corners orthogonal to the gradient axis must share the midpoint color
+        $this->assertSame($codes[0][2], $codes[2][0], 'anti-diagonal corners must be equal at 45°');
+    }
+
+    public function testAngle135ProducesMirroredDiagonal()
+    {
+        // At 135° the gradient runs top-right to bottom-left (opposite diagonal)
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(135));
+        $codes = $g->resolve(3, 3);
+
+        $firstColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+        $lastColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 100)->toBackgroundCode();
+
+        $this->assertSame($firstColor, $codes[0][2], 'top-right must be first color at 135°');
+        $this->assertSame($lastColor, $codes[2][0], 'bottom-left must be last color at 135°');
+    }
+
+    public function testNamedColorEndpointProducesConsistentRgbCode()
+    {
+        // At a gradient endpoint with a named color stop, the resolved code
+        // must be an RGB code (\x1b[48;2;...]) matching the format produced
+        // by intermediate rows via mix(). Without this, named colors produce
+        // ANSI codes (\x1b[41m] for red) that terminals render differently
+        // from the adjacent RGB-mixed rows, creating a visible lighter band.
+        $g = LinearGradient::topToBottom('#0000ff', 'red');
+        $codes = $g->resolve(1, 3); // 3 rows: blue at top, mix in middle, red at bottom
+
+        foreach ($codes as $row => $rowCodes) {
+            $this->assertStringStartsWith("\x1b[48;2;", $rowCodes[0],
+                "Row $row must produce an RGB bg code for visual consistency across all gradient steps");
+        }
+    }
+
+    public function testColorStopShiftsTransitionPoint()
+    {
+        // Without stop: red→blue uniform over 5 cols, midpoint at col 2
+        // With stop at 20%: green is at col 1 (offset=0.25 for width=5 → position=25 > stop=20)
+        // Key property: with green at 20%, col 0 (offset=0) = red, col 1 (offset=0.25) is past the stop → in green→blue segment
+        $g = LinearGradient::leftToRight(
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#00ff00', 20),
+            ColorStop::at('#0000ff', 100),
+        );
+        $codes = $g->resolve(5, 1);
+
+        // col 0 → offset=0 → red (mix red→green at 0%)
+        $this->assertSame(
+            Color::from('#ff0000')->mix(Color::from('#00ff00'), 0)->toBackgroundCode(),
+            $codes[0][0]
+        );
+        // col 4 → offset=1 → blue (mix green→blue at 100%)
+        $this->assertSame(
+            Color::from('#00ff00')->mix(Color::from('#0000ff'), 100)->toBackgroundCode(),
+            $codes[0][4]
+        );
+        // col 1 → offset=0.25 → past green stop (20%) → in green→blue segment at localOffset=(25-20)/80=6.25%
+        // The ratio stays in float, so this is 6.25% of the way, not a rounded 6%.
+        $this->assertSame(
+            Color::rgb(0, (int) round(255 * (1 - 0.0625)), (int) round(255 * 0.0625))->toBackgroundCode(),
+            $codes[0][1]
+        );
+    }
+
+    public function testInterpolationIsNotCappedAtOneHundredAndOneColors()
+    {
+        // Color::mix() takes an integer percentage, which capped a two-stop
+        // gradient at 101 distinct colors per segment and made wide gradients band.
+        $codes = LinearGradient::leftToRight('#000000', '#ffffff')->resolve(240, 1);
+
+        $this->assertGreaterThan(101, \count(array_unique($codes[0])));
+    }
+
+    public function testEveryStripIsMonotonicAcrossItsWidth()
+    {
+        // A greyscale ramp must never step backwards from one column to the next.
+        $codes = LinearGradient::leftToRight('#000000', '#ffffff')->resolve(200, 1);
+
+        $previous = -1;
+        foreach ($codes[0] as $col => $code) {
+            $this->assertSame(1, preg_match('/48;2;(\d+);/', $code, $m), "column $col must emit a truecolor bg code");
+            $this->assertGreaterThanOrEqual($previous, (int) $m[1], "column $col must not step back");
+            $previous = (int) $m[1];
+        }
+
+        $this->assertSame(255, $previous, 'the last column must reach the end color');
+    }
+
+    public function testHardStopProducesSharpChange()
+    {
+        // Two stops at the same position → sharp color change, no blend
+        $g = LinearGradient::leftToRight(
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#ff0000', 50),
+            ColorStop::at('#0000ff', 50),
+            ColorStop::at('#0000ff', 100),
+        );
+        $codes = $g->resolve(5, 1);
+
+        $red = Color::from('#ff0000')->mix(Color::from('#ff0000'), 0)->toBackgroundCode();
+        $blue = Color::from('#0000ff')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+
+        // cols 0-1 (offset=0,0.25) → red side
+        $this->assertSame($red, $codes[0][0]);
+        $this->assertSame($red, $codes[0][1]);
+        // cols 3-4 (offset=0.75,1) → blue side
+        $this->assertSame($blue, $codes[0][3]);
+        $this->assertSame($blue, $codes[0][4]);
+    }
+
+    public function testMixedPlainAndColorStopBackwardCompat()
+    {
+        // Plain colors still work (uniform distribution)
+        $g1 = LinearGradient::leftToRight('#ff0000', '#0000ff');
+        $g2 = LinearGradient::leftToRight(
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#0000ff', 100),
+        );
+        $this->assertSame($g1->resolve(4, 1), $g2->resolve(4, 1));
+    }
+
+    public function testFromRequiresAtLeastTwoColors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LinearGradient::from(['red'], GradientDirection::LeftToRight);
+    }
+
+    public function testResolveWithSingleCellReturnsFirstColor()
+    {
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+        $codes = $g->resolve(1, 1);
+
+        $this->assertSame(Color::from('#ff0000')->toBackgroundCode(), $codes[0][0]);
+    }
+
+    public function testFromExistingGradientWithoutDirectionReturnsSameInstance()
+    {
+        $g = LinearGradient::topToBottom('#000000', '#ffffff');
+
+        $this->assertSame($g, LinearGradient::from($g));
+    }
+
+    public function testFromExistingGradientOverridesDirection()
+    {
+        $g = LinearGradient::leftToRight('#000000', '#ffffff');
+        $rotated = LinearGradient::from($g, GradientDirection::TopToBottom);
+
+        $this->assertNotSame($g, $rotated);
+        $this->assertSame(
+            LinearGradient::from(['#000000', '#ffffff'], GradientDirection::TopToBottom)->resolve(4, 3),
+            $rotated->resolve(4, 3),
+            'stops must be preserved and the new direction applied'
+        );
+    }
+
+    public function testFromExistingGradientAcceptsAngle()
+    {
+        $g = LinearGradient::leftToRight('#000000', '#ffffff');
+        $rotated = LinearGradient::from($g, Angle::degrees(90));
+
+        $this->assertSame(
+            LinearGradient::from(['#000000', '#ffffff'], Angle::degrees(90))->resolve(4, 3),
+            $rotated->resolve(4, 3)
+        );
+    }
+
+    public function testFromExistingGradientLeavesTheSourceUntouched()
+    {
+        $g = LinearGradient::leftToRight('#000000', '#ffffff');
+        $before = $g->resolve(4, 3);
+
+        LinearGradient::from($g, GradientDirection::TopToBottom);
+
+        $this->assertSame($before, $g->resolve(4, 3));
+    }
+
+    public function testFromExistingGradientPreservesColorStopOffsets()
+    {
+        $stops = [ColorStop::at('#000000', 0), ColorStop::at('#ffffff', 25)];
+        $rotated = LinearGradient::from(LinearGradient::from($stops, GradientDirection::LeftToRight), GradientDirection::TopToBottom);
+
+        $this->assertSame(
+            LinearGradient::from($stops, GradientDirection::TopToBottom)->resolve(5, 5),
+            $rotated->resolve(5, 5)
+        );
+    }
+
+    public function testFromArrayWithoutDirectionDefaultsToLeftToRight()
+    {
+        $this->assertSame(
+            LinearGradient::from(['#000000', '#ffffff'], GradientDirection::LeftToRight)->resolve(4, 3),
+            LinearGradient::from(['#000000', '#ffffff'])->resolve(4, 3)
+        );
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/RadialGradientTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/RadialGradientTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\RadialGradient;
+
+final class RadialGradientTest extends TestCase
+{
+    public function testCenterCellGetsFirstColor()
+    {
+        // A 5×5 grid centered at (0.5, 0.5): cell (2,2) is the center, offset=0 → first color
+        $g = RadialGradient::from(['#ff0000', '#0000ff']);
+        $codes = $g->resolve(5, 5);
+
+        $firstColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+        $this->assertSame($firstColor, $codes[2][2], 'center cell must receive first color (offset=0)');
+    }
+
+    public function testFarthestCornerGetsLastColor()
+    {
+        // In a centered 5×5 grid all four corners are equidistant → offset=1 → last color
+        $g = RadialGradient::from(['#ff0000', '#0000ff']);
+        $codes = $g->resolve(5, 5);
+
+        $lastColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 100)->toBackgroundCode();
+        $this->assertSame($lastColor, $codes[0][0], 'top-left corner must receive last color (offset=1)');
+        $this->assertSame($lastColor, $codes[0][4], 'top-right corner must receive last color (offset=1)');
+        $this->assertSame($lastColor, $codes[4][0], 'bottom-left corner must receive last color (offset=1)');
+        $this->assertSame($lastColor, $codes[4][4], 'bottom-right corner must receive last color (offset=1)');
+    }
+
+    public function testCornersAreSymmetricAroundCenter()
+    {
+        // All four corners of a centered grid are equidistant regardless of aspect ratio
+        $g = RadialGradient::from(['#ff0000', '#0000ff']);
+        $codes = $g->resolve(5, 5);
+
+        $this->assertSame($codes[0][0], $codes[0][4]);
+        $this->assertSame($codes[0][0], $codes[4][0]);
+        $this->assertSame($codes[0][0], $codes[4][4]);
+
+        // Left/right symmetry: cells equidistant horizontally get the same color
+        $this->assertSame($codes[2][0], $codes[2][4]);
+        // Top/bottom symmetry: cells equidistant vertically get the same color
+        $this->assertSame($codes[0][2], $codes[4][2]);
+    }
+
+    public function testAspectRatioMakesCirclesVisual()
+    {
+        // With aspect ratio 2.0 (standard terminals: cells ~2× taller than wide),
+        // 2 columns of offset must equal 1 row of offset in visual distance.
+        // 5×3 grid centered at (col=2, row=1) is a clean case.
+        $g = RadialGradient::from(['#ff0000', '#0000ff'], 0.5, 0.5, 2.0);
+        $codes = $g->resolve(5, 3);
+
+        // 2 cols right of center == 1 row below center in corrected distance
+        $this->assertSame($codes[1][4], $codes[2][2],
+            'with ar=2.0, 2 columns right must equal 1 row down in visual distance');
+        // 2 cols left == 1 row above
+        $this->assertSame($codes[1][0], $codes[0][2],
+            'with ar=2.0, 2 columns left must equal 1 row up in visual distance');
+    }
+
+    public function testAspectRatio1ProducesSymmetricEdgeMidpoints()
+    {
+        // With ar=1.0 (square cells), horizontal and vertical edge midpoints
+        // of a square grid are equidistant from center
+        $g = RadialGradient::from(['#ff0000', '#0000ff'], 0.5, 0.5, 1.0);
+        $codes = $g->resolve(5, 5);
+
+        // All four edge midpoints equidistant at d=2
+        $this->assertSame($codes[0][2], $codes[2][0]);
+        $this->assertSame($codes[0][2], $codes[2][4]);
+        $this->assertSame($codes[0][2], $codes[4][2]);
+    }
+
+    public function testCustomCenterAtTopLeft()
+    {
+        // Center at (0, 0): top-left cell (0,0) is the origin → offset=0 → first color
+        $g = RadialGradient::from(['#ff0000', '#0000ff'], 0.0, 0.0);
+        $codes = $g->resolve(3, 3);
+
+        $firstColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+        $this->assertSame($firstColor, $codes[0][0], 'origin cell must get first color');
+
+        // Bottom-right corner is the farthest → last color
+        $lastColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 100)->toBackgroundCode();
+        $this->assertSame($lastColor, $codes[2][2], 'farthest corner must get last color');
+    }
+
+    public function testCenteredFactoryIsEquivalentToFromWithCenter()
+    {
+        $g1 = RadialGradient::centered('#ff0000', '#0000ff');
+        $g2 = RadialGradient::from(['#ff0000', '#0000ff'], 0.5, 0.5);
+
+        $this->assertSame($g1->resolve(6, 4), $g2->resolve(6, 4));
+    }
+
+    public function testFromRequiresAtLeastTwoColors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        RadialGradient::from(['red']);
+    }
+
+    #[DataProvider('invalidAspectRatioProvider')]
+    public function testFromRejectsAnUnusableAspectRatio(float $aspectRatio)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('aspect ratio of a radial gradient must be a finite number greater than 0');
+
+        RadialGradient::from(['#ff0000', '#0000ff'], 0.5, 0.5, $aspectRatio);
+    }
+
+    public static function invalidAspectRatioProvider(): iterable
+    {
+        yield 'zero flattens the vertical axis' => [0.0];
+        yield 'negative mirrors the distance' => [-2.0];
+        yield 'NAN propagates to every cell' => [\NAN];
+        yield 'INF collapses the gradient' => [\INF];
+    }
+
+    #[DataProvider('nonFiniteCenterProvider')]
+    public function testFromRejectsANonFiniteCenter(float $cx, float $cy)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('center of a radial gradient must be finite');
+
+        RadialGradient::from(['#ff0000', '#0000ff'], $cx, $cy);
+    }
+
+    public static function nonFiniteCenterProvider(): iterable
+    {
+        yield 'NAN on x' => [\NAN, 0.5];
+        yield 'NAN on y' => [0.5, \NAN];
+        yield 'INF on x' => [\INF, 0.5];
+    }
+
+    public function testFromRejectsAnUnusableAspectRatioOnAnExistingGradient()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        RadialGradient::from(RadialGradient::centered('#ff0000', '#0000ff'), null, null, 0.0);
+    }
+
+    public function testFromAcceptsACenterOutsideTheArea()
+    {
+        // CSS allows a center outside the box; only non-finite values are rejected.
+        $codes = RadialGradient::from(['#ff0000', '#0000ff'], 5.0, -3.0)->resolve(4, 3);
+
+        $this->assertCount(3, $codes);
+        $this->assertCount(4, $codes[0]);
+    }
+
+    public function testFromExistingGradientWithoutGeometryReturnsSameInstance()
+    {
+        $g = RadialGradient::from(['#ff0000', '#0000ff'], 0.2, 0.3, 1.0);
+
+        $this->assertSame($g, RadialGradient::from($g));
+    }
+
+    public function testFromExistingGradientOverridesCenter()
+    {
+        $g = RadialGradient::centered('#ff0000', '#0000ff');
+        $moved = RadialGradient::from($g, 0.0, 0.0);
+
+        $this->assertNotSame($g, $moved);
+        $this->assertSame(
+            RadialGradient::from(['#ff0000', '#0000ff'], 0.0, 0.0)->resolve(5, 5),
+            $moved->resolve(5, 5),
+            'stops must be preserved and the new center applied'
+        );
+    }
+
+    public function testFromExistingGradientKeepsUnspecifiedGeometry()
+    {
+        $g = RadialGradient::from(['#ff0000', '#0000ff'], 0.2, 0.3, 1.0);
+        $stretched = RadialGradient::from($g, null, null, 3.0);
+
+        $this->assertSame(
+            RadialGradient::from(['#ff0000', '#0000ff'], 0.2, 0.3, 3.0)->resolve(6, 4),
+            $stretched->resolve(6, 4),
+            '$cx/$cy must be inherited when only $aspectRatio is given'
+        );
+    }
+
+    public function testFromExistingGradientLeavesTheSourceUntouched()
+    {
+        $g = RadialGradient::centered('#ff0000', '#0000ff');
+        $before = $g->resolve(5, 5);
+
+        RadialGradient::from($g, 0.0, 0.0, 1.0);
+
+        $this->assertSame($before, $g->resolve(5, 5));
+    }
+
+    public function testFromArrayWithoutGeometryUsesDefaults()
+    {
+        $this->assertSame(
+            RadialGradient::from(['#ff0000', '#0000ff'], 0.5, 0.5, 2.0)->resolve(6, 4),
+            RadialGradient::from(['#ff0000', '#0000ff'])->resolve(6, 4)
+        );
+    }
+
+    public function testResolveIsStableForAGivenSize()
+    {
+        $g = RadialGradient::from(['#ff0000', '#0000ff']);
+
+        $a = $g->resolve(8, 6);
+        $b = $g->resolve(8, 6);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function testResolveKeepsOnlyTheLastSize()
+    {
+        $g = RadialGradient::centered('#000000', '#ffffff');
+        $g->resolve(1, 24);
+
+        $before = memory_get_usage();
+        for ($width = 2; $width <= 300; ++$width) {
+            $g->resolve($width, 24);
+        }
+        $retained = memory_get_usage() - $before;
+
+        $this->assertLessThan(5 * 1024 * 1024, $retained,
+            \sprintf('the cache must not grow with every size, %.1f MB retained', $retained / 1048576));
+    }
+
+    public function testResolveRecomputesASizeItHasEvicted()
+    {
+        $g = RadialGradient::centered('#000000', '#ffffff');
+
+        $first = $g->resolve(8, 6);
+        $g->resolve(16, 6);
+
+        $this->assertSame($first, $g->resolve(8, 6), 'an evicted size must be recomputed identically');
+    }
+
+    public function testThreeColorsInterpolateCorrectly()
+    {
+        // With 3 colors: center = first, mid-radius = second, edge = third
+        $g = RadialGradient::from(['#ff0000', '#00ff00', '#0000ff']);
+        $codes = $g->resolve(5, 5);
+
+        // Center (offset=0) → mix(red, green, 0) = red
+        $firstColor = Color::from('#ff0000')->mix(Color::from('#00ff00'), 0)->toBackgroundCode();
+        $this->assertSame($firstColor, $codes[2][2]);
+
+        // Corners (offset=1) → mix(green, blue, 100) = blue
+        $lastColor = Color::from('#00ff00')->mix(Color::from('#0000ff'), 100)->toBackgroundCode();
+        $this->assertSame($lastColor, $codes[0][0]);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/StyleTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/StyleTest.php
@@ -19,7 +19,10 @@ use Symfony\Component\Tui\Style\BorderPattern;
 use Symfony\Component\Tui\Style\Color;
 use Symfony\Component\Tui\Style\CursorShape;
 use Symfony\Component\Tui\Style\Direction;
+use Symfony\Component\Tui\Style\GradientDirection;
+use Symfony\Component\Tui\Style\LinearGradient;
 use Symfony\Component\Tui\Style\Padding;
+use Symfony\Component\Tui\Style\RadialGradient;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
 use Symfony\Component\Tui\Style\VerticalAlign;
@@ -420,5 +423,151 @@ class StyleTest extends TestCase
         $this->assertSame(Align::Right, $result->getAlign());
         $this->assertSame(VerticalAlign::Center, $result->getVerticalAlign());
         $this->assertSame(2, $result->getFlex());
+    }
+
+    public function testMergeAllGradientOverridesEarlierBackground()
+    {
+        $result = Style::mergeAll([
+            new Style(background: '#00ff00'),
+            (new Style())->withLinearGradient(['red', 'blue']),
+        ]);
+
+        $this->assertInstanceOf(LinearGradient::class, $result->getGradient());
+        $this->assertNull($result->getBackground());
+    }
+
+    public function testMergeAllBackgroundOverridesEarlierGradient()
+    {
+        $result = Style::mergeAll([
+            (new Style())->withLinearGradient(['red', 'blue']),
+            new Style(background: '#00ff00'),
+        ]);
+
+        $this->assertNull($result->getGradient());
+        $this->assertSame('#00ff00', $result->getBackground()->toHex());
+    }
+
+    public function testMergeAllKeepsGradientWhenLaterStylesSetNoBackground()
+    {
+        $result = Style::mergeAll([
+            (new Style())->withLinearGradient(['red', 'blue']),
+            new Style(bold: true),
+        ]);
+
+        $this->assertInstanceOf(LinearGradient::class, $result->getGradient());
+        $this->assertNull($result->getBackground());
+    }
+
+    public function testMergeAllKeepsBackgroundWhenLaterStylesSetNoGradient()
+    {
+        $result = Style::mergeAll([
+            new Style(background: '#00ff00'),
+            new Style(bold: true),
+        ]);
+
+        $this->assertNull($result->getGradient());
+        $this->assertSame('#00ff00', $result->getBackground()->toHex());
+    }
+
+    public function testWithLinearGradientFromArray()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue']);
+        $gradient = $style->getGradient();
+
+        $this->assertInstanceOf(LinearGradient::class, $gradient);
+        $this->assertNull($style->getBackground()); // gradient clears background
+    }
+
+    public function testWithLinearGradientFromObject()
+    {
+        $g = LinearGradient::leftToRight('red', 'blue');
+        $style = (new Style())->withLinearGradient($g);
+
+        $this->assertSame($g, $style->getGradient());
+    }
+
+    public function testWithLinearGradientWithDirection()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue'], GradientDirection::TopToBottom);
+        $codes = $style->getGradient()->resolve(2, 2);
+
+        // Vertical: col 0 and col 1 in same row are identical
+        $this->assertSame($codes[0][0], $codes[0][1]);
+        // Vertical: row 0 and row 1 differ
+        $this->assertNotSame($codes[0][0], $codes[1][0]);
+    }
+
+    public function testWithBackgroundClearsGradient()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue'])->withBackground('green');
+
+        $this->assertNull($style->getGradient());
+        $this->assertNotNull($style->getBackground());
+    }
+
+    public function testWithLinearGradientClearsBackground()
+    {
+        $style = (new Style())->withBackground('green')->withLinearGradient(['red', 'blue']);
+
+        $this->assertNull($style->getBackground());
+        $this->assertNotNull($style->getGradient());
+    }
+
+    public function testIsPlainFalseWhenGradientSet()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue']);
+
+        $this->assertFalse($style->isPlain());
+    }
+
+    public function testWithLinearGradientObjectAndDirectionOverridesDirection()
+    {
+        $g = LinearGradient::leftToRight('#000000', '#ffffff');
+        $style = (new Style())->withLinearGradient($g, GradientDirection::TopToBottom);
+
+        $this->assertNotSame($g, $style->getGradient());
+
+        $codes = $style->getGradient()->resolve(2, 2);
+        $this->assertSame($codes[0][0], $codes[0][1], 'vertical gradient: columns of a row are identical');
+        $this->assertNotSame($codes[0][0], $codes[1][0], 'vertical gradient: rows differ');
+    }
+
+    public function testWithRadialGradientFromArray()
+    {
+        $style = (new Style())->withRadialGradient(['red', 'blue']);
+
+        $this->assertInstanceOf(RadialGradient::class, $style->getGradient());
+        $this->assertNull($style->getBackground());
+    }
+
+    public function testWithRadialGradientFromObject()
+    {
+        $g = RadialGradient::centered('red', 'blue');
+        $style = (new Style())->withRadialGradient($g);
+
+        $this->assertSame($g, $style->getGradient());
+    }
+
+    public function testWithRadialGradientObjectAndCenterOverridesCenter()
+    {
+        $g = RadialGradient::centered('#ff0000', '#0000ff');
+        $style = (new Style())->withRadialGradient($g, 0.0, 0.0);
+
+        $this->assertNotSame($g, $style->getGradient());
+        $this->assertSame(
+            RadialGradient::from(['#ff0000', '#0000ff'], 0.0, 0.0)->resolve(5, 5),
+            $style->getGradient()->resolve(5, 5)
+        );
+    }
+
+    public function testWithRadialGradientObjectKeepsUnspecifiedGeometry()
+    {
+        $g = RadialGradient::from(['#ff0000', '#0000ff'], 0.2, 0.3, 1.0);
+        $style = (new Style())->withRadialGradient($g, null, null, 3.0);
+
+        $this->assertSame(
+            RadialGradient::from(['#ff0000', '#0000ff'], 0.2, 0.3, 3.0)->resolve(6, 4),
+            $style->getGradient()->resolve(6, 4)
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

## Description

Adds gradient backgrounds to the TUI component. Any widget — including its padding and border chrome — can display a smooth color transition via `withLinearGradient()` or `withRadialGradient()` on `Style`.

---

## Linear gradient

**2 colors, direction**

```php
$style->withLinearGradient(['#e74c3c', '#3498db']);  // left → right (default)
$style->withLinearGradient(['red', 'blue'], GradientDirection::TopToBottom);
$style->withLinearGradient(['red', 'blue'], GradientDirection::RightToLeft);
$style->withLinearGradient(['red', 'blue'], GradientDirection::BottomToTop);
```
<img width="1098" height="413" alt="image" src="https://github.com/user-attachments/assets/024d8f60-2939-4519-9273-1f25cd10dc70" />


**Arbitrary angle**

```php
$style->withLinearGradient(['#00e5ff', '#ff00e5'], Angle::degrees(45));
$style->withLinearGradient(['#00e5ff', '#ff00e5'], Angle::degrees(135));
$style->withLinearGradient(['#00e5ff', '#ff00e5'], Angle::radians(M_PI / 3));
```

<img width="1093" height="199" alt="image" src="https://github.com/user-attachments/assets/361eb9b7-01bb-4b6b-9811-fd6b94c99c8c" />

**N colors evenly distributed**

```php
$style->withLinearGradient(['#ff0000', '#ff8800', '#ffff00', '#00ff00', '#0000ff', '#8800ff'])
```

<img width="1093" height="199" alt="image" src="https://github.com/user-attachments/assets/35f83641-ec98-4f8c-af44-4ccf9ac09af4" />

---
Color stops

Plain colors without an explicit position are automatically distributed (CSS-compatible algorithm).
ColorStop::at($color, $position) sets an explicit position between 0 and 100.

// Asymmetric: short red burst, long blue tail
```php
$style->withLinearGradient([
    '#ff0000',
    ColorStop::at('#ffff00', 20),
    '#0000ff',
]);

// Hard stop: sharp color boundary (e.g. flag)
$style->withLinearGradient([
    ColorStop::at('blue',  33),
    ColorStop::at('white', 33),  // same position = hard edge
    ColorStop::at('white', 66),
    ColorStop::at('red',   66),
]);
```

<img width="1093" height="399" alt="image" src="https://github.com/user-attachments/assets/040deb6f-52fe-422b-90e1-04b2cd4f4c98" />

---
Radial gradient

```php
// Centered (shorthand)
$style->withRadialGradient(['#ffffff', '#001133']);
$style->withRadialGradient(RadialGradient::centered('yellow', 'red', '#000066'));
```
<img width="1085" height="192" alt="image" src="https://github.com/user-attachments/assets/61805976-f689-4512-8688-03cfa28a765f" />
```php
// Radial with color stop and not centered position
$style->withRadialGradient([
        'yellow', ColorStop::at('yellow', 10),  ColorStop::at('#001133', 10), '#001133'
    ], cx: 0.8, cy: 0.2)
```

<img width="1085" height="192" alt="image" src="https://github.com/user-attachments/assets/561a01c7-c6b9-455e-9845-36240dc885bc" />

---

## Notes

- `withLinearGradient()` and `withRadialGradient()` accept the same color formats as the rest of
  `Style`: named strings (`'red'`), hex strings (`'#ff0000'`), `Color` instances, or 256-palette ints.
- Both need a **truecolor** terminal. Every cell is emitted as a `48;2;R;G;B` sequence, so on a
  256-color terminal the gradient area renders with no background at all.
- A gradient and a background are mutually exclusive. The setters clear one another, and when styles
  cascade through `Style::mergeAll()` the last one set wins.
- The gradient covers the full widget box: content, padding and border chrome.
- Color stops without an explicit position are distributed the way CSS distributes them, and
  out-of-order positions are clamped up to the previous stop rather than sorted.
- Cost: a vertical gradient costs about the same output as a plain background, because the code is
  constant across a row. A horizontal one needs a distinct sequence per column, which measures at
  about 8 times the bytes of a plain background for an 80x24 frame.

- Bonus: for dynamic gradients, call `setStyle()` with `scheduleInterval()`

```php
$tui->scheduleInterval(static function () use (&$angle, $animatedBox): void {
    $angle = ($angle + 3) % 360;
    $animatedBox->setStyle(
        (new Style())
            ->withLinearGradient(['#0000ff', '#ff0000'], Angle::degrees($angle))
            ->withFlex(1)
            ->withPadding(Padding::all(4))
    );
}, 0.05);
```

<img width="1046" height="170" alt="animated" src="https://github.com/user-attachments/assets/cb98afd9-c2b8-421a-bf85-25091841358a" />

## For the documentation

- `Style::withLinearGradient(array|LinearGradient $gradient, GradientDirection|Angle $direction = GradientDirection::LeftToRight)`
  and `Style::withRadialGradient(array|RadialGradient $gradient, float $cx = 0.5, float $cy = 0.5, float $aspectRatio = 2.0)`.
- The four `GradientDirection` cases, and `Angle::degrees()` / `Angle::radians()` for an arbitrary angle.
- `ColorStop::at($color, $position)` with `$position` between 0 and 100, and the hard-stop trick of
  giving two stops the same position.
- `RadialGradient::centered()`, and `cx` / `cy` to move the center, `aspectRatio` to compensate for
  the height of a character cell.
- The truecolor requirement, and the mutual exclusion with `withBackground()`.
