### PR TITLE
[DomCrawler] Remove final keyword on `ChoiceFormField::addChoice()`

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -144,7 +144,7 @@ class ChoiceFormField extends FormField
      * @throws \LogicException When choice provided is neither multiple, radio nor select,
      *                         or when the node tag does not match the field type
      */
-    final public function addChoice(\DOMElement $node): void
+    public function addChoice(\DOMElement $node): void
     {
         if (!$this->multiple && !\in_array($this->type, ['radio', 'select'], true)) {
             throw new \LogicException(\sprintf('Unable to add a choice for "%s" as it is neither multiple, a radio button nor a select field (type is "%s").', $this->name, $this->type));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #64442 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT


This PR fixes #64442.

Previously, using the `symfony/dom-crawler` component with `symfony/panther` will produce the following error: 

`Cannot override final method Symfony\Component\DomCrawler\Field\ChoiceFormField::addChoice()`. 

This change remove the `final` keyword to ensure a backward compatibility with the `symfony/panther` component.


<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
