### PR TITLE
 Migrate table definitions to DBAL's `TableEditor` API

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception as DBALDriverException;
 use Doctrine\DBAL\Exception\DatabaseObjectExistsException;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
@@ -122,14 +123,25 @@ abstract class AbstractSchemaListener
         return static function (\Closure $exec) use ($connection): bool {
             $schemaManager = method_exists($connection, 'createSchemaManager') ? $connection->createSchemaManager() : $connection->getSchemaManager();
             $key = bin2hex(random_bytes(7));
-            $table = new Table('schema_subscriber_check_');
-            $table->addColumn('id', Types::INTEGER, ['autoincrement' => true, 'notnull' => true]);
-            $table->addColumn('random_key', Types::STRING, ['length' => 14, 'notnull' => true]);
 
-            if (class_exists(PrimaryKeyConstraint::class)) {
-                $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true));
+            if (method_exists(Table::class, 'editor')) {
+                $table = Table::editor()
+                    ->setUnquotedName('schema_subscriber_check_')
+                    ->addColumn(Column::editor()->setUnquotedName('id')->setTypeName(Types::INTEGER)->setAutoincrement(true)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName('random_key')->setTypeName(Types::STRING)->setLength(14)->setNotNull(true)->create())
+                    ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true))
+                    ->create();
             } else {
-                $table->setPrimaryKey(['id']);
+                // To be removed when doctrine/dbal minimum is bumped to ^4.4
+                $table = new Table('schema_subscriber_check_');
+                $table->addColumn('id', Types::INTEGER, ['autoincrement' => true, 'notnull' => true]);
+                $table->addColumn('random_key', Types::STRING, ['length' => 14, 'notnull' => true]);
+
+                if (class_exists(PrimaryKeyConstraint::class)) {
+                    $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true));
+                } else {
+                    $table->setPrimaryKey(['id']);
+                }
             }
 
             try {

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Security\RememberMe;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
@@ -208,10 +209,7 @@ final class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifi
     private function addTableToSchema(Schema $schema): Schema
     {
         if (method_exists($schema, 'edit')) {
-            $table = new Table('rememberme_token');
-            $this->configureSchemaTable($table);
-
-            return $schema->edit()->addTable($table)->create();
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
         }
 
         $this->configureSchemaTable($schema->createTable('rememberme_token'));
@@ -219,6 +217,22 @@ final class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifi
         return $schema;
     }
 
+    private function buildSchemaTable(): Table
+    {
+        return Table::editor()
+            ->setUnquotedName('rememberme_token')
+            ->addColumn(Column::editor()->setUnquotedName('series')->setTypeName(Types::STRING)->setLength(88)->create())
+            ->addColumn(Column::editor()->setUnquotedName('value')->setTypeName(Types::STRING)->setLength(88)->create())
+            ->addColumn(Column::editor()->setUnquotedName('lastUsed')->setTypeName(Types::DATETIME_IMMUTABLE)->create())
+            ->addColumn(Column::editor()->setUnquotedName('class')->setTypeName(Types::STRING)->setLength(100)->setDefaultValue('')->create())
+            ->addColumn(Column::editor()->setUnquotedName('username')->setTypeName(Types::STRING)->setLength(200)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('series'))], true))
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
     private function configureSchemaTable(Table $table): void
     {
         $table->addColumn('series', Types::STRING, ['length' => 88]);

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
@@ -62,8 +63,10 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
         $dbalAdapter->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
                 if (method_exists($schema, 'edit')) {
-                    $table = new Table('cache_items');
-                    $table->addColumn('item_id', 'string');
+                    $table = Table::editor()
+                        ->setUnquotedName('cache_items')
+                        ->addColumn(Column::editor()->setUnquotedName('item_id')->setTypeName('string')->create())
+                        ->create();
 
                     return $schema->edit()->addTable($table)->create();
                 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
@@ -61,8 +62,10 @@ class LockStoreSchemaListenerTest extends TestCase
         $lockStore->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
                 if (method_exists($schema, 'edit')) {
-                    $table = new Table('lock_keys');
-                    $table->addColumn('key_id', 'string');
+                    $table = Table::editor()
+                        ->setUnquotedName('lock_keys')
+                        ->addColumn(Column::editor()->setUnquotedName('key_id')->setTypeName('string')->create())
+                        ->create();
 
                     return $schema->edit()->addTable($table)->create();
                 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
@@ -195,10 +196,7 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
     private static function addMessengerMessages(Schema $schema): Schema
     {
         if (method_exists($schema, 'edit')) {
-            $table = new Table('messenger_messages');
-            $table->addColumn('id', 'integer', ['autoincrement' => true]);
-
-            return $schema->edit()->addTable($table)->create();
+            return $schema->edit()->addTable(self::buildMessengerMessagesTable())->create();
         }
 
         $schema->createTable('messenger_messages')->addColumn('id', 'integer', ['autoincrement' => true]);
@@ -209,15 +207,20 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
     private static function addMessengerMessagesWithSequence(Schema $schema): Schema
     {
         if (method_exists($schema, 'edit')) {
-            $table = new Table('messenger_messages');
-            $table->addColumn('id', 'integer', ['autoincrement' => true]);
-
-            return $schema->edit()->addTable($table)->addSequence(new Sequence('messenger_messages_seq'))->create();
+            return $schema->edit()->addTable(self::buildMessengerMessagesTable())->addSequence(new Sequence('messenger_messages_seq'))->create();
         }
 
         $schema->createTable('messenger_messages')->addColumn('id', 'integer', ['autoincrement' => true]);
         $schema->createSequence('messenger_messages_seq');
 
         return $schema;
+    }
+
+    private static function buildMessengerMessagesTable(): Table
+    {
+        return Table::editor()
+            ->setUnquotedName('messenger_messages')
+            ->addColumn(Column::editor()->setUnquotedName('id')->setTypeName('integer')->setAutoincrement(true)->create())
+            ->create();
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
@@ -63,8 +64,10 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
         $pdoSessionHandler->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
                 if (method_exists($schema, 'edit')) {
-                    $table = new Table('sessions');
-                    $table->addColumn('sess_id', 'string');
+                    $table = Table::editor()
+                        ->setUnquotedName('sessions')
+                        ->addColumn(Column::editor()->setUnquotedName('sess_id')->setTypeName('string')->create())
+                        ->create();
 
                     return $schema->edit()->addTable($table)->create();
                 }

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -409,10 +410,7 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
     private function addTableToSchema(Schema $schema): Schema
     {
         if (method_exists($schema, 'edit')) {
-            $table = new Table($this->table);
-            $this->configureSchemaTable($table);
-
-            return $schema->edit()->addTable($table)->create();
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
         }
 
         $this->configureSchemaTable($schema->createTable($this->table));
@@ -420,6 +418,26 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
         return $schema;
     }
 
+    private function buildSchemaTable(): Table
+    {
+        $types = [
+            'mysql' => 'binary',
+            'sqlite' => 'text',
+        ];
+
+        return Table::editor()
+            ->setUnquotedName($this->table)
+            ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName($types[$this->getPlatformName()] ?? 'string')->setLength(255)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName('blob')->setLength(16777215)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName('integer')->setUnsigned(true)->setNotNull(false)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName('integer')->setUnsigned(true)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true))
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
     private function configureSchemaTable(Table $table): void
     {
         $types = [

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
@@ -194,10 +196,7 @@ class PdoSessionHandler extends AbstractSessionHandler
         }
 
         if (method_exists($schema, 'edit')) {
-            $table = new Table($this->table);
-            $this->configureSchemaTable($table);
-
-            return $schema->edit()->addTable($table)->create();
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
         }
 
         $this->configureSchemaTable($schema->createTable($this->table));
@@ -205,6 +204,60 @@ class PdoSessionHandler extends AbstractSessionHandler
         return $schema;
     }
 
+    private function buildSchemaTable(): Table
+    {
+        $editor = Table::editor()->setUnquotedName($this->table);
+
+        switch ($this->driver) {
+            case 'mysql':
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::BINARY)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create())
+                    ->setOptions(['engine' => 'InnoDB']);
+                break;
+            case 'sqlite':
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::TEXT)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create());
+                break;
+            case 'pgsql':
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::STRING)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BINARY)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create());
+                break;
+            case 'oci':
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::STRING)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create());
+                break;
+            case 'sqlsrv':
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::STRING)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create());
+                break;
+            default:
+                throw new \DomainException(\sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));
+        }
+
+        return $editor
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true))
+            ->addIndex(Index::editor()->setUnquotedName($this->lifetimeCol.'_idx')->setUnquotedColumnNames($this->lifetimeCol)->create())
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
     private function configureSchemaTable(Table $table): void
     {
         switch ($this->driver) {

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -269,10 +270,7 @@ class DoctrineDbalStore implements PersistingStoreInterface
         }
 
         if (method_exists($schema, 'edit')) {
-            $table = new Table($this->table);
-            $this->configureSchemaTable($table);
-
-            return $schema->edit()->addTable($table)->create();
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
         }
 
         $this->configureSchemaTable($schema->createTable($this->table));
@@ -280,6 +278,20 @@ class DoctrineDbalStore implements PersistingStoreInterface
         return $schema;
     }
 
