### PR TITLE
 Update installation command for Stopwatch component

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -122,7 +122,7 @@
 
     {% if not collector.isStopwatchInstalled() %}
         <div class="empty empty-panel">
-            <p>The Stopwatch component is not installed. If you want to see timing events, run: <code>composer require symfony/stopwatch</code>.</p>
+            <p>The Stopwatch component is not installed. If you want to see timing events, run: <code>composer require symfony/stopwatch --dev</code>.</p>
         </div>
     {% elseif collector.events is empty %}
         <div class="empty">


### PR DESCRIPTION
For the profiler, it seems better to install the symfony/stopwatch component in dev environment.

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Hey, I just updated the twig template to require `symfony/stopwatch` in `dev` in the profiler section.
