### PR TITLE
[Translation] Update `CrowdinProvider` HTTP client’s base URI

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -8,6 +8,11 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/8.2/
 
 If you're upgrading from a version below 8.1, follow the [8.1 upgrade guide](UPGRADE-8.1.md) first.
 
+Crowdin Translation Provider
+----------------------------
+
+ * Add `$projectId` constructor parameter to `CrowdinProvider`
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `$projectId` constructor parameter to `CrowdinProvider`
+
 5.4
 ---
 

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -34,6 +34,11 @@ final class CrowdinProvider implements ProviderInterface
 {
     private const IMPORT_POLL_TIMEOUT_SECONDS = 300;
 
+    private readonly ?string $projectId;
+
+    /**
+     * @param string $projectId
+     */
     public function __construct(
         private readonly HttpClientInterface $client,
         private readonly LoaderInterface $loader,
@@ -41,7 +46,15 @@ final class CrowdinProvider implements ProviderInterface
         private readonly XliffFileDumper $xliffFileDumper,
         private readonly string $defaultLocale,
         private readonly string $endpoint,
+        /* string $projectId, */
     ) {
+        if (\func_num_args() < 7) {
+            trigger_deprecation('symfony/crowdin-translation-provider', '8.2', 'The "%s()" method will have a new "string $projectId" argument in version 9.0, not defining it is deprecated.', __METHOD__);
+
+            $this->projectId = null;
+        } else {
+            $this->projectId = func_get_arg(6);
+        }
     }
 
     public function __toString(): string
@@ -287,7 +300,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function addFile(string $domain, string $content): ?array
     {
-        $response = $this->client->request('POST', 'files', [
+        $response = $this->client->request('POST', $this->getProjectEndpoint('files'), [
             'json' => [
                 'storageId' => $this->addStorage($domain, $content),
                 'name' => \sprintf('%s.%s', $domain, 'xlf'),
@@ -313,7 +326,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function updateFile(int $fileId, string $domain, string $content): ?array
     {
-        $response = $this->client->request('PUT', 'files/'.$fileId, [
+        $response = $this->client->request('PUT', $this->getProjectEndpoint('files/'.$fileId), [
             'json' => [
                 'storageId' => $this->addStorage($domain, $content),
             ],
@@ -338,7 +351,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function importTranslations(int $fileId, string $domain, string $content, string $locale): ResponseInterface
     {
-        return $this->client->request('POST', 'translations/imports', [
+        return $this->client->request('POST', $this->getProjectEndpoint('translations/imports'), [
             'json' => [
                 'storageId' => $this->addStorage($domain, $content),
                 'languageIds' => [str_replace('_', '-', $locale)],
@@ -353,7 +366,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function checkImportTranslationsStatus(string $importTranslationId): ResponseInterface
     {
-        return $this->client->request('GET', 'translations/imports/'.$importTranslationId);
+        return $this->client->request('GET', $this->getProjectEndpoint('translations/imports/'.$importTranslationId));
     }
 
     /**
@@ -362,7 +375,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function exportProjectTranslations(string $languageId, int $fileId): ResponseInterface
     {
-        return $this->client->request('POST', 'translations/exports', [
+        return $this->client->request('POST', $this->getProjectEndpoint('translations/exports'), [
             'json' => [
                 'targetLanguageId' => str_replace('_', '-', $languageId),
                 'fileIds' => [$fileId],
@@ -376,7 +389,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function downloadSourceFile(int $fileId): ResponseInterface
     {
-        return $this->client->request('GET', \sprintf('files/%d/download', $fileId));
+        return $this->client->request('GET', $this->getProjectEndpoint(\sprintf('files/%d/download', $fileId)));
     }
 
     /**
@@ -385,7 +398,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function addStorage(string $domain, string $content): int
     {
-        $response = $this->client->request('POST', '../../storages', [
+        $response = $this->client->request('POST', \sprintf('%sstorages', $this->projectId ? '' : '../../'), [
             'headers' => [
                 'Crowdin-API-FileName' => urlencode(\sprintf('%s.%s', $domain, 'xlf')),
                 'Content-Type' => 'application/octet-stream',
@@ -406,7 +419,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function getFileList(): array
     {
-        $response = $this->client->request('GET', 'files');
+        $response = $this->client->request('GET', $this->getProjectEndpoint('files'));
 
         if (200 !== $response->getStatusCode()) {
             throw new ProviderException('Unable to list Crowdin files.', $response);
@@ -427,7 +440,7 @@ final class CrowdinProvider implements ProviderInterface
      */
     private function getLanguageMapping(): array
     {
-        $response = $this->client->request('GET', '');
+        $response = $this->client->request('GET', $this->getProjectEndpoint());
 
         if (200 !== $response->getStatusCode()) {
             throw new ProviderException('Unable to get project info.', $response);
@@ -440,5 +453,13 @@ final class CrowdinProvider implements ProviderInterface
         }
 
         return $mapping;
+    }
+
+    private function getProjectEndpoint(string $endpoint = ''): string
+    {
+        return $this->projectId
+            ? rtrim(\sprintf('projects/%s/%s', $this->projectId, $endpoint), '/')
+            : $endpoint
+        ;
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
@@ -48,11 +48,11 @@ final class CrowdinProviderFactory extends AbstractProviderFactory
         $endpoint .= $dsn->getPort() ? ':'.$dsn->getPort() : '';
 
         $client = new RetryableHttpClient($this->client, new GenericRetryStrategy(), 3, $this->logger);
-        $client = ScopingHttpClient::forBaseUri($client, \sprintf('https://%s/api/v2/projects/%d/', $endpoint, $this->getUser($dsn)), [
+        $client = ScopingHttpClient::forBaseUri($client, \sprintf('https://%s/api/v2/', $endpoint), [
             'auth_bearer' => $this->getPassword($dsn),
-        ], preg_quote('https://'.$endpoint.'/api/v2/'));
+        ]);
 
-        return new CrowdinProvider($client, $this->loader, $this->logger, $this->xliffFileDumper, $this->defaultLocale, $endpoint);
+        return new CrowdinProvider($client, $this->loader, $this->logger, $this->xliffFileDumper, $this->defaultLocale, $endpoint, $this->getUser($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -27,7 +27,6 @@ use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\Test\ProviderTestCase;
 use Symfony\Component\Translation\TranslatorBag;
-use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -38,34 +37,34 @@ class CrowdinProviderTest extends ProviderTestCase
         return $this->loader ??= new XliffFileLoader();
     }
 
-    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, ?TranslatorBagInterface $translatorBag = null): ProviderInterface
+    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint, ?string $projectId = null): ProviderInterface
     {
-        return new CrowdinProvider($client, $loader, $logger, new XliffFileDumper(), $defaultLocale, $endpoint);
+        return new CrowdinProvider($client, $loader, $logger, new XliffFileDumper(), $defaultLocale, $endpoint, $projectId);
     }
 
     public static function toStringProvider(): iterable
     {
         yield [
             self::createProvider((new MockHttpClient())->withOptions([
-                'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+                'base_uri' => 'https://api.crowdin.com/api/v2/',
                 'auth_bearer' => 'API_TOKEN',
-            ]), new ArrayLoader(), new NullLogger(), 'en', 'api.crowdin.com'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'api.crowdin.com', '1'),
             'crowdin://api.crowdin.com',
         ];
 
         yield [
             self::createProvider((new MockHttpClient())->withOptions([
-                'base_uri' => 'https://domain.api.crowdin.com/api/v2/projects/1/',
+                'base_uri' => 'https://domain.api.crowdin.com/api/v2/',
                 'auth_bearer' => 'API_TOKEN',
-            ]), new ArrayLoader(), new NullLogger(), 'en', 'domain.api.crowdin.com'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'domain.api.crowdin.com', '1'),
             'crowdin://domain.api.crowdin.com',
         ];
 
         yield [
             self::createProvider((new MockHttpClient())->withOptions([
-                'base_uri' => 'https://api.crowdin.com:99/api/v2/projects/1/',
+                'base_uri' => 'https://api.crowdin.com:99/api/v2/',
                 'auth_bearer' => 'API_TOKEN',
-            ]), new ArrayLoader(), new NullLogger(), 'en', 'api.crowdin.com:99'),
+            ]), new ArrayLoader(), new NullLogger(), 'en', 'api.crowdin.com:99', '1'),
             'crowdin://api.crowdin.com:99',
         ];
     }
@@ -120,7 +119,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
@@ -165,9 +164,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ]));
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $provider->write($translatorBag);
     }
@@ -204,7 +203,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
@@ -233,9 +232,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ]));
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to create a File in Crowdin for domain "messages".');
@@ -304,7 +303,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
@@ -345,9 +344,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ]));
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to update file in Crowdin for file ID "12" and domain "messages".');
@@ -429,7 +428,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
@@ -488,9 +487,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ]));
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to upload translations to Crowdin.');
@@ -572,7 +571,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
@@ -654,9 +653,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ]));
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $logger, $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $logger, $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $provider->write($translatorBag);
     }
