### PR TITLE
Make tests compatible with PHPUnit 13.2 and Twig 3.28

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -73,18 +73,19 @@ class DoctrineChoiceLoaderTest extends TestCase
         );
 
         $choices = [$this->obj1, $this->obj2, $this->obj3];
-        $value = static function () {};
-        $choiceList = new ArrayChoiceList($choices, $value);
+        $value = static fn ($choice) => $choice->name;
 
         $this->repository->expects($this->once())
             ->method('findAll')
             ->willReturn($choices);
 
-        $this->assertEquals($choiceList, $loader->loadChoiceList($value));
+        $expected = ['A' => $this->obj1, 'B' => $this->obj2, 'C' => $this->obj3];
+
+        $this->assertSame($expected, $loader->loadChoiceList($value)->getChoices());
 
         // no further loads on subsequent calls
 
-        $this->assertEquals($choiceList, $loader->loadChoiceList($value));
+        $this->assertSame($expected, $loader->loadChoiceList($value)->getChoices());
     }
 
     public function testLoadChoiceListUsesObjectLoaderIfAvailable()

--- a/src/Symfony/Bridge/Twig/Tests/Validator/Constraints/TwigValidatorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Validator/Constraints/TwigValidatorTest.php
@@ -18,6 +18,7 @@ use Symfony\Bridge\Twig\Validator\Constraints\TwigValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Twig\DeprecatedCallableInfo;
 use Twig\Environment;
+use Twig\Error\Error;
 use Twig\Loader\ArrayLoader;
 use Twig\TwigFilter;
 
@@ -109,11 +110,14 @@ class TwigValidatorTest extends ConstraintValidatorTestCase
 
     public static function getInvalidValues()
     {
+        // Twig 3.28 started reporting the column number in syntax errors
+        $column = method_exists(Error::class, 'getTemplateColumn') ? ' column 14' : '';
+
         return [
             // Invalid syntax example (missing end tag)
             ['{% if condition %}Oops', 'Unexpected end of template at line 1.', 1],
             // Another syntax error example (unclosed variable)
-            ['Hello {{ name', 'Unexpected token "end of template" ("end of print statement" expected) at line 1.', 1],
+            ['Hello {{ name', \sprintf('Unexpected token "end of template" ("end of print statement" expected) at line 1%s.', $column), 1],
             // Unknown filter error
             ['Hello {{ name|unknown_filter }}', 'Unknown "unknown_filter" filter at line 1.', 1],
             // Invalid variable syntax

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -70,16 +70,16 @@ class EventDispatcherTest extends TestCase
         $this->dispatcher->addListener('pre.foo', [$listener1, 'preFoo'], -10);
         $this->dispatcher->addListener('pre.foo', [$listener2, 'preFoo'], 10);
         $this->dispatcher->addListener('pre.foo', [$listener3, 'preFoo']);
-        $this->dispatcher->addListener('pre.foo', $listener4->preFoo(...), 20);
+        $this->dispatcher->addListener('pre.foo', $listener4Listener = $listener4->preFoo(...), 20);
 
         $expected = [
-            $listener4->preFoo(...),
+            $listener4Listener,
             [$listener2, 'preFoo'],
             [$listener3, 'preFoo'],
             [$listener1, 'preFoo'],
         ];
 
-        $this->assertEquals($expected, $this->dispatcher->getListeners('pre.foo'));
+        $this->assertSame($expected, $this->dispatcher->getListeners('pre.foo'));
     }
 
     public function testGetAllListenersSortsByPriority()

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -255,7 +255,7 @@ class DefaultChoiceListFactoryTest extends TestCase
         $value = static function () {};
         $list = $this->factory->createListFromLoader($loader, $value);
 
-        $this->assertEquals(new LazyChoiceList($loader, $value), $list);
+        $this->assertEqualsLazyChoiceList(new LazyChoiceList($loader, $value), $list);
     }
 
     public function testCreateFromLoaderWithFilter()

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -59,7 +59,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->childForm->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->childForm->getConfig()->getOptions()),
             'default_data' => [
                 'norm' => null,
                 'view' => '',
@@ -78,7 +78,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->form->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->form->getConfig()->getOptions()),
             'default_data' => [
                 'norm' => null,
             ],
