### PR TITLE
[FrameworkBundle][TwigBridge] Relax test assertions for generated `_fragment` URI

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -83,7 +83,7 @@ class HttpKernelExtensionTest extends TestCase
         ]));
         $twig->addRuntimeLoader($loader);
 
-        $this->assertMatchesRegularExpression('#/_fragment\?_hash=.+&amp;_path=template%3Dfoo.html.twig%26_format%3Dhtml%26_locale%3Den%26_controller%3DSymfony%255CBundle%255CFrameworkBundle%255CController%255CTemplateController%253A%253AtemplateAction$#', $twig->render('index'));
+        $this->assertMatchesRegularExpression('#/_fragment\?(?:_expiration=.+&amp;)?_hash=.+&amp;_path=template%3Dfoo.html.twig%26_format%3Dhtml%26_locale%3Den%26_controller%3DSymfony%255CBundle%255CFrameworkBundle%255CController%255CTemplateController%253A%253AtemplateAction$#', $twig->render('index'));
     }
 
     protected function getFragmentHandler($returnOrException): FragmentHandler

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
@@ -51,6 +51,6 @@ class FragmentTest extends AbstractWebTestCase
         $client = self::createClient(['test_case' => 'Fragment', 'root_config' => 'config.yml', 'debug' => true]);
         $client->request('GET', '/fragment_uri');
 
-        $this->assertMatchesRegularExpression('#/_fragment\?_hash=.+&_path=_format%3Dhtml%26_locale%3Den%26_controller%3DSymfony%255CBundle%255CFrameworkBundle%255CTests%255CFunctional%255CBundle%255CTestBundle%255CController%255CFragmentController%253A%253AindexAction$#', $client->getResponse()->getContent());
+        $this->assertMatchesRegularExpression('#/_fragment\?(?:_expiration=.+&)?_hash=.+&_path=_format%3Dhtml%26_locale%3Den%26_controller%3DSymfony%255CBundle%255CFrameworkBundle%255CTests%255CFunctional%255CBundle%255CTestBundle%255CController%255CFragmentController%253A%253AindexAction$#', $client->getResponse()->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

To help with #64455