### PR TITLE
[SecurityHttp] Make OidcTokenHandler `allowedTimeDrift` configurable

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `allowed_time_drift` option to the OIDC token handler configuration
+
 8.1
 ---
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -31,6 +31,7 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
             ->replaceArgument(2, $config['audience'])
             ->replaceArgument(3, $config['issuers'])
             ->replaceArgument(4, $config['claim'])
+            ->replaceArgument(7, $config['allowed_time_drift'])
             ->addTag('container.reversible')
         );
 
@@ -189,6 +190,11 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                                 ->isRequired()
                             ->end()
                         ->end()
+                    ->end()
+                    ->integerNode('allowed_time_drift')
+                        ->info('Allowed time drift in seconds for token validation (iat, nbf, exp claims).')
+                        ->defaultValue(0)
+                        ->min(0)
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -91,6 +91,7 @@ return static function (ContainerConfigurator $container) {
                 'sub',
                 service('logger')->nullOnInvalid(),
                 service('clock'),
+                0,
             ])
 
         ->set('security.access_token_handler.oidc_discovery.http_client', HttpClientInterface::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -175,6 +175,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_2' => 'audience',
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
+            'index_7' => 0,
         ];
         $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
     }
@@ -295,6 +296,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_2' => 'audience',
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
+            'index_7' => 0,
         ];
         $expectedCalls = [
             [
@@ -351,6 +353,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_2' => 'audience',
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
+            'index_7' => 0,
         ];
         $expectedCalls = [
             [
@@ -676,5 +679,39 @@ class AccessTokenFactoryTest extends TestCase
         $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
 
         $this->assertFalse($container->hasDefinition('security.access_token_handler.oidc.command.generate'));
+    }
+
+    public function testOidcTokenHandlerConfigurationWithAllowedTimeDrift()
+    {
+        $container = new ContainerBuilder();
+        $jwkset = '{"keys":[{"kty":"EC","crv":"P-256","x":"FtgMtrsKDboRO-Zo0XC7tDJTATHVmwuf9GK409kkars","y":"rWDE0ERU2SfwGYCo1DWWdgFEbZ0MiAXLRBBOzBgs_jY","d":"4G7bRIiKih0qrFxc0dtvkHUll19tTyctoCR3eIbOrO0"},{"kty":"EC","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220"}]}';
+        $config = [
+            'token_handler' => [
+                'oidc' => [
+                    'algorithms' => ['RS256', 'ES256'],
+                    'issuers' => ['https://www.example.com'],
+                    'audience' => 'audience',
+                    'keyset' => $jwkset,
+                    'allowed_time_drift' => 5,
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $expected = [
+            'index_0' => (new ChildDefinition('security.access_token_handler.oidc.signature'))
+                ->replaceArgument(0, ['RS256', 'ES256']),
+            'index_1' => (new ChildDefinition('security.access_token_handler.oidc.jwkset'))
+                ->replaceArgument(0, $jwkset),
+            'index_2' => 'audience',
+            'index_3' => ['https://www.example.com'],
+            'index_4' => 'sub',
+            'index_7' => 5,
+        ];
+        $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
     }
 }

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -63,6 +63,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         private string $claim = 'sub',
         private ?LoggerInterface $logger = null,
         private ClockInterface $clock = new Clock(),
+        private int $allowedTimeDrift = 0,
     ) {
     }
 
@@ -262,9 +263,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
     {
         // Verify the claims
         $checkers = [
-            new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0),
-            new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0),
-            new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0),
+            new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
+            new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
+            new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
             new Checker\AudienceChecker($this->audience),
             new Checker\IssuerChecker($this->issuers),
         ];
@@ -287,9 +288,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
                 new Checker\AlgorithmChecker($this->decryptionAlgorithms->list()),
                 new Checker\CallableChecker('enc', fn ($value) => \in_array($value, $this->decryptionAlgorithms->list())),
                 new Checker\CallableChecker('cty', static fn ($value) => 'JWT' === $value),
-                new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-                new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-                new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+                new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift, protectedHeaderOnly: true),
+                new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift, protectedHeaderOnly: true),
+                new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift, protectedHeaderOnly: true),
             ],
             [new JWETokenSupport()]
         );

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
+
 8.1
 ---
 

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -619,4 +619,93 @@ class OidcTokenHandlerTest extends TestCase
         $this->assertCount(1, $keys);
         $this->assertSame(['sign'], $keys[0]['key_ops']);
     }
+
+    public function testTokenWithFutureIatIsRejectedByDefault()
+    {
+        $time = time();
+        $claims = [
+            'iat' => $time + 3,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+        ];
+        $token = self::buildJWS(json_encode($claims));
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())->method('error');
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+        ))->getUserBadgeFrom($token);
+    }
+
+    public function testTokenWithFutureIatIsAcceptedWithAllowedTimeDrift()
+    {
+        $time = time();
+        $claims = [
+            'iat' => $time + 3,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+        ];
+        $token = self::buildJWS(json_encode($claims));
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->never())->method('error');
+
+        $userBadge = (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+            allowedTimeDrift: 5,
+        ))->getUserBadgeFrom($token);
+
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+    }
+
+    public function testTokenWithFutureIatBeyondAllowedTimeDriftIsRejected()
+    {
+        $time = time();
+        $claims = [
+            'iat' => $time + 10,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+        ];
+        $token = self::buildJWS(json_encode($claims));
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())->method('error');
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+            allowedTimeDrift: 5,
+        ))->getUserBadgeFrom($token);
+    }
 }


### PR DESCRIPTION
| Q             | A          
|---------------|------------
| Branch?       | 8.2        
| Bug fix?      | no         
| New feature?  | yes        
| Deprecations? | no         
| Issues        | Fix #64547 
| License       | MIT        

This PR makes the `allowedTimeDrift` parameter of the OIDC token handler configurable through `security.yaml`.

Currently, `allowedTimeDrift` is hardcoded to `0` in `OidcTokenHandler`, which causes token validation to fail when there is a small clock skew between the OIDC issuer and the verifying server (e.g. `"The JWT is issued in the future."`).

This adds an `allowed_time_drift` option (in seconds, default `0`) under the `oidc` node:

```yaml
# config/packages/security.yaml
security:
  firewalls:
    main:
      access_token:
        token_handler:
          oidc:
            algorithms: ['ES256', 'RS256']
            keyset: '{"keys":[...]}'
            audience: 'api-example'
            issuers: ['https://oidc.example.com']
            allowed_time_drift: 3 # seconds, default 0
```

The value is passed to the three time-based claim checkers (`IssuedAtChecker`, `NotBeforeChecker`, `ExpirationTimeChecker`) from `web-token/jwt-library`, which already support this parameter.

> [!NOTE]
>
> The original issue suggested three separate options (`iat_tolerance`, `nbf_tolerance`, `exp_tolerance`) for per-claim granularity.
>
> This PR starts with a single `allowed_time_drift` parameter — which maps directly to the existing `allowedTimeDrift` argument shared by all three checkers — to validate the technical approach.
>
> Happy to switch to per-claim configuration in this PR if maintainers prefer that granularity.