@@ -101,7 +101,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($this->childForm) => $childFormData,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testBuildMultiplePreliminaryFormTrees()
@@ -119,7 +119,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $form1->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($form1->getConfig()->getOptions()),
             'children' => [],
         ];
 
@@ -131,7 +131,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($form1) => $form1Data,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
 
         $this->dataCollector->buildPreliminaryFormTree($form2);
 
@@ -141,7 +141,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $form2->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($form2->getConfig()->getOptions()),
             'children' => [],
         ];
 
@@ -155,7 +155,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($form2) => $form2Data,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testBuildSamePreliminaryFormTreeMultipleTimes()
@@ -169,7 +169,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->form->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->form->getConfig()->getOptions()),
             'children' => [],
         ];
 
@@ -181,7 +181,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($this->form) => $formData,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
 
         $this->dataCollector->collectDefaultData($this->form);
         $this->dataCollector->buildPreliminaryFormTree($this->form);
@@ -192,7 +192,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->form->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->form->getConfig()->getOptions()),
             'default_data' => [
                 'norm' => null,
             ],
@@ -208,7 +208,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($this->form) => $formData,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testBuildPreliminaryFormTreeWithoutCollectingAnyData()
@@ -227,7 +227,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($this->form) => $formData,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testBuildFinalFormTree()
@@ -247,7 +247,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->childForm->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->childForm->getConfig()->getOptions()),
             'default_data' => [
                 'norm' => null,
                 'view' => '',
@@ -270,7 +270,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->form->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->form->getConfig()->getOptions()),
             'default_data' => [
                 'norm' => null,
             ],
@@ -297,7 +297,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($this->childForm) => $childFormData,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testSerializeWithFormAddedMultipleTimes()
@@ -368,7 +368,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($child2) => $child2Data,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
 
         $this->dataCollector->buildFinalFormTree($this->form, $this->view);
 
@@ -389,7 +389,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($child2) => $child2Data,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testChildViewsCanBeWithoutCorrespondingChildForms()
@@ -415,7 +415,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->form->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->form->getConfig()->getOptions()),
             'children' => [
                 'child' => $childFormData,
             ],
@@ -430,7 +430,7 @@ class FormDataCollectorTest extends TestCase
                 // no child entry
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testChildViewsWithoutCorrespondingChildFormsMayBeExplicitlyAssociated()
@@ -454,7 +454,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->childForm->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->childForm->getConfig()->getOptions()),
             'children' => [],
         ];
 
@@ -464,7 +464,7 @@ class FormDataCollectorTest extends TestCase
             'type_class' => FormType::class,
             'synchronized' => true,
             'passed_options' => [],
-            'resolved_options' => $this->form->getConfig()->getOptions(),
+            'resolved_options' => self::removeClosures($this->form->getConfig()->getOptions()),
             'children' => [
                 'child' => $childFormData,
             ],
@@ -479,7 +479,7 @@ class FormDataCollectorTest extends TestCase
                 spl_object_hash($this->childForm) => $childFormData,
             ],
             'nb_errors' => 0,
-        ], $this->dataCollector->getData());
+        ], self::removeClosures($this->dataCollector->getData()));
     }
 
     public function testCollectSubmittedDataCountsErrors()
@@ -614,5 +614,16 @@ class FormDataCollectorTest extends TestCase
     private function createChildForm(string $name, bool $compound = false): FormInterface
     {
         return $this->factory->createNamedBuilder($name, FormType::class, null, ['auto_initialize' => false, 'compound' => $compound])->getForm();
+    }
+
+    private static function removeClosures(array $data): array
+    {
+        array_walk_recursive($data, static function (&$value) {
+            if ($value instanceof \Closure) {
+                $value = '(closure)';
+            }
+        });
+
+        return $data;
     }
 }

