### PR TITLE
[Form] Don't re-add deleted collection entries on submit

### DIFF
--- a/src/Symfony/Component/Form/MissingDataHandler.php
+++ b/src/Symfony/Component/Form/MissingDataHandler.php
@@ -62,6 +62,7 @@ class MissingDataHandler
 
         if (\is_array($data)) {
             $children = $config->getCompound() ? $form->all() : [$form];
+            $allowDelete = $config->getOption('allow_delete', false);
 
             foreach ($children as $child) {
                 $name = $child->getName();
@@ -69,6 +70,9 @@ class MissingDataHandler
 
                 if (\array_key_exists($name, $data)) {
                     $childData = $data[$name];
+                } elseif ($allowDelete) {
+                    // Don't re-add a deleted collection entry so ResizeFormListener can remove it.
+                    continue;
                 }
 
                 $value = $this->handleMissingData($child, $childData);

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -28,6 +28,7 @@ use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\RequestHandlerInterface;
 use Symfony\Component\Form\ResolvedFormTypeFactory;
+use Symfony\Component\Form\Tests\Extension\Type\CheckboxCollectionEntryType;
 use Symfony\Component\Form\Tests\Extension\Type\ItemFileType;
 use Symfony\Component\Form\Util\ServerParams;
 
@@ -95,6 +96,29 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $this->requestHandler->handleRequest($form, $this->request);
 
         $this->assertSame([false, true, false], $form->getData());
+    }
+
+    #[DataProvider('methodExceptPatchProvider')]
+    public function testSubmitCollectionFormWithAllowDeleteRemovesMissingEntries($method)
+    {
+        $form = $this->factory->create(CollectionType::class, [
+            ['name' => 'first', 'active' => true],
+            ['name' => 'second', 'active' => true],
+        ], [
+            'entry_type' => CheckboxCollectionEntryType::class,
+            'allow_delete' => true,
+            'method' => $method,
+        ]);
+
+        $this->setRequestData($method, [
+            'collection' => [
+                0 => ['name' => 'first', 'active' => '1'],
+            ],
+        ]);
+
+        $this->requestHandler->handleRequest($form, $this->request);
+
+        $this->assertSame([0 => ['name' => 'first', 'active' => true]], $form->getData());
     }
 
     #[DataProvider('methodExceptPatchProvider')]

--- a/src/Symfony/Component/Form/Tests/Extension/Type/CheckboxCollectionEntryType.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Type/CheckboxCollectionEntryType.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class CheckboxCollectionEntryType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class, ['required' => false]);
+        $builder->add('active', CheckboxType::class, ['required' => false]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64436
| License       | MIT

Since 8.1 the request handlers call `MissingDataHandler::handle()` before `$form->submit()`. For a `CollectionType` with `allow_delete`, the handler walks the children that still exist at that point, including an entry the user removed, and synthesises `false_values` defaults for its `false_values`-aware children (`CheckboxType`, expanded multiple `ChoiceType`, ...). That re-adds the entry to the submitted data, so `ResizeFormListener::preSubmit()` (which drops entries whose key is absent via `isset()`) keeps it instead of removing it.

The fix skips a child entirely absent from the submitted data when the form has `allow_delete`, mirroring the `ResizeFormListener` condition, so a removed entry stays removed. A `false_values`-aware child inside a *kept* entry is still synthesised.

The regression test in `AbstractRequestHandlerTestCase` covers both `NativeRequestHandler` and `HttpFoundationRequestHandler` across POST/PUT/DELETE/GET; reverting the fix makes all 8 variants fail, applying it makes them pass.
