### PR TITLE
[Mailer] Register MicrosoftGraphTransportFactory in Transport::FACTORY_CLASSES

### DIFF
--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -26,6 +26,7 @@ use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailomat\Transport\MailomatTransportFactory;
 use Symfony\Component\Mailer\Bridge\MailPace\Transport\MailPaceTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapTransportFactory;
+use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postal\Transport\PostalTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
@@ -67,6 +68,7 @@ final class Transport
         PostalTransportFactory::class,
         PostmarkTransportFactory::class,
         MailtrapTransportFactory::class,
+        MicrosoftGraphTransportFactory::class,
         ResendTransportFactory::class,
         ScalewayTransportFactory::class,
         SendgridTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64586
| License       | MIT

The `MicrosoftGraphTransportFactory` (added in 7.4) was missing from
`Transport::FACTORY_CLASSES`, so `Transport::fromDsn('microsoftgraph+api://...')`
threw an `UnsupportedSchemeException` even when `symfony/microsoft-graph-mailer`
was installed — while the same DSN worked through FrameworkBundle. This registers
the factory like every other bridge.
