### PR TITLE
[Console] Strip terminal control characters from displayed file names

### DIFF
--- a/src/Symfony/Component/Console/Exception/InvalidFileException.php
+++ b/src/Symfony/Component/Console/Exception/InvalidFileException.php
@@ -16,4 +16,17 @@ namespace Symfony\Component\Console\Exception;
  */
 class InvalidFileException extends \RuntimeException implements ExceptionInterface
 {
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        // These messages embed the offending file path, which may be attacker-influenced
+        // (e.g. a name read from a directory the user does not control) and is rendered to
+        // the terminal by the console error output. Strip terminal-escape introducer bytes
+        // so a crafted path cannot inject escape sequences. Repeat until stable, since
+        // removing a byte can splice two survivors into a fresh control sequence.
+        do {
+            $message = preg_replace("/[\x00-\x08\x0b-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $message, -1, $count) ?? $message;
+        } while ($count > 0);
+
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Symfony/Component/Console/Helper/FileInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/FileInputHelper.php
@@ -81,10 +81,12 @@ final class FileInputHelper
 
     public function displayFile(OutputInterface $output, InputFile $file): void
     {
-        $link = \sprintf('<href=file://%s>%s</>', OutputFormatter::escape($file->getRealPath()), OutputFormatter::escape($file->getFilename()));
+        $path = self::sanitizeForDisplay((string) $file->getRealPath());
+        $filename = self::sanitizeForDisplay($file->getFilename());
+        $link = \sprintf('<href=file://%s>%s</>', OutputFormatter::escape($path), OutputFormatter::escape($filename));
 
         if ($output->isVeryVerbose()) {
-            $output->writeln(\sprintf('<info>%s</info> %s (<comment>%s, %s</comment>)', "\u{1F4CE}", $link, OutputFormatter::escape($file->getMimeType() ?? 'unknown'), $file->getHumanReadableSize()));
+            $output->writeln(\sprintf('<info>%s</info> %s (<comment>%s, %s</comment>)', "\u{1F4CE}", $link, OutputFormatter::escape(self::sanitizeForDisplay($file->getMimeType() ?? 'unknown')), $file->getHumanReadableSize()));
         } else {
             $output->writeln(\sprintf('<info>%s</info> %s', "\u{1F4CE}", $link));
         }
@@ -196,6 +198,27 @@ final class FileInputHelper
         }
 
         return null;
+    }
+
+    /**
+     * Strips terminal-escape introducer bytes from a file name or path before it is
+     * echoed back to the user, so a crafted name cannot inject escape sequences.
+     * OutputFormatter::escape() only neutralizes "<" and ">", not control bytes.
+     *
+     * Removes C0 controls (except TAB and LF), DEL, and the UTF-8 encoding of C1
+     * controls, matching Tui's StringUtils::stripControlBytes() (see GH#64297).
+     *
+     * The replacement is repeated until it reaches a fixed point: removing a byte
+     * can splice two survivors into a fresh control sequence (e.g. "\xc2\x1b\x9b"
+     * leaves "\xc2\x9b", the UTF-8 encoding of U+009B), so a single pass is not enough.
+     */
+    private static function sanitizeForDisplay(string $value): string
+    {
+        do {
+            $value = preg_replace("/[\x00-\x08\x0b-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $value, -1, $count) ?? '';
+        } while ($count > 0);
+
+        return $value;
     }
 
     private function isDisplayableImage(InputFile $file): bool

--- a/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
@@ -45,6 +45,83 @@ class FileInputHelperTest extends TestCase
         }
     }
 
