### PR TITLE
[HttpKernel][Security] Add allowed_classes => false to unserialize() in CacheWarmerAggregate, LoggerDataCollector, and HttpCache Store

### DIFF
--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -121,7 +121,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
                 restore_error_handler();
 
                 if (is_file($this->deprecationLogsFilepath)) {
-                    $previousLogs = unserialize(file_get_contents($this->deprecationLogsFilepath));
+                    $previousLogs = unserialize(file_get_contents($this->deprecationLogsFilepath), ['allowed_classes' => false]);
                     if (\is_array($previousLogs)) {
                         $collectedLogs = array_merge($previousLogs, $collectedLogs);
                     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -184,7 +184,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 
         $bootTime = filemtime($file);
         $logs = [];
-        foreach (unserialize($logContent) as $log) {
+        foreach (unserialize($logContent, ['allowed_classes' => false]) as $log) {
             $log['context'] = ['exception' => new SilencedErrorContext($log['type'], $log['file'], $log['line'], $log['trace'], $log['count'])];
             $log['timestamp'] = $bootTime;
             $log['timestamp_rfc3339'] = (new \DateTimeImmutable())->setTimestamp($bootTime)->format(\DateTimeInterface::RFC3339_EXTENDED);

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -308,7 +308,7 @@ class Store implements StoreInterface
             return [];
         }
 
-        return unserialize($entries) ?: [];
+        return unserialize($entries, ['allowed_classes' => false]) ?: [];
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR hardens three `unserialize()` call sites in `symfony/http-kernel` by adding `allowed_classes => false`, preventing PHP Object Injection via attacker-controlled cache files.

## Affected files

| File | Data deserialized | Objects expected? |
|------|-------------------|-------------------|
| `CacheWarmer/CacheWarmerAggregate.php` | Deprecation logs: `['type', 'message', 'file', 'line', 'trace', 'count']` — all scalars/arrays | ❌ No |
| `DataCollector/LoggerDataCollector.php` | Same deprecation log format from warmup phase | ❌ No |
| `HttpCache/Store.php` | HTTP cache metadata: arrays of `[request_env, response_headers]` — only strings/arrays | ❌ No |

## Security impact

If an attacker gains a **file write primitive** (e.g., via a separate vulnerability, path traversal, or compromised NFS/shared storage), they could craft a malicious `.meta` or deprecation log file containing a PHP gadget chain. Without `allowed_classes => false`, `unserialize()` would instantiate arbitrary PHP objects, enabling Remote Code Execution via PHP Object Injection.

Adding `allowed_classes => false` ensures `unserialize()` only returns plain arrays and scalars — exactly what these call sites expect — and converts any crafted object payload into a safe `__PHP_Incomplete_Class` that cannot trigger gadget chains.

## Verification

The data written to these files never includes PHP objects:
- `CacheWarmerAggregate` writes `serialize(array_values($collectedLogs))` where `$collectedLogs` contains only scalar/array entries from PHP's error handler
- `LoggerDataCollector` reads the same file written by `CacheWarmerAggregate`  
- `HttpCache\Store` writes `serialize($entries)` where `$entries` is an array of `[string[], string[]]` (request env + response headers)

This is a defense-in-depth improvement with zero functional impact.

---

| Q | A |
|---|---|
| Branch? | 6.4 |
| Bug fix? | yes |
| New feature? | no |
| Deprecations? | no |
| Tests needed? | no (behavior unchanged; `allowed_classes` only restricts what is already not present) |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |