### PR TITLE
[DependencyInjection] Allow computing #[AutoconfigureTag] attributes per tagged service

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -39,6 +39,9 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/compositetype_classes.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/intersectiontype_classes.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/MultipleArgumentsOptionalScalarNotReallyOptional.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTaggedWithClosure.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedWithClosure.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithClosureInterface.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ParentNotExists.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Preload/'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/BadClasses/MissingParent.php'):

--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class Autoconfigure
 {
     /**
-     * @param array<array<mixed>>|string[]|null $tags         The tags to add to the service
+     * @param array<array<mixed>>|string[]|null $tags         The tags to add to the service; a tag's attributes may be a \Closure or a [class-string, method] callable that computes them from each tagged service's class-string
      * @param array<array<mixed>>|null          $calls        The calls to be made when instantiating the service
      * @param array<string, mixed>|null         $bind         The bindings to declare for the service
      * @param bool|string|null                  $lazy         Whether the service is lazy-loaded

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutoconfigureTag.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutoconfigureTag.php
@@ -20,10 +20,13 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class AutoconfigureTag extends Autoconfigure
 {
     /**
-     * @param string|null  $name       The tag name to add
-     * @param array<mixed> $attributes The attributes to attach to the tag
+     * @param string|null           $name       The tag name to add
+     * @param array<mixed>|\Closure $attributes The attributes to attach to the tag. To compute them per tagged
+     *                                          service, pass a closure receiving the concrete class-string (requires
+     *                                          PHP 8.5), or a [class-string, method] callable whose static method is
+     *                                          called on each concrete class (works on PHP 8.4)
      */
-    public function __construct(?string $name = null, array $attributes = [])
+    public function __construct(?string $name = null, array|\Closure $attributes = [])
     {
         parent::__construct(
             tags: [

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
+
 8.1
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
@@ -71,11 +71,20 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
 
         self::$registerForAutoconfiguration = static function (ContainerBuilder $container, \ReflectionClass $class, \ReflectionAttribute $attribute) use ($parseDefinitions, $yamlLoader) {
             $attribute = (array) $attribute->newInstance();
+            $closureTags = [];
 
             foreach (['tags', 'resourceTags'] as $type) {
                 foreach ($attribute[$type] ?? [] as $i => $tag) {
                     if (\is_array($tag) && [0] === array_keys($tag)) {
-                        $attribute[$type][$i] = [$class->name => $tag[0]];
+                        $tag = $attribute[$type][$i] = [$class->name => $tag[0]];
+                    }
+
+                    // A closure attribute-set cannot be expressed in YAML and must not go
+                    // through the loader below; it is resolved per concrete class later, in
+                    // ResolveInstanceofConditionalsPass.
+                    if ('tags' === $type && \is_array($tag) && 1 === \count($tag) && current($tag) instanceof \Closure) {
+                        $closureTags[] = [key($tag), current($tag)];
+                        unset($attribute[$type][$i]);
                     }
                 }
             }
@@ -96,6 +105,12 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
                 $class->getFileName(),
                 false
             );
+
+            // The closure is wrapped in an array so addTag() keeps an array attribute-set;
+            // ResolveInstanceofConditionalsPass unwraps and resolves it per concrete class.
+            foreach ($closureTags as [$name, $closure]) {
+                $container->registerForAutoconfiguration($class->name)->addTag($name, [$closure]);
+            }
         };
 
         (self::$registerForAutoconfiguration)($container, $class, $attribute);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -120,6 +120,12 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 foreach ($tags as $k => $v) {
                     if (null === $definition->getDecoratedService() || $interface === $definition->getClass() || \in_array($k, $tagsToKeep, true)) {
                         foreach ($v as $v) {
+                            if (self::isLazyTagAttributes($v)) {
+                                if (!($r = $container->getReflectionClass($class, false)) || !$r->isInstantiable()) {
+                                    continue;
+                                }
+                                $v = self::resolveTagAttributes($v, $class, $k, $interface);
+                            }
                             if ($definition->hasTag($k) && \in_array($v, $definition->getTag($k), true)) {
                                 continue;
                             }
@@ -169,5 +175,52 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
         }
 
         return $conditionals;
+    }
+
+    /**
+     * Whether a tag attribute-set is a lazily-computed one to be resolved per concrete class: either a
+     * [\Closure] (a closure wrapped in an array so it survives addTag()) or a [class-string, method] callable.
+     */
+    private static function isLazyTagAttributes(mixed $attributes): bool
+    {
+        if (!\is_array($attributes)) {
+            return false;
+        }
+
+        if ([0] === array_keys($attributes) && $attributes[0] instanceof \Closure) {
+            return true;
+        }
+
+        return [0, 1] === array_keys($attributes)
+            && \is_string($attributes[0])
+            && \is_string($attributes[1])
+            && (class_exists($attributes[0]) || interface_exists($attributes[0]));
+    }
+
+    /**
+     * Computes the attributes of a tag whose attribute-set is a wrapped closure or a [class-string, method] callable.
+     */
+    private static function resolveTagAttributes(array $attributes, string $class, string $tag, string $interface): array
+    {
+        if ($attributes[0] instanceof \Closure) {
+            $resolved = $attributes[0]($class);
+            $source = \sprintf('The closure passed to the "%s" tag of "%s"', $tag, $interface);
+        } else {
+            [$declaringClass, $method] = $attributes;
+            if (!is_a($class, $declaringClass, true)) {
+                throw new InvalidArgumentException(\sprintf('Cannot tag "%s" through "%s::%s()" because it is not a subtype of "%s".', $class, $declaringClass, $method, $declaringClass));
+            }
+            if (!method_exists($class, $method)) {
+                throw new InvalidArgumentException(\sprintf('Cannot tag "%s" through "%s::%s()" because that method does not exist.', $class, $declaringClass, $method));
+            }
+            $resolved = $class::$method();
+            $source = \sprintf('The "%s::%s()" method computing the "%s" tag attributes', $declaringClass, $method, $tag);
+        }
+
+        if (!\is_array($resolved)) {
+            throw new InvalidArgumentException(\sprintf('%s must return an array of attributes, "%s" returned.', $source, get_debug_type($resolved)));
+        }
+
+        return $resolved;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -23,8 +23,11 @@ use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -38,9 +41,13 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredService1;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredService2;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutowireLocatorConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTaggedWithCallable;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTaggedWithClosure;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedForDefaultPriorityClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTaggedWithCallable;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTaggedWithClosure;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\StaticMethodTag;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedConsumerWithExclude;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedIteratorConsumer;
@@ -61,6 +68,9 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService3;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService3Configurator;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService4;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService5;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedWithCallableInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedWithClosureInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedWithClosureLocatorConsumer;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
@@ -343,6 +353,162 @@ class IntegrationTest extends TestCase
             'main_service_expected',
             $container,
         ];
+    }
+
+    public function testAutoconfiguredTagWithClosureAttributes()
+    {
+        if (\PHP_VERSION_ID < 80500) {
+            $this->markTestSkipped('Closures in constant expressions require PHP 8.5.');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register('foo', FooTaggedWithClosure::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+        $container->register('bar', BarTaggedWithClosure::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+
+        (new RegisterAutoconfigureAttributesPass())->processClass($container, new \ReflectionClass(TaggedWithClosureInterface::class));
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['key' => 'foo']], $container->getDefinition('foo')->getTag('app.handler'));
+        $this->assertSame([['key' => 'bar']], $container->getDefinition('bar')->getTag('app.handler'));
+    }
+
+    public function testAutoconfiguredTagWithClosureAttributesViaLocator()
+    {
+        if (\PHP_VERSION_ID < 80500) {
+            $this->markTestSkipped('Closures in constant expressions require PHP 8.5.');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register(TaggedWithClosureInterface::class)
+            ->setAbstract(true)
+            ->setAutoconfigured(true)
+        ;
+        $container->register('foo', FooTaggedWithClosure::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+        $container->register('bar', BarTaggedWithClosure::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+        $container->register(TaggedWithClosureLocatorConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        $locator = $container->get(TaggedWithClosureLocatorConsumer::class)->getLocator();
+
+        $this->assertSame($container->get('foo'), $locator->get('foo'));
+        $this->assertSame($container->get('bar'), $locator->get('bar'));
+    }
+
+    public function testAutoconfiguredTagWithCallableArrayAttributes()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FooTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+        $container->register('bar', BarTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+
+        (new RegisterAutoconfigureAttributesPass())->processClass($container, new \ReflectionClass(TaggedWithCallableInterface::class));
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['key' => 'foo']], $container->getDefinition('foo')->getTag('app.handler'));
+        $this->assertSame([['key' => 'bar']], $container->getDefinition('bar')->getTag('app.handler'));
+    }
+
+    public function testAutoconfiguredTagWithCallableArrayAttributesFromYaml()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Fixtures/yaml'));
+        $loader->load('services_with_callable_tag_attributes.yml');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['key' => 'foo']], $container->getDefinition('foo')->getTag('app.handler'));
+        $this->assertSame([['key' => 'bar']], $container->getDefinition('bar')->getTag('app.handler'));
+    }
+
+    public function testAutoconfiguredTagAttributesCanComputePriority()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FooTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+        $container->register('bar', BarTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+        ;
+        $container->registerForAutoconfiguration(TaggedWithCallableInterface::class)
+            ->addTag('app.handler', [static fn (string $class): array => $class::getTagAttributes() + ['priority' => FooTaggedWithCallable::class === $class ? 10 : 20]])
+        ;
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['key' => 'foo', 'priority' => 10]], $container->getDefinition('foo')->getTag('app.handler'));
+        $this->assertSame([['key' => 'bar', 'priority' => 20]], $container->getDefinition('bar')->getTag('app.handler'));
+    }
+
+    public function testAutoconfiguredTagAttributesMustReturnArray()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FooTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+        ;
+        $container->registerForAutoconfiguration(TaggedWithCallableInterface::class)
+            ->addTag('app.handler', [static fn (string $class) => 'not-an-array'])
+        ;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must return an array of attributes, "string" returned.');
+        (new ResolveInstanceofConditionalsPass())->process($container);
+    }
+
+    public function testAutoconfiguredTagWithCallableArrayDoesNotSilenceMethodTypos()
+    {
+        // The method name is not validated upfront, so a typo is reported when the tag is
+        // resolved instead of being silently treated as a literal attributes array.
+        $container = new ContainerBuilder();
+        $container->register('foo', FooTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+        ;
+        $container->registerForAutoconfiguration(TaggedWithCallableInterface::class)
+            ->addTag('app.handler', [TaggedWithCallableInterface::class, 'getTagAttribiutes'])
+        ;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('because that method does not exist');
+        (new ResolveInstanceofConditionalsPass())->process($container);
+    }
+
+    public function testAutoconfiguredTagCallableRejectsNonSubtypeDeclaringClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FooTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+        ;
+        // The declaring class must be a supertype of the tagged service, otherwise the static
+        // method would not be reachable on it; this is reported instead of failing silently.
+        $container->registerForAutoconfiguration(TaggedWithCallableInterface::class)
+            ->addTag('app.handler', [BarTaggedWithCallable::class, 'getTagAttributes'])
+        ;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot tag "'.FooTaggedWithCallable::class.'" through "'.BarTaggedWithCallable::class.'::getTagAttributes()" because it is not a subtype of');
+        (new ResolveInstanceofConditionalsPass())->process($container);
     }
 
     #[IgnoreDeprecations]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTaggedWithCallable.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class BarTaggedWithCallable implements TaggedWithCallableInterface