@@ -721,7 +720,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
@@ -761,9 +760,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ]));
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $provider->write($translatorBag);
     }
@@ -825,7 +824,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse([
                     'data' => [
@@ -890,9 +889,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ];
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $provider->write($translatorBag);
     }
@@ -1038,7 +1037,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse(['data' => ['languageMapping' => []]]);
             },
@@ -1081,7 +1080,7 @@ class CrowdinProviderTest extends ProviderTestCase
         ];
 
         $httpClient = (new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
         ]);
 
@@ -1090,7 +1089,8 @@ class CrowdinProviderTest extends ProviderTestCase
             new XliffFileLoader(),
             $this->getLogger(),
             $this->getDefaultLocale(),
-            'api.crowdin.com/api/v2/projects/1/',
+            'api.crowdin.com',
+            '1',
         );
 
         $provider->write($translatorBag);
@@ -1117,7 +1117,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse([
                     'data' => [
@@ -1150,9 +1150,9 @@ class CrowdinProviderTest extends ProviderTestCase
             ->willReturn($expectedTranslatorBag->getCatalogue($locale));
 
         $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $translatorBag = $crowdinProvider->read([$domain], [$locale]);
 
@@ -1241,7 +1241,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse([
                     'data' => [
@@ -1273,9 +1273,9 @@ class CrowdinProviderTest extends ProviderTestCase
             ->willReturn($expectedTranslatorBag->getCatalogue($locale));
 
         $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $translatorBag = $crowdinProvider->read([$domain], [$locale]);
 
@@ -1334,7 +1334,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse([
                     'data' => [
@@ -1355,9 +1355,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ];
 
         $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to export file.');
@@ -1383,7 +1383,7 @@ class CrowdinProviderTest extends ProviderTestCase
             },
             'getProject' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
-                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/', $url);
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
                 return new JsonMockResponse([
                     'data' => [
@@ -1410,9 +1410,9 @@ class CrowdinProviderTest extends ProviderTestCase
         ];
 
         $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage('Unable to download file content.');
@@ -1533,9 +1533,9 @@ class CrowdinProviderTest extends ProviderTestCase
         );
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $provider->delete($deletedStrings);
     }
@@ -1661,9 +1661,9 @@ class CrowdinProviderTest extends ProviderTestCase
         );
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $logger, $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $logger, $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $provider->delete($deletedStrings);
     }
@@ -1781,9 +1781,9 @@ class CrowdinProviderTest extends ProviderTestCase
         );
 
         $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
-            'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
-        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionMessage(

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/config": "^7.4|^8.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/translation": "^7.4|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

[Crowdin Get Project endpoint](https://support.crowdin.com/developer/api/v2/#tag/Projects/operation/api.projects.get) is `/projects/{projectId}`, but since the `CrowdinProvider` HTTP client base URI is `/projects/{projectId}/` (note the trailing slash) it is impossible to request the correct URI.

The Crowdin API issues 301 redirects in such case — which this PR now avoids. But since it **always** redirects using 301, the provider cannot call endpoints with a body at this URI, like [Edit Project](https://support.crowdin.com/developer/api/v2/#tag/Projects/operation/api.projects.patch). The latter will be needed to fix the inconsistency reported on https://github.com/symfony/symfony/issues/64155#issuecomment-4712065210 so this PR also acts as a prerequisite.

(Not sure how to test the deprecated path.)