### PR TITLE
 Fix Absolute URL generation by ignore tel: mailto: and other app links

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UrlHelperTest.php
@@ -52,6 +52,9 @@ class UrlHelperTest extends TestCase
             ['http://localhost/foo/bar?0#baz', '#baz', '/foo/bar?0'],
             ['http://localhost/foo/bar?baz=1#baz', '?baz=1#baz', '/foo/bar?foo=1'],
             ['http://localhost/foo/baz?baz=1#baz', 'baz?baz=1#baz', '/foo/bar?foo=1'],
+
+            ['mailto:hello@example.localhost', 'mailto:hello@example.localhost', '/'],
+            ['tel:123', 'tel:123', '/'],
         ];
     }
 

--- a/src/Symfony/Component/HttpFoundation/UrlHelper.php
+++ b/src/Symfony/Component/HttpFoundation/UrlHelper.php
@@ -29,7 +29,7 @@ final class UrlHelper
 
     public function getAbsoluteUrl(string $path): string
     {
-        if (str_contains($path, '://') || str_starts_with($path, '//') || preg_match('/^[a-z][a-z0-9+-.]*:/i', $path)) {
+        if (str_contains($path, '://') || str_starts_with($path, '//') || preg_match('/^[a-z][a-z0-9+.-]*:/i', $path)) {
             return $path;
         }
 

--- a/src/Symfony/Component/HttpFoundation/UrlHelper.php
+++ b/src/Symfony/Component/HttpFoundation/UrlHelper.php
@@ -29,7 +29,7 @@ final class UrlHelper
 
     public function getAbsoluteUrl(string $path): string
     {
-        if (str_contains($path, '://') || str_starts_with($path, '//')) {
+        if (str_contains($path, '://') || str_starts_with($path, '//') || preg_match('/^[a-z][a-z0-9+-.]*:/i', $path)) {
             return $path;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Somebody stumbled over in [Sulu](https://github.com/sulu/sulu/pull/8895) if making all URLs in different cases absolute App URLs like `mailto:...`, `tel:...` are converted also to `http://localhost/mailto:...`. I may think this something which maybe could be keep in mind for the URLHelper to avoid that other application run into the same bug.





<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
