### PR TITLE
[DependencyInjection] Fix decorating an event listener no longer replacing it

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -43,9 +43,9 @@ class DecoratorServicePass extends AbstractRecursivePass
         $decoratingDefinitions = [];
         $decoratedIds = [];
 
-        $tagsToKeep = $container->hasParameter('container.behavior_describing_tags')
-            ? $container->getParameter('container.behavior_describing_tags')
-            : ['proxy', 'container.do_not_inline', 'container.service_locator', 'container.service_subscriber', 'container.service_subscriber.locator'];
+        // These tags describe how the container wires a concrete service and must stay on the
+        // decorated service; role-describing tags (e.g. "kernel.event_listener") move to its decorators.
+        $tagsToKeep = ['proxy', 'container.do_not_inline', 'container.service_locator', 'container.service_subscriber', 'container.service_subscriber.locator'];
 
         foreach ($definitions as [$id, $definition]) {
             $decoratedService = $definition->getDecoratedService();
@@ -99,7 +99,6 @@ class DecoratorServicePass extends AbstractRecursivePass
                 $decoratingTags = $decoratingDefinition->getTags();
                 $resetTags = [];
 
-                // Behavior-describing tags must not be transferred out to decorators
                 foreach ($tagsToKeep as $containerTag) {
                     if (isset($decoratingTags[$containerTag])) {
                         $resetTags[$containerTag] = $decoratingTags[$containerTag];

--- a/src/Symfony/Component/DependencyInjection/Kernel/ServicesBundle.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/ServicesBundle.php
@@ -53,6 +53,7 @@ class ServicesBundle extends AbstractBundle
         if (class_exists(RegisterListenersPass::class)) {
             $container->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         }
+        // Must run before ResolveInstanceofConditionalsPass which consumes and removes the parameter
         $container->addCompilerPass(new AddBehaviorDescribingTagsPass([
             'container.do_not_inline',
             'container.service_locator',
@@ -60,7 +61,7 @@ class ServicesBundle extends AbstractBundle
             'kernel.event_subscriber',
             'kernel.event_listener',
             'kernel.reset',
-        ]));
+        ]), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
         $container->addCompilerPass(new ResettableServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -281,6 +281,25 @@ class DecoratorServicePassTest extends TestCase
         $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
+    public function testProcessIgnoresBehaviorDescribingTagsParameter()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('container.behavior_describing_tags', ['container.service_locator', 'kernel.event_listener']);
+        $container
+            ->register('foo')
+            ->setTags(['container.service_locator' => [0 => []], 'kernel.event_listener' => [['event' => 'foo']]])
+        ;
+        $container
+            ->register('baz')
+            ->setDecoratedService('foo')
+        ;
+
+        $this->process($container);
+
+        $this->assertEquals(['container.service_locator' => [0 => []]], $container->getDefinition('baz.inner')->getTags());
+        $this->assertEquals(['kernel.event_listener' => [['event' => 'foo']], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
+    }
+
     public function testCannotDecorateSyntheticService()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -20,10 +20,12 @@ use Symfony\Component\DependencyInjection\Compiler\AttributeAutoconfigurationPas
 use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\Tests\Fixtures\CustomEvent;
 use Symfony\Component\EventDispatcher\Tests\Fixtures\DummyEvent;
@@ -602,6 +604,59 @@ class RegisterListenersPassTest extends TestCase
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
     }
 
+    public function testDecoratingAListenerRegistersTheDecoratorAsListener()
+    {
+        $container = new ContainerBuilder();
+        new ServicesBundle()->build($container);
+
+        $container->register('event_dispatcher', EventDispatcher::class)->setPublic(true);
+        $container->register('listener', TaggedInvokableListener::class)
+            ->setPublic(true)
+            ->addTag('kernel.event_listener', ['event' => CustomEvent::class]);
+        $container->register('decorator', DecoratingListener::class)
+            ->setPublic(true)
+            ->setArguments([new Reference('decorator.inner')])
+            ->setDecoratedService('listener');
+
+        $container->compile();
+
+        $listeners = [];
+        foreach ($container->getDefinition('event_dispatcher')->getMethodCalls() as [$method, $arguments]) {
+            if ('addListener' === $method) {
+                $listeners[] = (string) $arguments[1][0]->getValues()[0];
+            }
+        }
+
+        $this->assertSame(['decorator'], $listeners);
+    }
+
+    public function testDecoratorThatIsAlsoAnEventSubscriberStaysRegistered()
+    {
+        $container = new ContainerBuilder();
+        new ServicesBundle()->build($container);
+        $container->registerForAutoconfiguration(EventSubscriberInterface::class)
+            ->addTag('kernel.event_subscriber');
+
+        $container->register('event_dispatcher', EventDispatcher::class)->setPublic(true);
+        $container->register('decorated', \stdClass::class);
+        $container->register('decorator', SubscribingDecorator::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+            ->setArguments([new Reference('decorator.inner')])
+            ->setDecoratedService('decorated');
+
+        $container->compile();
+
+        $listeners = [];
+        foreach ($container->getDefinition('event_dispatcher')->getMethodCalls() as [$method, $arguments]) {
+            if ('addListener' === $method) {
+                $listeners[] = (string) $arguments[1][0]->getValues()[0];
+            }
+        }
+
+        $this->assertSame(['decorator'], $listeners);
+    }
+
     private function createContainerBuilder(): ContainerBuilder
     {
         $container = new ContainerBuilder();
@@ -634,6 +689,33 @@ class InvokableListenerService
     }
 
     public function onEvent()
+    {
+    }
+}
+
+final class DecoratingListener
+{
+    public function __construct(private TaggedInvokableListener $inner)
+    {
+    }
+
+    public function __invoke(CustomEvent $event): void
+    {
+    }
+}
+
+final class SubscribingDecorator implements EventSubscriberInterface
+{
+    public function __construct(private object $inner)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onSomeEvent'];
+    }
+
+    public function onSomeEvent(): void
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64570
| License       | MIT

Decorating an event listener no longer replaced it: the original listener was registered instead of the decorator.

`container.behavior_describing_tags` is used by two passes with opposite needs. `ResolveInstanceofConditionalsPass` needs the full list (so an autoconfigured decorator keeps its own role tags) and consumes then removes the parameter, while `DecoratorServicePass` must *not* see the role tags (so `kernel.event_listener`/`kernel.event_subscriber` move from the decorated service to the decorator).

Before 8.1 the parameter was set in `FrameworkExtension::load()`, removed by `ResolveInstanceofConditionalsPass`, and gone by the time `DecoratorServicePass` ran. Since 8.1 `ServicesBundle` re-sets it via `AddBehaviorDescribingTagsPass` at the default priority, i.e. after `ResolveInstanceofConditionalsPass` removed it, so the role tags were back in the parameter when `DecoratorServicePass` ran and were kept on the decorated service.

This PR:
* registers that pass before `ResolveInstanceofConditionalsPass` (as `FrameworkBundle` already does), which also restores keeping the role tag on an autoconfigured decorator that is itself a subscriber;
* scopes the parameter to `ResolveInstanceofConditionalsPass` by giving `DecoratorServicePass` its own fixed list of wiring tags, removing the dependency on the parameter lifetime (this also covers #64467 without relying on the parameter).
