### PR TITLE
[Mailer][Mailchimp] Fix tests on low-deps

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^6.3|^7.0"
     },
+    "conflict": {
+        "symfony/mime": "<6.2"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Mailchimp\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Mailchimp bridge fails on the `low-deps` job:

```
MandrillApiTransportTest::testInlineImageUsesContentIdAsName
Error: Call to undefined method Symfony\Component\Mime\Email::addPart()
```

`Email::addPart()` was added in `symfony/mime` 6.2, but the bridge allows `symfony/mailer: ^5.4.21`, so `low-deps` installs `symfony/mime` 5.4. The inline-image tests added in 18d3054adc5 rely on `addPart()`.

This declares a conflict with `symfony/mime < 6.2`, consistently with the Sendgrid, Mailjet, Brevo and Sendinblue bridges which already do the same for the same reason.
