### PR TITLE
[DoctrineBridge] Store whether a query ran on a primary

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Connection.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Connection.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Middleware\Debug;
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 use Doctrine\DBAL\Driver\Result;
+use Doctrine\Persistence\ConnectionRegistry;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -29,6 +30,7 @@ final class Connection extends AbstractConnectionMiddleware
         private readonly DebugDataHolder $debugDataHolder,
         private readonly ?Stopwatch $stopwatch,
         private readonly string $connectionName,
+        private readonly ?ConnectionRegistry $connectionRegistry = null,
     ) {
         parent::__construct($connection);
     }
@@ -41,12 +43,14 @@ final class Connection extends AbstractConnectionMiddleware
             $this->connectionName,
             $sql,
             $this->stopwatch,
+            $this->connectionRegistry?->getConnection($this->connectionName),
         );
     }
 
     public function query(string $sql): Result
     {
-        $this->debugDataHolder->addQuery($this->connectionName, $query = new Query($sql));
+        $query = new Query($sql, $this->connectionRegistry?->getConnection($this->connectionName));
+        $this->debugDataHolder->addQuery($this->connectionName, $query);
 
         $this->stopwatch?->start('doctrine', 'doctrine');
         $query->start();
@@ -61,7 +65,8 @@ final class Connection extends AbstractConnectionMiddleware
 
     public function exec(string $sql): int
     {
-        $this->debugDataHolder->addQuery($this->connectionName, $query = new Query($sql));
+        $query = new Query($sql, $this->connectionRegistry?->getConnection($this->connectionName));
+        $this->debugDataHolder->addQuery($this->connectionName, $query);
 
         $this->stopwatch?->start('doctrine', 'doctrine');
         $query->start();
@@ -78,7 +83,7 @@ final class Connection extends AbstractConnectionMiddleware
 
     public function beginTransaction(): void
     {
-        $query = new Query('"START TRANSACTION"');
+        $query = new Query('"START TRANSACTION"', $this->connectionRegistry?->getConnection($this->connectionName));
         $this->debugDataHolder->addQuery($this->connectionName, $query);
 
         $this->stopwatch?->start('doctrine', 'doctrine');
@@ -94,7 +99,7 @@ final class Connection extends AbstractConnectionMiddleware
 
     public function commit(): void
     {
-        $query = new Query('"COMMIT"');
+        $query = new Query('"COMMIT"', $this->connectionRegistry?->getConnection($this->connectionName));
         $this->debugDataHolder->addQuery($this->connectionName, $query);
 
         $this->stopwatch?->start('doctrine', 'doctrine');
@@ -110,7 +115,7 @@ final class Connection extends AbstractConnectionMiddleware
 
     public function rollBack(): void
     {
-        $query = new Query('"ROLLBACK"');
+        $query = new Query('"ROLLBACK"', $this->connectionRegistry?->getConnection($this->connectionName));
         $this->debugDataHolder->addQuery($this->connectionName, $query);
 
         $this->stopwatch?->start('doctrine', 'doctrine');

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/DebugDataHolder.php
@@ -24,7 +24,9 @@ class DebugDataHolder
             'sql' => $query->getSql(),
             'params' => $query->getParams(),
             'types' => $query->getTypes(),
-            'executionMS' => $query->getDuration(...),  // stop() may not be called at this point
+            // stop() may not be called at this point
+            'executionMS' => $query->getDuration(...),
+            'ranOnPrimary' => $query->ranOnPrimary(...),
         ];
     }
 
@@ -34,6 +36,9 @@ class DebugDataHolder
             foreach ($dataForConn as $idx => $data) {
                 if (\is_callable($data['executionMS'])) {
                     $this->data[$connectionName][$idx]['executionMS'] = $data['executionMS']();
+                }
+                if (\is_callable($data['ranOnPrimary'])) {
+                    $this->data[$connectionName][$idx]['ranOnPrimary'] = $data['ranOnPrimary']();
                 }
             }
         }

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Driver.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Driver.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Middleware\Debug;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Doctrine\Persistence\ConnectionRegistry;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -28,6 +29,7 @@ final class Driver extends AbstractDriverMiddleware
         private readonly DebugDataHolder $debugDataHolder,
         private readonly ?Stopwatch $stopwatch,
         private readonly string $connectionName,
+        private readonly ?ConnectionRegistry $connectionRegistry = null,
     ) {
         parent::__construct($driver);
     }
@@ -40,7 +42,8 @@ final class Driver extends AbstractDriverMiddleware
             $connection,
             $this->debugDataHolder,
             $this->stopwatch,
-            $this->connectionName
+            $this->connectionName,
+            $this->connectionRegistry,
         );
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Middleware.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Middleware\Debug;
 
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
+use Doctrine\Persistence\ConnectionRegistry;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -26,11 +27,12 @@ final class Middleware implements MiddlewareInterface
         private readonly DebugDataHolder $debugDataHolder,
         private readonly ?Stopwatch $stopwatch,
         private readonly string $connectionName = 'default',
+        private readonly ?ConnectionRegistry $connectionRegistry = null,
     ) {
     }
 
     public function wrap(DriverInterface $driver): DriverInterface
     {
-        return new Driver($driver, $this->debugDataHolder, $this->stopwatch, $this->connectionName);
+        return new Driver($driver, $this->debugDataHolder, $this->stopwatch, $this->connectionName, $this->connectionRegistry);
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Query.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\Doctrine\Middleware\Debug;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\ParameterType;
 
 /**
@@ -28,8 +30,11 @@ class Query
     private ?float $start = null;
     private ?float $duration = null;
 
+    private ?bool $ranOnPrimary = null;
+
     public function __construct(
         private readonly string $sql,
+        private readonly ?Connection $connection = null,
     ) {
     }
 
@@ -42,6 +47,10 @@ class Query
     {
         if (null !== $this->start) {
             $this->duration = microtime(true) - $this->start;
+
+            if ($this->connection instanceof PrimaryReadReplicaConnection) {
+                $this->ranOnPrimary = $this->connection->isConnectedToPrimary();
+            }
         }
     }
 
@@ -100,6 +109,11 @@ class Query
     public function getDuration(): ?float
     {
         return $this->duration;
+    }
+
+    public function ranOnPrimary(): ?bool
+    {
+        return $this->ranOnPrimary;
     }
 
     public function __clone()

--- a/src/Symfony/Bridge/Doctrine/Middleware/Debug/Statement.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/Debug/Statement.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Middleware\Debug;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
 use Doctrine\DBAL\Driver\Statement as StatementInterface;
@@ -33,10 +34,11 @@ final class Statement extends AbstractStatementMiddleware
         private readonly string $connectionName,
         string $sql,
         private readonly ?Stopwatch $stopwatch = null,
+        ?Connection $connection = null,
     ) {
         parent::__construct($statement);
 
-        $this->query = new Query($sql);
+        $this->query = new Query($sql, $connection);
     }
 
     public function bindValue(int|string $param, mixed $value, ParameterType $type): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Symfony part of #62509 
| License       | MIT

Not sure how to test this: the current `MiddlewareTest` uses SQLite which doesn’t support primary/replicas.

To go with https://github.com/doctrine/DoctrineBundle/pull/2237