+    private function buildSchemaTable(): Table
+    {
+        return Table::editor()
+            ->setUnquotedName($this->table)
+            ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName('string')->setLength(64)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->tokenCol)->setTypeName('string')->setLength(44)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->expirationCol)->setTypeName('integer')->setUnsigned(true)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true))
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
     private function configureSchemaTable(Table $table): void
     {
         $table->addColumn($this->idCol, 'string', ['length' => 64]);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -21,7 +21,9 @@ use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
@@ -519,10 +521,7 @@ class Connection implements ResetInterface
         }
 
         if (method_exists($schema, 'edit')) {
-            $table = new Table($this->configuration['table_name']);
-            $this->configureSchemaTable($table, $idOptions);
-
-            $editor = $schema->edit()->addTable($table);
+            $editor = $schema->edit()->addTable($this->buildSchemaTable($oracleSequenceName));
             if (null !== $oracleSequenceName) {
                 $editor->addSequence(new Sequence($oracleSequenceName));
             }
@@ -539,7 +538,37 @@ class Connection implements ResetInterface
         return $schema;
     }
 
+    private function buildSchemaTable(?string $oracleSequenceName): Table
+    {
+        $idEditor = Column::editor()->setUnquotedName('id')->setTypeName(Types::BIGINT)->setNotNull(true);
+
+        if (null !== $oracleSequenceName) {
+            // disable the creation of SEQUENCE and TRIGGER, use the sequence's nextval as default instead
+            $idEditor->setAutoincrement(false)->setDefaultValue($oracleSequenceName.'.nextval');
+        } else {
+            $idEditor->setAutoincrement(true);
+        }
+
+        return Table::editor()
+            ->setUnquotedName($this->configuration['table_name'])
+            // add an internal option to mark that we created this & the non-namespaced table name
+            ->setOptions([self::TABLE_OPTION_NAME => $this->configuration['table_name']])
+            ->addColumn($idEditor->create())
+            ->addColumn(Column::editor()->setUnquotedName('body')->setTypeName(Types::TEXT)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('headers')->setTypeName(Types::TEXT)->setNotNull(true)->create())
+            // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
+            ->addColumn(Column::editor()->setUnquotedName('queue_name')->setTypeName(Types::STRING)->setLength(190)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('created_at')->setTypeName(Types::DATETIME_IMMUTABLE)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('available_at')->setTypeName(Types::DATETIME_IMMUTABLE)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('delivered_at')->setTypeName(Types::DATETIME_IMMUTABLE)->setNotNull(false)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true))
+            ->addIndex(Index::editor()->setUnquotedColumnNames('queue_name', 'available_at', 'delivered_at', 'id'))
+            ->create();
+    }
+
     /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     *
      * @param array<string, mixed> $idOptions
      */
     private function configureSchemaTable(Table $table, array $idOptions): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #64389.

DBAL 4.5 deprecates the `Table` mutators (`addColumn()`, `addIndex()`, `addPrimaryKeyConstraint()`, `addOption()`, see doctrine/dbal#7389), which currently makes CI fail on branch 7.4.

This PR builds tables using `Table::editor()`, `Column::editor()` and `Index::editor()` in the code paths that run on DBAL 4.5+ (4.4+ for `AbstractSchemaListener`, which doesn't need `Schema::edit()`), and keeps the previous code as a fallback for older versions of DBAL.

The generated tables are identical to the previous ones: columns, primary keys, options and index names are preserved, including the auto-generated name of the index of the Messenger transport's table.