### PR TITLE
[Validator] Allow cascading the current group sequence group to referenced objects

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -70,3 +70,5 @@ Validator
 ---------
 
  * Add argument `$restrictGroups` to `Valid::__construct()`
+ * [BC BREAK] Remove the `GroupSequence::$cascadedGroup` property, it has had no effect since the validator stopped reading it in 2014, and reading it has thrown since 7.4 typed it without a default
+ * Add argument `$cascadeCurrentGroup` to `GroupSequenceProvider::__construct()`

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `cascadeCurrentGroup` option to `GroupSequence` and `GroupSequenceProvider`
+ * Remove the unused `GroupSequence::$cascadedGroup` property
  * Add the `restrictGroups` option to the `Valid` constraint
  * Add the `Cron` constraint to validate cron expressions
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -57,26 +57,36 @@ class GroupSequence
     public array $groups;
 
     /**
-     * The group in which cascaded objects are validated when validating
-     * this sequence.
+     * Whether the group currently being stepped through must be cascaded to
+     * referenced objects, in addition to the "Default" group.
      *
-     * By default, cascaded objects are validated in each of the groups of
-     * the sequence.
+     * When a class declares a group sequence (through the {@see GroupSequence}
+     * attribute, {@see \Symfony\Component\Validator\Mapping\ClassMetadata::setGroupSequence()}
+     * or {@see \Symfony\Component\Validator\GroupSequenceProviderInterface}),
+     * referenced objects marked with the {@see Valid} constraint are, by default,
+     * only cascaded in the "Default" group. As a result, constraints registered
+     * on those objects for one of the sequence groups are never validated.
      *
-     * If a class has a group sequence attached, that sequence replaces the
-     * "Default" group. When validating that class in the "Default" group, the
-     * group sequence is used instead, but still the "Default" group should be
-     * cascaded to other objects.
+     * Setting this flag to "true" makes the validator cascade the group of the
+     * sequence currently being stepped through together with the "Default" group,
+     * so that such constraints are validated as well.
+     *
+     * The flag only applies to sequences declared on the class: when a sequence
+     * is passed explicitly to the validator, the group being stepped through is
+     * already the one cascaded to referenced objects.
      */
-    public string|GroupSequence $cascadedGroup;
+    public bool $cascadeCurrentGroup = false;
 
     /**
      * Creates a new group sequence.
      *
-     * @param array<string|string[]|GroupSequence> $groups The groups in the sequence
+     * @param array<string|string[]|GroupSequence> $groups              The groups in the sequence
+     * @param bool                                 $cascadeCurrentGroup Whether to also cascade the current sequence
+     *                                                                  group to referenced objects, on top of "Default"
      */
