### PR TITLE
[FrameworkBundle] Fix "allow_no_handlers" being ignored on message buses

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2428,7 +2428,7 @@ class FrameworkExtension extends Extension
 
             if ($bus['default_middleware']['enabled']) {
                 $defaultMiddleware['after'][0]['arguments'] = [$bus['default_middleware']['allow_no_senders']];
-                $defaultMiddleware['after'][1]['arguments'] = [$bus['default_middleware']['allow_no_handlers']];
+                $defaultMiddleware['after'][1]['arguments'] = ['index_1' => $bus['default_middleware']['allow_no_handlers']];
 
                 $middleware = array_merge($defaultMiddleware['before'], $middleware, $defaultMiddleware['after']);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1296,7 +1296,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
-            ['id' => 'handle_message', 'arguments' => [false]],
+            ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
         $this->assertSame([], $container->getDefinition('messenger.bus.events')->getArgument(0));
@@ -1309,7 +1309,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message', 'arguments' => [true]],
-            ['id' => 'handle_message', 'arguments' => [false]],
+            ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
         $this->assertTrue($container->has('messenger.bus.queries'));
         $this->assertSame([], $container->getDefinition('messenger.bus.queries')->getArgument(0));
@@ -1342,7 +1342,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ...(class_exists(DecodeFailedMessageMiddleware::class) ? [['id' => 'decode_failed_message_middleware']] : []),
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
-            ['id' => 'handle_message', 'arguments' => [false]],
+            ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
     }
 
@@ -1365,7 +1365,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
-            ['id' => 'handle_message', 'arguments' => [false]],
+            ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
         $this->assertSame([], $container->getDefinition('messenger.bus.events')->getArgument(0));
@@ -1379,7 +1379,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
             ['id' => 'deduplicate_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message', 'arguments' => [true]],
-            ['id' => 'handle_message', 'arguments' => [false]],
+            ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
         $this->assertTrue($container->has('messenger.bus.queries'));
         $this->assertSame([], $container->getDefinition('messenger.bus.queries')->getArgument(0));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since 8.1, the `allow_no_handlers` option configured on a message bus is silently ignored: dispatching a message with no handler on such a bus throws `NoHandlerForMessageException` even though `allow_no_handlers: true` is set.

#### Root cause

`HandleMessageMiddleware` gained a third constructor argument (`$clock`) in 8.1, and the abstract `messenger.middleware.handle_message` definition was updated accordingly:

```php
->set('messenger.middleware.handle_message', HandleMessageMiddleware::class)
    ->abstract()
    ->args([
        abstract_arg('bus handler resolver'), // index 0
        false,                                // index 1 — $allowNoHandlers
        service('clock')->nullOnInvalid(),    // index 2
    ])
```

But `FrameworkExtension` still wires `allow_no_handlers` as a bare positional argument:

```php
$defaultMiddleware['after'][1]['arguments'] = [$bus['default_middleware']['allow_no_handlers']];
```

When the per-bus child definition is resolved, numeric argument keys are *appended* (`ResolveChildDefinitionsPass` calls `addArgument()`), so the value lands at **index 3** — outside the constructor signature — while `$allowNoHandlers` keeps its hard-coded `false` at index 1:

```
[0] => Reference(resolver), [1] => false, [2] => Reference(clock), [3] => true
```

Before 8.1 the abstract definition had a single argument, so the appended value landed exactly on index 1 and the option worked — hence the regression.

#### Fix

Wire the value with an explicit `index_1` key so it replaces `$allowNoHandlers` instead of being appended:

```php
$defaultMiddleware['after'][1]['arguments'] = ['index_1' => $bus['default_middleware']['allow_no_handlers']];
```

The resolved definition becomes `[Reference(resolver), true, Reference(clock)]`, with `$clock` preserved.

The existing `FrameworkExtensionTestCase` assertions only checked the intermediate `messenger.bus.*.middleware` parameter, where `allow_no_handlers` defaults to `false`, so `false === false` masked the bug; they are updated to reflect the corrected wiring.

Note: `allow_no_senders` (the sibling `send_message` middleware) uses the same positional-append pattern but is unaffected, because its abstract definition has exactly two arguments and `$allowNoSenders` is the third — the append happens to land on the right index. It may be worth hardening it the same way for robustness.
