### PR TITLE
[DependencyInjection] Fix env var reported as never used for a removed autowired service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -95,7 +95,13 @@ class AutowirePass extends AbstractRecursivePass
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($value instanceof Autowire) {
-            return $this->processValue($this->container->getParameterBag()->resolveValue($value->value));
+            $value = $this->processValue($this->container->getParameterBag()->resolveValue($value->value));
+            // count env vars referenced by the attribute right away, so that removing the
+            // owning service (e.g. unused with an unrelated autowiring error) does not later
+            // report the env var as never used
+            $this->container->resolveEnvPlaceholders($value);
+
+            return $value;
         }
 
         if ($value instanceof AutowireDecorated || $value instanceof MapDecorated) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer;
 use Symfony\Component\DependencyInjection\Tests\Compiler\AInterface;
+use Symfony\Component\DependencyInjection\Tests\Compiler\EnvAutowireWithMissingArgument;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
 use Symfony\Component\DependencyInjection\Tests\Compiler\FooAnnotation;
 use Symfony\Component\DependencyInjection\Tests\Compiler\FooVoid;
@@ -787,6 +788,20 @@ class PhpDumperTest extends TestCase
         $dumper->dump();
 
         $this->assertGreaterThan(0, $container->getEnvCounters()['FOO']);
+    }
+
+    public function testEnvUsedByRemovedAutowiredServiceIsNotReportedAsNeverUsed()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', EnvAutowireWithMissingArgument::class)
+            ->setAutowired(true)
+        ;
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dumper->dump();
+
+        $this->assertGreaterThan(0, $container->getEnvCounters()['SOME_ENV']);
     }
 
     public function testCircularDynamicEnv()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -588,3 +588,13 @@ class MyCallable
         return 124;
     }
 }
+
+class EnvAutowireWithMissingArgument
+{
+    public function __construct(
+        #[Autowire(env: 'SOME_ENV')]
+        string $env,
+        string $missing,
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64642
| License       | MIT

An autowired service that reads an env var through `#[Autowire(env: 'FOO')]` and also has an argument that cannot be autowired gets dropped by `RemoveUnusedDefinitionsPass` when nothing references it. Resolving the attribute already registered the `FOO` placeholder, but the failed autowiring discarded the arguments, so the placeholder never reaches the definition. `RemoveAbstractDefinitionsPass` and the unused-definitions pass only re-count placeholders they find on the removed definition, so this one stays at zero and `PhpDumper` throws `Environment variables "FOO" are never used`, hiding the real autowiring error. Counting the env right after the attribute is resolved keeps it marked as used.
