### PR TITLE
[Tui] Add mouse event support

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add opt-in mouse tracking, dispatching a `MouseEvent` for button, drag and scroll-wheel interactions
+
 8.1
 ---
 

--- a/src/Symfony/Component/Tui/Event/MouseEvent.php
+++ b/src/Symfony/Component/Tui/Event/MouseEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Event;
+
+use Symfony\Component\Tui\Input\MouseButton;
+use Symfony\Component\Tui\Input\MouseEventKind;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event dispatched when a mouse interaction is received.
+ *
+ * Only dispatched while mouse tracking is enabled on the terminal
+ * (see {@see \Symfony\Component\Tui\Tui::enableMouseTracking()}).
+ * Dispatched before the input would otherwise reach the focused widget.
+ * Call {@see stopPropagation()} to consume the event.
+ *
+ * Coordinates are in terminal character cells, 0-indexed, with (0, 0)
+ * at the top-left corner of the screen.
+ *
+ * @experimental
+ *
+ * @author Louis-Arnaud Catoire <la.catoire@gmail.com>
+ */
+class MouseEvent extends Event
+{
+    public function __construct(
+        public readonly int $x,
+        public readonly int $y,
+        public readonly MouseButton $button,
+        public readonly MouseEventKind $kind,
+        public readonly bool $shift = false,
+        public readonly bool $alt = false,
+        public readonly bool $ctrl = false,
+    ) {
+    }
+
+    /**
+     * Whether this event is a scroll-wheel movement.
+     */
+    public function isWheel(): bool
+    {
+        return MouseButton::WheelUp === $this->button || MouseButton::WheelDown === $this->button;
+    }
+}

--- a/src/Symfony/Component/Tui/Input/MouseButton.php
+++ b/src/Symfony/Component/Tui/Input/MouseButton.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Input;
+
+/**
+ * The button reported by a mouse event.
+ *
+ * Wheel scrolling is reported as the dedicated WheelUp/WheelDown buttons
+ * rather than as a regular button press.
+ *
+ * @experimental
+ *
+ * @author Louis-Arnaud Catoire <la.catoire@gmail.com>
+ */
+enum MouseButton
+{
+    case None;
+    case Left;
+    case Middle;
+    case Right;
+    case WheelUp;
+    case WheelDown;
+}

--- a/src/Symfony/Component/Tui/Input/MouseEventKind.php
+++ b/src/Symfony/Component/Tui/Input/MouseEventKind.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Input;
+
+/**
+ * The kind of interaction reported by a mouse event.
+ *
+ * @experimental
+ *
+ * @author Louis-Arnaud Catoire <la.catoire@gmail.com>
+ */
+enum MouseEventKind
+{
+    case Press;
+    case Release;
+    case Drag;
+    case Move;
+}

