### PR TITLE
[Messenger] Make PhpSerializer tolerant to trailing CR/LF

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -51,6 +51,31 @@ class PhpSerializerTest extends TestCase
         $this->assertEquals($envelope, $serializer->decode($encoded));
     }
 
+    #[DataProvider('provideTrailingWhitespace')]
+    public function testDecodeToleratesTrailingWhitespace(string $suffix)
+    {
+        $serializer = $this->createPhpSerializer();
+
+        $envelope = new Envelope(new DummyMessage('Hello'));
+
+        // Raw body (UTF-8 payload) and base64 body (non-UTF-8 payload) take different
+        // code paths; both must tolerate the trailing bytes some transports append.
+        foreach ([new DummyMessage('Hello'), new DummyMessage("\xE9")] as $message) {
+            $encoded = $serializer->encode(new Envelope($message));
+            $encoded['body'] .= $suffix;
+
+            $this->assertEquals(new Envelope($message), $serializer->decode($encoded));
+            $this->assertSame($message::class, $serializer->getMessageType($encoded));
+        }
+    }
+
+    public static function provideTrailingWhitespace(): iterable
+    {
+        yield 'newline' => ["\n"];
+        yield 'carriage return + newline' => ["\r\n"];
+        yield 'multiple newlines' => ["\n\n"];
+    }
+
     public function testDecodingFailsWithMissingBodyKey()
     {
         $serializer = $this->createPhpSerializer();

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -45,11 +45,14 @@ class PhpSerializer implements SerializerInterface, MessageTypeAwareSerializerIn
             throw new MessageDecodingFailedException('Encoded envelope should have at least a "body", or maybe you should implement your own serializer.');
         }
 
-        if (!str_ends_with($encodedEnvelope['body'], '}')) {
-            $encodedEnvelope['body'] = base64_decode($encodedEnvelope['body']);
+        // Some transports append trailing CR/LF to the body; tolerate them as native unserialize() does.
+        $body = rtrim($encodedEnvelope['body'], "\r\n");
+
+        if (!str_ends_with($body, '}')) {
+            $body = base64_decode($body);
         }
 
-        $serializeEnvelope = stripslashes($encodedEnvelope['body']);
+        $serializeEnvelope = stripslashes($body);
 
         return $this->safelyUnserialize($serializeEnvelope);
     }
@@ -59,6 +62,9 @@ class PhpSerializer implements SerializerInterface, MessageTypeAwareSerializerIn
         if (!\is_string($body = $encodedEnvelope['body'] ?? null) || '' === $body) {
             return null;
         }
+
+        // Some transports append trailing CR/LF to the body; tolerate them as native unserialize() does.
+        $body = rtrim($body, "\r\n");
 
         if (!str_ends_with($body, '}') && false === $body = base64_decode($body, true)) {
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Comment on #64197
| License       | MIT

Some transports append trailing CR/LF to the body when storing large payloads as objects. Native `unserialize()` tolerates such trailing bytes, but `PhpSerializer` did not:

- `decode()` misroutes a body ending in `}\n` into `base64_decode()` (the `str_ends_with($body, '}')` heuristic no longer matches), producing garbage and failing with `Could not decode Envelope: unserialize(): Error at offset 0`.
- `getMessageType()` (added in #64197) returns `null` for the same reason, which is the regression reported in https://github.com/symfony/symfony/pull/64197#issuecomment-4657224407.

This `rtrim($body, "\r\n")`s the body in both methods before the base64 detection. It is scoped to CR/LF only, so the scanner still rejects arbitrary trailing garbage (the existing `}garbage` adversarial case keeps returning `null`).
