### PR TITLE
[Validator] Review French (fr) translations for XML constraints

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -556,15 +556,15 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Cette valeur n'est pas un XML valide.</target>
+                <target>Cette valeur n'est pas un XML valide.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Cette valeur n'est pas conforme au schéma XSD attendu.</target>
+                <target>Cette valeur n'est pas conforme au schéma XSD attendu.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Cette charge utile XML est trop volumineuse ({{ size }} octets) : elle dépasse la limite de {{ limit }} octets.</target>
+                <target>Cette charge utile XML est trop volumineuse ({{ size }} octets) : elle dépasse la limite de {{ limit }} octets.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64495
| License       | MIT

Reviews the three pending French translations (ids 143-145, XML constraints) and marks them as approved by removing the `needs-review-translation` state. Wording and punctuation follow the existing fr.xlf style (e.g. `un XML valide` mirrors `un JSON valide`, `octets` for bytes, regular space before `:` as in id 379).