### PR TITLE
[Validator] Add Cron constraint to validate cron expressions

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `Cron` constraint to validate cron expressions
+
 8.1
 ---
 

--- a/src/Symfony/Component/Validator/Constraints/Cron.php
+++ b/src/Symfony/Component/Validator/Constraints/Cron.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Cron\CronExpression;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\LogicException;
+
+/**
+ * Validates that a value is a valid cron expression.
+ *
+ * @see https://en.wikipedia.org/wiki/Cron
+ *
+ * @author Erfan Momeni <erfamm5@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Cron extends Constraint
+{
+    public const INVALID_FORMAT_ERROR = '4ef85758-9c41-4f9b-9b27-9c0b6f1f6f0e';
+
+    protected const ERROR_NAMES = [
+        self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
+    ];
+
+    public const MODE_STANDARD = 'standard';
+    public const MODE_ALIASES = 'aliases';
+    public const MODE_HASHED = 'hashed';
+
+    private const MODES = [
+        self::MODE_STANDARD,
+        self::MODE_ALIASES,
+        self::MODE_HASHED,
+    ];
+
+    public string $message = 'This value is not a valid cron expression.';
+    public string $mode = self::MODE_ALIASES;
+
+    /**
+     * @param string[]|null     $groups
+     * @param self::MODE_*|null $mode   The accepted cron expression flavor (defaults to {@see self::MODE_ALIASES})
+     */
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+        ?string $mode = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->mode = $mode ?? $this->mode;
+
+        if (!\in_array($this->mode, self::MODES, true)) {
+            throw new ConstraintDefinitionException(\sprintf('The "%s" validation mode is not supported. Use one of "%s".', $this->mode, implode('", "', self::MODES)));
+        }
+
+        if (!class_exists(CronExpression::class)) {
+            throw new LogicException(\sprintf('The "dragonmantank/cron-expression" package is required to use the "%s" constraint. Try running "composer require dragonmantank/cron-expression".', __CLASS__));
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/CronValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CronValidator.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Cron\CronExpression;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+/**
+ * Validates whether the value is a valid cron expression.
+ *
+ * @author Erfan Momeni <erfamm5@gmail.com>
+ */
+class CronValidator extends ConstraintValidator
+{
+    /**
+     * Aliases not understood by every supported version of dragonmantank/cron-expression,
+     * mapped to a semantically equivalent alias that is universally supported.
+     */
+    private const ALIAS_MAP = [
+        '@midnight' => '@daily',
+    ];
+
+    private const HASH_ALIAS_MAP = [
+        '#hourly' => '# * * * *',
+        '#daily' => '# # * * *',
+        '#weekly' => '# # * * #',
+        '#weekly@midnight' => '# #(0-2) * * #',
+        '#monthly' => '# # # * *',
+        '#monthly@midnight' => '# #(0-2) # * *',
+        '#annually' => '# # # # *',
+        '#annually@midnight' => '# #(0-2) # # *',
+        '#yearly' => '# # # # *',
+        '#yearly@midnight' => '# #(0-2) # # *',
+        '#midnight' => '# #(0-2) * * *',
+    ];
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof Cron) {
+            throw new UnexpectedTypeException($constraint, Cron::class);
+        }
+
+        if ($value instanceof \Stringable) {
+            $value = (string) $value;
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!\is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        if (!$this->isValid(trim($value), $constraint->mode)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Cron::INVALID_FORMAT_ERROR)
+                ->addViolation();
+        }
+    }
+
+    private function isValid(string $expression, string $mode): bool
+    {
+        if ('' === $expression) {
+            return false;
+        }
+
+        if ('@' === $expression[0]) {
+            if (Cron::MODE_STANDARD === $mode) {
+                return false;
+            }
+
+            $expression = self::ALIAS_MAP[$expression] ?? $expression;
+        }
+
+        if (str_contains($expression, '#')) {
+            if (Cron::MODE_HASHED !== $mode) {
+                return false;
+            }
+
+            $expression = self::resolveHashed($expression);
+        }
+
+        return CronExpression::isValidExpression($expression);
+    }
+
+    /**
+     * Replaces Scheduler-style hash placeholders (`#`, `#(min-max)`) and hash aliases
+     * (`#daily`, ...) with concrete values, so the resulting expression can be validated
+     * by the underlying cron parser.
+     */
+    private static function resolveHashed(string $expression): string
+    {
+        // Field minimums, matching CronExpressionTrigger::HASH_RANGES; used as a safe
+        // default when a "#" placeholder is encountered without an explicit range.
+        static $fieldMin = [0, 0, 1, 1, 0];
+
+        $expression = self::HASH_ALIAS_MAP[$expression] ?? $expression;
+        $parts = explode(' ', $expression);
+
+        if (5 !== \count($parts)) {
+            return $expression;
+        }
+
+        foreach ($parts as $position => $part) {
+            if (preg_match('#^\#(\((\d+)-(\d+)\))?$#', $part, $matches)) {
+                $parts[$position] = $matches[2] ?? (string) $fieldMin[$position];
+            }
+        }
+
+        return implode(' ', $parts);
+    }
+}

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -566,6 +566,10 @@
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
                 <target>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</target>
             </trans-unit>
