### PR TITLE
[Serializer] Fix support check for nested array items

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -89,8 +89,17 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
             throw new BadMethodCallException(\sprintf('The nested denormalizer needs to be set to allow "%s()" to be used.', __METHOD__));
         }
 
-        return str_ends_with($type, '[]')
-            && $this->denormalizer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
+        if (!str_ends_with($type, '[]') || !\is_array($data)) {
+            return false;
+        }
+
+        $itemType = substr($type, 0, -2);
+
+        foreach ($data as $item) {
+            return $this->denormalizer->supportsDenormalization($item, $itemType, $format, $context);
+        }
+
+        return true;
     }
 
     /**
@@ -103,9 +112,6 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
         return $this->denormalizer instanceof CacheableSupportsMethodInterface && $this->denormalizer->hasCacheableSupportsMethod();
     }
 
-    /**
-     * @param mixed $key
-     */
     private function validateKeyType(array $builtinTypes, $key, string $path): void
     {
         if (!$builtinTypes) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -59,7 +59,7 @@ class ArrayDenormalizerTest extends TestCase
         $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
         $nestedDenormalizer->expects($this->once())
             ->method('supportsDenormalization')
-            ->with($this->anything(), ArrayDummy::class, 'json', ['con' => 'text'])
+            ->with(['foo' => 'one', 'bar' => 'two'], ArrayDummy::class, 'json', ['con' => 'text'])
             ->willReturn(true);
         $denormalizer = new ArrayDenormalizer();
         $denormalizer->setDenormalizer($nestedDenormalizer);
@@ -107,6 +107,19 @@ class ArrayDenormalizerTest extends TestCase
                 ['foo' => 'one', 'bar' => 'two'],
                 ArrayDummy::class
             )
+        );
+    }
+
+    public function testSupportsEmptyArray()
+    {
+        $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
+        $nestedDenormalizer->expects($this->never())
+            ->method('supportsDenormalization');
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($nestedDenormalizer);
+
+        $this->assertTrue(
+            $denormalizer->supportsDenormalization([], __NAMESPACE__.'\ArrayDummy[]')
         );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1118,10 +1118,10 @@ class SerializerTest extends TestCase
             ],
             [
                 'currentType' => 'null',
-                'expectedTypes' => ['array'],
+                'expectedTypes' => ['Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]'],
                 'path' => 'anotherCollection',
                 'useMessageForUser' => false,
-                'message' => 'Data expected to be "Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]", "null" given.',
+                'message' => 'The type of the "anotherCollection" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74Full" must be one of "Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]" ("null" given).',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #62212, Fix #20837
| License       | MIT

`ArrayDenormalizer::supportsDenormalization()` passed the whole collection as `$data` while passing the item type (`Foo` for `Foo[]`). The `(data, type)` pair was therefore incoherent: any inner denormalizer that inspects `$data` received a collection where it expected a single item, leading to false negatives (`Could not denormalize ... no supporting normalizer found`).

This keeps `supportsDenormalization()` cheap, as agreed in #20837: rather than iterating the whole collection (which the maintainers there rejected for its performance cost without real benefit), it checks support against the first item only, which is representative of the collection. Denormalizers that ignore `$data` (the vast majority) are unaffected; data-dependent ones now receive a real item.

As a side effect, a `null` value for a collection-typed attribute is now reported with the regular "type of attribute must be one of ...[]" message during error collection, consistent with every other type mismatch, instead of a divergent one.

Alternative to #62472.
