### PR TITLE
[Console] Render formatter tags in ChoiceQuestion default value

### DIFF
--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -56,13 +56,13 @@ class SymfonyQuestionHelper extends QuestionHelper
                     $default[$key] = $choices[trim($value)];
                 }
 
-                $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape(implode(', ', $default)));
+                $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, implode(', ', $default));
 
                 break;
 
             case $question instanceof ChoiceQuestion:
                 $choices = $question->getChoices();
-                $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape($choices[$default] ?? $default));
+                $text = \sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, $choices[$default] ?? $default);
 
                 break;
 

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -97,6 +97,47 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
         $this->assertOutputContains('What is your favorite superhero? [Batman]', $output);
     }
 
+    public function testAskChoiceDefaultRendersFormatterTagsInsteadOfEscapingThem()
+    {
+        $questionHelper = new SymfonyQuestionHelper();
+        $helperSet = new HelperSet([new FormatterHelper()]);
+        $questionHelper->setHelperSet($helperSet);
+
+        $choices = ['<comment>Add new tag</comment>', 'hello', 'world'];
+        $question = new ChoiceQuestion('Select a tag', $choices, 0);
+        $question->setMaxAttempts(1);
+
+        $this->assertSame($choices[0], $questionHelper->ask(
+            $this->createStreamableInputInterfaceMock($this->getInputStream("\n")),
+            $output = $this->createOutputInterface(),
+            $question
+        ));
+        // The default value in the brackets must match how the same choice is rendered
+        // in the choices list below, instead of leaking its raw formatter markup.
+        $this->assertOutputContains('Select a tag [Add new tag]:', $output);
+        $this->assertOutputNotContains('[<comment>Add new tag</comment>]', $output);
+    }
+
+    public function testAskMultiselectChoiceDefaultRendersFormatterTagsInsteadOfEscapingThem()
+    {
+        $questionHelper = new SymfonyQuestionHelper();
+        $helperSet = new HelperSet([new FormatterHelper()]);
+        $questionHelper->setHelperSet($helperSet);
+
+        $choices = ['<comment>Add new tag</comment>', 'hello', 'world'];
+        $question = new ChoiceQuestion('Select tags', $choices, '0,1');
+        $question->setMultiselect(true);
+        $question->setMaxAttempts(1);
+
+        $questionHelper->ask(
+            $this->createStreamableInputInterfaceMock($this->getInputStream("\n")),
+            $output = $this->createOutputInterface(),
+            $question
+        );
+        $this->assertOutputContains('Select tags [Add new tag, hello]:', $output);
+        $this->assertOutputNotContains('[<comment>Add new tag</comment>, hello]', $output);
+    }
+
     public function testAskReturnsNullIfValidatorAllowsIt()
     {
         $questionHelper = new SymfonyQuestionHelper();
@@ -224,6 +265,12 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTestCase
         }
 
         $this->assertStringContainsString($expected, $stream);
+    }
+
+    private function assertOutputNotContains(string $unexpected, StreamOutput $output): void
+    {
+        rewind($output->getStream());
+        $this->assertStringNotContainsString($unexpected, stream_get_contents($output->getStream()));
     }
 
     public function testAskMultilineQuestionIncludesHelpText()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50007
| License       | MIT

`SymfonyQuestionHelper::writePrompt()` wraps the `ChoiceQuestion` default value in `OutputFormatter::escape()`. When a choice value contains intentional formatter markup (e.g. `<comment>Add new tag</comment>`), the default shown in the brackets leaks the **raw** markup, while the very same value is rendered cleanly in the choices list just below (via `formatChoiceQuestionChoices()`, which interpolates choices as-is). The result is inconsistent:

```
 Select a tag [<comment>Add new tag</comment>]:
  [0] Add new tag
  [1] hello
```

Choice values are developer-controlled — the same trust level as the choice list — so escaping the default is wrong. This drops the `escape()` for both the single and the multiselect default. After the fix:

```
 Select a tag [Add new tag]:
  [0] Add new tag
```

## Test verification (RED → GREEN)

Two tests added to `SymfonyQuestionHelperTest` (single + multiselect).
`vendor/bin/phpunit --filter '…RendersFormatterTags…' Tests/Helper/SymfonyQuestionHelperTest.php` on 6.4 (PHP 8.4 / PHPUnit 9.6):

**RED — without the patch (upstream 6.4 `SymfonyQuestionHelper`):**
```
Failed asserting that ' Select tags [<comment>Add new tag</comment>, hello]:
 …' contains "Select tags [Add new tag, hello]:".
Tests: 2, Assertions: 3, Failures: 2.
```

**GREEN — with the patch:**
```
OK (2 tests, 5 assertions)
```

Full `Console` suite shows no regression: `1317 → 1319` tests, `14` pre-existing (env-specific, SIGINT) failures unchanged.
