### PR TITLE
[Translation] Fix test failing without the intl extension

### DIFF
--- a/src/Symfony/Component/Translation/Tests/Catalogue/AbstractOperationTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/AbstractOperationTestCase.php
@@ -82,6 +82,9 @@ abstract class AbstractOperationTestCase extends TestCase
         );
     }
 
+    /**
+     * @requires extension intl
+     */
     public function testMovingMessagesToIntlDomainsKeepsCatalogueMetadata()
     {
         $target = new MessageCatalogue('en', ['messages' => ['foo' => 'bar']]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`MergeOperationTest` and `TargetOperationTest::testMovingMessagesToIntlDomainsKeepsCatalogueMetadata` fail on the Windows `minimal-exts` CI job, which runs without the `intl` extension:

```
Failed asserting that null is identical to Array ( 'foo' => 'bar' ).
```

`AbstractOperation::moveMessagesToIntlDomainsIfPossible()` is a no-op when `\MessageFormatter` is not available, so the `messages+intl-icu` domain and its copied metadata are never created and `getCatalogueMetadata()` returns `null`. The test, added in 489ec9ab695, is therefore missing an `@requires extension intl` guard, like the other intl-dependent tests of the component.
