### PR TITLE
[ObjectMapper] Fix fatal errors on unreadable source properties

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -226,11 +226,23 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             return $this->propertyAccessor->isReadable($source, $propertyName);
         }
 
-        if (!property_exists($source, $propertyName) && !isset($source->{$propertyName})) {
-            return false;
+        if (!property_exists($source, $propertyName)) {
+            return isset($source->{$propertyName});
         }
 
-        return true;
+        $refl = new \ReflectionClass($source);
+
+        if (!$refl->hasProperty($propertyName)) {
+            return true;
+        }
+
+        $property = $refl->getProperty($propertyName);
+
+        if (!$property->isPublic()) {
+            return method_exists($source, '__get');
+        }
+
+        return $property->isInitialized($source) || isset($source->{$propertyName});
     }
 
     private function getRawValue(object $source, string $propertyName): mixed

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUser.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUser.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: MagicGetUserView::class)]
+final class MagicGetUser
+{
+    public int $id = 1;
+    private string $name = 'magic-value';
+
+    public function __get(string $name): mixed
+    {
+        return $this->$name;
+    }
+
+    public function __isset(string $name): bool
+    {
+        return isset($this->$name);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUserView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MagicGet/MagicGetUserView.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet;
+
+final class MagicGetUserView
+{
+    public int $id;
+    public string $name;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/Post.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/Post.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: PostView::class)]
+final class Post
+{
+    public string $title = 'hello';
+    public ?string $summary;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/PostView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Uninitialized/PostView.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized;
+
+final class PostView
+{
+    public function __construct(
+        public string $title = '',
+        public ?string $summary = 'none',
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Unreadable/Order.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Unreadable/Order.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Unreadable;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: OrderView::class)]
+final class Order
+{
+    public string $ref = 'o1';
+    private array $auditTrail = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Unreadable/OrderView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/Unreadable/OrderView.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\Unreadable;
+
+final class OrderView
+{
+    public string $ref;
+    public ?array $auditTrail = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -57,6 +57,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallback\B as Instance
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\A as InstanceCallbackWithArgumentsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InstanceCallbackWithArguments\B as InstanceCallbackWithArgumentsB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\LazyFoo;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUser;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUserView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -99,7 +101,12 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized\Post;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized\PostView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Unreadable\Order;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Unreadable\OrderView;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 final class ObjectMapperTest extends TestCase
 {
@@ -686,6 +693,48 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(ReadOnlyPromotedPropertyBMapped::class, $out->b);
         $this->assertSame('foo', $out->var1);
         $this->assertSame('bar', $out->b->var2);
+    }
+
+    #[DataProvider('provideAccessor')]
+    public function testNonPublicSourcePropertyWithoutMagicGetIsIgnored(?PropertyAccessorInterface $accessor)
+    {
+        $mapper = new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), $accessor);
+
+        $view = $mapper->map(new Order());
+
+        $this->assertInstanceOf(OrderView::class, $view);
+        $this->assertSame('o1', $view->ref);
+        $this->assertNull($view->auditTrail);
+    }
+
+    #[DataProvider('provideAccessor')]
+    public function testNonPublicSourcePropertyExposedByMagicGetIsMapped(?PropertyAccessorInterface $accessor)
+    {
+        $mapper = new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), $accessor);
+
+        $view = $mapper->map(new MagicGetUser());
+
+        $this->assertInstanceOf(MagicGetUserView::class, $view);
+        $this->assertSame(1, $view->id);
+        $this->assertSame('magic-value', $view->name);
+    }
+
+    #[DataProvider('provideAccessor')]
+    public function testUninitializedSourcePropertyFallsBackToConstructorDefault(?PropertyAccessorInterface $accessor)
+    {
+        $mapper = new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), $accessor);
+
+        $view = $mapper->map(new Post());
+
+        $this->assertInstanceOf(PostView::class, $view);
+        $this->assertSame('hello', $view->title);
+        $this->assertSame('none', $view->summary);
+    }
+
+    public static function provideAccessor(): iterable
+    {
+        yield 'with property accessor' => [PropertyAccess::createPropertyAccessor()];
+        yield 'without property accessor' => [null];
     }
 
     public function testMissingSourcePropertiesAreIgnored()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Spotted while reviewing #64466: the readability check used when no PropertyAccessor is injected reports any declared property as readable, which lets two fatal errors through on 7.4:

- a non-public source property with a same-named property on the target throws `Cannot access private property`;
- an uninitialized public source property matched by a constructor parameter of the target throws `must not be accessed before initialization`.

This makes the check mirror PropertyAccessor semantics instead:

- non-public properties are readable only through magic `__get()`;
- uninitialized properties are skipped, unless `unset()` re-enabled magic methods on them (lazy-ghost style objects);
- dynamic properties remain readable: `property_exists()` matches them while `ReflectionClass` doesn't see them.

Once merged up, #64466 only needs to guard the branch added in 8.1 for reverse class maps.
