### PR TITLE
[Translation] Create Crowdin files before uploading translations

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -59,57 +59,53 @@ final class CrowdinProvider implements ProviderInterface
         $fileList = $this->getFileList();
         $languageMapping = $this->getLanguageMapping();
 
+        $defaultLocaleCatalogue = $translatorBag->getCatalogue($this->defaultLocale);
+
         $responses = [];
+
+        foreach ($defaultLocaleCatalogue->getDomains() as $domain) {
+            $content = $this->xliffFileDumper->formatCatalogue($defaultLocaleCatalogue, $domain, ['default_locale' => $this->defaultLocale]);
+
+            if ($fileId = $this->getFileIdByDomain($fileList, $domain)) {
+                $sourceFileInfo = $this->downloadSourceFile($fileId);
+                $sourceFile = $this->client->request('GET', $sourceFileInfo->toArray()['data']['url']);
+
+                $providerCatalogue = $this->loader->load($sourceFile->getContent(), $this->defaultLocale, $domain);
+                $allMessages = array_merge($providerCatalogue->all($domain), $defaultLocaleCatalogue->all($domain));
+
+                $content = $this->xliffFileDumper->formatCatalogue(
+                    new MessageCatalogue($this->defaultLocale, [$domain => $allMessages]),
+                    $domain,
+                    ['default_locale' => $this->defaultLocale],
+                );
+
+                $this->updateFile($fileId, $domain, $content);
+            } else {
+                $file = $this->addFile($domain, $content);
+
+                $fileList[$file['name']] = $file['id'];
+            }
+        }
 
         foreach ($translatorBag->getCatalogues() as $catalogue) {
             $locale = $catalogue->getLocale();
+
+            if ($locale === $this->defaultLocale) {
+                continue;
+            }
 
             foreach ($catalogue->getDomains() as $domain) {
                 if (0 === \count($catalogue->all($domain))) {
                     continue;
                 }
 
-                $content = $this->xliffFileDumper->formatCatalogue($catalogue, $domain, ['default_locale' => $this->defaultLocale]);
-
-                $fileId = $this->getFileIdByDomain($fileList, $domain);
-
-                if ($catalogue->getLocale() === $this->defaultLocale) {
-                    if (!$fileId) {
-                        $file = $this->addFile($domain, $content);
-                    } else {
-                        $sourceFileInfo = $this->downloadSourceFile($fileId);
-                        $sourceFile = $this->client->request('GET', $sourceFileInfo->toArray()['data']['url']);
-
-                        $providerCatalogue = $this->loader->load(
-                            $sourceFile->getContent(),
-                            $this->defaultLocale,
-                            $domain
-                        );
-                        $allMessages = array_merge(
-                            $providerCatalogue->all($domain),
-                            $catalogue->all($domain)
-                        );
-
-                        $content = $this->xliffFileDumper->formatCatalogue(
-                            new MessageCatalogue($this->defaultLocale, [$domain => $allMessages]),
-                            $domain,
-                            ['default_locale' => $this->defaultLocale],
-                        );
-
-                        $file = $this->updateFile($fileId, $domain, $content);
-                    }
-
-                    if (!$file) {
-                        continue;
-                    }
-
-                    $fileList[$file['name']] = $file['id'];
-                } else {
-                    if (!$fileId) {
-                        continue;
-                    }
-
-                    $responses[] = $this->uploadTranslations($fileId, $domain, $content, $languageMapping[$locale] ?? $locale);
+                if ($fileId = $this->getFileIdByDomain($fileList, $domain)) {
+                    $responses[] = $this->uploadTranslations(
+                        $fileId,
+                        $domain,
+                        $this->xliffFileDumper->formatCatalogue($catalogue, $domain, ['default_locale' => $this->defaultLocale]),
+                        $languageMapping[$locale] ?? $locale,
+                    );
                 }
             }
         }
@@ -265,8 +261,8 @@ final class CrowdinProvider implements ProviderInterface
         $storageId = $this->addStorage($domain, $content);
 
         /**
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.files.getMany (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.getMany (Crowdin Enterprise API)
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Files/operation/api.projects.files.getMany (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Source-Files/operation/api.projects.files.getMany (Crowdin Enterprise API)
          */
         $response = $this->client->request('POST', 'files', [
             'json' => [
@@ -293,8 +289,8 @@ final class CrowdinProvider implements ProviderInterface
         $storageId = $this->addStorage($domain, $content);
 
         /**
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.files.put (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.put (Crowdin Enterprise API)
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Files/operation/api.projects.files.put (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Source-Files/operation/api.projects.files.put (Crowdin Enterprise API)
          */
         $response = $this->client->request('PUT', 'files/'.$fileId, [
             'json' => [
@@ -319,9 +315,9 @@ final class CrowdinProvider implements ProviderInterface
     {
         $storageId = $this->addStorage($domain, $content);
 
-        /*
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.translations.postOnLanguage (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.translations.postOnLanguage (Crowdin Enterprise API)
+        /**
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Translations/operation/api.projects.translations.postOnLanguage (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Translations/operation/api.projects.translations.postOnLanguage (Crowdin Enterprise API)
          */
         return $this->client->request('POST', 'translations/'.str_replace('_', '-', $locale), [
             'json' => [
@@ -333,9 +329,9 @@ final class CrowdinProvider implements ProviderInterface
 
     private function exportProjectTranslations(string $languageId, int $fileId): ResponseInterface
     {
-        /*
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.translations.exports.post (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.translations.exports.post (Crowdin Enterprise API)
+        /**
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Translations/operation/api.projects.translations.exports.post (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Translations/operation/api.projects.translations.exports.post (Crowdin Enterprise API)
          */
         return $this->client->request('POST', 'translations/exports', [
             'json' => [
@@ -347,9 +343,9 @@ final class CrowdinProvider implements ProviderInterface
 
     private function downloadSourceFile(int $fileId): ResponseInterface
     {
-        /*
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.files.download.get (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.download.get (Crowdin Enterprise API)
+        /**
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Files/operation/api.projects.files.download.get (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Source-Files/operation/api.projects.files.download.get (Crowdin Enterprise API)
          */
         return $this->client->request('GET', \sprintf('files/%d/download', $fileId));
     }
@@ -357,8 +353,8 @@ final class CrowdinProvider implements ProviderInterface
     private function listStrings(int $fileId, int $limit, int $offset): array
     {
         /**
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.strings.getMany (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.getMany (Crowdin Enterprise API)
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Strings/operation/api.projects.strings.getMany (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Source-Strings/operation/api.projects.strings.getMany (Crowdin Enterprise API)
          */
         $response = $this->client->request('GET', 'strings', [
             'query' => [
@@ -377,9 +373,9 @@ final class CrowdinProvider implements ProviderInterface
 
     private function deleteString(int $stringId): ResponseInterface
     {
-        /*
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.strings.delete (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2#operation/api.projects.strings.delete (Crowdin Enterprise API)
+        /**
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Strings/operation/api.projects.strings.delete (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Source-Strings/operation/api.projects.strings.delete (Crowdin Enterprise API)
          */
         return $this->client->request('DELETE', 'strings/'.$stringId);
     }
@@ -387,8 +383,8 @@ final class CrowdinProvider implements ProviderInterface
     private function addStorage(string $domain, string $content): int
     {
         /**
-         * @see https://developer.crowdin.com/api/v2/#operation/api.storages.post (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.storages.post (Crowdin Enterprise API)
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Storage/operation/api.storages.post (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Storage/operation/api.storages.post (Crowdin Enterprise API)
          */
         $response = $this->client->request('POST', '../../storages', [
             'headers' => [
@@ -410,8 +406,8 @@ final class CrowdinProvider implements ProviderInterface
         $result = [];
 
         /**
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.files.getMany (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.getMany (Crowdin Enterprise API)
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Source-Files/operation/api.projects.files.getMany (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Source-Files/operation/api.projects.files.getMany (Crowdin Enterprise API)
          */
         $response = $this->client->request('GET', 'files');
 
@@ -431,8 +427,8 @@ final class CrowdinProvider implements ProviderInterface
     private function getLanguageMapping(): array
     {
         /**
-         * @see https://developer.crowdin.com/api/v2/#operation/api.projects.get (Crowdin API)
-         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.get (Crowdin Enterprise API)
+         * @see https://support.crowdin.com/developer/api/v2/#tag/Projects/operation/api.projects.get (Crowdin API)
+         * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Projects-and-Groups/operation/api.projects.get (Crowdin Enterprise API)
          */
         $response = $this->client->request('GET', '');
 

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -116,7 +116,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
-                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -132,7 +132,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
                 $this->assertSame('{"storageId":19,"name":"messages.xlf"}', $options['body']);
 
-                return new JsonMockResponse(['data' => ['id' => 199, 'name' => 'messages.xlf']]);
+                return new JsonMockResponse(['data' => ['id' => 199, 'name' => 'messages.xlf']], ['http_code' => 201]);
             },
             'addStorage2' => function (string $method, string $url, array $options = []) use ($expectedValidatorsFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -148,7 +148,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
                 $this->assertSame('{"storageId":19,"name":"validators.xlf"}', $options['body']);
 
-                return new JsonMockResponse(['data' => ['id' => 200, 'name' => 'validators.xlf']]);
+                return new JsonMockResponse(['data' => ['id' => 200, 'name' => 'validators.xlf']], ['http_code' => 201]);
             },
         ];
 
@@ -200,7 +200,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
-                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -287,20 +287,20 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
                 $this->assertSame('Authorization: Bearer API_TOKEN', $options['normalized_headers']['authorization'][0]);
 
-                return new MockResponse(json_encode([
+                return new JsonMockResponse([
                     'data' => [
                         ['data' => [
                             'id' => 12,
                             'name' => 'messages.xlf',
                         ]],
                     ],
-                ]));
+                ]);
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
-                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -425,7 +425,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
-                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -554,7 +554,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
-                return new MockResponse(json_encode(['data' => ['languageMapping' => []]]));
+                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -660,7 +660,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
 
-                return new MockResponse(json_encode([
+                return new JsonMockResponse([
                     'data' => [
                         'languageMapping' => [
                             'pt-PT' => [
@@ -668,7 +668,7 @@ class CrowdinProviderTest extends ProviderTestCase
                             ],
                         ],
                     ],
-                ]));
+                ]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -721,7 +721,7 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('Crowdin-API-FileName: messages.xlf', $options['normalized_headers']['crowdin-api-filename'][0]);
                 $this->assertStringMatchesFormat($expectedMessagesTranslationsContent, $options['body']);
 
-                return new MockResponse(json_encode(['data' => ['id' => 19]], ['http_code' => 201]));
+                return new JsonMockResponse(['data' => ['id' => 19]], ['http_code' => 201]);
             },
             'uploadTranslations2' => function (string $method, string $url, array $options = []) use ($expectedLocale): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -824,6 +824,117 @@ class CrowdinProviderTest extends ProviderTestCase
 
             XLIFF
         ];
+    }
+
+    public function testFilesAreAddedBeforeTranslations()
+    {
+        $arrayLoader = new ArrayLoader();
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue($arrayLoader->load([
+            'a' => 'trans_fr_a',
+        ], 'fr'));
+        $translatorBag->addCatalogue($arrayLoader->load([
+            'a' => 'trans_en_a',
+        ], 'en'));
+
+        $expectedMessagesFileContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%s" resname="a">
+                    <source>a</source>
+                    <target>trans_en_a</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+            XLIFF;
+
+        $expectedMessagesTranslationsContent = <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%s" resname="a">
+                    <source>a</source>
+                    <target>trans_fr_a</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+            XLIFF;
+
+        $responses = [
+            'listFiles' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+
+                return new JsonMockResponse(['data' => []]);
+            },
+            'getProject' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+
+                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+            },
+            'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+                $this->assertSame('Content-Type: application/octet-stream', $options['normalized_headers']['content-type'][0]);
+                $this->assertSame('Crowdin-API-FileName: messages.xlf', $options['normalized_headers']['crowdin-api-filename'][0]);
+                $this->assertStringMatchesFormat($expectedMessagesFileContent, $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 19]], ['http_code' => 201]);
+            },
+            'addFile' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files', $url);
+                $this->assertSame('{"storageId":19,"name":"messages.xlf"}', $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 199, 'name' => 'messages.xlf']], ['http_code' => 201]);
+            },
+            'addStorage2' => function (string $method, string $url, array $options = []) use ($expectedMessagesTranslationsContent): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/storages', $url);
+                $this->assertSame('Content-Type: application/octet-stream', $options['normalized_headers']['content-type'][0]);
+                $this->assertSame('Crowdin-API-FileName: messages.xlf', $options['normalized_headers']['crowdin-api-filename'][0]);
+                $this->assertStringMatchesFormat($expectedMessagesTranslationsContent, $options['body']);
+
+                return new JsonMockResponse(['data' => ['id' => 20]], ['http_code' => 201]);
+            },
+            'uploadTranslations' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/translations/fr', $url);
+                $this->assertSame('{"storageId":20,"fileId":199}', $options['body']);
+
+                return new MockResponse();
+            },
+        ];
+
+        $httpClient = (new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'auth_bearer' => 'API_TOKEN',
+        ]);
+
+        $provider = self::createProvider(
+            $httpClient,
+            new XliffFileLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.crowdin.com/api/v2/projects/1/',
+        );
+
+        $provider->write($translatorBag);
+
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The `CrowdinProvider` assumes the default locale comes first in the translator bag, but this isn’t guaranteed as it depends on the `framework.enabled_locales` configuration.

When it isn’t the case, translations of not-yet-created domains/files are silently skipped.

This PR also updates links to the Crowdin API reference and replaces `MockResponse` by `JsonMockResponse` where it makes sense.