### PR TITLE
[Validator] Merge target's own constraints when using #[ExtendsValidationFor]

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -66,13 +66,22 @@ class AttributeLoader implements LoaderInterface
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
     {
-        if (!$sourceClasses = $this->mappedClasses[$classMetadata->getName()] ??= $this->allowAnyClass ? [$classMetadata->getName()] : []) {
+        $className = $classMetadata->getName();
+
+        if (!$sourceClasses = $this->mappedClasses[$className] ??= $this->allowAnyClass ? [$className] : []) {
             return false;
+        }
+
+        // When a class is the target of #[ExtendsSerializationFor], its mapping only lists the
+        // extension classes. The target's own attributes must still be loaded and merged,
+        // so make sure the class is always part of its own source classes.
+        if (!\in_array($className, $sourceClasses, true)) {
+            array_unshift($sourceClasses, $className);
         }
 
         $success = false;
         foreach ($sourceClasses as $sourceClass) {
-            $reflectionClass = $classMetadata->getName() === $sourceClass ? $classMetadata->getReflectionClass() : new \ReflectionClass($sourceClass);
+            $reflectionClass = $className === $sourceClass ? $classMetadata->getReflectionClass() : new \ReflectionClass($sourceClass);
             $success = $this->doLoadClassMetadata($reflectionClass, $classMetadata) || $success;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -301,6 +301,21 @@ class AttributeLoaderTest extends TestCase
         $this->assertContains('default', $classMetadata->getAttributesMetadata()['name']->getGroups());
     }
 
+    public function testLoadClassMetadataMergesTargetOwnAttributes()
+    {
+        $targetClass = _AttrMap_TargetWithOwnAttributes::class;
+        $sourceClass = _AttrMap_ExtensionForTargetWithOwnAttributes::class;
+
+        $loader = new AttributeLoader(false, [$targetClass => [$sourceClass]]);
+        $classMetadata = new ClassMetadata($targetClass);
+
+        $this->assertTrue($loader->loadClassMetadata($classMetadata));
+
+        $attributeMetadata = $classMetadata->getAttributesMetadata()['value'];
+        $this->assertSame(['own'], $attributeMetadata->getGroups(), "The target class' own attributes are dropped.");
+        $this->assertSame('extended_value', $attributeMetadata->getSerializedName(), 'The extension class attributes are dropped.');
+    }
+
     protected function getLoaderForContextMapping(): AttributeLoader
     {
         return $this->loader;
@@ -319,6 +334,7 @@ class _AttrMap_Target
 
 use Symfony\Component\Serializer\Attribute\ExtendsSerializationFor;
 use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Serializer\Attribute\SerializedName;
 
 #[ExtendsSerializationFor(_AttrMap_Target::class)]
 class _AttrMap_Source
@@ -333,4 +349,17 @@ class _AttrMap_ClassLevelSource
 {
     #[Groups(['default'])]
     public string $name = '';
+}
+
+class _AttrMap_TargetWithOwnAttributes
+{
+    #[Groups(['own'])]
+    public string $value = '';
+}
+
+#[ExtendsSerializationFor(_AttrMap_TargetWithOwnAttributes::class)]
+class _AttrMap_ExtensionForTargetWithOwnAttributes
+{
+    #[SerializedName('extended_value')]
+    public string $value = '';
 }

--- a/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AttributeLoader.php
@@ -46,13 +46,22 @@ class AttributeLoader implements LoaderInterface
 
     public function loadClassMetadata(ClassMetadata $metadata): bool
     {
-        if (!$sourceClasses = $this->mappedClasses[$metadata->getClassName()] ??= $this->allowAnyClass ? [$metadata->getClassName()] : []) {
+        $className = $metadata->getClassName();
+
+        if (!$sourceClasses = $this->mappedClasses[$className] ??= $this->allowAnyClass ? [$className] : []) {
             return false;
+        }
+
+        // When a class is the target of #[ExtendsValidationFor], its mapping only lists the
+        // extension classes. The target's own constraints must still be loaded and merged,
+        // so make sure the class is always part of its own source classes.
+        if (!\in_array($className, $sourceClasses, true)) {
+            array_unshift($sourceClasses, $className);
         }
 
         $success = false;
         foreach ($sourceClasses as $sourceClass) {
-            $reflClass = $metadata->getClassName() === $sourceClass ? $metadata->getReflectionClass() : new \ReflectionClass($sourceClass);
+            $reflClass = $className === $sourceClass ? $metadata->getReflectionClass() : new \ReflectionClass($sourceClass);
             $success = $this->doLoadClassMetadata($reflClass, $metadata) || $success;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -277,7 +277,7 @@ class AttributeLoaderTest extends TestCase
         $metadata = new ClassMetadata($targetClass);
 
         $this->assertTrue($loader->loadClassMetadata($metadata));
-        $this->assertInstanceOf(NotBlank::class, $metadata->getPropertyMetadata('name', $sourceClass)[0]->getConstraints()[0]);
+        $this->assertInstanceOf(NotBlank::class, $metadata->getPropertyMetadata('name')[0]->getConstraints()[0]);
     }
 
     public function testLoadClassMetadataWithClassLevelConstraints()
@@ -317,7 +317,7 @@ class AttributeLoaderTest extends TestCase
         $this->assertEquals('this.name != null', $expressionConstraint->expression);
 
         // Check that property constraints are also added
-        $this->assertInstanceOf(NotBlank::class, $metadata->getPropertyMetadata('name', $sourceClass)[0]->getConstraints()[0]);
+        $this->assertInstanceOf(NotBlank::class, $metadata->getPropertyMetadata('name')[0]->getConstraints()[0]);
     }
 
     public function testLoadClassMetadataMergesTargetOwnConstraints()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -21,10 +21,12 @@ use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Sequentially;
 use Symfony\Component\Validator\Constraints\Type;
@@ -317,6 +319,28 @@ class AttributeLoaderTest extends TestCase
         // Check that property constraints are also added
         $this->assertInstanceOf(NotBlank::class, $metadata->getPropertyMetadata('name', $sourceClass)[0]->getConstraints()[0]);
     }
+
+    public function testLoadClassMetadataMergesTargetOwnConstraints()
+    {
+        $targetClass = _AttrMap_TargetWithOwnConstraints::class;
+        $sourceClass = _AttrMap_ExtensionForTargetWithOwnConstraints::class;
+
+        $loader = new AttributeLoader(false, [$targetClass => [$sourceClass]]);
+        $metadata = new ClassMetadata($targetClass);
+
+        $this->assertTrue($loader->loadClassMetadata($metadata));
+
+        // The target's own constraints must be merged with the extension's, not discarded.
+        $constraints = [];
+        foreach ($metadata->getPropertyMetadata('value') as $propertyMetadata) {
+            $constraints = array_merge($constraints, $propertyMetadata->getConstraints());
+        }
+
+        $constraintClasses = array_map('get_class', $constraints);
+        $this->assertCount(2, $constraintClasses);
+        $this->assertContains(Length::class, $constraintClasses, "The target class' own constraints are dropped.");
+        $this->assertContains(Regex::class, $constraintClasses, 'The extension class constraints are dropped.');
+    }
 }
 
 class _AttrMap_Target
@@ -339,6 +363,19 @@ class _AttrMap_Target
 class _AttrMap_Source
 {
     #[NotBlank] public string $name;
+}
+
+class _AttrMap_TargetWithOwnConstraints
+{
+    #[Length(max: 5)]
+    public string $value;
+}
+
+#[ExtendsValidationFor(_AttrMap_TargetWithOwnConstraints::class)]
+class _AttrMap_ExtensionForTargetWithOwnConstraints
+{
+    #[Regex('/^a/')]
+    public string $value;
 }
 
 #[ExtendsValidationFor(_AttrMap_Target::class)]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64618
| License       | MIT

`#[ExtendsValidationFor]` is documented to **merge** the constraints declared on the
extension class with those of the target class. In practice only the extension class
constraints were applied — the target's own constraints were silently discarded.

The cause is in `AttributeLoader::loadClassMetadata()`: once a class is the target of
`#[ExtendsValidationFor]`, its entry in `$mappedClasses` lists only the extension
classes, so the implicit self-mapping (`[$className => [$className]]`) never kicks in
and the target's own constraints are never read.

The fix makes the target class always part of its own source classes, so its
constraints are loaded first and then merged with the extension ones.

### Reproduces with

```php
class Entity
{
    #[Length(max: 5)]
    public string $value;
}

#[ExtendsValidationFor(Entity::class)]
abstract class EntityValidation
{
    #[Regex('/^a/')]
    public string $value;
}
```

Validating `Entity { value: 'b12345' }` reports only the `Regex` violation; the
`Length` violation declared on `Entity` itself is missing.

### Before / after

- **Before:** only `EntityValidation`'s constraints apply; `Entity`'s own constraints are dropped.
- **After:** both `Entity`'s and `EntityValidation`'s constraints apply, as documented.

### Tests

`testLoadClassMetadataMergesTargetOwnConstraints` was added and fails on the current
code (the target's `Length` constraint is absent) and passes with the fix. The
existing `AttributeLoaderTest` suite stays green (14/14).
