### PR TITLE
[AssetMapper] Fix stale dev asset cache in long-running runtimes

### DIFF
--- a/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Config\ResourceCheckerConfigCache;
 
 /**
  * Decorates the asset factory to load MappedAssets from cache when possible.
@@ -33,7 +34,13 @@ class CachedMappedAssetFactory implements MappedAssetFactoryInterface
     public function createMappedAsset(string $logicalPath, string $sourcePath): ?MappedAsset
     {
         $cachePath = $this->getCacheFilePath($logicalPath, $sourcePath);
-        $configCache = new ConfigCache($cachePath, $this->debug);
+
+        if ($this->debug) {
+            clearstatcache();
+            $configCache = new ResourceCheckerConfigCache($cachePath, [new NonCachingSelfCheckingResourceChecker()]);
+        } else {
+            $configCache = new ConfigCache($cachePath, false);
+        }
 
         if ($configCache->isFresh()) {
             return unserialize(file_get_contents($cachePath), ['allowed_classes' => true]);

--- a/src/Symfony/Component/AssetMapper/Factory/NonCachingSelfCheckingResourceChecker.php
+++ b/src/Symfony/Component/AssetMapper/Factory/NonCachingSelfCheckingResourceChecker.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AssetMapper\Factory;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
+use Symfony\Component\Config\ResourceCheckerInterface;
+
+/**
+ * Avoids process-wide freshness memoization for dev asset caches.
+ *
+ * @internal
+ */
+final class NonCachingSelfCheckingResourceChecker implements ResourceCheckerInterface
+{
+    public function supports(ResourceInterface $metadata): bool
+    {
+        return $metadata instanceof SelfCheckingResourceInterface;
+    }
+
+    /**
+     * @param SelfCheckingResourceInterface $resource
+     */
+    public function isFresh(ResourceInterface $resource, int $timestamp): bool
+    {
+        return $resource->isFresh($timestamp);
+    }
+}

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
@@ -85,6 +85,50 @@ class CachedMappedAssetFactoryTest extends TestCase
         $this->assertSame($mappedAsset->content, $actualAsset->content);
     }
 
+    public function testAssetCacheFreshnessIsNotMemoizedInDebugMode()
+    {
+        $sourcePath = $this->cacheDir.'/externally_built.css';
+        file_put_contents($sourcePath, 'old content');
+
+        $mappedAsset = new MappedAsset('externally_built.css', $sourcePath, content: 'cached content');
+        $this->saveConfigCache($mappedAsset);
+
+        // Start with a fresh asset cache so ConfigCache memoizes a positive freshness result.
+        $cachePath = $this->getConfigCachePath($mappedAsset);
+        $cacheTimestamp = time() - 10;
+        $sourceTimestamp = $cacheTimestamp - 10;
+        $newSourceTimestamp = $cacheTimestamp + 1;
+        touch($sourcePath, $sourceTimestamp);
+        touch($cachePath, $cacheTimestamp);
+        clearstatcache();
+
+        $configCache = new ConfigCache($cachePath, true);
+        $this->assertTrue($configCache->isFresh());
+
+        // Simulate an external build tool updating a dependency while the PHP process keeps running.
+        file_put_contents($sourcePath, 'new content');
+        touch($sourcePath, $newSourceTimestamp);
+        clearstatcache();
+
+        // AssetMapper should recheck the dependency instead of reusing ConfigCache's memoized answer.
+        $rebuiltAsset = new MappedAsset('externally_built.css', $sourcePath, content: 'rebuilt content');
+
+        $factory = $this->createMock(MappedAssetFactoryInterface::class);
+        $factory->expects($this->once())
+            ->method('createMappedAsset')
+            ->with('externally_built.css', $sourcePath)
+            ->willReturn($rebuiltAsset);
+
+        $cachedFactory = new CachedMappedAssetFactory(
+            $factory,
+            $this->cacheDir,
+            true
+        );
+
+        $actualAsset = $cachedFactory->createMappedAsset('externally_built.css', $sourcePath);
+        $this->assertSame($rebuiltAsset->content, $actualAsset->content);
+    }
+
     public function testAssetConfigCacheResourceContainsDependencies()
     {
         $sourcePath = realpath(__DIR__.'/../Fixtures/dir1/file1.css');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Found by using [TailwindBundle](https://symfony.com/bundles/TailwindBundle/current/index.html) with [FrankenPHP worker mode](https://frankenphp.dev/docs/worker/), which is basically a long-running environment mode.

Symptoms were:

1. FrankenPHP docker container would boot with Symfony DEV role, worker mode enabled
2. changes to tailwind managed CSS would be made
3. `tailwind:build` would create a new `var/tailwind/app.built.css` with a current mtime
4. but the changes would not cascade through the asset mapper, still serving the stale cached debug version

After some research, I found that [SelfCheckingResourceChecker](https://github.com/symfony/config/blob/6.4/Resource/SelfCheckingResourceChecker.php#L44)  would never call `isFresh`  again once the static `self::$cache[$key] ` was assigned, meaning the worker would be locked-in to a given cache, even though it may become stale.

To focus the fix, I did not touch `symfony/config`  but introduced a switch to the [CachedMappedAssetFactory](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php) that does two things:

1. Added a new ` NonCachingSelfCheckingResourceChecker` that wraps away from the misbehaving ` ConfigCache`  that [adds the static cache](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Config/ConfigCache.php#L40) in debug mode.
2. Ensure possible php file stat caches get purged in debug mode

I've added a test that replicates the exact issue.
I chose 6.4, because it should be the lowest maintained branch.
Not sure if that is enough to make it propagate to newer versions as well though, I hope it does?