### PR TITLE
[DependencyInjection] Keep behavior-describing tags 'proxy' and 'container.service_subscriber.locator' on decorated services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AddBehaviorDescribingTagsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AddBehaviorDescribingTagsPass.php
@@ -21,9 +21,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class AddBehaviorDescribingTagsPass implements CompilerPassInterface
 {
     private const DEFAULT_TAGS = [
+        'proxy',
         'container.do_not_inline',
         'container.service_locator',
         'container.service_subscriber',
+        'container.service_subscriber.locator',
     ];
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AddBehaviorDescribingTagsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AddBehaviorDescribingTagsPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\AddBehaviorDescribingTagsPass;
+use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AddBehaviorDescribingTagsPassTest extends TestCase
@@ -24,9 +25,11 @@ class AddBehaviorDescribingTagsPassTest extends TestCase
         (new AddBehaviorDescribingTagsPass(['kernel.event_subscriber', 'kernel.reset']))->process($container);
 
         $this->assertSame([
+            'proxy',
             'container.do_not_inline',
             'container.service_locator',
             'container.service_subscriber',
+            'container.service_subscriber.locator',
             'kernel.event_subscriber',
             'kernel.reset',
         ], $container->getParameter('container.behavior_describing_tags'));
@@ -40,9 +43,11 @@ class AddBehaviorDescribingTagsPassTest extends TestCase
         (new AddBehaviorDescribingTagsPass(['kernel.locale_aware']))->process($container);
 
         $this->assertSame([
+            'proxy',
             'container.do_not_inline',
             'container.service_locator',
             'container.service_subscriber',
+            'container.service_subscriber.locator',
             'kernel.event_subscriber',
             'kernel.reset',
             'kernel.locale_aware',
@@ -57,5 +62,41 @@ class AddBehaviorDescribingTagsPassTest extends TestCase
         (new AddBehaviorDescribingTagsPass(['new.tag']))->process($container);
 
         $this->assertSame(['existing.tag', 'new.tag'], $container->getParameter('container.behavior_describing_tags'));
+    }
+
+    /**
+     * @see https://github.com/symfony/symfony/issues/64467
+     */
+    public function testDefaultTagsCoverServiceSubscriberLocatorAndProxyTagsKeptByDecoratorServicePass()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setTags([
+                'proxy' => 'foo',
+                'container.service_subscriber' => [],
+                'container.service_subscriber.locator' => [],
+                'bar' => ['attr' => 'baz'],
+            ])
+        ;
+        $container
+            ->register('baz')
+            ->setTags(['foobar' => ['attr' => 'bar']])
+            ->setDecoratedService('foo')
+        ;
+
+        (new AddBehaviorDescribingTagsPass())->process($container);
+        (new DecoratorServicePass())->process($container);
+
+        $this->assertEquals([
+            'proxy' => 'foo',
+            'container.service_subscriber' => [],
+            'container.service_subscriber.locator' => [],
+        ], $container->getDefinition('baz.inner')->getTags());
+        $this->assertEquals([
+            'bar' => ['attr' => 'baz'],
+            'foobar' => ['attr' => 'bar'],
+            'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']],
+        ], $container->getDefinition('baz')->getTags());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64467
| License       | MIT

`AddBehaviorDescribingTagsPass` (introduced in 8.1) seeds the `container.behavior_describing_tags` parameter with a list missing two tags that `DecoratorServicePass` previously kept on the inner service via its own fallback: `proxy` and `container.service_subscriber.locator`.

As a result, decorating a service that has either of those tags (e.g. `router.default`, which is a service subscriber) moves the tag onto the decorator. The inner service's PSR-11 locator is then never registered, and container compilation fails with:

```
The service "App\Service\RouterDecorator.inner" has a dependency on a non-existent service "Psr\Container\ContainerInterface".
```

Reproduces with: decorating `router.default` via `#[AsDecorator('router.default')]`, then `bin/console cache:clear`.

This realigns `AddBehaviorDescribingTagsPass::DEFAULT_TAGS` with the fallback list in `DecoratorServicePass` (`['proxy', 'container.do_not_inline', 'container.service_locator', 'container.service_subscriber', 'container.service_subscriber.locator']`), restoring the behavior fixed in 3c7dbb4f13 (2022, service-subscriber locator) and cc11922f12 (2023, proxy tag).

A regression test `testDefaultTagsCoverServiceSubscriberLocatorAndProxyTagsKeptByDecoratorServicePass` runs both passes in order and asserts that the decorated service keeps both `proxy` and `container.service_subscriber.locator` on the renamed inner definition; without the fix it fails with the locator/proxy tags stripped.
