### PR TITLE
 fix(translations): review and approve Arabic translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">الرجاء إدخال UUID صالح.</target>
+                <target>الرجاء إدخال UUID صالح.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -556,15 +556,15 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">هذه القيمة ليست XML صالحة.</target>
+                <target>هذه القيمة ليست XML صالحة.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">هذه القيمة لا تتوافق مع مخطط XSD المتوقع.</target>
+                <target>هذه القيمة لا تتوافق مع مخطط XSD المتوقع.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">حمولة XML هذه كبيرة جدًا ({{ size }} بايت): فهي تتجاوز الحد البالغ {{ limit }} بايت.</target>
+                <target>حمولة XML هذه كبيرة جدًا ({{ size }} بايت): فهي تتجاوز الحد البالغ {{ limit }} بايت.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64480
| License       | MIT

Native Arabic speaker review of the 4 translations marked `needs-review-translation`:

- **Form**: "Please enter a valid UUID." → "الرجاء إدخال UUID صالح." ✓
- **Validator**: "This value is not valid XML." → "هذه القيمة ليست XML صالحة." ✓
- **Validator**: "This value does not conform to the expected XSD schema." → "هذه القيمة لا تتوافق مع مخطط XSD المتوقع." ✓
- **Validator**: "This XML payload is too large..." → "حمولة XML هذه كبيرة جدًا..." ✓

All translations are grammatically correct and use natural Arabic. Removed `state="needs-review-translation"` to approve them.