### PR TITLE
[Contracts] Rename ContainerAwareInterface to ContainerProviderInterface

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -25,12 +25,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Contracts\Service\ContainerAwareInterface;
+use Symfony\Contracts\Service\ContainerProviderInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Application extends BaseApplication implements ContainerAwareInterface
+class Application extends BaseApplication implements ContainerProviderInterface
 {
     private bool $commandsRegistered = false;
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -32,7 +32,7 @@
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php85": "^1.33",
         "symfony/routing": "^7.4|^8.0",
-        "symfony/service-contracts": "^3.7",
+        "symfony/service-contracts": "^3.7.1",
         "symfony/var-exporter": "^8.1"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Add support for the `max_connect_duration` option in `HttpClientInterface`
  * Add support for hooked properties in `ServiceMethodsSubscriberTrait`
- * Add `ContainerAwareInterface`
+ * Add `ContainerProviderInterface`
 
 3.6
 ---

--- a/src/Symfony/Contracts/Service/ContainerProviderInterface.php
+++ b/src/Symfony/Contracts/Service/ContainerProviderInterface.php
@@ -16,7 +16,7 @@ use Psr\Container\ContainerInterface;
 /**
  * Implemented by objects that expose a service container.
  */
-interface ContainerAwareInterface
+interface ContainerProviderInterface
 {
     public function getContainer(): ContainerInterface;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

As discussed in https://github.com/symfony/symfony/pull/63663#issuecomment-4067721552 and later forgotten in #63650

We're soon enough in the 8.1 release cycle to address this as a bugfix IMHO.