### PR TITLE
[Config] Accept env placeholders for scalar alternatives in generated array-shapes

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -145,6 +145,10 @@ final class ArrayShapeGenerator
             $types[$backedEnumIndex] = '\BackedEnum';
         }
 
+        if (array_intersect($types, [ExprBuilder::TYPE_STRING, '\BackedEnum'])) {
+            $types[] = '\\'.ParamConfigurator::class;
+        }
+
         sort($types);
 
         return $types;

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -108,7 +108,40 @@ class ArrayShapeGeneratorTest extends TestCase
         $root = new ArrayNodeDefinition('root');
         $root->append($proto);
 
-        $expected = "array{\n *     proto?: \BackedEnum|string|array<string, scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null>,\n * }";
+        $expected = "array{\n *     proto?: \BackedEnum|\Symfony\Component\Config\Loader\ParamConfigurator|string|array<string, scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null>,\n * }";
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root->getNode()));
+    }
+
+    public function testPrototypedArrayNodePhpDocWithStringAcceptAndWrap()
+    {
+        $proto = new ArrayNodeDefinition('proto');
+        $proto
+            ->useAttributeAsKey('name')
+            ->acceptAndWrap(['string'])
+            ->prototype('scalar')->end();
+
+        $root = new ArrayNodeDefinition('root');
+        $root->append($proto);
+
+        $expected = 'proto?: \Symfony\Component\Config\Loader\ParamConfigurator|string|array<string, scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null>,';
+
+        $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root->getNode()));
+    }
+
+    public function testPhpDocWithAcceptAndWrapOnPlainArrayNode()
+    {
+        $child = new ArrayNodeDefinition('child');
+        $child
+            ->acceptAndWrap(['string'], 'value')
+            ->children()
+                ->scalarNode('value')->end()
+            ->end();
+
+        $root = new ArrayNodeDefinition('root');
+        $root->append($child);
+
+        $expected = 'child?: \Symfony\Component\Config\Loader\ParamConfigurator|string|array{';
 
         $this->assertStringContainsString($expected, ArrayShapeGenerator::generate($root->getNode()));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When generating array-shapes for config builders, scalar **leaf** nodes are correctly widened with `ParamConfigurator` (so `env()`/`param()` are accepted), but scalar **alternatives** declared via `acceptAndWrap()` are not. Their type is emitted bare, which makes static analysis reject env placeholders even though they are perfectly valid at that position.

**Concrete case**
`framework.mailer.headers`, whose prototype is declared with `->prototype('array')->acceptAndWrap(['string'], 'value')`, currently generates `array<string, string|array{value?: mixed}>`. As a result, this is reported as invalid by PHPStan while it works fine at runtime:

```php
return App::config([
    'framework' => [
        'mailer' => [
            'headers' => [
                'From' => env('MAILER_FROM'), // rejected: not string|array{...}
            ],
        ],
    ],
]);
```

…whereas the equivalent leaf node accepts `env()` without issue. The fix makes `ArrayShapeGenerator::getNormalizedTypes()` append `ParamConfigurator` whenever a `string` or backed-enum alternative is present, mirroring what already happens for scalar leaf nodes, so the generated shape becomes `array<string, \Symfony\...\ParamConfigurator|string|array{value?: mixed}>`.
