### PR TITLE
[HttpFoundation] Deprecate not passing an expiry to `UriSigner::sign()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -162,6 +162,7 @@ class Configuration implements ConfigurationInterface
         $this->addEsiSection($rootNode);
         $this->addSsiSection($rootNode);
         $this->addFragmentsSection($rootNode);
+        $this->addUriSignerSection($rootNode);
         $this->addProfilerSection($rootNode);
         $this->addWorkflowSection($rootNode);
         $this->addRouterSection($rootNode);
@@ -347,6 +348,24 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('hinclude_default_template')->defaultNull()->end()
                         ->scalarNode('path')->defaultValue('/_fragment')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addUriSignerSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('uri_signer')
+                    ->info('URI signer configuration')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('expiration')
+                            ->info('Default expiration of signed URIs, in seconds.')
+                            ->defaultNull()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -417,6 +417,7 @@ class FrameworkExtension extends Extension
         $this->registerEsiConfiguration($config['esi'], $container, $loader);
         $this->registerSsiConfiguration($config['ssi'], $container, $loader);
         $this->registerFragmentsConfiguration($config['fragments'], $container, $loader);
+        $container->getDefinition('uri_signer')->setArgument(4, $config['uri_signer']['expiration']);
         $this->registerTranslatorConfiguration($config['translator'], $container, $loader, $config['default_locale'], $config['enabled_locales']);
         $this->registerWorkflowConfiguration($config['workflows'], $container, $loader);
         $this->registerDebugConfiguration($config['php_errors'], $container, $loader);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -738,6 +738,9 @@ class ConfigurationTest extends TestCase
                 'path' => '/_fragment',
                 'hinclude_default_template' => null,
             ],
+            'uri_signer' => [
+                'expiration' => null,
+            ],
             'profiler' => [
                 'enabled' => false,
                 'only_exceptions' => false,

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Deprecate not passing an expiry to `UriSigner::sign()`
+ * Add the `$defaultExpiration` argument to `UriSigner::__construct()`
+
 8.1
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpFoundation\Exception\ExpiredSignedUriException;
@@ -28,15 +29,22 @@ class UriSignerTest extends TestCase
     {
         $signer = new UriSigner('foobar');
 
-        $this->assertStringContainsString('?_hash=', $signer->sign('http://example.com/foo'));
-        $this->assertStringContainsString('?_hash=', $signer->sign('http://example.com/foo?foo=bar'));
-        $this->assertStringContainsString('&foo=', $signer->sign('http://example.com/foo?foo=bar'));
-
         $this->assertStringContainsString('?_expiration=', $signer->sign('http://example.com/foo', 1));
         $this->assertStringContainsString('&_hash=', $signer->sign('http://example.com/foo', 1));
         $this->assertStringContainsString('?_expiration=', $signer->sign('http://example.com/foo?foo=bar', 1));
         $this->assertStringContainsString('&_hash=', $signer->sign('http://example.com/foo?foo=bar', 1));
         $this->assertStringContainsString('&foo=', $signer->sign('http://example.com/foo?foo=bar', 1));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testSignWithoutExpiration()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertStringContainsString('?_hash=', $signer->sign('http://example.com/foo'));
+        $this->assertStringContainsString('?_hash=', $signer->sign('http://example.com/foo?foo=bar'));
+        $this->assertStringContainsString('&foo=', $signer->sign('http://example.com/foo?foo=bar'));
     }
 
     public function testCheck()
@@ -53,16 +61,24 @@ class UriSignerTest extends TestCase
         $this->assertFalse($signer->check('http://example.com/foo?_expiration=4070908800&foo=bar&_hash=foo'));
         $this->assertFalse($signer->check('http://example.com/foo?_expiration=4070908800&foo=bar&_hash=foo&bar=foo'));
 
-        $this->assertTrue($signer->check($signer->sign('http://example.com/foo')));
-        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar')));
-        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&0=integer')));
-
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo', new \DateTimeImmutable('2099-01-01 00:00:00'))));
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar', new \DateTimeImmutable('2099-01-01 00:00:00'))));
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&0=integer', new \DateTimeImmutable('2099-01-01 00:00:00'))));
 
-        $this->assertSame($signer->sign('http://example.com/foo?foo=bar&bar=foo'), $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
         $this->assertSame($signer->sign('http://example.com/foo?foo=bar&bar=foo', 1), $signer->sign('http://example.com/foo?bar=foo&foo=bar', 1));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testCheckWithoutExpiration()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo')));
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar')));
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&0=integer')));
+
+        $this->assertSame($signer->sign('http://example.com/foo?foo=bar&bar=foo'), $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
     }
 
     public function testCheckWithDifferentArgSeparator()
@@ -71,12 +87,6 @@ class UriSignerTest extends TestCase
 
         try {
             $signer = new UriSigner('foobar');
-
-            $this->assertSame(
-                'http://example.com/foo?_hash=rIOcC_F3DoEGo_vnESjSp7uU9zA9S_-OLhxgMexoPUM&baz=bay&foo=bar',
-                $signer->sign('http://example.com/foo?foo=bar&baz=bay')
-            );
-            $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
 
             $this->assertSame(
                 'http://example.com/foo?_expiration=2145916800&_hash=xLhnPMzV3KqqHaaUffBUJvtRDAZ4_Z9Y8Sw-gmS-82Q&baz=bay&foo=bar',
@@ -88,28 +98,48 @@ class UriSignerTest extends TestCase
         }
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testCheckWithDifferentArgSeparatorWithoutExpiration()
+    {
+        $oldArgSeparatorOutputValue = ini_set('arg_separator.output', '&amp;');
+
+        try {
+            $signer = new UriSigner('foobar');
+
+            $this->assertSame(
+                'http://example.com/foo?_hash=rIOcC_F3DoEGo_vnESjSp7uU9zA9S_-OLhxgMexoPUM&baz=bay&foo=bar',
+                $signer->sign('http://example.com/foo?foo=bar&baz=bay')
+            );
+            $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
+        } finally {
+            ini_set('arg_separator.output', $oldArgSeparatorOutputValue);
+        }
+    }
+
     public function testCheckWithRequest()
     {
         $signer = new UriSigner('foobar');
-
-        $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo'))));
-        $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo?foo=bar'))));
-        $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo?foo=bar&0=integer'))));
 
         $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo', new \DateTimeImmutable('2099-01-01 00:00:00')))));
         $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo?foo=bar', new \DateTimeImmutable('2099-01-01 00:00:00')))));
         $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo?foo=bar&0=integer', new \DateTimeImmutable('2099-01-01 00:00:00')))));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testCheckWithRequestWithoutExpiration()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo'))));
+        $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo?foo=bar'))));
+        $this->assertTrue($signer->checkRequest(Request::create($signer->sign('http://example.com/foo?foo=bar&0=integer'))));
+    }
+
     public function testCheckWithDifferentParameter()
     {
         $signer = new UriSigner('foobar', 'qux', 'abc');
-
-        $this->assertSame(
-            'http://example.com/foo?baz=bay&foo=bar&qux=rIOcC_F3DoEGo_vnESjSp7uU9zA9S_-OLhxgMexoPUM',
-            $signer->sign('http://example.com/foo?foo=bar&baz=bay')
-        );
-        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
 
         $this->assertSame(
             'http://example.com/foo?abc=2145916800&baz=bay&foo=bar&qux=kE4rK2MzeiwrYAKy-_GKvKA6bnzqCbACBdpC3yGnPVU',
@@ -118,16 +148,22 @@ class UriSignerTest extends TestCase
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay', new \DateTimeImmutable('2099-01-01 00:00:00'))));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testCheckWithDifferentParameterWithoutExpiration()
+    {
+        $signer = new UriSigner('foobar', 'qux', 'abc');
+
+        $this->assertSame(
+            'http://example.com/foo?baz=bay&foo=bar&qux=rIOcC_F3DoEGo_vnESjSp7uU9zA9S_-OLhxgMexoPUM',
+            $signer->sign('http://example.com/foo?foo=bar&baz=bay')
+        );
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
+    }
+
     public function testSignerWorksWithFragments()
     {
         $signer = new UriSigner('foobar');
-
-        $this->assertSame(
-            'http://example.com/foo?_hash=EhpAUyEobiM3QTrKxoLOtQq5IsWyWedoXDPqIjzNj5o&bar=foo&foo=bar#foobar',
-            $signer->sign('http://example.com/foo?bar=foo&foo=bar#foobar')
-        );
-
-        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?bar=foo&foo=bar#foobar')));
 
         $this->assertSame(
             'http://example.com/foo?_expiration=2145916800&_hash=jTdrIE9MJSorNpQmkX6tmOtocxXtHDzIJawcAW4IFYo&bar=foo&foo=bar#foobar',
@@ -137,6 +173,20 @@ class UriSignerTest extends TestCase
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?bar=foo&foo=bar#foobar', new \DateTimeImmutable('2099-01-01 00:00:00'))));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testSignerWorksWithFragmentsWithoutExpiration()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertSame(
+            'http://example.com/foo?_hash=EhpAUyEobiM3QTrKxoLOtQq5IsWyWedoXDPqIjzNj5o&bar=foo&foo=bar#foobar',
+            $signer->sign('http://example.com/foo?bar=foo&foo=bar#foobar')
+        );
+
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?bar=foo&foo=bar#foobar')));
+    }
+
     public function testSignWithUriExpiration()
     {
         $signer = new UriSigner('foobar');
@@ -144,6 +194,39 @@ class UriSignerTest extends TestCase
         $this->assertSame($signer->sign('http://example.com/foo?foo=bar&bar=foo', new \DateTimeImmutable('2038-01-01 00:00:00', new \DateTimeZone('UTC'))), $signer->sign('http://example.com/foo?bar=foo&foo=bar', 2145916800));
     }
 
+    public function testSignWithDefaultExpiration()
+    {
+        $clock = new MockClock(new \DateTimeImmutable('2000-01-01 00:00:00', new \DateTimeZone('UTC')));
+        $signer = new UriSigner('foobar', clock: $clock, defaultExpiration: new \DateInterval('PT1H'));
+
+        $uri = $signer->sign('http://example.com/foo');
+        $this->assertStringContainsString('_expiration=946688400', $uri);
+        $this->assertTrue($signer->check($uri));
+
+        $this->assertStringContainsString('_expiration=946684800', $signer->sign('http://example.com/foo', 946684800));
+    }
+
+    public function testSignWithDefaultExpirationInSeconds()
+    {
+        $clock = new MockClock(new \DateTimeImmutable('2000-01-01 00:00:00', new \DateTimeZone('UTC')));
+        $signer = new UriSigner('foobar', clock: $clock, defaultExpiration: 3600);
+
+        $uri = $signer->sign('http://example.com/foo');
+        $this->assertStringContainsString('_expiration=946688400', $uri);
+        $this->assertTrue($signer->check($uri));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testSignWithoutExpirationIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 8.2: Not passing an expiration to "Symfony\Component\HttpFoundation\UriSigner::sign()" is deprecated and will be required in 9.0; pass one explicitly, or set a default via the "$defaultExpiration" argument of "Symfony\Component\HttpFoundation\UriSigner::__construct()".');
+
+        (new UriSigner('foobar'))->sign('http://example.com/foo');
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testSignWithoutExpirationAndWithReservedHashParameter()
     {
         $signer = new UriSigner('foobar');
@@ -153,6 +236,8 @@ class UriSignerTest extends TestCase
         $signer->sign('http://example.com/foo?_hash=bar');
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testSignWithoutExpirationAndWithReservedParameter()
     {
         $signer = new UriSigner('foobar');

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -28,19 +28,25 @@ class UriSigner
     private const STATUS_MISSING = 3;
     private const STATUS_EXPIRED = 4;
 
+    private ?\DateInterval $defaultExpiration;
+
     /**
-     * @param string $hashParameter       Query string parameter to use
-     * @param string $expirationParameter Query string parameter to use for expiration
+     * @param string                 $hashParameter       Query string parameter to use
+     * @param string                 $expirationParameter Query string parameter to use for expiration
+     * @param \DateInterval|int|null $defaultExpiration   The expiration applied when none is passed to sign(); an int is a number of seconds
      */
     public function __construct(
         #[\SensitiveParameter] private string $secret,
         private string $hashParameter = '_hash',
         private string $expirationParameter = '_expiration',
         private ?ClockInterface $clock = null,
+        \DateInterval|int|null $defaultExpiration = null,
     ) {
         if (!$secret) {
             throw new \InvalidArgumentException('A non-empty secret is required.');
         }
+
+        $this->defaultExpiration = \is_int($defaultExpiration) ? \DateInterval::createFromDateString("$defaultExpiration seconds") : $defaultExpiration;
     }
 
     /**
@@ -53,12 +59,18 @@ class UriSigner
      *                                                              If $expiration is a \DateTimeInterface, it's expected to be the exact date + time.
      *                                                              If $expiration is a \DateInterval, the interval is added to "now" to get the date + time.
      *                                                              If $expiration is an int, it's expected to be a timestamp in seconds of the exact date + time.
-     *                                                              If $expiration is null, no expiration.
+     *                                                              If $expiration is null, the default expiration passed to the constructor is used.
      *
      * The expiration is added as a query string parameter.
      */
     public function sign(string $uri, \DateTimeInterface|\DateInterval|int|null $expiration = null): string
     {
+        $expiration ??= $this->defaultExpiration;
+
+        if (null === $expiration) {
+            trigger_deprecation('symfony/http-foundation', '8.2', 'Not passing an expiration to "%s::sign()" is deprecated and will be required in 9.0; pass one explicitly, or set a default via the "$defaultExpiration" argument of "%s::__construct()".', self::class, self::class);
+        }
+
         $url = parse_url($uri);
         $params = [];
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `#[AsControllerAttributeListener]` attribute to declare event listeners for controller attributes
+ * Add the `$expiration` argument to `FragmentUriGenerator::__construct()` and sign fragment URIs with a 5-year expiration by default
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGenerator.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGenerator.php
@@ -28,6 +28,7 @@ final class FragmentUriGenerator implements FragmentUriGeneratorInterface
         private string $fragmentPath,
         private ?UriSigner $signer = null,
         private ?RequestStack $requestStack = null,
