### PR TITLE
[TelegramNotifier] Add support for editing media messages

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for editing media messages via the `editMessageMedia` and `editMessageCaption` API methods
+
 8.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -319,6 +319,35 @@ $telegramOptions = (new TelegramOptions())
     );
 ```
 
+To edit a message that contains media, combine `edit()` with a media option
+(`photo()`, `video()`, `document()`, `audio()` or `animation()`). The media and
+its caption are replaced through the `editMessageMedia` API method.
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('My updated caption');
+$telegramOptions = (new TelegramOptions())
+    ->chatId($chatId)
+    ->edit($messageId)
+    ->photo('https://localhost/new-photo.png');
+```
+
+To update only the caption of an existing media message without re-sending the
+media, use `editCaption()`, which calls `editMessageCaption`. The subject of the
+message is used as the new caption.
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage('My updated caption');
+$telegramOptions = (new TelegramOptions())
+    ->chatId($chatId)
+    ->editCaption($messageId);
+```
+
 Answering Callback Queries
 --------------------------
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -161,6 +161,20 @@ final class TelegramOptions implements MessageOptionsInterface
     }
 
     /**
+     * Edits the caption of a message that contains media, without re-sending the
+     * media itself. The subject of the message is used as the new caption.
+     *
+     * @return $this
+     */
+    public function editCaption(int $messageId): static
+    {
+        $this->options['message_id'] = $messageId;
+        $this->options['edit_caption'] = true;
+
+        return $this;
+    }
+
+    /**
      * @return $this
      */
     public function answerCallbackQuery(string $callbackQueryId, bool $showAlert = false, int $cacheTime = 0): static

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Telegram;
 
+use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\MultipleExclusiveOptionsUsedException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
@@ -46,6 +47,9 @@ final class TelegramTransport extends AbstractTransport
         'contact',
         'sticker',
     ];
+
+    private const MEDIA_TYPES = ['photo', 'video', 'document', 'audio', 'animation'];
+    private const SPOILER_MEDIA_TYPES = ['photo', 'video', 'animation'];
 
     public function __construct(
         #[\SensitiveParameter] private string $token,
@@ -122,8 +126,12 @@ final class TelegramTransport extends AbstractTransport
         if (null !== $messageOption) {
             $options[$messageOption] = $text;
         }
-        $method = $this->getPath($options);
         $this->ensureExclusiveOptionsNotDuplicated($options);
+        $method = $this->getPath($options);
+        if ('editMessageMedia' === $method) {
+            $options = $this->buildInputMedia($options, $text);
+        }
+        unset($options['edit_caption']);
         $options = $this->expandOptions($options, 'contact', 'location', 'venue');
         $protocolSchema = $this->disableHttps ? 'http' : 'https';
 
@@ -158,7 +166,7 @@ final class TelegramTransport extends AbstractTransport
     private function getPath(array $options): string
     {
         return match (true) {
-            isset($options['message_id']) => 'editMessageText',
+            isset($options['message_id']) => $this->getEditMethod($options),
             isset($options['callback_query_id']) => 'answerCallbackQuery',
             isset($options['photo']) => 'sendPhoto',
             isset($options['location']) => 'sendLocation',
@@ -173,6 +181,50 @@ final class TelegramTransport extends AbstractTransport
         };
     }
 
+    private function getEditMethod(array $options): string
+    {
+        return match (true) {
+            isset($options['photo']), isset($options['video']), isset($options['document']),
+            isset($options['audio']), isset($options['animation']) => 'editMessageMedia',
+            isset($options['edit_caption']) => 'editMessageCaption',
+            default => 'editMessageText',
+        };
+    }
+
+    private function buildInputMedia(array $options, ?string $text): array
+    {
+        foreach (self::MEDIA_TYPES as $type) {
+            if (!isset($options[$type])) {
+                continue;
+            }
+
+            if (\is_resource($options[$type])) {
+                throw new LogicException('Editing a message with a locally uploaded media is not supported yet, use a URL or a Telegram file ID instead.');
+            }
+
+            $media = [
+                'type' => $type,
+                'media' => $options[$type],
+            ];
+            if (null !== $text) {
+                $media['caption'] = $text;
+            }
+            if (isset($options['parse_mode'])) {
+                $media['parse_mode'] = $options['parse_mode'];
+            }
+            if (isset($options['has_spoiler']) && \in_array($type, self::SPOILER_MEDIA_TYPES, true)) {
+                $media['has_spoiler'] = $options['has_spoiler'];
+            }
+
+            $options['media'] = $media;
+            unset($options[$type], $options['caption'], $options['parse_mode'], $options['has_spoiler']);
+
+            break;
+        }
+
+        return $options;
+    }
+
     private function getAction(array $options): string
     {
         return match (true) {
@@ -185,6 +237,7 @@ final class TelegramTransport extends AbstractTransport
     private function getTextOption(array $options): ?string
     {
         return match (true) {
+            isset($options['edit_caption']) => 'caption',
             isset($options['photo']) => 'caption',
             isset($options['audio']) => 'caption',
             isset($options['document']) => 'caption',
@@ -216,6 +269,12 @@ final class TelegramTransport extends AbstractTransport
     {
         $usedOptions = array_keys($options);
         $usedExclusiveOptions = array_intersect($usedOptions, self::EXCLUSIVE_OPTIONS);
+
+        // editing a message replaces its media, so "message_id" pairs with a single media type
+        if (isset($options['message_id']) && 1 === \count(array_intersect($usedOptions, self::MEDIA_TYPES))) {
+            $usedExclusiveOptions = array_diff($usedExclusiveOptions, ['message_id']);
+        }
+
         if (\count($usedExclusiveOptions) > 1) {
             throw new MultipleExclusiveOptionsUsedException($usedExclusiveOptions, self::EXCLUSIVE_OPTIONS);
         }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
@@ -68,6 +68,26 @@ final class TelegramOptionsTest extends TestCase
         yield 'cache time equals -10' => [-10];
     }
 
+    public function testEdit()
+    {
+        $options = new TelegramOptions();
+
+        $returnedOptions = $options->edit(123);
+
+        $this->assertSame($options, $returnedOptions);
+        $this->assertSame(['message_id' => 123], $options->toArray());
+    }
+
+    public function testEditCaption()
+    {
+        $options = new TelegramOptions();
+
+        $returnedOptions = $options->editCaption(123);
+
+        $this->assertSame($options, $returnedOptions);
+        $this->assertSame(['message_id' => 123, 'edit_caption' => true], $options->toArray());
+    }
+
     public function testTelegramOptions()
     {
         $options = new TelegramOptions([

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -16,8 +16,11 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\InlineKeyboardButton;
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\InlineKeyboardMarkup;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransport;
+use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\MultipleExclusiveOptionsUsedException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
@@ -148,8 +151,14 @@ final class TelegramTransportTest extends TransportTestCase
             ],
         ]);
 
-        $client = new MockHttpClient(function (string $method, string $url) use ($response): ResponseInterface {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
             $this->assertStringEndsWith('/editMessageText', $url);
+            $this->assertEqualsCanonicalizing([
+                'chat_id' => 'testChannel',
+                'message_id' => 123,
+                'text' => 'testMessage',
+                'parse_mode' => 'MarkdownV2',
+            ], json_decode($options['body'], true));
 
             return $response;
         });
@@ -158,6 +167,215 @@ final class TelegramTransportTest extends TransportTestCase
         $transport->send(new ChatMessage(
             'testMessage',
             (new TelegramOptions())->edit(123)
+        ));
+    }
+
+    /**
+     * @return iterable<string, array{messageOptions: TelegramOptions, expectedMedia: array<string, string>}>
+     */
+    public static function editMessageMediaProvider(): iterable
+    {
+        $types = [
+            'photo' => (new TelegramOptions())->edit(123)->photo('https://localhost/photo.png'),
+            'video' => (new TelegramOptions())->edit(123)->video('https://localhost/video.mp4'),
+            'document' => (new TelegramOptions())->edit(123)->document('https://localhost/document.odt'),
+            'audio' => (new TelegramOptions())->edit(123)->audio('https://localhost/audio.ogg'),
+            'animation' => (new TelegramOptions())->edit(123)->animation('https://localhost/animation.gif'),
+        ];
+
+        foreach ($types as $type => $messageOptions) {
+            $media = $messageOptions->toArray()[$type];
+
+            yield $type.' by http url' => [
+                'messageOptions' => $messageOptions,
+                'expectedMedia' => [
+                    'type' => $type,
+                    'media' => $media,
+                    'caption' => 'testMessage',
+                    'parse_mode' => 'MarkdownV2',
+                ],
+            ];
+
+            yield $type.' by file id' => [
+                'messageOptions' => (new TelegramOptions())->edit(123)->{$type}('ABCDEF'),
+                'expectedMedia' => [
+                    'type' => $type,
+                    'media' => 'ABCDEF',
+                    'caption' => 'testMessage',
+                    'parse_mode' => 'MarkdownV2',
+                ],
+            ];
+        }
+    }
+
+    #[DataProvider('editMessageMediaProvider')]
+    public function testSendWithOptionForEditMessageMedia(TelegramOptions $messageOptions, array $expectedMedia)
+    {
+        $response = new JsonMockResponse([
+            'ok' => true,
+            'result' => ['message_id' => 123],
+        ]);
+
+        $expectedBody = [
+            'chat_id' => 'testChannel',
+            'message_id' => 123,
+            'media' => $expectedMedia,
+        ];
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
+            $this->assertStringEndsWith('/editMessageMedia', $url);
+            $this->assertEqualsCanonicalizing($expectedBody, json_decode($options['body'], true));
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $transport->send(new ChatMessage('testMessage', $messageOptions));
+    }
+
+    public function testSendWithOptionForEditMessageMediaEscapesCaptionOnce()
+    {
+        $response = new JsonMockResponse([
+            'ok' => true,
+            'result' => ['message_id' => 123],
+        ]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+            $this->assertStringEndsWith('/editMessageMedia', $url);
+            $body = json_decode($options['body'], true);
+            $this->assertSame('I contain a \\. and a \\!', $body['media']['caption']);
+            $this->assertArrayNotHasKey('caption', $body);
+            $this->assertArrayNotHasKey('photo', $body);
+            $this->assertArrayNotHasKey('parse_mode', $body);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $transport->send(new ChatMessage(
+            'I contain a . and a !',
+            (new TelegramOptions())->edit(123)->photo('https://localhost/photo.png')
+        ));
+    }
+
+    public function testSendWithOptionForEditMessageCaption()
+    {
+        $response = new JsonMockResponse([
+            'ok' => true,
+            'result' => ['message_id' => 123],
+        ]);
+
+        $expectedBody = [
+            'chat_id' => 'testChannel',
+            'message_id' => 123,
+            'caption' => 'testMessage',
+            'parse_mode' => 'MarkdownV2',
+        ];
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
+            $this->assertStringEndsWith('/editMessageCaption', $url);
+            $this->assertEqualsCanonicalizing($expectedBody, json_decode($options['body'], true));
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $transport->send(new ChatMessage(
+            'testMessage',
+            (new TelegramOptions())->editCaption(123)
+        ));
+    }
+
+    public function testSendWithOptionForEditMessageMediaWithSpoiler()
+    {
+        $response = new JsonMockResponse([
+            'ok' => true,
+            'result' => ['message_id' => 123],
+        ]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+            $this->assertStringEndsWith('/editMessageMedia', $url);
+            $body = json_decode($options['body'], true);
+            $this->assertTrue($body['media']['has_spoiler']);
+            $this->assertArrayNotHasKey('has_spoiler', $body);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $transport->send(new ChatMessage(
+            'testMessage',
+            (new TelegramOptions())->edit(123)->photo('https://localhost/photo.png')->hasSpoiler(true)
+        ));
+    }
+
+    public function testSendWithOptionForEditMessageMediaKeepsReplyMarkupTopLevel()
+    {
+        $response = new JsonMockResponse([
+            'ok' => true,
+            'result' => ['message_id' => 123],
+        ]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+            $this->assertStringEndsWith('/editMessageMedia', $url);
+            $body = json_decode($options['body'], true);
+            $this->assertArrayHasKey('reply_markup', $body);
+            $this->assertArrayNotHasKey('reply_markup', $body['media']);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $transport->send(new ChatMessage(
+            'testMessage',
+            (new TelegramOptions())
+                ->edit(123)
+                ->photo('https://localhost/photo.png')
+                ->replyMarkup((new InlineKeyboardMarkup())->inlineKeyboard([
+                    (new InlineKeyboardButton('Click'))->callbackData('click'),
+                ]))
+        ));
+    }
+
+    public function testSendWithOptionForEditMessageCaptionWithHtmlParseModeDoesNotEscape()
+    {
+        $response = new JsonMockResponse([
+            'ok' => true,
+            'result' => ['message_id' => 123],
+        ]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+            $this->assertStringEndsWith('/editMessageCaption', $url);
+            $this->assertEqualsCanonicalizing([
+                'chat_id' => 'testChannel',
+                'message_id' => 123,
+                'caption' => 'I contain a . and a !',
+                'parse_mode' => 'HTML',
+            ], json_decode($options['body'], true));
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+        $transport->send(new ChatMessage(
+            'I contain a . and a !',
+            (new TelegramOptions())->parseMode(TelegramOptions::PARSE_MODE_HTML)->editCaption(123)
+        ));
+    }
+
+    public function testSendWithOptionForEditMessageMediaByLocalUploadThrows()
+    {
+        $client = new MockHttpClient(static function (): ResponseInterface {
+            self::fail('Telegram API should not be called');
+        });
+
+        $transport = $this->createTransport($client, 'testChannel');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Editing a message with a locally uploaded media is not supported yet');
+        $transport->send(new ChatMessage(
+            'testMessage',
+            (new TelegramOptions())->edit(123)->uploadPhoto(self::FIXTURE_FILE)
         ));
     }
 
@@ -1038,7 +1256,10 @@ final class TelegramTransportTest extends TransportTestCase
     public static function exclusiveOptionsDataProvider(): array
     {
         return [
-            'edit' => [(new TelegramOptions())->edit(1)->video('')],
+            'edit and answerCallbackQuery' => [(new TelegramOptions())->edit(1)->answerCallbackQuery('')],
+            'edit and location' => [(new TelegramOptions())->edit(1)->location(48.8566, 2.3522)],
+            'edit and sticker' => [(new TelegramOptions())->edit(1)->sticker('')],
+            'edit and two media' => [(new TelegramOptions())->edit(1)->photo('')->video('')],
             'answerCallbackQuery' => [(new TelegramOptions())->answerCallbackQuery('')->video('')],
             'photo' => [(new TelegramOptions())->photo('')->video('')],
             'location' => [(new TelegramOptions())->location(48.8566, 2.3522)->video('')],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60104
| License       | MIT

`TelegramOptions::edit()` always routed to `editMessageText`, so editing a message that carries media failed with "message text is empty": the text of a media message lives in `caption`, not `text`.

`edit()` combined with a media option now routes to `editMessageMedia`. The transport builds the `InputMedia` object and moves `caption`, `parse_mode` and `has_spoiler` into it:

```php
$chatMessage = new ChatMessage('My updated caption');
$options = (new TelegramOptions())
    ->chatId($chatId)
    ->edit($messageId)
    ->photo('https://example.com/new-photo.png');
```

The five media types `editMessageMedia` accepts are supported: `photo()`, `video()`, `document()`, `audio()` and `animation()`.

A new `editCaption()` method routes to `editMessageCaption` to change the caption of an existing media message without re-sending the media. The subject of the `ChatMessage` becomes the new caption:

```php
$chatMessage = new ChatMessage('My updated caption');
$options = (new TelegramOptions())
    ->chatId($chatId)
    ->editCaption($messageId);
```

`edit()` remains mutually exclusive with every other exclusive option, so `answerCallbackQuery()`, `location()`, `venue()`, `contact()` and `sticker()` still raise `MultipleExclusiveOptionsUsedException` when combined with it, and so do two media types at once. The single new combination is `edit()` plus one media type.

Editing with a locally uploaded media (`attach://`) is not supported: `uploadPhoto()` and friends combined with `edit()` throw a `LogicException` rather than sending a broken request. Left as a follow-up, along with the remaining `InputMedia` fields and `editMessageReplyMarkup`.

Documentation points: the `edit()` plus media combination and the media types it accepts, `editCaption()` and that the message subject becomes the caption, the exclusivity rule above, and the unsupported local upload.
