### PR TITLE
[Validator] Remove needs-review-translation state from Spanish cron e…

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -568,7 +568,7 @@
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Este valor no es una expresión cron válida.</target>
+                <target>Este valor no es una expresión cron válida.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64687
| License       | MIT

Remove `state="needs-review-translation"` from the Spanish translation of the cron expression validator message (id 146), confirming the translation is correct.