### PR TITLE
[Serializer] Fix denormalization of pre-instantiated nested objects

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -618,6 +618,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $expectedTypes[TypeIdentifier::OBJECT === $typeIdentifier && $class ? $class : $typeIdentifier->value] = true;
 
                 if (TypeIdentifier::OBJECT === $typeIdentifier && null !== $class) {
+                    if (\is_object($data) && $data instanceof $class) {
+                        return $data;
+                    }
+
                     if (!$this->serializer instanceof DenormalizerInterface) {
                         throw new LogicException(\sprintf('Cannot denormalize attribute "%s" for class "%s" because injected serializer is not a denormalizer.', $attribute, $class));
                     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -138,6 +138,23 @@ class AbstractObjectNormalizerTest extends TestCase
         );
     }
 
+    public function testDenormalizeWithPreInstantiatedObject()
+    {
+        $extractor = new ReflectionExtractor();
+        $normalizer = new ObjectNormalizer(null, null, null, $extractor);
+        $serializer = new Serializer([$normalizer], []);
+        $normalizer->setSerializer($serializer);
+
+        $child = new DummyChild();
+        $child->bar = 'test_value';
+
+        $dummy = $normalizer->denormalize(['child' => $child], DummyWithPreInstantiatedChild::class);
+
+        $this->assertInstanceOf(DummyWithPreInstantiatedChild::class, $dummy);
+        $this->assertSame($child, $dummy->child);
+        $this->assertSame('test_value', $dummy->child->bar);
+    }
+
     public function testDenormalizePlainObject()
     {
         $extractor = new PhpDocExtractor();
@@ -2191,4 +2208,9 @@ class DummyWithIterableOfDtos
             yield from $items;
         })());
     }
+}
+
+class DummyWithPreInstantiatedChild
+{
+    public DummyChild $child;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64571
| License       | MIT

When `#[MapRequestPayload]` denormalizes a nested DTO that contains an `UploadedFile` property, the `RequestPayloadValueResolver` (via PR #62925) injects already-constructed `UploadedFile` instances into the data array. The Serializer's `AbstractObjectNormalizer::validateAndDenormalize()` then tries to re-denormalize these pre-instantiated objects through `$this->serializer->denormalize()`, which results in an `(array)` cast that:

1. Loses `SplFileInfo`'s internal `$path` property (stored in C internals, not as a PHP property)
2. Mangles private property keys with `\0ClassName\0` prefixes

Causing: `Cannot create an instance of "UploadedFile" from serialized data because its constructor requires the following parameters to be present: "$path", "$originalName".`

This fix adds an early return in `validateAndDenormalize()` when `$data` is already an instance of the expected `$class`, bypassing the serializer re-denormalization entirely.

## Test verification (RED → GREEN)

### RED (fix reverted)

```
$ vendor/bin/simple-phpunit --filter testDenormalizeWithPreInstantiatedObject Tests/Normalizer/AbstractObjectNormalizerTest.php

Testing Symfony\Component\Serializer\Tests\Normalizer\AbstractObjectNormalizerTest
F                                                                   1 / 1 (100%)

Time: 00:00.031, Memory: 10.00 MB

There was 1 failure:

1) Symfony\Component\Serializer\Tests\Normalizer\AbstractObjectNormalizerTest::testDenormalizeWithPreInstantiatedObject
Failed asserting that two variables reference the same object.

/tmp/test-serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php:152

FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
```

### GREEN (with fix)

```
$ vendor/bin/simple-phpunit --filter testDenormalizeWithPreInstantiatedObject Tests/Normalizer/AbstractObjectNormalizerTest.php

Testing Symfony\Component\Serializer\Tests\Normalizer\AbstractObjectNormalizerTest
.                                                                   1 / 1 (100%)

Time: 00:00.030, Memory: 10.00 MB

OK (1 test, 3 assertions)
```
