### PR TITLE
[ObjectMapper] Make existing-object mapping behavior consistent

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -101,21 +101,23 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         $objectMap[$source] = $mappedTarget;
         $ctorArguments = [];
         $targetConstructor = $targetRefl->getConstructor();
-        foreach ($targetConstructor?->getParameters() ?? [] as $parameter) {
-            $parameterName = $parameter->getName();
+        if (!$mappingToObject || !$rootCall) {
+            foreach ($targetConstructor?->getParameters() ?? [] as $parameter) {
+                $parameterName = $parameter->getName();
 
-            if ($targetRefl->hasProperty($parameterName)) {
-                $property = $targetRefl->getProperty($parameterName);
+                if ($targetRefl->hasProperty($parameterName)) {
+                    $property = $targetRefl->getProperty($parameterName);
 
-                if ($property->isReadOnly() && $property->isInitialized($mappedTarget)) {
-                    continue;
+                    if ($property->isReadOnly() && $property->isInitialized($mappedTarget)) {
+                        continue;
+                    }
                 }
-            }
 
-            if ($this->isReadable($source, $parameterName)) {
-                $ctorArguments[$parameterName] = $this->getRawValue($source, $parameterName);
-            } else {
-                $ctorArguments[$parameterName] = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
+                if ($this->isReadable($source, $parameterName)) {
+                    $ctorArguments[$parameterName] = $this->getRawValue($source, $parameterName);
+                } else {
+                    $ctorArguments[$parameterName] = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
+                }
             }
         }
 
@@ -193,14 +195,6 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
         }
 
-        if ($mappingToObject && $rootCall && $ctorArguments) {
-            foreach ($ctorArguments as $property => $value) {
-                if ($this->propertyIsMappable($refl, $property) && $this->propertyIsMappable($targetRefl, $property)) {
-                    $mapToProperties[$property] = $value;
-                }
-            }
-        }
-
         foreach ($mapToProperties as $property => $value) {
             if ($this->propertyAccessor) {
                 if ($this->propertyAccessor->isWritable($mappedTarget, $property)) {
@@ -210,7 +204,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 continue;
             }
 
-            if (!$targetRefl->hasProperty($property)) {
+            if (!$this->propertyIsMappable($targetRefl, $property)) {
                 continue;
             }
 

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/ExistingObjectWithPublicProperty.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/ExistingObjectWithPublicProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject;
+
+final class ExistingObjectWithPublicProperty
+{
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/ExistingObjectWithSetter.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/ExistingObjectWithSetter.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject;
+
+final class ExistingObjectWithSetter
+{
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -59,6 +59,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\
 use Symfony\Component\ObjectMapper\Tests\Fixtures\LazyFoo;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUserView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\ExistingObjectWithPublicProperty;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\ExistingObjectWithSetter;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -156,6 +158,14 @@ final class ObjectMapperTest extends TestCase
         $d->concat = 'shouldtestme';
 
         yield [$d, [$a], [new ReflectionObjectMapperMetadataFactory(), PropertyAccess::createPropertyAccessor()]];
+
+        $existingObjectWithSetterExpected = new ExistingObjectWithSetter('bar');
+        $existingObjectWithSetterTarget = new ExistingObjectWithSetter('foo');
+        yield [$existingObjectWithSetterExpected, [(object) ['name' => 'bar'], $existingObjectWithSetterTarget], [new ReflectionObjectMapperMetadataFactory(), PropertyAccess::createPropertyAccessor()]];
+
+        $existingObjectWithPublicPropertyExpected = new ExistingObjectWithPublicProperty('bar');
+        $existingObjectWithPublicPropertyTarget = new ExistingObjectWithPublicProperty('foo');
+        yield [$existingObjectWithPublicPropertyExpected, [(object) ['name' => 'bar'], $existingObjectWithPublicPropertyTarget], [new ReflectionObjectMapperMetadataFactory(), PropertyAccess::createPropertyAccessor()]];
 
         yield [new MultipleTargetsC(foo: 'bar'), [new MultipleTargetsA()]];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

When mapping to an existing object target, constructor handling was interfering with normal property updates.

### Problem

For existing-object mapping, `ObjectMapper` still built constructor argument state (`$ctorArguments`) and mixed that with property mapping logic.  
That constructor-oriented path is useful when creating a new target instance, but for an already-instantiated target it introduced inconsistent behavior.

With a public property, updates happened as expected:

```php
final class Person
{
    public string $name;

    public function __construct(string $name)
    {
        $this->name = $name;
    }
}
```

```php
$mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
$person = new Person('Emily Timmings');

$mapper->map((object) ['name' => 'Emily Bond'], $person);

echo $person->name; // "Emily Bond"
```

But with a private constructor property exposed via setter/getter, the same update could be skipped because the mapping flow was still influenced by constructor-argument handling:

```php
final class Person
{
    private string $name;

    public function __construct(string $name)
    {
        $this->name = $name;
    }

    public function setName(string $name): void
    {
        $this->name = $name;
    }

    public function getName(): string
    {
        return $this->name;
    }
}
```

```php
$mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessor());
$person = new Person('Emily Timmings');

$mapper->map((object) ['name' => 'Emily Bond'], $person);

echo $person->getName(); // "Emily Timmings" (before this fix)
```

### Fix

For **root mapping to an existing object**, constructor handling is now skipped.

In other words:
- no constructor-argument collection for existing root targets
- no constructor-based update path for existing root targets
- updates rely only on normal writable-property mapping (including setters via `PropertyAccessor`)

This makes existing-object mapping behaviour consistent with expectations: if a property is writable (public or setter-backed), it is updated.