### PR TITLE
[Mailer] Fix inline images in MandrillApiTransport by using the Content-ID as image name

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class MandrillApiTransportTest extends TestCase
@@ -155,5 +156,53 @@ class MandrillApiTransportTest extends TestCase
         $this->assertArrayNotHasKey('headers', $payload['message']);
         $this->assertArrayHasKey('tags', $payload['message']);
         $this->assertSame(['password-reset', 'user', 'another'], $payload['message']['tags']);
+    }
+
+    public function testInlineImageUsesContentIdAsName()
+    {
+        $imagePart = new DataPart('image-content', 'logo.png', 'image/png');
+        $imagePart->asInline();
+        $cid = $imagePart->getContentId();
+
+        $email = new Email();
+        $email->from('from@example.com')
+            ->to('to@example.com')
+            ->html(\sprintf('<img src="cid:%s">', $cid))
+            ->addPart($imagePart);
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('images', $payload['message']);
+        $this->assertCount(1, $payload['message']['images']);
+        // The HTML references "cid:<content-id>", so Mandrill's image "name" (which it
+        // uses as the Content-ID) must match the part's Content-ID, not the filename.
+        $this->assertNotSame('logo.png', $payload['message']['images'][0]['name']);
+        $this->assertSame($cid, $payload['message']['images'][0]['name']);
+    }
+
+    public function testInlineImageWithoutContentIdKeepsFilenameAsName()
+    {
+        $imagePart = new DataPart('image-content', 'logo.png', 'image/png');
+        $imagePart->asInline();
+
+        $email = new Email();
+        $email->from('from@example.com')
+            ->to('to@example.com')
+            ->html('<img src="cid:logo.png">')
+            ->addPart($imagePart);
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('images', $payload['message']);
+        $this->assertCount(1, $payload['message']['images']);
+        // The HTML references "cid:logo.png" and no Content-ID was set, so the image
+        // "name" must keep matching the filename rather than an auto-generated Content-ID.
+        $this->assertSame('logo.png', $payload['message']['images'][0]['name']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -111,6 +111,9 @@ class MandrillApiTransport extends AbstractApiTransport
             }
 
             if ('inline' === $disposition) {
+                if ($attachment->hasContentId()) {
+                    $att['name'] = $attachment->getContentId();
+                }
                 $payload['message']['images'][] = $att;
             } else {
                 $payload['message']['attachments'][] = $att;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64428
| License       | MIT

`MandrillApiTransport` sends inline/embedded images to the Mandrill API using the part's **filename** as the image `name`. Mandrill uses that `name` as the image's `Content-ID` (the value referenced in HTML via `<img src="cid:...">`).

However, the rendered HTML body references each embedded image by its **Content-ID**, not by its filename. Since `WrappedTemplatedEmail::image()` (and `Email::embed*()`) generate a random Content-ID (e.g. `1a2b3c…@symfony`), the HTML points at `cid:1a2b3c…@symfony` while the transport tells Mandrill to label the image `Content-Id: <logo.png>`. The two no longer match, so clients (e.g. Gmail) cannot resolve the reference and the inline image is **not displayed**.

This regressed when `WrappedTemplatedEmail::image()` switched from returning `cid:<name>` (the filename) to `cid:<generated-content-id>`; the Mandrill transport still maps inline images by filename.

Per Mandrill's Messages API, the `images[].name` field is documented as the image's Content-ID ("use `<img src='cid:THIS_VALUE'>` to reference the image"). This PR sets the inline image `name` to the part's `Content-ID` so the `cid:` references in the HTML resolve. Regular (non-inline) attachments keep using the filename.

A test is included asserting that an inline image's `name` in the payload equals the part's Content-ID.
