### PR TITLE
[ObjectMapper] Fix reverse class map dropping per-property #[Map(transform:)] when targets share a source

### DIFF
--- a/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
+++ b/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
@@ -30,8 +30,8 @@ final class ReverseMappingPass implements CompilerPassInterface
         $classes = [];
         foreach ($container->findTaggedResourceIds('object_mapper.map') as $tags) {
             foreach ($tags as $tag) {
-                if (isset($tag['source'], $tag['target'])) {
-                    $classes[$tag['source']] = $tag['target'];
+                if (isset($tag['source'], $tag['target']) && !\in_array($tag['target'], $classes[$tag['source']] ?? [], true)) {
+                    $classes[$tag['source']][] = $tag['target'];
                 }
             }
         }

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -26,18 +26,35 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
     private array $attributesCache = [];
 
     /**
-     * @param array<class-string, class-string> $classMap
+     * @var array<class-string, list<class-string>>
+     */
+    private readonly array $classMap;
+
+    /**
+     * @param array<class-string, class-string|list<class-string>> $classMap A single target
+     *                                                                      per source is
+     *                                                                      accepted for
+     *                                                                      backward
+     *                                                                      compatibility.
      */
     public function __construct(
         private readonly ObjectMapperMetadataFactoryInterface $objectMapperMetadataFactory,
-        private readonly array $classMap,
+        array $classMap,
     ) {
+        $normalized = [];
+        foreach ($classMap as $source => $target) {
+            $normalized[$source] = array_values((array) $target);
+        }
+        $this->classMap = $normalized;
     }
 
     public function create(object $object, ?string $property = null, array $context = []): array
     {
         $class = $object::class;
-        $key = $class.($property ? '.'.$property : '');
+        // When several targets share one source, the active target is propagated
+        // via $context to pick the right per-property metadata; cache per target too.
+        $contextTarget = $context['target'] ?? null;
+        $key = $class.($property ? '.'.$property : '').($contextTarget ? '.'.$contextTarget : '');
 
         if (isset($this->attributesCache[$key])) {
             return $this->attributesCache[$key];
@@ -45,17 +62,21 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
 
         $mappings = $this->objectMapperMetadataFactory->create($object, $property, $context);
 
-        if (!$targetClass = $this->classMap[$class] ?? null) {
+        if (!$targets = $this->classMap[$class] ?? null) {
             return $mappings;
         }
 
         if (!$property) {
-            $mappings[] = new Mapping($targetClass);
+            foreach ($targets as $targetClass) {
+                $mappings[] = new Mapping($targetClass);
+            }
 
             return $this->attributesCache[$key] = $mappings;
         }
 
-        $refl = new \ReflectionClass($targetClass);
+        $resolvedTarget = null !== $contextTarget && \in_array($contextTarget, $targets, true) ? $contextTarget : $targets[0];
+
+        $refl = new \ReflectionClass($resolvedTarget);
         foreach ($refl->getProperties() as $reflProperty) {
             $attributes = $reflProperty->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
 

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -135,7 +135,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
 
             $propertyName = $property->getName();
-            $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName);
+            $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName, ['target' => $mappedTarget::class]);
             foreach ($mappings as $mapping) {
                 $sourcePropertyName = $propertyName;
                 if ($mapping->source && (!$refl->hasProperty($propertyName) || !isset($source->$propertyName))) {

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedSource.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class SharedSource
+{
+    public int $value = 21;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithTransform.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithTransform.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: SharedSource::class)]
+final class SharedTargetWithTransform
+{
+    #[Map(source: 'value', transform: [self::class, 'double'])]
+    public int $value;
+
+    public static function double(mixed $v): int
+    {
+        return $v * 2;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithoutTransform.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithoutTransform.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: SharedSource::class)]
+final class SharedTargetWithoutTransform
+{
+    public int $value;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -36,6 +36,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSource
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\SharedSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\SharedTargetWithoutTransform;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\SharedTargetWithTransform;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\A as ClassRuleA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\B as ClassRuleB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\C as ClassRuleC;
@@ -847,6 +850,30 @@ final class ObjectMapperTest extends TestCase
         $this->assertEquals('bar', $costRequestView->foo, 'Explicit mapping should work');
         $this->assertEquals(10, $costRequestView->amount, 'Auto-mapping should also work for properties with the same name');
         $this->assertEquals(20, $costRequestView->tax);
+    }
+
+    public function testClassMapWithMultipleTargetsSharingOneSourceAppliesEachTargetsTransform()
+    {
+        // Two distinct targets share the same source: per-property `#[Map(transform:)]`
+        // on each target must be honored when the user maps to that specific target,
+        // rather than being silently dropped because the class map only stores one
+        // target per source.
+        $classMap = [
+            SharedSource::class => [
+                SharedTargetWithTransform::class,
+                SharedTargetWithoutTransform::class,
+            ],
+        ];
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+
+        $withTransform = $mapper->map(new SharedSource(), SharedTargetWithTransform::class);
+        $this->assertInstanceOf(SharedTargetWithTransform::class, $withTransform);
+        $this->assertSame(42, $withTransform->value, 'Transform on the explicit target must be applied');
+
+        $withoutTransform = $mapper->map(new SharedSource(), SharedTargetWithoutTransform::class);
+        $this->assertInstanceOf(SharedTargetWithoutTransform::class, $withoutTransform);
+        $this->assertSame(21, $withoutTransform->value, 'Mapping to the other target must not pick up the first target\'s transform');
     }
 
     public function testMissingSourcePropertiesAreIgnored()

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -876,6 +876,27 @@ final class ObjectMapperTest extends TestCase
         $this->assertSame(21, $withoutTransform->value, 'Mapping to the other target must not pick up the first target\'s transform');
     }
 
+    public function testClassMapWithMultipleTargetsSharingOneSourceRequiresAnExplicitTarget()
+    {
+        // When several targets share one source, mapping without an explicit
+        // target is genuinely ambiguous: there is no way to know which target
+        // is meant. The mapper must reject it with a clear exception rather
+        // than silently picking an arbitrary one.
+        $classMap = [
+            SharedSource::class => [
+                SharedTargetWithTransform::class,
+                SharedTargetWithoutTransform::class,
+            ],
+        ];
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Ambiguous mapping for "'.SharedSource::class.'".');
+
+        $mapper->map(new SharedSource());
+    }
+
     public function testMissingSourcePropertiesAreIgnored()
     {
         $mapper = new ObjectMapper();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64425
| License       | MIT

When several classes declare `#[Map(source: SameSource::class)]`, the
auto-built class map collapsed to one target per source.
`ReverseClassObjectMapperMetadataFactory` then read property metadata from
that single winning target, silently dropping each other target's
per-property `#[Map(transform:)]` (and `source`) — producing wrong values,
or a `TypeError` when the property is typed as a distinct sub-DTO.

This PR:

- Accepts `array<class-string, class-string|list<class-string>>` in
  `ReverseClassObjectMapperMetadataFactory::__construct()`. The old
  single-target shape is normalized to a list internally, so existing
  callers keep working.
- Propagates the active target class from `ObjectMapper::map()` through
  the metadata factory's `$context` (`['target' => $mappedTarget::class]`)
  so the reverse factory reads the right target's reflection metadata.
- Updates `ReverseMappingPass` in `FrameworkBundle` to build the
  multi-target shape from `object_mapper.map` tags instead of overwriting.

## Reproduces with

```php
class Source { public int $value = 21; }

#[Map(source: Source::class)]
class TargetA {
    #[Map(source: 'value', transform: [self::class, 'double'])]
    public int $value;
    public static function double(mixed $v): int { return $v * 2; }
}

#[Map(source: Source::class)]
class TargetB {}

$classMap = [Source::class => TargetB::class]; // what FrameworkBundle auto-builds
$mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(
    new ReflectionObjectMapperMetadataFactory(), $classMap));

echo $mapper->map(new Source(), TargetA::class)->value, "\n"; // 21 — transform dropped
```

## Behavior note

When several targets share one source, mapping to a **specific** target keeps
working and now honors that target's own per-property `#[Map(transform:)]`:

```php
$mapper->map(new Source(), TargetA::class); // TargetA's transform is applied
```

Mapping **without** an explicit target is genuinely ambiguous — nothing says
which target is meant — so it now throws a clear `MappingException`
(`Ambiguous mapping for "…"`) instead of silently picking an arbitrary
target.

## Test verification (RED → GREEN)

Two tests in `Tests/ObjectMapperTest.php` (fixtures `SharedSource`,
`SharedTargetWithTransform`, `SharedTargetWithoutTransform`):

- `testClassMapWithMultipleTargetsSharingOneSourceAppliesEachTargetsTransform`
  — mapping to each explicit target applies that target's own transform.
- `testClassMapWithMultipleTargetsSharingOneSourceRequiresAnExplicitTarget`
  — mapping without an explicit target throws `MappingException`.

RED — both tests on `8.1` with the prod fix reverted, the tests kept:

```
1) …AppliesEachTargetsTransform
TypeError: Symfony\Component\ObjectMapper\Attribute\Map::__construct():
Argument #1 ($target) must be of type ?string, array given, called in
ReverseClassObjectMapperMetadataFactory.php on line 53

2) …RequiresAnExplicitTarget
Failed asserting that exception of type "TypeError" matches expected
exception "Symfony\Component\ObjectMapper\Exception\MappingException".
```

GREEN — same tests with the prod fix applied:

```
OK
Tests: 2, Assertions: 6
```

Full `Tests/` suite (PHP 8.4): 67 → 69 tests, 190 → 196 assertions, 0
failures, 0 errors (the delta is exactly the two new tests; the PHPUnit
runner warnings about `deprecationTrigger`/`SymfonyExtension` are
pre-existing infra noise unaffected by this patch).

## BC

- The constructor signature stays `array $classMap`. A single-target value
  is cast to `[$target]` at construction time, so every existing call site
  (FrameworkBundle wiring, third-party callers passing the previously
  documented shape) behaves identically.
- `$context['target']` is an additive key on
  `ObjectMapperMetadataFactoryInterface::create()`; the parameter was
  already an open `array<string, mixed>`.
