### PR TITLE
[HttpKernel] Attribute on controller has higher priority than one on class during resolution in `ControllerEvent::getAttributes()`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -101,7 +101,7 @@ final class ControllerEvent extends KernelEvent
             };
             $attributes = [];
 
-            foreach (array_merge($class?->getAttributes() ?? [], $this->controllerReflector->getAttributes()) as $attribute) {
+            foreach (array_merge($this->controllerReflector->getAttributes(), $class->getAttributes() ?? []) as $attribute) {
                 if (class_exists($attribute->getName())) {
                     $attributes[] = $attribute->newInstance();
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

We are use to write `$r->getAttributes(XXX::class)[0] ?? null`
It means we think the most useful attributes is in first position.

With previous code, we use the class attriute, not the one on the method.

IMHO, the one method should have an higher priority.

Example:

```php
[Loggable(level: 'info')]
class TopicController extends AbstractController
{
    public function __construct(
        private readonly TopicRepository $topicRepository,
        private readonly EntityManagerInterface $em,
    ) {
    }

    #[Loggable(level: 'warning')]
    #[Route('/', name: 'topic_index')]
    public function index(): Response
```

I would expect to log the index controller at `warning` level, not info level.
