### PR TITLE
[Messenger][Routing] add `RequestContext::runWith()` to temporarily generate URLs for another context

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/RouterContextMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/RouterContextMiddleware.php
@@ -47,39 +47,16 @@ class RouterContextMiddleware implements MiddlewareInterface
             return $stack->next()->handle($envelope, $stack);
         }
 
-        $currentBaseUrl = $context->getBaseUrl();
-        $currentMethod = $context->getMethod();
-        $currentHost = $context->getHost();
-        $currentScheme = $context->getScheme();
-        $currentHttpPort = $context->getHttpPort();
-        $currentHttpsPort = $context->getHttpsPort();
-        $currentPathInfo = $context->getPathInfo();
-        $currentQueryString = $context->getQueryString();
-
-        $context
-            ->setBaseUrl($contextStamp->getBaseUrl())
-            ->setMethod($contextStamp->getMethod())
-            ->setHost($contextStamp->getHost())
-            ->setScheme($contextStamp->getScheme())
-            ->setHttpPort($contextStamp->getHttpPort())
-            ->setHttpsPort($contextStamp->getHttpsPort())
-            ->setPathInfo($contextStamp->getPathInfo())
-            ->setQueryString($contextStamp->getQueryString())
-        ;
-
-        try {
-            return $stack->next()->handle($envelope, $stack);
-        } finally {
-            $context
-                ->setBaseUrl($currentBaseUrl)
-                ->setMethod($currentMethod)
-                ->setHost($currentHost)
-                ->setScheme($currentScheme)
-                ->setHttpPort($currentHttpPort)
-                ->setHttpsPort($currentHttpsPort)
-                ->setPathInfo($currentPathInfo)
-                ->setQueryString($currentQueryString)
-            ;
-        }
+        return $context->runWith(
+            static fn () => $stack->next()->handle($envelope, $stack),
+            baseUrl: $contextStamp->getBaseUrl(),
+            method: $contextStamp->getMethod(),
+            host: $contextStamp->getHost(),
+            scheme: $contextStamp->getScheme(),
+            httpPort: $contextStamp->getHttpPort(),
+            httpsPort: $contextStamp->getHttpsPort(),
+            pathInfo: $contextStamp->getPathInfo(),
+            queryString: $contextStamp->getQueryString(),
+        );
     }
 }

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -31,7 +31,7 @@
         "symfony/process": "^7.4|^8.0",
         "symfony/property-access": "^7.4|^8.0",
         "symfony/rate-limiter": "^7.4|^8.0",
-        "symfony/routing": "^7.4|^8.0",
+        "symfony/routing": "^8.2",
         "symfony/serializer": "^7.4.4|^8.0.4",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/stopwatch": "^7.4|^8.0",
@@ -43,6 +43,7 @@
         "symfony/dependency-injection": "<8.1",
         "symfony/event-dispatcher-contracts": "<2.5",
         "symfony/lock": "<7.4",
