### PR TITLE
[Serializer] Allow associative `csv_headers` to map and reorder columns when encoding

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Allow passing an associative array to `CsvEncoder::HEADERS_KEY` to map and reorder columns when encoding
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property
 
 8.1

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -26,6 +26,15 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
     public const DELIMITER_KEY = 'csv_delimiter';
     public const ENCLOSURE_KEY = 'csv_enclosure';
     public const KEY_SEPARATOR_KEY = 'csv_key_separator';
+
+    /**
+     * A list of column names (e.g. ['name', 'user.email']) used to order the columns when encoding,
+     * any extra column being appended after them.
+     *
+     * When encoding, an associative array (e.g. ['Name' => 'name', 'Email' => 'user.email']) maps each
+     * column label to the path it reads from the flattened row; only the listed columns are then emitted,
+     * in the listed order.
+     */
     public const HEADERS_KEY = 'csv_headers';
     public const ESCAPE_FORMULAS_KEY = 'csv_escape_formulas';
     public const AS_COLLECTION_KEY = 'as_collection';
@@ -88,7 +97,22 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         }
         unset($value);
 
-        $headers = array_merge(array_values($headers), array_diff($this->extractHeaders($data), $headers));
+        if ($headers && !array_is_list($headers)) {
+            // Associative HEADERS_KEY: keys are the CSV column labels, values are the paths into the
+            // flattened row. Only the listed columns are emitted, in the listed order, and no extra
+            // column is appended.
+            foreach ($data as &$value) {
+                $remapped = [];
+                foreach ($headers as $label => $path) {
+                    $remapped[$label] = $value[$path] ?? '';
+                }
+                $value = $remapped;
+            }
+            unset($value);
+            $headers = array_keys($headers);
+        } else {
+            $headers = array_merge(array_values($headers), array_diff($this->extractHeaders($data), $headers));
+        }
         $endOfLine = $context[self::END_OF_LINE] ?? $this->defaultContext[self::END_OF_LINE];
 
         if (!($context[self::NO_HEADERS_KEY] ?? $this->defaultContext[self::NO_HEADERS_KEY])) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -264,6 +264,83 @@ class CsvEncoderTest extends TestCase
         $this->assertEquals($csv, $this->encoder->encode($value, 'csv', $context));
     }
 
+    public function testEncodeWithAssociativeHeaders()
+    {
+        $data = [
+            ['firstName' => 'Alice', 'lastName' => 'A', 'age' => 30],
+            ['firstName' => 'Bob', 'lastName' => 'B', 'age' => 25],
+        ];
+
+        $this->assertSame(
+            "Prénom,Nom\nAlice,A\nBob,B\n",
+            $this->encoder->encode($data, 'csv', [
+                CsvEncoder::HEADERS_KEY => ['Prénom' => 'firstName', 'Nom' => 'lastName'],
+            ])
+        );
+    }
+
+    public function testEncodeWithAssociativeHeadersAndNestedPaths()
+    {
+        $data = [
+            ['user' => ['first' => 'Alice', 'last' => 'A']],
+            ['user' => ['first' => 'Bob', 'last' => 'B']],
+        ];
+
+        $this->assertSame(
+            "firstName,lastName\nAlice,A\nBob,B\n",
+            $this->encoder->encode($data, 'csv', [
+                CsvEncoder::HEADERS_KEY => ['firstName' => 'user.first', 'lastName' => 'user.last'],
+            ])
+        );
+    }
+
+    public function testEncodeWithAssociativeHeadersFillsMissingPathsWithEmptyString()
+    {
+        $data = [
+            ['firstName' => 'Alice', 'lastName' => 'A'],
+            ['firstName' => 'Bob', 'lastName' => 'B'],
+        ];
+
+        $this->assertSame(
+            "Prénom,Missing\nAlice,\nBob,\n",
+            $this->encoder->encode($data, 'csv', [
+                CsvEncoder::HEADERS_KEY => ['Prénom' => 'firstName', 'Missing' => 'unknown'],
+            ])
+        );
+    }
+
+    public function testEncodeWithAssociativeHeadersHonorsKeySeparator()
+    {
+        $data = [
+            ['user' => ['first' => 'Alice']],
+            ['user' => ['first' => 'Bob']],
+        ];
+
+        $this->assertSame(
+            "firstName\nAlice\nBob\n",
+            $this->encoder->encode($data, 'csv', [
+                CsvEncoder::KEY_SEPARATOR_KEY => '-',
+                CsvEncoder::HEADERS_KEY => ['firstName' => 'user-first'],
+            ])
+        );
+    }
+
+    public function testEncodeWithAssociativeHeadersAndNoHeaders()
+    {
+        $data = [
+            ['firstName' => 'Alice', 'lastName' => 'A'],
+            ['firstName' => 'Bob', 'lastName' => 'B'],
+        ];
+
+        $this->assertSame(
+            "Alice,A\nBob,B\n",
+            $this->encoder->encode($data, 'csv', [
+                CsvEncoder::NO_HEADERS_KEY => true,
+                CsvEncoder::HEADERS_KEY => ['Prénom' => 'firstName', 'Nom' => 'lastName'],
+            ])
+        );
+    }
+
     public function testEncodeFormulas()
     {
         $this->encoder = new CsvEncoder([CsvEncoder::ESCAPE_FORMULAS_KEY => true]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`CsvEncoder::HEADERS_KEY` accepted a plain list of column names, used to order the
columns (known ones first, the rest appended). This PR additionally accepts an
associative array when encoding, mapping each column label to the path it reads from
the flattened row:

```php
$encoder->encode($data, 'csv', [
    CsvEncoder::HEADERS_KEY => ['Prénom' => 'firstName', 'Nom' => 'user.lastName'],
]);
```

Only the listed columns are emitted, in the listed order, and no extra column is
appended. The path honors `KEY_SEPARATOR_KEY`, so nested values can be selected. A
missing path yields an empty cell. The existing list form is unchanged.
