### PR TITLE
 Messenger commands don't yet make use of listable Redis capabilities

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
@@ -17,8 +17,10 @@ use Symfony\Component\Messenger\Bridge\Redis\Transport\Connection;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisReceivedStamp;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransport;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
+use Symfony\Component\Serializer as SerializerComponent;
 
 class RedisTransportTest extends TestCase
 {
@@ -55,6 +57,35 @@ class RedisTransportTest extends TestCase
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());
     }
 
+    public function testAll()
+    {
+        $serializer = $this->createSerializer();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('findAll')->with(50)->willReturn([
+            $this->createRedisEnvelope(),
+            $this->createRedisEnvelope(),
+        ]);
+
+        $transport = $this->getTransport($serializer, $connection);
+
+        $envelopes = [...$transport->all(50)];
+        $this->assertCount(2, $envelopes);
+        $this->assertEquals(new DummyMessage('Hi'), $envelopes[0]->getMessage());
+    }
+
+    public function testFind()
+    {
+        $serializer = $this->createSerializer();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('find')->with('5')->willReturn($this->createRedisEnvelope());
+
+        $transport = $this->getTransport($serializer, $connection);
+
+        $this->assertEquals(new DummyMessage('Hi'), $transport->find('5')->getMessage());
+    }
+
     public function testKeepalive()
     {
         $transport = $this->getTransport(
@@ -73,5 +104,27 @@ class RedisTransportTest extends TestCase
         $connection ??= $this->createStub(Connection::class);
 
         return new RedisTransport($connection, $serializer);
+    }
+
+    private function createRedisEnvelope(): array
+    {
+        return [
+            'id' => '1-0',
+            'data' => [
+                'message' => json_encode([
+                    'body' => '{"message": "Hi"}',
+                    'headers' => [
+                        'type' => DummyMessage::class,
+                    ],
+                ]),
+            ],
+        ];
+    }
+
+    private function createSerializer(): Serializer
+    {
+        return new Serializer(
+            new SerializerComponent\Serializer([new SerializerComponent\Normalizer\ObjectNormalizer()], ['json' => new SerializerComponent\Encoder\JsonEncoder()])
+        );
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\CloseableTransportInterface;
 use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -24,7 +25,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisTransport implements TransportInterface, KeepaliveReceiverInterface, SetupableTransportInterface, CloseableTransportInterface, MessageCountAwareInterface
+class RedisTransport implements TransportInterface, KeepaliveReceiverInterface, SetupableTransportInterface, CloseableTransportInterface, MessageCountAwareInterface, ListableReceiverInterface
 {
     private SerializerInterface $serializer;
     private RedisReceiver $receiver;
@@ -75,6 +76,16 @@ class RedisTransport implements TransportInterface, KeepaliveReceiverInterface, 
     public function getMessageCount(): int
     {
         return $this->getReceiver()->getMessageCount();
+    }
+
+    public function all(?int $limit = null): iterable
+    {
+        return $this->getReceiver()->all($limit);
+    }
+
+    public function find(mixed $id): ?Envelope
+    {
+        return $this->getReceiver()->find($id);
     }
 
     public function close(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64639
| License       | MIT

This PR completes https://github.com/symfony/symfony/issues/61462 by implementing the remaining `\Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface` requirement on the transport itself.

By doing this, we allow the three Messenger _failed_ commands to operate.

Tests added for transport, they are mostly inspired by the existing tests, particularly `\Symfony\Component\Messenger\Bridge\Redis\Tests\Transport\RedisReceiverTest`. The utility methods and namespace import are also inspired.