### PR TITLE
[HttpKernel] Fix TypeError in ResponseEvent when argument resolution throws

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -216,7 +216,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      */
     private function filterResponse(Response $response, Request $request, int $type, ?ControllerMetadata $controllerMetadata = null): Response
     {
-        $event = new ResponseEvent($this, $request, $type, $response, $controllerMetadata);
+        $event = new ResponseEvent($this, $request, $type, $response, $controllerMetadata instanceof ControllerArgumentsMetadata ? $controllerMetadata : null);
 
         $this->dispatcher->dispatch($event, KernelEvents::RESPONSE);
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -553,6 +553,31 @@ class HttpKernelTest extends TestCase
         $this->assertSame(['meta'], $capturedArguments);
     }
 
+    public function testResponseEventWhenArgumentResolutionThrows()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::EXCEPTION, static function ($event) {
+            $event->setResponse(new Response('handled', 400));
+        });
+
+        $controllerResolver = $this->createStub(ControllerResolverInterface::class);
+        $controllerResolver
+            ->method('getController')
+            ->willReturn(static fn () => new Response('never'));
+
+        $argumentResolver = $this->createStub(ArgumentResolverInterface::class);
+        $argumentResolver
+            ->method('getArguments')
+            ->willThrowException(new BadRequestHttpException('boom'));
+
+        $kernel = new HttpKernel($dispatcher, $controllerResolver, null, $argumentResolver);
+
+        $response = $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, true);
+
+        $this->assertSame('handled', $response->getContent());
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
     public function testFinishRequestEventKeepsControllerMetadata()
     {
         $dispatcher = new EventDispatcher();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64423, Fix #64412
| License       | MIT

In `HttpKernel::handleRaw()`, `$controllerMetadata` is first set to the parent `ControllerMetadata` and only upgraded to `ControllerArgumentsMetadata` after the arguments have been resolved. When argument resolution throws in between (e.g. `#[MapRequestPayload]`/`#[MapQueryString]` validation failures, or any `ValueResolverInterface` raising an exception), the throwable flows through `handleThrowable()` -> `filterResponse()` (typed `?ControllerMetadata`) -> `new ResponseEvent(...)`, whose last argument was tightened to `?ControllerArgumentsMetadata` in 8.1.0. Passing the parent type triggers a `TypeError` and the error response built by the EXCEPTION listener is discarded.

This downgrades the metadata to `null` when it is not a `ControllerArgumentsMetadata`, keeping `ResponseEvent`'s signature unchanged: when the arguments were never resolved, there is no argument metadata to expose anyway.