### PR TITLE
[Yaml] Restrict block parser regexps to the ASCII grammar

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -336,7 +336,7 @@ class Inline
      */
     private static function parseQuotedScalar(string $scalar, int &$i = 0): string
     {
-        if (!Parser::preg_match('/'.self::REGEX_QUOTED_STRING.'/Au', substr($scalar, $i), $match)) {
+        if (!Parser::preg_match('/'.self::REGEX_QUOTED_STRING.'/A', substr($scalar, $i), $match)) {
             throw new ParseException(\sprintf('Malformed inline YAML string: "%s".', substr($scalar, $i)), self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
         }
 

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -25,7 +25,7 @@ class Parser
 {
     public const TAG_PATTERN = '(?P<tag>![\w!.\/:-]+)';
     public const BLOCK_SCALAR_HEADER_PATTERN = '(?P<separator>\||>)(?P<modifiers>\+|\-|\d+|\+\d+|\-\d+|\d+\+|\d+\-)?(?P<comments> +#.*)?';
-    public const REFERENCE_PATTERN = '#^&(?P<ref>[^ ]++) *+(?P<value>.*)#u';
+    public const REFERENCE_PATTERN = '#^&(?P<ref>[^ ]++) *+(?P<value>.*)#';
     public const DEFAULT_MAX_NESTING_LEVEL = 128;
     public const DEFAULT_MAX_ALIASES_FOR_COLLECTIONS = 128;
 
@@ -167,7 +167,7 @@ class Parser
             Inline::initialize($flags, $this->getRealCurrentLineNb(), $this->filename);
 
             $isRef = $mergeNode = false;
-            if ('-' === $this->currentLine[0] && self::preg_match('#^\-((?P<leadspaces>\s+)(?P<value>.+))?$#u', rtrim($this->currentLine), $values)) {
+            if ('-' === $this->currentLine[0] && self::preg_match('#^\-((?P<leadspaces>\s+)(?P<value>.+))?$#', rtrim($this->currentLine), $values)) {
                 if ($context && 'mapping' == $context) {
                     throw new ParseException('You cannot define a sequence item when in a mapping.', $this->getRealCurrentLineNb() + 1, $this->currentLine, $this->filename);
                 }
@@ -205,7 +205,7 @@ class Parser
                         isset($values['leadspaces'])
                         && (
                             '!' === $values['value'][0]
-                            || self::preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\{\[].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->trimTag($values['value']), $matches)
+                            || self::preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\{\[].*?) *\:(\s+(?P<value>.+?))?\s*$#', $this->trimTag($values['value']), $matches)
                         )
                     ) {
                         $block = $values['value'];
@@ -223,7 +223,7 @@ class Parser
                     array_pop($this->refsBeingParsed);
                 }
             } elseif (
-                self::preg_match('#^(?P<key>(?:![^\s]++\s++)?(?:'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\[\{!].*?)) *\:(( |\t)++(?P<value>.+))?$#u', rtrim($this->currentLine), $values)
+                self::preg_match('#^(?P<key>(?:![^\s]++\s++)?(?:'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\[\{!].*?)) *\:(( |\t)++(?P<value>.+))?$#', rtrim($this->currentLine), $values)
                 && (!str_contains($values['key'], ' #') || \in_array($values['key'][0], ['"', "'"], true))
             ) {
                 if ($context && 'sequence' == $context) {
@@ -249,7 +249,7 @@ class Parser
                     $key = (string) $key;
                 }
 
-                if ('<<' === $key && (!isset($values['value']) || '&' !== $values['value'][0] || !self::preg_match('#^&(?P<ref>[^ ]+)#u', $values['value'], $refMatches))) {
+                if ('<<' === $key && (!isset($values['value']) || '&' !== $values['value'][0] || !self::preg_match('#^&(?P<ref>[^ ]+)#', $values['value'], $refMatches))) {
                     $mergeNode = true;
                     $allowOverwrite = true;
                     if (isset($values['value'][0]) && '*' === $values['value'][0]) {
@@ -1028,7 +1028,7 @@ class Parser
 
         // strip YAML header
         $count = 0;
-        $value = preg_replace('#^%YAML[: ][\d.]++[^\n]*+\n#u', '', $value, -1, $count);
+        $value = preg_replace('#^%YAML[: ][\d.]++[^\n]*+\n#', '', $value, -1, $count);
         $this->offset += $count;
 
         // remove leading comments

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -190,6 +190,11 @@ class ParserTest extends TestCase
         ];
     }
 
+    public function testNonBreakingSpaceIsNotAWhitespaceSeparator()
+    {
+        $this->assertSame("-\u{A0}foo", $this->parser->parse("-\u{A0}foo"));
+    }
+
     public function testParserIsStateless()
     {
         $yamlString = '# translations/messages.en.yaml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Several regexps in the block `Parser` (and the inline quoted-string matcher) carried the `u` modifier. In PHP that enables Unicode character properties, so `\s` and `\d` no longer mean "ASCII whitespace" and `[0-9]`, but match Unicode whitespace and digits.

That is wider than the YAML grammar, where `s-white` is `x20 | x09` and `ns-dec-digit` is `[x30-x39]`. Concretely, on `8.2`:

```php
Yaml::parse("-\u{A0}foo");        // ['foo']  (NBSP treated as a sequence separator)
Yaml::parse("%YAML \u{0661}.\u{0662}\nfoo: bar"); // accepted as a version directive
```

The parser already rejects invalid UTF-8 upfront (`preg_match('//u', $value)`), and these patterns only locate boundaries or match whole tokens, so on valid UTF-8 the matched bytes are identical with or without the modifier. Removing it therefore leaves multibyte content untouched while bringing `\s`/`\d` back to the spec: the non-breaking space above now parses as the plain scalar `-\u{A0}foo`, and the non-ASCII version directive is no longer silently accepted.

The `u` modifier is kept where it is load-bearing:
- the UTF-8 validity checks (`//u`),
- the double-quote unescaping callback in `Unescaper`, where `.` must consume a whole code point,
- the `Escaper`, where the dumper deliberately stays Unicode-aware (`\p{Zs}`).