### PR TITLE
[FrameworkBundle] Avoid resolving all env vars when building the router request context

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1244,7 +1244,20 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('messenger.middleware.router_context');
         }
 
+        // Read the deprecated "router.request_context.{host,scheme}" parameters before routing.php
+        // sets their defaults, so that an explicit user value takes precedence. They are inlined as
+        // arguments of the "router.request_context" service below: this avoids both triggering their
+        // deprecation and eagerly resolving every env-var-based parameter through ParameterBag::all()
+        // at runtime.
+        $parameters = $container->getParameterBag()->all();
+        $requestContextHost = $parameters['router.request_context.host'] ?? 'localhost';
+        $requestContextScheme = $parameters['router.request_context.scheme'] ?? 'http';
+
         $loader->load('routing.php');
+
+        $container->getDefinition('router.request_context')
+            ->setArgument(1, $requestContextHost)
+            ->setArgument(2, $requestContextScheme);
 
         $container->deprecateParameter('router.request_context.scheme', 'symfony/framework-bundle', '8.1', 'Parameter "router.request_context.scheme" is deprecated, use "router.request_context.base_url" parameter or the "framework.router.default_uri" config option instead.');
         $container->deprecateParameter('router.request_context.host', 'symfony/framework-bundle', '8.1', 'Parameter "router.request_context.host" is deprecated, use "router.request_context.base_url" parameter or the "framework.router.default_uri" config option instead.');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
@@ -158,18 +158,8 @@ return static function (ContainerConfigurator $container) {
             ->factory([RequestContext::class, 'fromUri'])
             ->args([
                 param('router.request_context.base_url'),
-                inline_service('array')->factory('array_first')->args([
-                    inline_service('array')->factory('array_intersect_key')->args([
-                        inline_service('array')->factory([service('parameter_bag'), 'all']),
-                        array_flip(['router.request_context.host']),
-                    ]),
-                ]),
-                inline_service('array')->factory('array_first')->args([
-                    inline_service('array')->factory('array_intersect_key')->args([
-                        inline_service('array')->factory([service('parameter_bag'), 'all']),
-                        array_flip(['router.request_context.scheme']),
-                    ]),
-                ]),
+                abstract_arg('Set in FrameworkExtension from the "router.request_context.host" parameter'),
+                abstract_arg('Set in FrameworkExtension from the "router.request_context.scheme" parameter'),
                 param('request_listener.http_port'),
                 param('request_listener.https_port'),
             ])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -836,6 +836,36 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame(['_locale' => 'fr|en'], $container->getDefinition('routing.loader')->getArgument(2));
     }
 
+    public function testRouterRequestContextInlinesHostAndScheme()
+    {
+        $container = $this->createContainerFromFile('full');
+
+        // The host and scheme are inlined as plain values instead of being read through
+        // ParameterBag::all() at runtime, which would eagerly resolve every env var and
+        // fail during cache warmup when one of them is missing.
+        $requestContext = $container->getDefinition('router.request_context');
+        $this->assertSame('localhost', $requestContext->getArgument(1));
+        $this->assertSame('http', $requestContext->getArgument(2));
+    }
+
+    public function testRouterRequestContextUsesHostAndSchemeParameters()
+    {
+        $container = $this->createContainerFromClosure(function ($container) {
+            $container->setParameter('router.request_context.host', 'example.com');
+            $container->setParameter('router.request_context.scheme', 'https');
+            $container->loadFromExtension('framework', [
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'router' => ['resource' => '%kernel.project_dir%/config/routing.xml'],
+            ]);
+        });
+
+        $requestContext = $container->getDefinition('router.request_context');
+        $this->assertSame('example.com', $requestContext->getArgument(1));
+        $this->assertSame('https', $requestContext->getArgument(2));
+    }
+
     public function testRouterEnabledLocalesWithEnvPlaceholders()
     {
         $container = $this->createContainerFromFile('router_enabled_locales_env');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64448
| License       | MIT

Since #61457 deprecated the `router.request_context.host` and `router.request_context.scheme` parameters, the `router.request_context` service reads them through `ParameterBag::all()`, so that reading them does not trigger their deprecation:

```php
->args([
    param('router.request_context.base_url'),
    inline_service('array')->factory('array_first')->args([
        inline_service('array')->factory('array_intersect_key')->args([
            inline_service('array')->factory([service('parameter_bag'), 'all']),
            array_flip(['router.request_context.host']),
        ]),
    ]),
    // ... same for scheme
])
```

The issue is that, in the compiled container, `ParameterBag::all()` resolves *every* dynamic parameter. `RouterCacheWarmer` instantiates `router.request_context` on `cache:warmup` (and thus `cache:clear`), so building the cache now eagerly resolves all env-var-based parameters and fails as soon as one has no default:

```
In EnvVarProcessor.php line 224:

  Environment variable not found: "MESSENGER_TRANSPORT_DSN".
```

This breaks building the cache for any application referencing an env var without a default in a parameter, which is common for serverless or containerized deployments where such env vars are only available at runtime.

This PR reads the (still deprecated) host and scheme parameters once at build time, before `routing.php` registers their defaults so that an explicit value still takes precedence, and inlines them as arguments of the `router.request_context` service. User overrides keep working, the parameters' deprecation is not triggered, and building the request context no longer resolves unrelated env vars.
