### PR TITLE
[EventSourceHttpClient] Prevent re-yielding of the first chunk after reconnect

### DIFF
--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -58,6 +58,7 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
             public ?string $lastEventId = null;
             public float $reconnectionTime;
             public ?float $lastError = null;
+            public bool $firstChunkSeen = false;
         };
         $state->reconnectionTime = $this->reconnectionTime;
 
@@ -115,7 +116,10 @@ final class EventSourceHttpClient implements HttpClientInterface, ResetInterface
                     $context->passthru();
                 }
 
-                yield $chunk;
+                if (!$state->firstChunkSeen) {
+                    $state->firstChunkSeen = true;
+                    yield $chunk;
+                }
 
                 return;
             }

--- a/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/EventSourceHttpClientTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpClient\Chunk\LastChunk;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Component\HttpClient\Exception\EventSourceException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Response\ResponseStream;
@@ -217,6 +218,41 @@ class EventSourceHttpClientTest extends TestCase
         }
 
         $this->assertSame([], $expected);
+    }
+
+    public function testFirstChunkIsNotYieldedAgainAfterReconnect()
+    {
+        $es = new EventSourceHttpClient(new MockHttpClient([
+            new MockResponse((static function (): \Generator {
+                yield "id: 1\nevent: message\ndata: hello\n\n";
+
+                throw new TransportException('Connection dropped');
+            })(), [
+                'response_headers' => ['content-type: text/event-stream'],
+            ]),
+            new MockResponse("id: 2\nevent: message\ndata: world\n\n", [
+                'response_headers' => ['content-type: text/event-stream'],
+            ]),
+        ]), reconnectionTime: 0.0);
+
+        $res = $es->connect('http://localhost:8080/events');
+
+        $events = [];
+        foreach ($es->stream($res) as $chunk) {
+            if ($chunk->isTimeout()) {
+                continue;
+            }
+
+            if ($chunk->isLast()) {
+                break;
+            }
+
+            if ($chunk instanceof ServerSentEvent) {
+                $events[] = [$chunk->getId(), trim($chunk->getData())];
+            }
+        }
+
+        $this->assertSame([['1', 'hello'], ['2', 'world']], $events);
     }
 
     public static function contentTypeProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |  NO
| License       | MIT

EventSourceHttpClient crashes on the first reconnect after a transport error with LogicException: A chunk passthru cannot yield more than one "isFirst()" chunk.

 This was introduced in #63692 ("Always yield the first chunk"), which made the first chunk be re-yielded unconditionally. On a reconnect, the response buffer is already open, so re-yielding the FirstChunk triggers a second openBuffer() and throws. The previous guard (null === $lastError) over-corrected the other way and is what #63692 was fixing, so neither approach is right on its own.

 This PR tracks whether a FirstChunk was already emitted (firstChunkSeen): it is yielded once and swallowed on reconnects, which keeps #63692's timeout-before-data case working while no longer crashing when data was already received. A regression test covers the non-timeout reconnect path.

 Standalone reproducer (no network/Mercure needed): https://github.com/nacorp/symfony63692

