### PR TITLE
[HttpKernel] Allow leading zeros in int request attributes

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
@@ -53,13 +53,21 @@ final class RequestAttributeValueResolver implements ValueResolverInterface
             }
 
             $value = (string) $value;
-        } elseif ($filter = match ($type) {
-            'int' => \FILTER_VALIDATE_INT,
-            'float' => \FILTER_VALIDATE_FLOAT,
-            'bool' => \FILTER_VALIDATE_BOOL,
+        } elseif ('bool' === $type) {
+            if (null === $value = filter_var($value, \FILTER_VALIDATE_BOOL, ['flags' => \FILTER_NULL_ON_FAILURE | \FILTER_REQUIRE_SCALAR])) {
+                throw new NotFoundHttpException(\sprintf('The value for the "%s" route parameter is invalid.', $name));
+            }
+        } elseif (null !== $cast = match ($type) {
+            'int' => static fn (int $v): int => $v,
+            'float' => static fn (float $v): float => $v,
             default => null,
         }) {
-            if (null === $value = $request->attributes->filter($name, null, $filter, ['flags' => \FILTER_NULL_ON_FAILURE | \FILTER_REQUIRE_SCALAR])) {
+            // Coerce the value as PHP would when passing it to the typed controller
+            // argument, so a zero-padded "06" still resolves to 6 while a value that
+            // would raise a TypeError (overflow, "abc") becomes a 404.
+            try {
+                $value = $cast($value);
+            } catch (\TypeError) {
                 throw new NotFoundHttpException(\sprintf('The value for the "%s" route parameter is invalid.', $name));
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestAttributeValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestAttributeValueResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
@@ -64,5 +65,106 @@ class RequestAttributeValueResolverTest extends TestCase
         $result = iterator_to_array($resolver->resolve($request, $metadata));
 
         $this->assertSame([null], $result);
+    }
+
+    /**
+     * A zero-padded decimal (e.g. "06" from a {month} placeholder with a "\d+"
+     * requirement) must resolve to its int value instead of becoming a 404.
+     */
+    #[DataProvider('provideLeadingZeroInts')]
+    public function testLeadingZeroIntIsAccepted(string $value, int $expected)
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $request->attributes->set('id', $value);
+        $metadata = new ArgumentMetadata('id', 'int', false, false, null);
+
+        $result = iterator_to_array($resolver->resolve($request, $metadata));
+
+        $this->assertSame([$expected], $result);
+    }
+
+    public static function provideLeadingZeroInts(): iterable
+    {
+        yield 'single leading zero' => ['06', 6];
+        yield 'multiple leading zeros' => ['007', 7];
+        yield 'would-be-octal stays decimal' => ['08', 8];
+        yield 'all zeros' => ['00', 0];
+        yield 'negative with leading zero' => ['-06', -6];
+    }
+
+    public function testLeadingZeroOutOfRangeIntBecomes404()
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        // leading zero in front of (PHP_INT_MAX + 1) must still overflow, not silently truncate
+        $request->attributes->set('id', '09223372036854775808');
+        $metadata = new ArgumentMetadata('id', 'int', false, false, null);
+
+        $this->expectException(NotFoundHttpException::class);
+        iterator_to_array($resolver->resolve($request, $metadata));
+    }
+
+    #[DataProvider('provideFloats')]
+    public function testFloatIsCoerced(string $value, float $expected)
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $request->attributes->set('price', $value);
+        $metadata = new ArgumentMetadata('price', 'float', false, false, null);
+
+        $result = iterator_to_array($resolver->resolve($request, $metadata));
+
+        $this->assertSame([$expected], $result);
+    }
+
+    public static function provideFloats(): iterable
+    {
+        yield 'decimal' => ['1.5', 1.5];
+        yield 'leading zero' => ['06', 6.0];
+    }
+
+    public function testInvalidFloatBecomes404()
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $request->attributes->set('price', 'abc');
+        $metadata = new ArgumentMetadata('price', 'float', false, false, null);
+
+        $this->expectException(NotFoundHttpException::class);
+        iterator_to_array($resolver->resolve($request, $metadata));
+    }
+
+    #[DataProvider('provideStrictBools')]
+    public function testBoolUsesStrictValidation(string $value, bool $expected)
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $request->attributes->set('active', $value);
+        $metadata = new ArgumentMetadata('active', 'bool', false, false, null);
+
+        $result = iterator_to_array($resolver->resolve($request, $metadata));
+
+        $this->assertSame([$expected], $result);
+    }
+
+    public static function provideStrictBools(): iterable
+    {
+        yield 'one' => ['1', true];
+        yield 'zero' => ['0', false];
+        yield 'true' => ['true', true];
+        yield 'false' => ['false', false];
+    }
+
+    public function testNonTokenBoolBecomes404()
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        // unlike PHP's coercion (any non-empty string is true), bool keeps strict token validation
+        $request->attributes->set('active', 'banana');
+        $metadata = new ArgumentMetadata('active', 'bool', false, false, null);
+
+        $this->expectException(NotFoundHttpException::class);
+        iterator_to_array($resolver->resolve($request, $metadata));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64432
| License       | MIT

Since 8.1, typed request-attribute validation rejects zero-padded decimals
for `int` arguments. A route such as:

```php
#[Route('/month/{year}/{month}', requirements: ['year' => '\d{4}', 'month' => '\d+'])]
public function controller(int $month, int $year): Response
```

called with `/month/2026/06` throws a `NotFoundHttpException`, because
`filter_var()` with `FILTER_VALIDATE_INT` rejects the leading zero in `06`.
Before typed validation was introduced, the raw string was passed to the
controller and PHP coerced it to `int 6`.

The root cause is that `filter_var()` is stricter than PHP's own type
coercion. `int` and `float` attributes are now validated by coercing them the
way PHP does when calling the controller, turning a value that would raise a
`TypeError` into a 404. `bool` keeps its strict `filter_var()` validation.

| input  | before | after |
| ------ | ------ | ----- |
| `06`   | 404    | 6     |
| `007`  | 404    | 7     |
| `-06`  | 404    | -6    |
| `abc`  | 404    | 404   |
| `09223372036854775808` | 404 | 404 (overflow) |
