### PR TITLE
[Cache][DoctrineBridge][HttpFoundation][Lock][Messenger] Restore compat with DBAL 4.5

### DIFF
--- a/.github/deprecation-ignore
+++ b/.github/deprecation-ignore
@@ -1,0 +1,4 @@
+# Schema mutator deprecations triggered by doctrine/orm's SchemaTool on DBAL 4.5+.
+# These are vendor-internal: ORM has not yet migrated SchemaTool to the DBAL
+# Schema/Table editor API. Symfony's own schema code already uses the editor API.
+%^Doctrine\\DBAL\\Schema\\(Table|Schema)::\w+\(?\)? is deprecated%

--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -144,7 +144,7 @@ diff --git a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/Regist
 diff --git a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
 --- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
 +++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
-@@ -164,5 +164,5 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
+@@ -168,5 +168,5 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
       * @return array{0:ClassMetadata<T>, 1:string}|null
       */
 -    protected function getMetadata(string $class)
@@ -212,23 +212,40 @@ diff --git a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineClearEntityManagerWor
 +    public function onWorkerMessageFailed(): void
      {
          $this->clearEntityManagers();
+diff --git a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
++++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+@@ -35,5 +35,5 @@ abstract class AbstractSchemaListener
+      * @return Schema The (possibly new) schema after filtering
+      */
+-    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator)
++    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator): Schema
+     {
+         $filter = $connection->getConfiguration()->getSchemaAssetsFilter();
 diff --git a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
 --- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
 +++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
-@@ -73,5 +73,5 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
+@@ -78,5 +78,5 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
       * @return void
       */
 -    public function deleteTokenBySeries(string $series)
 +    public function deleteTokenBySeries(string $series): void
      {
          $sql = 'DELETE FROM rememberme_token WHERE series=:series';
-@@ -103,5 +103,5 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
+@@ -108,5 +108,5 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
       * @return void
       */
 -    public function createNewToken(PersistentTokenInterface $token)
 +    public function createNewToken(PersistentTokenInterface $token): void
      {
          $sql = 'INSERT INTO rememberme_token (class, username, series, value, lastUsed) VALUES (:class, :username, :series, :value, :lastUsed)';
+@@ -197,5 +197,5 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */)
++    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): Schema
+     {
+         if ($schema->hasTable('rememberme_token')) {
 diff --git a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
 --- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
 +++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -252,7 +269,7 @@ diff --git a/src/Symfony/Bridge/Doctrine/Validator/DoctrineInitializer.php b/src
 diff --git a/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php b/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
 --- a/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
 +++ b/src/Symfony/Bridge/Monolog/Command/ServerLogCommand.php
-@@ -56,5 +56,5 @@ class ServerLogCommand extends Command
+@@ -58,5 +58,5 @@ class ServerLogCommand extends Command
       * @return void
       */
 -    protected function configure()
@@ -633,7 +650,7 @@ diff --git a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExt
 +    public function load(array $configs, ContainerBuilder $container): void
      {
          $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
-@@ -3024,5 +3024,5 @@ class FrameworkExtension extends Extension
+@@ -3027,5 +3027,5 @@ class FrameworkExtension extends Extension
       * @return void
       */
 -    public static function registerRateLimiter(ContainerBuilder $container, string $name, array $limiterConfig)
@@ -650,7 +667,7 @@ diff --git a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php b/src/Symfon
 +    public function boot(): void
      {
          $_ENV['DOCTRINE_DEPRECATIONS'] = $_SERVER['DOCTRINE_DEPRECATIONS'] ??= 'trigger';
-@@ -129,5 +129,5 @@ class FrameworkBundle extends Bundle
+@@ -135,5 +135,5 @@ class FrameworkBundle extends Bundle
       * @return void
       */
 -    public function build(ContainerBuilder $container)
@@ -1279,6 +1296,16 @@ diff --git a/src/Symfony/Component/Cache/Adapter/ChainAdapter.php b/src/Symfony/
 +    public function reset(): void
      {
          foreach ($this->adapters as $adapter) {
+diff --git a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
++++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+@@ -137,5 +137,5 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */)
++    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): Schema
+     {
+         if ($schema->hasTable($this->table)) {
 diff --git a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
 --- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
 +++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
@@ -1325,7 +1352,7 @@ diff --git a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php b/src/Symfo
 -    public function reset()
 +    public function reset(): void
      {
-         $this->commit();
+         try {
 diff --git a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
 --- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
 +++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -2908,8 +2935,8 @@ diff --git a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php b/src
 -    public function overwrite(string|iterable $message)
 +    public function overwrite(string|iterable $message): void
      {
-         $this->clear();
-@@ -166,5 +166,5 @@ class ConsoleSectionOutput extends StreamOutput
+         if (!$this->content || !$this->isDecorated()) {
+@@ -189,5 +189,5 @@ class ConsoleSectionOutput extends StreamOutput
       * @return void
       */
 -    protected function doWrite(string $message, bool $newline)
@@ -3494,7 +3521,7 @@ diff --git a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularRef
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
 --- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
-@@ -38,5 +38,5 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
+@@ -37,5 +37,5 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
       * @throws RuntimeException When the Definition is invalid
       */
 -    public function process(ContainerBuilder $container)
@@ -3610,49 +3637,49 @@ diff --git a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionCo
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
 --- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
 +++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
-@@ -127,5 +127,5 @@ class PassConfig
+@@ -128,5 +128,5 @@ class PassConfig
       * @throws InvalidArgumentException when a pass type doesn't exist
       */
 -    public function addPass(CompilerPassInterface $pass, string $type = self::TYPE_BEFORE_OPTIMIZATION, int $priority = 0)
 +    public function addPass(CompilerPassInterface $pass, string $type = self::TYPE_BEFORE_OPTIMIZATION, int $priority = 0): void
      {
          $property = $type.'Passes';
-@@ -203,5 +203,5 @@ class PassConfig
+@@ -204,5 +204,5 @@ class PassConfig
       * @return void
       */
 -    public function setMergePass(CompilerPassInterface $pass)
 +    public function setMergePass(CompilerPassInterface $pass): void
      {
          $this->mergePass = $pass;
-@@ -215,5 +215,5 @@ class PassConfig
+@@ -216,5 +216,5 @@ class PassConfig
       * @return void
       */
 -    public function setAfterRemovingPasses(array $passes)
 +    public function setAfterRemovingPasses(array $passes): void
      {
          $this->afterRemovingPasses = [$passes];
-@@ -227,5 +227,5 @@ class PassConfig
+@@ -228,5 +228,5 @@ class PassConfig
       * @return void
       */
 -    public function setBeforeOptimizationPasses(array $passes)
 +    public function setBeforeOptimizationPasses(array $passes): void
      {
          $this->beforeOptimizationPasses = [$passes];
-@@ -239,5 +239,5 @@ class PassConfig
+@@ -240,5 +240,5 @@ class PassConfig
       * @return void
       */
 -    public function setBeforeRemovingPasses(array $passes)
 +    public function setBeforeRemovingPasses(array $passes): void
      {
          $this->beforeRemovingPasses = [$passes];
-@@ -251,5 +251,5 @@ class PassConfig
+@@ -252,5 +252,5 @@ class PassConfig
       * @return void
       */
 -    public function setOptimizationPasses(array $passes)
 +    public function setOptimizationPasses(array $passes): void
      {
          $this->optimizationPasses = [$passes];
-@@ -263,5 +263,5 @@ class PassConfig
+@@ -264,5 +264,5 @@ class PassConfig
       * @return void
       */
 -    public function setRemovingPasses(array $passes)
@@ -3920,98 +3947,98 @@ diff --git a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php b
 diff --git a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
 --- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
 +++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
-@@ -177,5 +177,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -182,5 +182,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function setResourceTracking(bool $track)
 +    public function setResourceTracking(bool $track): void
      {
          $this->trackResources = $track;
-@@ -195,5 +195,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -200,5 +200,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function setProxyInstantiator(InstantiatorInterface $proxyInstantiator)
 +    public function setProxyInstantiator(InstantiatorInterface $proxyInstantiator): void
      {
          $this->proxyInstantiator = $proxyInstantiator;
-@@ -203,5 +203,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -208,5 +208,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function registerExtension(ExtensionInterface $extension)
 +    public function registerExtension(ExtensionInterface $extension): void
      {
          $this->extensions[$extension->getAlias()] = $extension;
-@@ -485,5 +485,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -490,5 +490,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @throws BadMethodCallException When this ContainerBuilder is compiled
       */
 -    public function set(string $id, ?object $service)
 +    public function set(string $id, ?object $service): void
      {
          if ($this->isCompiled() && (isset($this->definitions[$id]) && !$this->definitions[$id]->isSynthetic())) {
-@@ -502,5 +502,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -507,5 +507,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function removeDefinition(string $id)
 +    public function removeDefinition(string $id): void
      {
          if (isset($this->definitions[$id])) {
-@@ -614,5 +614,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -619,5 +619,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @throws BadMethodCallException When this ContainerBuilder is compiled
       */
 -    public function merge(self $container)
 +    public function merge(self $container): void
      {
          if ($this->isCompiled()) {
-@@ -706,5 +706,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -711,5 +711,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function prependExtensionConfig(string $name, array $config)
 +    public function prependExtensionConfig(string $name, array $config): void
      {
          if (!isset($this->extensionConfigs[$name])) {
-@@ -751,5 +751,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -756,5 +756,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function compile(bool $resolveEnvPlaceholders = false)
 +    public function compile(bool $resolveEnvPlaceholders = false): void
      {
          $compiler = $this->getCompiler();
-@@ -815,5 +815,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -820,5 +820,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function addAliases(array $aliases)
 +    public function addAliases(array $aliases): void
      {
          foreach ($aliases as $alias => $id) {
-@@ -829,5 +829,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -834,5 +834,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function setAliases(array $aliases)
 +    public function setAliases(array $aliases): void
      {
          $this->aliasDefinitions = [];
-@@ -863,5 +863,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -868,5 +868,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function removeAlias(string $alias)
 +    public function removeAlias(string $alias): void
      {
          if (isset($this->aliasDefinitions[$alias])) {
-@@ -925,5 +925,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -930,5 +930,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function addDefinitions(array $definitions)
 +    public function addDefinitions(array $definitions): void
      {
          foreach ($definitions as $id => $definition) {
-@@ -939,5 +939,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -944,5 +944,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function setDefinitions(array $definitions)
 +    public function setDefinitions(array $definitions): void
      {
          $this->definitions = [];
-@@ -1332,5 +1332,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
+@@ -1337,5 +1337,5 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
       * @return void
       */
 -    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
@@ -4505,42 +4532,42 @@ diff --git a/src/Symfony/Component/DomCrawler/Crawler.php b/src/Symfony/Componen
 +    public function addXmlContent(string $content, string $charset = 'UTF-8', int $options = \LIBXML_NONET): void
      {
          // remove the default namespace if it's the only namespace to make XPath expressions simpler
-@@ -246,5 +246,5 @@ class Crawler implements \Countable, \IteratorAggregate
+@@ -245,5 +245,5 @@ class Crawler implements \Countable, \IteratorAggregate
       * @return void
       */
 -    public function addDocument(\DOMDocument $dom)
 +    public function addDocument(\DOMDocument $dom): void
      {
          if ($dom->documentElement) {
-@@ -260,5 +260,5 @@ class Crawler implements \Countable, \IteratorAggregate
+@@ -259,5 +259,5 @@ class Crawler implements \Countable, \IteratorAggregate
       * @return void
       */
 -    public function addNodeList(\DOMNodeList $nodes)
 +    public function addNodeList(\DOMNodeList $nodes): void
      {
          foreach ($nodes as $node) {
-@@ -276,5 +276,5 @@ class Crawler implements \Countable, \IteratorAggregate
+@@ -275,5 +275,5 @@ class Crawler implements \Countable, \IteratorAggregate
       * @return void
       */
 -    public function addNodes(array $nodes)
 +    public function addNodes(array $nodes): void
      {
          foreach ($nodes as $node) {
-@@ -290,5 +290,5 @@ class Crawler implements \Countable, \IteratorAggregate
+@@ -289,5 +289,5 @@ class Crawler implements \Countable, \IteratorAggregate
       * @return void
       */
 -    public function addNode(\DOMNode $node)
 +    public function addNode(\DOMNode $node): void
      {
          if ($node instanceof \DOMDocument) {
-@@ -891,5 +891,5 @@ class Crawler implements \Countable, \IteratorAggregate
+@@ -890,5 +890,5 @@ class Crawler implements \Countable, \IteratorAggregate
       * @return void
       */
 -    public function setDefaultNamespacePrefix(string $prefix)
 +    public function setDefaultNamespacePrefix(string $prefix): void
      {
          $this->defaultNamespacePrefix = $prefix;
-@@ -899,5 +899,5 @@ class Crawler implements \Countable, \IteratorAggregate
+@@ -898,5 +898,5 @@ class Crawler implements \Countable, \IteratorAggregate
       * @return void
       */
 -    public function registerNamespace(string $prefix, string $namespace)
@@ -4578,7 +4605,7 @@ diff --git a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php b/src/Sy
 +    public function setValue(string|array|bool|null $value): void
      {
          if ('checkbox' === $this->type && false === $value) {
-@@ -191,5 +191,5 @@ class ChoiceFormField extends FormField
+@@ -195,5 +195,5 @@ class ChoiceFormField extends FormField
       * @throws \LogicException When node type is incorrect
       */
 -    protected function initialize()
@@ -5073,7 +5100,7 @@ diff --git a/src/Symfony/Component/ExpressionLanguage/SerializedParsedExpression
 -    public function getNodes()
 +    public function getNodes(): Node
      {
-         return unserialize($this->nodes);
+         return unserialize($this->nodes, ['allowed_classes' => true]);
 diff --git a/src/Symfony/Component/ExpressionLanguage/TokenStream.php b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
 --- a/src/Symfony/Component/ExpressionLanguage/TokenStream.php
 +++ b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
@@ -6682,7 +6709,7 @@ diff --git a/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidator
 diff --git a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
 --- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
 +++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
-@@ -42,5 +42,5 @@ class ViolationMapper implements ViolationMapperInterface
+@@ -43,5 +43,5 @@ class ViolationMapper implements ViolationMapperInterface
       * @return void
       */
 -    public function mapViolation(ConstraintViolation $violation, FormInterface $form, bool $allowNonSynchronized = false)
@@ -7202,49 +7229,49 @@ diff --git a/src/Symfony/Component/HttpFoundation/Request.php b/src/Symfony/Comp
 +    public function setSession(SessionInterface $session): void
      {
          $this->session = $session;
-@@ -1212,5 +1212,5 @@ class Request
+@@ -1208,5 +1208,5 @@ class Request
       * @return void
       */
 -    public function setMethod(string $method)
 +    public function setMethod(string $method): void
      {
          $this->method = null;
-@@ -1342,5 +1342,5 @@ class Request
+@@ -1338,5 +1338,5 @@ class Request
       * @return void
       */
 -    public function setFormat(?string $format, string|array $mimeTypes)
 +    public function setFormat(?string $format, string|array $mimeTypes): void
      {
          if (null === static::$formats) {
-@@ -1374,5 +1374,5 @@ class Request
+@@ -1370,5 +1370,5 @@ class Request
       * @return void
       */
 -    public function setRequestFormat(?string $format)
 +    public function setRequestFormat(?string $format): void
      {
          $this->format = $format;
-@@ -1406,5 +1406,5 @@ class Request
+@@ -1402,5 +1402,5 @@ class Request
       * @return void
       */
 -    public function setDefaultLocale(string $locale)
 +    public function setDefaultLocale(string $locale): void
      {
          $this->defaultLocale = $locale;
-@@ -1428,5 +1428,5 @@ class Request
+@@ -1424,5 +1424,5 @@ class Request
       * @return void
       */
 -    public function setLocale(string $locale)
 +    public function setLocale(string $locale): void
      {
          $this->setPhpDefaultLocale($this->locale = $locale);
-@@ -1785,5 +1785,5 @@ class Request
+@@ -1781,5 +1781,5 @@ class Request
       * @return string
       */
 -    protected function prepareRequestUri()
 +    protected function prepareRequestUri(): string
      {
          $requestUri = '';
-@@ -1954,5 +1954,5 @@ class Request
+@@ -1950,5 +1950,5 @@ class Request
       * @return void
       */
 -    protected static function initializeFormats()
@@ -7644,7 +7671,14 @@ diff --git a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php b
 diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
 --- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
 +++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
-@@ -241,5 +241,5 @@ class PdoSessionHandler extends AbstractSessionHandler
+@@ -190,5 +190,5 @@ class PdoSessionHandler extends AbstractSessionHandler
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null)
++    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null): Schema
+     {
+         if ($schema->hasTable($this->table) || ($isSameDatabase && !$isSameDatabase($this->getConnection()->exec(...)))) {
+@@ -319,5 +319,5 @@ class PdoSessionHandler extends AbstractSessionHandler
       * @throws \DomainException When an unsupported PDO driver is used
       */
 -    public function createTable()
@@ -8373,28 +8407,28 @@ diff --git a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php b/src/Symfony/Co
 diff --git a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
 --- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
 +++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
-@@ -255,5 +255,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
+@@ -265,5 +265,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
       * @return void
       */
 -    public function terminate(Request $request, Response $response)
 +    public function terminate(Request $request, Response $response): void
      {
          // Do not call any listeners in case of a cache hit.
-@@ -475,5 +475,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
+@@ -485,5 +485,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
       * @return Response
       */
 -    protected function forward(Request $request, bool $catch = false, ?Response $entry = null)
 +    protected function forward(Request $request, bool $catch = false, ?Response $entry = null): Response
      {
          $this->surrogate?->addSurrogateCapability($request);
-@@ -600,5 +600,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
+@@ -611,5 +611,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
       * @throws \Exception
       */
 -    protected function store(Request $request, Response $response)
 +    protected function store(Request $request, Response $response): void
      {
          try {
-@@ -678,5 +678,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
+@@ -689,5 +689,5 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
       * @return void
       */
 -    protected function processResponseBody(Request $request, Response $response)
@@ -9225,27 +9259,34 @@ diff --git a/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php b/
 diff --git a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
 --- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
 +++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
-@@ -100,5 +100,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
+@@ -105,5 +105,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
       * @return void
       */
 -    public function save(Key $key)
 +    public function save(Key $key): void
      {
          $key->reduceLifetime($this->initialTtl);
-@@ -142,5 +142,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
+@@ -194,5 +194,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
       * @return void
       */
 -    public function putOffExpiration(Key $key, $ttl)
 +    public function putOffExpiration(Key $key, $ttl): void
      {
          if ($ttl < 1) {
-@@ -176,5 +176,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
+@@ -228,5 +228,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
       * @return void
       */
 -    public function delete(Key $key)
 +    public function delete(Key $key): void
      {
          $this->conn->delete($this->table, [
+@@ -272,5 +272,5 @@ class DoctrineDbalStore implements PersistingStoreInterface
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema/* , \Closure $isSameDatabase */)
++    public function configureSchema(Schema $schema/* , \Closure $isSameDatabase */): Schema
+     {
+         if ($schema->hasTable($this->table)) {
 diff --git a/src/Symfony/Component/Lock/Store/FlockStore.php b/src/Symfony/Component/Lock/Store/FlockStore.php
 --- a/src/Symfony/Component/Lock/Store/FlockStore.php
 +++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -9394,14 +9435,14 @@ diff --git a/src/Symfony/Component/Lock/Store/PdoStore.php b/src/Symfony/Compone
 +    public function save(Key $key): void
      {
          $key->reduceLifetime($this->initialTtl);
-@@ -129,5 +129,5 @@ class PdoStore implements PersistingStoreInterface
+@@ -188,5 +188,5 @@ class PdoStore implements PersistingStoreInterface
       * @return void
       */
 -    public function putOffExpiration(Key $key, float $ttl)
 +    public function putOffExpiration(Key $key, float $ttl): void
      {
          if ($ttl < 1) {
-@@ -157,5 +157,5 @@ class PdoStore implements PersistingStoreInterface
+@@ -216,5 +216,5 @@ class PdoStore implements PersistingStoreInterface
       * @return void
       */
 -    public function delete(Key $key)
@@ -9566,10 +9607,20 @@ diff --git a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSq
 +    private function getReceiver(): MessageCountAwareInterface&ReceiverInterface
      {
          return $this->receiver ??= new AmazonSqsReceiver($this->connection, $this->serializer);
+diff --git a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
++++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+@@ -85,5 +85,5 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
+      * @return Schema The (possibly new) schema with the table added
+      */
+-    public function configureSchema(Schema $schema, DbalConnection $forConnection/* , \Closure $isSameDatabase */)
++    public function configureSchema(Schema $schema, DbalConnection $forConnection/* , \Closure $isSameDatabase */): Schema
+     {
+         $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
 diff --git a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
 --- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
 +++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
-@@ -132,5 +132,5 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
+@@ -131,5 +131,5 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
       * @return void
       */
 -    protected function interact(InputInterface $input, OutputInterface $output)
@@ -9695,7 +9746,7 @@ diff --git a/src/Symfony/Component/Mime/DependencyInjection/AddMimeTypeGuesserPa
 -    public function process(ContainerBuilder $container)
 +    public function process(ContainerBuilder $container): void
      {
-         if ($container->has('mime_types')) {
+         if (!$container->has('mime_types')) {
 diff --git a/src/Symfony/Component/Mime/Email.php b/src/Symfony/Component/Mime/Email.php
 --- a/src/Symfony/Component/Mime/Email.php
 +++ b/src/Symfony/Component/Mime/Email.php
@@ -9978,21 +10029,21 @@ diff --git a/src/Symfony/Component/Process/Process.php b/src/Symfony/Component/P
 +    public function start(?callable $callback = null, array $env = []): void
      {
          if ($this->isRunning()) {
-@@ -1147,5 +1147,5 @@ class Process implements \IteratorAggregate
+@@ -1151,5 +1151,5 @@ class Process implements \IteratorAggregate
       * @throws ProcessTimedOutException In case the timeout was reached
       */
 -    public function checkTimeout()
 +    public function checkTimeout(): void
      {
          if (self::STATUS_STARTED !== $this->status) {
-@@ -1188,5 +1188,5 @@ class Process implements \IteratorAggregate
+@@ -1192,5 +1192,5 @@ class Process implements \IteratorAggregate
       * @return void
       */
 -    public function setOptions(array $options)
 +    public function setOptions(array $options): void
      {
          if ($this->isRunning()) {
-@@ -1285,5 +1285,5 @@ class Process implements \IteratorAggregate
+@@ -1289,5 +1289,5 @@ class Process implements \IteratorAggregate
       * @return void
       */
 -    protected function updateStatus(bool $blocking)
@@ -10462,14 +10513,14 @@ diff --git a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php b/src/Symfony/
 +    public function setContext(RequestContext $context): void
      {
          $this->context = $context;
-@@ -106,5 +106,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
+@@ -109,5 +109,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
       * @return void
       */
 -    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
 +    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider): void
      {
          $this->expressionLanguageProviders[] = $provider;
-@@ -260,5 +260,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
+@@ -263,5 +263,5 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
       * @return ExpressionLanguage
       */
 -    protected function getExpressionLanguage()
@@ -10691,28 +10742,28 @@ diff --git a/src/Symfony/Component/Security/Core/Authentication/RememberMe/Token
 diff --git a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
 --- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
 +++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
-@@ -57,5 +57,5 @@ abstract class AbstractToken implements TokenInterface, \Serializable
+@@ -63,5 +63,5 @@ abstract class AbstractToken implements TokenInterface
       * @return void
       */
 -    public function setUser(UserInterface $user)
 +    public function setUser(UserInterface $user): void
      {
          $this->user = $user;
-@@ -65,5 +65,5 @@ abstract class AbstractToken implements TokenInterface, \Serializable
+@@ -71,5 +71,5 @@ abstract class AbstractToken implements TokenInterface
       * @return void
       */
 -    public function eraseCredentials()
 +    public function eraseCredentials(): void
      {
          if ($this->getUser() instanceof UserInterface) {
-@@ -122,5 +122,5 @@ abstract class AbstractToken implements TokenInterface, \Serializable
+@@ -128,5 +128,5 @@ abstract class AbstractToken implements TokenInterface
       * @return void
       */
 -    public function setAttributes(array $attributes)
 +    public function setAttributes(array $attributes): void
      {
          $this->attributes = $attributes;
-@@ -144,5 +144,5 @@ abstract class AbstractToken implements TokenInterface, \Serializable
+@@ -150,5 +150,5 @@ abstract class AbstractToken implements TokenInterface
       * @return void
       */
 -    public function setAttribute(string $name, mixed $value)
@@ -10883,7 +10934,7 @@ diff --git a/src/Symfony/Component/Security/Core/Exception/AuthenticationExcepti
 +    public function setToken(TokenInterface $token): void
      {
          $this->token = $token;
-@@ -85,5 +85,5 @@ class AuthenticationException extends RuntimeException
+@@ -91,5 +91,5 @@ class AuthenticationException extends RuntimeException
       * @return string
       */
 -    public function getMessageKey()
@@ -11372,63 +11423,63 @@ diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php 
 diff --git a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
 --- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
-@@ -146,5 +146,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -145,5 +145,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return bool
       */
 -    public function supportsNormalization(mixed $data, ?string $format = null /* , array $context = [] */)
 +    public function supportsNormalization(mixed $data, ?string $format = null /* , array $context = [] */): bool
      {
          return \is_object($data) && !$data instanceof \Traversable;
-@@ -154,5 +154,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -153,5 +153,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return array|string|int|float|bool|\ArrayObject|null
       */
 -    public function normalize(mixed $object, ?string $format = null, array $context = [])
 +    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
      {
          $context['_read_attributes'] = true;
-@@ -236,5 +236,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -235,5 +235,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return object
       */
 -    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, ?string $format = null)
 +    protected function instantiateObject(array &$data, string $class, array &$context, \ReflectionClass $reflectionClass, array|bool $allowedAttributes, ?string $format = null): object
      {
          if ($class !== $mappedClass = $this->getMappedClass($data, $class, $context)) {
-@@ -287,5 +287,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -286,5 +286,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return string[]
       */
 -    abstract protected function extractAttributes(object $object, ?string $format = null, array $context = []);
 +    abstract protected function extractAttributes(object $object, ?string $format = null, array $context = []): array;
  
      /**
-@@ -294,5 +294,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
-      * @return mixed
+@@ -295,5 +295,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @throws UninitializedPropertyException When the attribute exists but is not initialized on the object
       */
 -    abstract protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []);
 +    abstract protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []): mixed;
  
      /**
-@@ -301,5 +301,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -302,5 +302,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return bool
       */
 -    public function supportsDenormalization(mixed $data, string $type, ?string $format = null /* , array $context = [] */)
 +    public function supportsDenormalization(mixed $data, string $type, ?string $format = null /* , array $context = [] */): bool
      {
          return class_exists($type) || (interface_exists($type, false) && null !== $this->classDiscriminatorResolver?->getMappingForClass($type));
-@@ -309,5 +309,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -310,5 +310,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
       * @return mixed
       */
 -    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
 +    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
      {
          $context['_read_attributes'] = false;
-@@ -442,5 +442,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
-      * @return void
+@@ -436,5 +436,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+      * @throws NotNormalizableValueException When the value cannot be assigned to the attribute (e.g. type mismatch)
       */
 -    abstract protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []);
 +    abstract protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []): void;
  
      /**
-@@ -786,5 +786,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
+@@ -780,5 +780,5 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      }
  
 -    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false)
@@ -11473,14 +11524,14 @@ diff --git a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.p
 diff --git a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
 --- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
-@@ -175,5 +175,5 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
+@@ -183,5 +183,5 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
       * @return void
       */
 -    protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = [])
 +    protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []): void
      {
          $setter = 'set'.$attribute;
-@@ -189,5 +189,5 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
+@@ -197,5 +197,5 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
      }
  
 -    protected function isAllowedAttribute($classOrObject, string $attribute, ?string $format = null, array $context = [])
@@ -11526,14 +11577,14 @@ diff --git a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
 diff --git a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
 --- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
-@@ -131,5 +131,5 @@ class ObjectNormalizer extends AbstractObjectNormalizer
+@@ -133,5 +133,5 @@ class ObjectNormalizer extends AbstractObjectNormalizer
       * @return void
       */
 -    protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = [])
 +    protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []): void
      {
          try {
-@@ -140,5 +140,5 @@ class ObjectNormalizer extends AbstractObjectNormalizer
+@@ -144,5 +144,5 @@ class ObjectNormalizer extends AbstractObjectNormalizer
      }
  
 -    protected function isAllowedAttribute($classOrObject, string $attribute, ?string $format = null, array $context = [])
@@ -11543,7 +11594,7 @@ diff --git a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php b/
 diff --git a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
 --- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
 +++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
-@@ -196,5 +196,5 @@ class PropertyNormalizer extends AbstractObjectNormalizer
+@@ -201,5 +201,5 @@ class PropertyNormalizer extends AbstractObjectNormalizer
       * @return void
       */
 -    protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = [])
@@ -11782,7 +11833,7 @@ diff --git a/src/Symfony/Component/Templating/StreamingEngineInterface.php b/src
 diff --git a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
 --- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
 +++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
-@@ -184,4 +184,4 @@ abstract class AbstractOperation implements OperationInterface
+@@ -190,4 +190,4 @@ abstract class AbstractOperation implements OperationInterface
       * @return void
       */
 -    abstract protected function processDomain(string $domain);

--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
         "doctrine/annotations": "^1.13.1|^2",
         "doctrine/collections": "^1.0|^2.0",
         "doctrine/data-fixtures": "^1.1|^2",
-        "doctrine/dbal": "^2.13.1|^3.0",
+        "doctrine/dbal": "^2.13.1|^3|^4",
         "doctrine/orm": "^2.15|^3",
         "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^2.1.10|^3.1|^4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <ini name="memory_limit" value="-1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0&amp;ignoreFile=./.github/deprecation-ignore" />
         <env name="DUMP_LIGHT_ARRAY" value="" />
         <env name="DUMP_STRING_LENGTH" value="" />
         <env name="LDAP_HOST" value="localhost" />

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/AbstractSchemaListener.php
@@ -12,8 +12,14 @@
 namespace Symfony\Bridge\Doctrine\SchemaListener;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Exception as DBALDriverException;
+use Doctrine\DBAL\Exception\DatabaseObjectExistsException;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
@@ -23,60 +29,145 @@ abstract class AbstractSchemaListener
 {
     abstract public function postGenerateSchema(GenerateSchemaEventArgs $event): void;
 
-    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator): void
+    /**
+     * @param callable(): Schema $configurator returns the (possibly new) schema with the table added
+     *
+     * @return Schema The (possibly new) schema after filtering
+     */
+    protected function filterSchemaChanges(Schema $schema, Connection $connection, callable $configurator)
     {
         $filter = $connection->getConfiguration()->getSchemaAssetsFilter();
+        $getName = static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName();
 
-        if (null === $filter) {
-            $configurator();
-
-            return;
+        if (null !== $filter) {
+            $previousTableNames = array_map($getName, $schema->getTables());
+            $previousSequenceNames = array_map($getName, $schema->getSequences());
         }
 
-        $getNames = static fn ($array) => array_map(static fn ($object) => $object instanceof NamedObject ? $object->getObjectName()->toString() : $object->getName(), $array);
-        $previousTableNames = $getNames($schema->getTables());
-        $previousSequenceNames = $getNames($schema->getSequences());
+        $newSchema = $configurator() ?? $schema;
 
-        $configurator();
+        if (null !== $filter) {
+            $tablesToFilter = [];
+            foreach ($newSchema->getTables() as $table) {
+                $name = $getName($table);
+                if (!\in_array($name, $previousTableNames, true) && !$filter($name)) {
+                    $tablesToFilter[] = $table;
+                }
+            }
 
-        foreach (array_diff($getNames($schema->getTables()), $previousTableNames) as $addedTable) {
-            if (!$filter($addedTable)) {
-                $schema->dropTable($addedTable);
+            $sequencesToFilter = [];
+            foreach ($newSchema->getSequences() as $sequence) {
+                $name = $getName($sequence);
+                if (!\in_array($name, $previousSequenceNames, true) && !$filter($name)) {
+                    $sequencesToFilter[] = $sequence;
+                }
+            }
+
+            if ($tablesToFilter || $sequencesToFilter) {
+                // When doctrine/dbal minimum is bumped to ^4.5, the `else` branch
+                // (and the same fallback in every configureSchema() implementation)
+                // can be removed: Schema::edit() is then always available.
+                if (method_exists($newSchema, 'edit')) {
+                    $editor = $newSchema->edit();
+                    foreach ($tablesToFilter as $table) {
+                        $editor->dropTable($table->getObjectName());
+                    }
+                    foreach ($sequencesToFilter as $sequence) {
+                        $editor->dropSequence($sequence->getObjectName());
+                    }
+
+                    $newSchema = $editor->create();
+                } else {
+                    foreach ($tablesToFilter as $table) {
+                        $newSchema->dropTable($getName($table));
+                    }
+                    foreach ($sequencesToFilter as $sequence) {
+                        $newSchema->dropSequence($getName($sequence));
+                    }
+                }
             }
         }
 
-        foreach (array_diff($getNames($schema->getSequences()), $previousSequenceNames) as $addedSequence) {
-            if (!$filter($addedSequence)) {
-                $schema->dropSequence($addedSequence);
-            }
+        // Backfill the original $schema with new tables/sequences from $newSchema so that callers holding
+        // a reference to it (e.g. ORM's GenerateSchemaEventArgs prior to setSchema() being available) still
+        // see the changes. Goes through the protected _addTable/_addSequence to bypass the deprecated
+        // public createTable/createSequence.
+        //
+        // When doctrine/orm minimum is bumped to a version providing
+        // GenerateSchemaEventArgs::setSchema() (>= 3.6.8) and doctrine/dbal minimum is bumped
+        // to ^4.5, this whole block can be dropped and the
+        // `if (method_exists($schema, 'edit') && method_exists($event, 'setSchema'))` guards in
+        // each *SchemaListener subclass can become unconditional `$event->setSchema($schema);` calls.
+        // The Schema::edit() check is required because GenerateSchemaEventArgs::setSchema() itself
+        // relies on it and throws when running on a DBAL version that does not provide it.
+        if ($newSchema !== $schema) {
+            \Closure::bind(static function (Schema $schema) use ($newSchema, $getName): void {
+                foreach ($newSchema->getTables() as $table) {
+                    if (!$schema->hasTable($getName($table))) {
+                        $schema->_addTable($table);
+                    }
+                }
+                foreach ($newSchema->getSequences() as $sequence) {
+                    if (!$schema->hasSequence($getName($sequence))) {
+                        $schema->_addSequence($sequence);
+                    }
+                }
+            }, null, Schema::class)($schema);
         }
+
+        return $newSchema;
     }
 
+    /**
+     * @return \Closure(\Closure(string): mixed): bool
+     */
     protected function getIsSameDatabaseChecker(Connection $connection): \Closure
     {
         return static function (\Closure $exec) use ($connection): bool {
             $schemaManager = method_exists($connection, 'createSchemaManager') ? $connection->createSchemaManager() : $connection->getSchemaManager();
-            $checkTable = 'schema_subscriber_check_'.bin2hex(random_bytes(7));
-            $table = new Table($checkTable);
-            $table->addColumn('id', Types::INTEGER)
-                ->setAutoincrement(true)
-                ->setNotnull(true);
-            $table->setPrimaryKey(['id']);
+            $key = bin2hex(random_bytes(7));
 
-            $schemaManager->createTable($table);
+            if (method_exists(Table::class, 'editor')) {
+                $table = Table::editor()
+                    ->setUnquotedName('schema_subscriber_check_')
+                    ->addColumn(Column::editor()->setUnquotedName('id')->setTypeName(Types::INTEGER)->setAutoincrement(true)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName('random_key')->setTypeName(Types::STRING)->setLength(14)->setNotNull(true)->create())
+                    ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true))
+                    ->create();
+            } else {
+                // To be removed when doctrine/dbal minimum is bumped to ^4.4
+                $table = new Table('schema_subscriber_check_');
+                $table->addColumn('id', Types::INTEGER, ['autoincrement' => true, 'notnull' => true]);
+                $table->addColumn('random_key', Types::STRING, ['length' => 14, 'notnull' => true]);
 
-            try {
-                $exec(\sprintf('DROP TABLE %s', $checkTable));
-            } catch (\Exception) {
-                // ignore
+                if (class_exists(PrimaryKeyConstraint::class)) {
+                    $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true));
+                } else {
+                    $table->setPrimaryKey(['id']);
+                }
             }
 
             try {
-                $schemaManager->dropTable($checkTable);
+                $schemaManager->createTable($table);
+            } catch (DatabaseObjectExistsException) {
+            }
 
-                return false;
-            } catch (DatabaseObjectNotFoundException) {
-                return true;
+            $connection->executeStatement('INSERT INTO schema_subscriber_check_ (random_key) VALUES (:key)', ['key' => $key], ['key' => Types::STRING]);
+
+            try {
+                $exec(\sprintf('DELETE FROM schema_subscriber_check_ WHERE random_key = %s', $connection->getDatabasePlatform()->quoteStringLiteral($key)));
+            } catch (DBALDriverException|\PDOException) {
+            }
+
+            try {
+                return !$connection->executeStatement('DELETE FROM schema_subscriber_check_ WHERE random_key = :key', ['key' => $key], ['key' => Types::STRING]);
+            } finally {
+                if (!$connection->executeQuery('SELECT count(id) FROM schema_subscriber_check_')->fetchOne()) {
+                    try {
+                        $schemaManager->dropTable('schema_subscriber_check_');
+                    } catch (DatabaseObjectNotFoundException) {
+                    }
+                }
             }
         };
     }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/DoctrineDbalCacheAdapterSchemaListener.php
@@ -35,9 +35,11 @@ class DoctrineDbalCacheAdapterSchemaListener extends AbstractSchemaListener
 
         foreach ($this->dbalAdapters as $dbalAdapter) {
             $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-            $this->filterSchemaChanges($schema, $connection, static function () use ($dbalAdapter, $schema, $connection, $isSameDatabaseChecker) {
-                $dbalAdapter->configureSchema($schema, $connection, $isSameDatabaseChecker);
-            });
+            $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $dbalAdapter->configureSchema($schema, $connection, $isSameDatabaseChecker)) ?? $schema;
+        }
+
+        if (method_exists($schema, 'edit') && method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/LockStoreSchemaListener.php
@@ -36,9 +36,11 @@ final class LockStoreSchemaListener extends AbstractSchemaListener
             }
 
             $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-            $this->filterSchemaChanges($schema, $connection, static function () use ($store, $schema, $isSameDatabaseChecker) {
-                $store->configureSchema($schema, $isSameDatabaseChecker);
-            });
+            $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $store->configureSchema($schema, $isSameDatabaseChecker)) ?? $schema;
+        }
+
+        if (method_exists($schema, 'edit') && method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaListener.php
@@ -42,9 +42,11 @@ class MessengerTransportDoctrineSchemaListener extends AbstractSchemaListener
             }
 
             $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-            $this->filterSchemaChanges($schema, $connection, static function () use ($transport, $schema, $connection, $isSameDatabaseChecker) {
-                $transport->configureSchema($schema, $connection, $isSameDatabaseChecker);
-            });
+            $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $transport->configureSchema($schema, $connection, $isSameDatabaseChecker)) ?? $schema;
+        }
+
+        if (method_exists($schema, 'edit') && method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/PdoSessionHandlerSchemaListener.php
@@ -36,8 +36,10 @@ final class PdoSessionHandlerSchemaListener extends AbstractSchemaListener
         $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
         $sessionHandler = $this->sessionHandler;
 
-        $this->filterSchemaChanges($schema, $connection, static function () use ($sessionHandler, $schema, $isSameDatabaseChecker) {
-            $sessionHandler->configureSchema($schema, $isSameDatabaseChecker);
-        });
+        $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $sessionHandler->configureSchema($schema, $isSameDatabaseChecker)) ?? $schema;
+
+        if (method_exists($schema, 'edit') && method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
+        }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/RememberMeTokenProviderDoctrineSchemaListener.php
@@ -40,11 +40,12 @@ class RememberMeTokenProviderDoctrineSchemaListener extends AbstractSchemaListen
                 && ($tokenProvider = $rememberMeHandler->getTokenProvider()) instanceof DoctrineTokenProvider
             ) {
                 $isSameDatabaseChecker = $this->getIsSameDatabaseChecker($connection);
-                $this->filterSchemaChanges($schema, $connection, static function () use ($tokenProvider, $schema, $connection, $isSameDatabaseChecker) {
-                    /* @var DoctrineTokenProvider $tokenProvider */
-                    $tokenProvider->configureSchema($schema, $connection, $isSameDatabaseChecker);
-                });
+                $schema = $this->filterSchemaChanges($schema, $connection, static fn () => $tokenProvider->configureSchema($schema, $connection, $isSameDatabaseChecker)) ?? $schema;
             }
+        }
+
+        if (method_exists($schema, 'edit') && method_exists($event, 'setSchema')) {
+            $event->setSchema($schema);
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -15,7 +15,12 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
@@ -188,30 +193,63 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
      * Adds the Table to the Schema if "remember me" uses this Connection.
      *
      * @param \Closure $isSameDatabase
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */)
     {
         if ($schema->hasTable('rememberme_token')) {
-            return;
+            return $schema;
         }
 
         $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
 
         if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema($schema);
     }
 
-    private function addTableToSchema(Schema $schema): void
+    private function addTableToSchema(Schema $schema): Schema
     {
-        $table = $schema->createTable('rememberme_token');
+        if (method_exists($schema, 'edit')) {
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable('rememberme_token'));
+
+        return $schema;
+    }
+
+    private function buildSchemaTable(): Table
+    {
+        return Table::editor()
+            ->setUnquotedName('rememberme_token')
+            ->addColumn(Column::editor()->setUnquotedName('series')->setTypeName(Types::STRING)->setLength(88)->create())
+            ->addColumn(Column::editor()->setUnquotedName('value')->setTypeName(Types::STRING)->setLength(88)->create())
+            ->addColumn(Column::editor()->setUnquotedName('lastUsed')->setTypeName(Types::DATETIME_IMMUTABLE)->create())
+            ->addColumn(Column::editor()->setUnquotedName('class')->setTypeName(Types::STRING)->setLength(100)->setDefaultValue('')->create())
+            ->addColumn(Column::editor()->setUnquotedName('username')->setTypeName(Types::STRING)->setLength(200)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('series'))], true))
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
+    private function configureSchemaTable(Table $table): void
+    {
         $table->addColumn('series', Types::STRING, ['length' => 88]);
         $table->addColumn('value', Types::STRING, ['length' => 88]);
         $table->addColumn('lastUsed', Types::DATETIME_IMMUTABLE);
-        $table->addColumn('class', Types::STRING, ['length' => 100]);
+        $table->addColumn('class', Types::STRING, ['length' => 100, 'default' => '']);
         $table->addColumn('username', Types::STRING, ['length' => 200]);
-        $table->setPrimaryKey(['series']);
+
+        if (class_exists(PrimaryKeyConstraint::class)) {
+            $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('series'))], true));
+        } else {
+            $table->setPrimaryKey(['series']);
+        }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/DoctrineDbalCacheAdapterSchemaListenerTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +39,7 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
         $dbalAdapter = $this->createMock(DoctrineDbalAdapter::class);
         $dbalAdapter->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection, static fn () => true);
+            ->with($schema, $dbalConnection, $this->callback(static fn () => true));
 
         $subscriber = new DoctrineDbalCacheAdapterSchemaListener([$dbalAdapter]);
         $subscriber->postGenerateSchema($event);
@@ -60,13 +62,24 @@ class DoctrineDbalCacheAdapterSchemaListenerTest extends TestCase
         $dbalAdapter = $this->createStub(DoctrineDbalAdapter::class);
         $dbalAdapter->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
+                if (method_exists($schema, 'edit')) {
+                    $table = Table::editor()
+                        ->setUnquotedName('cache_items')
+                        ->addColumn(Column::editor()->setUnquotedName('item_id')->setTypeName('string')->create())
+                        ->create();
+
+                    return $schema->edit()->addTable($table)->create();
+                }
+
                 $table = $schema->createTable('cache_items');
                 $table->addColumn('item_id', 'string');
+
+                return $schema;
             });
 
         $listener = new DoctrineDbalCacheAdapterSchemaListener([$dbalAdapter]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('cache_items'));
+        $this->assertFalse($event->getSchema()->hasTable('cache_items'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/LockStoreSchemaListenerTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +38,7 @@ class LockStoreSchemaListenerTest extends TestCase
         $lockStore = $this->createMock(DoctrineDbalStore::class);
         $lockStore->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, static fn () => true);
+            ->with($schema, $this->callback(static fn () => true));
 
         $subscriber = new LockStoreSchemaListener((static fn () => yield $lockStore)());
         $subscriber->postGenerateSchema($event);
@@ -59,13 +61,23 @@ class LockStoreSchemaListenerTest extends TestCase
         $lockStore = $this->createStub(DoctrineDbalStore::class);
         $lockStore->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('lock_keys');
-                $table->addColumn('key_id', 'string');
+                if (method_exists($schema, 'edit')) {
+                    $table = Table::editor()
+                        ->setUnquotedName('lock_keys')
+                        ->addColumn(Column::editor()->setUnquotedName('key_id')->setTypeName('string')->create())
+                        ->create();
+
+                    return $schema->edit()->addTable($table)->create();
+                }
+
+                $schema->createTable('lock_keys')->addColumn('key_id', 'string');
+
+                return $schema;
             });
 
         $listener = new LockStoreSchemaListener([$lockStore]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('lock_keys'));
+        $this->assertFalse($event->getSchema()->hasTable('lock_keys'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaListenerTest.php
@@ -15,7 +15,9 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -40,7 +42,7 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
         $doctrineTransport = $this->createMock(DoctrineTransport::class);
         $doctrineTransport->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection, static fn () => true);
+            ->with($schema, $dbalConnection, $this->callback(static fn () => true));
         $otherTransport = $this->createMock(TransportInterface::class);
         $otherTransport->expects($this->never())
             ->method($this->anything());
@@ -125,15 +127,12 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
 
         $doctrineTransport = $this->createStub(DoctrineTransport::class);
         $doctrineTransport->method('configureSchema')
-            ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('messenger_messages');
-                $table->addColumn('id', 'integer', ['autoincrement' => true]);
-            });
+            ->willReturnCallback(self::addMessengerMessages(...));
 
         $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('messenger_messages'));
+        $this->assertFalse($event->getSchema()->hasTable('messenger_messages'));
     }
 
     public function testPostGenerateSchemaRespectsSchemaFilterIncludingSequences()
@@ -153,23 +152,23 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
 
         $doctrineTransport = $this->createStub(DoctrineTransport::class);
         $doctrineTransport->method('configureSchema')
-            ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('messenger_messages');
-                $table->addColumn('id', 'integer', ['autoincrement' => true]);
-                $schema->createSequence('messenger_messages_seq');
-            });
+            ->willReturnCallback(self::addMessengerMessagesWithSequence(...));
 
         $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('messenger_messages'));
-        $this->assertFalse($schema->hasSequence('messenger_messages_seq'));
+        $this->assertFalse($event->getSchema()->hasTable('messenger_messages'));
+        $this->assertFalse($event->getSchema()->hasSequence('messenger_messages_seq'));
     }
 
     public function testPostGenerateSchemaFilterDoesNotAffectPreExistingSequences()
     {
-        $schema = new Schema();
-        $schema->createSequence('existing_seq');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addSequence(new Sequence('existing_seq'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createSequence('existing_seq');
+        }
 
         $configuration = new Configuration();
         $excluded = ['messenger_messages', 'messenger_messages_seq', 'existing_seq'];
@@ -184,17 +183,44 @@ class MessengerTransportDoctrineSchemaListenerTest extends TestCase
 
         $doctrineTransport = $this->createStub(DoctrineTransport::class);
         $doctrineTransport->method('configureSchema')
-            ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('messenger_messages');
-                $table->addColumn('id', 'integer', ['autoincrement' => true]);
-                $schema->createSequence('messenger_messages_seq');
-            });
+            ->willReturnCallback(self::addMessengerMessagesWithSequence(...));
 
         $listener = new MessengerTransportDoctrineSchemaListener([$doctrineTransport]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('messenger_messages'));
-        $this->assertFalse($schema->hasSequence('messenger_messages_seq'));
-        $this->assertTrue($schema->hasSequence('existing_seq'));
+        $this->assertFalse($event->getSchema()->hasTable('messenger_messages'));
+        $this->assertFalse($event->getSchema()->hasSequence('messenger_messages_seq'));
+        $this->assertTrue($event->getSchema()->hasSequence('existing_seq'));
+    }
+
+    private static function addMessengerMessages(Schema $schema): Schema
+    {
+        if (method_exists($schema, 'edit')) {
+            return $schema->edit()->addTable(self::buildMessengerMessagesTable())->create();
+        }
+
+        $schema->createTable('messenger_messages')->addColumn('id', 'integer', ['autoincrement' => true]);
+
+        return $schema;
+    }
+
+    private static function addMessengerMessagesWithSequence(Schema $schema): Schema
+    {
+        if (method_exists($schema, 'edit')) {
+            return $schema->edit()->addTable(self::buildMessengerMessagesTable())->addSequence(new Sequence('messenger_messages_seq'))->create();
+        }
+
+        $schema->createTable('messenger_messages')->addColumn('id', 'integer', ['autoincrement' => true]);
+        $schema->createSequence('messenger_messages_seq');
+
+        return $schema;
+    }
+
+    private static function buildMessengerMessagesTable(): Table
+    {
+        return Table::editor()
+            ->setUnquotedName('messenger_messages')
+            ->addColumn(Column::editor()->setUnquotedName('id')->setTypeName('integer')->setAutoincrement(true)->create())
+            ->create();
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoSessionHandlerSchemaListenerTest.php
@@ -13,11 +13,15 @@ namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\SchemaListener\PdoSessionHandlerSchemaListener;
+use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
 class PdoSessionHandlerSchemaListenerTest extends TestCase
@@ -36,7 +40,7 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
         $pdoSessionHandler = $this->createMock(PdoSessionHandler::class);
         $pdoSessionHandler->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, static fn () => true);
+            ->with($schema, $this->callback(static fn () => true));
 
         $subscriber = new PdoSessionHandlerSchemaListener($pdoSessionHandler);
         $subscriber->postGenerateSchema($event);
@@ -59,8 +63,16 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
         $pdoSessionHandler = $this->createStub(PdoSessionHandler::class);
         $pdoSessionHandler->method('configureSchema')
             ->willReturnCallback(static function (Schema $schema) {
-                $table = $schema->createTable('sessions');
-                $table->addColumn('sess_id', 'string');
+                if (method_exists($schema, 'edit')) {
+                    $table = Table::editor()
+                        ->setUnquotedName('sessions')
+                        ->addColumn(Column::editor()->setUnquotedName('sess_id')->setTypeName('string')->create())
+                        ->create();
+
+                    return $schema->edit()->addTable($table)->create();
+                }
+
+                $schema->createTable('sessions')->addColumn('sess_id', 'string');
 
                 return $schema;
             });
@@ -68,6 +80,26 @@ class PdoSessionHandlerSchemaListenerTest extends TestCase
         $listener = new PdoSessionHandlerSchemaListener($pdoSessionHandler);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('sessions'));
+        $this->assertFalse($event->getSchema()->hasTable('sessions'));
+    }
+
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testPostGenerateSchemaWithDifferentDatabaseDoesNotThrow()
+    {
+        $entityManager = DoctrineTestHelper::createTestEntityManager();
+        $schema = new Schema();
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $sessionPdo = new \PDO('sqlite::memory:');
+        $sessionPdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $sessionHandler = new PdoSessionHandler($sessionPdo);
+        $subscriber = new PdoSessionHandlerSchemaListener($sessionHandler);
+
+        // When the session handler uses a different PDO connection than Doctrine's,
+        // the schema listener must not fail (it should just detect databases differ).
+        $subscriber->postGenerateSchema($event);
+
+        self::assertFalse($schema->hasTable('sessions'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/RememberMeTokenProviderDoctrineSchemaListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/RememberMeTokenProviderDoctrineSchemaListenerTest.php
@@ -54,7 +54,7 @@ class RememberMeTokenProviderDoctrineSchemaListenerTest extends TestCase
         $listener = new RememberMeTokenProviderDoctrineSchemaListener([$rememberMeHandler]);
         $listener->postGenerateSchema($event);
 
-        $this->assertTrue($schema->hasTable('rememberme_token'));
+        $this->assertTrue($event->getSchema()->hasTable('rememberme_token'));
     }
 
     public function testPostGenerateSchemaRespectsSchemaFilter()
@@ -82,6 +82,6 @@ class RememberMeTokenProviderDoctrineSchemaListenerTest extends TestCase
         $listener = new RememberMeTokenProviderDoctrineSchemaListener([$rememberMeHandler]);
         $listener->postGenerateSchema($event);
 
-        $this->assertFalse($schema->hasTable('rememberme_token'));
+        $this->assertFalse($event->getSchema()->hasTable('rememberme_token'));
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineDbalAdapter.php
@@ -19,8 +19,13 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\ServerVersionProvider;
 use Doctrine\DBAL\Tools\DsnParser;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
@@ -119,8 +124,7 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
      */
     public function createTable(): void
     {
-        $schema = new Schema();
-        $this->addTableToSchema($schema);
+        $schema = $this->addTableToSchema(new Schema());
 
         foreach ($schema->toSql($this->conn->getDatabasePlatform()) as $sql) {
             $this->conn->executeStatement($sql);
@@ -129,20 +133,22 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
 
     /**
      * @param \Closure $isSameDatabase
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema, Connection $forConnection/* , \Closure $isSameDatabase */)
     {
         if ($schema->hasTable($this->table)) {
-            return;
+            return $schema;
         }
 
         $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
 
         if ($forConnection !== $this->conn && !$isSameDatabase($this->conn->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema($schema);
     }
 
     public function prune(): bool
@@ -419,18 +425,53 @@ class DoctrineDbalAdapter extends AbstractAdapter implements PruneableInterface
         return $this->serverVersion = $conn->getAttribute(\PDO::ATTR_SERVER_VERSION);
     }
 
-    private function addTableToSchema(Schema $schema): void
+    private function addTableToSchema(Schema $schema): Schema
+    {
+        if (method_exists($schema, 'edit')) {
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->table));
+
+        return $schema;
+    }
+
+    private function buildSchemaTable(): Table
     {
         $types = [
             'mysql' => 'binary',
             'sqlite' => 'text',
         ];
 
-        $table = $schema->createTable($this->table);
+        return Table::editor()
+            ->setUnquotedName($this->table)
+            ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName($types[$this->getPlatformName()] ?? 'string')->setLength(255)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName('blob')->setLength(16777215)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName('integer')->setUnsigned(true)->setNotNull(false)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName('integer')->setUnsigned(true)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true))
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
+    private function configureSchemaTable(Table $table): void
+    {
+        $types = [
+            'mysql' => 'binary',
+            'sqlite' => 'text',
+        ];
+
         $table->addColumn($this->idCol, $types[$this->getPlatformName()] ?? 'string', ['length' => 255]);
         $table->addColumn($this->dataCol, 'blob', ['length' => 16777215]);
         $table->addColumn($this->lifetimeCol, 'integer', ['unsigned' => true, 'notnull' => false]);
         $table->addColumn($this->timeCol, 'integer', ['unsigned' => true]);
-        $table->setPrimaryKey([$this->idCol]);
+
+        if (class_exists(PrimaryKeyConstraint::class)) {
+            $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true));
+        } else {
+            $table->setPrimaryKey([$this->idCol]);
+        }
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineDbalAdapterTest.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\Cache\Tests\Fixtures\DriverWrapper;
@@ -83,10 +84,9 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         }
 
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile], $this->getDbalConfig());
-        $schema = new Schema();
 
         $adapter = new DoctrineDbalAdapter($connection);
-        $adapter->configureSchema($schema, $connection, static fn () => true);
+        $schema = $adapter->configureSchema(new Schema(), $connection, static fn () => true);
         $this->assertTrue($schema->hasTable('cache_items'));
     }
 
@@ -97,10 +97,9 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         }
 
         $otherConnection = $this->createConnection();
-        $schema = new Schema();
 
         $adapter = $this->createCachePool();
-        $adapter->configureSchema($schema, $otherConnection, static fn () => false);
+        $schema = $adapter->configureSchema(new Schema(), $otherConnection, static fn () => false);
         $this->assertFalse($schema->hasTable('cache_items'));
     }
 
@@ -111,13 +110,17 @@ class DoctrineDbalAdapterTest extends AdapterTestCase
         }
 
         $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile], $this->getDbalConfig());
-        $schema = new Schema();
-        $schema->createTable('cache_items');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new Table('cache_items'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('cache_items');
+        }
 
         $adapter = new DoctrineDbalAdapter($connection);
-        $adapter->configureSchema($schema, $connection, static fn () => true);
+        $schema = $adapter->configureSchema($schema, $connection, static fn () => true);
         $table = $schema->getTable('cache_items');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -11,7 +11,13 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 
 /**
@@ -180,50 +186,122 @@ class PdoSessionHandler extends AbstractSessionHandler
 
     /**
      * Adds the Table to the Schema if it doesn't exist.
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null): void
+    public function configureSchema(Schema $schema, ?\Closure $isSameDatabase = null)
     {
         if ($schema->hasTable($this->table) || ($isSameDatabase && !$isSameDatabase($this->getConnection()->exec(...)))) {
-            return;
+            return $schema;
         }
 
-        $table = $schema->createTable($this->table);
+        if (method_exists($schema, 'edit')) {
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->table));
+
+        return $schema;
+    }
+
+    private function buildSchemaTable(): Table
+    {
+        $editor = Table::editor()->setUnquotedName($this->table);
+
         switch ($this->driver) {
             case 'mysql':
-                $table->addColumn($this->idCol, Types::BINARY)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
-                $table->addOption('engine', 'InnoDB');
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::BINARY)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create())
+                    ->setOptions(['engine' => 'InnoDB']);
                 break;
             case 'sqlite':
-                $table->addColumn($this->idCol, Types::TEXT)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::TEXT)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create());
                 break;
             case 'pgsql':
-                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BINARY)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::STRING)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BINARY)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create());
                 break;
             case 'oci':
-                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setNotnull(true);
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::STRING)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setNotNull(true)->create());
                 break;
             case 'sqlsrv':
-                $table->addColumn($this->idCol, Types::STRING)->setLength(128)->setNotnull(true);
-                $table->addColumn($this->dataCol, Types::BLOB)->setNotnull(true);
-                $table->addColumn($this->lifetimeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
-                $table->addColumn($this->timeCol, Types::INTEGER)->setUnsigned(true)->setNotnull(true);
+                $editor
+                    ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName(Types::STRING)->setLength(128)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->dataCol)->setTypeName(Types::BLOB)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->lifetimeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create())
+                    ->addColumn(Column::editor()->setUnquotedName($this->timeCol)->setTypeName(Types::INTEGER)->setUnsigned(true)->setNotNull(true)->create());
                 break;
             default:
                 throw new \DomainException(\sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));
         }
-        $table->setPrimaryKey([$this->idCol]);
+
+        return $editor
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true))
+            ->addIndex(Index::editor()->setUnquotedName($this->lifetimeCol.'_idx')->setUnquotedColumnNames($this->lifetimeCol)->create())
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
+    private function configureSchemaTable(Table $table): void
+    {
+        switch ($this->driver) {
+            case 'mysql':
+                $table->addColumn($this->idCol, Types::BINARY, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
+                $table->addOption('engine', 'InnoDB');
+                break;
+            case 'sqlite':
+                $table->addColumn($this->idCol, Types::TEXT, ['notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['notnull' => true]);
+                break;
+            case 'pgsql':
+                $table->addColumn($this->idCol, Types::STRING, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BINARY, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['notnull' => true]);
+                break;
+            case 'oci':
+                $table->addColumn($this->idCol, Types::STRING, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['notnull' => true]);
+                break;
+            case 'sqlsrv':
+                $table->addColumn($this->idCol, Types::STRING, ['length' => 128, 'notnull' => true]);
+                $table->addColumn($this->dataCol, Types::BLOB, ['notnull' => true]);
+                $table->addColumn($this->lifetimeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
+                $table->addColumn($this->timeCol, Types::INTEGER, ['unsigned' => true, 'notnull' => true]);
+                break;
+            default:
+                throw new \DomainException(\sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));
+        }
+
+        if (class_exists(PrimaryKeyConstraint::class)) {
+            $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true));
+        } else {
+            $table->setPrimaryKey([$this->idCol]);
+        }
+
         $table->addIndex([$this->lifetimeCol], $this->lifetimeCol.'_idx');
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
@@ -329,31 +330,31 @@ class PdoSessionHandlerTest extends TestCase
 
     public function testConfigureSchemaDifferentDatabase()
     {
-        $schema = new Schema();
-
         $pdoSessionHandler = new PdoSessionHandler($this->getMemorySqlitePdo());
-        $pdoSessionHandler->configureSchema($schema, static fn () => false);
+        $schema = $pdoSessionHandler->configureSchema(new Schema(), static fn () => false);
         $this->assertFalse($schema->hasTable('sessions'));
     }
 
     public function testConfigureSchemaSameDatabase()
     {
-        $schema = new Schema();
-
         $pdoSessionHandler = new PdoSessionHandler($this->getMemorySqlitePdo());
-        $pdoSessionHandler->configureSchema($schema, static fn () => true);
+        $schema = $pdoSessionHandler->configureSchema(new Schema(), static fn () => true);
         $this->assertTrue($schema->hasTable('sessions'));
     }
 
     public function testConfigureSchemaTableExistsPdo()
     {
-        $schema = new Schema();
-        $schema->createTable('sessions');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new Table('sessions'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('sessions');
+        }
 
         $pdoSessionHandler = new PdoSessionHandler($this->getMemorySqlitePdo());
-        $pdoSessionHandler->configureSchema($schema, static fn () => true);
+        $schema = $pdoSessionHandler->configureSchema($schema, static fn () => true);
         $table = $schema->getTable('sessions');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 
     public static function provideUrlDsnPairs()

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalStore.php
@@ -17,8 +17,13 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tools\DsnParser;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
@@ -251,8 +256,8 @@ class DoctrineDbalStore implements PersistingStoreInterface
      */
     public function createTable(): void
     {
-        $schema = new Schema();
-        $this->configureSchema($schema);
+        $initialSchema = new Schema();
+        $schema = $this->configureSchema($initialSchema) ?? $initialSchema;
 
         foreach ($schema->toSql($this->conn->getDatabasePlatform()) as $sql) {
             $this->conn->executeStatement($sql);
@@ -263,20 +268,46 @@ class DoctrineDbalStore implements PersistingStoreInterface
      * Adds the Table to the Schema if it doesn't exist.
      *
      * @param \Closure $isSameDatabase
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema/* , \Closure $isSameDatabase */)
     {
         if ($schema->hasTable($this->table)) {
-            return;
+            return $schema;
         }
 
         $isSameDatabase = 1 < \func_num_args() ? func_get_arg(1) : static fn () => true;
 
         if (!$isSameDatabase($this->conn->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $table = $schema->createTable($this->table);
+        if (method_exists($schema, 'edit')) {
+            return $schema->edit()->addTable($this->buildSchemaTable())->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->table));
+
+        return $schema;
+    }
+
+    private function buildSchemaTable(): Table
+    {
+        return Table::editor()
+            ->setUnquotedName($this->table)
+            ->addColumn(Column::editor()->setUnquotedName($this->idCol)->setTypeName('string')->setLength(64)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->tokenCol)->setTypeName('string')->setLength(44)->create())
+            ->addColumn(Column::editor()->setUnquotedName($this->expirationCol)->setTypeName('integer')->setUnsigned(true)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted($this->idCol))], true))
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     */
+    private function configureSchemaTable(Table $table): void
+    {
         $table->addColumn($this->idCol, 'string', ['length' => 64]);
         $table->addColumn($this->tokenCol, 'string', ['length' => 44]);
         $table->addColumn($this->expirationCol, 'integer', ['unsigned' => true]);

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalStoreTest.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
@@ -366,35 +367,32 @@ class DoctrineDbalStoreTest extends AbstractStoreTestCase
     public function testConfigureSchemaDifferentDatabase()
     {
         $conn = $this->createStub(Connection::class);
-        $someFunction = static fn () => false;
-        $schema = new Schema();
-
         $dbalStore = new DoctrineDbalStore($conn);
-        $dbalStore->configureSchema($schema, $someFunction);
+        $schema = $dbalStore->configureSchema(new Schema(), static fn () => false);
         $this->assertFalse($schema->hasTable('lock_keys'));
     }
 
     public function testConfigureSchemaSameDatabase()
     {
         $conn = $this->createStub(Connection::class);
-        $someFunction = static fn () => true;
-        $schema = new Schema();
-
         $dbalStore = new DoctrineDbalStore($conn);
-        $dbalStore->configureSchema($schema, $someFunction);
+        $schema = $dbalStore->configureSchema(new Schema(), static fn () => true);
         $this->assertTrue($schema->hasTable('lock_keys'));
     }
 
     public function testConfigureSchemaTableExists()
     {
-        $conn = $this->createStub(Connection::class);
-        $schema = new Schema();
-        $schema->createTable('lock_keys');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new Table('lock_keys'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('lock_keys');
+        }
 
+        $conn = $this->createStub(Connection::class);
         $dbalStore = new DoctrineDbalStore($conn);
-        $someFunction = static fn () => true;
-        $dbalStore->configureSchema($schema, $someFunction);
+        $schema = $dbalStore->configureSchema($schema, static fn () => true);
         $table = $schema->getTable('lock_keys');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 }

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -21,11 +21,11 @@
         "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.13|^3|^4",
+        "doctrine/dbal": "^2.13.1|^3|^4",
         "predis/predis": "^1.1|^2.0"
     },
     "conflict": {
-        "doctrine/dbal": "<2.13",
+        "doctrine/dbal": "<2.13.1",
         "symfony/cache": "<6.2"
     },
     "autoload": {

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -25,8 +25,10 @@ use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
@@ -621,10 +623,9 @@ class ConnectionTest extends TestCase
     public function testConfigureSchema()
     {
         $driverConnection = $this->getDBALConnection();
-        $schema = new Schema();
 
         $connection = new Connection(['table_name' => 'queue_table'], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection, static fn () => true);
+        $schema = $connection->configureSchema(new Schema(), $driverConnection, static fn () => true);
         $this->assertTrue($schema->hasTable('queue_table'));
 
         // Ensure the covering index for the SELECT query exists
@@ -648,23 +649,26 @@ class ConnectionTest extends TestCase
     {
         $driverConnection = $this->getDBALConnection();
         $driverConnection2 = $this->getDBALConnection();
-        $schema = new Schema();
 
         $connection = new Connection([], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection2, static fn () => false);
+        $schema = $connection->configureSchema(new Schema(), $driverConnection2, static fn () => false);
         $this->assertFalse($schema->hasTable('messenger_messages'));
     }
 
     public function testConfigureSchemaTableExists()
     {
         $driverConnection = $this->getDBALConnection();
-        $schema = new Schema();
-        $schema->createTable('messenger_messages');
+        if (method_exists(Schema::class, 'edit')) {
+            $schema = (new Schema())->edit()->addTable(new Table('messenger_messages'))->create();
+        } else {
+            $schema = new Schema();
+            $schema->createTable('messenger_messages');
+        }
 
         $connection = new Connection([], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection, static fn () => true);
+        $schema = $connection->configureSchema($schema, $driverConnection, static fn () => true);
         $table = $schema->getTable('messenger_messages');
-        $this->assertEmpty($table->getColumns(), 'The table was not overwritten');
+        $this->assertSame([], $table->getColumns(), 'The table was not overwritten');
     }
 
     /**
@@ -733,16 +737,27 @@ class ConnectionTest extends TestCase
     {
         $driverConnection = $this->createStub(DBALConnection::class);
         $driverConnection->method('getDatabasePlatform')->willReturn(new OraclePlatform());
-        $schema = new Schema();
+
+        // Mock the result returned by executeQuery to be an Oracle version 12.1.0 or higher.
+        $result = $this->createStub(Result::class);
+        $result->method('fetchOne')->willReturn('12.1.0');
+        $driverConnection->method('executeQuery')->willReturn($result);
 
         $connection = new Connection(['table_name' => 'messenger_messages'], $driverConnection);
-        $connection->configureSchema($schema, $driverConnection, static fn () => true);
+        $schema = $connection->configureSchema(new Schema(), $driverConnection, static fn () => true);
 
         $expectedSuffix = '_seq';
         $sequences = $schema->getSequences();
         $this->assertCount(1, $sequences);
         $sequence = array_pop($sequences);
-        $sequenceNameSuffix = substr($sequence->getName(), -\strlen($expectedSuffix));
+        if ($sequence instanceof NamedObject) {
+            // DBAL 4.4+
+            $sequenceName = $sequence->getObjectName()->toString();
+        } else {
+            // DBAL < 4.4
+            $sequenceName = $sequence->getName();
+        }
+        $sequenceNameSuffix = substr($sequenceName, -\strlen($expectedSuffix));
         $this->assertSame($expectedSuffix, $sequenceNameSuffix);
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
@@ -62,11 +62,12 @@ class DoctrineTransportTest extends TestCase
         $schema = new Schema();
         $dbalConnection = $this->createStub(DbalConnection::class);
 
+        $isSameDatabaseChecker = static fn () => true;
         $connection->expects($this->once())
             ->method('configureSchema')
-            ->with($schema, $dbalConnection, static fn () => true);
+            ->with($schema, $dbalConnection, $isSameDatabaseChecker);
 
-        $transport->configureSchema($schema, $dbalConnection, static fn () => true);
+        $transport->configureSchema($schema, $dbalConnection, $isSameDatabaseChecker);
     }
 
     private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null): DoctrineTransport

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -24,10 +24,16 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
+use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
@@ -336,17 +342,17 @@ class Connection implements ResetInterface
     /**
      * @internal
      */
-    public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase): void
+    public function configureSchema(Schema $schema, DBALConnection $forConnection, \Closure $isSameDatabase): Schema
     {
         if ($schema->hasTable($this->configuration['table_name'])) {
-            return;
+            return $schema;
         }
 
         if ($forConnection !== $this->driverConnection && !$isSameDatabase($this->executeStatement(...))) {
-            return;
+            return $schema;
         }
 
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema($schema);
     }
 
     /**
@@ -486,42 +492,93 @@ class Connection implements ResetInterface
 
     private function getSchema(): Schema
     {
-        $schema = new Schema([], [], $this->createSchemaManager()->createSchemaConfig());
-        $this->addTableToSchema($schema);
+        return $this->addTableToSchema(new Schema([], [], $this->createSchemaManager()->createSchemaConfig()));
+    }
+
+    private function addTableToSchema(Schema $schema): Schema
+    {
+        $oracleSequenceName = null;
+        $idOptions = ['autoincrement' => true, 'notnull' => true];
+
+        // We need to create a sequence for Oracle and set the id column to get the correct nextval
+        if ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
+            $serverVersion = $this->driverConnection->executeQuery("SELECT version FROM product_component_version WHERE product LIKE 'Oracle Database%'")->fetchOne();
+            if (version_compare($serverVersion, '12.1.0', '>=')) {
+                $oracleSequenceName = $this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX;
+                // disable the creation of SEQUENCE and TRIGGER, use the sequence's nextval as default instead
+                $idOptions = ['autoincrement' => false, 'notnull' => true, 'default' => $oracleSequenceName.'.nextval'];
+            }
+        }
+
+        if (method_exists($schema, 'edit')) {
+            $editor = $schema->edit()->addTable($this->buildSchemaTable($oracleSequenceName));
+            if (null !== $oracleSequenceName) {
+                $editor->addSequence(new Sequence($oracleSequenceName));
+            }
+
+            return $editor->create();
+        }
+
+        $this->configureSchemaTable($schema->createTable($this->configuration['table_name']), $idOptions);
+
+        if (null !== $oracleSequenceName) {
+            $schema->createSequence($oracleSequenceName);
+        }
 
         return $schema;
     }
 
-    private function addTableToSchema(Schema $schema): void
+    private function buildSchemaTable(?string $oracleSequenceName): Table
     {
-        $table = $schema->createTable($this->configuration['table_name']);
+        $idEditor = Column::editor()->setUnquotedName('id')->setTypeName(Types::BIGINT)->setNotNull(true);
+
+        if (null !== $oracleSequenceName) {
+            // disable the creation of SEQUENCE and TRIGGER, use the sequence's nextval as default instead
+            $idEditor->setAutoincrement(false)->setDefaultValue($oracleSequenceName.'.nextval');
+        } else {
+            $idEditor->setAutoincrement(true);
+        }
+
+        return Table::editor()
+            ->setUnquotedName($this->configuration['table_name'])
+            // add an internal option to mark that we created this & the non-namespaced table name
+            ->setOptions([self::TABLE_OPTION_NAME => $this->configuration['table_name']])
+            ->addColumn($idEditor->create())
+            ->addColumn(Column::editor()->setUnquotedName('body')->setTypeName(Types::TEXT)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('headers')->setTypeName(Types::TEXT)->setNotNull(true)->create())
+            // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
+            ->addColumn(Column::editor()->setUnquotedName('queue_name')->setTypeName(Types::STRING)->setLength(190)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('created_at')->setTypeName(Types::DATETIME_IMMUTABLE)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('available_at')->setTypeName(Types::DATETIME_IMMUTABLE)->setNotNull(true)->create())
+            ->addColumn(Column::editor()->setUnquotedName('delivered_at')->setTypeName(Types::DATETIME_IMMUTABLE)->setNotNull(false)->create())
+            ->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true))
+            ->addIndex(Index::editor()->setUnquotedColumnNames('queue_name', 'available_at', 'delivered_at', 'id'))
+            ->create();
+    }
+
+    /**
+     * To be removed when doctrine/dbal minimum is bumped to ^4.5.
+     *
+     * @param array<string, mixed> $idOptions
+     */
+    private function configureSchemaTable(Table $table, array $idOptions): void
+    {
         // add an internal option to mark that we created this & the non-namespaced table name
         $table->addOption(self::TABLE_OPTION_NAME, $this->configuration['table_name']);
-        $idColumn = $table->addColumn('id', Types::BIGINT)
-            ->setAutoincrement(true)
-            ->setNotnull(true);
-        $table->addColumn('body', Types::TEXT)
-            ->setNotnull(true);
-        $table->addColumn('headers', Types::TEXT)
-            ->setNotnull(true);
-        $table->addColumn('queue_name', Types::STRING)
-            ->setLength(190) // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
-            ->setNotnull(true);
-        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(true);
-        $table->addColumn('available_at', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(true);
-        $table->addColumn('delivered_at', Types::DATETIME_IMMUTABLE)
-            ->setNotnull(false);
-        $table->setPrimaryKey(['id']);
-        $table->addIndex(['queue_name', 'available_at', 'delivered_at', 'id']);
-
-        // We need to create a sequence for Oracle and set the id column to get the correct nextval
-        if ($this->driverConnection->getDatabasePlatform() instanceof OraclePlatform) {
-            $idColumn->setDefault($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX.'.nextval');
-
-            $schema->createSequence($this->configuration['table_name'].self::ORACLE_SEQUENCES_SUFFIX);
+        $table->addColumn('id', Types::BIGINT, $idOptions);
+        $table->addColumn('body', Types::TEXT, ['notnull' => true]);
+        $table->addColumn('headers', Types::TEXT, ['notnull' => true]);
+        // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
+        $table->addColumn('queue_name', Types::STRING, ['length' => 190, 'notnull' => true]);
+        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE, ['notnull' => true]);
+        $table->addColumn('available_at', Types::DATETIME_IMMUTABLE, ['notnull' => true]);
+        $table->addColumn('delivered_at', Types::DATETIME_IMMUTABLE, ['notnull' => false]);
+        if (class_exists(PrimaryKeyConstraint::class)) {
+            $table->addPrimaryKeyConstraint(new PrimaryKeyConstraint(null, [new UnqualifiedName(Identifier::unquoted('id'))], true));
+        } else {
+            $table->setPrimaryKey(['id']);
         }
+        $table->addIndex(['queue_name', 'available_at', 'delivered_at', 'id']);
     }
 
     private function decodeEnvelopeHeaders(array $doctrineEnvelope): array

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -81,12 +81,14 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
      * Adds the Table to the Schema if this transport uses this connection.
      *
      * @param \Closure $isSameDatabase
+     *
+     * @return Schema The (possibly new) schema with the table added
      */
-    public function configureSchema(Schema $schema, DbalConnection $forConnection/* , \Closure $isSameDatabase */): void
+    public function configureSchema(Schema $schema, DbalConnection $forConnection/* , \Closure $isSameDatabase */)
     {
         $isSameDatabase = 2 < \func_num_args() ? func_get_arg(2) : static fn () => false;
 
-        $this->connection->configureSchema($schema, $forConnection, $isSameDatabase);
+        return $this->connection->configureSchema($schema, $forConnection, $isSameDatabase) ?? $schema;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #64588 (and its prerequisite #64389) to 6.4.

DBAL 4.5 deprecates the `Table`/`Schema` mutators (`addColumn()`, `addIndex()`, `addPrimaryKeyConstraint()`, `addOption()`, `Schema::createTable()`/`createSequence()`). These code paths were never migrated on 6.4 because the root `composer.json` constrained `doctrine/dbal` to `^2.13.1|^3.0`, so CI never resolved DBAL 4.x even though the component manifests already allowed `^4`. The previous commit widens the root constraint to `^4` and this migrates the table definitions accordingly.

The schema is built using `Table::editor()`, `Column::editor()` and `Index::editor()` on the code paths that run on DBAL 4.5+, keeping the previous mutators as a fallback for older versions. `configureSchema()` now returns the (possibly new, immutable) schema, and `AbstractSchemaListener::filterSchemaChanges()` filters via `Schema::edit()` and backfills the original schema for callers still holding a reference (ORM's `GenerateSchemaEventArgs` prior to `setSchema()`).

The generated tables are identical: columns, primary keys, options and index names are preserved.
