### PR TITLE
[HttpFoundation] Add RFC6598 Shared Address Space to IpUtils::PRIVATE_SUBNETS

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -26,6 +26,7 @@ class IpUtils
         '169.254.0.0/16', // RFC3927
         '0.0.0.0/8',      // RFC5735
         '240.0.0.0/4',    // RFC1112
+        '100.64.0.0/10',  // RFC6598
         '::1/128',        // Loopback
         'fc00::/7',       // Unique Local Address
         'fe80::/10',      // Link Local Address

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -187,6 +187,7 @@ class IpUtilsTest extends TestCase
             ['169.254.0.1',     true],
             ['0.0.0.1',         true],
             ['240.0.0.1',       true],
+            ['100.64.0.1',      true],
             ['::1',             true],
             ['fc00::1',         true],
             ['fe80::1',         true],


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64421
| License       | MIT

Add the `100.64.0.0/10` defined in [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598) to  `IpUtils::PRIVATE_SUBNETS`