+{
+    public static function getTagAttributes(): array
+    {
+        return ['key' => 'bar'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTaggedWithClosure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTaggedWithClosure.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class BarTaggedWithClosure implements TaggedWithClosureInterface
+{
+    public static function getKey(): string
+    {
+        return 'bar';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedWithCallable.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooTaggedWithCallable implements TaggedWithCallableInterface
+{
+    public static function getTagAttributes(): array
+    {
+        return ['key' => 'foo'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedWithClosure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedWithClosure.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooTaggedWithClosure implements TaggedWithClosureInterface
+{
+    public static function getKey(): string
+    {
+        return 'foo';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithCallableInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithCallableInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.handler', attributes: [self::class, 'getTagAttributes'])]
+interface TaggedWithCallableInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getTagAttributes(): array;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithClosureInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithClosureInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.handler', attributes: static function (string $class): array {
+    return ['key' => $class::getKey()];
+})]
+interface TaggedWithClosureInterface
+{
+    public static function getKey(): string;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithClosureLocatorConsumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithClosureLocatorConsumer.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+
+final class TaggedWithClosureLocatorConsumer
+{
+    public function __construct(
+        #[AutowireLocator('app.handler', indexAttribute: 'key')]
+        private ContainerInterface $locator,
+    ) {
+    }
+
+    public function getLocator(): ContainerInterface
+    {
+        return $this->locator;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_callable_tag_attributes.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_callable_tag_attributes.yml
@@ -1,0 +1,13 @@
+services:
+    _instanceof:
+        Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedWithCallableInterface:
+            tags:
+                - app.handler: [Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedWithCallableInterface, getTagAttributes]
+
+    foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\FooTaggedWithCallable
+        public: true
+
+    bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\BarTaggedWithCallable
+        public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64407
| License       | MIT

#62339 deprecated the `defaultIndexMethod`/`defaultPriorityMethod` of tagged locators/iterators. As reported in #64407, this removed a useful property: an interface method tied the locator keys (or priorities) to a statically-analyzable type, so a typo in an implementation was caught by Psalm/PHPStan.

This PR brings that property back, on the tagging side, by allowing tag attributes to be computed per tagged service instead of attaching a single static array to all of them.

The attributes can be given as a closure receiving the concrete class-string:

```php
#[AutoconfigureTag('app.handler', attributes: static function (string $class): array {
    return ['key' => $class::getSupportedBatchAction()];
})]
interface StripeBatchHandlerInterface
{
    public static function getSupportedBatchAction(): string;
}
```

Closures in attributes require PHP 8.5, so a `[class-string, method]` callable is also accepted as an equivalent that already works on PHP 8.4. The static method is called on each tagged service's concrete class (late static binding), the class-string being the type that declares it (typically `self::class`), which is what static analysis anchors on:

```php
#[AutoconfigureTag('app.handler', attributes: [self::class, 'getTagAttributes'])]
interface StripeBatchHandlerInterface
{
    public static function getTagAttributes(): array;
}
```

Both forms also work through the lower-level `#[Autoconfigure(tags: ...)]`, and the `[class-string, method]` form is expressible in YAML `_instanceof` too:

```yaml
services:
    _instanceof:
        App\StripeBatchHandlerInterface:
            tags:
                - app.handler: [App\StripeBatchHandlerInterface, getTagAttributes]
```

This restores something for YAML users in particular, who got no replacement when `default_index_method` was deprecated (`#[AsTaggedItem]` being attribute-only).

The attributes are computed at compile time, per concrete and instantiable service, in `ResolveInstanceofConditionalsPass`, so nothing ever reaches the dumped container that couldn't be dumped.
