### PR TITLE
 Unsafe unserialize phpstan rule

### DIFF
--- a/.github/sa-tools/.gitignore
+++ b/.github/sa-tools/.gitignore
@@ -2,5 +2,6 @@
 !.gitignore
 !psalm.baseline.xml
 !phpstan-diff.php
+!UnserializeMissingAllowedClassesRule.php
 !stubs
 !stubs/*

--- a/.github/sa-tools/UnserializeMissingAllowedClassesRule.php
+++ b/.github/sa-tools/UnserializeMissingAllowedClassesRule.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+
+/**
+ * @implements Rule<Node\Expr\FuncCall>
+ */
+class UnserializeMissingAllowedClassesRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Name
+            || 'unserialize' !== strtolower($node->name->name)
+            || $this->hasAllowedClassesKey($scope, $node)
+        ) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message('unserialize() calls must specify the "allowed_classes" option.')
+                ->identifier('symfony.unserializeMissingAllowedClasses')
+                ->build(),
+        ];
+    }
+
+    private function hasAllowedClassesKey(Scope $scope, Node\Expr\FuncCall $node): bool
+    {
+        if (null === $optionsArg = $node->getArg('options', 1)) {
+            return false;
+        }
+
+        if (!$constantArrays = $scope->getType($optionsArg->value)->getConstantArrays()) {
+            return false;
+        }
+
+        foreach ($constantArrays as $constantArray) {
+            $hasAllowedClasses = false;
+            foreach ($constantArray->getKeyTypes() as $keyType) {
+                if (($keyType instanceof ConstantStringType || $keyType instanceof ConstantIntegerType) && 'allowed_classes' === $keyType->getValue()) {
+                    $hasAllowedClasses = true;
+                    break;
+                }
+            }
+
+            if (!$hasAllowedClasses) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -84,7 +84,7 @@ jobs:
           composer require --no-progress --ansi --no-plugins phpstan/phpstan:@stable phpstan/phpstan-deprecation-rules:@stable phpunit/phpunit:^9.5 php-http/discovery psr/event-dispatcher mongodb/mongodb
 
       - name: PHPStan on target branch
-        run: ./vendor/bin/phpstan analyse --error-format=json --no-progress > .github/sa-tools/phpstan-base.json || true
+        run: ./vendor/bin/phpstan analyse --error-format=json --no-progress --autoload-file='.github/sa-tools/UnserializeMissingAllowedClassesRule.php' > .github/sa-tools/phpstan-base.json || true
 
       - name: Switch to PR
         run: |
@@ -94,5 +94,5 @@ jobs:
 
       - name: PHPStan
         run: |
-          ./vendor/bin/phpstan analyse --error-format=json --no-progress > .github/sa-tools/phpstan-pr.json || true
+          ./vendor/bin/phpstan analyse --error-format=json --no-progress --autoload-file='.github/sa-tools/UnserializeMissingAllowedClassesRule.php' > .github/sa-tools/phpstan-pr.json || true
           php .github/sa-tools/phpstan-diff.php .github/sa-tools/phpstan-base.json .github/sa-tools/phpstan-pr.json

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -16,3 +16,9 @@ parameters:
     ignoreErrors:
         # Added in PHP 8.4
         - '#^Class BcMath\\Number not found\.$#'
+
+services:
+    -
+        class: UnserializeMissingAllowedClassesRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -120,7 +120,7 @@ class Deprecation
 
         set_error_handler(static function () {});
         try {
-            $parsedMsg = unserialize($this->message);
+            $parsedMsg = unserialize($this->message, ['allowed_classes' => false]);
         } finally {
             restore_error_handler();
         }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -264,7 +264,7 @@ class SymfonyTestsListenerTrait
             putenv('SYMFONY_EXPECTED_DEPRECATIONS_SERIALIZE');
             $expectedDeprecations = file_get_contents($file);
             if ($expectedDeprecations) {
-                self::$expectedDeprecations = array_merge(self::$expectedDeprecations, unserialize($expectedDeprecations));
+                self::$expectedDeprecations = array_merge(self::$expectedDeprecations, unserialize($expectedDeprecations, ['allowed_classes' => false]));
                 if (!self::$previousErrorHandler) {
                     self::$previousErrorHandler = set_error_handler([self::class, 'handleError']);
                 }
@@ -293,7 +293,7 @@ class SymfonyTestsListenerTrait
             $deprecations = file_get_contents($this->runsInSeparateProcess);
             unlink($this->runsInSeparateProcess);
             putenv('SYMFONY_DEPRECATIONS_SERIALIZE');
-            foreach ($deprecations ? unserialize($deprecations) : [] as $deprecation) {
+            foreach ($deprecations ? unserialize($deprecations, ['allowed_classes' => false]) : [] as $deprecation) {
                 $error = serialize(['deprecation' => $deprecation[1], 'class' => $className, 'method' => $test->getName(false), 'triggering_file' => $deprecation[2] ?? null, 'files_stack' => $deprecation[3] ?? []]);
                 if ($deprecation[0]) {
                     // unsilenced on purpose
@@ -345,7 +345,7 @@ class SymfonyTestsListenerTrait
         }
         // If the message is serialized we need to extract the message. This occurs when the error is triggered by
         // by the isolated test path in \Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait::endTest().
-        $parsedMsg = @unserialize($msg);
+        $parsedMsg = @unserialize($msg, ['allowed_classes' => false]);
         if (\is_array($parsedMsg)) {
             $msg = $parsedMsg['deprecation'];
         }

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -54,7 +54,7 @@ abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
         // the ArrayAdapter stores the values serialized
         // to avoid mutation of the data after it was written to the cache
         // so here we un-serialize the values first
-        $values = array_map(static fn ($val) => null !== $val ? unserialize($val) : null, $arrayAdapter->getValues());
+        $values = array_map(static fn ($val) => null !== $val ? unserialize($val, ['allowed_classes' => true]) : null, $arrayAdapter->getValues());
 
         return $this->warmUpPhpArrayAdapter(new PhpArrayAdapter($this->phpArrayFile, new NullAdapter()), $values);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -174,7 +174,7 @@ class JsonDescriptor extends Descriptor
             throw new RuntimeException('The deprecation file does not exist, please try warming the cache first.');
         }
 
-        $logs = unserialize(file_get_contents($containerDeprecationFilePath));
+        $logs = unserialize(file_get_contents($containerDeprecationFilePath), ['allowed_classes' => false]);
 
         $formattedLogs = [];
         $remainingCount = 0;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -122,7 +122,7 @@ class MarkdownDescriptor extends Descriptor
             throw new RuntimeException('The deprecation file does not exist, please try warming the cache first.');
         }
 
-        $logs = unserialize(file_get_contents($containerDeprecationFilePath));
+        $logs = unserialize(file_get_contents($containerDeprecationFilePath), ['allowed_classes' => false]);
         if (0 === \count($logs)) {
             $this->write("## There are no deprecations in the logs!\n");
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -403,7 +403,7 @@ class TextDescriptor extends Descriptor
             return;
         }
 
-        $logs = unserialize(file_get_contents($containerDeprecationFilePath));
+        $logs = unserialize(file_get_contents($containerDeprecationFilePath), ['allowed_classes' => false]);
         if (0 === \count($logs)) {
             $options['output']->success('There are no deprecations in the logs!');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -115,7 +115,7 @@ class XmlDescriptor extends Descriptor
             throw new RuntimeException('The deprecation file does not exist, please try warming the cache first.');
         }
 
-        $logs = unserialize(file_get_contents($containerDeprecationFilePath));
+        $logs = unserialize(file_get_contents($containerDeprecationFilePath), ['allowed_classes' => false]);
 
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($deprecationsXML = $dom->createElement('deprecations'));

--- a/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
@@ -36,7 +36,7 @@ class CachedMappedAssetFactory implements MappedAssetFactoryInterface
         $configCache = new ConfigCache($cachePath, $this->debug);
 
         if ($configCache->isFresh()) {
-            return unserialize(file_get_contents($cachePath));
+            return unserialize(file_get_contents($cachePath), ['allowed_classes' => true]);
         }
 
         $mappedAsset = $this->innerFactory->createMappedAsset($logicalPath, $sourcePath);

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -433,7 +433,7 @@ abstract class AbstractBrowser
         if (file_exists($deprecationsFile)) {
             $deprecations = file_get_contents($deprecationsFile);
             unlink($deprecationsFile);
-            foreach ($deprecations ? unserialize($deprecations) : [] as $deprecation) {
+            foreach ($deprecations ? unserialize($deprecations, ['allowed_classes' => false]) : [] as $deprecation) {
                 if ($deprecation[0]) {
                     // unsilenced on purpose
                     trigger_error($deprecation[1], \E_USER_DEPRECATED);
@@ -447,7 +447,7 @@ abstract class AbstractBrowser
             throw new RuntimeException(\sprintf('OUTPUT: %s ERROR OUTPUT: %s.', $process->getOutput(), $process->getErrorOutput()));
         }
 
-        return unserialize($process->getOutput());
+        return unserialize($process->getOutput(), ['allowed_classes' => true]);
     }
 
     /**

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -347,7 +347,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
         }
         if (\is_string($value) && isset($value[2]) && ':' === $value[1]) {
             try {
-                $value = unserialize($value);
+                $value = unserialize($value, ['allowed_classes' => true]);
             } catch (\Exception $e) {
                 CacheItem::log($this->logger, 'Failed to unserialize key "{key}": '.$e->getMessage(), ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]);
                 $value = false;

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -98,7 +98,7 @@ final class LockRegistry
             return $callback($item, $save);
         }
 
-        self::$signalingException ??= unserialize("O:9:\"Exception\":1:{s:16:\"\0Exception\0trace\";a:0:{}}");
+        self::$signalingException ??= unserialize("O:9:\"Exception\":1:{s:16:\"\0Exception\0trace\";a:0:{}}", ['allowed_classes' => [\Exception::class]]);
         self::$signalingCallback ??= static fn () => throw self::$signalingException;
 
         while (true) {

--- a/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/DefaultMarshaller.php
@@ -71,7 +71,7 @@ class DefaultMarshaller implements MarshallerInterface
         $unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
         try {
             if (':' === ($value[1] ?? ':')) {
-                if (false !== $value = unserialize($value)) {
+                if (false !== $value = unserialize($value, ['allowed_classes' => true])) {
                     return $value;
                 }
             } elseif (false === $igbinaryNull) {

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -158,7 +158,7 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
         });
 
         try {
-            $meta = unserialize($content);
+            $meta = unserialize($content, ['allowed_classes' => true]);
         } catch (\Throwable $e) {
             if ($e !== $signalingException) {
                 throw $e;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
@@ -92,7 +92,7 @@ class ResolveDecoratorStackPass implements CompilerPassInterface
         foreach ($stacks[$id] as $k => $definition) {
             if ($definition instanceof ChildDefinition && isset($stacks[$definition->getParent()])) {
                 $path[] = $definition->getParent();
-                $definition = unserialize(serialize($definition)); // deep clone
+                $definition = unserialize(serialize($definition), ['allowed_classes' => true]); // deep clone
             } elseif ($definition instanceof Definition) {
                 $definitions[$decoratedId = $prefix.$k] = $definition;
                 continue;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -116,7 +116,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $definition = substr_replace($definition, 'Child', 44, 0);
             }
             /** @var ChildDefinition $definition */
-            $definition = unserialize($definition);
+            $definition = unserialize($definition, ['allowed_classes' => true]);
             $definition->setParent($parent);
 
             if (null !== $shared && !isset($definition->getChanges()['shared'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
@@ -53,7 +53,7 @@ class PrototypeConfigurator extends AbstractServiceConfigurator
         $definition->setAutowired($defaults->isAutowired());
         $definition->setAutoconfigured($defaults->isAutoconfigured());
         // deep clone, to avoid multiple process of the same instance in the passes
-        $definition->setBindings(unserialize(serialize($defaults->getBindings())));
+        $definition->setBindings(unserialize(serialize($defaults->getBindings()), ['allowed_classes' => true]));
         $definition->setChanges([]);
 
         $this->loader = $loader;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -88,7 +88,7 @@ class ServicesConfigurator extends AbstractConfigurator
         $definition->setAutowired($defaults->isAutowired());
         $definition->setAutoconfigured($defaults->isAutoconfigured());
         // deep clone, to avoid multiple process of the same instance in the passes
-        $definition->setBindings(unserialize(serialize($defaults->getBindings())));
+        $definition->setBindings(unserialize(serialize($defaults->getBindings()), ['allowed_classes' => true]));
         $definition->setChanges([]);
 
         $configurator = new ServiceConfigurator($this->container, $this->instanceof, true, $this, $definition, $id, $defaults->getTags(), $this->path);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
@@ -36,7 +36,7 @@ trait ParentTrait
             $definition = serialize($this->definition);
             $definition = substr_replace($definition, '53', 2, 2);
             $definition = substr_replace($definition, 'Child', 44, 0);
-            $definition = unserialize($definition);
+            $definition = unserialize($definition, ['allowed_classes' => true]);
 
             $this->definition = $definition->setParent($parent);
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -134,7 +134,7 @@ abstract class FileLoader extends BaseFileLoader
                 if (strpos($serialized, 'O:48:"Symfony\Component\DependencyInjection\Definition"')
                     || strpos($serialized, 'O:53:"Symfony\Component\DependencyInjection\ChildDefinition"')
                 ) {
-                    $getPrototype = static fn () => $getPrototype()->{'set'.$key}(unserialize($serialized));
+                    $getPrototype = static fn () => $getPrototype()->{'set'.$key}(unserialize($serialized, ['allowed_classes' => true]));
                 }
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -379,7 +379,7 @@ class XmlFileLoader extends FileLoader
         }
 
         // deep clone, to avoid multiple process of the same instance in the passes
-        $bindings = array_merge(unserialize(serialize($defaults->getBindings())), $bindings);
+        $bindings = array_merge(unserialize(serialize($defaults->getBindings()), ['allowed_classes' => true]), $bindings);
 
         if ($bindings) {
             $definition->setBindings($bindings);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -662,7 +662,7 @@ class YamlFileLoader extends FileLoader
         if (isset($defaults['bind']) || isset($service['bind'])) {
             // deep clone, to avoid multiple process of the same instance in the passes
             $bindings = $definition->getBindings();
-            $bindings += isset($defaults['bind']) ? unserialize(serialize($defaults['bind'])) : [];
+            $bindings += isset($defaults['bind']) ? unserialize(serialize($defaults['bind']), ['allowed_classes' => true]) : [];
 
             if (isset($service['bind'])) {
                 if (!\is_array($service['bind'])) {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -64,7 +64,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
     public function getEnvPlaceholderUniquePrefix(): string
     {
         if (!isset($this->envPlaceholderUniquePrefix)) {
-            $reproducibleEntropy = unserialize(serialize($this->parameters));
+            $reproducibleEntropy = unserialize(serialize($this->parameters), ['allowed_classes' => true]);
             array_walk_recursive($reproducibleEntropy, static function (&$v) { $v = null; });
             $this->envPlaceholderUniquePrefix = 'env_'.substr(hash('xxh128', serialize($reproducibleEntropy)), -16);
         }

--- a/src/Symfony/Component/ExpressionLanguage/SerializedParsedExpression.php
+++ b/src/Symfony/Component/ExpressionLanguage/SerializedParsedExpression.php
@@ -37,6 +37,6 @@ class SerializedParsedExpression extends ParsedExpression
      */
     public function getNodes()
     {
-        return unserialize($this->nodes);
+        return unserialize($this->nodes, ['allowed_classes' => true]);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -145,7 +145,7 @@ class MockFileSessionStorage extends MockArraySessionStorage
             restore_error_handler();
         }
 
-        $this->data = $data ? unserialize($data) : [];
+        $this->data = $data ? unserialize($data, ['allowed_classes' => true]) : [];
 
         $this->loadSession();
     }

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -316,7 +316,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
             $data = @gzdecode($data) ?: $data;
         }
 
-        if (!$data = unserialize($data)) {
+        if (!$data = unserialize($data, ['allowed_classes' => true])) {
             return null;
         }
 

--- a/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
+++ b/src/Symfony/Component/Intl/Transliterator/EmojiTransliterator.php
@@ -57,7 +57,7 @@ if (!class_exists(\Transliterator::class)) {
                 $instance = ($newInstance ??= (new \ReflectionClass(self::class))->newInstanceWithoutConstructor(...))();
                 $instance->id = $id;
             } else {
-                $instance = unserialize(\sprintf('O:%d:"%s":1:{s:2:"id";s:%d:"%s";}', \strlen(self::class), self::class, \strlen($id), $id));
+                $instance = unserialize(\sprintf('O:%d:"%s":1:{s:2:"id";s:%d:"%s";}', \strlen(self::class), self::class, \strlen($id), $id), ['allowed_classes' => true]);
             }
 
             $instance->map = $maps[$id] ??= str_ends_with($file, '.gz') ? GzipStreamWrapper::require($file) : require $file;

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -90,7 +90,7 @@ class PhpSerializer implements SerializerInterface
 
         try {
             /** @var Envelope */
-            $envelope = unserialize($contents);
+            $envelope = unserialize($contents, ['allowed_classes' => true]);
         } catch (\Throwable $e) {
             if ($e instanceof MessageDecodingFailedException) {
                 throw $e;

--- a/src/Symfony/Component/RateLimiter/Storage/InMemoryStorage.php
+++ b/src/Symfony/Component/RateLimiter/Storage/InMemoryStorage.php
@@ -38,7 +38,7 @@ class InMemoryStorage implements StorageInterface
             return null;
         }
 
-        return unserialize($limiterState);
+        return unserialize($limiterState, ['allowed_classes' => true]);
     }
 
     public function delete(string $limiterStateId): void

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -284,7 +284,7 @@ class ContextListener extends AbstractListener
         });
 
         try {
-            $token = unserialize($serializedToken);
+            $token = unserialize($serializedToken, ['allowed_classes' => true]);
         } catch (\ErrorException $e) {
             if (0x37313BC !== $e->getCode()) {
                 throw $e;

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -240,7 +240,7 @@ class ExceptionCaster
                         if (isset($f['object'])) {
                             $template = $f['object'];
                         } elseif ((new \ReflectionClass($f['class']))->isInstantiable()) {
-                            $template = unserialize(\sprintf('O:%d:"%s":0:{}', \strlen($f['class']), $f['class']));
+                            $template = unserialize(\sprintf('O:%d:"%s":0:{}', \strlen($f['class']), $f['class']), ['allowed_classes' => true]);
                         }
                         if (null !== $template) {
                             $ellipsis = 0;

--- a/src/Symfony/Component/VarExporter/Instantiator.php
+++ b/src/Symfony/Component/VarExporter/Instantiator.php
@@ -49,9 +49,9 @@ final class Instantiator
         } elseif (null === Registry::$prototypes[$class]) {
             throw new NotInstantiableTypeException($class);
         } elseif ($reflector->implementsInterface('Serializable') && !method_exists($class, '__unserialize')) {
-            $instance = unserialize('C:'.\strlen($class).':"'.$class.'":0:{}');
+            $instance = unserialize('C:'.\strlen($class).':"'.$class.'":0:{}', ['allowed_classes' => true]);
         } else {
-            $instance = unserialize('O:'.\strlen($class).':"'.$class.'":0:{}');
+            $instance = unserialize('O:'.\strlen($class).':"'.$class.'":0:{}', ['allowed_classes' => true]);
         }
 
         return $properties || $scopedProperties ? Hydrator::hydrate($instance, $properties, $scopedProperties) : $instance;

--- a/src/Symfony/Component/VarExporter/Internal/Registry.php
+++ b/src/Symfony/Component/VarExporter/Internal/Registry.php
@@ -40,7 +40,7 @@ class Registry
 
         try {
             foreach ($serializables as $k => $v) {
-                $objects[$k] = unserialize($v);
+                $objects[$k] = unserialize($v, ['allowed_classes' => true]);
             }
         } finally {
             ini_set('unserialize_callback_func', $unserializeCallback);
@@ -91,7 +91,7 @@ class Registry
                     $proto = null;
                 } else {
                     try {
-                        $proto = @unserialize($proto.\strlen($class).':"'.$class.'":0:{}');
+                        $proto = @unserialize($proto.\strlen($class).':"'.$class.'":0:{}', ['allowed_classes' => true]);
                     } catch (\Exception $e) {
                         if (__FILE__ !== $e->getFile()) {
                             throw $e;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -694,7 +694,7 @@ class Inline
                                 throw new ParseException('Missing value for tag "!php/object".', self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
                             }
 
-                            return unserialize(self::parseScalar(substr($scalar, 12)));
+                            return unserialize(self::parseScalar(substr($scalar, 12)), ['allowed_classes' => true]);
                         }
 
                         if (self::$exceptionOnInvalidType) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

Adds a PHPStan rule that will flag `unserialize()` calls that don't use the `allowed_classes` option.

Related to this comment: https://github.com/symfony/symfony/pull/64419#issuecomment-4602376174
