### PR TITLE
[Serializer] Fix denormalization of already-instantiated nested objects

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -311,6 +311,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
     {
+        if ($data instanceof $type) {
+            return $data;
+        }
+
         $context['_read_attributes'] = false;
 
         if (!isset($context['cache_key'])) {
@@ -567,6 +571,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $expectedTypes[Type::BUILTIN_TYPE_OBJECT === $builtinType && $class ? $class : $builtinType] = true;
 
                 if (Type::BUILTIN_TYPE_OBJECT === $builtinType && null !== $class) {
+                    if ($data instanceof $class) {
+                        return $data;
+                    }
+
                     if (!$this->serializer instanceof DenormalizerInterface) {
                         throw new LogicException(\sprintf('Cannot denormalize attribute "%s" for class "%s" because injected serializer is not a denormalizer.', $attribute, $class));
                     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -48,7 +48,9 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\GroupDummyWithIsPrefixedProperty;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyPrivatePropertyWithoutGetter;
+use Symfony\Component\Serializer\Tests\Fixtures\DummyWithObjectConstructor;
 use Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion;
 use Symfony\Component\Serializer\Tests\Fixtures\FormatAndContextAwareNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\MagicSetDummy;
@@ -1428,6 +1430,20 @@ class ObjectNormalizerTest extends TestCase
         $normalized = $normalizer->normalize($obj);
 
         $this->assertSame(['name' => 'John', 'foo' => 42, 'hello' => 'Hello i am John'], $normalized);
+    }
+
+    public function testDenormalizeWithAlreadyInstantiatedObject()
+    {
+        $nested = new DummyFirstChildQuux('foo');
+        $obj = $this->normalizer->denormalize(
+            ['nested' => $nested],
+            DummyWithObjectConstructor::class,
+            'any'
+        );
+
+        $this->assertInstanceOf(DummyWithObjectConstructor::class, $obj);
+        $this->assertSame($nested, $obj->nested);
+        $this->assertSame('foo', $obj->nested->getValue());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64571
| License       | MIT

When denormalizing nested objects with `#[MapRequestPayload]`, `UploadedFile` instances injected by `mergeParamsAndFiles()` are fed back into the Serializer as already-instantiated objects. The `ObjectNormalizer::denormalize()` method casts them to `(array)` via `prepareForDenormalization()`, which destroys their internal state and causes `MissingConstructorArgumentsException` (e.g., `$path` is missing from `SplFileInfo` internals).

This also affects any scenario where an already-instantiated object appears in the data tree passed to the Serializer — not just `UploadedFile`.

The defect is not specific to 8.1: the `(array)` cast in `prepareForDenormalization()` is unchanged down to 6.4, so this targets 6.4 to merge up.

The fix adds two early returns in `AbstractObjectNormalizer`:

1. In `denormalize()`: if `$data` is already an instance of the target `$type`, return it directly instead of re-denormalizing.
2. In `validateAndDenormalize()`, in the object-delegation branch (`Type::BUILTIN_TYPE_OBJECT === $builtinType && null !== $class`): same guard before delegating to `$this->serializer->supportsDenormalization()`.

## Test verification (RED → GREEN)

Run on 6.4 (PHPUnit 9.6.34, PHP 8.3).

### RED (fix reverted)

```
$ vendor/bin/phpunit --filter testDenormalizeWithAlreadyInstantiatedObject Tests/Normalizer/ObjectNormalizerTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

There was 1 error:

1) Symfony\Component\Serializer\Tests\Normalizer\ObjectNormalizerTest::testDenormalizeWithAlreadyInstantiatedObject
Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: Cannot create an instance of "Symfony\Component\Serializer\Tests\Fixtures\DummyFirstChildQuux" from serialized data because its constructor requires the following parameters to be present : "$value".

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

### GREEN (with fix)

```
$ vendor/bin/phpunit --filter testDenormalizeWithAlreadyInstantiatedObject Tests/Normalizer/ObjectNormalizerTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

OK (1 test, 3 assertions)
```

Full Serializer suite stays green: `Tests: 1136, Assertions: 2209, Skipped: 13` — 0 failures, 0 errors.
