### PR TITLE
[ObjectMapper] Fix reverse class map throwing on unreadable source

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -255,8 +255,20 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         $refl ??= new \ReflectionClass($source);
 
-        // a dynamic (undeclared) property exists on the instance and is publicly readable
-        return !$refl->hasProperty($propertyName) || $refl->getProperty($propertyName)->isPublic();
+        if (!$refl->hasProperty($propertyName)) {
+            // ReflectionClass doesn't see dynamic properties: property_exists() matched one, and those are always public
+            return true;
+        }
+
+        $property = $refl->getProperty($propertyName);
+
+        if (!$property->isPublic()) {
+            // a non-public property can only be read through magic __get()
+            return method_exists($source, '__get');
+        }
+
+        // an uninitialized property is not readable, unless unset() re-enabled magic methods on it
+        return $property->isInitialized($source) || isset($source->{$propertyName});
     }
 
     private function getRawValue(object $source, string $propertyName): mixed

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -189,6 +189,10 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 continue;
             }
 
+            if (!$this->isReadable($source, $propertyName, $refl)) {
+                continue;
+            }
+
             $rawValue = $this->getRawValue($source, $propertyName);
             if (
                 \is_object($rawValue)
@@ -239,17 +243,20 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         return $mappedTarget;
     }
 
-    private function isReadable(object $source, string $propertyName): bool
+    private function isReadable(object $source, string $propertyName, ?\ReflectionClass $refl = null): bool
     {
         if ($this->propertyAccessor) {
             return $this->propertyAccessor->isReadable($source, $propertyName);
         }
 
-        if (!property_exists($source, $propertyName) && !isset($source->{$propertyName})) {
-            return false;
+        if (!property_exists($source, $propertyName)) {
+            return isset($source->{$propertyName});
         }
 
-        return true;
+        $refl ??= new \ReflectionClass($source);
+
+        // a dynamic (undeclared) property exists on the instance and is publicly readable
+        return !$refl->hasProperty($propertyName) || $refl->getProperty($propertyName)->isPublic();
     }
 
     private function getRawValue(object $source, string $propertyName): mixed

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RichDomainUser.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RichDomainUser.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+/**
+ * A rich domain object, intentionally free of mapping metadata, with a private
+ * property that has no public getter (not readable through PropertyAccess) and
+ * no counterpart on the target view.
+ */
+final class RichDomainUser
+{
+    public int $id = 1;
+    public string $username = 'john';
+    private array $reviews = []; // unreadable + absent from the target: triggers the guarded branch
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RichDomainUserView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RichDomainUserView.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: RichDomainUser::class)]
+final class RichDomainUserView
+{
+    #[Map(source: 'id')]
+    public int $id;
+
+    #[Map(source: 'username')]
+    public string $username;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RichDomainUserView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RichDomainUserView.php
@@ -4,7 +4,6 @@ namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
 
 use Symfony\Component\ObjectMapper\Attribute\Map;
 
-#[Map(source: RichDomainUser::class)]
 final class RichDomainUserView
 {
     #[Map(source: 'id')]

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUser.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUser.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: MagicGetUserView::class)]
+final class MagicGetUser
+{
+    public int $id = 1;
+    private string $name = 'magic-value';
+
+    public function __get(string $name): mixed
+    {
+        return $this->$name;
+    }
+
+    public function __isset(string $name): bool
+    {
+        return isset($this->$name);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUserView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUserView.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet;
+
+final class MagicGetUserView
+{
+    public int $id;
+    public string $name;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/Draft.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/Draft.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: DraftView::class)]
+final class Draft
+{
+    public string $title = 'hello';
+    public ?string $summary;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/DraftView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/DraftView.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized;
+
+final class DraftView
+{
+    public string $title;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -77,6 +77,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\IsNotNullCondition\IsNotNullSo
 use Symfony\Component\ObjectMapper\Tests\Fixtures\IsNotNullCondition\IsNotNullTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\IsNotNullCondition\IsNotNullTargetMapping;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\LazyFoo;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUser;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUserView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -133,6 +135,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized\Draft;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized\DraftView;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -874,6 +878,29 @@ final class ObjectMapperTest extends TestCase
     {
         yield 'with property accessor' => [PropertyAccess::createPropertyAccessor()];
         yield 'without property accessor' => [null];
+    }
+
+    #[DataProvider('provideAccessor')]
+    public function testNonPublicSourcePropertyExposedByMagicGetIsMapped(?PropertyAccessorInterface $accessor)
+    {
+        $mapper = new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), $accessor);
+
+        $view = $mapper->map(new MagicGetUser());
+
+        $this->assertInstanceOf(MagicGetUserView::class, $view);
+        $this->assertSame(1, $view->id);
+        $this->assertSame('magic-value', $view->name);
+    }
+
+    #[DataProvider('provideAccessor')]
+    public function testUninitializedSourcePropertyAbsentFromTargetIsIgnored(?PropertyAccessorInterface $accessor)
+    {
+        $mapper = new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), $accessor);
+
+        $view = $mapper->map(new Draft());
+
+        $this->assertInstanceOf(DraftView::class, $view);
+        $this->assertSame('hello', $view->title);
     }
 
     public function testMissingSourcePropertiesAreIgnored()

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -36,6 +36,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSource
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RichDomainUser;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RichDomainUserView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\A as ClassRuleA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\B as ClassRuleB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\C as ClassRuleC;
@@ -132,6 +134,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 final class ObjectMapperTest extends TestCase
 {
@@ -847,6 +850,30 @@ final class ObjectMapperTest extends TestCase
         $this->assertEquals('bar', $costRequestView->foo, 'Explicit mapping should work');
         $this->assertEquals(10, $costRequestView->amount, 'Auto-mapping should also work for properties with the same name');
         $this->assertEquals(20, $costRequestView->tax);
+    }
+
+    #[DataProvider('provideAccessor')]
+    public function testClassMapIgnoresUnreadableSourcePropertyAbsentFromTarget(?PropertyAccessorInterface $accessor)
+    {
+        $mapper = new ObjectMapper(
+            new ReverseClassObjectMapperMetadataFactory(
+                new ReflectionObjectMapperMetadataFactory(),
+                [RichDomainUser::class => RichDomainUserView::class],
+            ),
+            $accessor,
+        );
+
+        $view = $mapper->map(new RichDomainUser());
+
+        $this->assertInstanceOf(RichDomainUserView::class, $view);
+        $this->assertSame(1, $view->id);
+        $this->assertSame('john', $view->username);
+    }
+
+    public static function provideAccessor(): iterable
+    {
+        yield 'with property accessor' => [PropertyAccess::createPropertyAccessor()];
+        yield 'without property accessor' => [null];
     }
 
     public function testMissingSourcePropertiesAreIgnored()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64465
| License       | MIT

When mapping is defined on the target class (ReverseClassObjectMapperMetadataFactory), doMap() iterates the source properties. A source property absent from the target falls through to the embeddable-detection branch, which read the raw value without a readability guard, throwing NoSuchPropertyException (or a PHP Error without a PropertyAccessor) for private properties with no getter -- common in rich domain entities.

Add the same isReadable() guard the same-name branch already has, and make isReadable() reflect real accessibility when no PropertyAccessor is used (property_exists() returns true for private properties, so it must check visibility via ReflectionProperty).
