### PR TITLE
[Form] Add missing translation for invalid UUID

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.af.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Voer assblief 'n geldige week in.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Voer assblief 'n geldige UUID in.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>الرجاء إدخال أسبوع صالح.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">الرجاء إدخال UUID صالح.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.az.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.az.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Zəhmət olmasa doğru bir həftə seçin.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Zəhmət olmasa doğru bir UUID daxil edin.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.be.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Калі ласка, увядзіце карэктны тыдзень.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Калі ласка, увядзіце карэктны UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Моля въведете валидна седмица.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Моля въведете валиден UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Molim upišite ispravnu sedmicu.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Molim upišite ispravan UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ca.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Introduïu una setmana vàlida.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Introduïu un UUID vàlid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Prosím zadejte platný týden.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Prosím zadejte platný UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.cy.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target state="needs-review-translation">Nodwch wythnos ddilys.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Nodwch UUID dilys.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.da.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Indtast venligst en gyldig uge.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Indtast venligst en gyldig UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Bitte geben Sie eine gültige Woche ein.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Bitte geben Sie eine gültige UUID ein.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.el.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Παρακαλούμε εισάγετε μία έγκυρη εβδομάδα.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Παρακαλούμε εισάγετε ένα έγκυρο UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Please enter a valid week.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target>Please enter a valid UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Por favor, ingrese una semana válida.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Por favor, ingrese un UUID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.et.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Palun sisesta korrektne nädal.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Palun sisesta korrektne UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.eu.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Mesedez, sartu baliozko aste bat.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Mesedez, sartu baliozko UUID bat.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>لطفاً یک هفته‌ معتبر وارد کنید.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">لطفاً یک UUID معتبر وارد کنید.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Syötä kelvollinen viikko.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Syötä kelvollinen UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fr.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Veuillez entrer une semaine valide.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target>Veuillez entrer un UUID valide.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.gl.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Por favor, introduce unha semana válida.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Por favor, introduce un UUID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>אנא הזן שבוע תקף.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">אנא הזן UUID תקף.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hr.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Molim unesite ispravni tjedan.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Molim unesite ispravan UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hu.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Kérjük, adjon meg egy érvényes hetet.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Kérjük, adjon meg egy érvényes UUID-t.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hy.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Մուտքագրեք վավեր շաբաթ։</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Մուտքագրեք վավեր UUID։</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.id.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Silahkan masukkan minggu yang sah.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Silahkan masukkan UUID yang sah.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Per favore, inserisci una settimana valida.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Per favore, inserisci un UUID valido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>有効な週を入力してください。</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">有効なUUIDを入力してください。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lb.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>W.e.g. eng gëlteg Woch aginn.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">W.e.g. eng gëlteg UUID aginn.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lt.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Prašome įvesti tinkamą savaitę.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Prašome įvesti tinkamą UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Lūdzu, ievadiet derīgu nedēļu.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Lūdzu, ievadiet derīgu UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.mk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.mk.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Ве молиме внесете валидна недела.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Ве молиме внесете валиден UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.mn.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Үнэн зөв долоо хоног сонгоно уу.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Үнэн зөв UUID оруулна уу.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.my.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.my.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>ကျေးဇူးပြု၍ မှန်ကန်သောရက်သတ္တပတ်ကိုထည့်ပါ။</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">ကျေးဇူးပြု၍ မှန်ကန်သော UUID ကိုထည့်ပါ။</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Vennligst skriv inn en gyldig uke.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Vennligst skriv inn en gyldig UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nl.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Vul een geldige week in.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Vul een geldige UUID in.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Gje opp ei gyldig veke.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Gje opp ein gyldig UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Vennligst skriv inn en gyldig uke.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Vennligst skriv inn en gyldig UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pl.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Proszę wybrać prawidłowy tydzień.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Proszę podać prawidłowy UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pt.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Por favor, selecione uma semana válida.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Por favor, introduza um UUID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Por favor, informe uma semana válida.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Por favor, informe um UUID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Vă rugăm să introduceți o săptămână validă.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Vă rugăm să introduceți un UUID valid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ru.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Пожалуйста, введите действительную неделю.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Пожалуйста, введите действительный UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sk.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Prosím zadajte platný týždeň.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Prosím zadajte platný UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sl.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Prosimo, vnesite veljaven teden.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Prosimo, vnesite veljaven UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
@@ -143,6 +143,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Ju lutemi shkruani një javë të vlefshme.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Ju lutemi shkruani një UUID të vlefshëm.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sr_Cyrl.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Молим упишите исправну седмицу.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Молим упишите исправан UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sr_Latn.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Molim upišite ispravnu sedmicu.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Molim upišite ispravan UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Ange en giltig vecka.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Ange ett giltigt UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.th.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>กรุณากรอกค่าสัปดาห์ที่ถูกต้อง</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">กรุณากรอกค่า UUID ที่ถูกต้อง</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.tl.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Pakilagay ang balidong linggo.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Pakilagay ang balidong UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Lütfen geçerli bir hafta girin.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Lütfen geçerli bir UUID girin.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Будь ласка, введіть дійсний тиждень.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Будь ласка, введіть дійсний UUID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ur.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>براۓ کرم ایک درست ہفتہ درج کریں</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">براۓ کرم ایک درست UUID درج کریں</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.uz.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Iltimos, haqiqiy haftani kiriting.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Iltimos, haqiqiy UUID kiriting.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.vi.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>Vui lòng nhập một tuần hợp lệ.</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">Vui lòng nhập một UUID hợp lệ.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>请输入有效的星期。</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">请输入有效的 UUID。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.zh_TW.xlf
@@ -134,6 +134,10 @@
                 <source>Please enter a valid week.</source>
                 <target>請輸入有效的星期。</target>
             </trans-unit>
+            <trans-unit id="129">
+                <source>Please enter a valid UUID.</source>
+                <target state="needs-review-translation">請輸入有效的 UUID。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Hi, this PR adds a missing key in Form translation files: `Please enter a valid UUID.`

I added the correct translation for French, and added the English version with `state="needs-translation"` for other locales.