-    public function __construct(array $groups)
+    public function __construct(array $groups, bool $cascadeCurrentGroup = false)
     {
         $this->groups = $groups;
+        $this->cascadeCurrentGroup = $cascadeCurrentGroup;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequenceProvider.php
@@ -19,7 +19,13 @@ namespace Symfony\Component\Validator\Constraints;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class GroupSequenceProvider
 {
-    public function __construct(public ?string $provider = null)
-    {
+    /**
+     * @param bool $cascadeCurrentGroup Whether the group being stepped through must be cascaded to referenced
+     *                                  objects on top of "Default"; see {@see GroupSequence::$cascadeCurrentGroup}
+     */
+    public function __construct(
+        public ?string $provider = null,
+        public bool $cascadeCurrentGroup = false,
+    ) {
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -52,6 +52,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     private ?GroupSequence $groupSequence = null;
     private bool $groupSequenceProvider = false;
     private ?string $groupProvider = null;
+    private bool $cascadeCurrentGroup = false;
 
     /**
      * The strategy for cascading objects.
@@ -94,6 +95,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             'groupSequence' => $this->groupSequence,
             'groupSequenceProvider' => $this->groupSequenceProvider,
             'groupProvider' => $this->groupProvider,
+            'cascadeCurrentGroup' => $this->cascadeCurrentGroup,
             'members' => $this->members,
             'name' => $this->name,
             'properties' => $this->properties,
@@ -423,6 +425,20 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     public function getGroupProvider(): ?string
     {
         return $this->groupProvider;
+    }
+
+    /**
+     * Sets whether the group being stepped through is cascaded to referenced objects,
+     * for a sequence returned by the group sequence provider as a plain array.
+     */
+    public function setCascadeCurrentGroup(bool $cascadeCurrentGroup): void
+    {
+        $this->cascadeCurrentGroup = $cascadeCurrentGroup;
+    }
+
+    public function getCascadeCurrentGroup(): bool
+    {
+        return $this->cascadeCurrentGroup;
     }
 
     public function getCascadingStrategy(): int

--- a/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
@@ -75,9 +75,10 @@ class AttributeLoader implements LoaderInterface
 
         foreach ($this->getAttributes($reflClass) as $constraint) {
             if ($constraint instanceof GroupSequence) {
-                $metadata->setGroupSequence($constraint->groups);
+                $metadata->setGroupSequence($constraint);
             } elseif ($constraint instanceof GroupSequenceProvider) {
                 $metadata->setGroupProvider($constraint->provider);
+                $metadata->setCascadeCurrentGroup($constraint->cascadeCurrentGroup);
                 $metadata->setGroupSequenceProvider(true);
             } elseif ($constraint instanceof Constraint) {
                 $metadata->addConstraint($constraint);

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Mapping\Loader;
 
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -209,7 +210,10 @@ class XmlFileLoader extends FileLoader
 
         foreach ($classDescription->{'group-sequence'} as $groupSequence) {
             if (\count($groupSequence->value) > 0) {
-                $metadata->setGroupSequence($this->parseValues($groupSequence[0]->value));
+                $groups = $this->parseValues($groupSequence[0]->value);
+                $cascadeCurrentGroup = XmlUtils::phpize($groupSequence['cascade-current-group'] ?? false);
+
+                $metadata->setGroupSequence($cascadeCurrentGroup ? new GroupSequence($groups, true) : $groups);
             }
         }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping\Loader;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser as YamlParser;
@@ -154,7 +155,17 @@ class YamlFileLoader extends FileLoader
         }
 
         if (isset($classDescription['group_sequence'])) {
-            $metadata->setGroupSequence($classDescription['group_sequence']);
+            $groupSequence = $classDescription['group_sequence'];
+
+            // a mapping with a "groups" key carries options on top of the sequence itself
+            if (\is_array($groupSequence) && !array_is_list($groupSequence)) {
+                $metadata->setGroupSequence(new GroupSequence(
+                    $groupSequence['groups'],
+                    $groupSequence['cascade_current_group'] ?? false,
+                ));
+            } else {
+                $metadata->setGroupSequence($groupSequence);
+            }
         }
 
         if (isset($classDescription['constraints']) && \is_array($classDescription['constraints'])) {

--- a/src/Symfony/Component/Validator/Mapping/Loader/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd
+++ b/src/Symfony/Component/Validator/Mapping/Loader/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd
@@ -65,12 +65,14 @@
     <xsd:annotation>
       <xsd:documentation><![CDATA[
         Contains the group sequence of a class. Each group should be written
-        into a "value" tag.
+        into a "value" tag. Set "cascade-current-group" to also cascade the group
+        being stepped through to referenced objects, on top of "Default".
       ]]></xsd:documentation>
     </xsd:annotation>
     <xsd:sequence>
       <xsd:element name="value" type="value" minOccurs="1" maxOccurs="unbounded" />
     </xsd:sequence>
+    <xsd:attribute name="cascade-current-group" type="xsd:boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="group-sequence-provider">

--- a/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
@@ -24,5 +24,17 @@ class GroupSequenceTest extends TestCase
         $sequence = new GroupSequence(['Group 1', 'Group 2']);
 
         $this->assertSame(['Group 1', 'Group 2'], $sequence->groups);
+        $this->assertFalse($sequence->cascadeCurrentGroup);
+    }
+
+    public function testUnserializeSequenceSerializedBeforeCascadeCurrentGroupExisted()
+    {
+        // a validator.mapping.cache entry written before the flag existed carries no "cascadeCurrentGroup"
+        $serialized = 'O:'.\strlen(GroupSequence::class).':"'.GroupSequence::class.'":1:{s:6:"groups";a:1:{i:0;s:7:"Group 1";}}';
+
+        $sequence = unserialize($serialized);
+
+        $this->assertSame(['Group 1'], $sequence->groups);
+        $this->assertFalse($sequence->cascadeCurrentGroup);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/GroupSequenceCascadeEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/GroupSequenceCascadeEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures\Attribute;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Assert\GroupSequence(['Foo', 'GroupSequenceCascadeEntity'], cascadeCurrentGroup: true)]
+class GroupSequenceCascadeEntity
+{
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/GroupSequenceProviderCascadeEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/GroupSequenceProviderCascadeEntity.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures\Attribute;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\GroupSequenceProviderInterface;
+
+#[Assert\GroupSequenceProvider(cascadeCurrentGroup: true)]
+class GroupSequenceProviderCascadeEntity implements GroupSequenceProviderInterface
+{
+    #[Assert\Valid]
+    public ?GroupSequenceProviderCascadeChild $child = null;
+
+    public function getGroupSequence(): array|GroupSequence
+    {
+        // a plain array, as in the reported case
+        return ['GroupSequenceProviderCascadeEntity', 'my_group'];
+    }
+}
+
+class GroupSequenceProviderCascadeChild
+{
+    #[Assert\Length(exactly: 2, groups: ['my_group'])]
+    public ?string $a = null;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceCascadeEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceCascadeEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class GroupSequenceCascadeEntity
+{
+    public $reference;
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
 use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto;
+use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupSequenceCascadeEntity;
 use Symfony\Component\Validator\Tests\Fixtures\CallbackClass;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
@@ -199,6 +200,17 @@ class AttributeLoaderTest extends TestCase
         $this->assertCount(2, $otherMetadata);
         $this->assertInstanceOf(Type::class, $otherMetadata[0]->getConstraints()[0]);
         $this->assertInstanceOf(NotNull::class, $otherMetadata[1]->getConstraints()[0]);
+    }
+
+    public function testLoadGroupSequenceCascadeCurrentGroupAttribute()
+    {
+        $loader = new AttributeLoader();
+
+        $metadata = new ClassMetadata(GroupSequenceCascadeEntity::class);
+        $loader->loadClassMetadata($metadata);
+
+        $this->assertSame(['Foo', 'GroupSequenceCascadeEntity'], $metadata->getGroupSequence()->groups);
+        $this->assertTrue($metadata->getGroupSequence()->cascadeCurrentGroup);
     }
 
     public function testLoadGroupSequenceProviderAttribute()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
 use Symfony\Component\Validator\Tests\Fixtures\Entity_81;
+use Symfony\Component\Validator\Tests\Fixtures\GroupSequenceCascadeEntity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\GroupSequenceProviderEntity;
 use Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithNamedArguments;
@@ -122,6 +123,19 @@ class XmlFileLoaderTest extends TestCase
         $expected->addPropertyConstraint('title', new ConstraintWithRequiredArgument('X'));
 
         $this->assertEquals($expected, $metadata);
+    }
+
+    public function testLoadGroupSequenceCascadingTheCurrentGroup()
+    {
+        $loader = new XmlFileLoader(__DIR__.'/constraint-mapping.xml');
+        $metadata = new ClassMetadata(GroupSequenceCascadeEntity::class);
+
+        $loader->loadClassMetadata($metadata);
+
+        $groupSequence = $metadata->getGroupSequence();
+
+        $this->assertSame(['Foo', 'GroupSequenceCascadeEntity'], $groupSequence->groups);
+        $this->assertTrue($groupSequence->cascadeCurrentGroup);
     }
 
     public function testLoadGroupSequenceProvider()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithRequiredArgument;
 use Symfony\Component\Validator\Tests\Fixtures\Entity_81;
+use Symfony\Component\Validator\Tests\Fixtures\GroupSequenceCascadeEntity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\GroupSequenceProviderEntity;
 use Symfony\Component\Validator\Tests\Mapping\Loader\Fixtures\ConstraintWithNamedArguments;
@@ -162,6 +163,19 @@ class YamlFileLoaderTest extends TestCase
         $expected->addPropertyConstraint('title', new ConstraintWithRequiredArgument('X'));
 
         $this->assertEquals($expected, $metadata);
+    }
+
+    public function testLoadGroupSequenceCascadingTheCurrentGroup()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');
+        $metadata = new ClassMetadata(GroupSequenceCascadeEntity::class);
+
+        $loader->loadClassMetadata($metadata);
+
+        $groupSequence = $metadata->getGroupSequence();
+
+        $this->assertSame(['Foo', 'GroupSequenceCascadeEntity'], $groupSequence->groups);
+        $this->assertTrue($groupSequence->cascadeCurrentGroup);
     }
 
     public function testLoadGroupSequenceProvider()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
@@ -139,6 +139,15 @@
     </getter>
   </class>
 
+  <class name="Symfony\Component\Validator\Tests\Fixtures\GroupSequenceCascadeEntity">
+
+    <group-sequence cascade-current-group="true">
+       <value>Foo</value>
+       <value>GroupSequenceCascadeEntity</value>
+    </group-sequence>
+
+  </class>
+
   <class name="Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\GroupSequenceProviderEntity">
 
     <!-- GROUP SEQUENCE PROVIDER -->

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
@@ -73,6 +73,11 @@ Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity:
     permissions:
       - "IsTrue": ~
 
+Symfony\Component\Validator\Tests\Fixtures\GroupSequenceCascadeEntity:
+  group_sequence:
+    groups: [Foo, GroupSequenceCascadeEntity]
+    cascade_current_group: true
+
 Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\GroupSequenceProviderEntity:
   group_sequence_provider: true
 

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -50,6 +50,8 @@ use Symfony\Component\Validator\Tests\Constraints\Fixtures\ChildA;
 use Symfony\Component\Validator\Tests\Constraints\Fixtures\ChildB;
 use Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider;
 use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupProviderDto;
+use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupSequenceProviderCascadeChild;
+use Symfony\Component\Validator\Tests\Fixtures\Attribute\GroupSequenceProviderCascadeEntity;
 use Symfony\Component\Validator\Tests\Fixtures\CascadedChild;
 use Symfony\Component\Validator\Tests\Fixtures\CascadingEntity;
 use Symfony\Component\Validator\Tests\Fixtures\EntityWithGroupedConstraintOnMethods;
@@ -59,6 +61,7 @@ use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\EntityParent;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\GroupSequenceProviderEntity;
 use Symfony\Component\Validator\Tests\Fixtures\Reference;
+use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\LazyProperty;
 use Symfony\Component\Validator\Validator\RecursiveValidator;
@@ -1269,6 +1272,20 @@ class RecursiveValidatorTest extends TestCase
         $this->assertCount(0, $violations);
     }
 
+    public function testGroupSequenceProviderReturningAnArrayCanCascadeTheCurrentGroup()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+
+        $entity = new GroupSequenceProviderCascadeEntity();
+        $entity->child = new GroupSequenceProviderCascadeChild();
+        $entity->child->a = 'too long';
+
+        $violations = $validator->validate($entity);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('child.a', $violations[0]->getPropertyPath());
+    }
+
     public function testPropagateDefaultGroupToReferenceWhenReplacingDefaultGroup()
     {
         $entity = new Entity();
@@ -1296,6 +1313,74 @@ class RecursiveValidatorTest extends TestCase
 
         $violations = $this->validate($entity, null, 'Default');
 
+        /* @var ConstraintViolationInterface[] $violations */
+        $this->assertCount(1, $violations);
+        $this->assertSame('Violation in Default group', $violations[0]->getMessage());
+    }
+
+    public function testPropagateCurrentGroupToReferenceWhenReplacingDefaultGroupAndCascadingCurrentGroup()
+    {
+        $entity = new Entity();
+        $entity->reference = new Reference();
+
+        $callback1 = static function ($value, ExecutionContextInterface $context) {
+            $context->addViolation('Violation in Default group');
+        };
+        $callback2 = static function ($value, ExecutionContextInterface $context) {
+            $context->addViolation('Violation in group sequence');
+        };
+
+        $this->metadata->addPropertyConstraint('reference', new Valid());
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Default'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 1'],
+        ));
+
+        $sequence = new GroupSequence(['Group 1', 'Entity'], cascadeCurrentGroup: true);
+        $this->metadata->setGroupSequence($sequence);
+
+        $violations = $this->validate($entity, null, 'Default');
+
+        // With "cascadeCurrentGroup" enabled, the "Group 1" constraint of the
+        // referenced object is validated alongside its "Default" constraints.
+        /* @var ConstraintViolationInterface[] $violations */
+        $this->assertCount(2, $violations);
+        $this->assertSame('Violation in Default group', $violations[0]->getMessage());
+        $this->assertSame('Violation in group sequence', $violations[1]->getMessage());
+    }
+
+    public function testDoNotPropagateCurrentGroupToReferenceWhenNotCascadingCurrentGroup()
+    {
+        $entity = new Entity();
+        $entity->reference = new Reference();
+
+        $callback1 = static function ($value, ExecutionContextInterface $context) {
+            $context->addViolation('Violation in Default group');
+        };
+        $callback2 = static function ($value, ExecutionContextInterface $context) {
+            $context->addViolation('Violation in group sequence');
+        };
+
+        $this->metadata->addPropertyConstraint('reference', new Valid());
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback1,
+            groups: ['Default'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: $callback2,
+            groups: ['Group 1'],
+        ));
+
+        $this->metadata->setGroupSequence(new GroupSequence(['Group 1', 'Entity']));
+
+        $violations = $this->validate($entity, null, 'Default');
+
+        // Without "cascadeCurrentGroup", the referenced object is only validated
+        // in the "Default" group, as before
         /* @var ConstraintViolationInterface[] $violations */
         $this->assertCount(1, $violations);
         $this->assertSame('Violation in Default group', $violations[0]->getMessage());

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -31,6 +31,7 @@ use Symfony\Component\Validator\Exception\UnsupportedMetadataException;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\GroupSequenceProviderInterface;
 use Symfony\Component\Validator\Mapping\CascadingStrategy;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\GenericMetadata;
