### PR TITLE
[Console] Decorate stdout and stderr independently when a formatter is injected

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -41,19 +41,9 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
     {
         parent::__construct($this->openOutputStream(), $verbosity, $decorated, $formatter);
 
-        if (null === $formatter) {
-            // for BC reasons, stdErr has it own Formatter only when user don't inject a specific formatter.
-            $this->stderr = new StreamOutput($this->openErrorStream(), $verbosity, $decorated);
-
-            return;
-        }
-
-        $actualDecorated = $this->isDecorated();
-        $this->stderr = new StreamOutput($this->openErrorStream(), $verbosity, $decorated, $this->getFormatter());
-
-        if (null === $decorated) {
-            $this->setDecorated($actualDecorated && $this->stderr->isDecorated());
-        }
+        // stderr gets its own formatter: decoration is held by the formatter, so a shared one
+        // would force both streams to the same state instead of detecting each independently
+        $this->stderr = new StreamOutput($this->openErrorStream(), $verbosity, $decorated, $formatter ? clone $formatter : null);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
@@ -30,7 +30,17 @@ class ConsoleOutputTest extends TestCase
         $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true, $formatter = new OutputFormatter());
         $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '__construct() takes the verbosity as its first argument');
         $this->assertSame($formatter, $output->getFormatter());
-        $this->assertSame($formatter, $output->getErrorOutput()->getFormatter(), 'Output and ErrorOutput should use the same provided formatter');
+        $this->assertEquals($formatter, $output->getErrorOutput()->getFormatter(), 'ErrorOutput should use an equivalent formatter');
+    }
+
+    public function testStdoutAndStderrAreDecoratedIndependently()
+    {
+        $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true, new OutputFormatter());
+
+        $output->getErrorOutput()->setDecorated(false);
+
+        $this->assertTrue($output->isDecorated());
+        $this->assertFalse($output->getErrorOutput()->isDecorated());
     }
 
     public function testSetFormatter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64590
| License       | MIT

Decoration is held by the formatter, not by the output: `Output::setDecorated()` delegates to `$this->formatter->setDecorated()`. So when a formatter was passed to the `ConsoleOutput` constructor, both streams shared it and could not have different states.

Two things followed from that. Building the stderr `StreamOutput` ran `Output::__construct` on the same formatter and overwrote the detection already done for stdout. Then the levelling below it pinned both streams to `stdout_is_tty && stderr_is_tty`.

Net effect with an injected formatter: colour only when both file descriptors are ttys.

That is exactly the combination a child process started with `Process::setPty(true)` does not have. `UnixPipes::getDescriptors()` uses `['pty'], ['pty'], ['pipe', 'w']`, keeping stderr in a pipe on purpose so output and error stay separable, so stdout is a tty and stderr is not, and the output came out uncoloured.

Measured with real ptys, `isDecorated()` for stdout / stderr with an injected formatter:

| fd1 tty | fd2 tty | before | after |
| --- | --- | --- | --- |
| yes | yes | true / true | true / true |
| yes | no | **false** / false | **true** / false |
| no | yes | false / **false** | false / **true** |
| no | no | false / false | false / false |

The no-formatter path is byte-identical before and after in all four combinations.

Retargeted from 8.2 to 6.4 during review: the defect is present unchanged on 6.4, 7.4, 8.1 and 8.2, verified by running the extracted Console component of each branch under a pty.

No Process change is needed. The `['pipe', 'w']` on stderr is deliberate, from #59949, and the Console side was the only broken part. The title changed accordingly.

Note that `getErrorOutput()->getFormatter()` is no longer the injected instance. Symfony does not guarantee that identity, and the two-branch construction that produced it existed only to preserve it.
