### PR TITLE
[Cache] Ensure RelayProxy compatibility with Relay extension 0.30.0

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Relay/Relay30Trait.php
+++ b/src/Symfony/Component/Cache/Traits/Relay/Relay30Trait.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits\Relay;
+
+if (version_compare(phpversion('relay'), '0.30.0', '>=')) {
+    /**
+     * @internal
+     */
+    trait Relay30Trait
+    {
+        public function increx($key, $value = null, $options = null): \Relay\Relay|array|false
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->increx(...\func_get_args());
+        }
+
+        public function unwatch(): \Relay\Relay|bool|string
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
+        }
+
+        public function xnack($key, $group, $mode, $ids, $options = null): \Relay\Relay|false|int
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->xnack(...\func_get_args());
+        }
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait Relay30Trait
+    {
+        public function unwatch(): \Relay\Relay|bool
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
+        }
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RelayProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RelayProxy.php
@@ -28,6 +28,7 @@ use Symfony\Component\Cache\Traits\Relay\Relay12Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay20Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay21Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay22Trait;
+use Symfony\Component\Cache\Traits\Relay\Relay30Trait;
 use Symfony\Component\Cache\Traits\Relay\SwapdbTrait;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Component\VarExporter\LazyProxyTrait;
@@ -64,6 +65,7 @@ class RelayProxy extends \Relay\Relay implements ResetInterface, LazyObjectInter
     use Relay20Trait;
     use Relay21Trait;
     use Relay22Trait;
+    use Relay30Trait;
     use SwapdbTrait;
 
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];
@@ -941,11 +943,6 @@ class RelayProxy extends \Relay\Relay implements ResetInterface, LazyObjectInter
     public function wait($replicas, $timeout): \Relay\Relay|false|int
     {
         return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->wait(...\func_get_args());
-    }
-
-    public function unwatch(): \Relay\Relay|bool
-    {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->unwatch(...\func_get_args());
     }
 
     public function discard(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #64122 for Relay 0.30.0, which "Added support for `INCREX` and `XNACK` commands" and "Fixed arity and reply type of various commands".

`RelayProxy` extends `\Relay\Relay`, so its method signatures must stay compatible with the installed extension. On Relay 0.30.0, `RedisProxiesTest::testRelayProxy` fails: the proxy is missing `increx()` and `xnack()`, and declares `unwatch(): \Relay\Relay|bool` while the extension now returns `\Relay\Relay|bool|string`.

These are declared through a version-gated `Relay30Trait`, mirroring the existing `Relay20`/`Relay21`/`Relay22` traits. `unwatch()` moves out of the base proxy into the trait so each reply type can be expressed per Relay version.

The cluster counterpart `RelayClusterProxy` only exists since 7.3 and is handled in #64645.
