### PR TITLE
[Messenger] Add an optional LoggingMiddleware logging processing time and memory usage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -34,6 +34,7 @@ use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\LoggingMiddleware;
 use Symfony\Component\Messenger\Middleware\RejectRedeliveredMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
@@ -154,6 +155,13 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('router'),
             ])
+
+        ->set('messenger.middleware.logging', LoggingMiddleware::class)
+            ->args([
+                service('logger'),
+                service('clock'),
+            ])
+            ->tag('monolog.logger', ['channel' => 'messenger'])
 
         // Discovery
         ->set('messenger.receiver_locator', ServiceLocator::class)

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add a `--redispatch` option to the `messenger:failed:retry` command to send messages back to their transport instead of handling them in the command
  * Allow prioritizing receivers so that `messenger:consume --all` consumes receivers in a predefined order
  * Add an optional `extra` key to the encoded envelope passed to `SerializerInterface::decode()`, holding metadata added by the receiving transport
+ * Add an optional `LoggingMiddleware` logging the processing time and memory usage of each message
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+
+/**
+ * Measures processing time and memory consumption, then logs whether the
+ * message was handled, sent to a transport, or failed.
+ *
+ * Optional middleware: add it at whatever position in the stack suits
+ * your logging needs.
+ *
+ * @author Marie Charles <marie.charles@hetic.net>
+ */
+class LoggingMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var \Closure(): int
+     */
+    private \Closure $memoryResolver;
+
+    /**
+     * @param ?(callable(): int) $memoryResolver
+     */
+    public function __construct(
+        private LoggerInterface $logger,
+        private ClockInterface $clock = new Clock(),
+        ?callable $memoryResolver = null,
+    ) {
+        $memoryResolver ??= static fn (): int => memory_get_usage();
+        $this->memoryResolver = $memoryResolver(...);
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $context = [
+            'class' => get_debug_type($envelope->getMessage()),
+        ];
+
+        $memoryResolver = $this->memoryResolver;
+
+        $startTime = (float) $this->clock->now()->format('U.u');
+        $startMemory = $memoryResolver();
+
+        $success = false;
+
+        try {
+            $envelope = $stack->next()->handle($envelope, $stack);
+
+            $success = true;
+
+            return $envelope;
+        } catch (\Throwable $exception) {
+            $context['exception'] = $exception;
+
+            throw $exception;
+        } finally {
+            $endTime = (float) $this->clock->now()->format('U.u');
+
+            $context = [
+                ...$context,
+                'duration_ms' => (int) round(($endTime - $startTime) * 1000),
+                'memory_usage' => $memoryResolver() - $startMemory,
+            ];
+
+            if (!$success) {
+                $this->logger->error('Unable to handle "{class}" message.', $context);
+            } elseif ($envelope->last(SentStamp::class)) {
+                $this->logger->info('"{class}" message sent to transport.', $context);
+            } else {
+                $this->logger->info('"{class}" message successfully handled.', $context);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/LoggingMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/LoggingMiddlewareTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\LoggingMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
+
+class LoggingMiddlewareTest extends MiddlewareTestCase
+{
+    #[DataProvider('provideDurationAndMemoryUsageByStack')]
+    public function testHandle(
+        callable $nextMiddlewares,
+        int $durationInMilliseconds,
+        int $memoryUsageDelta,
+    ) {
+        $clock = new MockClock();
+        $memoryResolver = $this->createMemoryResolver($memoryUsageDelta);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with('"{class}" message successfully handled.', [
+                'class' => DummyMessage::class,
+                'duration_ms' => $durationInMilliseconds,
+                'memory_usage' => $memoryUsageDelta,
+            ])
+        ;
+
+        $loggingMiddleware = new LoggingMiddleware($logger, $clock, $memoryResolver);
+
+        $loggingMiddleware->handle(new Envelope(
+            new DummyMessage('Hello')),
+            new StackMiddleware(new \ArrayIterator([null, ...$nextMiddlewares($clock)]))
+        );
+    }
+
+    public static function provideDurationAndMemoryUsageByStack(): iterable
+    {
+        $nextMiddleware = static fn (ClockInterface $clock, int $durationInSeconds): MiddlewareInterface => new class($clock, $durationInSeconds) implements MiddlewareInterface {
+            public function __construct(private ClockInterface $clock, private int $durationInSeconds)
+            {
+            }
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                $this->clock->sleep($this->durationInSeconds);
+
+                return $stack->next()->handle($envelope, $stack);
+            }
+        };
+
+        yield 'Stack is empty' => [
+            static fn (): array => [],
+            0,
+            0,
+        ];
+
+        yield 'One middleware in stack' => [
+            static fn (ClockInterface $clock): array => [
+                $nextMiddleware($clock, 1),
+            ],
+            1000,
+            1024,
+        ];
+
+        yield 'More than one middleware in stack' => [
+            static fn (ClockInterface $clock): array => [
+                $nextMiddleware($clock, 1),
+                $nextMiddleware($clock, 2),
+            ],
+            3000,
+            2048,
+        ];
+    }
+
+    public function testHandleWhenTheMessageIsOnlySentToATransport()
+    {
+        $clock = new MockClock();
+        $memoryResolver = $this->createMemoryResolver(0);
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->once())->method('send')->willReturnArgument(0);
+
+        $sendersLocator = new class($sender) implements SendersLocatorInterface {
+            public function __construct(private SenderInterface $sender)
+            {
+            }
+
+            public function getSenders(Envelope $envelope): iterable
+            {
+                yield 'async' => $this->sender;
+            }
+        };
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with('"{class}" message sent to transport.', [
+                'class' => DummyMessage::class,
+                'duration_ms' => 0,
+                'memory_usage' => 0,
+            ])
+        ;
+
+        $loggingMiddleware = new LoggingMiddleware($logger, $clock, $memoryResolver);
+
+        $loggingMiddleware->handle(
+            new Envelope(new DummyMessage('Hello')),
+            new StackMiddleware(new \ArrayIterator([null, new SendMessageMiddleware($sendersLocator)]))
+        );
+    }
+
+    public function testHandleWithException()
+    {
+        $clock = new MockClock();
+        $memoryResolver = $this->createMemoryResolver(0);
+
+        $exception = new \RuntimeException('Thrown from next middleware.');
+
+        $nextMiddleware = $this->createMock(MiddlewareInterface::class);
+        $nextMiddleware->expects($this->once())
+            ->method('handle')
+            ->willThrowException($exception)
+        ;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('Unable to handle "{class}" message.', [
+                'class' => DummyMessage::class,
+                'duration_ms' => 0,
+                'memory_usage' => 0,
+                'exception' => $exception,
+            ])
+        ;
+
+        $loggingMiddleware = new LoggingMiddleware($logger, $clock, $memoryResolver);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
+
+        $loggingMiddleware->handle(new Envelope(
+            new DummyMessage('Hello')),
+            new StackMiddleware(new \ArrayIterator([null, $nextMiddleware]))
+        );
+    }
+
+    /**
+     * @return callable(): int
+     */
+    private function createMemoryResolver(int $memoryUsageDelta): callable
+    {
+        $values = [0, $memoryUsageDelta];
+        $index = 0;
+
+        return static function () use ($values, &$index): int {
+            return $values[$index++];
+        };
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Adds an opt-in `LoggingMiddleware` that logs, for every message going through a bus, how long it took and how much memory it used. The goal is observability of Messenger workloads in production: spotting slow or memory heavy messages, and building dashboards and alerts from the logs.

Enabling it, per bus:

```yaml
framework:
    messenger:
        buses:
            messenger.bus.default:
                middleware:
                    - logging
```

The service is `messenger.middleware.logging` and sits in no default stack, so applications that do not list it are unaffected. Its position in the stack decides what is measured: everything below it.

What it logs, on the `messenger` channel:

| level | message | when |
| --- | --- | --- |
| `info` | `"{class}" message successfully handled.` | the message was handled |
| `info` | `"{class}" message sent to transport.` | the message was only queued |
| `error` | `Unable to handle "{class}" message.` | the stack threw |

Context keys: `class`, `duration_ms`, `memory_usage` (a delta in bytes), plus `exception` for the failure case.

The two `info` cases are separate on purpose. An asynchronous message is logged twice in its life: once when it is dispatched, where the duration is the time to hand it to the transport, and once in the worker, where the duration is the time to handle it. One message for both would make a dashboard count every message twice and read send latency as handling time.

The middleware takes an optional `ClockInterface` and an optional memory resolver as second and third arguments, which keeps it testable without a hidden clock. The registered service passes the `clock` service.

Documentation points:

- how to enable it, per bus, and that its position in the stack decides what is measured
- the three log messages, their levels and their context keys
- the sent versus handled distinction, and what it means when building dashboards
- `memory_usage` is a `memory_get_usage()` delta, so it can be negative when a handler frees more than it allocates
