### PR TITLE
[DependencyInjection] Improve TaggedIteratorArgument deprecation warning

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -43,7 +43,7 @@ class TaggedIteratorArgument extends IteratorArgument
 
         if (\func_num_args() > 5 || !\is_bool($needsIndexes) || !\is_array($exclude) || !\is_bool($excludeSelf)) {
             [, , $defaultIndexMethod, $needsIndexes, $defaultPriorityMethod, $exclude, $excludeSelf] = \func_get_args() + [2 => null, false, null, [], true];
-            trigger_deprecation('symfony/dependency-injection', '8.1', 'The $defaultIndexMethod and $defaultPriorityMethod arguments of tagged locators and iterators are deprecated, use the #[AsTaggedItem] attribute instead.');
+            trigger_deprecation('symfony/dependency-injection', '8.1', 'The $defaultIndexMethod and $defaultPriorityMethod arguments of tagged locators and iterators are deprecated, use the #[AsTaggedItem] attribute instead. (tag: "%s")', $tag);
         } else {
             $defaultIndexMethod = $defaultPriorityMethod = false;
         }


### PR DESCRIPTION
In 8.1, `TaggedIteratorArgument` triggers a deprecation warning if the `$defaultIndexMethod` or `$defaultPriorityMethod` arguments are used.

Add the name of the tag that caused the deprecation warning, so the user knows where in their code (or in third-party packages) to look to resolve the warning.

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

The new deprecation warning is not directly actionable by itself, because it doesn't provide enough context to allow the developer to determine where the warning is coming from. This patch adds the name of the tag, so it is more clear.

Before:
> Since symfony/dependency-injection 8.1: The $defaultIndexMethod and $defaultPriorityMethod arguments of tagged locators and iterators are deprecated, use the #[AsTaggedItem] attribute instead.

After:
> Since symfony/dependency-injection 8.1: The $defaultIndexMethod and $defaultPriorityMethod arguments of tagged locators and iterators are deprecated, use the #[AsTaggedItem] attribute instead. (tag: "**some_tag_name_here**")