--- a/src/Symfony/Component/Tui/Input/MouseParser.php
+++ b/src/Symfony/Component/Tui/Input/MouseParser.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Input;
+
+use Symfony\Component\Tui\Event\MouseEvent;
+
+/**
+ * Decodes terminal mouse-reporting sequences into {@see MouseEvent} objects.
+ *
+ * Supports both the modern SGR encoding (ESC [ < b ; x ; y M/m) and the
+ * legacy X10 encoding (ESC [ M cb cx cy). Returns null for any input that
+ * is not a complete mouse sequence, so callers can fall back to normal
+ * key handling.
+ *
+ * @experimental
+ *
+ * @internal
+ *
+ * @author Louis-Arnaud Catoire <la.catoire@gmail.com>
+ */
+final class MouseParser
+{
+    // Modifier flags carried in the button byte.
+    private const int FLAG_SHIFT = 4;
+    private const int FLAG_ALT = 8;
+    private const int FLAG_CTRL = 16;
+    private const int FLAG_MOTION = 32;
+    private const int FLAG_WHEEL = 64;
+    private const int FLAG_EXTRA_BUTTON = 128;
+
+    /**
+     * Parse a single input sequence into a MouseEvent, or null if it is not one.
+     */
+    public function parse(string $data): ?MouseEvent
+    {
+        // SGR: ESC [ < b ; x ; y (M|m)
+        if (preg_match('/^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/', $data, $m)) {
+            return $this->build((int) $m[1], (int) $m[2], (int) $m[3], 'm' === $m[4]);
+        }
+
+        // X10: ESC [ M followed by exactly three bytes, each offset by 32.
+        if (6 === \strlen($data) && str_starts_with($data, "\x1b[M")) {
+            return $this->build(
+                \ord($data[3]) - 32,
+                \ord($data[4]) - 32,
+                \ord($data[5]) - 32,
+                null,
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @param int       $cb         the raw button byte (modifier and wheel flags included)
+     * @param int       $x          1-indexed column as reported by the terminal
+     * @param int       $y          1-indexed row as reported by the terminal
+     * @param bool|null $sgrRelease true/false for an SGR release/press, null for X10 (no explicit release)
+     */
+    private function build(int $cb, int $x, int $y, ?bool $sgrRelease): ?MouseEvent
+    {
+        $isWheel = (bool) ($cb & self::FLAG_WHEEL);
+        $isMotion = (bool) ($cb & self::FLAG_MOTION);
+        $low = $cb & 3;
+
+        // Out of scope, ignored rather than reported as a misleading event:
+        // horizontal wheel (low 2/3) and the additional buttons 8-11 (flagged
+        // by bit 128, e.g. the back/forward side buttons), which would
+        // otherwise be decoded as a phantom Left/Middle/Right click.
+        if (($isWheel && $low >= 2) || ($cb & self::FLAG_EXTRA_BUTTON)) {
+            return null;
+        }
+
+        $button = match (true) {
+            $isWheel && 0 === $low => MouseButton::WheelUp,
+            $isWheel => MouseButton::WheelDown,
+            0 === $low => MouseButton::Left,
+            1 === $low => MouseButton::Middle,
+            2 === $low => MouseButton::Right,
+            default => MouseButton::None,
+        };
+
+        $kind = match (true) {
+            $isWheel => MouseEventKind::Press,
+            true === $sgrRelease => MouseEventKind::Release,
+            $isMotion => MouseButton::None === $button ? MouseEventKind::Move : MouseEventKind::Drag,
+            // X10 reports a release as button code 3 without an explicit release flag.
+            null === $sgrRelease && 3 === $low => MouseEventKind::Release,
+            default => MouseEventKind::Press,
+        };
+
+        return new MouseEvent(
+            max(0, $x - 1),
+            max(0, $y - 1),
+            $button,
+            $kind,
+            (bool) ($cb & self::FLAG_SHIFT),
+            (bool) ($cb & self::FLAG_ALT),
+            (bool) ($cb & self::FLAG_CTRL),
+        );
+    }
+}

--- a/src/Symfony/Component/Tui/Terminal/TeeTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/TeeTerminal.php
@@ -126,6 +126,18 @@ final class TeeTerminal implements TerminalInterface
         $this->secondary->bell();
     }
 
+    public function enableMouseTracking(): void
+    {
+        $this->primary->enableMouseTracking();
+        $this->secondary->enableMouseTracking();
+    }
+
+    public function disableMouseTracking(): void
+    {
+        $this->primary->disableMouseTracking();
+        $this->secondary->disableMouseTracking();
+    }
+
     public function isVirtual(): bool
     {
         return $this->primary->isVirtual();

--- a/src/Symfony/Component/Tui/Terminal/Terminal.php
+++ b/src/Symfony/Component/Tui/Terminal/Terminal.php
@@ -25,8 +25,12 @@ final class Terminal implements TerminalInterface
 {
     private ?StdinBuffer $stdinBuffer = null;
 
+    private const string MOUSE_ENABLE = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+    private const string MOUSE_DISABLE = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+
     private string $initialSttyState = '';
     private bool $kittyProtocolActive = false;
+    private bool $mouseTracking = false;
     private bool $started = false;
     private ?string $stdinCallbackId = null;
     private ?string $signalCallbackId = null;
@@ -74,6 +78,11 @@ final class Terminal implements TerminalInterface
 
         // Enable bracketed paste mode
         $this->write("\x1b[?2004h");
+
+        // Enable mouse reporting if it was requested before start()
+        if ($this->mouseTracking) {
+            $this->write(self::MOUSE_ENABLE);
+        }
 
         // Set up signal handlers for resize using Revolt's event loop
         if (\defined('SIGWINCH')) {
@@ -129,6 +138,11 @@ final class Terminal implements TerminalInterface
 
         // Disable bracketed paste mode
         $this->write("\x1b[?2004l");
+
+        // Disable mouse reporting if we enabled it
+        if ($this->mouseTracking) {
+            $this->write(self::MOUSE_DISABLE);
+        }
 
         // Disable Kitty keyboard protocol if we enabled it
         if ($this->kittyProtocolActive) {
@@ -232,6 +246,32 @@ final class Terminal implements TerminalInterface
         }
 
         $this->write("\x07");
+    }
+
+    public function enableMouseTracking(): void
+    {
+        if ($this->mouseTracking) {
+            return;
+        }
+
+        $this->mouseTracking = true;
+
+        if ($this->started) {
+            $this->write(self::MOUSE_ENABLE);
+        }
+    }
+
+    public function disableMouseTracking(): void
+    {
+        if (!$this->mouseTracking) {
+            return;
+        }
+
+        $this->mouseTracking = false;
+
+        if ($this->started) {
+            $this->write(self::MOUSE_DISABLE);
+        }
     }
 
     public function isVirtual(): bool

--- a/src/Symfony/Component/Tui/Terminal/TerminalInterface.php
+++ b/src/Symfony/Component/Tui/Terminal/TerminalInterface.php
@@ -110,6 +110,19 @@ interface TerminalInterface
     public function bell(): void;
 
     /**
+     * Enable mouse reporting (button, drag and scroll-wheel events).
+     *
+     * Opt-in: terminals do not report mouse activity until this is called.
+     * The reporting is turned off again on {@see stop()}.
+     */
+    public function enableMouseTracking(): void;
+
+    /**
+     * Disable mouse reporting previously enabled with {@see enableMouseTracking()}.
+     */
+    public function disableMouseTracking(): void;
+
+    /**
      * Whether this is a virtual (non-TTY) terminal.
      */
     public function isVirtual(): bool;

--- a/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
@@ -30,9 +30,13 @@ use Symfony\Component\Tui\Input\StdinBuffer;
  */
 final class VirtualTerminal implements TerminalInterface
 {
+    private const string MOUSE_ENABLE = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+    private const string MOUSE_DISABLE = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+
     private string $output = '';
     private ?StdinBuffer $stdinBuffer = null;
     private ?\Closure $onResize = null;
+    private bool $mouseTracking = false;
 
     public function __construct(
         private int $columns = 80,
@@ -53,6 +57,10 @@ final class VirtualTerminal implements TerminalInterface
         $this->stdinBuffer->onPaste(static function (string $content) use ($onInput): void {
             $onInput("\x1b[200~".$content."\x1b[201~");
         });
+
+        if ($this->mouseTracking) {
+            $this->write(self::MOUSE_ENABLE);
+        }
     }
 
     public function stop(): void
@@ -124,6 +132,32 @@ final class VirtualTerminal implements TerminalInterface
     public function bell(): void
     {
         $this->write("\x07");
+    }
+
+    public function enableMouseTracking(): void
+    {
+        if ($this->mouseTracking) {
+            return;
+        }
+
+        $this->mouseTracking = true;
+
+        if (null !== $this->stdinBuffer) {
+            $this->write(self::MOUSE_ENABLE);
+        }
+    }
+
+    public function disableMouseTracking(): void
+    {
+        if (!$this->mouseTracking) {
+            return;
+        }
+
+        $this->mouseTracking = false;
+
+        if (null !== $this->stdinBuffer) {
+            $this->write(self::MOUSE_DISABLE);
+        }
     }
 
     public function isVirtual(): bool

--- a/src/Symfony/Component/Tui/Tests/Input/MouseParserTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/MouseParserTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Input;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Event\MouseEvent;
+use Symfony\Component\Tui\Input\MouseButton;
+use Symfony\Component\Tui\Input\MouseEventKind;
+use Symfony\Component\Tui\Input\MouseParser;
+
+class MouseParserTest extends TestCase
+{
+    private MouseParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new MouseParser();
+    }
+
+    #[DataProvider('provideSgrSequences')]
+    public function testParseSgr(string $sequence, int $x, int $y, MouseButton $button, MouseEventKind $kind, bool $shift = false, bool $alt = false, bool $ctrl = false)
+    {
+        $event = $this->parser->parse($sequence);
+
+        $this->assertInstanceOf(MouseEvent::class, $event);
+        $this->assertSame($x, $event->x);
+        $this->assertSame($y, $event->y);
+        $this->assertSame($button, $event->button);
+        $this->assertSame($kind, $event->kind);
+        $this->assertSame($shift, $event->shift);
+        $this->assertSame($alt, $event->alt);
+        $this->assertSame($ctrl, $event->ctrl);
+    }
+
+    public static function provideSgrSequences(): iterable
+    {
+        yield 'left press, top-left' => ["\x1b[<0;1;1M", 0, 0, MouseButton::Left, MouseEventKind::Press];
+        yield 'left release' => ["\x1b[<0;1;1m", 0, 0, MouseButton::Left, MouseEventKind::Release];
+        yield 'middle press' => ["\x1b[<1;3;2M", 2, 1, MouseButton::Middle, MouseEventKind::Press];
+        yield 'right press' => ["\x1b[<2;10;5M", 9, 4, MouseButton::Right, MouseEventKind::Press];
+        yield 'wheel up' => ["\x1b[<64;3;3M", 2, 2, MouseButton::WheelUp, MouseEventKind::Press];
+        yield 'wheel down' => ["\x1b[<65;3;3M", 2, 2, MouseButton::WheelDown, MouseEventKind::Press];
+        yield 'left drag' => ["\x1b[<32;5;6M", 4, 5, MouseButton::Left, MouseEventKind::Drag];
+        yield 'move, no button' => ["\x1b[<35;5;6M", 4, 5, MouseButton::None, MouseEventKind::Move];
+        yield 'shift + left press' => ["\x1b[<4;1;1M", 0, 0, MouseButton::Left, MouseEventKind::Press, true];
+        yield 'alt + left press' => ["\x1b[<8;1;1M", 0, 0, MouseButton::Left, MouseEventKind::Press, false, true];
+        yield 'ctrl + left press' => ["\x1b[<16;1;1M", 0, 0, MouseButton::Left, MouseEventKind::Press, false, false, true];
+        yield 'large coordinates' => ["\x1b[<0;240;120M", 239, 119, MouseButton::Left, MouseEventKind::Press];
+    }
+
+    public function testParseX10LeftPress()
+    {
+        // ESC [ M, then cb=32 (button 0), cx=33 (col 1), cy=33 (row 1), each offset by 32.
+        $event = $this->parser->parse("\x1b[M".\chr(32).\chr(33).\chr(33));
+
+        $this->assertInstanceOf(MouseEvent::class, $event);
+        $this->assertSame(0, $event->x);
+        $this->assertSame(0, $event->y);
+        $this->assertSame(MouseButton::Left, $event->button);
+        $this->assertSame(MouseEventKind::Press, $event->kind);
+    }
+
+    public function testParseX10Release()
+    {
+        // Button code 3 with no wheel/motion flags is a release in the X10 encoding.
+        $event = $this->parser->parse("\x1b[M".\chr(32 + 3).\chr(33).\chr(33));
+
+        $this->assertInstanceOf(MouseEvent::class, $event);
+        $this->assertSame(MouseButton::None, $event->button);
+        $this->assertSame(MouseEventKind::Release, $event->kind);
+    }
+
+    public function testParseX10WheelUp()
+    {
+        $event = $this->parser->parse("\x1b[M".\chr(32 + 64).\chr(33).\chr(33));
+
+        $this->assertInstanceOf(MouseEvent::class, $event);
+        $this->assertSame(MouseButton::WheelUp, $event->button);
+        $this->assertSame(MouseEventKind::Press, $event->kind);
+    }
+
+    #[DataProvider('provideNonMouseSequences')]
+    public function testNonMouseSequencesReturnNull(string $sequence)
+    {
+        $this->assertNull($this->parser->parse($sequence));
+    }
+
+    public static function provideNonMouseSequences(): iterable
+    {
+        yield 'plain character' => ['a'];
+        yield 'up arrow' => ["\x1b[A"];
+        yield 'bracketed paste start' => ["\x1b[200~"];
+        yield 'malformed sgr (missing final)' => ["\x1b[<0;1;1"];
+        yield 'malformed sgr (non-numeric)' => ["\x1b[<a;1;1M"];
+        yield 'x10 too short' => ["\x1b[M".\chr(32).\chr(33)];
+        yield 'empty' => [''];
+        // Horizontal wheel and the additional buttons 8-11 are out of scope and
+        // must be ignored rather than reported as a phantom button press.
+        yield 'horizontal wheel right' => ["\x1b[<66;5;5M"];
+        yield 'horizontal wheel left' => ["\x1b[<67;5;5M"];
+        yield 'back button (8)' => ["\x1b[<128;5;5M"];
+        yield 'forward button (9)' => ["\x1b[<129;5;5M"];
+        yield 'button 10' => ["\x1b[<130;5;5M"];
+        yield 'button 11' => ["\x1b[<131;5;5M"];
+    }
+
+    public function testIsWheel()
+    {
+        $this->assertTrue($this->parser->parse("\x1b[<64;1;1M")->isWheel());
+        $this->assertFalse($this->parser->parse("\x1b[<0;1;1M")->isWheel());
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Terminal/MouseTrackingTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/MouseTrackingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Terminal;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Terminal\VirtualTerminal;
+
+class MouseTrackingTest extends TestCase
+{
+    private const ENABLE = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+    private const DISABLE = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+
+    public function testDisabledByDefault()
+    {
+        $terminal = new VirtualTerminal();
+        $terminal->start(static function () {}, static function () {}, static function () {});
+
+        $this->assertStringNotContainsString(self::ENABLE, $terminal->getOutput());
+    }
+
+    public function testEnableAfterStartEmitsSequence()
+    {
+        $terminal = new VirtualTerminal();
+        $terminal->start(static function () {}, static function () {}, static function () {});
+        $terminal->clearOutput();
+
+        $terminal->enableMouseTracking();
+
+        $this->assertSame(self::ENABLE, $terminal->getOutput());
+    }
+
+    public function testEnableBeforeStartIsEmittedOnStart()
+    {
+        $terminal = new VirtualTerminal();
+        $terminal->enableMouseTracking();
+
+        $terminal->start(static function () {}, static function () {}, static function () {});
+
+        $this->assertStringContainsString(self::ENABLE, $terminal->getOutput());
+    }
+
+    public function testDisableEmitsSequence()
+    {
+        $terminal = new VirtualTerminal();
+        $terminal->start(static function () {}, static function () {}, static function () {});
+        $terminal->enableMouseTracking();
+        $terminal->clearOutput();
+
+        $terminal->disableMouseTracking();
+
+        $this->assertSame(self::DISABLE, $terminal->getOutput());
+    }
+
+    public function testEnableIsIdempotent()
+    {
+        $terminal = new VirtualTerminal();
+        $terminal->start(static function () {}, static function () {}, static function () {});
+        $terminal->enableMouseTracking();
+        $terminal->clearOutput();
+
+        $terminal->enableMouseTracking();
+
+        $this->assertSame('', $terminal->getOutput());
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/TuiTest.php
+++ b/src/Symfony/Component/Tui/Tests/TuiTest.php
@@ -14,10 +14,13 @@ namespace Symfony\Component\Tui\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Event\InputEvent;
+use Symfony\Component\Tui\Event\MouseEvent;
 use Symfony\Component\Tui\Event\TickEvent;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Input\Key;
 use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Input\MouseButton;
+use Symfony\Component\Tui\Input\MouseEventKind;
 use Symfony\Component\Tui\Render\Renderer;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
@@ -550,6 +553,65 @@ class TuiTest extends TestCase
         $terminal->simulateInput('z');
 
         $this->assertSame('z', $received);
+        $tui->stop();
+    }
+
+    public function testMouseSequenceIsDispatchedAsMouseEvent()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $tui->start();
+        $tui->enableMouseTracking();
+
+        $received = null;
+        $tui->addListener(static function (MouseEvent $event) use (&$received): void {
+            $received = $event;
+        });
+
+        $terminal->simulateInput("\x1b[<0;5;3M");
+
+        $this->assertInstanceOf(MouseEvent::class, $received);
+        $this->assertSame(4, $received->x);
+        $this->assertSame(2, $received->y);
+        $this->assertSame(MouseButton::Left, $received->button);
+        $this->assertSame(MouseEventKind::Press, $received->kind);
+
+        $tui->stop();
+    }
+
+    public function testEnableMouseTrackingForwardsToTerminal()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $tui->start();
+        $terminal->clearOutput();
+
+        $tui->enableMouseTracking();
+        $this->assertStringContainsString("\x1b[?1006h", $terminal->getOutput());
+
+        $terminal->clearOutput();
+        $tui->disableMouseTracking();
+        $this->assertStringContainsString("\x1b[?1006l", $terminal->getOutput());
+
+        $tui->stop();
+    }
+
+    public function testMouseSequenceDoesNotLeakToFocusedWidget()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+
+        $input = new InputWidget();
+        $tui->add($input);
+        $tui->setFocus($input);
+
+        $tui->start();
+        $tui->enableMouseTracking();
+
+        $terminal->simulateInput("\x1b[<0;5;3M");
+
+        $this->assertSame('', $input->getValue());
+
         $tui->stop();
     }
 }

--- a/src/Symfony/Component/Tui/Tui.php
+++ b/src/Symfony/Component/Tui/Tui.php
@@ -21,6 +21,7 @@ use Symfony\Component\Tui\Event\TickEvent;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Focus\FocusManager;
 use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Input\MouseParser;
 use Symfony\Component\Tui\Loop\AdaptativeTicker;
 use Symfony\Component\Tui\Loop\TickRuntimeInterface;
 use Symfony\Component\Tui\Loop\TickScheduler;
@@ -67,6 +68,7 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
     private FocusManager $focusManager;
     private TickScheduler $tickScheduler;
     private AdaptativeTicker $adaptativeTicker;
+    private MouseParser $mouseParser;
     private EventDispatcherInterface $eventDispatcher;
 
     /** @var (\Closure(TickEvent): mixed)|null */
@@ -111,6 +113,7 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
         $this->widgetTree->setRoot($this->root);
         $this->tickScheduler = new TickScheduler();
         $this->adaptativeTicker = new AdaptativeTicker($this);
+        $this->mouseParser = new MouseParser();
     }
 
     /**
@@ -376,6 +379,34 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
     }
 
     /**
+     * Enable mouse reporting on the terminal.
+     *
+     * Once enabled, mouse interactions are dispatched as
+     * {@see Event\MouseEvent} through the event
+     * dispatcher; listen for them with {@see addListener()}. Off by default.
+     *
+     * @return $this
+     */
+    public function enableMouseTracking(): static
+    {
+        $this->terminal->enableMouseTracking();
+
+        return $this;
+    }
+
+    /**
+     * Disable mouse reporting previously enabled with {@see enableMouseTracking()}.
+     *
+     * @return $this
+     */
+    public function disableMouseTracking(): static
+    {
+        $this->terminal->disableMouseTracking();
+
+        return $this;
+    }
+
+    /**
      * Set the focused component.
      *
      * @return $this
@@ -478,6 +509,15 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
      */
     public function handleInput(string $data): void
     {
+        // Mouse sequences are dispatched as a MouseEvent and consumed here, so
+        // they never leak into keyboard handling. Terminals only report them
+        // once tracking has been enabled (see enableMouseTracking()).
+        if (null !== $mouse = $this->mouseParser->parse($data)) {
+            $this->eventDispatcher->dispatch($mouse);
+
+            return;
+        }
+
         $event = $this->eventDispatcher->dispatch(new InputEvent($data));
         if ($event->isPropagationStopped()) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64129
| License       | MIT

Opt-in mouse tracking for the TUI component. `StdinBuffer` already parses X10 and SGR mouse sequences but they were silently discarded; this wires them up.

- `Terminal::enableMouseTracking()` / `disableMouseTracking()` emit/clear the DECSET sequences (`?1000`/`?1002`/`?1006`), off by default and restored on stop.
- A `MouseEvent` value object (x, y as 0-indexed cells; `MouseButton` and `MouseEventKind` enums; shift/alt/ctrl) and a `MouseParser` decoding both encodings. Out-of-scope inputs (horizontal wheel, extra buttons 8-11) are ignored rather than reported as phantom clicks.
- `Tui::handleInput()` dispatches the `MouseEvent` through the event dispatcher, so listeners use `$tui->addListener(fn(MouseEvent $e) => ...)` instead of peeking into `InputEvent::getData()`. Mouse bytes no longer leak into keyboard handling.

This is the infrastructure slice; routing to the widget under the cursor (via `PositionTracker`) and wheel-scroll on viewport widgets is a planned follow-up.