### PR TITLE
[Cache] Ensure RelayClusterProxy compatibility with Relay extension 0.30.0

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Relay/RelayCluster30Trait.php
+++ b/src/Symfony/Component/Cache/Traits/Relay/RelayCluster30Trait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits\Relay;
+
+if (version_compare(phpversion('relay'), '0.30.0', '>=')) {
+    /**
+     * @internal
+     */
+    trait RelayCluster30Trait
+    {
+        public function increx($key, $value = null, $options = null): \Relay\Cluster|array|false
+        {
+            return $this->initializeLazyObject()->increx(...\func_get_args());
+        }
+
+        public function xnack($key, $group, $mode, $ids, $options = null): \Relay\Cluster|false|int
+        {
+            return $this->initializeLazyObject()->xnack(...\func_get_args());
+        }
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait RelayCluster30Trait
+    {
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RelayClusterProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RelayClusterProxy.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\Cache\Traits\Relay\RelayCluster20Trait;
 use Symfony\Component\Cache\Traits\Relay\RelayCluster21Trait;
+use Symfony\Component\Cache\Traits\Relay\RelayCluster30Trait;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -31,6 +32,7 @@ class RelayClusterProxy extends \Relay\Cluster implements ResetInterface, LazyOb
     }
     use RelayCluster20Trait;
     use RelayCluster21Trait;
+    use RelayCluster30Trait;
 
     public function __construct($name, $seeds = null, $connect_timeout = 0, $command_timeout = 0, $persistent = false, #[\SensitiveParameter] $auth = null, $context = null)
     {
@@ -1082,7 +1084,7 @@ class RelayClusterProxy extends \Relay\Cluster implements ResetInterface, LazyOb
         return $this->initializeLazyObject()->vrandmember(...\func_get_args());
     }
 
-    public function vrange($key, $end, $start, $count = -1): \Relay\Cluster|array|bool
+    public function vrange($key, $min, $max, $count = -1): \Relay\Cluster|array|false
     {
         return $this->initializeLazyObject()->vrange(...\func_get_args());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64644
| License       | MIT

`RelayClusterProxy` extends `\Relay\Cluster`, so its method signatures must stay compatible with the extension. Relay 0.30.0 ("Fixed arity and reply type of various commands") declares:

```
Relay\Cluster::vrange(mixed $key, string $min, string $max, int $count = -1): \Relay\Cluster|array|false
```

but the committed proxy still declared `vrange($key, $end, $start, $count = -1): \Relay\Cluster|array|bool`. The `bool` return type is wider than the extension's `false`, which violates return-type covariance and makes the class fail to load:

> Declaration of `Symfony\Component\Cache\Traits\RelayClusterProxy::vrange(...)` must be compatible with `Relay\Cluster::vrange(...)`

Being a fatal at class-declaration time, it breaks the whole test suite wherever a recent Relay extension is installed (currently red on CI). This syncs the signature, mirroring the already-correct `RelayProxy::vrange()` and the Redis proxies.

Relay 0.30.0 also added the `INCREX` and `XNACK` commands. They are declared through a version-gated `RelayCluster30Trait`, following the existing `RelayCluster20`/`RelayCluster21` traits and #64122, so `RedisProxiesTest` stays in sync across Relay versions.

The non-cluster `RelayProxy` needs the same `increx`/`xnack` additions plus the `unwatch` reply-type change. As `RelayClusterProxy` only exists since 7.3, that is handled in a separate PR on 6.4.
