### PR TITLE
[Form][Validator] Review Bulgarian (bg) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Моля въведете валиден UUID.</target>
+                <target>Моля въведете валиден UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -556,15 +556,15 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Тази стойност не е валиден XML.</target>
+                <target>Тази стойност не е валиден XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Тази стойност не съответства на очаквания XSD шаблон.</target>
+                <target>Тази стойност не съответства на очакваната XSD схема.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Този XML товар е твърде голям ({{ size }} байта): надвишава ограничението от {{ limit }} байта.</target>
+                <target>Този XML е твърде голям ({{ size }} байта): надвишава ограничението от {{ limit }} байта.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64485
| License       | MIT

Reviewed the Bulgarian translations flagged in #64485 as a native speaker and removed the `needs-review-translation` state:

- Validator `143` — kept the draft wording.
- Validator `144` — fixed "XSD шаблон" → "XSD схема": "шаблон" means *template* (and is already used for "Twig template" in unit `121`); the correct Bulgarian term for an XSD schema is "схема".
- Validator `145` — reworded "Този XML товар" → "Този XML е твърде голям…": "товар" means physical cargo and is not used for data payloads in Bulgarian. Since Bulgarian has no established term for "payload", the noun is dropped, following the same approach as the reviewed Polish translation.
- Form `129` (UUID) — kept the draft wording, which matches the existing "Моля въведете валиден…" style of the file.

Wording, punctuation and indentation follow the existing style of both `bg.xlf` files.
