### PR TITLE
[Messenger] Fix `#[AsMessage]` on abstract classes

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -414,7 +414,7 @@ class MessengerPass implements CompilerPassInterface
         }
 
         $typeToClassMap = [];
-        foreach ($container->findTaggedResourceIds('messenger.message') as $id => $tags) {
+        foreach ($container->findTaggedResourceIds('messenger.message', false) as $id => $tags) {
             $class = $container->getDefinition($id)->getClass();
             foreach ($tags as $tag) {
                 if (!isset($tag['serializedTypeName'])) {

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -1054,6 +1054,12 @@ class MessengerPassTest extends TestCase
             ->setArguments([null, 'json', [], []]);
 
         $container
+            ->register('App\Message\AbstractMessage', 'App\Message\AbstractMessage')
+            ->setAbstract(true)
+            ->addTag('container.excluded')
+            ->addTag('messenger.message')
+        ;
+        $container
             ->register('App\Message\MessageA', 'App\Message\MessageA')
             ->addTag('container.excluded')
             ->addTag('messenger.message', ['serializedTypeName' => 'type.a'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64630
| License       | MIT

#63061 forgot to pass `ContainerBuilder::findTaggedResourceIds()`’s `$throwOnAbstract` to `false`.