### PR TITLE
[FrameworkBundle] Add `--dispatchers` option to `debug:event-dispatcher` command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `--dispatchers` option to `debug:event-dispatcher` command
+
 8.1
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -49,6 +49,7 @@ class EventDispatcherDebugCommand extends Command
             ->setDefinition([
                 new InputArgument('event', InputArgument::OPTIONAL, 'An event name or a part of the event name'),
                 new InputOption('dispatcher', null, InputOption::VALUE_REQUIRED, 'To view events of a specific event dispatcher', self::DEFAULT_DISPATCHER),
+                new InputOption('dispatchers', null, InputOption::VALUE_NONE, 'To list all available event dispatchers'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, \sprintf('The output format ("%s")', implode('", "', $this->getAvailableFormatOptions())), 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw description'),
             ])
@@ -60,6 +61,10 @@ class EventDispatcherDebugCommand extends Command
                 To get specific listeners for an event, specify its name:
 
                   <info>php %command.full_name% kernel.request</info>
+
+                To list all available event dispatchers:
+
+                  <info>php %command.full_name% --dispatchers</info>
 
                 The <info>--format</info> option specifies the format of the command output:
 
@@ -76,6 +81,14 @@ class EventDispatcherDebugCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        if ($input->getOption('dispatchers')) {
+            if ($this->dispatchers instanceof ServiceProviderInterface) {
+                $io->table(['Event Dispatcher'], array_map(static fn ($name) => [$name], array_keys($this->dispatchers->getProvidedServices())));
+            }
+
+            return 0;
+        }
 
         $options = [];
         $dispatcherServiceName = $input->getOption('dispatcher');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/EventDispatcherDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/EventDispatcherDebugCommandTest.php
@@ -15,12 +15,29 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Command\EventDispatcherDebugCommand;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Mailer\Event\MessageEvent;
 
 class EventDispatcherDebugCommandTest extends TestCase
 {
+    public function testDispatchersOption()
+    {
+        $dispatchers = new ServiceLocator([
+            'event_dispatcher' => static fn () => new EventDispatcher(),
+            'other_event_dispatcher' => static fn () => new EventDispatcher(),
+        ]);
+        $command = new EventDispatcherDebugCommand($dispatchers);
+        $tester = new CommandTester($command);
+        $tester->execute(['--dispatchers' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('event_dispatcher', $output);
+        $this->assertStringContainsString('other_event_dispatcher', $output);
+    }
+
     #[DataProvider('provideCompletionSuggestions')]
     public function testComplete(array $input, array $expectedSuggestions)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

This is especially useful when debbuging security:

```
I have no name! /app/server/backend bin/console  debug:event --dispatchers
 ------------------------------------------- 
  Event Dispatcher                           
 ------------------------------------------- 
  event_dispatcher                           
  security.event_dispatcher.api_jwt          
  security.event_dispatcher.api              
  security.event_dispatcher.api_agent_proxy  
  security.event_dispatcher.api_agent        
  security.event_dispatcher.api_stripe       
  security.event_dispatcher.api_public       
  security.event_dispatcher.deployment       
  security.event_dispatcher.admin            
  security.event_dispatcher.mcp              
 ------------------------------------------- 

```
