### PR TITLE
[Messenger] Add test coverage for the Doctrine transport's all() and find()

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
@@ -19,8 +19,10 @@ use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineReceivedStamp;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
+use Symfony\Component\Serializer as SerializerComponent;
 
 class DoctrineTransportTest extends TestCase
 {
@@ -51,6 +53,34 @@ class DoctrineTransportTest extends TestCase
 
         $envelopes = $transport->get();
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());
+    }
+
+    public function testAll()
+    {
+        $serializer = $this->createSerializer();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('findAll')->with(50)->willReturn([
+            $this->createDoctrineEnvelope(),
+            $this->createDoctrineEnvelope(),
+        ]);
+
+        $transport = $this->getTransport($serializer, $connection);
+
+        $envelopes = [...$transport->all(50)];
+        $this->assertEquals(new DummyMessage('Hi'), $envelopes[0]->getMessage());
+    }
+
+    public function testFind()
+    {
+        $serializer = $this->createSerializer();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('find')->with('5')->willReturn($this->createDoctrineEnvelope());
+
+        $transport = $this->getTransport($serializer, $connection);
+
+        $this->assertEquals(new DummyMessage('Hi'), $transport->find('5')->getMessage());
     }
 
     public function testConfigureSchema()
@@ -93,5 +123,23 @@ class DoctrineTransportTest extends TestCase
         $connection ??= $this->createStub(Connection::class);
 
         return new DoctrineTransport($connection, $serializer);
+    }
+
+    private function createDoctrineEnvelope(): array
+    {
+        return [
+            'id' => 1,
+            'body' => '{"message": "Hi"}',
+            'headers' => [
+                'type' => DummyMessage::class,
+            ],
+        ];
+    }
+
+    private function createSerializer(): Serializer
+    {
+        return new Serializer(
+            new SerializerComponent\Serializer([new SerializerComponent\Normalizer\ObjectNormalizer()], ['json' => new SerializerComponent\Encoder\JsonEncoder()])
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | None
| License       | MIT

This PR duplicates the same coverage added in #64640 for testing the Redis messenger transport (`RedisTransport`) to the Doctrine equivalent (`DoctrineTransport`).

There is no functional changes or bug fixes. This is exclusively an improvement in test coverage.

In case Listable is brought to other transports in the future, this new coverage may assist in ensuring those transports are made fully listable, just as #61462 had originally intended for Redis.