### PR TITLE
[Serializer] Keep the collection value type for iterable constructor parameters

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -1043,7 +1043,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         if (null !== $parameterType && $parameterTypeResolver ??= class_exists(ReflectionTypeResolver::class) ? new ReflectionTypeResolver() : false) {
             $resolvedParameterType = $parameterTypeResolver->resolve($parameterType, ($parameterTypeContextFactory ??= new TypeContextFactory())->createFromClassName($class->name, $parameter->getDeclaringClass()?->name));
             if ($resolvedParameterType->isSatisfiedBy(static fn (Type $t) => match (true) {
-                $t instanceof BuiltinType && \in_array($t->getTypeIdentifier(), [TypeIdentifier::ARRAY, TypeIdentifier::ITERABLE], true) => !$type->isIdentifiedBy(TypeIdentifier::ARRAY) && !$type->isIdentifiedBy(TypeIdentifier::ITERABLE),
+                $t instanceof BuiltinType && \in_array($t->getTypeIdentifier(), [TypeIdentifier::ARRAY, TypeIdentifier::ITERABLE], true) => !$type->isIdentifiedBy(TypeIdentifier::ARRAY) && !$type->isIdentifiedBy(TypeIdentifier::ITERABLE) && !$type->isSatisfiedBy(static fn (Type $c) => $c instanceof CollectionType),
                 $t instanceof BuiltinType && !\in_array($t->getTypeIdentifier(), [TypeIdentifier::NULL, TypeIdentifier::MIXED], true) => !$type->isIdentifiedBy($t->getTypeIdentifier()),
                 $t instanceof ObjectType => !$type->isIdentifiedBy($t->getClassName()),
                 default => false,

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1135,6 +1135,27 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame(42, $result->getEntity()->id);
     }
 
+    public function testDenormalizeArrayObjectConstructorParameterDenormalizesItems()
+    {
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
+            $this->markTestSkipped('The PropertyInfo component before Symfony 7.1 does not keep the collection value type for iterable constructor parameters.');
+        }
+
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new ObjectNormalizer(null, null, null, new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()])),
+        ]);
+
+        $result = $serializer->denormalize(
+            ['items' => [['value' => 'foo'], ['value' => 'bar']]],
+            DummyWithArrayObjectOfDtos::class,
+        );
+
+        $this->assertInstanceOf(DummyWithArrayObjectOfDtos::class, $result);
+        $this->assertContainsOnlyInstancesOf(DummyDtoItem::class, $result->items);
+        $this->assertSame(['foo', 'bar'], array_map(static fn (DummyDtoItem $i) => $i->value, $result->items->getArrayCopy()));
+    }
+
     public function testDenormalizeWithNumberAsSerializedNameAndNoArrayReindex()
     {
         $normalizer = new AbstractObjectNormalizerWithMetadata();
@@ -2317,5 +2338,16 @@ class DummyWithIterableOfDtos
         $this->items = iterator_to_array((static function () use ($items) {
             yield from $items;
         })());
+    }
+}
+
+class DummyWithArrayObjectOfDtos
+{
+    /** @var \ArrayObject<DummyDtoItem> */
+    public \ArrayObject $items;
+
+    public function __construct(iterable $items)
+    {
+        $this->items = new \ArrayObject(iterator_to_array($items));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`AbstractObjectNormalizer::denormalizeParameter()` replaces the type coming from the property extractor with the bare reflection type whenever the two look incompatible. A `CollectionType` wrapping an object, such as the `ArrayObject<Item>` produced for `/** @var \ArrayObject<Item> */`, answers `false` to both `isIdentifiedBy(ARRAY)` and `isIdentifiedBy(ITERABLE)`, so the rich type was dropped and `validateAndDenormalize()` handed the raw payload to the constructor.

#64477 fixed the `array<T>` and `iterable<T>` shapes of this. Every other collection carrier still fell through, because they are all modelled as a `CollectionType` wrapping an `ObjectType`.

Retargeted from 8.1 to 7.4 during review: the flawed guard was introduced by #63401, released in 7.4.6, and `origin/7.4` reproduces the defect identically. 6.4 has no type-override block at all, so it is not affected.

Measured on 7.4, denormalizing `{"items":[{"value":"foo"},{"value":"bar"}]}` into a constructor taking `iterable $items`:

| property docblock | before | after |
| --- | --- | --- |
| `\ArrayObject<Item>` | raw arrays | `Item` |
| `\Traversable<Item>` | raw arrays | `Item` |
| `\ArrayIterator<Item>` | raw arrays | `Item` |
| `\Generator<Item>` | raw arrays | `Item` |
| `\ArrayObject<Item>` with an `array` parameter | raw arrays | `Item` |
| `\ArrayObject<Item>\|null` | raw arrays | `Item` |
| `array<Item>` | `Item` | `Item` |

Changed during review: the guard tests for a `CollectionType` rather than for any object type. Both fix the seven shapes above, but `!isIdentifiedBy(OBJECT)` also stops overriding non-collection object types, and that turns a working case into a fatal one. `PhpDocExtractor` cannot parse `@var iterable<T>`; it falls back to `Type::object('iterable<\Item>')`, a class name that does not exist. Today that bogus type is silently replaced by the reflection type; with the object-wide guard it survives and `validateAndDenormalize()` throws `The type of the "items" attribute for class "..." must be one of "iterable<\Item>" ("array" given)`. Testing for `CollectionType` keeps that case on its current behaviour.

Note that `@var iterable<T>` on a property whose constructor parameter is `iterable` therefore still denormalizes to raw arrays. That is a `PhpDocExtractor` limitation, not something this guard can fix, and it is out of scope here.
