### PR TITLE
[Translation] Make `LocoProvider::read()` fetch every locale when passed none

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/Bridge/Loco/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Calling `LocoProvider::read()` without locale now fetch them all
+
 7.2
 ---
 

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -94,6 +94,7 @@ final class LocoProvider implements ProviderInterface
     public function read(array $domains, array $locales): TranslatorBag
     {
         $domains = $domains ?: ['*'];
+        $locales = $locales ?: $this->getLocales();
         $translatorBag = new TranslatorBag();
         $responses = new \SplObjectStorage();
 
@@ -416,17 +417,12 @@ final class LocoProvider implements ProviderInterface
     private function getLocales(): array
     {
         $response = $this->client->request('GET', 'locales');
-        $content = $response->toArray(false);
 
         if (200 !== $response->getStatusCode()) {
-            throw new ProviderException(\sprintf('Unable to get locales on Loco: "%s".', $response->getContent(false)), $response);
+            throw new ProviderException('Unable to get locales on Loco.', $response);
         }
 
-        return array_reduce($content, static function ($carry, $locale) {
-            $carry[] = $locale['code'];
-
-            return $carry;
-        }, []);
+        return array_column($response->toArray(), 'code');
     }
 
     private function retrieveKeyFromId(string $id, string $domain): string

--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Translation\Bridge\Loco\LocoProvider;
 use Symfony\Component\Translation\Exception\ProviderException;
@@ -748,6 +749,75 @@ class LocoProviderTest extends ProviderTestCase
         }
 
         $this->assertEquals($expectedTranslatorBag->getCatalogues(), $translatorBag->getCatalogues());
+    }
+
+    public function testReadForNoLocales()
+    {
+        $responses = [
+            'getLocales' => function (string $method, string $url): MockResponse {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://localise.biz/api/locales', $url);
+
+                return new JsonMockResponse([['code' => 'en'], ['code' => 'fr']]);
+            },
+            'getEnMessages' => function (string $method, string $url): MockResponse {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://localise.biz/api/export/locale/en.xlf?filter=messages&status=translated%2Cblank-translation', $url);
+
+                return new MockResponse(<<<'XLIFF'
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+                      <file original="https://localise.biz/user/symfony-translation-provider" source-language="en" datatype="database" tool-id="loco">
+                        <header>
+                          <tool tool-id="loco" tool-name="Loco" tool-version="1.0.25 20201211-1" tool-company="Loco"/>
+                        </header>
+                        <body>
+                          <trans-unit id="loco:5fd89b853ee27904dd6c5f67" resname="index.hello" datatype="plaintext">
+                            <source>index.hello</source>
+                            <target state="translated">Hello</target>
+                          </trans-unit>
+                        </body>
+                      </file>
+                    </xliff>
+                    XLIFF);
+            },
+            'getFrMessages' => function (string $method, string $url): MockResponse {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://localise.biz/api/export/locale/fr.xlf?filter=messages&status=translated%2Cblank-translation', $url);
+
+                return new MockResponse(<<<'XLIFF'
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+                      <file original="https://localise.biz/user/symfony-translation-provider" source-language="en" datatype="database" tool-id="loco">
+                        <header>
+                          <tool tool-id="loco" tool-name="Loco" tool-version="1.0.25 20201211-1" tool-company="Loco"/>
+                        </header>
+                        <body>
+                          <trans-unit id="loco:5fd89b853ee27904dd6c5f67" resname="index.hello" datatype="plaintext">
+                            <source>index.hello</source>
+                            <target state="translated">Bonjour</target>
+                          </trans-unit>
+                        </body>
+                      </file>
+                    </xliff>
+                    XLIFF);
+            },
+        ];
+
+        $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://localise.biz/api/',
+            'headers' => [
+                'Authorization' => 'Loco API_KEY',
+            ],
+        ]), new XliffFileLoader(), $this->getLogger(), 'en', 'localise.biz/api/');
+
+        $this->assertEquals(
+            ['en', 'fr'],
+            array_map(
+                static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(),
+                $provider->read(['messages'], [])->getCatalogues()
+            ),
+        );
     }
 
     #[DataProvider('getResponsesForReadWithLastModified')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

As mentioned in https://github.com/symfony/symfony/issues/64155#issuecomment-4678350152 providers don’t behave the same way when their `read` method is called with no locale. I think only the `LokaliseProvider` behaves correctly since it will fetch every locale, while other providers will return an empty bag.

This PR aligns the `LocoProvider`’s behavior with the `LokaliseProvider`’s.

(An alternative would be to force `framework.enabled_locales` to be configured when using providers; that way `$locales` would never be empty.)