### PR TITLE
[GHA] Add PHPStan rules to spot non-constant-time comparisons to hash_hmac() and __toString-based trampolines

### DIFF
--- a/.github/sa-tools/.gitignore
+++ b/.github/sa-tools/.gitignore
@@ -2,6 +2,9 @@
 !.gitignore
 !psalm.baseline.xml
 !phpstan-diff.php
+!phpstan-rules.php
 !UnserializeMissingAllowedClassesRule.php
+!HardenedComparisonRule.php
+!UnserializeToStringTrampolineRule.php
 !stubs
 !stubs/*

--- a/.github/sa-tools/HardenedComparisonRule.php
+++ b/.github/sa-tools/HardenedComparisonRule.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags comparing an HMAC against an expected value with a non-constant-time
+ * operator ("===", "!==", "==" or "!="). Signatures and message authentication
+ * codes must be compared with hash_equals() to avoid a timing side channel.
+ *
+ * Only the inline form, where hash_hmac() is an operand of the comparison
+ * (optionally wrapped in an encoder such as base64_encode()), is detected; the
+ * assign-then-compare idiom is out of reach of a syntactic rule.
+ *
+ * @see Symfony\Component\Mailer\Bridge\Mailchimp\Webhook\MailchimpRequestParser
+ *
+ * @implements Rule<Expr\BinaryOp>
+ */
+class HardenedComparisonRule implements Rule
+{
+    private const ENCODERS = ['base64_encode', 'bin2hex', 'strtoupper', 'strtolower', 'trim', 'rtrim'];
+    private const MAX_DEPTH = 3;
+
+    public function getNodeType(): string
+    {
+        return Expr\BinaryOp::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof Expr\BinaryOp\Identical
+            && !$node instanceof Expr\BinaryOp\NotIdentical
+            && !$node instanceof Expr\BinaryOp\Equal
+            && !$node instanceof Expr\BinaryOp\NotEqual
+        ) {
+            return [];
+        }
+
+        if (!$this->isMac($node->left) && !$this->isMac($node->right)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message('Comparing an HMAC with "===", "!==", "==" or "!=" is not constant-time; use hash_equals() instead.')
+                ->identifier('symfony.nonConstantTimeHmacComparison')
+                ->build(),
+        ];
+    }
+
+    private function isMac(Expr $expr, int $depth = 0): bool
+    {
+        if (!$expr instanceof Expr\FuncCall || !$expr->name instanceof Node\Name) {
+            return false;
+        }
+
+        $name = $expr->name->toLowerString();
+
+        if ('hash_hmac' === $name) {
+            return true;
+        }
+
+        if ($depth < self::MAX_DEPTH && \in_array($name, self::ENCODERS, true)) {
+            $args = $expr->getArgs();
+            if (isset($args[0])) {
+                return $this->isMac($args[0]->value, $depth + 1);
+            }
+        }
+
+        return false;
+    }
+}