--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/StringSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/StringSanitizerTest.php
@@ -61,7 +61,7 @@ class StringSanitizerTest extends TestCase
         ];
 
         foreach ($cases as $input => $expected) {
-            yield $input => [$input, $expected];
+            yield ('' === $input ? 'empty string' : $input) => [$input, $expected];
         }
     }
 

--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -881,7 +881,7 @@ class UrlSanitizerTest extends TestCase
         ];
 
         foreach ($urls as $url => $expected) {
-            yield $url => [$url, $expected];
+            yield ('' === $url ? 'empty string' : $url) => [$url, $expected];
         }
     }
 }

--- a/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/AttributePropertyMetadataLoaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Mapping/Read/AttributePropertyMetadataLoaderTest.php
@@ -41,12 +41,21 @@ class AttributePropertyMetadataLoaderTest extends TestCase
             StringToBooleanValueTransformer::class => new StringToBooleanValueTransformer(),
         ]), TypeResolver::create());
 
-        $this->assertEquals([
-            'id' => new PropertyMetadata('id', Type::string(), [DivideStringAndCastToIntValueTransformer::class]),
-            'active' => new PropertyMetadata('active', Type::string(), [StringToBooleanValueTransformer::class]),
-            'name' => new PropertyMetadata('name', Type::string(), [\Closure::fromCallable('strtoupper')]),
-            'range' => new PropertyMetadata('range', Type::string(), [\Closure::fromCallable(DummyWithValueTransformerAttributes::explodeRange(...))]),
-        ], $loader->load(DummyWithValueTransformerAttributes::class));
+        $metadata = $loader->load(DummyWithValueTransformerAttributes::class);
+
+        $this->assertSame(['id', 'active', 'name', 'range'], array_keys($metadata));
+        $this->assertEquals(new PropertyMetadata('id', Type::string(), [DivideStringAndCastToIntValueTransformer::class]), $metadata['id']);
+        $this->assertEquals(new PropertyMetadata('active', Type::string(), [StringToBooleanValueTransformer::class]), $metadata['active']);
+
+        $this->assertSame('name', $metadata['name']->getName());
+        $this->assertEquals(Type::string(), $metadata['name']->getType());
+        $this->assertCount(1, $metadata['name']->getValueTransformers());
+        $this->assertSame('FOO', $metadata['name']->getValueTransformers()[0]('foo'));
+
+        $this->assertSame('range', $metadata['range']->getName());
+        $this->assertEquals(Type::string(), $metadata['range']->getType());
+        $this->assertCount(1, $metadata['range']->getValueTransformers());
+        $this->assertSame([1, 2], $metadata['range']->getValueTransformers()[0]('1..2'));
     }
 
     public function testThrowWhenCannotRetrieveValueTransformer()

--- a/src/Symfony/Component/JsonStreamer/Tests/Mapping/Write/AttributePropertyMetadataLoaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Mapping/Write/AttributePropertyMetadataLoaderTest.php
@@ -41,12 +41,21 @@ class AttributePropertyMetadataLoaderTest extends TestCase
             BooleanToStringValueTransformer::class => new BooleanToStringValueTransformer(),
         ]), TypeResolver::create());
 
-        $this->assertEquals([
-            'id' => new PropertyMetadata('id', Type::string(), [DoubleIntAndCastToStringValueTransformer::class]),
-            'active' => new PropertyMetadata('active', Type::string(), [BooleanToStringValueTransformer::class]),
-            'name' => new PropertyMetadata('name', Type::string(), [\Closure::fromCallable('strtolower')]),
-            'range' => new PropertyMetadata('range', Type::string(), [\Closure::fromCallable(DummyWithValueTransformerAttributes::concatRange(...))]),
-        ], $loader->load(DummyWithValueTransformerAttributes::class));
+        $metadata = $loader->load(DummyWithValueTransformerAttributes::class);
+
+        $this->assertSame(['id', 'active', 'name', 'range'], array_keys($metadata));
+        $this->assertEquals(new PropertyMetadata('id', Type::string(), [DoubleIntAndCastToStringValueTransformer::class]), $metadata['id']);
+        $this->assertEquals(new PropertyMetadata('active', Type::string(), [BooleanToStringValueTransformer::class]), $metadata['active']);
+
+        $this->assertSame('name', $metadata['name']->getName());
+        $this->assertEquals(Type::string(), $metadata['name']->getType());
+        $this->assertCount(1, $metadata['name']->getValueTransformers());
+        $this->assertSame('foo', $metadata['name']->getValueTransformers()[0]('FOO'));
+
+        $this->assertSame('range', $metadata['range']->getName());
+        $this->assertEquals(Type::string(), $metadata['range']->getType());
+        $this->assertCount(1, $metadata['range']->getValueTransformers());
+        $this->assertSame('10..20', $metadata['range']->getValueTransformers()[0]([10, 20]));
     }
 
     public function testThrowWhenCannotRetrieveValueTransformer()

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -28,9 +28,12 @@ class HandlersLocatorTest extends TestCase
         ]);
 
         $descriptor = new HandlerDescriptor($handler);
