### PR TITLE
[AssetMapper] Render an empty import map as a JSON object

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -96,7 +96,7 @@ class ImportMapRenderer
         }
 
         $scriptAttributes = $this->createAttributesString($attributes);
-        $importMapJson = json_encode(['imports' => $importMap], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG);
+        $importMapJson = json_encode(['imports' => $importMap ?: new \stdClass()], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG);
         $output .= <<<HTML
 
             <script type="importmap"$scriptAttributes>

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapRendererTest.php
@@ -204,4 +204,19 @@ class ImportMapRendererTest extends TestCase
         $this->assertSame(['as' => 'style'], $linkProvider->getLinks()[0]->getAttributes());
         $this->assertSame('/assets/styles/app-preload-d1g35t.css', $linkProvider->getLinks()[0]->getHref());
     }
+
+    public function testEmptyImportMapRendersAsJsonObject()
+    {
+        $importMapGenerator = $this->createMock(ImportMapGenerator::class);
+        $importMapGenerator->expects($this->once())
+            ->method('getImportMapData')
+            ->with([])
+            ->willReturn([]);
+
+        $renderer = new ImportMapRenderer($importMapGenerator);
+        $html = $renderer->render([]);
+
+        $this->assertStringContainsString('"imports": {}', $html);
+        $this->assertStringNotContainsString('"imports": []', $html);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64422
| License       | MIT

When no entrypoint is passed (`{{ importmap([]) }}`) or the import map is
empty, `ImportMapRenderer` rendered the `imports` value as a JSON array:

```json
{
    "imports": []
}
```

The import map specification requires `imports` to be a JSON **object**, so
browsers reject the empty array:

> Uncaught TypeError: Failed to parse import map: "imports" top-level key must be a JSON object.

An empty map is now serialized as a JSON object (`{}`); non-empty maps are
unchanged (an associative array already encodes as an object).
