### PR TITLE
[VarExporter] Fix exporting objects that cannot be instantiated empty

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -79,6 +79,15 @@ class Exporter
             $sleep = null;
             $proto = Registry::$prototypes[$class];
 
+            if (null === $proto && !$value instanceof \Serializable && method_exists($class, '__unserialize')) {
+                // The class cannot be instantiated empty; let serialize()/unserialize()
+                // deal with reconstructing the whole value.
+                ++$objectsCount;
+                $objectsPool[$value] = [$id = \count($objectsPool), serialize($value), [], 0];
+                $value = new Reference($id);
+                goto handle_value;
+            }
+
             if ($reflector->hasMethod('__serialize')) {
                 if (!$reflector->getMethod('__serialize')->isPublic()) {
                     throw new \Error(\sprintf('Call to %s method "%s::__serialize()".', $reflector->getMethod('__serialize')->isProtected() ? 'protected' : 'private', $class));

--- a/src/Symfony/Component/VarExporter/Internal/Registry.php
+++ b/src/Symfony/Component/VarExporter/Internal/Registry.php
@@ -93,13 +93,21 @@ class Registry
                     try {
                         $proto = @unserialize($proto.\strlen($class).':"'.$class.'":0:{}');
                     } catch (\Exception $e) {
-                        if (__FILE__ !== $e->getFile()) {
+                        if (method_exists($class, '__unserialize')) {
+                            // The class cannot be instantiated empty but defines __serialize()/__unserialize();
+                            // it'll be reconstructed by serializing the whole value.
+                            $proto = null;
+                        } elseif (__FILE__ !== $e->getFile()) {
                             throw $e;
+                        } else {
+                            throw new NotInstantiableTypeException($class, $e);
                         }
-                        throw new NotInstantiableTypeException($class, $e);
                     }
                     if (false === $proto) {
-                        throw new NotInstantiableTypeException($class);
+                        if (!method_exists($class, '__unserialize')) {
+                            throw new NotInstantiableTypeException($class);
+                        }
+                        $proto = null;
                     }
                 }
             }

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -83,7 +83,6 @@ class VarExporterTest extends TestCase
 
     public static function provideFailingSerialization()
     {
-        yield [hash_init('md5')];
         yield [new \ReflectionClass(\stdClass::class)];
         yield [(new \ReflectionFunction(function (): int {}))->getReturnType()];
         yield [new \ReflectionGenerator((function () { yield 123; })())];
@@ -102,6 +101,35 @@ class VarExporterTest extends TestCase
         $a[0] = &$a;
 
         yield [$a];
+    }
+
+    public function testHashContext()
+    {
+        $value = hash_init('md5');
+        hash_update($value, 'foo');
+
+        $copy = eval('return '.VarExporter::export($value).';');
+
+        hash_update($value, 'bar');
+        hash_update($copy, 'bar');
+
+        $this->assertSame(hash_final($value), hash_final($copy));
+    }
+
+    public function testBcMathNumber()
+    {
+        if (!class_exists(\BcMath\Number::class)) {
+            $this->markTestSkipped('The "bcmath" extension with the BcMath\Number class is required.');
+        }
+
+        $value = new \BcMath\Number('9999.99');
+
+        $marshalledValue = VarExporter::export($value);
+        $copy = eval('return '.$marshalledValue.';');
+
+        $this->assertInstanceOf(\BcMath\Number::class, $copy);
+        $this->assertSame((string) $value, (string) $copy);
+        $this->assertTrue($value == $copy);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64323
| License       | MIT

`VarExporter` reconstructs objects by first creating an empty instance (via `newInstanceWithoutConstructor()` or an `O:...:0:{}` unserialization) and then hydrating it. This doesn't work for internal final classes whose `__unserialize()` rejects empty data, e.g. `BcMath\Number`:

```php
VarExporter::export(new BcMath\Number('9999.99'));
// Type "BcMath\Number" is not instantiable.
```

This surfaces in real apps when warming up the validator metadata cache (`PhpArrayAdapter`) for a constraint holding such a value, e.g.:

```php
#[Assert\LessThanOrEqual(new BcMath\Number('9999.99'))]
public ?BcMath\Number $number;
```

Since these objects can still be (un)serialized losslessly through their own `__serialize()`/`__unserialize()`, this PR reconstructs them by storing their `serialize()` output, reusing the same path already used for `Serializable` objects. `HashContext` benefits from the same fix.