-        $descriptor->getName();
 
-        $this->assertEquals([$descriptor], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+        $handlers = iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a'))));
+
+        $this->assertCount(1, $handlers);
+        $this->assertSame($descriptor->getName(), $handlers[0]->getName());
+        $this->assertSame($handler, (new \ReflectionFunction($handlers[0]->getHandler()))->getClosureThis());
     }
 
     public function testItReturnsOnlyHandlersMatchingTransport()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -247,7 +247,9 @@ class ContextListenerTest extends TestCase
 
         $dispatcher->expects($this->once())
             ->method('addListener')
-            ->with(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
+            ->with(KernelEvents::RESPONSE, $this->callback(static fn ($l) => $l instanceof \Closure
+                && $listener === (new \ReflectionFunction($l))->getClosureThis()
+                && 'onKernelResponse' === (new \ReflectionFunction($l))->name));
 
         $listener->authenticate(new RequestEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST));
     }
@@ -268,7 +270,9 @@ class ContextListenerTest extends TestCase
 
         $dispatcher->expects($this->once())
             ->method('removeListener')
-            ->with(KernelEvents::RESPONSE, $listener->onKernelResponse(...));
+            ->with(KernelEvents::RESPONSE, $this->callback(static fn ($l) => $l instanceof \Closure
+                && $listener === (new \ReflectionFunction($l))->getClosureThis()
+                && 'onKernelResponse' === (new \ReflectionFunction($l))->name));
 
         $listener->onKernelResponse($event);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/MacAddressTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MacAddressTest.php
@@ -25,7 +25,7 @@ class MacAddressTest extends TestCase
     {
         $mac = new MacAddress(normalizer: 'trim');
 
-        $this->assertEquals(trim(...), $mac->normalizer);
+        $this->assertSame('trim', (new \ReflectionFunction($mac->normalizer))->name);
     }
 
     public function testAttributes()
@@ -36,7 +36,7 @@ class MacAddressTest extends TestCase
 
         [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
         self::assertSame('myMessage', $aConstraint->message);
-        self::assertEquals(trim(...), $aConstraint->normalizer);
+        self::assertSame('trim', (new \ReflectionFunction($aConstraint->normalizer))->name);
         self::assertSame(MacAddress::ALL, $aConstraint->type);
         self::assertSame(['Default', 'MacAddressDummy'], $aConstraint->groups);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Makes the test suite pass with the latest testing dependencies.

**PHPUnit 13.2** introduced two stricter behaviors that make tests fail:

1. Data-set keys in data providers must not be empty strings (hard error). Two `HtmlSanitizer` providers key their data sets by the input string, which is empty for one case.
2. `assertEquals()` now warns when it has to compare closures (`Comparing closures for equality is problematic because there is no reliable way to determine whether two closures are equal`). With `failOnWarning="true"` this turns into a failure. This affects `JsonStreamer`, `Form`, `Validator`, `Messenger`, `EventDispatcher`, `Security\Http` and the `Doctrine` bridge.

**Twig 3.28** now reports the column number in syntax errors, changing one expected message in `TwigValidatorTest`. The change is feature-detected so the test keeps passing on earlier Twig versions.

This only touches tests, no production code is changed.
