### PR TITLE
[Form] Translate TranslatableInterface label in violation messages

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -21,6 +21,7 @@ use Symfony\Component\PropertyAccess\PropertyPathIterator;
 use Symfony\Component\PropertyAccess\PropertyPathIteratorInterface;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -184,24 +185,28 @@ class ViolationMapper implements ViolationMapperInterface
                     }
 
                     if (null !== $this->translator) {
-                        $form = $scope;
-                        $translationParameters[] = $form->getConfig()->getOption('label_translation_parameters', []);
+                        if ($label instanceof TranslatableInterface) {
+                            $label = $label->trans($this->translator);
+                        } else {
+                            $form = $scope;
+                            $translationParameters[] = $form->getConfig()->getOption('label_translation_parameters', []);
 
-                        do {
-                            $translationDomain = $form->getConfig()->getOption('translation_domain');
-                            array_unshift(
+                            do {
+                                $translationDomain = $form->getConfig()->getOption('translation_domain');
+                                array_unshift(
+                                    $translationParameters,
+                                    $form->getConfig()->getOption('label_translation_parameters', [])
+                                );
+                            } while (null === $translationDomain && null !== $form = $form->getParent());
+
+                            $translationParameters = array_merge([], ...$translationParameters);
+
+                            $label = $this->translator->trans(
+                                $label,
                                 $translationParameters,
-                                $form->getConfig()->getOption('label_translation_parameters', [])
+                                $translationDomain
                             );
-                        } while (null === $translationDomain && null !== $form = $form->getParent());
-
-                        $translationParameters = array_merge([], ...$translationParameters);
-
-                        $label = $this->translator->trans(
-                            $label,
-                            $translationParameters,
-                            $translationDomain
-                        );
+                        }
                     }
 
                     $message = str_replace('{{ label }}', $label, $message);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -27,6 +27,9 @@ use Symfony\Component\Form\Tests\Extension\Validator\ViolationMapper\Fixtures\Is
 use Symfony\Component\Form\Tests\Fixtures\DummyFormRendererEngine;
 use Symfony\Component\Form\Tests\Fixtures\FixedTranslator;
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -1632,6 +1635,44 @@ class ViolationMapperTest extends TestCase
             /** @var FormError $error */
             $error = $errors[0];
             $this->assertSame('Message Translated Label', $error->getMessage());
+        }
+    }
+
+    public function testMessageWithTranslatableLabel()
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', ['options_label' => 'Translated %what% Label'], 'en', 'custom_domain');
+
+        $this->mapper = new ViolationMapper(null, $translator);
+
+        $parent = $this->getForm('parent');
+
+        $config = new FormConfigBuilder('name', null, $this->dispatcher, [
+            'error_mapping' => [],
+            'label' => new TranslatableMessage('options_label', ['%what%' => 'Custom'], 'custom_domain'),
+        ]);
+        $config->setMapped(true);
+        $config->setInheritData(false);
+        $config->setPropertyPath('name');
+        $config->setCompound(true);
+        $config->setDataMapper(new DataMapper());
+
+        $child = new Form($config);
+        $parent->add($child);
+
+        $parent->submit([]);
+
+        $violation = new ConstraintViolation('Message {{ label }}', null, [], null, 'data.name', null);
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertCount(1, $child->getErrors(), $child->getName().' should have an error, but has none');
+
+        $errors = iterator_to_array($child->getErrors());
+        if (isset($errors[0])) {
+            /** @var FormError $error */
+            $error = $errors[0];
+            $this->assertSame('Message Translated Custom Label', $error->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64401
| License       | MIT

When a violation message contains the `{{ label }}` placeholder, the `ViolationMapper` resolves the label through the translator. If the field's `label` option is a `TranslatableInterface` (e.g. a `TranslatableMessage`), it was passed as-is to `$translator->trans()`. Since `TranslatableMessage` has a `__toString()`, this didn't crash, but the object was coerced to its raw message key and translated with the *form's* domain/parameters — silently ignoring the `TranslatableMessage`'s own message, parameters and domain. As a result the label was not translated.

This PR detects `TranslatableInterface` labels and resolves them via `$label->trans($this->translator)`, so their own message, parameters and domain are honored.