+        "symfony/routing": "<8.2",
         "symfony/serializer": "<7.4.4|>=8.0,<8.0.4"
     },
     "autoload": {

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow defining default query parameters with the `_query` route default
+ * Add `RequestContext::runWith()` to generate and match URLs for another host, scheme or base URL without leaking the change
 
 8.1
 ---

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -308,4 +308,46 @@ class RequestContext
     {
         return 'https' === $this->scheme;
     }
+
+    /**
+     * Runs the given callback with the given values temporarily applied to this context.
+     *
+     * Arguments left to null keep their current value. The values are applied to this very
+     * instance, so that every service sharing it generates and matches URLs accordingly, and
+     * they are restored afterwards, including when the callback throws.
+     *
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    public function runWith(callable $callback, ?string $baseUrl = null, ?string $method = null, ?string $host = null, ?string $scheme = null, ?int $httpPort = null, ?int $httpsPort = null, ?string $pathInfo = null, ?string $queryString = null, ?array $parameters = null): mixed
+    {
+        $original = clone $this;
+
+        null === $baseUrl || $this->setBaseUrl($baseUrl);
+        null === $method || $this->setMethod($method);
+        null === $host || $this->setHost($host);
+        null === $scheme || $this->setScheme($scheme);
+        null === $httpPort || $this->setHttpPort($httpPort);
+        null === $httpsPort || $this->setHttpsPort($httpsPort);
+        null === $pathInfo || $this->setPathInfo($pathInfo);
+        null === $queryString || $this->setQueryString($queryString);
+        null === $parameters || $this->setParameters($parameters);
+
+        try {
+            return $callback();
+        } finally {
+            $this->baseUrl = $original->baseUrl;
+            $this->pathInfo = $original->pathInfo;
+            $this->method = $original->method;
+            $this->host = $original->host;
+            $this->scheme = $original->scheme;
+            $this->httpPort = $original->httpPort;
+            $this->httpsPort = $original->httpsPort;
+            $this->queryString = $original->queryString;
+            $this->parameters = $original->parameters;
+        }
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/RequestContextTest.php
+++ b/src/Symfony/Component/Routing/Tests/RequestContextTest.php
@@ -240,4 +240,107 @@ class RequestContextTest extends TestCase
         $this->assertSame($requestContext, $requestContext->setParameters([]));
         $this->assertSame($requestContext, $requestContext->setParameter('foo', 'bar'));
     }
+
+    public function testRunWithAppliesValuesAndRestoresThem()
+    {
+        $context = self::createFullContext();
+
+        $returned = $context->runWith(function () use ($context) {
+            $this->assertSame('acme.example.com', $context->getHost());
+            $this->assertSame('https', $context->getScheme());
+            $this->assertSame('/other.php', $context->getBaseUrl());
+
+            return 'from the callback';
+        }, baseUrl: '/other.php', host: 'acme.example.com', scheme: 'https');
+
+        $this->assertSame('from the callback', $returned);
+        self::assertIsFullContext($context);
+    }
+
+    public function testRunWithLeavesNullArgumentsUnchanged()
+    {
+        $context = self::createFullContext();
+
+        $context->runWith(function () use ($context) {
+            $this->assertSame('acme.example.com', $context->getHost());
+            $this->assertSame('http', $context->getScheme());
+            $this->assertSame('POST', $context->getMethod());
+            $this->assertSame('foo=bar', $context->getQueryString());
+            $this->assertSame(['_locale' => 'en'], $context->getParameters());
+        }, host: 'acme.example.com');
+
+        self::assertIsFullContext($context);
+    }
+
+    public function testRunWithAcceptsEmptyValues()
+    {
+        $context = self::createFullContext();
+
+        $context->runWith(function () use ($context) {
+            $this->assertSame('', $context->getQueryString());
+            $this->assertSame([], $context->getParameters());
+        }, queryString: '', parameters: []);
+
+        self::assertIsFullContext($context);
+    }
+
+    public function testRunWithRestoresOnException()
+    {
+        $context = self::createFullContext();
+
+        try {
+            $context->runWith(static fn () => throw new \RuntimeException('Something went wrong.'), host: 'acme.example.com');
+            $this->fail('The exception should have bubbled up.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Something went wrong.', $e->getMessage());
+        }
+
+        self::assertIsFullContext($context);
+    }
+
+    public function testRunWithNests()
+    {
+        $context = self::createFullContext();
+
+        $context->runWith(function () use ($context) {
+            $this->assertSame('a.example.com', $context->getHost());
+
+            $context->runWith(function () use ($context) {
+                $this->assertSame('b.example.com', $context->getHost());
+            }, host: 'b.example.com');
+
+            $this->assertSame('a.example.com', $context->getHost());
+        }, host: 'a.example.com');
+
+        self::assertIsFullContext($context);
+    }
+
+    public function testRunWithDoesNotKeepChangesMadeByTheCallback()
+    {
+        $context = self::createFullContext();
+
+        $context->runWith(static function () use ($context) {
+            $context->setParameter('_locale', 'fr');
+        }, host: 'acme.example.com');
+
+        self::assertIsFullContext($context);
+    }
+
+    private static function createFullContext(): RequestContext
+    {
+        return new RequestContext('/app.php', 'POST', 'localhost', 'http', 8080, 8443, '/index', 'foo=bar', ['_locale' => 'en']);
+    }
+
+    private static function assertIsFullContext(RequestContext $context): void
+    {
+        self::assertSame('/app.php', $context->getBaseUrl());
+        self::assertSame('POST', $context->getMethod());
+        self::assertSame('localhost', $context->getHost());
+        self::assertSame('http', $context->getScheme());
+        self::assertSame(8080, $context->getHttpPort());
+        self::assertSame(8443, $context->getHttpsPort());
+        self::assertSame('/index', $context->getPathInfo());
+        self::assertSame('foo=bar', $context->getQueryString());
+        self::assertSame(['_locale' => 'en'], $context->getParameters());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Router;
 
@@ -211,6 +213,29 @@ class RouterTest extends TestCase
         $p = new \ReflectionProperty($generator, 'defaultLocale');
 
         $this->assertSame('hr', $p->getValue($generator));
+    }
+
+    public function testGenerateWithinRunWithUsesTheGivenContext()
+    {
+        $routes = new RouteCollection();
+        $routes->add('home', new Route('/home'));
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+
+        $context = new RequestContext('', 'GET', 'localhost', 'http');
+        $router = new Router($loader, 'routing.yml', [], $context);
+
+        $this->assertSame('http://localhost/home', $router->generate('home', [], UrlGeneratorInterface::ABSOLUTE_URL));
+
+        $url = $context->runWith(
+            static fn () => $router->generate('home', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            host: 'acme.example.com',
+            scheme: 'https',
+        );
+
+        $this->assertSame('https://acme.example.com/home', $url);
+        $this->assertSame('http://localhost/home', $router->generate('home', [], UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     private function getRouter(?LoaderInterface $loader = null): Router


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60187
| License       | MIT

Generating a URL for a host, scheme or base URL other than the current request's currently means mutating the shared `RequestContext` and restoring it by hand, which is error-prone. This is a recurring need for multi-tenant or multi-domain apps, e.g. building links in e-mails that must point to a given tenant's domain.

This PR adds `RequestContext::runWith()`, which applies the given values for the duration of a callback and restores them afterwards, including when the callback throws:

```php
$url = $router->getContext()->runWith(
    fn () => $router->generate('invoice_show', ['id' => $invoice->getId()], UrlGeneratorInterface::ABSOLUTE_URL),
    host: 'acme.example.com',
    scheme: 'https',
);
```

Arguments left to `null` keep their current value. The values are applied to the context instance itself, so everything sharing it follows: the router, anything decorating it, and the other services holding a `RequestContext` such as `UrlHelper` and `LoginLinkHandler`.

`Messenger`'s `RouterContextMiddleware` was doing this by hand with eight locals, eight setters and eight more in a `finally`. It now uses the new method and loses 34 lines.
