### PR TITLE
[Translation] PoFileDumper unconditionally splits strings containing pipes (|), breaking ICU and template formatters

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -67,6 +67,12 @@ class PoFileDumper extends FileDumper
 
     private function getStandardRules(string $id): array
     {
+        // If the string contains a pipe inside double braces, it cannot be a legacy plural string.
+        // e.g. "{{subject}} must not be an instance of {{class|quote}}"
+        if (preg_match('/\{\{[^}]*\|[^}]*\}\}/', $id)) {
+            return [];
+        }
+
         // Partly copied from TranslatorTrait::trans.
         $parts = [];
         if (preg_match('/^\|++$/', $id)) {

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -67,17 +67,11 @@ class PoFileDumper extends FileDumper
 
     private function getStandardRules(string $id): array
     {
-        // If the string contains a pipe inside double braces, it cannot be a legacy plural string.
-        // e.g. "{{subject}} must not be an instance of {{class|quote}}"
-        if (preg_match('/\{\{[^}]*\|[^}]*\}\}/', $id)) {
-            return [];
-        }
-
         // Partly copied from TranslatorTrait::trans.
         $parts = [];
         if (preg_match('/^\|++$/', $id)) {
             $parts = explode('|', $id);
-        } elseif (preg_match_all('/(?:\|\||[^\|])++/', $id, $matches)) {
+        } elseif (preg_match_all('/(?:\{\{[^}]*\}\}|\|\||[^\|])++/', $id, $matches)) {
             $parts = $matches[0];
         }
 

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -67,11 +67,16 @@ class PoFileDumper extends FileDumper
 
     private function getStandardRules(string $id): array
     {
-        // Partly copied from TranslatorTrait::trans.
+        $doubleBraceBlock = '\{\{[^}]*\}\}';
+        $simplePipe = '\|';
+        $doublePipe = '\|\|';
+        $nonPipe = '[^\|]';
+
+        // Adapted from TranslatorTrait::trans.
         $parts = [];
-        if (preg_match('/^\|++$/', $id)) {
+        if (preg_match("/^(?:$simplePipe)++$/", $id)) {
             $parts = explode('|', $id);
-        } elseif (preg_match_all('/(?:\{\{[^}]*\}\}|\|\||[^\|])++/', $id, $matches)) {
+        } elseif (preg_match_all("/(?:$doubleBraceBlock|$doublePipe|$nonPipe)++/", $id, $matches)) {
             $parts = $matches[0];
         }
 

--- a/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
@@ -58,4 +58,21 @@ class PoFileDumperTest extends TestCase
 
         $this->assertStringEqualsFile(__DIR__.'/../Fixtures/plurals.po', $dumper->formatCatalogue($catalogue, 'messages'));
     }
+
+    public function testDumpPipeInBraces()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->add([
+            // Pipe inside double braces must not be treated as a plural separator
+            '{{subject}} must not be an instance of {{class|quote}}' => '{{subject}} must not be an instance of {{class|quote}}',
+            // Pipe inside ICU-style single braces must not be treated as a plural separator
+            'Found {count, plural, one{# item|filtered} other{# items|filtered}}' => 'Found {count, plural, one{# item|filtered} other{# items|filtered}}',
+            // Legacy plural must still work
+            'apple|apples' => 'pomme|pommes',
+        ]);
+
+        $dumper = new PoFileDumper();
+
+        $this->assertStringEqualsFile(__DIR__.'/../Fixtures/pipe-in-braces.po', $dumper->formatCatalogue($catalogue, 'messages'));
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
@@ -69,6 +69,14 @@ class PoFileDumperTest extends TestCase
             'Found {count, plural, one{# item|filtered} other{# items|filtered}}' => 'Found {count, plural, one{# item|filtered} other{# items|filtered}}',
             // Legacy plural must still work
             'apple|apples' => 'pomme|pommes',
+            // Pipe between double-brace blocks is still a valid legacy plural
+            '{{subject}} has no apple|{{subject}} has apples' => '{{subject}} has no apple|{{subject}} has apples',
+            // Multiple pipes inside different double-brace blocks
+            '{{subject|quote}} and {{class|raw}}' => '{{subject|quote}} and {{class|raw}}',
+            // Double pipe inside double braces (escaped pipe)
+            '{{subject||class}}' => '{{subject||class}}',
+            // Lone pipe
+            '|' => '|',
         ]);
 
         $dumper = new PoFileDumper();

--- a/src/Symfony/Component/Translation/Tests/Fixtures/pipe-in-braces.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/pipe-in-braces.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+
+msgid "{{subject}} must not be an instance of {{class|quote}}"
+msgstr "{{subject}} must not be an instance of {{class|quote}}"
+
+msgid "Found {count, plural, one{# item|filtered} other{# items|filtered}}"
+msgstr "Found {count, plural, one{# item|filtered} other{# items|filtered}}"
+
+msgid "apple"
+msgid_plural "apples"
+msgstr[0] "pomme"
+msgstr[1] "pommes"

--- a/src/Symfony/Component/Translation/Tests/Fixtures/pipe-in-braces.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/pipe-in-braces.po
@@ -14,3 +14,19 @@ msgid "apple"
 msgid_plural "apples"
 msgstr[0] "pomme"
 msgstr[1] "pommes"
+
+msgid "{{subject}} has no apple"
+msgid_plural "{{subject}} has apples"
+msgstr[0] "{{subject}} has no apple"
+msgstr[1] "{{subject}} has apples"
+
+msgid "{{subject|quote}} and {{class|raw}}"
+msgstr "{{subject|quote}} and {{class|raw}}"
+
+msgid "{{subject||class}}"
+msgstr "{{subject||class}}"
+
+msgid ""
+msgid_plural ""
+msgstr[0] ""
+msgstr[1] ""


### PR DESCRIPTION
| Q             | A          
|---------------|------------
| Branch?       | 6.4        
| Bug fix?      | yes        
| New feature?  | no         
| Deprecations? | no         
| Issues        | Fix #64585 
| License       | MIT        

**UPDATED** — Reworked approach after review: the split regex itself now treats `{{...}}` as an atomic token instead of using a guard clause.

---

The issue was originally reported against Symfony 7.4.10, but the bug exists since 6.4 and this fix has been backported accordingly.

`PoFileDumper::getStandardRules()` splits any string containing a pipe (`|`) to detect legacy plural forms (e.g. `apple|apples`). This breaks strings where `|` appears inside double braces, such as template formatters used by Respect/Validation (`{{class|quote}}`).

The fix makes the existing split regex aware of double-brace blocks by treating `{{...}}` as an atomic token, so the pipe inside is never used as a separator.

**Before:**

```php
preg_match_all('/(?:\|\||[^\|])++/', $id, $matches)
// "{{class|quote}}" → ["{{class", "quote}}"] → false plural
```

**After:**

```php
preg_match_all("/(?:$doubleBraceBlock|$doublePipe|$nonPipe)++/", $id, $matches)
// "{{class|quote}}" → ["{{class|quote}}"] → single token, not a plural
```

No guard clause, no special-casing — just a smarter split regex. All existing plural forms (`apple|apples`, `{0} none|{1} one|[2,Inf] many`) are unaffected.