### PR TITLE
[HttpKernel] Restore null-on-invalid for nullable #[Autowire(service:)] controller args

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -171,7 +171,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                     }
 
                     if ($autowireAttributes) {
-                        $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+                        $invalidBehavior = $p->allowsNull() ? ContainerInterface::NULL_ON_INVALID_REFERENCE : ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
                         $attribute = $autowireAttributes[0]->newInstance();
                         $value = $parameterBag->resolveValue($attribute->value);
 

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -555,6 +555,26 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $container->compile();
     }
 
+    public function testAutowireAttributeNullableInvalidReferenceResolvesToNull()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register('foo', WithAutowireAttributeNullableInvalidReference::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+        $container->compile();
+
+        /** @var ServiceLocator $locator */
+        $locator = $container->get($locatorId)->get('foo::invalidReference');
+
+        $this->assertNull($locator->get('service'));
+    }
+
     public function testTaggedIteratorAndTaggedLocatorAttributes()
     {
         $container = new ContainerBuilder();
@@ -799,7 +819,16 @@ class WithAutowireAttributeInvalidReference
 {
     public function invalidReference(
         #[Autowire(service: 'invalid.id')]
-        ?\stdClass $service2 = null,
+        \stdClass $service2,
+    ) {
+    }
+}
+
+class WithAutowireAttributeNullableInvalidReference
+{
+    public function invalidReference(
+        #[Autowire(service: 'invalid.id')]
+        ?\stdClass $service,
     ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64530
| License       | MIT

PR #63724 made every invalid `#[Autowire(service:)]` reference throw a `ServiceNotFoundException` at container compile time. That broke the previous contract where a nullable controller argument resolved to `null` when the requested service was missing in the current environment.

**Before (6.4, pre-#63724):** `#[Autowire(service: 'profiler')] ?Profiler $profiler` → `null` when `profiler` is absent (e.g., in `prod`).
**After #63724:** same code throws `ServiceNotFoundException` during container compilation. Production deploys break when a dev-only service is injected into a nullable argument.

This mirrors the convention already used on the non-Autowire path (`allowsNull() && !isOptional()` → `NULL_ON_INVALID_REFERENCE`, line 144-146 of the same file). With this fix:
- A nullable parameter without a default (`?Profiler $profiler`) resolves to `null` when the service is missing.
- A nullable parameter with an explicit `= null` default still throws — preserving the test added in #63724.

## Test verification (RED → GREEN)

### RED (fix reverted — `EXCEPTION_ON_INVALID_REFERENCE` unconditionally)

```
$ ./phpunit --filter testAutowireAttributeNullableInvalidReferenceResolvesToNull
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 00:00.019, Memory: 26.91 MB

There was 1 error:

1) Symfony\Component\HttpKernel\Tests\DependencyInjection\RegisterControllerArgumentLocatorsPassTest::testAutowireAttributeNullableInvalidReferenceResolvesToNull
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The service ".service_locator..L98dv1" has a dependency on a non-existent service "invalid.id".

/home/ousama/www/public/symfony/src/Symfony/Component/HttpKernel/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:116
...
ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

### GREEN (with fix — `NULL_ON_INVALID_REFERENCE` for nullable non-optional params)

```
$ ./phpunit --filter testAutowireAttributeNullableInvalidReferenceResolvesToNull
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.018, Memory: 26.91 MB

OK (1 test, 1 assertion)
```