--- a/.github/sa-tools/UnserializeToStringTrampolineRule.php
+++ b/.github/sa-tools/UnserializeToStringTrampolineRule.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\StringType;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Flags __unserialize() implementations that assign a value coming from the
+ * unserialized payload into a string-typed property without first rejecting
+ * object values. An object exposing __toString() would be coerced to string
+ * during unserialize(), turning the property assignment into a "trampoline"
+ * that fires the gadget. The accepted fix rejects \Stringable values up front.
+ *
+ * @see Symfony\Component\Routing\Route::__unserialize()
+ * @see Symfony\Component\RateLimiter\Policy\TokenBucket::__unserialize()
+ *
+ * @implements Rule<Node\Stmt\ClassMethod>
+ */
+class UnserializeToStringTrampolineRule implements Rule
+{
+    private const TYPE_PROBES = ['is_object', 'is_scalar', 'is_string', 'gettype', 'get_debug_type'];
+
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ('__unserialize' !== $node->name->toLowerString() || null === $node->stmts) {
+            return [];
+        }
+
+        if (null === $classReflection = $scope->getClassReflection()) {
+            return [];
+        }
+
+        $params = $node->getParams();
+        if (!isset($params[0]) || !$params[0]->var instanceof Expr\Variable || !\is_string($params[0]->var->name)) {
+            return [];
+        }
+        $dataParam = $params[0]->var->name;
+
+        // A single up-front object/Stringable guard is treated as sufficient,
+        // matching how the accepted fixes guard every slot at once.
+        if ($this->hasGuard($node->stmts)) {
+            return [];
+        }
+
+        $finder = new NodeFinder();
+        $errors = [];
+
+        foreach ($finder->findInstanceOf($node->stmts, Expr\Assign::class) as $assign) {
+            // The right-hand side must read from the unserialized payload.
+            if (null === $finder->findFirst($assign->expr, static fn (Node $n): bool => $n instanceof Expr\Variable && $dataParam === $n->name)) {
+                continue;
+            }
+
+            foreach ($this->targetProperties($assign->var) as $propName) {
+                if (!$classReflection->hasNativeProperty($propName)) {
+                    continue;
+                }
+
+                $propType = $classReflection->getNativeProperty($propName)->getNativeType();
+                if (!TypeCombinator::removeNull($propType) instanceof StringType) {
+                    continue;
+                }
+
+                $errors[] = RuleErrorBuilder::message(\sprintf('Property "$%s" is assigned from the unserialized payload without rejecting \Stringable values first; an object would fire __toString() during unserialize(). Reject object values up front, e.g. with "instanceof \Stringable".', $propName))
+                    ->identifier('symfony.unserializeToStringTrampoline')
+                    ->line($assign->getStartLine())
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Property names written by an assignment, covering both "$this->prop = ..."
+     * and list destructuring "[$this->a, $this->b] = $data".
+     *
+     * @return list<string>
+     */
+    private function targetProperties(Expr $var): array
+    {
+        if ($var instanceof Expr\PropertyFetch) {
+            return $var->name instanceof Node\Identifier ? [$var->name->toString()] : [];
+        }
+
+        if ($var instanceof Expr\List_ || $var instanceof Expr\Array_) {
+            $props = [];
+            foreach ($var->items as $item) {
+                if (null !== $item) {
+                    $props = array_merge($props, $this->targetProperties($item->value));
+                }
+            }
+
+            return $props;
+        }
+
+        return [];
+    }
+
+    /**
+     * @param Node\Stmt[] $stmts
+     */
+    private function hasGuard(array $stmts): bool
+    {
+        $finder = new NodeFinder();
+
+        if (null !== $finder->findFirst($stmts, static fn (Node $n): bool => $n instanceof Expr\Instanceof_)) {
+            return true;
+        }
+
+        return null !== $finder->findFirst($stmts, function (Node $n): bool {
+            return $n instanceof Expr\FuncCall
+                && $n->name instanceof Node\Name
+                && \in_array($n->name->toLowerString(), self::TYPE_PROBES, true);
+        });
+    }
+}

--- a/.github/sa-tools/phpstan-rules.php
+++ b/.github/sa-tools/phpstan-rules.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Loads the custom PHPStan rules so they can be referenced from phpstan.dist.neon.
+// Passed to PHPStan via --autoload-file in .github/workflows/static-analysis.yml.
+
+require __DIR__.'/UnserializeMissingAllowedClassesRule.php';
+require __DIR__.'/HardenedComparisonRule.php';
+require __DIR__.'/UnserializeToStringTrampolineRule.php';

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -84,7 +84,7 @@ jobs:
           composer require --no-progress --ansi --no-plugins phpstan/phpstan:@stable phpstan/phpstan-deprecation-rules:@stable phpunit/phpunit:^9.5 php-http/discovery psr/event-dispatcher mongodb/mongodb
 
       - name: PHPStan on target branch
-        run: ./vendor/bin/phpstan analyse --error-format=json --no-progress --autoload-file='.github/sa-tools/UnserializeMissingAllowedClassesRule.php' > .github/sa-tools/phpstan-base.json || true
+        run: ./vendor/bin/phpstan analyse --error-format=json --no-progress --autoload-file='.github/sa-tools/phpstan-rules.php' > .github/sa-tools/phpstan-base.json || true
 
       - name: Switch to PR
         run: |
@@ -94,5 +94,5 @@ jobs:
 
       - name: PHPStan
         run: |
-          ./vendor/bin/phpstan analyse --error-format=json --no-progress --autoload-file='.github/sa-tools/UnserializeMissingAllowedClassesRule.php' > .github/sa-tools/phpstan-pr.json || true
+          ./vendor/bin/phpstan analyse --error-format=json --no-progress --autoload-file='.github/sa-tools/phpstan-rules.php' > .github/sa-tools/phpstan-pr.json || true
           php .github/sa-tools/phpstan-diff.php .github/sa-tools/phpstan-base.json .github/sa-tools/phpstan-pr.json

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -22,3 +22,11 @@ services:
         class: UnserializeMissingAllowedClassesRule
         tags:
             - phpstan.rules.rule
+    -
+        class: HardenedComparisonRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: UnserializeToStringTrampolineRule
+        tags:
+            - phpstan.rules.rule


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This might help spot security-sensitive issues early on.