### PR TITLE
[Serializer] Keep collection value type for iterable constructor parameters

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -1025,6 +1025,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         if (null !== $parameterType && $parameterTypeResolver ??= class_exists(ReflectionTypeResolver::class) ? new ReflectionTypeResolver() : false) {
             $resolvedParameterType = $parameterTypeResolver->resolve($parameterType, ($parameterTypeContextFactory ??= new TypeContextFactory())->createFromClassName($class->name, $parameter->getDeclaringClass()?->name));
             if ($resolvedParameterType->isSatisfiedBy(static fn (Type $t) => match (true) {
+                $t instanceof BuiltinType && \in_array($t->getTypeIdentifier(), [TypeIdentifier::ARRAY, TypeIdentifier::ITERABLE], true) => !$type->isIdentifiedBy(TypeIdentifier::ARRAY) && !$type->isIdentifiedBy(TypeIdentifier::ITERABLE),
                 $t instanceof BuiltinType && !\in_array($t->getTypeIdentifier(), [TypeIdentifier::NULL, TypeIdentifier::MIXED], true) => !$type->isIdentifiedBy($t->getTypeIdentifier()),
                 $t instanceof ObjectType => !$type->isIdentifiedBy($t->getClassName()),
                 default => false,

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1031,6 +1031,23 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame(42, $result->getEntity()->id);
     }
 
+    public function testDenormalizeIterableConstructorParameterDenormalizesItems()
+    {
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new ObjectNormalizer(null, null, null, new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()])),
+        ]);
+
+        $result = $serializer->denormalize(
+            ['items' => [['value' => 'foo'], ['value' => 'bar']]],
+            DummyWithIterableOfDtos::class,
+        );
+
+        $this->assertInstanceOf(DummyWithIterableOfDtos::class, $result);
+        $this->assertContainsOnlyInstancesOf(DummyDtoItem::class, $result->items);
+        $this->assertSame(['foo', 'bar'], array_map(static fn (DummyDtoItem $i) => $i->value, $result->items));
+    }
+
     #[Group('legacy')]
     #[IgnoreDeprecations]
     public function testDenormalizeMixedConstructorParameterUsesExtractorTypeLegacy()
@@ -2206,5 +2223,26 @@ class DummyWithMixedConstructorParamAndEntityGetter
     public function getEntity(): ?DummyEntity
     {
         return $this->entity;
+    }
+}
+
+class DummyDtoItem
+{
+    public string $value;
+}
+
+class DummyWithIterableOfDtos
+{
+    /** @var array<DummyDtoItem> */
+    public array $items;
+
+    /**
+     * @param iterable<DummyDtoItem> $items
+     */
+    public function __construct(iterable $items)
+    {
+        $this->items = iterator_to_array((static function () use ($items) {
+            yield from $items;
+        })());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64444
| License       | MIT

Regression from the constructor parameter type-override added in 7.4.6: when a
constructor argument is typed `iterable` (or `array`) but the property type
extractor reports a more precise collection type such as `array<A>`, the
override replaced the rich extractor type with the bare reflection type. The
collection value type (`A`) was lost, so nested items were left un-denormalized
(raw arrays instead of `A` instances).

```php
final class A { public function __construct(public string $foo) {} }
final class B {
    /** @var array<A> */ public array $items;
    /** @param iterable<A> $items */
    public function __construct(iterable $items) { $this->items = iterator_to_array($items); }
}
// before: B::$items contains stdClass/arrays - after: contains A instances
```

The fix keeps the extractor's collection type when it is already an
`array`/`iterable` compatible with the parameter type, so the value type is
preserved and items are denormalized. Genuinely incompatible types (e.g.
extractor `string` vs parameter `int`) are still overridden as before.
