### PR TITLE
[Cache] Fix "Serialization of 'Closure' is not allowed" in ArrayAdapter::getValues()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -303,7 +303,12 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
             if (null === $v) {
                 continue;
             }
-            $values[$k] = serialize($v instanceof DeepCloner ? $v->clone() : $v);
+            try {
+                $values[$k] = serialize($v instanceof DeepCloner ? $v->clone() : $v);
+            } catch (\Exception $e) {
+                unset($values[$k]);
+                CacheItem::log($this->logger, 'Failed to serialize key "{key}": '.$e->getMessage(), ['key' => $k, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]);
+            }
         }
 
         return $values;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64464
| License       | MIT

In Symfony 8.1, `ArrayAdapter` was updated to use `DeepCloner` instead of
immediately serializing values in `freeze()`. The old `freeze()` would call
`serialize()` eagerly and catch any exception (e.g. for Closure values),
logging and skipping the item gracefully.

With `DeepCloner`, construction does not throw for values containing Closures,
so they get stored. When `getValues()` is later called (e.g. during
`cache:clear` in `prod` with `debug=false`), `serialize()` is called on those
values and throws `"Serialization of 'Closure' is not allowed"`, crashing
the cache warmer.

The fix wraps `serialize()` in `getValues()` with a try-catch, logging and
skipping any value that cannot be serialized — restoring the graceful
behaviour of the old code.