+    public function testDisplayFileStripsTerminalControlCharactersFromName()
+    {
+        $marker = bin2hex(random_bytes(4));
+        // ESC + OSC "set window title" + BEL smuggled into the file name
+        $name = "sf_console_{$marker}_\x1b]0;HIJACK\x07.txt";
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.$name;
+
+        if (false === @file_put_contents($path, 'x')) {
+            $this->markTestSkipped('Filesystem does not allow control characters in filenames.');
+        }
+
+        try {
+            $file = new InputFile($path);
+            $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+
+            (new FileInputHelper())->displayFile($output, $file);
+
+            $display = $output->fetch();
+
+            // The injected escape sequence must not survive into terminal output...
+            $this->assertStringNotContainsString("\x1b]0;", $display);
+            $this->assertStringNotContainsString("\x07", $display);
+            // ...while the printable remainder of the name is still shown.
+            $this->assertStringContainsString('HIJACK', $display);
+            $this->assertStringContainsString($marker, $display);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testDisplayFileStripsControlCharactersReassembledAfterAFirstPass()
+    {
+        $marker = bin2hex(random_bytes(4));
+        // Removing the ESC splices "\xc2" and "\x9b" into "\xc2\x9b", the UTF-8
+        // encoding of U+009B (CSI), which a single stripping pass would leave behind.
+        $name = "sf_console_{$marker}_\xc2\x1b\x9b.txt";
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.$name;
+
+        if (false === @file_put_contents($path, 'x')) {
+            $this->markTestSkipped('Filesystem does not allow control characters in filenames.');
+        }
+
+        try {
+            $file = new InputFile($path);
+            $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+
+            (new FileInputHelper())->displayFile($output, $file);
+
+            $display = $output->fetch();
+
+            // A single stripping pass would leave the spliced "\xc2\x9b" (U+009B) behind;
+            // the loop must remove it. (The legitimate OSC 8 link the formatter emits does
+            // contain ESC, so a bare "\x1b" assertion would be wrong here.)
+            $this->assertStringNotContainsString("\xc2\x9b", $display);
+            $this->assertStringContainsString($marker, $display);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testInvalidFileExceptionStripsControlCharactersFromThePath()
+    {
+        // fromPath() embeds the missing path verbatim into the exception message,
+        // which the console error output renders to the terminal.
+        $path = "/does/not/exist_\x1b]0;HIJACK\x07_\xc2\x1b\x9b";
+
+        try {
+            InputFile::fromPath($path);
+            $this->fail('Expected an InvalidFileException.');
+        } catch (InvalidFileException $e) {
+            $this->assertStringNotContainsString("\x1b", $e->getMessage());
+            $this->assertStringNotContainsString("\x07", $e->getMessage());
+            $this->assertStringNotContainsString("\xc2\x9b", $e->getMessage());
+            $this->assertStringContainsString('HIJACK', $e->getMessage());
+        }
+    }
+
     public function testReadWithPasteDetectionAbortsBeyondMaxBytes()
     {
         $cap = (new \ReflectionClassConstant(FileInputHelper::class, 'MAX_PASTE_BYTES'))->getValue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`FileInputHelper::displayFile()` writes the selected file's name and path back to the terminal as an OSC 8 hyperlink. It escapes the two formatter metacharacters `<` and `>` via `OutputFormatter::escape()`, but that helper leaves control bytes untouched. A file name containing a raw ESC (`0x1b`) or BEL (`0x07`) keeps those bytes through `escape()` and into the rendered output, so an embedded escape sequence runs in the user's terminal.

On Linux a file name may hold any byte except `/` and NUL, so the name can be attacker-chosen (a downloaded, extracted, or shared file) while the victim runs a console tool that calls `SymfonyStyle::askForFile()` or uses an `#[Ask]` `InputFile` argument. Depending on the terminal emulator this allows title spoofing, clipboard writes via OSC 52, and similar escape-sequence effects.

This strips C0 controls (except TAB and LF), DEL, and the UTF-8 encoding of C1 controls from the name, path, and MIME type before they are formatted, the same set as `StringUtils::stripControlBytes()` added for the Tui component in #64297. The existing `testDisplayFileEscapesFormatterMetaCharactersInPath` already asserts that `displayFile()` neutralizes `<`/`>` in file names; this extends that to control bytes, with a regression test covering an ESC/BEL payload.

Two more points are covered here:

- The stripping is repeated until it reaches a fixed point. A single pass can splice two survivors into a fresh control sequence: `"\xc2\x1b\x9b"` loses the ESC and becomes `"\xc2\x9b"`, the UTF-8 encoding of U+009B (CSI). A regression test pins this.
- The same paths reach the terminal through `InvalidFileException` messages (`File "..." does not exist.`, `File "..." is not valid or readable.`) rendered by the console error output. The bytes are stripped in that exception's constructor, the single point shared by both `InputFile` and `FileInputHelper` throwing sites, so an unreadable or missing file with a crafted name cannot inject sequences either.
