### PR TITLE
[FrameworkBundle] Fix service _instanceof type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -121,7 +121,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * %A}
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
- *     _instanceof?: InstanceofType,
+ *     _instanceof?: array<class-string, InstanceofType>,
  *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
  * }
  * @psalm-type ExtensionType = array<string, mixed>

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
@@ -130,7 +130,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
- *     _instanceof?: InstanceofType,
+ *     _instanceof?: array<class-string, InstanceofType>,
  *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
  * }
  * @psalm-type ExtensionType = array<string, mixed>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | N/A <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Upgrading to PHPStan 2.2 with bleeding edge enabled flags false positives anywhere that `_instanceof` is used correctly due it having the wrong shape, and how PHPStan 2.2 has become a lot more strict on array shapes and introducing sealed/unsealed arrays, more info here: https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys

```
💡  Offset 'services' (array{_defaults?: array{public?: bool, tags?: mixed, resource_tags?: mixed, autowire?: bool, autoconfigure?: bool, bind?: array<string, mixed>}, _instanceof?: array{shared?: bool,   
         lazy?: bool|string, public?: bool, properties?: array<string, mixed>, configurator?: array{string|Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator, string}|Closure|string|  
         Symfony\Component\DependencyInjection\Loader\Configurator\ExpressionConfigurator|Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator, calls?: list<array<0|1|2|string,          
         array<int<0, max>|string, mixed>|bool|string>>, tags?: mixed, resource_tags?: mixed, ...}, ...<string, array<int<0, max>|string, mixed>|string|null>}) does not accept type array{_defaults:                
         array{autowire: true, autoconfigure: true}, _instanceof: array{App\SomeInterface: array{tags: array{'a_tag'}},                      
         App\SomeInterface: array{tags: array{'a_tag'}}},, ...}: Offset '_instanceof' (array{shared?: bool, lazy?: bool|string, public?: bool, properties?: array<string, mixed>, conf  
         igurator?: array{string|Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator,                                                                                                     string}|Closure|string|Symfony\Component\DependencyInjection\Loader\Configurator\ExpressionConfigurator|Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator, calls?:            
         list<array<0|1|2|string, array<int<0, max>|string, mixed>|bool|string>>, tags?: mixed, resource_tags?: mixed, ...}) does not accept type                                                                    
         array{App\SomeInterface: array{tags: array{'a_tag'}}: Sealed array shape does not accept array with extra key                          
```