+            <trans-unit id="146">
+                <source>This value is not a valid cron expression.</source>
+                <target>This value is not a valid cron expression.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/CronTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CronTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Cron;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
+
+class CronTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(CronDummy::class);
+        $loader = new AttributeLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'CronDummy'], $bConstraint->groups);
+        self::assertSame(Cron::MODE_HASHED, $bConstraint->mode);
+
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
+        self::assertSame(['my_group'], $cConstraint->groups);
+        self::assertSame('some attached data', $cConstraint->payload);
+    }
+
+    public function testUnknownModeThrows()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "invalid" validation mode is not supported.');
+
+        new Cron(mode: 'invalid');
+    }
+}
+
+class CronDummy
+{
+    #[Cron]
+    private $a;
+
+    #[Cron(message: 'myMessage', mode: Cron::MODE_HASHED)]
+    private $b;
+
+    #[Cron(groups: ['my_group'], payload: 'some attached data')]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/CronValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CronValidatorTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Validator\Constraints\Cron;
+use Symfony\Component\Validator\Constraints\CronValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class CronValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): CronValidator
+    {
+        return new CronValidator();
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validate(null, new Cron());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->validate('', new Cron());
+
+        $this->assertNoViolation();
+    }
+
+    public function testExpectsStringCompatibleType()
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->validate(new \stdClass(), new Cron());
+    }
+
+    /**
+     * Standard expressions must be accepted in every mode (mode hierarchy: STANDARD ⊂ ALIASES ⊂ HASHED).
+     */
+    #[DataProvider('getStandardExpressionsAcrossAllModes')]
+    public function testStandardExpressionsAreAcceptedInEveryMode(string $expression, string $mode)
+    {
+        $this->validate($expression, new Cron(mode: $mode));
+
+        $this->assertNoViolation();
+    }
+
+    public static function getStandardExpressionsAcrossAllModes(): iterable
+    {
+        foreach (self::getValidStandardCronExpressions() as [$expression]) {
+            yield [$expression, Cron::MODE_STANDARD];
+            yield [$expression, Cron::MODE_ALIASES];
+            yield [$expression, Cron::MODE_HASHED];
+        }
+    }
+
+    public static function getValidStandardCronExpressions(): array
+    {
+        return [
+            ['* * * * *'],
+            ['*/5 * * * *'],
+            ['0 0 * * *'],
+            ['0 9-17 * * 1-5'],
+            ['0 0 1 1 *'],
+            ['30 6 * * 0'],
+            ['0,15,30,45 * * * *'],
+            ['0 0 1 JAN,JUL *'],
+            ['0 9 * * MON-FRI'],
+            ['15-45/15 * * * *'],
+            ['0 0 * * 7'],
+            ['  * * * * *  '],
+            ['*	*	*	*	*'],
+        ];
+    }
+
+    /**
+     * @-prefixed aliases must be accepted in the aliases and hashed modes.
+     */
+    #[DataProvider('getAliasExpressionsAcrossPermissiveModes')]
+    public function testAliasExpressionsAreAcceptedInAliasesAndHashedModes(string $expression, string $mode)
+    {
+        $this->validate($expression, new Cron(mode: $mode));
+
+        $this->assertNoViolation();
+    }
+
+    public static function getAliasExpressionsAcrossPermissiveModes(): iterable
+    {
+        foreach (self::getValidAliasExpressions() as [$expression]) {
+            yield [$expression, Cron::MODE_ALIASES];
+            yield [$expression, Cron::MODE_HASHED];
+        }
+    }
+
+    /**
+     * @-prefixed aliases must be rejected in the strict standard mode.
+     */
+    #[DataProvider('getValidAliasExpressions')]
+    public function testAliasExpressionsAreRejectedInStandardMode(string $expression)
+    {
+        $constraint = new Cron(message: 'testMessage', mode: Cron::MODE_STANDARD);
+
+        $this->validate($expression, $constraint);
+
+        $this->buildViolation('testMessage')
+            ->setParameter('{{ value }}', '"'.$expression.'"')
+            ->setCode(Cron::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getValidAliasExpressions(): array
+    {
+        return [
+            ['@yearly'],
+            ['@annually'],
+            ['@monthly'],
+            ['@weekly'],
+            ['@daily'],
+            ['@midnight'],
+            ['@hourly'],
+        ];
+    }
+
+    /**
+     * #-prefixed hashed expressions must be accepted only in the hashed mode.
+     */
+    #[DataProvider('getValidHashedExpressions')]
+    public function testHashedExpressionsAreAcceptedInHashedMode(string $expression)
+    {
+        $this->validate($expression, new Cron(mode: Cron::MODE_HASHED));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * #-prefixed hashed expressions must be rejected in the standard and aliases modes.
+     */
+    #[DataProvider('getHashedExpressionsAcrossStricterModes')]
+    public function testHashedExpressionsAreRejectedInStandardAndAliasesModes(string $expression, string $mode)
+    {
+        $constraint = new Cron(message: 'testMessage', mode: $mode);
+
+        $this->validate($expression, $constraint);
+
+        $this->buildViolation('testMessage')
+            ->setParameter('{{ value }}', '"'.$expression.'"')
+            ->setCode(Cron::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getHashedExpressionsAcrossStricterModes(): iterable
+    {
+        foreach (self::getValidHashedExpressions() as [$expression]) {
+            yield [$expression, Cron::MODE_STANDARD];
+            yield [$expression, Cron::MODE_ALIASES];
+        }
+    }
+
+    public static function getValidHashedExpressions(): array
+    {
+        return [
+            ['#hourly'],
+            ['#daily'],
+            ['#weekly'],
+            ['#monthly'],
+            ['#yearly'],
+            ['#annually'],
+            ['#midnight'],
+            ['# # * * *'],
+            ['# #(0-2) * * #'],
+        ];
+    }
+
+    #[DataProvider('getInvalidCronExpressions')]
+    public function testInvalidCronExpressions(string $expression)
+    {
+        $constraint = new Cron(message: 'testMessage');
+
+        $this->validate($expression, $constraint);
+
+        $this->buildViolation('testMessage')
+            ->setParameter('{{ value }}', '"'.$expression.'"')
+            ->setCode(Cron::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
+    public static function getInvalidCronExpressions(): array
+    {
+        return [
+            ['not a cron'],
+            ['* * *'],
+            ['* * * * * *'],
+            ['60 * * * *'],
+            ['* 24 * * *'],
+            ['* * 32 * *'],
+            ['* * * 13 *'],
+            ['* * * * 8'],
+            ['*/0 * * * *'],
+            ['*/ * * * *'],
+            ['/5 * * * *'],
+            ['1,,2 * * * *'],
+            ['* * * FOO *'],
+            ['@invalid'],
+        ];
+    }
+}

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -23,6 +23,7 @@
         "symfony/translation-contracts": "^2.5|^3"
     },
     "require-dev": {
+        "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^2.1.10|^3|^4",
         "symfony/cache": "^7.4|^8.0",
         "symfony/clock": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
  | ------------- | ---
  | Branch?       | 8.2
  | Bug fix?      | no
  | New feature?  | yes
  | Deprecations? | no                                                                                                                                     
  | Issues        | -
  | License       | MIT

Symfony's Scheduler is built around cron expressions, but the Validator component still has no way to check that a value actually *is* one. In practice this leaves two options, both unsatisfying:

* `#[Regex(...)]` — matches the shape but happily lets through `60 * * * *`, `0 17-9 * * *`, `*/0 * * * *`, `0 0 * FOO *`, and similar nonsense.
* `#[Callback(...)]` wrapping a third-party parser — works, but every project ends up writing the same eight lines of glue.

This PR adds a first-class `Cron` constraint with a self-contained parser. No new dependency is introduced.

The constraint exposes three modes so it can match the dialect actually used at the call site:

| Mode | Accepts |                                                                                                                                       
  | --- | --- |
  | `MODE_STANDARD` | Strict 5-field Vixie cron |
  | `MODE_ALIASES` *(default)* | Standard + `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@midnight`, `@hourly` |
  | `MODE_HASHED` | Standard + `@`-aliases + Scheduler's hashed forms (`#daily`, `# # * * #`, `#(0-2)`, …) — kept in sync with the alias map in `CronExpressionTrigger`, so anything the Scheduler will accept the validator accepts too |

Field parsing handles wildcards, comma lists, ranges, steps (including ranged steps like `0-30/5`), and the standard 3-letter month/weekday names (`JAN`–`DEC`, `SUN`–`SAT`, case-insensitive). Day-of-week treats both `0` and `7` as Sunday, matching POSIX.

Default is `MODE_ALIASES` because the bare `@daily`/`@hourly` forms are what most users actually type into a form field; `MODE_STANDARD` is available for codepaths where the stricter contract matters.

### Usage

```php
use Symfony\Component\Validator\Constraints\Cron;

class Task
{
      #[Cron]
      public string $schedule;

      #[Cron(mode: Cron::MODE_STANDARD)]
      public string $strictSchedule;

      // Validates inputs intended to be passed to Symfony Scheduler
      #[Cron(mode: Cron::MODE_HASHED)]
      public string $scheduledTask;
}
```
Before/after

Before:
```  
#[Callback([self::class, 'validateCron'])]
public string $schedule;

public static function validateCron(?string $value, ExecutionContextInterface $context): void
{
      if (null !== $value && !\Cron\CronExpression::isValidExpression($value)) {
          $context->buildViolation('Invalid cron expression.')->addViolation();
      }
 }
```
After:
```
#[Cron]
public string $schedule;
```
A single INVALID_FORMAT_ERROR code is exposed on the violation; sub-codes were considered and rejected — they would leak parser internals without giving the user anything actionable for an expression they can see in full.
  
