### PR TITLE
[FrameworkBundle] Register the argument resolver in ConsoleCommandAssertionsTrait::runCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ConsoleCommandAssertionsTrait.php
@@ -29,7 +29,13 @@ trait ConsoleCommandAssertionsTrait
      */
     public static function runCommand(string $name, array $input = [], array $interactiveInputs = [], ?bool $interactive = null, ?bool $decorated = null, ?int $verbosity = null, array $normalizers = []): ExecutionResult
     {
-        $application = new Application(static::getContainer()->get('kernel'));
+        $container = static::getContainer();
+        $application = new Application($container->get('kernel'));
+
+        if ($container->has('console.argument_resolver')) {
+            $application->setArgumentResolver($container->get('console.argument_resolver'));
+        }
+
         $command = $application->find($name);
         $commandTester = new CommandTester($command);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RunCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RunCommandTest.php
@@ -46,4 +46,15 @@ class RunCommandTest extends AbstractWebTestCase
         $this->assertCommandIsSuccessful($result);
         $this->assertStringContainsString('debug', $result->getOutput());
     }
+
+    public function testRunCommandResolvesArgumentsFromTheContainer()
+    {
+        $result = static::runCommand('app:advanced', ['name' => 'test-advanced']);
+
+        $this->assertCommandIsSuccessful($result);
+        $this->assertStringContainsString('Autowired: Service injected!', $result->getOutput());
+        $this->assertStringContainsString('Targeted: Service injected!', $result->getOutput());
+        $this->assertStringContainsString('Regular: Service injected!', $result->getOutput());
+        $this->assertStringContainsString('Name: test-advanced', $result->getOutput());
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/config.yml
@@ -1,2 +1,12 @@
 imports:
     - { resource: ../config/default.yml }
+
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\TestService: ~
+
+    test_service:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\TestService
+
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\AdvancedCommand:
+        autowire: true
+        autoconfigure: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Use the same logic in `ConsoleCommandAssertionsTrait::runCommand` as in [`Application::doRun`](https://github.com/symfony/symfony/blob/13293112f358399383d60fa80dab0601ce2e98ac/src/Symfony/Bundle/FrameworkBundle/Console/Application.php#L75).

`runCommand()` calls `Application::find()` and then `CommandTester::run()`, so it never goes through `Application::doRun()`, which is the only place that injects `console.argument_resolver`. `InvokableCommand` then falls back to `ArgumentResolver::getDefaultArgumentValueResolvers()`, a container-free list that lacks `ServiceValueResolver`, every resolver tagged `console.argument_value_resolver`, the `console.targeted_value_resolver` locator, and the validator inside `MapInputValueResolver`.

Three symptoms under `runCommand()` before this fix:

* a service argument throws `Could not resolve parameter ...`;
* a `#[ValueResolver('name')]` argument silently resolves to its default;
* `#[MapInput]` validation is silently skipped, so invalid input is accepted with exit code 0.

The two silent ones mean a test using `runCommand()` can pass while the same command fails in production.

Added during review:

* a functional test, `RunCommandTest::testRunCommandResolvesArgumentsFromTheContainer`, reusing the existing `AdvancedCommand` fixture, which covers `#[Autowire]` with a service and with a parameter, `#[Target]` named autowiring and plain autowiring. It fails on the base branch with `Could not resolve parameter "$autowiredService"`;
* the container is now resolved once instead of three times.

`setDispatcher()` was considered and left out: every `ConsoleEvents` dispatch happens in `Application::doRunCommand()` / `Application::run()`, which `CommandTester` never reaches, so the call would be unused code.

Note for the merger: `#[MapInput]` validation now really runs under `runCommand()`, so a test that feeds invalid input and asserts on output will start seeing `InputValidationFailedException`. That matches the real console.
