### PR TITLE
[Security][SecurityBundle] Add allowedTokenClasses option to ContextListener to restrict token deserialization

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -53,6 +53,13 @@ class ContextListener extends AbstractListener
 
     /**
      * @param iterable<mixed, UserProviderInterface> $userProviders
+     * @param array|true $allowedTokenClasses Passed as the `allowed_classes` option to `unserialize()`
+     *                                         when reading the security token from the session.
+     *                                         Defaults to `true` (allow all classes) for backwards
+     *                                         compatibility. Set to an explicit array of token class
+     *                                         names (including any custom token classes used by your
+     *                                         application) to harden against PHP Object Injection.
+     *                                         Example: [PostAuthenticationToken::class, SwitchUserToken::class]
      */
     public function __construct(
         private TokenStorageInterface $tokenStorage,
@@ -62,6 +69,7 @@ class ContextListener extends AbstractListener
         private ?EventDispatcherInterface $dispatcher = null,
         ?AuthenticationTrustResolverInterface $trustResolver = null,
         ?callable $sessionTrackerEnabler = null,
+        private array|bool $allowedTokenClasses = true,
     ) {
         if (!$contextKey) {
             throw new \InvalidArgumentException('$contextKey must not be empty.');
@@ -282,7 +290,9 @@ class ContextListener extends AbstractListener
         });
 
         try {
-            $token = unserialize($serializedToken);
+            $token = $this->allowedTokenClasses !== true
+                ? unserialize($serializedToken, ['allowed_classes' => $this->allowedTokenClasses])
+                : unserialize($serializedToken);
         } catch (\ErrorException $e) {
             if (0x37313BC !== $e->getCode()) {
                 throw $e;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | n/a
| License       | MIT

## Summary

`ContextListener::safelyUnserialize()` reads the security token from the PHP session and calls `unserialize()` **without restricting `allowed_classes`**.

The existing `unserialize_callback_func` guard only catches instantiation of *not-yet-loaded* classes. It does **not** prevent PHP Object Injection via gadget chains composed of classes that are already loaded in the process (e.g., Doctrine, Monolog, Guzzle, any installed library with a dangerous `__destruct`/`__wakeup`).

## Attack scenario

1. Attacker can write to the PHP session store (compromised session backend, session fixation + session file write, or an unrelated deserialization vuln that writes to session storage).
2. Attacker crafts a serialized payload using gadget classes already loaded by Symfony/Doctrine.
3. On the next authenticated request, `ContextListener` reads and deserializes the token → gadget chain fires → **RCE**.

## Fix

Add an optional `$allowedTokenClasses` constructor parameter (defaulting to `true` for full backwards compatibility) that is forwarded to `unserialize()` as `allowed_classes`.

## Configuration

Regarding @nicolas-grekas's question about how users configure this:

**Option 1 — Explicit constructor injection** (works today, no new config):
```php
// In services.yaml:
Security\Core\Authentication\Token\Storage\TokenStorage: ~

Security\Http\Firewall\ContextListener:
    arguments:
        $allowedTokenClasses:
            - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
            - Symfony\Component\Security\Core\Authentication\Token\RememberMeToken
            - App\Security\Token\ApiToken
```

**Option 2 — Auto-discovery** (could be a follow-up): scan the container for all services implementing `TokenInterface` and build the list automatically. This would be a separate PR/feature.

I propose we land Option 1 first (explicit, opt-in, backwards-compatible — `true` by default means no breakage) and discuss auto-discovery as a follow-up. This gives security-conscious users a way to harden their apps now without forcing a breaking change on everyone.

Happy to adjust the approach based on feedback.