### PR TITLE
[HttpKernel] Fix #[MapRequestPayload] being handled before #[IsGranted]

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -209,8 +209,10 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
 
     public static function getSubscribedEvents(): array
     {
+        // Keep this priority lower than ControllerAttributesListener (-10000) so that gate
+        // attributes such as #[IsGranted] are handled before the payload is mapped.
         return [
-            KernelEvents::CONTROLLER_ARGUMENTS => 'onKernelControllerArguments',
+            KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', -10100],
         ];
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -26,10 +27,14 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestPayloadValue
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Buz;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\BasicTypesController;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\ControllerAttributesController;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
@@ -332,6 +337,37 @@ class RequestPayloadValueResolverTest extends TestCase
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertSame('This value should be of type string.', $validationFailedException->getViolations()[0]->getMessage());
         }
+    }
+
+    public function testControllerAttributeListenersRunBeforePayloadMapping()
+    {
+        $content = '{"price": 50.0, "title": ["not a string"]}';
+        $serializer = new Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()]);
+
+        $resolver = new RequestPayloadValueResolver($serializer, (new ValidatorBuilder())->getValidator());
+
+        $argument = new ArgumentMetadata('invalid', RequestPayload::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], $content);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, [new ControllerAttributesController(), 'buzAction'], $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($resolver);
+        $dispatcher->addSubscriber(new ControllerAttributesListener([
+            KernelEvents::CONTROLLER_ARGUMENTS => [Buz::class => true],
+        ]));
+        $dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS.'.'.Buz::class, static function () {
+            throw new \RuntimeException('Access denied by a controller attribute listener.');
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Access denied by a controller attribute listener.');
+
+        $dispatcher->dispatch($event, KernelEvents::CONTROLLER_ARGUMENTS);
     }
 
     public function testValidationFailedOnInvalidBackedEnum()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64439
| License       | MIT

In 8.1, `#[MapRequestPayload]` (and `#[MapQueryString]` / `#[MapUploadedFile]`) are mapped and validated *before* controller-attribute listeners such as `#[IsGranted]` run. As a result, an unauthorized request that also carries a malformed body gets a `422` (validation error) instead of a `401`/`403` (authorization error).

This is a priority inversion introduced by the new attribute-dispatch architecture. `RequestPayloadValueResolver` performs the actual mapping in a `kernel.controller_arguments` listener at the default priority `0`, while the new `ControllerAttributesListener` (which dispatches `#[IsGranted]` and friends) runs at `-10000`, so payload mapping now happens first. Before 8.1, the gate attributes ran at priorities 30/25/20/10, all above the resolver's `0`.

The fix lowers the resolver's listener priority below `ControllerAttributesListener` so the gate attributes (`#[IsGranted]`, `#[IsCsrfTokenValid]`, `#[IsSignatureValid]`, `#[Cache]`, `#[RateLimit]`) are all handled before the payload is mapped. This restores the "security gate first" default established in #50125 (fixing #50120); the inverse use case (accessing the payload from `#[IsGranted]`) remains a separate, opt-in topic as discussed there.
