### PR TITLE
[Scheduler] Add env option to #[AsCronTask] and #[AsPeriodicTask]

### DIFF
--- a/src/Symfony/Component/Scheduler/Attribute/AsCronTask.php
+++ b/src/Symfony/Component/Scheduler/Attribute/AsCronTask.php
@@ -30,6 +30,7 @@ class AsCronTask
      * @param string                   $schedule   The name of the schedule responsible for triggering the task
      * @param string|null              $method     The method to run as the task when the attribute target is a class
      * @param string[]|string|null     $transports One or many transports through which the message scheduling the task will go
+     * @param string[]|string          $env        One or many environments the task is scheduled in; all of them when empty
      */
     public function __construct(
         public readonly string $expression,
@@ -39,6 +40,7 @@ class AsCronTask
         public readonly string $schedule = 'default',
         public readonly ?string $method = null,
         public readonly array|string|null $transports = null,
+        public readonly array|string $env = [],
     ) {
     }
 }

--- a/src/Symfony/Component/Scheduler/Attribute/AsPeriodicTask.php
+++ b/src/Symfony/Component/Scheduler/Attribute/AsPeriodicTask.php
@@ -31,6 +31,7 @@ class AsPeriodicTask
      * @param string                   $schedule   The name of the schedule responsible for triggering the task
      * @param string|null              $method     The method to run as the task when the attribute target is a class
      * @param string[]|string|null     $transports One or many transports through which the message scheduling the task will go
+     * @param string[]|string          $env        One or many environments the task is scheduled in; all of them when empty
      */
     public function __construct(
         public readonly string|int $frequency,
@@ -41,6 +42,7 @@ class AsPeriodicTask
         public readonly string $schedule = 'default',
         public readonly ?string $method = null,
         public readonly array|string|null $transports = null,
+        public readonly array|string $env = [],
     ) {
     }
 }

--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add a "Next Run In" column to `debug:scheduler` showing the time until the next run
+ * Add `env` option to `#[AsCronTask]` and `#[AsPeriodicTask]` to restrict a task to one or more environments
 
 8.1
 ---

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -55,11 +55,29 @@ class AddScheduleMessengerPass implements CompilerPassInterface
             $scheduleProviderIds[$name] = $serviceId;
         }
 
+        $knownEnvs = $container->hasParameter('.container.known_envs') ? $container->getParameter('.container.known_envs') : [];
+        $currentEnv = $container->hasParameter('kernel.environment') ? $container->getParameter('kernel.environment') : null;
+
         $tasksPerSchedule = [];
         foreach ($container->findTaggedServiceIds('scheduler.task') as $serviceId => $tags) {
             foreach ($tags as $tagAttributes) {
-                $serviceDefinition = $container->getDefinition($serviceId);
                 $scheduleName = $tagAttributes['schedule'] ?? 'default';
+
+                // keep the schedule known even when every one of its tasks is filtered out,
+                // so that its receiver still exists and workers can be started in any environment
+                $tasksPerSchedule[$scheduleName] ??= [];
+
+                if ($envs = (array) ($tagAttributes['env'] ?? [])) {
+                    if ($knownEnvs && $unknownEnvs = array_diff($envs, $knownEnvs)) {
+                        $container->log($this, \sprintf('Task "%s" is restricted to environment(s) "%s", which are not among the known ones ("%s"); check for a typo.', $serviceId, implode('", "', $unknownEnvs), implode('", "', $knownEnvs)));
+                    }
+
+                    if (null !== $currentEnv && !\in_array($currentEnv, $envs, true)) {
+                        continue;
+                    }
+                }
+
+                $serviceDefinition = $container->getDefinition($serviceId);
 
                 if ($commandTags = $serviceDefinition->getTag('console.command')) {
                     /** @var AsCommand|null $attribute */
@@ -108,7 +126,11 @@ class AddScheduleMessengerPass implements CompilerPassInterface
 
         foreach ($tasksPerSchedule as $scheduleName => $tasks) {
             $id = "scheduler.provider.$scheduleName";
-            $schedule = (new Definition(Schedule::class))->addMethodCall('add', $tasks);
+            $schedule = new Definition(Schedule::class);
+
+            if ($tasks) {
+                $schedule->addMethodCall('add', $tasks);
+            }
 
             if (isset($scheduleProviderIds[$scheduleName])) {
                 $schedule

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -74,6 +74,129 @@ class AddScheduleMessengerPassTest extends TestCase
         yield 'tag command attribute with hidden leading pipe' => [['command' => '|real-name'], 'real-name'];
     }
 
+    public function testTaskIsScheduledWhenEnvironmentMatches()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'prod');
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'env' => ['prod', 'staging']]);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition('scheduler.provider.default'));
+        $this->assertCount(1, $container->getDefinition('scheduler.provider.default')->getMethodCalls());
+    }
+
+    public function testTaskIsScheduledWhenEnvironmentMatchesWithStringEnv()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'prod');
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'env' => 'prod']);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition('scheduler.provider.default'));
+    }
+
+    public function testTaskIsNotScheduledWhenEnvironmentDoesNotMatch()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'dev');
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'env' => ['prod', 'staging']]);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $this->assertSame([], $container->getDefinition('scheduler.provider.default')->getMethodCalls());
+    }
+
+    public function testScheduleAndItsReceiverSurviveWhenEveryTaskIsFilteredOut()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'dev');
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'schedule' => 'nightly', 'env' => 'prod']);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        // the worker command must keep working in every environment
+        $this->assertTrue($container->hasDefinition('messenger.transport.scheduler_nightly'));
+        $this->assertSame([], $container->getDefinition('scheduler.provider.nightly')->getMethodCalls());
+    }
+
+    public function testUnknownEnvironmentIsReported()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'dev');
+        $container->setParameter('.container.known_envs', ['dev', 'test', 'prod']);
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'env' => 'porduction']);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $this->assertStringContainsString('is restricted to environment(s) "porduction"', implode("\n", $container->getCompiler()->getLog()));
+    }
+
+    public function testUnknownEnvironmentIsNotReportedWhenNoEnvironmentIsKnown()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'dev');
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'env' => 'staging']);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $this->assertSame([], $container->getCompiler()->getLog());
+    }
+
+    public function testTaskWithEmptyEnvIsScheduledInAnyEnvironment()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.environment', 'dev');
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'env' => []]);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition('scheduler.provider.default'));
+    }
+
+    public function testTaskWithEnvIsScheduledWhenKernelEnvironmentIsUnknown()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'env' => 'prod']);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition('scheduler.provider.default'));
+    }
+
     public static function processSchedulerTaskCommandProvider(): iterable
     {
         yield 'no arguments' => [['trigger' => 'every', 'frequency' => '1 hour'], 'schedulable'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64646
| License       | MIT

Some tasks should be scheduled only in certain environments (for example a periodic command running in `prod` but triggered manually in `staging`). There was no built-in way to express this with the attributes.

This adds an `env` option to `#[AsCronTask]` and `#[AsPeriodicTask]` accepting one or more environment names. When set, the task is only registered when `kernel.environment` matches; otherwise the behavior is unchanged.

```php
#[AsCronTask('* * * * *', env: 'prod')]
#[AsPeriodicTask('1 hour', env: ['prod', 'staging'])]
```
