### PR TITLE
[Tui] Deduplicate the terminal title escape sequence into a trait

### DIFF
--- a/src/Symfony/Component/Tui/Terminal/Terminal.php
+++ b/src/Symfony/Component/Tui/Terminal/Terminal.php
@@ -23,6 +23,8 @@ use Symfony\Component\Tui\Input\StdinBuffer;
  */
 final class Terminal implements TerminalInterface
 {
+    use TerminalEscapeTrait;
+
     private ?StdinBuffer $stdinBuffer = null;
 
     private string $initialSttyState = '';
@@ -179,46 +181,6 @@ final class Terminal implements TerminalInterface
     public function isKittyProtocolActive(): bool
     {
         return $this->kittyProtocolActive;
-    }
-
-    public function moveBy(int $lines): void
-    {
-        if ($lines > 0) {
-            $this->write("\x1b[{$lines}B");
-        } elseif ($lines < 0) {
-            $this->write("\x1b[".(-$lines).'A');
-        }
-    }
-
-    public function hideCursor(): void
-    {
-        $this->write("\x1b[?25l");
-    }
-
-    public function showCursor(): void
-    {
-        $this->write("\x1b[?25h");
-    }
-
-    public function clearLine(): void
-    {
-        $this->write("\x1b[2K");
-    }
-
-    public function clearFromCursor(): void
-    {
-        $this->write("\x1b[0J");
-    }
-
-    public function clearScreen(): void
-    {
-        $this->write("\x1b[2J\x1b[H");
-    }
-
-    public function setTitle(string $title): void
-    {
-        $safe = preg_replace("/[\x00-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $title);
-        $this->write("\x1b]0;{$safe}\x07");
     }
 
     public function bell(): void

--- a/src/Symfony/Component/Tui/Terminal/TerminalEscapeTrait.php
+++ b/src/Symfony/Component/Tui/Terminal/TerminalEscapeTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Terminal;
+
+/**
+ * Shares the escape sequences emitted by terminal implementations.
+ *
+ * @internal
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+trait TerminalEscapeTrait
+{
+    abstract public function write(string $data): void;
+
+    public function moveBy(int $lines): void
+    {
+        if ($lines > 0) {
+            $this->write("\x1b[{$lines}B");
+        } elseif ($lines < 0) {
+            $this->write("\x1b[".(-$lines).'A');
+        }
+    }
+
+    public function hideCursor(): void
+    {
+        $this->write("\x1b[?25l");
+    }
+
+    public function showCursor(): void
+    {
+        $this->write("\x1b[?25h");
+    }
+
+    public function clearLine(): void
+    {
+        $this->write("\x1b[2K");
+    }
+
+    public function clearFromCursor(): void
+    {
+        $this->write("\x1b[0J");
+    }
+
+    public function clearScreen(): void
+    {
+        $this->write("\x1b[2J\x1b[H");
+    }
+
+    public function setTitle(string $title): void
+    {
+        // Strip C0/C1 control characters so an attacker-controlled title
+        // cannot break out of the OSC sequence or inject further escapes.
+        $safe = preg_replace("/[\x00-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $title);
+
+        $this->write("\x1b]0;{$safe}\x07");
+    }
+}

--- a/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
@@ -30,6 +30,8 @@ use Symfony\Component\Tui\Input\StdinBuffer;
  */
 final class VirtualTerminal implements TerminalInterface
 {
+    use TerminalEscapeTrait;
+
     private string $output = '';
     private ?StdinBuffer $stdinBuffer = null;
     private ?\Closure $onResize = null;
@@ -79,46 +81,6 @@ final class VirtualTerminal implements TerminalInterface
     public function isKittyProtocolActive(): bool
     {
         return $this->kittyProtocolActive;
-    }
-
-    public function moveBy(int $lines): void
-    {
-        if ($lines > 0) {
-            $this->write("\x1b[{$lines}B");
-        } elseif ($lines < 0) {
-            $this->write("\x1b[".(-$lines).'A');
-        }
-    }
-
-    public function hideCursor(): void
-    {
-        $this->write("\x1b[?25l");
-    }
-
-    public function showCursor(): void
-    {
-        $this->write("\x1b[?25h");
-    }
-
-    public function clearLine(): void
-    {
-        $this->write("\x1b[2K");
-    }
-
-    public function clearFromCursor(): void
-    {
-        $this->write("\x1b[0J");
-    }
-
-    public function clearScreen(): void
-    {
-        $this->write("\x1b[2J\x1b[H");
-    }
-
-    public function setTitle(string $title): void
-    {
-        $safe = preg_replace("/[\x00-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $title);
-        $this->write("\x1b]0;{$safe}\x07");
     }
 
     public function bell(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

As this is security-related, I think it makes sense to have it centralized and available for other TerminalInterface implementations.