### PR TITLE
[Form] Document the hidden placeholder of required ChoiceType fields

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -56,6 +56,10 @@ Form
 
  * Deprecate passing boolean as the second argument of `ValidatorExtension` and `FormTypeValidatorExtension`'s constructors; pass a `ViolationMapperInterface` instead
  * Add argument `$violationMapper` to `ValidatorExtensionTrait` and `TypeTestCase`'s `getExtensions()` methods
+ * The placeholder option of a required collapsed `ChoiceType` field is now rendered with the `hidden` attribute,
+   so browsers no longer offer it in the dropdown once a value is selected. Set the `placeholder_attr` option to
+   `[]` to restore the previous rendering, or declare the field with `'required' => false` if re-selecting the
+   placeholder to reset the field should be possible
 
 Filesystem
 ----------

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTestCase.php
@@ -775,13 +775,14 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
             'placeholder' => 'Test&Me',
         ]);
 
+        $placeholderHidden = $this->isRequiredPlaceholderHiddenByDefault() ? '[@hidden="hidden"]' : '[not(@hidden)]';
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/select
     [@name="name"]
     [@class="my&class form-control"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.="[trans]Test&Me[/trans]"]
+        ./option[@value=""][not(@selected)][not(@disabled)]'.$placeholderHidden.'[.="[trans]Test&Me[/trans]"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -799,13 +800,15 @@ abstract class AbstractBootstrap3LayoutTestCase extends AbstractLayoutTestCase
             'expanded' => false,
         ]);
 
+        // The hidden attribute is only defaulted for the "placeholder" option:
+        // placeholders injected via view variables render without it.
         $this->assertWidgetMatchesXpath($form->createView(), ['placeholder' => '', 'attr' => ['class' => 'my&class']],
             '/select
     [@name="name"]
     [@class="my&class form-control"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.=""]
+        ./option[@value=""][not(@selected)][not(@disabled)][not(@hidden)][.=""]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
@@ -783,13 +783,14 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
             'placeholder' => 'Test&Me',
         ]);
 
+        $placeholderHidden = $this->isRequiredPlaceholderHiddenByDefault() ? '[@hidden="hidden"]' : '[not(@hidden)]';
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/select
     [@name="name"]
     [@class="my&class form-select"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.="[trans]Test&Me[/trans]"]
+        ./option[@value=""][not(@selected)][not(@disabled)]'.$placeholderHidden.'[.="[trans]Test&Me[/trans]"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -807,13 +808,15 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
             'expanded' => false,
         ]);
 
+        // The hidden attribute is only defaulted for the "placeholder" option:
+        // placeholders injected via view variables render without it.
         $this->assertWidgetMatchesXpath($form->createView(), ['placeholder' => '', 'attr' => ['class' => 'my&class']],
             '/select
     [@name="name"]
     [@class="my&class form-select"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.=""]
+        ./option[@value=""][not(@selected)][not(@disabled)][not(@hidden)][.=""]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -63,6 +63,21 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         }
     }
 
+    /**
+     * The "hidden" placeholder_attr default of required ChoiceType fields depends
+     * on the installed symfony/form version (the default was introduced in 8.1).
+     */
+    protected function isRequiredPlaceholderHiddenByDefault(): bool
+    {
+        $view = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
+            'choices' => [],
+            'required' => true,
+            'placeholder' => 'placeholder',
+        ])->createView();
+
+        return (bool) ($view->vars['placeholder_attr']['hidden'] ?? false);
+    }
+
     protected function assertWidgetMatchesXpath(FormView $view, array $vars, $xpath)
     {
         // include ampersands everywhere to validate escaping
@@ -820,7 +835,7 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
     [@name="name"]
     [not(@required)]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.="[trans]Select&Anything&Not&Me[/trans]"]
+        ./option[@value=""][not(@selected)][not(@disabled)][not(@hidden)][.="[trans]Select&Anything&Not&Me[/trans]"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -842,12 +857,13 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         // The "disabled" attribute was removed again due to a bug in the
         // BlackBerry 10 browser.
         // See https://github.com/symfony/symfony/pull/7678
+        $placeholderHidden = $this->isRequiredPlaceholderHiddenByDefault() ? '[@hidden="hidden"]' : '[not(@hidden)]';
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/select
     [@name="name"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.="[trans]Test&Me[/trans]"]
+        ./option[@value=""][not(@selected)][not(@disabled)]'.$placeholderHidden.'[.="[trans]Test&Me[/trans]"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -868,12 +884,14 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         // The "disabled" attribute was removed again due to a bug in the
         // BlackBerry 10 browser.
         // See https://github.com/symfony/symfony/pull/7678
+        // The hidden attribute is only defaulted for the "placeholder" option:
+        // placeholders injected via view variables render without it.
         $this->assertWidgetMatchesXpath($form->createView(), ['placeholder' => ''],
             '/select
     [@name="name"]
     [@required="required"]
     [
-        ./option[@value=""][not(@selected)][not(@disabled)][.=""]
+        ./option[@value=""][not(@selected)][not(@disabled)][not(@hidden)][.=""]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add default `min`/`max` attributes to `BirthdayType` when `widget` is `single_text`
  * Add `labels` option to `DateType` to customize the year, month and day sub-field labels
  * Use `translation_domain` instead of `choice_translation_domain` for the expanded `ChoiceType` placeholder
+ * Render the placeholder option of required collapsed `ChoiceType` fields with the `hidden` attribute by default; set the `placeholder_attr` option to `[]` to restore the previous rendering
 
 8.0
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64638
| License       | MIT

Since 8.1 (#63649), `placeholder_attr` defaults to `['hidden' => true]` on required collapsed `ChoiceType` fields, so the placeholder no longer shows up in the dropdown once a value is selected. That change is intended: on a required select, re-selecting the placeholder makes the field fail HTML constraint validation anyway ("placeholder label option" per the WHATWG spec), so the entry is not an actionable choice. Fields that should be resettable to empty are optional by definition and belong to `'required' => false`, which keeps the previous rendering (as pointed out by @stof on #64638 and by @MatTheCat on this PR).

What was actually missing, and what this PR now provides:

- a CHANGELOG entry and an UPGRADE-8.1 note for the new default, including how to restore the previous rendering (`'placeholder_attr' => []`) and the `required => false` guidance, since #63649 changed the rendered HTML of every required select without either;
- HTML-level layout assertions: no test asserted the `hidden` attribute at all. The div, bootstrap 3 and bootstrap 5 layout tests (inherited by the table, horizontal, bootstrap 4 and DaisyUI variants) now pin `hidden` on the placeholder option of required fields, its absence on non-required fields, and its absence for placeholders injected via view variables, where the default does not apply (`placeholder_attr` is only exported to the view together with the `placeholder` option). The required-field assertions feature-detect the installed `symfony/form` behavior, so the bridge suite keeps passing against form 7.4/8.0 in the lowest-dependencies jobs (`symfony/form` is allowed down to `^7.4.4` there).

The previous revision of this PR made the placeholder selectable again once a value was picked. That direction is abandoned here: it only had an effect under `novalidate`, it silently stripped an explicitly configured `placeholder_attr`, and the rendering oscillated between round trips.
