### PR TITLE
[Tui] Avoid splitting Unicode ellipsis when truncating

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -290,7 +290,7 @@ final class AnsiUtils
         $targetWidth = $maxWidth - $ellipsisWidth;
 
         if ($targetWidth <= 0) {
-            return substr($ellipsis, 0, $maxWidth);
+            return '' === $ellipsis || $maxWidth <= 0 ? '' : self::truncateToWidth($ellipsis, $maxWidth, '', $pad);
         }
 
         // Fast path: pure printable ASCII, direct substr avoids sliceByColumn overhead

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -177,6 +177,26 @@ class AnsiUtilsTest extends TestCase
         $this->assertSame(10, AnsiUtils::visibleWidth($result));
     }
 
+    #[DataProvider('unicodeEllipsisProvider')]
+    public function testTruncateToWidthDoesNotSplitUnicodeEllipsis(string $ellipsis, int $maxWidth, string $expectedText, int $expectedWidth)
+    {
+        $result = AnsiUtils::truncateToWidth('Hello', $maxWidth, $ellipsis);
+
+        $this->assertTrue(mb_check_encoding($result, 'UTF-8'));
+        $this->assertSame($expectedWidth, AnsiUtils::visibleWidth($result));
+        $this->assertSame($expectedText, AnsiUtils::stripAnsiCodes($result));
+    }
+
+    /**
+     * @return iterable<string, array{string, int, string, int}>
+     */
+    public static function unicodeEllipsisProvider(): iterable
+    {
+        yield 'unicode ellipsis' => ['…', 1, '…', 1];
+        yield 'emoji ellipsis' => ['😀', 2, '😀', 2];
+        yield 'emoji ellipsis too wide' => ['😀', 1, '', 0];
+    }
+
     public function testSliceByColumn()
     {
         $this->assertSame('llo', AnsiUtils::sliceByColumn('Hello', 2, 3));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT


`AnsiUtils::truncateToWidth()` can currently return invalid UTF-8 when a custom Unicode ellipsis needs to be truncated.

When the ellipsis itself does not fit within the requested width, the current code uses byte-based truncation:

```php
return substr($ellipsis, 0, $maxWidth);
```

However, $maxWidth represents terminal columns, while substr() cuts bytes. This can split multi-byte characters.

For example:

```php
$result = AnsiUtils::truncateToWidth('Hello', 1, '…');
```

bin2hex($result); // e2
mb_check_encoding($result, 'UTF-8'); // false
This patch reuses the existing width-aware truncation logic for the ellipsis itself, so Unicode ellipses are not split at byte boundaries.

Tests were added for Unicode and emoji ellipses.
