### PR TITLE
[Cache][VarExporter] Add argument $allowNamedClosure to DeepClone to fit ext-deepclone v0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/contracts": "^3.7",
         "symfony/polyfill-ctype": "^1.8",
-        "symfony/polyfill-deepclone": "^1.37",
+        "symfony/polyfill-deepclone": "^1.40",
         "symfony/polyfill-intl-grapheme": "^1.33",
         "symfony/polyfill-intl-icu": "^1.0",
         "symfony/polyfill-intl-idn": "^1.10",

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -55,7 +55,7 @@ abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
             if (null === $value) {
                 unset($values[$key]);
             } elseif ($value instanceof DeepCloner) {
-                $values[$key] = $value->clone();
+                $values[$key] = $value->clone(null, true);
             } elseif (\is_string($value) && str_contains($value, ':')) {
                 $values[$key] = unserialize($value, ['allowed_classes' => true]);
             }

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -184,7 +184,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
         }
         if ($this->deepClone) {
             try {
-                $cloner = new DeepCloner($value);
+                $cloner = new DeepCloner($value, null, true);
             } catch (\Exception $e) {
                 if (!isset($this->expiries[$key])) {
                     unset($this->values[$key]);
@@ -311,7 +311,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
                 continue;
             }
             try {
-                $values[$k] = serialize($v instanceof DeepCloner ? $v->clone() : $v);
+                $values[$k] = serialize($v instanceof DeepCloner ? $v->clone(null, true) : $v);
             } catch (\Exception) {
                 // skip values that cannot be serialized, e.g. when they hold a Closure
                 unset($values[$k]);
@@ -369,7 +369,7 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, NamespacedPoolIn
 
         if ($value instanceof DeepCloner) {
             try {
-                return $value->clone();
+                return $value->clone(null, true);
             } catch (\Exception $e) {
                 CacheItem::log($this->logger, 'Failed to clone key "{key}": '.$e->getMessage(), ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]);
                 $isHit = false;

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -78,7 +78,7 @@ class ArrayAdapterTest extends AdapterTestCase
 
         $raw = $cache->getValues(true);
         $this->assertInstanceOf(DeepCloner::class, $raw['foo']);
-        $this->assertInstanceOf(\Closure::class, $raw['foo']->clone()[0]);
+        $this->assertInstanceOf(\Closure::class, $raw['foo']->clone(null, true)[0]);
     }
 
     public function testGetValuesDistinguishesRecordedNullFromMiss()

--- a/src/Symfony/Component/VarExporter/DeepCloner.php
+++ b/src/Symfony/Component/VarExporter/DeepCloner.php
@@ -56,17 +56,17 @@ final class DeepCloner
     private array $payload;
 
     /**
-     * @param T                 $value
-     * @param list<string>|null $allowedClasses Classes that may be serialized.
-     *                                          null (default) allows all classes. An empty array allows none.
+     * @param T                       $value
+     * @param list<class-string>|null $allowedClasses    Classes that may be instantiated; null (default) allows all; an empty array allows none
+     * @param bool                    $allowNamedClosure Whether to allow cloning of named closures, enable only if you trust the payload
      *
      * @throws NotInstantiableTypeException When $value (or a nested value) cannot be serialized
      * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
-    public function __construct(mixed $value, ?array $allowedClasses = null)
+    public function __construct(mixed $value, ?array $allowedClasses = null, bool $allowNamedClosure = false)
     {
         try {
-            $this->payload = deepclone_to_array($value, $allowedClasses);
+            $this->payload = deepclone_to_array($value, $allowedClasses, $allowNamedClosure);
         } catch (\DeepClone\NotInstantiableException $e) {
             throw new NotInstantiableTypeException($e);
         }
@@ -81,8 +81,9 @@ final class DeepCloner
      *
      * @template U
      *
-     * @param U                 $value
-     * @param list<string>|null $allowedClasses classes that may be serialized/deserialized
+     * @param U                       $value
+     * @param list<class-string>|null $allowedClasses    Classes that may be instantiated; null (default) allows all; an empty array allows none
+     * @param bool                    $allowNamedClosure Whether to allow cloning of named closures, enable only if you trust the payload
      *
      * @return U
      *
@@ -90,9 +91,9 @@ final class DeepCloner
      * @throws NotInstantiableTypeException When $value (or a nested value) cannot be serialized/instantiated
      * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
-    public static function deepClone(mixed $value, ?array $allowedClasses = null): mixed
+    public static function deepClone(mixed $value, ?array $allowedClasses = null, bool $allowNamedClosure = false): mixed
     {
-        return (new self($value, $allowedClasses))->clone($allowedClasses);
+        return (new self($value, $allowedClasses, $allowNamedClosure))->clone($allowedClasses, $allowNamedClosure);
     }
 
     /**
@@ -112,8 +113,8 @@ final class DeepCloner
      * lets any loaded class be instantiated and runs __wakeup() / __unserialize() on it,
      * reproducing the unserialize-gadget surface. Pass an explicit list (or [] for none).
      *
-     * @param list<string>|null $allowedClasses Classes that may be instantiated.
-     *                                          null (default) allows all classes. An empty array allows none.
+     * @param list<class-string>|null $allowedClasses    Classes that may be instantiated; null (default) allows all; an empty array allows none
+     * @param bool                    $allowNamedClosure Whether to allow cloning of named closures, enable only if you trust the payload
      *
      * @return T
      *
@@ -121,14 +122,14 @@ final class DeepCloner
      * @throws NotInstantiableTypeException When a class in the graph cannot be instantiated
      * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
-    public function clone(?array $allowedClasses = null): mixed
+    public function clone(?array $allowedClasses = null, bool $allowNamedClosure = false): mixed
     {
         if (\array_key_exists('value', $this->payload)) {
             return $this->payload['value'];
         }
 
         try {
-            return deepclone_from_array($this->payload, $allowedClasses);
+            return deepclone_from_array($this->payload, $allowedClasses, $allowNamedClosure);
         } catch (\DeepClone\ClassNotFoundException $e) {
             throw new ClassNotFoundException($e);
         } catch (\DeepClone\NotInstantiableException $e) {
@@ -149,9 +150,9 @@ final class DeepCloner
      *
      * @template U of object
      *
-     * @param class-string<U>   $class
-     * @param list<string>|null $allowedClasses Classes that may be instantiated.
-     *                                          null (default) allows all classes. An empty array allows none.
+     * @param class-string<U>         $class
+     * @param list<class-string>|null $allowedClasses    Classes that may be instantiated; null (default) allows all; an empty array allows none
+     * @param bool                    $allowNamedClosure Whether to allow cloning of named closures, enable only if you trust the payload
      *
      * @return U
      *
@@ -160,7 +161,7 @@ final class DeepCloner
      * @throws NotInstantiableTypeException When $class or another class in the graph cannot be instantiated
      * @throws \ValueError                  When a class in the graph is not in $allowedClasses
      */
-    public function cloneAs(string $class, ?array $allowedClasses = null): object
+    public function cloneAs(string $class, ?array $allowedClasses = null, bool $allowNamedClosure = false): object
     {
         if (\array_key_exists('value', $this->payload) || !\is_int($this->payload['prepared'] ?? null) || $this->payload['prepared'] < 0) {
             throw new LogicException('DeepCloner::cloneAs() requires the value to be an object.');
@@ -192,7 +193,7 @@ final class DeepCloner
         $payload['objectMeta'] = $meta;
 
         try {
-            return deepclone_from_array($payload, $allowedClasses);
+            return deepclone_from_array($payload, $allowedClasses, $allowNamedClosure);
         } catch (\DeepClone\ClassNotFoundException $e) {
             throw new ClassNotFoundException($e);
         } catch (\DeepClone\NotInstantiableException $e) {

--- a/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/DeepCloneTest.php
@@ -430,9 +430,16 @@ class DeepCloneTest extends TestCase
     public function testNamedClosure()
     {
         $fn = strlen(...);
-        $clone = DeepCloner::deepClone($fn);
+        $clone = DeepCloner::deepClone($fn, null, true);
 
         $this->assertSame(5, $clone('hello'));
+    }
+
+    public function testNamedClosureIsRefusedByDefault()
+    {
+        $this->expectException(\ValueError::class);
+
+        DeepCloner::deepClone(strlen(...));
     }
 
     public function testRepeatedClones()
@@ -646,12 +653,12 @@ class DeepCloneTest extends TestCase
 
         // Named closure (global function)
         $fn = strlen(...);
-        self::assertPureArray((new DeepCloner($fn))->__serialize());
+        self::assertPureArray((new DeepCloner($fn, null, true))->__serialize());
 
         // Object with closure property
         $obj = new \stdClass();
         $obj->fn = strlen(...);
-        self::assertPureArray((new DeepCloner($obj))->__serialize());
+        self::assertPureArray((new DeepCloner($obj, null, true))->__serialize());
 
         // Hard references
         $value = [(object) []];
@@ -670,9 +677,9 @@ class DeepCloneTest extends TestCase
     public function testSerializeRoundtripWithNamedClosure()
     {
         $fn = strlen(...);
-        $cloner = new DeepCloner($fn);
+        $cloner = new DeepCloner($fn, null, true);
         $restored = unserialize(serialize($cloner));
-        $clone = $restored->clone();
+        $clone = $restored->clone(null, true);
 
         $this->assertSame(5, $clone('hello'));
     }
@@ -683,9 +690,9 @@ class DeepCloneTest extends TestCase
         $obj->fn = strlen(...);
         $obj->name = 'test';
 
-        $cloner = new DeepCloner($obj);
+        $cloner = new DeepCloner($obj, null, true);
         $restored = unserialize(serialize($cloner));
-        $clone = $restored->clone();
+        $clone = $restored->clone(null, true);
 
         $this->assertSame('test', $clone->name);
         $this->assertSame(5, ($clone->fn)('hello'));
@@ -906,12 +913,12 @@ class DeepCloneTest extends TestCase
 
     public function testToArrayFromArrayWithNamedClosure()
     {
-        $cloner = new DeepCloner(strlen(...));
+        $cloner = new DeepCloner(strlen(...), null, true);
         $data = $cloner->toArray();
         self::assertPureArray($data);
 
         $restored = DeepCloner::fromArray($data);
-        $this->assertSame(5, $restored->clone()('hello'));
+        $this->assertSame(5, $restored->clone(null, true)('hello'));
     }
 
     public function testToArrayFromArrayWithCircularRef()

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/__serialize-but-no-__unserialize.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/__serialize-but-no-__unserialize.php
@@ -15,4 +15,4 @@ return \deepclone_from_array([
             'bar' => ['ddd'],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/__unserialize-but-no-__serialize.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/__unserialize-but-no-__serialize.php
@@ -12,4 +12,4 @@ return \deepclone_from_array([
             ['foo' => 'ccc'],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/abstract-parent.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/abstract-parent.php
@@ -10,4 +10,4 @@ return \deepclone_from_array([
             'bar' => [234],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/array-iterator.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/array-iterator.php
@@ -17,4 +17,4 @@ return \deepclone_from_array([
             ],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/array-object-custom.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/array-object-custom.php
@@ -17,4 +17,4 @@ return \deepclone_from_array([
             ],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/array-object.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/array-object.php
@@ -31,4 +31,4 @@ return \deepclone_from_array([
             ],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/backed-property.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/backed-property.php
@@ -9,4 +9,4 @@ return \deepclone_from_array([
             'name' => ['name'],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/clone.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/clone.php
@@ -5,4 +5,4 @@ return \deepclone_from_array([
     'objectMeta' => [0, 1],
     'prepared' => [0, 1],
     'mask' => [true, true],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/datetime.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/datetime.php
@@ -44,4 +44,4 @@ return \deepclone_from_array([
             ['start' => true, 'interval' => true],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/error.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/error.php
@@ -16,4 +16,4 @@ return \deepclone_from_array([
         ],
     ],
     'states' => [1 => 0],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/final-array-iterator.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/final-array-iterator.php
@@ -17,4 +17,4 @@ return \deepclone_from_array([
             ],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/final-error.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/final-error.php
@@ -16,4 +16,4 @@ return \deepclone_from_array([
         ],
     ],
     'states' => [1 => 0],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/final-stdclass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/final-stdclass.php
@@ -4,4 +4,4 @@ return \deepclone_from_array([
     'classes' => 'Symfony\\Component\\VarExporter\\Tests\\FinalStdClass',
     'objectMeta' => 1,
     'prepared' => 0,
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/foo-serializable.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/foo-serializable.php
@@ -4,4 +4,4 @@ return \deepclone_from_array([
     'classes' => 'C:60:"Symfony\\Component\\VarExporter\\Tests\\Fixtures\\FooSerializable":20:{a:1:{i:0;s:3:"bar";}}',
     'objectMeta' => 1,
     'prepared' => 0,
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/hard-references-recursive.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/hard-references-recursive.php
@@ -11,4 +11,4 @@ return \deepclone_from_array([
     'refMasks' => [
         1 => [false],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/hard-references.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/hard-references.php
@@ -7,4 +7,4 @@ return \deepclone_from_array([
     'mask' => [false, false, true],
     'refs' => [1 => 0],
     'refMasks' => [1 => true],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/incomplete-class.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/incomplete-class.php
@@ -4,4 +4,4 @@ return \deepclone_from_array([
     'classes' => 'O:20:"SomeNotExistingClass":0:{}',
     'objectMeta' => 1,
     'prepared' => 0,
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-method.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-method.php
@@ -5,4 +5,4 @@ return \deepclone_from_array([
     'objectMeta' => 1,
     'prepared' => [0, 'testMethod'],
     'mask' => 0,
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-static.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/named-closure-static.php
@@ -5,4 +5,4 @@ return \deepclone_from_array([
     'objectMeta' => 0,
     'prepared' => ['Symfony\\Component\\VarExporter\\Tests\\TestClass', 'testStaticMethod'],
     'mask' => 0,
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/php74-serializable.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/php74-serializable.php
@@ -14,4 +14,4 @@ return \deepclone_from_array([
             [true],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/private-constructor.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/private-constructor.php
@@ -9,4 +9,4 @@ return \deepclone_from_array([
             'prop' => ['bar'],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/private-fcc.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/private-fcc.php
@@ -3,10 +3,6 @@
 return \deepclone_from_array([
     'classes' => '',
     'objectMeta' => 0,
-    'prepared' => [
-        ['Symfony\\Component\\VarExporter\\Tests\\Fixtures\\PrivateFCC', 'testMethod'],
-        'Symfony\\Component\\VarExporter\\Tests\\Fixtures\\PrivateFCC',
-        'testMethod',
-    ],
-    'mask' => 0,
-]);
+    'prepared' => ['Symfony\\Component\\VarExporter\\Tests\\Fixtures\\PrivateFCC', '', 1, 0, 18],
+    'mask' => 1,
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/private.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/private.php
@@ -11,4 +11,4 @@ return \deepclone_from_array([
             'priv' => [234, 234],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/readonly.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/readonly.php
@@ -10,4 +10,4 @@ return \deepclone_from_array([
             'value' => ['v'],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/serializable.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/serializable.php
@@ -5,4 +5,4 @@ return \deepclone_from_array([
     'objectMeta' => 1,
     'prepared' => [0, 0],
     'mask' => [true, true],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/spl-object-storage.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/spl-object-storage.php
@@ -19,4 +19,4 @@ return \deepclone_from_array([
             ],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/var-on-sleep.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/var-on-sleep.php
@@ -13,4 +13,4 @@ return \deepclone_from_array([
             'bar' => ['morning'],
         ],
     ],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/wakeup-refl.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/wakeup-refl.php
@@ -7,4 +7,4 @@ return \deepclone_from_array([
     ],
     'prepared' => 0,
     'states' => [1 => 0],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/wakeup.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/wakeup.php
@@ -19,4 +19,4 @@ return \deepclone_from_array([
         ],
     ],
     'states' => [1 => 1, 0],
-]);
+], null, true);

--- a/src/Symfony/Component/VarExporter/VarExporter.php
+++ b/src/Symfony/Component/VarExporter/VarExporter.php
@@ -48,7 +48,7 @@ final class VarExporter
         }
 
         try {
-            $data = deepclone_to_array($value);
+            $data = deepclone_to_array($value, null, true);
         } catch (\DeepClone\NotInstantiableException $e) {
             throw new NotInstantiableTypeException($e);
         }
@@ -68,6 +68,6 @@ final class VarExporter
             $foundClasses[$classes] = $classes;
         }
 
-        return '\deepclone_from_array('.Exporter::export($data).')';
+        return '\deepclone_from_array('.Exporter::export($data).', null, true)';
     }
 }

--- a/src/Symfony/Component/VarExporter/composer.json
+++ b/src/Symfony/Component/VarExporter/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/deprecation-contracts": "^2.5|^3",
-        "symfony/polyfill-deepclone": "^1.38.2"
+        "symfony/polyfill-deepclone": "^1.40"
     },
     "require-dev": {
         "symfony/property-access": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Required hardening after https://github.com/symfony/php-ext-deepclone/releases/tag/v0.8.0