@@ -473,7 +474,9 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
                     $defaultOverridden = true;
 
                     if (!$group instanceof GroupSequence) {
-                        $group = new GroupSequence($group);
+                        // a provider returning a plain array carries no flag of its own,
+                        // so the one declared on the class applies
+                        $group = new GroupSequence($group, $metadata instanceof ClassMetadata && $metadata->getCascadeCurrentGroup());
                     }
                 }
             }
@@ -704,6 +707,12 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         foreach ($groupSequence->groups as $groupInSequence) {
             $groups = (array) $groupInSequence;
 
+            // $cascadedGroup is non-null only when the sequence replaced the class's "Default" group
+            $stepCascadedGroups = $cascadedGroups;
+            if (null !== $cascadedGroup && $groupSequence->cascadeCurrentGroup) {
+                $stepCascadedGroups = array_values(array_unique([$cascadedGroup, ...array_filter($groups, \is_string(...))]));
+            }
+
             if ($metadata instanceof ClassMetadataInterface) {
                 $this->validateClassNode(
                     $value,
@@ -711,7 +720,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
                     $metadata,
                     $propertyPath,
                     $groups,
-                    $cascadedGroups,
+                    $stepCascadedGroups,
                     $traversalStrategy,
                     $context
                 );
@@ -723,7 +732,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
                     $metadata,
                     $propertyPath,
                     $groups,
-                    $cascadedGroups,
+                    $stepCascadedGroups,
                     $traversalStrategy,
                     $context
                 );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64365
| License       | MIT

When a class declares a group sequence, the sequence replaces the `Default` group, and referenced objects are then validated against `Default` only. The group being stepped through does not reach them, so a constraint placed in one of the sequence's own groups never runs on a referenced object.

`cascadeCurrentGroup` cascades that group as well:

```php
#[Assert\GroupSequence(['basic', 'Order'], cascadeCurrentGroup: true)]
class Order
{
    #[Assert\Valid]
    public Address $address;
}
```

Validating an `Order` now validates `$address` against `Default` and against `basic` while that step runs, instead of `Default` alone. The default is `false`, so nothing changes for existing sequences.

It is available from the four mapping formats:

```yaml
Order:
    group_sequence:
        groups: [basic, Order]
        cascade_current_group: true
```

```xml
<class name="Order">
    <group-sequence cascade-current-group="true">
        <value>basic</value>
        <value>Order</value>
    </group-sequence>
</class>
```

and through `ClassMetadata::setGroupSequence(new GroupSequence([...], true))`.

A group sequence provider can opt in without changing what it returns, by declaring the flag on the class:

```php
#[Assert\GroupSequenceProvider(cascadeCurrentGroup: true)]
class Order implements GroupSequenceProviderInterface
{
    public function getGroupSequence(): array|GroupSequence
    {
        return ['basic', 'Order'];
    }
}
```

One limit worth knowing: the flag applies to sequences declared by a class. Passing a sequence explicitly to the validator, through the `validation_groups` form option for instance, already validates referenced objects against the group being stepped through.

While at it, the `GroupSequence::$cascadedGroup` property is removed. It carried the same idea, the group to cascade while stepping through a sequence, but only in the node-traverser prototype of 2014; the validator has computed that value itself ever since, and nothing has read the property in any released version. Since 7.4 typed it without a default, reading it threw `must not be accessed before initialization`, so no working code can depend on it.

Points for the documentation:

* `GroupSequence` accepts `cascadeCurrentGroup`, default `false`
* with it, referenced objects are validated against `Default` plus the group being stepped through
* available from attributes, XML (`cascade-current-group`), YAML (the `groups` / `cascade_current_group` mapping form) and `ClassMetadata::setGroupSequence()`
* a group sequence provider opts in through `#[Assert\GroupSequenceProvider(cascadeCurrentGroup: true)]`, whatever it returns
* the unused `GroupSequence::$cascadedGroup` property is gone
