### PR TITLE
[Validator] Fix GroupSequenceProviderInterface not cascading custom groups to child objects

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1289,7 +1289,62 @@ class RecursiveValidatorTest extends TestCase
             ['addGetterConstraint'],
         ];
     }
+    public function testGroupSequenceProviderValidatesChildClassesWithCustomGroups()
+    {
+        /* When using GroupSequenceProviderInterface, child objects decorated with
+           #[Assert\Valid] must be validated using groups from the sequence, not
+           just the "Default" group.  issue #64365 */
+        $entity = new GroupSequenceProviderEntity(new GroupSequence(['Default', 'custom_group']));
+        $entity->firstName = 'toolongvalue';
 
+        $entityMetadata = new ClassMetadata(GroupSequenceProviderEntity::class);
+        $entityMetadata->setGroupSequenceProvider(true);
+        $entityMetadata->addPropertyConstraint(
+            'firstName',
+            new Length(max: 3, groups: ['custom_group'])
+        );
+        $this->metadataFactory->addMetadata($entityMetadata);
+
+        $violations = $this->validate($entity, null, 'Default');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame(
+            'This value is too long. It should have 3 characters or less.',
+            $violations[0]->getMessage()
+        );
+    }
+
+    public function testGroupSequenceProviderValidatesChildObjectWithCustomGroups()
+    {
+        /* When using GroupSequenceProviderInterface, child objects decorated with
+           #[Assert\Valid] must be validated using the groups from the provider's
+           sequence, not just the "Default" group. issue #64365 */
+        $entity = new GroupSequenceProviderEntity(new GroupSequence(['GroupSequenceProviderEntity', 'custom_group']));
+        $reference = new Reference();
+        $reference->value = 'invalid';
+
+        $entityMetadata = new ClassMetadata(GroupSequenceProviderEntity::class);
+        $entityMetadata->setGroupSequenceProvider(true);
+        $entityMetadata->addPropertyConstraint('firstName', new Valid());
+        $this->metadataFactory->addMetadata($entityMetadata);
+
+        $referenceMetadata = new ClassMetadata(Reference::class);
+        $referenceMetadata->addPropertyConstraint(
+            'value',
+            new Length(max: 3, groups: ['custom_group'])
+        );
+        $this->metadataFactory->addMetadata($referenceMetadata);
+
+        $entity->firstName = $reference;
+
+        $violations = $this->validate($entity, null, 'Default');
+
+        $this->assertCount(1, $violations);
+        $this->assertSame(
+            'This value is too long. It should have 3 characters or less.',
+            $violations[0]->getMessage()
+        );
+    }
     public static function getTestReplaceDefaultGroup()
     {
         return [

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -471,7 +471,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
                     $propertyPath,
                     $traversalStrategy,
                     $group,
-                    $defaultOverridden ? Constraint::DEFAULT_GROUP : null,
+                    $defaultOverridden && !$metadata->isGroupSequenceProvider() ? Constraint::DEFAULT_GROUP : null,
                     $context
                 );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64365
| License       | MIT

## Summary

When using `GroupSequenceProviderInterface`, child objects decorated with `#[Assert\Valid]` were not validated using the groups returned by the provider's sequence. They were only validated against the `Default` group because `stepThroughGroupSequence()` was called with `Constraint::DEFAULT_GROUP` as the cascaded group, overriding the sequence groups for cascaded objects.

**Fix:** Do not pass `Constraint::DEFAULT_GROUP` as the cascade group when the group sequence originates from a `GroupSequenceProviderInterface`. Static group sequences (`hasGroupSequence()`) retain the existing behavior.
