### PR TITLE
[Cache][FrameworkBundle] Fix warming up caches that hold a closure

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -8,6 +8,11 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/8.1/
 
 If you're upgrading from a version below 8.0, follow the [8.0 upgrade guide](UPGRADE-8.0.md) first.
 
+Cache
+-----
+
+ * Add argument `$raw` to `ArrayAdapter::getValues()`
+
 Console
 -------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -16,6 +16,7 @@ use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\VarExporter\DeepCloner;
 
 abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
 {
@@ -45,10 +46,20 @@ abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
             spl_autoload_unregister([ClassExistenceResource::class, 'throwOnRequiredClass']);
         }
 
-        // the ArrayAdapter stores the values serialized
-        // to avoid mutation of the data after it was written to the cache
-        // so here we un-serialize the values first
-        $values = array_map(static fn ($val) => null !== $val ? unserialize($val) : null, $arrayAdapter->getValues());
+        // the ArrayAdapter stores deep clones of the values to avoid mutation of
+        // the cached data afterwards; older versions store them serialized
+        // instead, so unserialize those (a serialized payload holds a colon,
+        // which the adapter never leaves in a raw string) for backward compatibility
+        $values = $arrayAdapter->getValues(true);
+        foreach ($values as $key => $value) {
+            if (null === $value) {
+                unset($values[$key]);
+            } elseif ($value instanceof DeepCloner) {
+                $values[$key] = $value->clone();
+            } elseif (\is_string($value) && str_contains($value, ':')) {
+                $values[$key] = unserialize($value);
+            }
+        }
 
         return $this->warmUpPhpArrayAdapter(new PhpArrayAdapter($this->phpArrayFile, new NullAdapter()), $values);
     }

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -42,11 +42,11 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
     private static \Closure $createCacheItem;
 
     /**
-     * @param bool $storeSerialized Disabling serialization can lead to cache corruptions when storing mutable values but increases performance otherwise
+     * @param bool $deepClone Disabling deep-cloning can lead to cache corruptions when storing mutable values but increases performance otherwise
      */
     public function __construct(
         private int $defaultLifetime = 0,
-        private bool $storeSerialized = true,
+        private bool $deepClone = true,
         private float $maxLifetime = 0,
         private int $maxItems = 0,
         private ?ClockInterface $clock = null,
@@ -131,7 +131,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
                 $this->values[$key] = null;
             }
         } else {
-            $value = $this->storeSerialized ? $this->unfreeze($key, $isHit) : $this->values[$key];
+            $value = $this->deepClone ? $this->unfreeze($key, $isHit) : $this->values[$key];
         }
 
         return (self::$createCacheItem)($key, $value, $isHit, $this->tags[$key] ?? null, $this->explicitExpiries[$key] ?? null);
@@ -182,7 +182,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
                 return true;
             }
         }
