### PR TITLE
[Yaml] Fix line folding after trailing backslashes in quoted strings

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1184,7 +1184,7 @@ class Parser
             if ($this->isCurrentLineBlank()) {
                 $previousLineWasNewline = true;
                 $previousLineWasTerminatedWithBackslash = false;
-            } elseif ('\\' === $this->currentLine[-1]) {
+            } elseif ('"' === $quotation && 1 === (\strlen($this->currentLine) - \strlen(rtrim($this->currentLine, '\\'))) % 2) {
                 $previousLineWasNewline = false;
                 $previousLineWasTerminatedWithBackslash = true;
             } else {

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1700,6 +1700,26 @@ class ParserTest extends TestCase
         $this->assertSame($expected, $this->parser->parse($yaml));
     }
 
+    public function testTrailingBackslashesBeforeNewlineInQuotedMultiLineString()
+    {
+        $yaml = <<<YAML
+            foobar: "foo\\\\
+                bar"
+            YAML;
+
+        $this->assertSame(['foobar' => 'foo\\ bar'], $this->parser->parse($yaml));
+    }
+
+    public function testTrailingBackslashInSingleQuotedMultiLineString()
+    {
+        $yaml = <<<YAML
+            foobar: 'foo\\
+                bar'
+            YAML;
+
+        $this->assertSame(['foobar' => 'foo\\ bar'], $this->parser->parse($yaml));
+    }
+
     /**
      * @dataProvider wrappedUnquotedStringsProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A multi-line quoted string whose line ends with a backslash lost the folded space. The lexer treated any trailing backslash as a line continuation, for both single and double quotes.

```yaml
foo: "bar\\
  baz"
```

This parsed as `bar\baz` instead of `bar\ baz`.

Line continuation only applies to double-quoted strings, and only when the run of trailing backslashes is odd. An even run is an escaped literal backslash, and single-quoted strings have no continuation at all, so both now fold the break to a space.