### PR TITLE
[Mailer][Bridge][MicrosoftGraphApi] Set recipients from $envelope instead of the $email headers

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Tests/Transport/MicrosoftGraphApiTransportTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Tests\TokenManagerMock;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphApiTransport;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -123,6 +124,28 @@ class MicrosoftGraphApiTransportTest extends TestCase
             ->text('Hello world');
 
         $transport->send($mail);
+    }
+
+    public function testEnvelopeRecipientsAreUsedInsteadOfToHeader()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $message = json_decode($options['body'], true)['message'];
+
+            $this->assertCount(1, $message['toRecipients']);
+            $this->assertSame('override@symfony.com', $message['toRecipients'][0]['emailAddress']['address']);
+
+            return new MockResponse('', ['http_code' => 202]);
+        });
+
+        $transport = new MicrosoftGraphApiTransport('graph', new TokenManagerMock(), false, $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('bob@symfony.com', 'Bob'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $transport->send($mail, new Envelope(new Address('fabpot@symfony.com'), [new Address('override@symfony.com')]));
     }
 
     public function testHtmlBody()

--- a/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MicrosoftGraph/Transport/MicrosoftGraphApiTransport.php
@@ -78,7 +78,7 @@ class MicrosoftGraphApiTransport extends AbstractApiTransport
             'subject' => $email->getSubject(),
             'body' => $this->getBodyPayload($email),
             'importance' => $this->getImportanceLevel($email),
-            'toRecipients' => array_map($this->getEmailAddress(...), $email->getTo()),
+            'toRecipients' => array_map($this->getEmailAddress(...), $this->getRecipients($email, $envelope)),
         ];
 
         if ($email->getFrom()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64582
| License       | MIT

This PR fixes #64582 by allowing overriding recipients via the mailer config for the MicrosoftGraphApi transport.

Seems critical to me because it can lead to unwanted emails being sent.
