### PR TITLE
[Tui] Truncate InputWidget prompt when wider than available columns

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
@@ -450,6 +450,36 @@ class InputTest extends TestCase
         $this->assertSame(12, AnsiUtils::visibleWidth($lines[0]));
     }
 
+    public function testRenderWithPromptWiderThanAvailableColumns()
+    {
+        // When prompt is wider than available columns, it should be truncated
+        // to the column width, not returned verbatim.
+        $input = new InputWidget();
+        $input->setPrompt('This prompt is way too long to fit: ');
+        $input->setValue('hidden');
+
+        $columns = 10;
+        $lines = $input->render(new RenderContext($columns, 24));
+
+        $this->assertCount(1, $lines);
+        $this->assertSame($columns, AnsiUtils::visibleWidth($lines[0]));
+        // The truncated prompt should be a prefix of the original
+        $stripped = AnsiUtils::stripAnsiCodes($lines[0]);
+        $this->assertStringStartsWith('This', $stripped);
+    }
+
+    public function testRenderWithPromptWiderThanAvailableColumnsEmptyPrompt()
+    {
+        $input = new InputWidget();
+        $input->setPrompt('');
+        $input->setValue('hello');
+
+        $lines = $input->render(new RenderContext(5, 24));
+
+        $this->assertCount(1, $lines);
+        $this->assertSame(5, AnsiUtils::visibleWidth($lines[0]));
+    }
+
     public function testRenderScrollingWithMixedWidthCharacters()
     {
         $input = new InputWidget();

--- a/src/Symfony/Component/Tui/Widget/InputWidget.php
+++ b/src/Symfony/Component/Tui/Widget/InputWidget.php
@@ -277,7 +277,7 @@ class InputWidget extends AbstractWidget implements FocusableInterface
         $availableColumns = $columns - AnsiUtils::visibleWidth($prompt);
 
         if ($availableColumns <= 0) {
-            return [$prompt];
+            return [AnsiUtils::truncateToWidth($prompt, $columns, '', true)];
         }
 
         $value = $this->line->getText();


### PR DESCRIPTION
| Q             | A
|----------------|------
| Branch?         | 8.1
| Bug fix?        | yes
| New feature?    | no
| Deprecations?   | no
| Issues          | Fix #64525
| License         | MIT

When the prompt alone is wider than the RenderContext columns, InputWidget::render() computed a non-positive $availableColumns but returned the prompt unchanged, violating the widget render contract that the returned line's visible width should not exceed RenderContext::getColumns().

This PR truncates the prompt using AnsiUtils::truncateToWidth() when $availableColumns <= 0, ensuring the returned line's visible width never exceeds the available columns.

---

### Verified RED → GREEN (local, PHP 8.4.21 / PHPUnit 11.5.55)

`vendor/bin/phpunit Tests/Widget/InputTest.php --filter PromptWiderThanAvailableColumns`

**GREEN (patch applied):**
```
..                                                                  2 / 2 (100%)
OK (2 tests, 5 assertions)
```

**RED (production change reverted to `return [$prompt];`):**
```
F.                                                                  2 / 2 (100%)
1) ...InputTest::testRenderWithPromptWiderThanAvailableColumns
Failed asserting that 36 is identical to 10.
FAILURES! Tests: 2, Assertions: 4, Failures: 1.
```
The test fails without the patch (un-truncated 36-wide prompt vs the 10-column contract) and passes with it — it asserts the behaviour, not the implementation.
