### PR TITLE
[Config] Generate unsealed array shapes for any normalizers

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -70,7 +70,7 @@ final class ArrayShapeGenerator
             $arrayShape .= \sprintf(",%s\n", !$child instanceof ArrayNode ? self::generateInlinePhpDocForNode($child) : '');
         }
 
-        if ($node->shouldIgnoreExtraKeys()) {
+        if ($node->shouldIgnoreExtraKeys() || \in_array(ExprBuilder::TYPE_ANY, $node->getNormalizedTypes(), true)) {
             $arrayShape .= str_repeat('    ', $nestingLevel)."...<string, mixed>\n";
         }
 

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -274,6 +274,28 @@ class ArrayShapeGeneratorTest extends TestCase
             CODE, ArrayShapeGenerator::generate($root->getNode()));
     }
 
+    public function testBeforeNormalizationIfTrueMakesArrayShapeUnsealed()
+    {
+        $root = new ArrayNodeDefinition('root');
+        $root
+            ->children()
+                ->scalarNode('child')->end()
+            ->end()
+            ->beforeNormalization()
+                ->ifTrue(static fn ($v) => \is_array($v) && isset($v['extra']))
+                ->then(static fn ($v) => $v)
+            ->end();
+
+        $shape = ArrayShapeGenerator::generate($root->getNode());
+
+        $this->assertStringContainsString(<<<'CODE'
+            array{
+             *     child?: scalar|\Symfony\Component\Config\Loader\ParamConfigurator|null,
+             *     ...<string, mixed>
+             * }
+            CODE, $shape);
+    }
+
     #[DataProvider('provideQuotedNodes')]
     public function testPhpdocQuoteNodeName(NodeInterface $node, string $expected)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64695
| License       | MIT

`ArrayShapeGenerator` generates PHPDoc array shapes for config references. With PHPStan 2.2 sealed array shapes, valid pre-normalization config can be reported as invalid when a node has an opaque `any`-typed `beforeNormalization()` path.

Following the review discussion, this PR no longer adds `mixed` to the union. `mixed|array{...}` collapses to `mixed` and stops checking the whole subtree.

Instead, for regular `array{...}` shapes whose node has an `any` normalization, the generated shape is made unsealed by adding `...<string, mixed>`. This keeps known keys typed while allowing extra pre-normalization keys that the generator cannot describe.

Prototyped arrays are intentionally left unchanged because `list<...>` and `array<string, ...>` cannot be made unsealed in the same way.

## Test verification (RED -> GREEN)

RED, before the fix:

```text
Failed asserting that mixed|array{...} contains array{... ...<string, mixed> ...}.

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

GREEN, after the fix:

```text
OK (1 test, 1 assertion)
```

Local `./run-ci.sh` passes syntax checks and the focused `ArrayShapeGeneratorTest` suite on PHP 8.4:

```text
OK (41 tests, 43 assertions)
```
