### PR TITLE
[FrameworkBundle] Don’t reference potentially missing `WorkflowEvents` class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -555,7 +555,7 @@ class Configuration implements ConfigurationInterface
 
                                                 return \in_array('!'.WorkflowEvents::GUARD, $v, true);
                                             })
-                                            ->thenInvalid(\sprintf('The "%s" event cannot be disabled in "events_to_dispatch": it is always dispatched.', WorkflowEvents::GUARD))
+                                            ->thenInvalid('The "workflow.guard" event cannot be disabled in "events_to_dispatch": it is always dispatched.')
                                         ->end()
                                         ->info('Select which Transition events should be dispatched for this Workflow. Prefix an event with "!" to disable it (e.g. ["!workflow.announce"]); future events are dispatched by default in block-list mode.')
                                         ->example(['workflow.enter', 'workflow.transition'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Following #64221

`thenInvalid`’s message is immediately evaluated so it would crash if `WorkflowEvents` is missing.