### PR TITLE
[Messenger][Amqp] Populate RedeliveryStamp from the x-death header

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add a `RedeliveryStamp` to received messages based on the broker `x-death` header
+
 8.1
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -20,7 +20,9 @@ use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Serializer as SerializerComponent;
@@ -191,13 +193,109 @@ class AmqpReceiverTest extends TestCase
         $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
     }
 
-    private function createAMQPEnvelope(?string $messageId = null, string $body = '{"message": "Hi"}'): \AMQPEnvelope
+    public function testItAddsARedeliveryStampFromTheXDeathHeader()
+    {
+        $serializer = new Serializer(
+            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+        );
+
+        $amqpEnvelope = $this->createAMQPEnvelope(headers: ['x-death' => [['count' => 3, 'time' => 1717000000]]]);
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->expects($this->once())->method('get')->with('queueName')->willReturn($amqpEnvelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+        $envelope = iterator_to_array($receiver->get())[0];
+
+        $stamp = $envelope->last(RedeliveryStamp::class);
+        $this->assertInstanceOf(RedeliveryStamp::class, $stamp);
+        // The broker redelivery must not feed the Messenger retry counter.
+        $this->assertSame(0, $stamp->getRetryCount());
+        $this->assertSame(1717000000, $stamp->getRedeliveredAt()->getTimestamp());
+        $this->assertSame('+00:00', $stamp->getRedeliveredAt()->getTimezone()->getName());
+    }
+
+    public function testItAddsARedeliveryStampFromADateTimeXDeathHeader()
+    {
+        $serializer = new Serializer(
+            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+        );
+
+        $amqpEnvelope = $this->createAMQPEnvelope(headers: ['x-death' => [['count' => 3, 'time' => new \DateTimeImmutable('@1717000000')]]]);
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->expects($this->once())->method('get')->with('queueName')->willReturn($amqpEnvelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+        $envelope = iterator_to_array($receiver->get())[0];
+
+        $stamp = $envelope->last(RedeliveryStamp::class);
+        $this->assertInstanceOf(RedeliveryStamp::class, $stamp);
+        $this->assertSame(1717000000, $stamp->getRedeliveredAt()->getTimestamp());
+    }
+
+    public function testItDoesNotAddARedeliveryStampWithoutTheXDeathHeader()
+    {
+        $serializer = new Serializer(
+            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+        );
+
+        $amqpEnvelope = $this->createAMQPEnvelope();
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->expects($this->once())->method('get')->with('queueName')->willReturn($amqpEnvelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+        $envelope = iterator_to_array($receiver->get())[0];
+
+        $this->assertNull($envelope->last(RedeliveryStamp::class));
+    }
+
+    public function testItDoesNotAddARedeliveryStampWhenTheXDeathHeaderHasNoUsableTime()
+    {
+        $serializer = new Serializer(
+            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+        );
+
+        $amqpEnvelope = $this->createAMQPEnvelope(headers: ['x-death' => [['count' => 3]]]);
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->expects($this->once())->method('get')->with('queueName')->willReturn($amqpEnvelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+        $envelope = iterator_to_array($receiver->get())[0];
+
+        $this->assertNull($envelope->last(RedeliveryStamp::class));
+    }
+
+    public function testItKeepsTheRedeliveryStampCarriedByTheMessage()
+    {
+        $serializer = new PhpSerializer();
+
+        $existing = new RedeliveryStamp(7, new \DateTimeImmutable('@1700000000'));
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('Hi'), [$existing]));
+
+        $amqpEnvelope = $this->createAMQPEnvelope(body: $encoded['body'], headers: ['x-death' => [['count' => 3, 'time' => 1717000000]]]);
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getQueueNames')->willReturn(['queueName']);
+        $connection->expects($this->once())->method('get')->with('queueName')->willReturn($amqpEnvelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+        $envelope = iterator_to_array($receiver->get())[0];
+
+        $stamp = $envelope->last(RedeliveryStamp::class);
+        $this->assertInstanceOf(RedeliveryStamp::class, $stamp);
+        $this->assertSame(7, $stamp->getRetryCount());
+        $this->assertSame(1700000000, $stamp->getRedeliveredAt()->getTimestamp());
+    }
+
+    private function createAMQPEnvelope(?string $messageId = null, string $body = '{"message": "Hi"}', array $headers = []): \AMQPEnvelope
     {
         $envelope = $this->createStub(\AMQPEnvelope::class);
         $envelope->method('getBody')->willReturn($body);
         $envelope->method('getHeaders')->willReturn([
             'type' => DummyMessage::class,
-        ]);
+        ] + $headers);
         $envelope->method('getMessageId')->willReturn($messageId);
 
         return $envelope;

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -15,6 +15,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
@@ -111,16 +112,53 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
             ...($id ? [new TransportMessageIdStamp($id)] : []),
         ];
 
+        $headers = $amqpEnvelope->getHeaders();
         $data = [
             'body' => false === $body ? '' : $body,
-            'headers' => $amqpEnvelope->getHeaders(),
+            'headers' => $headers,
         ];
 
         try {
-            return $this->serializer->decode($data)->withoutAll(TransportMessageIdStamp::class)->with(...$stamps);
+            $envelope = $this->serializer->decode($data)->withoutAll(TransportMessageIdStamp::class)->with(...$stamps);
         } catch (MessageDecodingFailedException $e) {
             return MessageDecodingFailedException::wrap($data, $e->getMessage(), $e->getCode(), $e)->with(...$stamps);
         }
+
+        if (null === $envelope->last(RedeliveryStamp::class) && $redeliveryStamp = $this->createRedeliveryStamp($headers)) {
+            $envelope = $envelope->with($redeliveryStamp);
+        }
+
+        return $envelope;
+    }
+
+    /**
+     * Builds a RedeliveryStamp from the "x-death" header that brokers such as
+     * RabbitMQ add when a message is dead-lettered, so the redelivery date is
+     * available even when the redelivery was not driven by the Messenger retry
+     * mechanism. Returns null when the header is absent or does not carry a
+     * usable timestamp.
+     */
+    private function createRedeliveryStamp(array $headers): ?RedeliveryStamp
+    {
+        $xDeath = $headers['x-death'] ?? null;
+        if (!\is_array($xDeath) || !\is_array($death = $xDeath[0] ?? null)) {
+            return null;
+        }
+
+        $time = $death['time'] ?? null;
+        if ($time instanceof \DateTimeInterface) {
+            $redeliveredAt = $time;
+        } elseif (\is_int($time) || (\is_string($time) && ctype_digit($time))) {
+            // The broker reports the death time as a UTC timestamp.
+            $redeliveredAt = new \DateTimeImmutable('@'.$time);
+        } else {
+            return null;
+        }
+
+        // The retry count is left at 0: the redelivery was performed by the
+        // broker, not by the Messenger retry mechanism, so it must not feed
+        // the retry counter read by RedeliveryStamp::getRetryCountFromEnvelope().
+        return new RedeliveryStamp(0, $redeliveredAt);
     }
 
     public function ack(Envelope $envelope): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64061
| License       | MIT

When a broker such as RabbitMQ redelivers a message that was not re-sent by the Messenger retry mechanism, `RedeliveryStamp` (and its `redeliveredAt` date) was never available on the received envelope.

`AmqpReceiver` now reads the `x-death` header the broker adds on dead-lettering and, when no `RedeliveryStamp` is already present, builds one from its `time`. Nothing is synthesized when the header is missing, the retry count is left at 0 so broker redeliveries do not feed the Messenger retry counter, and the existing retry path is untouched.