### PR TITLE
 Precise return type of Uuid::toString

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -20,6 +20,10 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
 {
     /**
      * The identifier in its canonic representation.
+     *
+     * @var non-empty-string
+     *
+     * @phpstan-var non-empty-string&non-decimal-int-string
      */
     protected string $uid;
 
@@ -137,6 +141,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      * @example 09748193-048a-4bfb-b825-8528cf74fdc1 (len=36)
      *
      * @return non-empty-string
+     *
+     * @phpstan-return non-empty-string&non-decimal-int-string
      */
     public function toRfc4122(): string
     {
@@ -155,6 +161,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
      * @example 0x09748193048a4bfbb8258528cf74fdc1 (len=34)
      *
      * @return non-empty-string
+     *
+     * @phpstan-return non-empty-string&non-decimal-int-string
      */
     public function toHex(): string
     {
@@ -175,6 +183,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
 
     /**
      * @return non-empty-string
+     *
+     * @phpstan-return non-empty-string&non-decimal-int-string
      */
     public function hash(): string
     {
@@ -188,6 +198,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
 
     /**
      * @return non-empty-string
+     *
+     * @phpstan-return non-empty-string&non-decimal-int-string
      */
     final public function toString(): string
     {
@@ -196,6 +208,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
 
     /**
      * @return non-empty-string
+     *
+     * @phpstan-return non-empty-string&non-decimal-int-string
      */
     public function __toString(): string
     {
@@ -204,6 +218,8 @@ abstract class AbstractUid implements \JsonSerializable, \Stringable, HashableIn
 
     /**
      * @return non-empty-string
+     *
+     * @phpstan-return non-empty-string&non-decimal-int-string
      */
     public function jsonSerialize(): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

See https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys#safer-array-keys

In PHPStan 2.2+, there is a new type `non-decimal-int-string` to tell that if the string is used as an array key it won't be casted to int.
Updating Uuid::toString is useful when the uuid is used as an array key. (and then keys are used later on method accepting only string, either because strict_type is used or just to avoid a false-positive error from PHPStan)

I used the `phpstan-` prefixed annotation since not all static analysis tool will support the syntax I think.