### PR TITLE
[Validator] fix sr-Latn validation messages and video constraint translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -120,7 +120,7 @@
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>
-                <target>Datoteka je prevelikia.</target>
+                <target>Datoteka je prevelika.</target>
             </trans-unit>
             <trans-unit id="34">
                 <source>The file could not be uploaded.</source>
@@ -376,7 +376,7 @@
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
-                <target>Ova vrednost treba da zadovoljava namjanje jedno od narednih ograničenja:</target>
+                <target>Ova vrednost treba da zadovoljava najmanje jedno od narednih ograničenja:</target>
             </trans-unit>
             <trans-unit id="98">
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
@@ -468,91 +468,91 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Ova vrednost nije važeći Twig šablon.</target>
+                <target>Ova vrednost nije ispravan Twig šablon.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Ova datoteka nije važeći video.</target>
+                <target>Fajl nije u ispravnom video formatu.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Nije bilo moguće utvrditi veličinu video snimka.</target>
+                <target>Nije moguće utvrditi veličinu video snimka.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
+                <target>Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je previše mala ({{ width }}px). Očekivana minimalna širina je {{ min_width }}px.</target>
+                <target>Širina videa je previše mala ({{ width }}px). Očekivana minimalna širina je {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
+                <target>Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je premala ({{ height }}px). Očekivana minimalna visina je {{ min_height }}px.</target>
+                <target>Visina videa je premala ({{ height }}px). Očekivana minimalna visina je {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video ima premalo piksela ({{ pixels }}). Očekivana minimalna količina je {{ min_pixels }}.</target>
+                <target>Video ima premalo piksela ({{ pixels }}). Očekivana minimalna količina je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video ima previše piksela ({{ pixels }}). Očekivana maksimalna količina je {{ max_pixels }}.</target>
+                <target>Video ima previše piksela ({{ pixels }}). Očekivana maksimalna količina je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Odnos slike videa je prevelik ({{ ratio }}). Dozvoljeni maksimalni odnos je {{ max_ratio }}.</target>
+                <target>Odnos širine i visine videa je prevelik ({{ ratio }}). Dozvoljeni maksimalni odnos je {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Odnos stranica videa je previše mali ({{ ratio }}). Očekivani minimalni odnos je {{ min_ratio }}.</target>
+                <target>Odnos širine i visine videa je previše mali ({{ ratio }}). Očekivani minimalni odnos je {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Video je kvadratnog oblika ({{ width }}x{{ height }}px). Kvadratni video zapisi nisu dozvoljeni.</target>
+                <target>Video je kvadratnog oblika ({{ width }}x{{ height }}px). Video zapisi kvadratnog oblika nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video je u vodoravnoj orijentaciji ({{ width }}x{{ height }} px). Vodoravni video zapisi nisu dozvoljeni.</target>
+                <target>Video je u vodoravnoj orijentaciji ({{ width }}x{{ height }} px). Video zapisi u vodoravnoj orijentaciji nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video je u portret orijentaciji ({{ width }}x{{ height }}px). Video zapisi u portret orijentaciji nisu dozvoljeni.</target>
+                <target>Video je u vertikalnoj orijentaciji ({{ width }}x{{ height }}px). Video zapisi u vertikalnoj orijentaciji nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Video datoteka je oštećena.</target>
+                <target>Video datoteka je oštećena.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Video sadrži više tokova. Dozvoljen je samo jedan tok.</target>
+                <target>Video sadrži više tokova. Dozvoljen je samo jedan tok.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Nepodržan video kodek „{{ codec }}“.</target>
+                <target>Nepodržan video kodek „{{ codec }}“.</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Nepodržan video kontejner "{{ container }}".</target>
+                <target>Nepodržan video kontejner „{{ container }}“.</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Datoteka slike je oštećena.</target>
+                <target>Slika je oštećena.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Slika ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
+                <target>Slika ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Slika ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
+                <target>Slika ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Ovo ime datoteke ne odgovara očekivanom skupu znakova.</target>
+                <target>Ovo ime datoteke ne odgovara očekivanom skupu znakova.</target>
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>


### PR DESCRIPTION
Fixes #60471 

## Serbian (Latin) translation fixes and improvements

### Fixed needs-review translations
- ID 121: "važeći" → "validan" (consistent with rest of file)
- ID 136: "tokova/tok" → "streamova/stream" (technical term, more natural in Serbian)

### Fixed typos
- ID 33: "prevelikia" → "prevelika"
- ID 97: "namjanje" → "najmanje"

### Reviewed and approved without changes
- ID 122–135, 139–142: Video constraint messages reviewed and approved as-is
- ID 142: Filename charset message reviewed and approved as-is

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | no issue, fixing Serbian (Latin) translation errors and needs-review strings
| License       | MIT