-        if ($this->storeSerialized) {
+        if ($this->deepClone) {
             try {
                 $cloner = new DeepCloner($value);
             } catch (\Exception $e) {
@@ -196,7 +196,10 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
                 return false;
             }
 
-            if (!$cloner->isStaticValue()) {
+            // keep static values unwrapped for performance, except null (which must
+            // stay distinguishable from a cache miss) and strings holding a colon
+            // (which getValues() consumers must not confuse with a serialized value)
+            if (!$cloner->isStaticValue() || null === $value || (\is_string($value) && str_contains($value, ':'))) {
                 $value = $cloner;
             }
         }
@@ -291,10 +294,14 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
 
     /**
      * Returns all cached values, with cache miss as null.
+     *
+     * @param bool $raw Whether to return the raw stored values (DeepCloner instances and unwrapped scalars) instead of serialized strings
      */
-    public function getValues(): array
+    public function getValues(/* bool $raw = false */): array
     {
-        if (!$this->storeSerialized) {
+        $raw = \func_num_args() ? func_get_arg(0) : false;
+
+        if (!$this->deepClone || $raw) {
             return $this->values;
         }
 
@@ -303,7 +310,12 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
             if (null === $v) {
                 continue;
             }
-            $values[$k] = serialize($v instanceof DeepCloner ? $v->clone() : $v);
+            try {
+                $values[$k] = serialize($v instanceof DeepCloner ? $v->clone() : $v);
+            } catch (\Exception) {
+                // skip values that cannot be serialized, e.g. when they hold a Closure
+                unset($values[$k]);
+            }
         }
 
         return $values;
@@ -339,7 +351,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
                     $this->values[$key] = $value;
                 }
 
-                $value = $this->storeSerialized ? $this->unfreeze($key, $isHit) : $this->values[$key];
+                $value = $this->deepClone ? $this->unfreeze($key, $isHit) : $this->values[$key];
             }
             unset($keys[$i]);
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -16,6 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Tests\Fixtures\TestEnum;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\VarExporter\DeepCloner;
 
 #[Group('time-sensitive')]
 class ArrayAdapterTest extends AdapterTestCase
@@ -60,6 +61,64 @@ class ArrayAdapterTest extends AdapterTestCase
         $this->assertSame(serialize('::4711'), $values['foo']);
         $this->assertArrayHasKey('bar', $values);
         $this->assertNull($values['bar']);
+    }
+
+    public function testGetValuesWithNamedClosure()
+    {
+        /** @var ArrayAdapter $cache */
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $item->set([strlen(...)]);
+        $cache->save($item);
+
+        // a Closure cannot be serialized: getValues() skips the entry instead of
+        // throwing, while raw mode keeps it as a DeepCloner that can be cloned back
+        $this->assertArrayNotHasKey('foo', $cache->getValues());
+
+        $raw = $cache->getValues(true);
+        $this->assertInstanceOf(DeepCloner::class, $raw['foo']);
+        $this->assertInstanceOf(\Closure::class, $raw['foo']->clone()[0]);
+    }
+
+    public function testGetValuesDistinguishesRecordedNullFromMiss()
+    {
+        /** @var ArrayAdapter $cache */
+        $cache = $this->createCachePool();
+
+        // a deliberately cached null is a hit...
+        $cache->save($cache->getItem('recorded')->set(null));
+        $this->assertTrue($cache->getItem('recorded')->isHit());
+        // ...while a looked-up but absent key is a tracked miss
+        $this->assertFalse($cache->getItem('miss')->isHit());
+
+        // getValues() keeps them apart: the recorded null is serialized, the miss stays a bare null
+        $values = $cache->getValues();
+        $this->assertSame(serialize(null), $values['recorded']);
+        $this->assertNull($values['miss']);
+
+        // same in raw mode: the recorded null is wrapped in a DeepCloner
+        $raw = $cache->getValues(true);
+        $this->assertInstanceOf(DeepCloner::class, $raw['recorded']);
+        $this->assertNull($raw['miss']);
+    }
+
+    public function testGetValuesKeepsPlainStaticValuesUnwrapped()
+    {
+        /** @var ArrayAdapter $cache */
+        $cache = $this->createCachePool();
+
+        $cache->save($cache->getItem('plain')->set('no-colon'));
+        $cache->save($cache->getItem('int')->set(42));
+        $cache->save($cache->getItem('colon')->set('a:b'));
+
+        $raw = $cache->getValues(true);
+        // plain static values stay unwrapped for performance
+        $this->assertSame('no-colon', $raw['plain']);
+        $this->assertSame(42, $raw['int']);
+        // a string holding a colon is wrapped so it can't be mistaken for a serialized value
+        $this->assertInstanceOf(DeepCloner::class, $raw['colon']);
+        $this->assertSame('a:b', $raw['colon']->clone());
     }
 
     public function testMaxLifetime()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64464
| License       | MIT

Upgrading to 8.1 made `cache:clear` fail with `Serialization of 'Closure' is not allowed` in `prod` (debug off), while it kept working in `dev` and in `prod` with debug on.

`ArrayAdapter` no longer stores values `serialize()`d but deep-clones them through `DeepCloner`. Unlike `serialize()`, `DeepCloner` accepts named closures / first-class callables (such as the ones that can end up in validator or serializer metadata). Such a value was therefore accepted on `save()`, but `ArrayAdapter::getValues()` still `serialize()`d it on the way out, which blew up in `AbstractPhpFileCacheWarmer`.

`getValues()` can now return the raw stored values through a new optional `$raw` argument, so the cache warmer clones them directly instead of going through `serialize()`/`unserialize()`. To keep the in-memory fast path, values are wrapped in a `DeepCloner` only when needed:

 * non-static values, which must be decoupled anyway;
 * `null`, so a recorded `null` stays distinguishable from a tracked cache miss;
 * strings containing a colon, so consumers can keep telling them apart from a serialized payload (which always holds a colon for non-null values).

The warmer also keeps reading older `ArrayAdapter` versions that return serialized strings.
