### PR TITLE
[Translation] Copy domains metadata when moving messages to intl ones

### DIFF
--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
@@ -149,7 +149,7 @@ abstract class AbstractOperation implements OperationInterface
      */
     public function moveMessagesToIntlDomainsIfPossible(string $batch = self::ALL_BATCH): void
     {
-        // If MessageFormatter class does not exists, intl domains are not supported.
+        // If MessageFormatter class does not exist, intl domains are not supported.
         if (!class_exists(\MessageFormatter::class)) {
             return;
         }
@@ -172,6 +172,10 @@ abstract class AbstractOperation implements OperationInterface
             $currentMessages = array_diff_key($messages, $result->all($domain));
             $result->replace($currentMessages, $domain);
             $result->replace($allIntlMessages + $messages, $intlDomain);
+
+            foreach ($result->getCatalogueMetadata('', $domain) ?? [] as $key => $value) {
+                $result->setCatalogueMetadata($key, $value, $intlDomain);
+            }
         }
     }
 

--- a/src/Symfony/Component/Translation/Tests/Catalogue/AbstractOperationTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/AbstractOperationTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Tests\Catalogue;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Catalogue\AbstractOperation;
 use Symfony\Component\Translation\Exception\LogicException;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\MessageCatalogueInterface;
@@ -81,5 +82,16 @@ abstract class AbstractOperationTestCase extends TestCase
         );
     }
 
-    abstract protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target);
+    public function testMovingMessagesToIntlDomainsKeepsCatalogueMetadata()
+    {
+        $target = new MessageCatalogue('en', ['messages' => ['foo' => 'bar']]);
+        $target->setCatalogueMetadata('foo', 'bar');
+
+        $operation = $this->createOperation(new MessageCatalogue('en'), $target);
+        $operation->moveMessagesToIntlDomainsIfPossible();
+
+        $this->assertSame(['foo' => 'bar'], $operation->getResult()->getCatalogueMetadata(domain: 'messages+intl-icu'));
+    }
+
+    abstract protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target): AbstractOperation;
 }

--- a/src/Symfony/Component/Translation/Tests/Catalogue/MergeOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/MergeOperationTest.php
@@ -113,7 +113,7 @@ class MergeOperationTest extends AbstractOperationTestCase
         );
     }
 
-    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target): MergeOperation
     {
         return new MergeOperation($source, $target);
     }

--- a/src/Symfony/Component/Translation/Tests/Catalogue/TargetOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/TargetOperationTest.php
@@ -155,7 +155,7 @@ class TargetOperationTest extends AbstractOperationTestCase
         );
     }
 
-    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target): TargetOperation
     {
         return new TargetOperation($source, $target);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

When running `translation:pull --force --intl-icu`, `AbstractOperation::moveMessagesToIntlDomainsIfPossible()` didn’t copy the catalogue’s metadata under the new intl domains, so they were missing in the dumped files.