### PR TITLE
[Console] use mb_convert_encoding() instead of mb_convert_variables()

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1319,9 +1319,7 @@ class Application implements ResetInterface
 
         $lines[] = \count($lines) ? str_pad($line, $width) : $line;
 
-        mb_convert_variables($encoding, 'utf8', $lines);
-
-        return $lines;
+        return mb_convert_encoding($lines, $encoding, 'utf8');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Potential php-src change for PHP 8.6
| License       | MIT

Replace the call to `mb_convert_variables()` with `mb_convert_encoding()` as I'm investigating use of the former as it is extremely whack and can effectively just be replaced by `mb_convert_encoding()` in this case.

