### PR TITLE
[HttpKernel] Fix nullable autowired service reference resolving to exception instead of null

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -171,7 +171,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                     }
 
                     if ($autowireAttributes) {
-                        $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+                        $invalidBehavior = $p->allowsNull() ? ContainerInterface::NULL_ON_INVALID_REFERENCE : ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
                         $attribute = $autowireAttributes[0]->newInstance();
                         $value = $parameterBag->resolveValue($attribute->value);
 

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -538,12 +538,31 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $this->assertFalse($locator->has('service2'));
     }
 
-    public function testAutowireAttributeInvalidReference()
+    public function testAutowireAttributeInvalidReferenceNullable()
     {
         $container = new ContainerBuilder();
         $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
 
         $container->register('foo', WithAutowireAttributeInvalidReference::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $locator = $container->get($locatorId)->get('foo::invalidReference');
+        $this->assertNull($locator->get('service2'));
+    }
+
+    public function testAutowireAttributeInvalidReferenceNonNullable()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register('foo', WithAutowireAttributeInvalidReferenceNonNullable::class)
             ->addTag('controller.service_arguments');
 
         (new RegisterControllerArgumentLocatorsPass())->process($container);
@@ -800,6 +819,15 @@ class WithAutowireAttributeInvalidReference
     public function invalidReference(
         #[Autowire(service: 'invalid.id')]
         ?\stdClass $service2 = null,
+    ) {
+    }
+}
+
+class WithAutowireAttributeInvalidReferenceNonNullable
+{
+    public function invalidReference(
+        #[Autowire(service: 'invalid.id')]
+        \stdClass $service2,
     ) {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64530
| License       | MIT

When a controller parameter uses `#[Autowire(service: '...')]` and is nullable (e.g. `?Profiler $profiler`), a missing service in the current environment should resolve to `null`, not throw a build-time exception. PR #63724 introduced build-time validation for autowired controller arguments, which correctly catches non-nullable invalid references, but broke the existing behavior for nullable parameters.

This fix checks `$p->allowsNull()` and uses `NULL_ON_INVALID_REFERENCE` for nullable parameters, preserving the build-time check for non-nullable ones.

**Before:** `#[Autowire(service: 'profiler')] ?Profiler $profiler` throws `ServiceNotFoundException` in prod (where the profiler service does not exist).

**After:** `#[Autowire(service: 'profiler')] ?Profiler $profiler` resolves to `null` in prod, matching the pre-#63724 behavior.

## Test verification (RED → GREEN)

### RED — fix reverted (nullable throws instead of returning null):
```
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

.E.                                                                 3 / 3 (100%)

There was 1 error:

1) Symfony\Component\HttpKernel\Tests\DependencyInjection\RegisterControllerArgumentLocatorsPassTest::testAutowireAttributeInvalidReferenceNullable
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The service ".service_locator.DYRBANj" has a dependency on a non-existent service "invalid.id".

/tmp/sym-64-test/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:116
...
/tmp/sym-64-test/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php:554

ERRORS!
Tests: 3, Assertions: 15, Errors: 1.
```

### GREEN — with fix applied (all tests pass):
```
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

...                                                                 3 / 3 (100%)

Time: 00:00.033, Memory: 8.00 MB

OK (3 tests, 16 assertions)
```

Full suite: **33/33 tests pass, 91 assertions**.
