### PR TITLE
[FrameworkBundle] Fix custom config directory being ignored when registering bundles

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -43,10 +43,16 @@ trait MicroKernelTrait
 
     public function registerBundles(): iterable
     {
-        if (!is_file($bundlesPath = $this->getBundlesPath())) {
+        if (!is_file($this->getBundlesPath())) {
             yield new FrameworkBundle();
-        } else {
-            yield from parent::registerBundles();
+
+            return;
+        }
+
+        foreach ($this->getBundlesDefinition() as $class => $envs) {
+            if ($envs[$this->environment] ?? $envs['all'] ?? false) {
+                yield new $class();
+            }
         }
     }
 
@@ -140,10 +146,8 @@ trait MicroKernelTrait
      */
     protected function getKernelParameters(): array
     {
-        // `doGetKernelParameters() + parent::getKernelParameters()` is left-biased on the shared
-        // `kernel.bundles_metadata` key, so the namespace written by parent::getKernelParameters()
-        // is shadowed. Re-apply it here to keep both `path` (from KernelTrait) and `namespace`.
-        $parameters = $this->doGetKernelParameters() + parent::getKernelParameters();
+        $parameters = $this->doGetKernelParameters();
+        $parameters['kernel.charset'] = $this->getCharset();
 
         foreach ($this->bundles as $name => $bundle) {
             $parameters['kernel.bundles_metadata'][$name]['namespace'] = $bundle->getNamespace();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -243,6 +243,7 @@ class MicroKernelTraitTest extends TestCase
         $parameters = $kernel->getKernelParameters();
 
         $this->assertSame($kernel->getConfigDir(), $parameters['.kernel.config_dir']);
+        $this->assertSame($kernel->getCharset(), $parameters['kernel.charset']);
         $this->assertSame(['test'], $parameters['.container.known_envs']);
         $this->assertSame(['Symfony\Bundle\FrameworkBundle\FrameworkBundle' => ['all' => true]], $parameters['.kernel.bundles_definition']);
     }
@@ -315,6 +316,26 @@ class MicroKernelTraitTest extends TestCase
         $this->assertSame($projectDir.'/var/custom-build/test', $kernel->getBuildDir());
         $this->assertSame($projectDir.'/var/custom-share/test', $kernel->getShareDir());
     }
+
+    public function testOverriddenConfigDirIsUsedToRegisterBundles()
+    {
+        $projectDir = sys_get_temp_dir().'/'.uniqid('sf_custom_config_dir_', true);
+        $configDir = $projectDir.'/config1/config';
+        $fs = new Filesystem();
+        $fs->mkdir($configDir.'/packages');
+        file_put_contents($configDir.'/bundles.php', "<?php\n\nreturn [\n    Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle::class => ['all' => true],\n];\n");
+        file_put_contents($configDir.'/packages/framework.yaml', "framework:\n    secret: \$ecret\n    http_method_override: false\n    test: true\n");
+
+        $kernel = $this->kernel = new CustomConfigDirKernel($projectDir);
+
+        try {
+            $kernel->boot();
+
+            $this->assertSame('$ecret', $kernel->getContainer()->getParameter('kernel.secret'));
+        } finally {
+            $fs->remove($projectDir);
+        }
+    }
 }
 
 class DebugWarmupKernel extends Kernel
@@ -359,6 +380,36 @@ class EnvDirKernel extends Kernel
     public function getProjectDir(): string
     {
         return $this->projectDir;
+    }
+}
+
+class CustomConfigDirKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct(private readonly string $projectDir)
+    {
+        parent::__construct('test', false);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->projectDir;
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->projectDir.'/var/cache/'.$this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->projectDir.'/var/log';
+    }
+
+    public function getConfigDir(): string
+    {
+        return $this->projectDir.'/config1/config';
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64545
| License       | MIT

Overriding `getConfigDir()` (as documented to relocate the `config/` directory) was ignored by the framework internals: installing a bundle failed with `There is no extension able to load the configuration for "framework"`, because bundles were looked up in the default `config/` directory.

The `KernelTrait` lives in the DependencyInjection component and is composed into both `HttpKernel\Kernel` and `MicroKernelTrait`. `MicroKernelTrait::registerBundles()` deferred to `parent::registerBundles()`, whose body runs in the `Kernel` class scope. There, the private `getConfigDir()`/`getBundlesPath()`/`getBundlesDefinition()` chain is resolved non-polymorphically against `Kernel`'s own copies, so the override (and `MicroKernelTrait`'s own definitions) were bypassed and `bundles.php` was read from the default directory, leaving the bundles and their extensions unregistered.

This registers the bundles in the trait's own scope instead of delegating to `parent::`. The same pattern affected `getKernelParameters()`, which recomputed the whole parameter set through `parent::getKernelParameters()` against the default directory only to discard it via the left-biased merge; it now builds on `doGetKernelParameters()` directly.

The other `parent::` calls (`initializeBundles()`, `initializeContainer()`) are unaffected because they bounce back to the kernel scope through their `protected do*()` aliases.
