### PR TITLE
[Form] Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled
+
 8.1
 ---
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
@@ -29,6 +29,7 @@ class IntegerType extends AbstractType
     {
         if ($options['grouping']) {
             $view->vars['type'] = 'text';
+            $view->vars['attr']['inputmode'] = 'numeric';
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -59,6 +59,14 @@ class IntegerTypeTest extends BaseTypeTestCase
         $this->assertSame('١٢٣٬٤٥٦', $form->getViewData());
     }
 
+    public function testNumericInputmodeWhenGrouping()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, ['grouping' => true])->createView();
+
+        $this->assertSame('text', $view->vars['type']);
+        $this->assertSame('numeric', $view->vars['attr']['inputmode']);
+    }
+
     public function testSubmitRejectsFloats()
     {
         $form = $this->factory->create(static::TESTED_TYPE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

At least for consistency with NumberType, but also for improved UX of course.

> [!NOTE]
> I considered adding an `html5` option but thought this would serve no purpose: nobody would want to turn html5-mode off (it's the default already, to generate a `type="number"`).