### PR TITLE
[Mailer] Reorder EsmtpTransport authenticators to prefer PLAIN over obsolete LOGIN

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Reorder EsmtpTransport authenticators to prefer PLAIN over obsolete LOGIN
+
 8.0
 ---
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportTest.php
@@ -126,7 +126,7 @@ class EsmtpTransportTest extends TestCase
             $transport->send($message);
             $this->fail('Symfony\Component\Mailer\Exception\TransportException to be thrown');
         } catch (TransportException $e) {
-            $this->assertStringStartsWith('Failed to authenticate on SMTP server with username "testuser" using the following authenticators: "CRAM-MD5", "LOGIN", "PLAIN", "XOAUTH2".', $e->getMessage());
+            $this->assertStringStartsWith('Failed to authenticate on SMTP server with username "testuser" using the following authenticators: "CRAM-MD5", "PLAIN", "LOGIN", "XOAUTH2".', $e->getMessage());
         }
 
         $this->assertEquals(
@@ -140,15 +140,15 @@ class EsmtpTransportTest extends TestCase
                 // S: 535 5.7.139 Authentication unsuccessful
                 "RSET\r\n",
                 // S: 250 2.0.0 Resetting
+                "AUTH PLAIN dGVzdHVzZXIAdGVzdHVzZXIAcDRzc3cwcmQ=\r\n",
+                // S: 535 5.7.139 Authentication unsuccessful
+                "RSET\r\n",
+                // S: 250 2.0.0 Resetting
                 "AUTH LOGIN\r\n",
                 // S: 334 VXNlcm5hbWU6
                 "dGVzdHVzZXI=\r\n",
                 // S: 334 UGFzc3dvcmQ6
                 "cDRzc3cwcmQ=\r\n",
-                // S: 535 5.7.139 Authentication unsuccessful
-                "RSET\r\n",
-                // S: 250 2.0.0 Resetting
-                "AUTH PLAIN dGVzdHVzZXIAdGVzdHVzZXIAcDRzc3cwcmQ=\r\n",
                 // S: 535 5.7.139 Authentication unsuccessful
                 "RSET\r\n",
                 // S: 250 2.0.0 Resetting

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -44,8 +44,8 @@ class EsmtpTransport extends SmtpTransport
             // order is important here (roughly most secure and popular first)
             $authenticators = [
                 new Auth\CramMd5Authenticator(),
-                new Auth\LoginAuthenticator(),
                 new Auth\PlainAuthenticator(),
+                new Auth\LoginAuthenticator(),
                 new Auth\XOAuth2Authenticator(),
             ];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        |  <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

The [IANA SASL mechanism registry](https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml) marks LOGIN as OBSOLETE, referencing [draft-murchison-sasl-login-00](https://datatracker.ietf.org/doc/html/draft-murchison-sasl-login-00), which states:

> "The LOGIN SASL mechanism SHOULD NOT be used by a client when other plaintext mechanisms are offered by a server." 

LOGIN was always an informal mechanism and never had a proper RFC. PLAIN, its documented replacement, is standardised in RFC 4616.

Currently, when a server advertises both LOGIN and PLAIN, Symfony Mailer selects LOGIN because it appears first in the default authenticator list. This PR moves PLAIN before LOGIN so that the standard mechanism is preferred.

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
