### PR TITLE
 Clarify #[Target] attribute in UPGRADE-8.1

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -21,8 +21,10 @@ DependencyInjection
 
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
  * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
- * Deprecate named autowiring alias that don't use `#[Target]`
+ * Deprecate named autowiring aliases that don't use `#[Target]`
    ```diff
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+
     public function __construct(
    +    #[Target]
         private StorageInterface $imageStorage,

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -17,7 +17,7 @@ CHANGELOG
  * Allow environment variables with `.` in them
  * Add argument `exclude` to `ContainerConfigurator::import()`
  * Add `target` parameter to `#[AsAlias]` to create target-specific autowiring aliases
- * Deprecate named autowiring alias that don't use `#[Target]`
+ * Deprecate named autowiring aliases that don't use `#[Target]`
  * Allow passing a `Definition` instance to `Definition::setFactory()` and `Definition::setConfigurator()`, its `__invoke()` method will be called
  * Add `ServicesResetter`, `ServicesResetterInterface`, and `Compiler\ResettableServicePass` (moved from HttpKernel)
  * Allow resetting non-shared services tagged with `kernel.reset`


### PR DESCRIPTION
Add a use statement to provide the FQCN of the `Target` attribute, for people who are not familiar with all the attributes in the DI component.

Also make a minor grammar fix.

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

As described above, update the UPGRADE-8.1 instructions for the DI component to make it clear what the `#[Target]` attribute is, so someone upgrading doesn't have to hunt down the FQCN for the use statement that would be required to use it.