### PR TITLE
[CI] Make the PHPStan job report only new errors

### DIFF
--- a/.github/sa-tools/.gitignore
+++ b/.github/sa-tools/.gitignore
@@ -1,6 +1,6 @@
 *
 !.gitignore
 !psalm.baseline.xml
-!phpstan.baseline.neon
+!phpstan-diff.php
 !stubs
 !stubs/*

--- a/.github/sa-tools/phpstan-diff.php
+++ b/.github/sa-tools/phpstan-diff.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Compares two PHPStan JSON reports and fails if the second one (the PR) holds
+// errors that are not already present in the first one (the target branch).
+// Errors are matched on (file, message), ignoring line numbers, so that they
+// keep being recognized when surrounding code shifts. This mirrors how Psalm's
+// baseline works and, unlike PHPStan's own baseline, also covers errors PHPStan
+// marks as non-ignorable.
+
+function load(string $file): array
+{
+    $report = json_decode(file_get_contents($file), true) ?: [];
+
+    $bag = [];
+    foreach ($report['files'] ?? [] as $path => $data) {
+        foreach ($data['messages'] ?? [] as $message) {
+            $key = $path."\0".$message['message'];
+            $bag[$key] = ($bag[$key] ?? 0) + 1;
+        }
+    }
+    foreach ($report['errors'] ?? [] as $error) {
+        $bag["\0".$error] = ($bag["\0".$error] ?? 0) + 1;
+    }
+
+    return [$report, $bag];
+}
+
+function annotation(string $message): string
+{
+    return strtr($message, ["\r" => '', "\n" => ' ', '%' => '%25']);
+}
+
+[, $baseBag] = load($argv[1]);
+[$pr] = load($argv[2]);
+
+$new = [];
+
+foreach ($pr['files'] ?? [] as $path => $data) {
+    foreach ($data['messages'] ?? [] as $message) {
+        $key = $path."\0".$message['message'];
+        if (0 < ($baseBag[$key] ?? 0)) {
+            --$baseBag[$key];
+            continue;
+        }
+        $new[] = sprintf('::error file=%s,line=%d::%s', $path, $message['line'] ?? 0, annotation($message['message']));
+    }
+}
+
+foreach ($pr['errors'] ?? [] as $error) {
+    $key = "\0".$error;
+    if (0 < ($baseBag[$key] ?? 0)) {
+        --$baseBag[$key];
+        continue;
+    }
+    $new[] = '::error::'.annotation($error);
+}
+
+if ($new) {
+    echo implode("\n", $new), "\n";
+    exit(1);
+}
+
+echo "No new PHPStan errors.\n";

--- a/.github/sa-tools/phpstan.baseline.neon
+++ b/.github/sa-tools/phpstan.baseline.neon
@@ -1,2 +1,0 @@
-parameters:
-    ignoreErrors: []

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -83,8 +83,8 @@ jobs:
           composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
           composer require --no-progress --ansi --no-plugins phpstan/phpstan:@stable phpstan/phpstan-deprecation-rules:@stable phpunit/phpunit:^9.5 php-http/discovery psr/event-dispatcher mongodb/mongodb
 
-      - name: Generate PHPStan baseline
-        run: ./vendor/bin/phpstan analyse --generate-baseline=.github/sa-tools/phpstan.baseline.neon --allow-empty-baseline --no-progress
+      - name: PHPStan on target branch
+        run: ./vendor/bin/phpstan analyse --error-format=json --no-progress > .github/sa-tools/phpstan-base.json || true
 
       - name: Switch to PR
         run: |
@@ -93,4 +93,6 @@ jobs:
           git checkout -m FETCH_HEAD
 
       - name: PHPStan
-        run: ./vendor/bin/phpstan analyse --no-progress || ./vendor/bin/phpstan analyse --error-format=github --no-progress
+        run: |
+          ./vendor/bin/phpstan analyse --error-format=json --no-progress > .github/sa-tools/phpstan-pr.json || true
+          php .github/sa-tools/phpstan-diff.php .github/sa-tools/phpstan-base.json .github/sa-tools/phpstan-pr.json

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,6 +1,5 @@
 includes:
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - .github/sa-tools/phpstan.baseline.neon
 
 parameters:
     level: 5


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The PHPStan job is red on every PR, no matter what the PR changes.

It relies on `phpstan analyse --generate-baseline` to record the errors already present on the target branch, but PHPStan refuses to baseline errors it marks as non-ignorable (method-signature/LSP violations such as the `RedisCluster*Proxy` covariance errors, and a few others). The baseline step says so explicitly:

```
[WARNING] Baseline generated with 2829 errors.
          Some errors could not be put into baseline. Re-run PHPStan with "-vv"
```

Those ~40 non-baselineable errors then leak through on the PR run and fail the job.

This replaces the native baseline with the same approach the Psalm job already uses in spirit: run PHPStan on the target branch, switch to the PR, run again, and fail only on errors that are not already present on the target branch. Errors are matched on `(file, message)` ignoring line numbers, so unrelated code shifts don't reintroduce them, and unlike PHPStan's baseline this also covers the non-ignorable ones.