### PR TITLE
[Security] Make RoleHierarchy::getReachableRoleNames() return a list again

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -130,7 +130,6 @@ Security
 --------
 
  * Add `getParentRoleNames()` method to `RoleHierarchyInterface`
- * Make `RoleHierarchyInterface::getReachableRoleNames()` return roles as both keys and values
  * Deprecate `SameOriginCsrfTokenManager::onKernelResponse()`, `SameOriginCsrfTokenManager::clearCookies()` and `SameOriginCsrfTokenManager::persistStrategy()`; this logic is now handled automatically by `SameOriginCsrfListener`
  * Deprecate passing the `$eraseCredentials` argument to `AuthenticatorManager::__construct()`, as the `eraseCredentials()` method was removed in Symfony 8.0
 

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -6,7 +6,6 @@ CHANGELOG
 
  * Add support for enums in `SignatureHasher::computeSignatureHash()`
  * Add `getParentRoleNames()` method to `RoleHierarchyInterface`
- * Make `RoleHierarchyInterface::getReachableRoleNames()` return roles as both keys and values
 
 8.0
 ---

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -44,13 +44,13 @@ class RoleHierarchy implements RoleHierarchyInterface
             }
         }
 
-        return $reachableRoles;
+        return array_values($reachableRoles);
     }
 
     /**
      * @param string[] $roles
      *
-     * @return array<string, string>
+     * @return list<string>
      */
     public function getParentRoleNames(array $roles): array
     {
@@ -66,7 +66,7 @@ class RoleHierarchy implements RoleHierarchyInterface
             }
         }
 
-        return $parentRoles;
+        return array_values($parentRoles);
     }
 
     protected function buildRoleMap(): void

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Core\Role;
 /**
  * RoleHierarchyInterface is the interface for a role hierarchy.
  *
- * @method array<string, string> getParentRoleNames(string[] $roles)
+ * @method list<string> getParentRoleNames(string[] $roles)
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -23,7 +23,7 @@ interface RoleHierarchyInterface
     /**
      * @param string[] $roles
      *
-     * @return array<string, string>
+     * @return list<string>
      */
     public function getReachableRoleNames(array $roles): array;
 }

--- a/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
@@ -23,12 +23,14 @@ class RoleHierarchyTest extends TestCase
             'ROLE_SUPER_ADMIN' => ['ROLE_ADMIN', 'ROLE_FOO'],
         ]);
 
-        $this->assertEqualsCanonicalizing(['ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_USER']));
-        $this->assertEqualsCanonicalizing(['ROLE_FOO' => 'ROLE_FOO'], $role->getReachableRoleNames(['ROLE_FOO']));
-        $this->assertEqualsCanonicalizing(['ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_ADMIN']));
-        $this->assertEqualsCanonicalizing(['ROLE_FOO' => 'ROLE_FOO', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_FOO', 'ROLE_ADMIN']));
-        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_FOO' => 'ROLE_FOO', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN']));
-        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_FOO' => 'ROLE_FOO', 'ROLE_USER' => 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_USER'], $role->getReachableRoleNames(['ROLE_USER']));
+        $this->assertEqualsCanonicalizing(['ROLE_FOO'], $role->getReachableRoleNames(['ROLE_FOO']));
+        $this->assertEqualsCanonicalizing(['ROLE_ADMIN', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_FOO', 'ROLE_ADMIN', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_FOO', 'ROLE_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
+
+        $this->assertTrue(array_is_list($role->getReachableRoleNames(['ROLE_SUPER_ADMIN'])));
     }
 
     public function testGetParentRoleNames()
@@ -39,12 +41,14 @@ class RoleHierarchyTest extends TestCase
             'ROLE_USER' => ['ROLE_BAR'],
         ]);
 
-        $this->assertEquals(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN']));
-        $this->assertEquals(['ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_ADMIN']));
-        $this->assertEquals(['ROLE_USER' => 'ROLE_USER', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_USER']));
-        $this->assertEquals(['ROLE_BAR' => 'ROLE_BAR', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getParentRoleNames(['ROLE_BAR']));
-        $this->assertEquals(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
-        $this->assertEquals(['ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_USER' => 'ROLE_USER', 'ROLE_ADMIN' => 'ROLE_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_USER']));
-        $this->assertEquals(['ROLE_BAR' => 'ROLE_BAR', 'ROLE_FOO' => 'ROLE_FOO', 'ROLE_ADMIN' => 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN' => 'ROLE_SUPER_ADMIN', 'ROLE_USER' => 'ROLE_USER'], $role->getParentRoleNames(['ROLE_BAR', 'ROLE_FOO']));
+        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_ADMIN', 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_USER', 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_USER']));
+        $this->assertEqualsCanonicalizing(['ROLE_BAR', 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_USER'], $role->getParentRoleNames(['ROLE_BAR']));
+        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
+        $this->assertEqualsCanonicalizing(['ROLE_SUPER_ADMIN', 'ROLE_USER', 'ROLE_ADMIN'], $role->getParentRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_USER']));
+        $this->assertEqualsCanonicalizing(['ROLE_BAR', 'ROLE_FOO', 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_USER'], $role->getParentRoleNames(['ROLE_BAR', 'ROLE_FOO']));
+
+        $this->assertTrue(array_is_list($role->getParentRoleNames(['ROLE_BAR', 'ROLE_FOO'])));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64406
| License       | MIT

#53998 made `RoleHierarchyInterface::getReachableRoleNames()` return role names as both keys and values. As the return type is still `array`, this is an easy-to-miss BC break, e.g. `json_encode()` now turns the list into an object:

```php
$roleHierarchy = new RoleHierarchy(['ROLE_ADMIN' => ['ROLE_USER']]);
json_encode($roleHierarchy->getReachableRoleNames(['ROLE_ADMIN']));
// 8.0: ["ROLE_ADMIN","ROLE_USER"]
// 8.1: {"ROLE_ADMIN":"ROLE_ADMIN","ROLE_USER":"ROLE_USER"}
```

This reverts the shape change so the method returns a list again, and keeps the new `getParentRoleNames()` (added in the same PR) consistent.
