### PR TITLE
[ObjectMapper] Fix reverse class mapping of private properties from parent classes

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\ObjectMapper\Metadata;
 
 use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\ClassHierarchyTrait;
 
 /**
  * Maps classes based on attributes found on the target's properties.
@@ -20,6 +21,8 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
  */
 final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetadataFactoryInterface
 {
+    use ClassHierarchyTrait;
+
     /**
      * @var array<string, list<Mapping>>
      */
@@ -61,7 +64,7 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
         }
 
         foreach ($targetClasses as $targetClass) {
-            foreach ((new \ReflectionClass($targetClass))->getProperties() as $reflProperty) {
+            foreach ($this->getAllProperties(new \ReflectionClass($targetClass)) as $reflProperty) {
                 foreach ($reflProperty->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
                     $map = $attribute->newInstance();
                     if ($map->source !== $property) {

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PrivateMappedChildView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PrivateMappedChildView.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Cost::class)]
+final class PrivateMappedChildView extends PrivateMappedParentView
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PrivateMappedParentView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PrivateMappedParentView.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+class PrivateMappedParentView
+{
+    #[Map(source: 'bar')]
+    private ?string $foo = null;
+
+    public function getFoo(): ?string
+    {
+        return $this->foo;
+    }
+
+    public function setFoo(?string $foo): void
+    {
+        $this->foo = $foo;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -42,6 +42,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\ExtensibleTargetChild
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\ExtensibleTargetParent;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PreMappedSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PreMappedTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PrivateMappedChildView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RichDomainUser;
@@ -870,6 +871,27 @@ final class ObjectMapperTest extends TestCase
 
         $this->assertInstanceOf(CostRequestWithSourceView::class, $costRequestView);
         $this->assertEquals('bar', $costRequestView->foo);
+    }
+
+    public function testClassMapWithSourceAttributeOnPrivateParentProperty()
+    {
+        $classMap = [
+            Cost::class => PrivateMappedChildView::class,
+        ];
+
+        $cost = new Cost(10, 20, 'bar');
+
+        $mapper = new ObjectMapper(
+            new ReverseClassObjectMapperMetadataFactory(new ReflectionObjectMapperMetadataFactory(), $classMap),
+            PropertyAccess::createPropertyAccessor(),
+        );
+
+        $view = $mapper->map($cost);
+
+        // The "#[Map(source: 'bar')]" attribute sits on a private property
+        // inherited from the parent class and must still be discovered.
+        $this->assertInstanceOf(PrivateMappedChildView::class, $view);
+        $this->assertSame('bar', $view->getFoo());
     }
 
     public function testClassMapWithSourceAttributeDoesNotBreakAutoMapping()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follow-up to #63791
| License       | MIT

Follow-up to #63791 (merged on 7.4). As @stof asked and @soyuka confirmed in that thread, `ReverseClassObjectMapperMetadataFactory` is 8.1-only and was dropped from the merge-up, but it carries the same bug.

`#[Map(source: ...)]` attributes placed on **private properties inherited from a parent class** of the target are never discovered, because `(new \ReflectionClass($targetClass))->getProperties()` skips inherited private properties.

The fix mirrors #63791: it reuses the `ClassHierarchyTrait::getAllProperties()` helper introduced there (now merged up to 8.1) instead of `ReflectionClass::getProperties()`. Added a regression test that fails without the change (`null`) and passes with it.

cc @nicolas-grekas @soyuka @stof — thanks for spotting that it goes further than the original scope! 🙏
