### PR TITLE
[Webhook] Fix Content-Type key in createRequest method

### DIFF
--- a/src/Symfony/Component/Webhook/Test/AbstractRequestParserTestCase.php
+++ b/src/Symfony/Component/Webhook/Test/AbstractRequestParserTestCase.php
@@ -58,7 +58,7 @@ abstract class AbstractRequestParserTestCase extends TestCase
     protected function createRequest(string $payload): Request
     {
         return Request::create('/', 'POST', [], [], [], [
-            'Content-Type' => 'application/json',
+            'CONTENT_TYPE' => 'application/json',
         ], $payload);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

The default behaviour of the abstract test sets the content-type wrong. It will default to a `application/x-www-form-urlencoded` when not set in full caps.

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
