### PR TITLE
[FrameworkBundle] Fix dumping the debug container on `cache:clear`/`cache:warmup`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Kernel\KernelTrait;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\Loader\PhpFileLoader as RoutingPhpFileLoader;
 use Symfony\Component\Routing\RouteCollection;
@@ -154,5 +155,10 @@ trait MicroKernelTrait
     private function getBundlesDefinition(): array
     {
         return $this->doGetBundlesDefinition() ?: [FrameworkBundle::class => ['all' => true]];
+    }
+
+    private function getEffectiveBuildDir(): string
+    {
+        return \Closure::bind(fn () => $this->warmupDir, $this, Kernel::class)() ?? $this->getBuildDir();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -211,6 +211,31 @@ class MicroKernelTraitTest extends TestCase
         $this->assertSame('OK', $response->getContent());
     }
 
+    public function testRebootDumpsDebugContainerInWarmupDir()
+    {
+        $cacheDir = sys_get_temp_dir().'/'.uniqid('sf_debug_warmup_', true);
+        $warmupDir = $cacheDir.'_warmup';
+        $fs = new Filesystem();
+        $fs->remove([$cacheDir, $warmupDir]);
+
+        $kernel = $this->kernel = new DebugWarmupKernel($cacheDir);
+
+        try {
+            $kernel->boot();
+            $containerClass = $kernel->getContainer()->getParameter('kernel.container_class');
+
+            // Rebooting in a fresh warmup directory must recompile the container there,
+            // so that ContainerBuilderDebugDumpPass (which only runs during compile())
+            // re-dumps the debug container used by tooling (e.g. debug:container, phpstan).
+            $kernel->reboot($warmupDir);
+
+            $this->assertSame(realpath($warmupDir), realpath($kernel->getContainer()->getParameter('kernel.build_dir')));
+            $this->assertFileExists($warmupDir.'/'.$containerClass.'.xml');
+        } finally {
+            $fs->remove($warmupDir);
+        }
+    }
+
     public function testGetKernelParameters()
     {
         $kernel = $this->kernel = new ConcreteMicroKernel('test', false);
@@ -289,6 +314,36 @@ class MicroKernelTraitTest extends TestCase
         $this->assertSame($projectDir.'/var/custom-cache/test', $kernel->getCacheDir());
         $this->assertSame($projectDir.'/var/custom-build/test', $kernel->getBuildDir());
         $this->assertSame($projectDir.'/var/custom-share/test', $kernel->getShareDir());
+    }
+}
+
+class DebugWarmupKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct(private readonly string $cacheDir)
+    {
+        parent::__construct('test', true);
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->cacheDir;
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->cacheDir;
+    }
+
+    protected function configureContainer(ContainerConfigurator $c): void
+    {
+        $c->extension('framework', ['http_method_override' => false, 'handle_all_throwables' => true]);
+        $c->services()->set('logger', NullLogger::class);
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64434
| License       | MIT

Since the 8.1 kernel/DI refactor, `cache:clear` and `cache:warmup` stopped re-dumping the debug container (`var/cache/<env>/App_Kernel<Env>DebugContainer.xml`), breaking tooling that reads it (`debug:container`, `lint:container`, phpstan-symfony's `containerXmlPath`...). Running `cache:clear` repeatedly even toggled the file on and off.

Root cause: `MicroKernelTrait` does its own `use KernelTrait`, so `KernelTrait::getEffectiveBuildDir()` gets re-imported at the final kernel level and shadows the warmup-aware override of `HttpKernel\Kernel` (PHP trait precedence is "current class > trait > inherited parent"). During a `cache:clear`, the warmup `reboot()` therefore resolved to the regular build dir, found a fresh container and reused it instead of recompiling into the warmup dir. Since `ContainerBuilderDebugDumpPass` only runs during `compile()`, the XML was never re-dumped on that path.

The fix restores the warmup awareness from `MicroKernelTrait` only, without touching the `HttpKernel` and `DependencyInjection` components: it re-declares `getEffectiveBuildDir()` and reads the parent `Kernel`'s `$warmupDir`.