### PR TITLE
[DependencyInjection] Fix deprecation when handling tagged iterator YAML short syntax

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -825,7 +825,7 @@ trait ContentLoaderTrait
                         $argument = new TaggedIteratorArgument($tag, $indexBy, $forLocator, $exclude, $excludeSelf);
                     }
                 } elseif (\is_string($argument) && $argument) {
-                    $argument = new TaggedIteratorArgument($argument, null, null, $forLocator);
+                    $argument = new TaggedIteratorArgument($argument, null, $forLocator);
                 } else {
                     throw new InvalidArgumentException(\sprintf('"!%s" tags only accept a non empty string or an array with a key "tag" in "%s".', $value->getTag(), $file));
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -117,13 +117,10 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsGeneratedFile('services_inline.yml', $dumper->dump());
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedArguments()
     {
-        $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', false, 'getPriority');
-        $taggedIterator2 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz']);
-        $taggedIterator3 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz', 'qux'], false);
+        $taggedIterator = new TaggedIteratorArgument('foo', null, false, ['baz']);
+        $taggedIterator2 = new TaggedIteratorArgument('foo', null, false, ['baz', 'qux'], false);
 
         $container = new ContainerBuilder();
 
@@ -133,15 +130,33 @@ class YamlDumperTest extends TestCase
 
         $container->register('foo_service_tagged_iterator', 'Bar')->addArgument($taggedIterator);
         $container->register('foo2_service_tagged_iterator', 'Bar')->addArgument($taggedIterator2);
-        $container->register('foo3_service_tagged_iterator', 'Bar')->addArgument($taggedIterator3);
 
         $container->register('foo_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator));
         $container->register('foo2_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator2));
-        $container->register('foo3_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator3));
         $container->register('bar_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument(new TaggedIteratorArgument('foo')));
 
         $dumper = new YamlDumper($container);
         $this->assertStringEqualsGeneratedFile('services_with_tagged_argument.yml', $dumper->dump());
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDeprecatedTaggedArguments()
+    {
+        $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', false, 'getPriority');
+
+        $container = new ContainerBuilder();
+
+        $container->register('foo_service', 'Foo')->addTag('foo');
+        $container->register('baz_service', 'Baz')->addTag('foo');
+        $container->register('qux_service', 'Qux')->addTag('foo');
+
+        $container->register('foo_service_tagged_iterator', 'Bar')->addArgument($taggedIterator);
+
+        $container->register('foo_service_tagged_locator', 'Bar')->addArgument(new ServiceLocatorArgument($taggedIterator));
+
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsGeneratedFile('services_with_deprecated_tagged_argument.yml', $dumper->dump());
     }
 
     public function testTaggedArgumentsOmitsAutoDerivedDefaultMethods()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_deprecated_tagged_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_deprecated_tagged_argument.yml
@@ -1,0 +1,24 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo_service:
+        class: Foo
+        tags:
+            - foo
+    baz_service:
+        class: Baz
+        tags:
+            - foo
+    qux_service:
+        class: Qux
+        tags:
+            - foo
+    foo_service_tagged_iterator:
+        class: Bar
+        arguments: [!tagged_iterator { tag: foo, index_by: barfoo, default_index_method: foobar, default_priority_method: getPriority }]
+    foo_service_tagged_locator:
+        class: Bar
+        arguments: [!tagged_locator { tag: foo, index_by: barfoo, default_index_method: foobar, default_priority_method: getPriority }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
@@ -18,20 +18,14 @@ services:
             - foo
     foo_service_tagged_iterator:
         class: Bar
-        arguments: [!tagged_iterator { tag: foo, index_by: barfoo, default_index_method: foobar, default_priority_method: getPriority }]
-    foo2_service_tagged_iterator:
-        class: Bar
         arguments: [!tagged_iterator { tag: foo, exclude: baz }]
-    foo3_service_tagged_iterator:
+    foo2_service_tagged_iterator:
         class: Bar
         arguments: [!tagged_iterator { tag: foo, exclude: [baz, qux], exclude_self: false }]
     foo_service_tagged_locator:
         class: Bar
-        arguments: [!tagged_locator { tag: foo, index_by: barfoo, default_index_method: foobar, default_priority_method: getPriority }]
-    foo2_service_tagged_locator:
-        class: Bar
         arguments: [!tagged_locator { tag: foo, exclude: baz }]
-    foo3_service_tagged_locator:
+    foo2_service_tagged_locator:
         class: Bar
         arguments: [!tagged_locator { tag: foo, exclude: [baz, qux], exclude_self: false }]
     bar_service_tagged_locator:

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -418,9 +418,7 @@ class YamlFileLoaderTest extends TestCase
         }
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
-    public function testTaggedArgumentsWithIndex()
+    public function testTaggedArguments()
     {
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
@@ -430,22 +428,37 @@ class YamlFileLoaderTest extends TestCase
         $this->assertCount(1, $container->getDefinition('foo_service_tagged_iterator')->getArguments());
         $this->assertCount(1, $container->getDefinition('foo_service_tagged_locator')->getArguments());
 
+        $taggedIterator = new TaggedIteratorArgument('foo', null, false, ['baz']);
+        $this->assertEquals($taggedIterator, $container->getDefinition('foo_service_tagged_iterator')->getArgument(0));
+        $taggedIterator2 = new TaggedIteratorArgument('foo', null, false, ['baz', 'qux'], false);
+        $this->assertEquals($taggedIterator2, $container->getDefinition('foo2_service_tagged_iterator')->getArgument(0));
+
+        $taggedIterator = new TaggedIteratorArgument('foo', 'foo', true, ['baz']);
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_service_tagged_locator')->getArgument(0));
+        $taggedIterator2 = new TaggedIteratorArgument('foo', 'foo', true, ['baz', 'qux'], false);
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator2), $container->getDefinition('foo2_service_tagged_locator')->getArgument(0));
+
+        $taggedIterator = new TaggedIteratorArgument('foo', null, true);
+        $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('bar_service_tagged_locator')->getArgument(0));
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDeprecatedTaggedArguments()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_deprecated_tagged_argument.yml');
+
+        $this->assertCount(1, $container->getDefinition('foo_service')->getTag('foo'));
+        $this->assertCount(1, $container->getDefinition('foo_service_tagged_iterator')->getArguments());
+        $this->assertCount(1, $container->getDefinition('foo_service_tagged_locator')->getArguments());
+
         $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', false, 'getPriority');
         $this->assertEquals($taggedIterator, $container->getDefinition('foo_service_tagged_iterator')->getArgument(0));
-        $taggedIterator2 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz']);
-        $this->assertEquals($taggedIterator2, $container->getDefinition('foo2_service_tagged_iterator')->getArgument(0));
-        $taggedIterator3 = new TaggedIteratorArgument('foo', null, null, false, null, ['baz', 'qux'], false);
-        $this->assertEquals($taggedIterator3, $container->getDefinition('foo3_service_tagged_iterator')->getArgument(0));
 
         $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', true, 'getPriority');
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('foo_service_tagged_locator')->getArgument(0));
-        $taggedIterator2 = new TaggedIteratorArgument('foo', 'foo', 'getDefaultFooName', true, 'getDefaultFooPriority', ['baz']);
-        $this->assertEquals(new ServiceLocatorArgument($taggedIterator2), $container->getDefinition('foo2_service_tagged_locator')->getArgument(0));
-        $taggedIterator3 = new TaggedIteratorArgument('foo', 'foo', 'getDefaultFooName', true, 'getDefaultFooPriority', ['baz', 'qux'], false);
-        $this->assertEquals(new ServiceLocatorArgument($taggedIterator3), $container->getDefinition('foo3_service_tagged_locator')->getArgument(0));
-
-        $taggedIterator = new TaggedIteratorArgument('foo', null, null, true);
-        $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('bar_service_tagged_locator')->getArgument(0));
     }
 
     public function testServiceWithServiceLocatorArgument()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64622
| License       | MIT

Deprecated code paths were split from `YamlFileLoaderTest::testTaggedArgumentsWithIndex()`.