+        private \DateTimeInterface|\DateInterval|int $expiration = new \DateInterval('P5Y'),
     ) {
     }
 
@@ -68,7 +69,7 @@ final class FragmentUriGenerator implements FragmentUriGeneratorInterface
             return $fragmentUri;
         }
 
-        $fragmentUri = $this->signer->sign($fragmentUri);
+        $fragmentUri = $this->signer->sign($fragmentUri, $this->expiration);
 
         return $absolute ? $fragmentUri : substr($fragmentUri, \strlen($request->getSchemeAndHttpHost()));
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
@@ -76,7 +76,7 @@ class FragmentListenerTest extends TestCase
     public function testWithSignature()
     {
         $signer = new UriSigner('foo');
-        $request = Request::create($signer->sign('http://example.com/_fragment?_path=foo%3Dbar%26_controller%3Dfoo'), 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
+        $request = Request::create($signer->sign('http://example.com/_fragment?_path=foo%3Dbar%26_controller%3Dfoo', new \DateTimeImmutable('2099-01-01 00:00:00')), 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
 
         $listener = new FragmentListener($signer);
         $event = $this->createRequestEvent($request);
@@ -102,7 +102,7 @@ class FragmentListenerTest extends TestCase
     public function testRemovesPathWithControllerNotDefined()
     {
         $signer = new UriSigner('foo');
-        $request = Request::create($signer->sign('http://example.com/_fragment?_path=foo%3Dbar'), 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
+        $request = Request::create($signer->sign('http://example.com/_fragment?_path=foo%3Dbar', new \DateTimeImmutable('2099-01-01 00:00:00')), 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
 
         $listener = new FragmentListener($signer);
         $event = $this->createRequestEvent($request);

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -61,7 +61,7 @@ class EsiFragmentRendererTest extends TestCase
         $altReference = new ControllerReference('alt_controller', [], []);
 
         $this->assertMatchesRegularExpression(
-            '#^<esi:include src="/_fragment\?_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" alt="/_fragment\?_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dalt_controller" />$#',
+            '#^<esi:include src="/_fragment\?_expiration=.+&_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" alt="/_fragment\?_expiration=.+&_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dalt_controller" />$#',
             $strategy->render($reference, $request, ['alt' => $altReference])->getContent()
         );
     }
@@ -79,7 +79,7 @@ class EsiFragmentRendererTest extends TestCase
         $altReference = new ControllerReference('alt_controller', [], []);
 
         $this->assertMatchesRegularExpression(
-            '#^<esi:include src="http://localhost/_fragment\?_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" alt="http://localhost/_fragment\?_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dalt_controller" />$#',
+            '#^<esi:include src="http://localhost/_fragment\?_expiration=.+&_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" alt="http://localhost/_fragment\?_expiration=.+&_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dalt_controller" />$#',
             $strategy->render($reference, $request, ['alt' => $altReference, 'absolute_uri' => true])->getContent()
         );
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
@@ -32,7 +32,7 @@ class HIncludeFragmentRendererTest extends TestCase
     {
         $strategy = new HIncludeFragmentRenderer(null, new UriSigner('foo'));
 
-        $this->assertMatchesRegularExpression('#^<hx:include src="/_fragment\?_hash=.+&amp;_path=_format%3Dhtml%26_locale%3Den%26_controller%3Dmain_controller"></hx:include>$#', $strategy->render(new ControllerReference('main_controller', [], []), Request::create('/'))->getContent());
+        $this->assertMatchesRegularExpression('#^<hx:include src="/_fragment\?_expiration=.+&amp;_hash=.+&amp;_path=_format%3Dhtml%26_locale%3Den%26_controller%3Dmain_controller"></hx:include>$#', $strategy->render(new ControllerReference('main_controller', [], []), Request::create('/'))->getContent());
     }
 
     public function testRenderWithUri()

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/SsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/SsiFragmentRendererTest.php
@@ -52,7 +52,7 @@ class SsiFragmentRendererTest extends TestCase
         $altReference = new ControllerReference('alt_controller', [], []);
 
         $this->assertMatchesRegularExpression(
-            '{^<!--#include virtual="/_fragment\?_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" -->$}',
+            '{^<!--#include virtual="/_fragment\?_expiration=.+&_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" -->$}',
             $strategy->render($reference, $request, ['alt' => $altReference])->getContent()
         );
     }
@@ -70,7 +70,7 @@ class SsiFragmentRendererTest extends TestCase
         $altReference = new ControllerReference('alt_controller', [], []);
 
         $this->assertMatchesRegularExpression(
-            '{^<!--#include virtual="http://localhost/_fragment\?_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" -->$}',
+            '{^<!--#include virtual="http://localhost/_fragment\?_expiration=.+&_hash=.+&_path=_format%3Dhtml%26_locale%3Dfr%26_controller%3Dmain_controller" -->$}',
             $strategy->render($reference, $request, ['alt' => $altReference, 'absolute_uri' => true])->getContent()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | n/a
| License       | MIT

Per a slack discussion with Nicolas.
