### PR TITLE
[ObjectMapper] Handle N targets per source in reverse class map

### DIFF
--- a/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
+++ b/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
@@ -30,8 +30,11 @@ final class ReverseMappingPass implements CompilerPassInterface
         $classes = [];
         foreach ($container->findTaggedResourceIds('object_mapper.map') as $tags) {
             foreach ($tags as $tag) {
-                if (isset($tag['source'], $tag['target'])) {
-                    $classes[$tag['source']] = $tag['target'];
+                if (!isset($tag['source'], $tag['target'])) {
+                    continue;
+                }
+                if (!\in_array($tag['target'], $classes[$tag['source']] ?? [], true)) {
+                    $classes[$tag['source']][] = $tag['target'];
                 }
             }
         }

--- a/src/Symfony/Component/ObjectMapper/Metadata/Mapping.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/Mapping.php
@@ -22,4 +22,13 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
  */
 final class Mapping extends Map
 {
+    public function __construct(
+        ?string $target = null,
+        ?string $source = null,
+        mixed $if = null,
+        mixed $transform = null,
+        public readonly ?string $targetClass = null,
+    ) {
+        parent::__construct($target, $source, $if, $transform);
+    }
 }

--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -26,7 +26,7 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
     private array $attributesCache = [];
 
     /**
-     * @param array<class-string, class-string> $classMap
+     * @param array<class-string, class-string|list<class-string>> $classMap Targets for a given source must be unique
      */
     public function __construct(
         private readonly ObjectMapperMetadataFactoryInterface $objectMapperMetadataFactory,
@@ -44,33 +44,32 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
         }
 
         $mappings = $this->objectMapperMetadataFactory->create($object, $property, $context);
+        $targetClasses = (array) ($this->classMap[$class] ?? []);
 
-        if (!$targetClass = $this->classMap[$class] ?? null) {
+        if (!$targetClasses) {
             return $mappings;
         }
 
         if (!$property) {
-            $mappings[] = new Mapping($targetClass);
+            foreach ($targetClasses as $targetClass) {
+                if (!array_any($mappings, static fn (Mapping $m): bool => $m->target === $targetClass)) {
+                    $mappings[] = new Mapping($targetClass);
+                }
+            }
 
             return $this->attributesCache[$key] = $mappings;
         }
 
-        $refl = new \ReflectionClass($targetClass);
-        foreach ($refl->getProperties() as $reflProperty) {
-            $attributes = $reflProperty->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF);
+        foreach ($targetClasses as $targetClass) {
+            foreach ((new \ReflectionClass($targetClass))->getProperties() as $reflProperty) {
+                foreach ($reflProperty->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                    $map = $attribute->newInstance();
+                    if ($map->source !== $property) {
+                        continue;
+                    }
 
-            foreach ($attributes as $attribute) {
-                $map = $attribute->newInstance();
-                // We're forcing the target on a reverse mapping to the property name, doesn't make sense without a source
-                if (!$map->source) {
-                    continue;
+                    $mappings[] = new Mapping($reflProperty->getName(), $map->source, $map->if, $map->transform, targetClass: $targetClass);
                 }
-
-                if ($map->source !== $property) {
-                    continue;
-                }
-
-                $mappings[] = new Mapping($reflProperty->getName(), $map->source, $map->if, $map->transform);
             }
         }
 

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -131,6 +131,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         $mapToProperties = [];
+        $targetName = $targetRefl->getName();
         foreach ($refl->getProperties() as $property) {
             if ($property->isStatic()) {
                 continue;
@@ -138,6 +139,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
             $propertyName = $property->getName();
             $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName);
+            $mappings = array_filter($mappings, static fn (Mapping $m): bool => !$m->targetClass || is_a($targetName, $m->targetClass, true));
             foreach ($mappings as $mapping) {
                 $sourcePropertyName = $propertyName;
                 if ($mapping->source && (!$refl->hasProperty($propertyName) || !isset($source->$propertyName))) {
@@ -200,9 +202,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 \is_object($rawValue)
                 && !$objectMap->offsetExists($rawValue)
                 && ($innerMetadata = $this->metadataFactory->create($rawValue))
-                && ($mapTo = $this->getMapTarget($innerMetadata, $rawValue, $source, $mappedTarget))
-                && \is_string($mapTo->target)
-                && $mapTo->target === $targetRefl->getName()
+                && array_any($innerMetadata, static fn (Mapping $m): bool => \is_string($m->target) && is_a($targetName, $m->target, true))
             ) {
                 ($this->objectMapper ?? $this)->map($rawValue, $mappedTarget);
             }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedFlatTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedFlatTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class AutoNestedFlatTarget
+{
+    public string $outer;
+    public string $inner;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedInnerSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedInnerSource.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: AutoNestedFlatTarget::class)]
+final class AutoNestedInnerSource
+{
+    public string $inner = 'from inner';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedOtherTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedOtherTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class AutoNestedOtherTarget
+{
+    public string $inner;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedOuterSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/AutoNestedOuterSource.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: AutoNestedFlatTarget::class)]
+final class AutoNestedOuterSource
+{
+    public string $outer = 'from outer';
+    public AutoNestedInnerSource $child;
+
+    public function __construct()
+    {
+        $this->child = new AutoNestedInnerSource();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/ExtensibleTargetChild.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/ExtensibleTargetChild.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class ExtensibleTargetChild extends ExtensibleTargetParent
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/ExtensibleTargetParent.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/ExtensibleTargetParent.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class ExtensibleTargetParent
+{
+    #[Map(source: 'value', transform: [self::class, 'double'])]
+    public int $value;
+
+    public static function double(mixed $v): int
+    {
+        return $v * 2;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PreMappedSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PreMappedSource.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: PreMappedTarget::class)]
+final class PreMappedSource
+{
+    public int $value = 1;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PreMappedTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PreMappedTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class PreMappedTarget
+{
+    public int $value;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedSource.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class SharedSource
+{
+    public int $value = 21;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithTransform.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithTransform.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: SharedSource::class)]
+final class SharedTargetWithTransform
+{
+    #[Map(source: 'value', transform: [self::class, 'double'])]
+    public int $value;
+
+    public static function double(mixed $v): int
+    {
+        return $v * 2;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithoutTransform.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/SharedTargetWithoutTransform.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: SharedSource::class)]
+final class SharedTargetWithoutTransform
+{
+    public int $value;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -30,14 +30,25 @@ use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedFlatTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedInnerSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedOtherTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedOuterSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Cost;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceAndAutoMappedView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\ExtensibleTargetChild;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\ExtensibleTargetParent;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PreMappedSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PreMappedTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RichDomainUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RichDomainUserView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\SharedSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\SharedTargetWithoutTransform;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\SharedTargetWithTransform;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\A as ClassRuleA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\B as ClassRuleB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassRule\C as ClassRuleC;
@@ -939,6 +950,84 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(PostView::class, $view);
         $this->assertSame('hello', $view->title);
         $this->assertSame('none', $view->summary);
+    }
+
+    public function testClassMapWithMultipleTargetsSharingOneSourceAppliesEachTargetsTransform()
+    {
+        $classMap = [
+            SharedSource::class => [
+                SharedTargetWithTransform::class,
+                SharedTargetWithoutTransform::class,
+            ],
+        ];
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+
+        $withTransform = $mapper->map(new SharedSource(), SharedTargetWithTransform::class);
+        $this->assertInstanceOf(SharedTargetWithTransform::class, $withTransform);
+        $this->assertSame(42, $withTransform->value);
+
+        $withoutTransform = $mapper->map(new SharedSource(), SharedTargetWithoutTransform::class);
+        $this->assertInstanceOf(SharedTargetWithoutTransform::class, $withoutTransform);
+        $this->assertSame(21, $withoutTransform->value);
+    }
+
+    public function testClassMapWithMultipleTargetsSharingOneSourceRequiresAnExplicitTarget()
+    {
+        $classMap = [
+            SharedSource::class => [
+                SharedTargetWithTransform::class,
+                SharedTargetWithoutTransform::class,
+            ],
+        ];
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Ambiguous mapping for "'.SharedSource::class.'".');
+
+        $mapper->map(new SharedSource());
+    }
+
+    public function testClassMapEntryDuplicatingSourceTargetAttributeDoesNotRaiseAmbiguity()
+    {
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(
+            new ReflectionObjectMapperMetadataFactory(),
+            [PreMappedSource::class => PreMappedTarget::class],
+        ));
+
+        $result = $mapper->map(new PreMappedSource());
+
+        $this->assertInstanceOf(PreMappedTarget::class, $result);
+        $this->assertSame(1, $result->value);
+    }
+
+    public function testClassMapFilterAcceptsSubclassTarget()
+    {
+        $classMap = [SharedSource::class => ExtensibleTargetParent::class];
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+        $result = $mapper->map(new SharedSource(), ExtensibleTargetChild::class);
+
+        $this->assertInstanceOf(ExtensibleTargetChild::class, $result);
+        $this->assertSame(42, $result->value);
+    }
+
+    public function testNestedAutoMapPicksMatchingTargetFromMultiTargetClassMap()
+    {
+        $classMap = [
+            AutoNestedInnerSource::class => [
+                AutoNestedFlatTarget::class,
+                AutoNestedOtherTarget::class,
+            ],
+        ];
+
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap));
+        $result = $mapper->map(new AutoNestedOuterSource(), AutoNestedFlatTarget::class);
+
+        $this->assertInstanceOf(AutoNestedFlatTarget::class, $result);
+        $this->assertSame('from outer', $result->outer);
+        $this->assertSame('from inner', $result->inner);
     }
 
     public function testMissingSourcePropertiesAreIgnored()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64425
| License       | MIT

Supersedes #64539 — incorporates that PR's fix and tests, plus a dedupe
fix for a related symptom: when ReverseMappingPass auto-populates the
class map from a source's own #[Map(target:)] attribute, the factory
appended a duplicate Mapping entry and threw a spurious
"Ambiguous mapping" exception.