### PR TITLE
[Translation] Verify Tagalog (tl) validator strings and remove needs-…

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.tl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Pakilagay ang balidong UUID.</target>
+                <target>Pakilagay ang wastong UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -556,15 +556,15 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Ang halagang ito ay hindi wastong XML.</target>
+                <target>Ang nilalaman na ito ay hindi wastong XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Ang halagang ito ay hindi tumutugma sa inaasahang XSD schema.</target>
+                <target>Ang nilalaman na ito ay hindi tumutugma sa inaasahang XSD schema.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Masyadong malaki ang XML payload na ito ({{ size }} bytes): lumampas ito sa limitasyong {{ limit }} bytes.</target>
+                <target>Masyadong malaki ang XML payload na ito ({{ size }} bytes): lumampas ito sa limitasyong {{ limit }} bytes.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
…review flags

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64519
| License       | MIT

This PR verifies and improves the automated Tagalog (`tl`) translation strings for the Form and Validator components.

As a native speaker, I have reviewed the strings and made the following updates:
- Removed the `state="needs-review-translation"` attributes to officially mark the translations as verified.
- Corrected a machine-translation error in `validators.tl.xlf` (Validator component) where "value" was translated to "halaga" (which contextually implies monetary worth or price). Changed it to "nilalaman" (content) so it reads naturally in a data-validation context.
- Harmonized the UUID validation string in `validators.tl.xlf` (Form component) to use "wastong" instead of the loanword "balidong" to match the rest of the codebase's terminology for "valid".