### PR TITLE
[FrameworkBundle] Add an interactive debug command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
  * Allow prefixing entries with `!` in `framework.workflows.<name>.events_to_dispatch` to permanently disable an event; e.g. `events_to_dispatch: ['!workflow.announce']` fires every event except `workflow.announce`. The GuardEvent can never be disabled; `!workflow.guard` is rejected at config compile time. Mixing allow-list and block-list entries in the same list is rejected at config compile time too.
  * Add support for the HttpClient `max_connect_duration` option to the `http_client` configuration
+ * Add a unified `debug` command with an interactive full-screen terminal UI (powered by the Tui component),
+   a direct search mode (`debug --routes user_`, `debug csrf`) and a `debug.section` extension point
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -40,8 +40,10 @@ trait BuildDebugContainerTrait
 
         if (!$file || !(new ConfigCache($file, true))->isFresh()) {
             $buildContainer = \Closure::bind(function () {
+                /* @psalm-suppress UndefinedMethod */
                 $this->initializeBundles();
 
+                /* @psalm-suppress UndefinedMethod */
                 return $this->buildContainer();
             }, $kernel, $kernel::class);
             $container = $buildContainer();
@@ -50,7 +52,10 @@ trait BuildDebugContainerTrait
             $container->compile();
         } else {
             $buildContainer = \Closure::bind(function () {
+                /* @psalm-suppress TooFewArguments */
                 $containerBuilder = $this->getContainerBuilder();
+
+                /* @psalm-suppress UndefinedMethod */
                 $this->prepareContainer($containerBuilder);
 
                 return $containerBuilder;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugCommand.php
@@ -1,0 +1,410 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugApplication;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugResultListWidget;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugSectionInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Helper\ProgressIndicator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Terminal;
+use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Style\Direction;
+use Symfony\Component\Tui\Style\Style;
+use Symfony\Component\Tui\Style\StyleSheet;
+use Symfony\Component\Tui\Style\VerticalAlign;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+/**
+ * A single command to debug everything: services, routes, config, etc.
+ *
+ * Run without arguments, it renders a full-screen terminal UI (powered by the
+ * Tui component) whose tabs are contributed by services tagged "debug.section".
+ * Only the sections whose underlying feature is installed show up, so the
+ * command degrades gracefully.
+ *
+ * Pass a search term and/or one of the per-section options to print the
+ * matching item directly instead (this direct mode does not need the Tui
+ * component); when several items match, an interactive prompt asks which one
+ * to display.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[AsCommand(name: 'debug', description: 'Interactively debug the application or search its services, routes, config, …')]
+class DebugCommand extends Command
+{
+    /** @var array<string, DebugSectionInterface>|null */
+    private ?array $resolvedSections = null;
+
+    /**
+     * @param iterable<string, DebugSectionInterface> $sections     The sections, keyed by machine name and ordered by priority
+     * @param list<string>                            $sectionNames The section machine names, known without instantiating the (lazy) sections
+     */
+    public function __construct(
+        private readonly iterable $sections,
+        private readonly array $sectionNames = [],
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('query', InputArgument::OPTIONAL, 'A term to search for (across all sections unless a section option is passed)');
+
+        foreach ($this->sectionNames as $name) {
+            $this->addOption($name, null, InputOption::VALUE_OPTIONAL, \sprintf('Search only the "%s" section (omit the value to list all of its items)', $name), false);
+        }
+
+        $this->setHelp(<<<'EOF'
+            The <info>%command.name%</info> command opens a full-screen, interactive UI to debug
+            every area of the application (services, routes, config, …):
+
+              <info>php %command.full_name%</info>
+
+            Pass a search term to print the matching item instead. When several items
+            match, an interactive prompt asks which one to display:
+
+              <info>php %command.full_name% csrf</info>
+
+            Pass one of the section options to search a single section, or to list all
+            of its items when the value is omitted:
+
+              <info>php %command.full_name% --container http_client</info>
+              <info>php %command.full_name% --routes user_</info>
+              <info>php %command.full_name% --config framework</info>
+              <info>php %command.full_name% --routes</info>
+            EOF
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $selected = [];
+        foreach ($this->sectionNames as $name) {
+            if (false !== $value = $input->getOption($name)) {
+                $selected[$name] = \is_string($value) ? $value : null;
+            }
+        }
+
+        if (\count($selected) > 1) {
+            $io->getErrorStyle()->error(\sprintf('Pass only one section option at a time (got "--%s").', implode('", "--', array_keys($selected))));
+
+            return Command::INVALID;
+        }
+
+        $query = $input->getArgument('query');
+
+        if (!$selected && null === $query) {
+            return $this->runInteractiveUi($input, $io);
+        }
+
+        $sectionName = $selected ? array_key_first($selected) : null;
+
+        return $this->runDirectSearch($input, $output, $io, $sectionName, null !== $sectionName ? $selected[$sectionName] : null, $query);
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        foreach ($this->sectionNames as $name) {
+            if (!$input->mustSuggestOptionValuesFor($name)) {
+                continue;
+            }
+
+            if (!$section = $this->getSections()[$name] ?? null) {
+                return;
+            }
+
+            try {
+                $items = $section->search($input->getCompletionValue());
+            } catch (\Throwable) {
+                return;
+            }
+
+            $values = [];
+            foreach ($items as $item) {
+                // suggest only shell-safe labels (no whitespace, no control bytes)
+                if (!preg_match('/\s|[\x00-\x1f\x7f]/', $item->label)) {
+                    $values[] = $item->label;
+                }
+            }
+            $suggestions->suggestValues($values);
+
+            return;
+        }
+    }
+
+    /**
+     * Runs the full-screen interactive UI (requires the Tui component and a real terminal).
+     */
+    private function runInteractiveUi(InputInterface $input, SymfonyStyle $io): int
+    {
+        if (!class_exists(Tui::class)) {
+            $io->getErrorStyle()->error('The "debug" command requires the Tui component. Try running "composer require symfony/tui".');
+
+            return Command::FAILURE;
+        }
+
+        if (!$input->isInteractive()) {
+            $io->getErrorStyle()->error('The interactive UI requires an interactive terminal. Pass a search term or a section option (e.g. "debug --routes app_login") to print the results instead.');
+
+            return Command::INVALID;
+        }
+
+        $sections = array_values($this->getSections());
+
+        if (!$sections) {
+            $io->warning('No debug sections are available.');
+
+            return Command::SUCCESS;
+        }
+
+        (new DebugApplication($sections, $this->createTui(...)))->run();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Searches one section (or all of them) and prints the matching item; this
+     * mode works without the Tui component and without a real terminal.
+     */
+    private function runDirectSearch(InputInterface $input, OutputInterface $output, SymfonyStyle $io, ?string $sectionName, ?string $sectionQuery, ?string $query): int
+    {
+        $errorStyle = $io->getErrorStyle();
+        $sections = $this->getSections();
+
+        if (!$sections) {
+            $io->warning('No debug sections are available.');
+
+            return Command::SUCCESS;
+        }
+
+        if (null !== $sectionName && !isset($sections[$sectionName])) {
+            $errorStyle->error(\sprintf('The "%s" debug section is not available.', $sectionName));
+
+            return Command::FAILURE;
+        }
+
+        // the option value wins; an option with no value falls back to the argument
+        // ("debug foo --routes" is the same as "debug --routes foo")
+        $query = $sectionQuery ?? $query ?? '';
+        $width = max(20, (new Terminal())->getWidth() - 2);
+
+        if (null !== $sectionName) {
+            $section = $sections[$sectionName];
+
+            try {
+                $results = $this->buildResults([$sectionName => $section], $section->search($query), false);
+            } catch (\Throwable $e) {
+                $errorStyle->error(\sprintf('Searching the "%s" section failed: %s', $sectionName, $e->getMessage()));
+
+                return Command::FAILURE;
+            }
+        } else {
+            $results = $this->searchAllSections($sections, $query, $input, $output, $errorStyle);
+        }
+
+        if (!$results) {
+            $errorStyle->error('' === $query ? 'No items found.' : \sprintf('No items match "%s".', $query));
+
+            if (null !== $sectionName && '' !== $query && $alternatives = $this->findAlternatives($sections[$sectionName], $query)) {
+                $errorStyle->comment('Did you mean one of these?');
+                $errorStyle->listing($alternatives);
+            }
+
+            return Command::FAILURE;
+        }
+
+        if (1 === \count($results)) {
+            $this->printDetail($results[0]['section'], $results[0]['item'], $width, $output);
+
+            return Command::SUCCESS;
+        }
+
+        if (!$input->isInteractive()) {
+            foreach ($results as $result) {
+                $output->writeln($this->sanitizeLabel($result['label']), OutputInterface::OUTPUT_RAW);
+            }
+            $errorStyle->comment(\sprintf('Found %d matching items; run the command interactively or refine the search term to display one of them.', \count($results)));
+
+            return Command::SUCCESS;
+        }
+
+        $choices = [];
+        foreach ($results as $result) {
+            $label = $this->sanitizeLabel($result['label']);
+            if (isset($choices[$label]) && null !== $result['item']->group) {
+                $label = \sprintf('%s (%s)', $label, $result['item']->group);
+            }
+            $unique = $label;
+            for ($i = 2; isset($choices[$unique]); ++$i) {
+                $unique = \sprintf('%s (%d)', $label, $i);
+            }
+            $choices[$unique] = $result;
+        }
+
+        $answer = $io->choice(\sprintf('Found %d matching items, select the one to display', \count($results)), array_keys($choices));
+        $this->printDetail($choices[$answer]['section'], $choices[$answer]['item'], $width, $output);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array<string, DebugSectionInterface> $sections
+     *
+     * @return list<array{section: DebugSectionInterface, item: DebugItem, label: string}>
+     */
+    private function searchAllSections(array $sections, string $query, InputInterface $input, OutputInterface $output, SymfonyStyle $errorStyle): array
+    {
+        $errorOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
+        $progress = null;
+        if ($input->isInteractive() && $errorOutput->isDecorated()) {
+            $progress = new ProgressIndicator($errorOutput);
+            $progress->start('Searching...');
+        }
+
+        $results = [];
+        $failures = [];
+        foreach ($sections as $name => $section) {
+            if ($progress) {
+                $progress->setMessage(\sprintf('Searching %s...', $section->getLabel()));
+                $progress->advance();
+            }
+
+            try {
+                $results[] = $this->buildResults([$name => $section], $section->search($query), true);
+            } catch (\Throwable $e) {
+                $failures[$section->getLabel()] = $e;
+            }
+        }
+
+        $progress?->finish('Searched all sections.');
+
+        // a broken section must not prevent searching the others
+        foreach ($failures as $label => $e) {
+            $errorStyle->warning(\sprintf('Searching the "%s" section failed: %s', $label, $e->getMessage()));
+            if ($output->isVerbose()) {
+                $errorStyle->writeln((string) $e);
+            }
+        }
+
+        return array_merge(...$results);
+    }
+
+    /**
+     * @param array<string, DebugSectionInterface> $sections
+     * @param list<DebugItem>                      $items
+     *
+     * @return list<array{section: DebugSectionInterface, item: DebugItem, label: string}>
+     */
+    private function buildResults(array $sections, array $items, bool $prefixSectionLabel): array
+    {
+        $section = reset($sections);
+
+        $results = [];
+        foreach ($items as $item) {
+            $results[] = [
+                'section' => $section,
+                'item' => $item,
+                'label' => $prefixSectionLabel ? \sprintf('%s › %s', $section->getLabel(), $item->label) : $item->label,
+            ];
+        }
+
+        return $results;
+    }
+
+    private function printDetail(DebugSectionInterface $section, DebugItem $item, int $width, OutputInterface $output): void
+    {
+        $detail = $item->detail ?? $section->describe($item, $width);
+
+        if (!$output->isDecorated()) {
+            // strip the raw ANSI codes produced by the section descriptors (CSI
+            // sequences and OSC 8 hyperlinks); Helper::removeDecoration() is not
+            // used on purpose, it would re-format literal "<...>" text
+            $detail = preg_replace('/\e\]8;[^\e\x07]*(?:\e\\\\|\x07)/', '', $detail) ?? $detail;
+            $detail = preg_replace('/\e\[[0-9;?]*[ -\/]*[@-~]/', '', $detail) ?? $detail;
+        }
+
+        // OUTPUT_RAW is mandatory: the detail may contain "<" characters that the
+        // console formatter would misinterpret as formatting tags
+        $output->writeln(rtrim($detail, "\n"), OutputInterface::OUTPUT_RAW);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findAlternatives(DebugSectionInterface $section, string $query): array
+    {
+        try {
+            // the failed search already built and memoized the section index, so this is cheap
+            $items = $section->search('');
+        } catch (\Throwable) {
+            return [];
+        }
+
+        $query = strtolower($query);
+        $alternatives = [];
+        foreach ($items as $item) {
+            $label = $this->sanitizeLabel($item->label);
+            $distance = levenshtein($query, strtolower($label));
+            if ($distance <= \strlen($query) / 3) {
+                $alternatives[$label] = $distance;
+            }
+        }
+        asort($alternatives);
+
+        return \array_slice(array_keys($alternatives), 0, 5);
+    }
+
+    private function sanitizeLabel(string $label): string
+    {
+        return preg_replace("/[\x00-\x08\x0b-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $label) ?? '';
+    }
+
+    /**
+     * @return array<string, DebugSectionInterface>
+     */
+    private function getSections(): array
+    {
+        return $this->resolvedSections ??= $this->sections instanceof \Traversable ? iterator_to_array($this->sections) : $this->sections;
+    }
+
+    /**
+     * Builds the Tui instance. Isolated in its own method so tests can override
+     * it to inject a virtual terminal without referencing Tui in the public API.
+     */
+    protected function createTui(Keybindings $keybindings): Tui
+    {
+        $styleSheet = new StyleSheet([
+            ':root' => new Style(direction: Direction::Vertical, gap: 0, verticalAlign: VerticalAlign::Top),
+            DebugResultListWidget::class.'::selected' => new Style(reverse: true),
+            DebugResultListWidget::class.'::selected:focus' => new Style(reverse: true),
+            SelectListWidget::class.'::selected' => new Style(reverse: true),
+            SelectListWidget::class.'::selected:focus' => new Style(reverse: true),
+        ]);
+
+        return new Tui(styleSheet: $styleSheet, keybindings: $keybindings);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/DebugApplication.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/DebugApplication.php
@@ -1,0 +1,734 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Event\InputEvent;
+use Symfony\Component\Tui\Event\SelectionChangeEvent;
+use Symfony\Component\Tui\Event\TickEvent;
+use Symfony\Component\Tui\Input\Key;
+use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Style\Border;
+use Symfony\Component\Tui\Style\Direction;
+use Symfony\Component\Tui\Style\Padding;
+use Symfony\Component\Tui\Style\Style;
+use Symfony\Component\Tui\Style\VerticalAlign;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+/**
+ * The full-screen Tui application backing the "debug" command.
+ *
+ * Interaction model:
+ *   - typing anything updates the search and refreshes the list in real time;
+ *   - left/right arrows switch the active tab (section);
+ *   - up/down arrows move the selection in the list (the detail follows);
+ *   - PgUp/PgDown paginates the detail panel contents
+ *   - Esc clears the search query (or exits when it is already empty), Ctrl+C exits.
+ *
+ * Keystrokes are handled globally: text edits the search query, while arrows
+ * drive tab/list navigation.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class DebugApplication
+{
+    private const array LOADING_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    private const float LOADING_FRAME_INTERVAL = 0.08;
+    private const string DEFAULT_SECTION_LABEL = 'Container';
+
+    private Tui $tui;
+    private Keybindings $keybindings;
+
+    private TextWidget $topBar;
+    private TextWidget $footer;
+    private TextWidget $sidebarHeader;
+    private DebugResultListWidget $list;
+    private DebugDetailWidget $detail;
+    private SpacerWidget $sidebarFiller;
+    private int $panelInnerRows;
+    private int $listMaxVisible;
+    private int $terminalRows;
+    private int $terminalColumns;
+    private int $sidebarLineCount = 0;
+    private bool $sidebarHasHeader = true;
+
+    private int $activeIndex = 0;
+    private string $query = '';
+    private int $refreshGeneration = 0;
+    private int $detailGeneration = 0;
+    private int $loadingFrame = 0;
+    private float $loadingFrameElapsed = 0.0;
+
+    private ?DebugAsyncTask $listTask = null;
+    private ?DebugAsyncTask $detailTask = null;
+
+    /** @var array<int, list<DebugItem>> */
+    private array $listCache = [];
+
+    /** @var array<string, string> */
+    private array $detailCache = [];
+
+    /** @var array<string, DebugItem> */
+    private array $itemsByKey = [];
+
+    /**
+     * @param list<DebugSectionInterface> $sections
+     * @param \Closure(Keybindings): Tui  $tuiFactory Builds the Tui (lets the command inject a terminal in tests)
+     */
+    public function __construct(
+        private readonly array $sections,
+        \Closure $tuiFactory,
+    ) {
+        $this->keybindings = new Keybindings([
+            'debug_exit' => ['ctrl+c'],
+            'debug_tab_prev' => [Key::LEFT],
+            'debug_tab_next' => [Key::RIGHT],
+            'debug_list_up' => [Key::UP],
+            'debug_list_down' => [Key::DOWN],
+            'debug_detail_page_up' => [Key::PAGE_UP],
+            'debug_detail_page_down' => [Key::PAGE_DOWN],
+            'debug_detail_home' => [Key::HOME],
+            'debug_detail_end' => [Key::END],
+            'debug_search_backspace' => [Key::BACKSPACE],
+            'debug_search_clear' => [Key::ESCAPE],
+        ]);
+
+        $this->tui = ($tuiFactory)($this->keybindings);
+        $this->activeIndex = $this->getDefaultSectionIndex();
+
+        $this->build();
+    }
+
+    public function run(): void
+    {
+        $terminal = $this->tui->getTerminal();
+
+        // run this as a real full-screen UI. Rendering into the normal scrollback
+        // can push the first line just above the viewport when the frame uses the
+        // full terminal height
+        $terminal->write("\x1b[?1049h\x1b[2J\x1b[H");
+
+        try {
+            $this->tui->requestRender(true);
+            $this->tui->run();
+        } finally {
+            $this->cancelListTask();
+            $this->cancelDetailTask();
+            $terminal->write("\x1b[?1049l");
+        }
+    }
+
+    private function build(): void
+    {
+        $this->topBar = new TextWidget('', true);
+
+        $this->sidebarHeader = new TextWidget('', true);
+
+        $this->terminalRows = $this->tui->getTerminal()->getRows();
+        $this->terminalColumns = $this->tui->getTerminal()->getColumns();
+        $this->panelInnerRows = max(1, $this->terminalRows - 5);
+        $this->listMaxVisible = max(1, $this->terminalRows - 8);
+
+        $this->list = new DebugResultListWidget($this->listMaxVisible);
+        $this->sidebarFiller = new SpacerWidget();
+
+        $sidebar = new ContainerWidget();
+        $sidebar->expandVertically(true);
+        $sidebar->setStyle(new Style(border: Border::all(1, color: 'gray'), padding: Padding::from([0, 1]), verticalAlign: VerticalAlign::Top, flex: 1));
+        $sidebar->add($this->sidebarHeader);
+        $sidebar->add($this->list);
+        $sidebar->add($this->sidebarFiller);
+
+        $this->detail = new DebugDetailWidget();
+        $this->detail->expandVertically(true);
+
+        $detailBox = new ContainerWidget();
+        $detailBox->expandVertically(true);
+        $detailBox->setStyle(new Style(border: Border::all(1, color: 'gray'), padding: Padding::from([0, 1]), verticalAlign: VerticalAlign::Top, flex: 3));
+        $detailBox->add($this->detail);
+
+        $mainRow = new ContainerWidget();
+        $mainRow->expandVertically(true);
+        $mainRow->setStyle(new Style(direction: Direction::Horizontal, gap: 1, verticalAlign: VerticalAlign::Top));
+        $mainRow->add($sidebar);
+        $mainRow->add($detailBox);
+
+        $this->footer = new TextWidget("\e[2mType to search | <Esc> reset | ←/→ sections | ↑/↓ results | PgUp/PgDn detail | Ctrl+C quit\e[22m", true);
+
+        $this->tui->add($this->topBar);
+        $this->tui->add($mainRow);
+        $this->tui->add($this->footer);
+
+        $this->registerListeners();
+
+        $this->topBar->setText($this->renderTopBar());
+        $this->refreshList();
+    }
+
+    private function registerListeners(): void
+    {
+        $this->tui->addListener(function (InputEvent $event): void {
+            $data = $event->getData();
+            $kb = $this->keybindings;
+
+            if ($kb->matches($data, 'debug_exit')) {
+                $event->stopPropagation();
+                $this->tui->stop();
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_tab_prev')) {
+                $event->stopPropagation();
+                $this->switchTab(-1);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_tab_next')) {
+                $event->stopPropagation();
+                $this->switchTab(1);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_list_up') || $kb->matches($data, 'debug_list_down')) {
+                $event->stopPropagation();
+                $this->list->handleInput($data);
+                $this->tui->requestRender(true);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_detail_page_up')) {
+                $event->stopPropagation();
+                $this->detail->pageUp();
+                $this->tui->requestRender(true);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_detail_page_down')) {
+                $event->stopPropagation();
+                $this->detail->pageDown();
+                $this->tui->requestRender(true);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_detail_home')) {
+                $event->stopPropagation();
+                $this->detail->scrollToTop();
+                $this->tui->requestRender(true);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_detail_end')) {
+                $event->stopPropagation();
+                $this->detail->scrollToBottom();
+                $this->tui->requestRender(true);
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_search_backspace')) {
+                $event->stopPropagation();
+                $this->updateQuery($this->removeLastGrapheme($this->query));
+
+                return;
+            }
+
+            if ($kb->matches($data, 'debug_search_clear')) {
+                $event->stopPropagation();
+                if ('' === $this->query) {
+                    $this->tui->stop();
+
+                    return;
+                }
+
+                $this->updateQuery('');
+
+                return;
+            }
+
+            if (!$this->hasControlChars($data)) {
+                $event->stopPropagation();
+                $this->updateQuery($this->query.$data);
+            }
+        });
+
+        $this->list->onSelectionChange(function (SelectionChangeEvent $event): void {
+            $this->refreshDetail($event->getValue());
+            $this->tui->requestRender(true);
+        });
+
+        $this->tui->onTick(function (TickEvent $event): bool {
+            $terminal = $this->tui->getTerminal();
+            if ($terminal->getRows() !== $this->terminalRows || $terminal->getColumns() !== $this->terminalColumns) {
+                $this->handleResize();
+
+                return true;
+            }
+
+            if (null !== $this->listTask) {
+                $this->advanceLoadingFrame($event->getDeltaTime());
+                $this->showLoadingList($this->sections[$this->activeIndex]);
+
+                return true;
+            }
+
+            if (null !== $this->detailTask) {
+                $this->advanceLoadingFrame($event->getDeltaTime());
+                $this->showLoadingDetail();
+
+                return true;
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * Adapts the layout to the new terminal dimensions (the panel sizing is
+     * computed manually, so it is not refreshed by the Tui layout engine).
+     */
+    private function handleResize(): void
+    {
+        $terminal = $this->tui->getTerminal();
+        $this->terminalRows = $terminal->getRows();
+        $this->terminalColumns = $terminal->getColumns();
+        $this->panelInnerRows = max(1, $this->terminalRows - 5);
+        $this->listMaxVisible = max(1, $this->terminalRows - 8);
+
+        $this->list->setMaxVisible($this->listMaxVisible);
+        $this->topBar->setText($this->renderTopBar());
+        $this->setSidebarFiller($this->sidebarLineCount, $this->sidebarHasHeader);
+        // the detail is rendered for the panel width, so it must be recomputed
+        // (the detail cache is keyed by width, making this correct and cheap)
+        $this->refreshDetail($this->list->getSelectedItem()['value'] ?? null);
+        $this->tui->requestRender(true);
+    }
+
+    private function switchTab(int $delta): void
+    {
+        $count = \count($this->sections);
+        $this->activeIndex = (($this->activeIndex + $delta) % $count + $count) % $count;
+
+        $this->topBar->setText($this->renderTopBar());
+        $this->refreshList();
+        $this->tui->requestRender(true);
+    }
+
+    private function getDefaultSectionIndex(): int
+    {
+        foreach ($this->sections as $i => $section) {
+            if (self::DEFAULT_SECTION_LABEL === $section->getLabel()) {
+                return $i;
+            }
+        }
+
+        return 0;
+    }
+
+    private function updateQuery(string $query): void
+    {
+        $query = $this->stripControlBytes($this->sanitizeUtf8($query));
+
+        if ($query === $this->query) {
+            return;
+        }
+
+        $this->query = $query;
+        $this->topBar->setText($this->renderTopBar());
+        $this->refreshList();
+    }
+
+    private function refreshList(): void
+    {
+        $this->cancelListTask();
+        $this->cancelDetailTask();
+
+        $section = $this->sections[$this->activeIndex];
+        $generation = ++$this->refreshGeneration;
+        ++$this->detailGeneration;
+        $query = $this->query;
+        $sectionIndex = $this->activeIndex;
+
+        // once the full item list of a section is cached, every keystroke filters
+        // it synchronously in this process: no fork, no index rebuild
+        if (isset($this->listCache[$sectionIndex])) {
+            $this->renderList($section, '' === $query ? $this->listCache[$sectionIndex] : $section->filter($this->listCache[$sectionIndex], $query));
+
+            return;
+        }
+
+        $this->showLoadingList($section);
+
+        $this->listTask = DebugAsyncTask::run(
+            static fn (): array => $section->search($query),
+            function (mixed $result, ?string $error) use ($section, $generation, $query, $sectionIndex): void {
+                $this->listTask = null;
+
+                if ($generation !== $this->refreshGeneration) {
+                    return;
+                }
+
+                if (null !== $error) {
+                    $this->renderListError($error);
+
+                    return;
+                }
+
+                if (!\is_array($result)) {
+                    $this->renderListError('The debug task did not return a result list.');
+
+                    return;
+                }
+
+                if ('' === $query) {
+                    $this->listCache[$sectionIndex] = $result;
+                }
+
+                $this->renderList($section, $result);
+            },
+        );
+    }
+
+    /**
+     * @param list<DebugItem> $items
+     */
+    private function renderList(DebugSectionInterface $section, array $items): void
+    {
+        $this->itemsByKey = [];
+        $listItems = [];
+        $groupCounts = [];
+
+        foreach ($items as $item) {
+            if (null !== $item->group) {
+                $groupCounts[$item->group] = ($groupCounts[$item->group] ?? 0) + 1;
+            }
+        }
+        $hasGroupHeaders = [] !== $groupCounts;
+
+        $itemCount = 0;
+        $previousGroup = null;
+        foreach ($items as $i => $item) {
+            $key = (string) $i;
+            $this->itemsByKey[$key] = $item;
+            ++$itemCount;
+
+            if (null !== $item->group && $item->group !== $previousGroup) {
+                $listItems[] = [
+                    'header' => true,
+                    'label' => \sprintf('%s (%d)', $this->stripControlBytes($item->group), $groupCounts[$item->group]),
+                ];
+                $previousGroup = $item->group;
+            }
+
+            $listItems[] = ['value' => $key, 'label' => $this->stripControlBytes($item->label)];
+        }
+
+        $this->list->setItems($listItems);
+        $this->sidebarHeader->setText($hasGroupHeaders ? '' : \sprintf("\e[2m%s (%d)\e[22m", $section->getLabel(), $itemCount));
+        $this->setSidebarFiller(\count($listItems), !$hasGroupHeaders);
+
+        $this->refreshDetail($this->list->getSelectedItem()['value'] ?? null);
+        $this->tui->requestRender(true);
+    }
+
+    private function renderListError(string $message): void
+    {
+        ++$this->detailGeneration;
+        $this->itemsByKey = [];
+        $this->list->setItems([]);
+        $this->sidebarHeader->setText("\e[2mError\e[22m");
+        $this->setSidebarFiller(0, true);
+        $this->detail->setText($this->stripControlBytes($message));
+        $this->tui->requestRender(true);
+    }
+
+    private function showLoadingList(DebugSectionInterface $section): void
+    {
+        $frame = $this->getLoadingFrame();
+        $this->itemsByKey = [];
+        $this->list->setItems([
+            ['header' => true, 'label' => \sprintf('%s Loading %s...', $frame, $this->stripControlBytes($section->getLabel()))],
+        ]);
+        $this->sidebarHeader->setText('');
+        $this->setSidebarFiller(1, false);
+        $this->detail->setText('');
+        $this->tui->requestRender(true);
+    }
+
+    private function cancelListTask(): void
+    {
+        if (null !== $this->listTask) {
+            $this->listTask->cancel();
+            $this->listTask = null;
+        }
+    }
+
+    private function cancelDetailTask(): void
+    {
+        if (null !== $this->detailTask) {
+            $this->detailTask->cancel();
+            $this->detailTask = null;
+        }
+    }
+
+    private function refreshDetail(?string $key): void
+    {
+        $this->cancelDetailTask();
+
+        if (null === $key || !isset($this->itemsByKey[$key])) {
+            ++$this->detailGeneration;
+            $this->detail->setText('');
+
+            return;
+        }
+
+        $generation = ++$this->detailGeneration;
+        $section = $this->sections[$this->activeIndex];
+        $item = $this->itemsByKey[$key];
+        $width = max(20, $this->tui->getTerminal()->getColumns() - 4);
+        $cacheKey = $this->getDetailCacheKey($this->activeIndex, $item, $width);
+
+        if (isset($this->detailCache[$cacheKey])) {
+            $this->renderDetail($this->detailCache[$cacheKey]);
+
+            return;
+        }
+
+        if (null !== $item->detail) {
+            $this->detailCache[$cacheKey] = $item->detail;
+            $this->renderDetail($item->detail);
+
+            return;
+        }
+
+        $this->showLoadingDetail();
+
+        $this->detailTask = DebugAsyncTask::run(
+            static fn (): string => $section->describe($item, $width),
+            function (mixed $result, ?string $error) use ($generation, $cacheKey): void {
+                $this->detailTask = null;
+
+                if ($generation !== $this->detailGeneration) {
+                    return;
+                }
+
+                if (null !== $error) {
+                    $this->renderDetailError($error);
+
+                    return;
+                }
+
+                $detail = (string) $result;
+                $this->detailCache[$cacheKey] = $detail;
+                $this->renderDetail($detail);
+            },
+        );
+    }
+
+    private function renderDetail(string $detail): void
+    {
+        // The detail keeps the ANSI produced by the console descriptors on purpose.
+        $this->detail->setText($detail);
+
+        $this->tui->requestRender(true);
+    }
+
+    private function renderDetailError(string $message): void
+    {
+        $detail = $this->stripControlBytes($message);
+        $this->detail->setText($detail);
+        $this->tui->requestRender(true);
+    }
+
+    private function getDetailCacheKey(int $sectionIndex, DebugItem $item, int $width): string
+    {
+        return $sectionIndex."\0".$item->type."\0".$item->value."\0".$width;
+    }
+
+    private function showLoadingDetail(): void
+    {
+        $frame = $this->getLoadingFrame();
+        $detail = "\e[2m".$frame." Loading details...\e[22m";
+
+        $this->detail->setText($detail);
+        $this->tui->requestRender(true);
+    }
+
+    private function getLoadingFrame(): string
+    {
+        $frameCount = \count(self::LOADING_FRAMES);
+        $frame = $this->loadingFrame % $frameCount;
+
+        if ($frame < 0) {
+            $frame += $frameCount;
+        }
+
+        \assert(isset(self::LOADING_FRAMES[$frame]));
+
+        return self::LOADING_FRAMES[$frame];
+    }
+
+    private function advanceLoadingFrame(float $deltaTime): void
+    {
+        $this->loadingFrameElapsed += $deltaTime;
+
+        if ($this->loadingFrameElapsed < self::LOADING_FRAME_INTERVAL) {
+            return;
+        }
+
+        $steps = (int) floor($this->loadingFrameElapsed / self::LOADING_FRAME_INTERVAL);
+        $this->loadingFrame = ($this->loadingFrame + $steps) % \count(self::LOADING_FRAMES);
+        $this->loadingFrameElapsed -= $steps * self::LOADING_FRAME_INTERVAL;
+    }
+
+    private function setSidebarFiller(int $itemCount, bool $hasHeader): void
+    {
+        $this->sidebarLineCount = $itemCount;
+        $this->sidebarHasHeader = $hasHeader;
+        $this->sidebarFiller->setRows($this->getSidebarFillerLines($itemCount, $hasHeader));
+    }
+
+    private function getSidebarFillerLines(int $itemCount, bool $hasHeader): int
+    {
+        if (0 === $itemCount) {
+            $listLines = 1; // DebugResultListWidget renders "No matching items".
+        } else {
+            $listLines = min($itemCount, $this->listMaxVisible);
+            if ($itemCount > $this->listMaxVisible) {
+                ++$listLines; // scroll indicator
+            }
+        }
+
+        $contentRows = ($hasHeader ? 1 : 0) + $listLines;
+        if ($contentRows >= $this->panelInnerRows) {
+            return 0;
+        }
+
+        return $this->panelInnerRows - $contentRows;
+    }
+
+    private function renderTopBar(): string
+    {
+        $columns = $this->tui->getTerminal()->getColumns();
+        $searchColumns = max(16, intdiv(max(1, $columns - 1), 4));
+        $menuColumns = max(1, $columns - $searchColumns - 1);
+        $menu = $this->renderMenu($menuColumns);
+        $searchMarginLeft = 2; // matches the left panel border + padding
+        $searchInnerColumns = max(1, $searchColumns - $searchMarginLeft);
+
+        $icon = '> ';
+        $availableSearchColumns = max(1, $searchInnerColumns - AnsiUtils::visibleWidth($icon));
+        $search = '';
+        if ('' !== $this->query) {
+            $search = $this->truncatePlainText($this->stripControlBytes($this->query), $availableSearchColumns);
+        }
+
+        $search = $icon.$search;
+        $search .= str_repeat(' ', max(0, $searchInnerColumns - AnsiUtils::visibleWidth($search) + 1));
+        $search = str_repeat(' ', $searchMarginLeft - 1).$search;
+        $searchBorder = str_repeat(' ', $searchMarginLeft - 1).str_repeat('─', AnsiUtils::visibleWidth($search) - ($searchMarginLeft - 1));
+
+        return $search.' '.$menu."\n".$searchBorder;
+    }
+
+    private function renderMenu(int $availableColumns): string
+    {
+        $menu = $this->doRenderMenu(false);
+
+        if (AnsiUtils::visibleWidth($menu) <= $availableColumns) {
+            return $menu;
+        }
+
+        return $this->doRenderMenu(true);
+    }
+
+    private function doRenderMenu(bool $short): string
+    {
+        $parts = [];
+        foreach ($this->sections as $i => $section) {
+            $label = $this->stripControlBytes($short ? $section->getShortLabel() : $section->getLabel());
+            $parts[] = $i === $this->activeIndex
+                ? "\e[7m {$label} \e[27m"
+                : " {$label} ";
+        }
+
+        return implode(' ', $parts);
+    }
+
+    private function truncatePlainText(string $text, int $maxLength): string
+    {
+        $width = AnsiUtils::visibleWidth($text);
+        if ($width <= $maxLength) {
+            return $text;
+        }
+
+        return AnsiUtils::sliceByColumn($text, $width - $maxLength, $maxLength, true);
+    }
+
+    private function removeLastGrapheme(string $text): string
+    {
+        $length = $this->graphemeLength($text);
+
+        if ($length <= 1) {
+            return '';
+        }
+
+        $truncated = grapheme_substr($text, 0, $length - 1);
+
+        return false === $truncated ? substr($text, 0, -1) : $truncated;
+    }
+
+    private function graphemeLength(string $text): int
+    {
+        $length = grapheme_strlen($text);
+
+        return null === $length || false === $length ? \strlen($text) : $length;
+    }
+
+    private function hasControlChars(string $data): bool
+    {
+        for ($i = 0, $iMax = \strlen($data); $i < $iMax; ++$i) {
+            $code = \ord($data[$i]);
+            if ($code < 32 || 0x7F === $code) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function sanitizeUtf8(string $value): string
+    {
+        if ('' === $value || false !== preg_match('//u', $value)) {
+            return $value;
+        }
+
+        $sanitized = @iconv('UTF-8', 'UTF-8//IGNORE', $value);
+
+        return false === $sanitized ? '' : $sanitized;
+    }
+
+    private function stripControlBytes(string $value): string
+    {
+        return preg_replace("/[\x00-\x08\x0b-\x1f\x7f]|\xc2[\x80-\x9f]/", '', $value) ?? '';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/DebugAsyncTask.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/DebugAsyncTask.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug;
+
+use Revolt\EventLoop;
+
+/**
+ * @internal
+ */
+final class DebugAsyncTask
+{
+    /** @var resource|null */
+    private $socket;
+    private string $buffer = '';
+    private ?string $readWatcher = null;
+    private bool $finished = false;
+
+    /**
+     * @param positive-int                       $pid
+     * @param callable(mixed, string|null): void $onComplete
+     */
+    private function __construct(
+        private readonly int $pid,
+        mixed $socket,
+        private readonly \Closure $onComplete,
+    ) {
+        $this->socket = $socket;
+        stream_set_blocking($this->socket, false);
+
+        $this->readWatcher = EventLoop::onReadable($this->socket, $this->read(...));
+    }
+
+    /**
+     * @param callable(): mixed                  $work
+     * @param callable(mixed, string|null): void $onComplete
+     */
+    public static function run(callable $work, callable $onComplete): ?self
+    {
+        if (!self::isSupported()) {
+            try {
+                $onComplete($work(), null);
+            } catch (\Throwable $e) {
+                $onComplete(null, $e->getMessage());
+            }
+
+            return null;
+        }
+
+        $sockets = stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        if (false === $sockets) {
+            try {
+                $onComplete($work(), null);
+            } catch (\Throwable $e) {
+                $onComplete(null, $e->getMessage());
+            }
+
+            return null;
+        }
+
+        $pid = pcntl_fork();
+        if (-1 === $pid) {
+            fclose($sockets[0]);
+            fclose($sockets[1]);
+
+            try {
+                $onComplete($work(), null);
+            } catch (\Throwable $e) {
+                $onComplete(null, $e->getMessage());
+            }
+
+            return null;
+        }
+
+        if (0 === $pid) {
+            fclose($sockets[0]);
+
+            try {
+                $payload = serialize(['result' => $work(), 'error' => null]);
+            } catch (\Throwable $e) {
+                $payload = serialize(['result' => null, 'error' => $e->getMessage()]);
+            }
+
+            fwrite($sockets[1], $payload);
+            fclose($sockets[1]);
+            exit(0);
+        }
+
+        fclose($sockets[1]);
+
+        return new self($pid, $sockets[0], $onComplete(...));
+    }
+
+    public function cancel(): void
+    {
+        if ($this->finished) {
+            return;
+        }
+
+        $this->finished = true;
+        $this->close();
+
+        if (\function_exists('posix_kill')) {
+            @posix_kill($this->pid, \defined('SIGTERM') ? \SIGTERM : 15);
+        }
+
+        self::reap($this->pid);
+    }
+
+    private static function isSupported(): bool
+    {
+        return \function_exists('pcntl_fork') && \function_exists('pcntl_waitpid') && \function_exists('stream_socket_pair') && \defined('STREAM_PF_UNIX');
+    }
+
+    private static function reap(int $pid, int $attempt = 0): void
+    {
+        if (0 < pcntl_waitpid($pid, $status, \WNOHANG) || $attempt >= 10) {
+            return;
+        }
+
+        EventLoop::delay(0.1, static function () use ($pid, $attempt): void {
+            self::reap($pid, $attempt + 1);
+        });
+    }
+
+    private function read(): void
+    {
+        if (null === $this->socket) {
+            return;
+        }
+
+        $chunk = fread($this->socket, 8192);
+        if (false !== $chunk && '' !== $chunk) {
+            $this->buffer .= $chunk;
+        }
+
+        if (!feof($this->socket)) {
+            return;
+        }
+
+        $this->finished = true;
+        $this->close();
+        self::reap($this->pid);
+
+        $payload = '' === $this->buffer ? false : @unserialize($this->buffer, ['allowed_classes' => [DebugItem::class]]);
+        if (!\is_array($payload) || !\array_key_exists('result', $payload) || !\array_key_exists('error', $payload)) {
+            ($this->onComplete)(null, 'The debug task did not return a valid result.');
+
+            return;
+        }
+
+        ($this->onComplete)($payload['result'], $payload['error']);
+    }
+
+    private function close(): void
+    {
+        if (null !== $this->readWatcher) {
+            EventLoop::cancel($this->readWatcher);
+            $this->readWatcher = null;
+        }
+
+        if (null !== $this->socket) {
+            $socket = $this->socket;
+            $this->socket = null;
+            fclose($socket);
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/DebugDetailWidget.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/DebugDetailWidget.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\VerticallyExpandableInterface;
+
+/**
+ * @internal
+ */
+final class DebugDetailWidget extends AbstractWidget implements VerticallyExpandableInterface
+{
+    /** @var list<string> */
+    private array $lines = [];
+    private int $scrollOffset = 0;
+    private int $lastPageSize = 1;
+    private bool $verticallyExpanded = false;
+
+    public function setText(string $text): void
+    {
+        $lines = '' === $text ? [] : preg_split('/\r\n|\n|\r/', $text);
+        $lines = false === $lines ? [] : $lines;
+
+        while ($lines && '' === trim($lines[0])) {
+            array_shift($lines);
+        }
+
+        if ($lines === $this->lines) {
+            return;
+        }
+
+        $this->lines = array_values($lines);
+        $this->scrollOffset = 0;
+        $this->invalidate();
+    }
+
+    public function pageUp(): void
+    {
+        $this->scrollBy(-$this->lastPageSize);
+    }
+
+    public function pageDown(): void
+    {
+        $this->scrollBy($this->lastPageSize);
+    }
+
+    public function scrollToTop(): void
+    {
+        $this->setScrollOffset(0);
+    }
+
+    public function scrollToBottom(): void
+    {
+        $this->setScrollOffset(max(0, \count($this->lines) - $this->lastPageSize));
+    }
+
+    public function expandVertically(bool $expand): static
+    {
+        if ($this->verticallyExpanded !== $expand) {
+            $this->verticallyExpanded = $expand;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function isVerticallyExpanded(): bool
+    {
+        return $this->verticallyExpanded;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function render(RenderContext $context): array
+    {
+        $columns = $context->getColumns();
+        $rows = max(1, $context->getRows());
+        $lineCount = \count($this->lines);
+
+        if (0 === $lineCount) {
+            $this->lastPageSize = $rows;
+
+            return array_fill(0, $rows, '');
+        }
+
+        $hasOverflow = $lineCount > $rows;
+        $contentRows = $hasOverflow ? max(1, $rows - 1) : $rows;
+        $maxOffset = max(0, $lineCount - $contentRows);
+        $this->scrollOffset = min($this->scrollOffset, $maxOffset);
+        $this->lastPageSize = $contentRows;
+
+        $lines = [];
+        if ($hasOverflow) {
+            $lines[] = $this->renderScrollIndicator($columns, $this->scrollOffset, $lineCount);
+        }
+
+        foreach (\array_slice($this->lines, $this->scrollOffset, $contentRows) as $line) {
+            $lines[] = AnsiUtils::truncateToWidth($line, $columns);
+        }
+
+        while (\count($lines) < $rows) {
+            $lines[] = '';
+        }
+
+        return $lines;
+    }
+
+    private function scrollBy(int $delta): void
+    {
+        $this->setScrollOffset($this->scrollOffset + $delta);
+    }
+
+    private function setScrollOffset(int $offset): void
+    {
+        $offset = max(0, min($offset, max(0, \count($this->lines) - 1)));
+
+        if ($offset === $this->scrollOffset) {
+            return;
+        }
+
+        $this->scrollOffset = $offset;
+        $this->invalidate();
+    }
+
+    private function renderScrollIndicator(int $columns, int $offset, int $lineCount): string
+    {
+        $current = min($lineCount, $offset + 1);
+        $indicator = \sprintf('(%d/%d) PgUp/PgDn', $current, $lineCount);
+        $indicator = AnsiUtils::truncateToWidth($indicator, $columns, '');
+
+        return "\e[2m".str_repeat(' ', max(0, $columns - AnsiUtils::visibleWidth($indicator))).$indicator."\e[22m";
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/DebugItem.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/DebugItem.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug;
+
+/**
+ * A single entry shown in the left-hand list of the interactive "debug" command.
+ *
+ * Kept intentionally minimal: the {@see $type} discriminates how the item is
+ * described in the detail pane (and doubles as the facet it belongs to), while
+ * {@see $value} is the real identifier passed back to the owning section.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class DebugItem
+{
+    /**
+     * @param string      $type       An opaque, section-defined kind (e.g. "service", "parameter", "tag")
+     * @param string      $value      The real id/name used by the section to describe the item
+     * @param string      $label      The text rendered in the list (sanitized before display)
+     * @param string|null $group      An optional heading the item belongs to; consecutive items sharing
+     *                                the same group are rendered under a single header in the list. When
+     *                                null, the item is listed without a header.
+     * @param string|null $detail     optional precomputed detail, used when building the detail would
+     *                                otherwise redo expensive work already done for the list
+     * @param string|null $searchText Optional extra text the item is matched against, in addition to
+     *                                its label and value (e.g. a route's path and controller). When
+     *                                null, only the label and value are matched.
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly string $value,
+        public readonly string $label,
+        public readonly ?string $group = null,
+        public readonly ?string $detail = null,
+        public readonly ?string $searchText = null,
+    ) {
+    }
+
+    /**
+     * Whether the item matches the given case-insensitive search query.
+     */
+    public function matches(string $query): bool
+    {
+        return '' === $query
+            || false !== stripos($this->label, $query)
+            || false !== stripos($this->value, $query)
+            || (null !== $this->searchText && false !== stripos($this->searchText, $query));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/DebugResultListWidget.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/DebugResultListWidget.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Event\SelectionChangeEvent;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+/**
+ * Result list tailored for the interactive debug command.
+ *
+ * The built-in SelectListWidget renders a hardcoded arrow prefix and applies
+ * selected styles only to the text. This command needs a full-width selection
+ * band while keeping the generic Tui component unchanged.
+ *
+ * @internal
+ */
+final class DebugResultListWidget extends SelectListWidget
+{
+    /** @var array<array{value: string, label: string}|array{header: true, label: string}> */
+    private array $debugItems = [];
+
+    private int $debugSelectedIndex = 0;
+
+    public function __construct(
+        private int $debugMaxVisible = 5,
+    ) {
+        parent::__construct([], $debugMaxVisible);
+    }
+
+    public function setMaxVisible(int $maxVisible): void
+    {
+        $this->debugMaxVisible = max(1, $maxVisible);
+        $this->invalidate();
+    }
+
+    /**
+     * @param array<array{value: string, label: string}|array{header: true, label: string}> $items
+     */
+    public function setItems(array $items): static
+    {
+        $this->debugItems = $items;
+        $this->debugSelectedIndex = $this->seekSelectable(0, 1);
+        $this->invalidate();
+
+        return $this;
+    }
+
+    /**
+     * @return array{value: string, label: string}|null
+     */
+    public function getSelectedItem(): ?array
+    {
+        $item = $this->debugItems[$this->debugSelectedIndex] ?? null;
+
+        if (!$item || isset($item['header'])) {
+            return null;
+        }
+
+        return [
+            'value' => $item['value'],
+            'label' => $item['label'],
+        ];
+    }
+
+    public function handleInput(string $data): void
+    {
+        if (!$this->debugItems) {
+            return;
+        }
+
+        $keybindings = $this->getKeybindings();
+        if ($keybindings->matches($data, 'select_up')) {
+            $this->debugSelectedIndex = $this->seekSelectable($this->debugSelectedIndex - 1, -1);
+            $this->notifyDebugSelectionChange();
+
+            return;
+        }
+
+        if ($keybindings->matches($data, 'select_down')) {
+            $this->debugSelectedIndex = $this->seekSelectable($this->debugSelectedIndex + 1, 1);
+            $this->notifyDebugSelectionChange();
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function render(RenderContext $context): array
+    {
+        $columns = $context->getColumns();
+
+        if (!$this->debugItems) {
+            return [$this->applyElement('no-match', AnsiUtils::truncateToWidth('No matching items', $columns, ''))];
+        }
+
+        $startIndex = max(
+            0,
+            min(
+                $this->debugSelectedIndex - (int) floor($this->debugMaxVisible / 2),
+                \count($this->debugItems) - $this->debugMaxVisible,
+            ),
+        );
+        $endIndex = min($startIndex + $this->debugMaxVisible, \count($this->debugItems));
+
+        $lines = [];
+        for ($i = $startIndex; $i < $endIndex; ++$i) {
+            $label = $this->debugItems[$i]['label'];
+
+            if (isset($this->debugItems[$i]['header'])) {
+                $lines[] = "\e[2m".$this->truncateLabel($label, $columns)."\e[22m";
+
+                continue;
+            }
+
+            if ($i === $this->debugSelectedIndex) {
+                $lines[] = $this->applyElement('selected', $this->truncateLabel($label, $columns));
+
+                continue;
+            }
+
+            $lines[] = $this->truncateLabel($label, $columns);
+        }
+
+        if ($startIndex > 0 || $endIndex < \count($this->debugItems)) {
+            [$position, $total] = $this->selectablePosition();
+            $scrollText = \sprintf('(%d/%d)', $position, $total);
+            $lines[] = $this->applyElement('scroll-info', AnsiUtils::truncateToWidth($scrollText, $columns, ''));
+        }
+
+        return $lines;
+    }
+
+    private function notifyDebugSelectionChange(): void
+    {
+        $this->invalidate();
+
+        if (null !== $selectedItem = $this->getSelectedItem()) {
+            $this->dispatch(new SelectionChangeEvent($this, $selectedItem));
+        }
+    }
+
+    /**
+     * Returns the nearest selectable (non-header) index from $from following $step,
+     * wrapping around. Returns $from when no selectable item exists.
+     */
+    private function seekSelectable(int $from, int $step): int
+    {
+        $count = \count($this->debugItems);
+        if (0 === $count) {
+            return 0;
+        }
+
+        $index = ($from % $count + $count) % $count;
+        for ($i = 0; $i < $count; ++$i) {
+            if (!isset($this->debugItems[$index]['header'])) {
+                return $index;
+            }
+            $index = ($index + $step % $count + $count) % $count;
+        }
+
+        return $from;
+    }
+
+    /**
+     * @return array{0: int, 1: int} The 1-based rank of the selected item and the total selectable count
+     */
+    private function selectablePosition(): array
+    {
+        $total = 0;
+        $position = 0;
+        foreach ($this->debugItems as $i => $item) {
+            if (isset($item['header'])) {
+                continue;
+            }
+            ++$total;
+            if ($i === $this->debugSelectedIndex) {
+                $position = $total;
+            }
+        }
+
+        return [$position, $total];
+    }
+
+    private function truncateLabel(string $label, int $columns): string
+    {
+        if (AnsiUtils::visibleWidth($label) <= $columns) {
+            return $label;
+        }
+
+        if ($columns <= 1) {
+            return AnsiUtils::sliceByColumn('…', 0, $columns, true);
+        }
+
+        if ($columns <= 5) {
+            $labelWidth = AnsiUtils::visibleWidth($label);
+
+            return AnsiUtils::sliceByColumn($label, max(0, $labelWidth - $columns), $columns, true);
+        }
+
+        $prefix = AnsiUtils::sliceByColumn($label, 0, 3, true);
+        $ellipsis = "\e[2m…\e[22m";
+        $labelWidth = AnsiUtils::visibleWidth($label);
+        $suffixColumns = max(1, $columns - AnsiUtils::visibleWidth($prefix) - AnsiUtils::visibleWidth($ellipsis));
+        $suffixStart = max(0, $labelWidth - $suffixColumns);
+
+        return $prefix.$ellipsis.AnsiUtils::sliceByColumn($label, $suffixStart, $suffixColumns, true);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/DebugSectionInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/DebugSectionInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug;
+
+/**
+ * Contributes a tab to the interactive "debug" command.
+ *
+ * Each section owns one area of the application (container, routing, config, …). It is
+ * registered as a service tagged "debug.section" so that any bundle can plug its
+ * own area into the unified command; sections whose underlying component is not
+ * installed simply do not register, and the command degrades gracefully.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+interface DebugSectionInterface
+{
+    /**
+     * The label shown in the top menu (e.g. "Container").
+     */
+    public function getLabel(): string;
+
+    /**
+     * The compact label shown when the top menu does not fit (e.g. "DI").
+     */
+    public function getShortLabel(): string;
+
+    /**
+     * The items shown in the left-hand list, filtered by the search query.
+     *
+     * An empty query must return the full, unfiltered set.
+     *
+     * @return list<DebugItem>
+     */
+    public function search(string $query): array;
+
+    /**
+     * Filters an already-built item list by the search query.
+     *
+     * Must return the same result as search($query) does when $items is the
+     * full set returned by search(''). It runs in the UI process on cached
+     * items on every keystroke, so it must be fast and must not rebuild any
+     * index.
+     *
+     * @param list<DebugItem> $items
+     *
+     * @return list<DebugItem>
+     */
+    public function filter(array $items, string $query): array;
+
+    /**
+     * The detail of the given item, rendered in the right-hand pane.
+     *
+     * The returned string may contain ANSI escape sequences (it is rendered
+     * verbatim), allowing sections to reuse the output of the existing
+     * "debug:*" descriptors.
+     *
+     * @param int $width The number of columns available in the detail pane
+     */
+    public function describe(DebugItem $item, int $width): string;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/AbstractDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/AbstractDebugSection.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugSectionInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Base class for debug sections backed by a memoized, in-memory item list.
+ *
+ * Sections only build their full item list (once) in buildItems(); searching,
+ * filtering and result ranking are shared and rely on the label, value and
+ * searchText of each item (see DebugItem::matches()).
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+abstract class AbstractDebugSection implements DebugSectionInterface
+{
+    /**
+     * Separates the parts of composite item values (e.g. "dispatcher\0event").
+     */
+    protected const string VALUE_SEPARATOR = "\0";
+
+    /** @var list<DebugItem>|null */
+    private ?array $items = null;
+
+    public function search(string $query): array
+    {
+        return $this->filter($this->items ??= $this->buildItems(), $query);
+    }
+
+    public function filter(array $items, string $query): array
+    {
+        if ('' === $query) {
+            return $items;
+        }
+
+        $matches = array_values(array_filter($items, static fn (DebugItem $item): bool => $item->matches($query)));
+
+        // rank items matching on their label before items matching only on their value
+        // or extra search text, without breaking the contiguity of item groups (the
+        // list renders one header per consecutive run of items sharing a group)
+        $groupOrder = [];
+        foreach ($matches as $item) {
+            $groupOrder[$item->group ?? ''] ??= \count($groupOrder);
+        }
+        usort($matches, static fn (DebugItem $a, DebugItem $b): int => [$groupOrder[$a->group ?? ''], false === stripos($a->label, $query)] <=> [$groupOrder[$b->group ?? ''], false === stripos($b->label, $query)]);
+
+        return $matches;
+    }
+
+    /**
+     * Builds the full, unfiltered item list once. Recomputing it on every search
+     * would be costly on large applications.
+     *
+     * @return list<DebugItem>
+     */
+    abstract protected function buildItems(): array;
+
+    /**
+     * Renders console-style output into a decorated string, the way the
+     * "debug:*" descriptors do.
+     *
+     * @param \Closure(SymfonyStyle): void $describe
+     */
+    protected function describeToBuffer(\Closure $describe): string
+    {
+        $buffer = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $describe(new SymfonyStyle(new ArrayInput([]), $buffer));
+
+        return $buffer->fetch();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/AssetMapperDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/AssetMapperDebugSection.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\ImportMap\JavaScriptImport;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * The "Assets" tab of the interactive "debug" command.
+ *
+ * Reuses the same data source ({@see AssetMapperInterface}) as the
+ * "debug:asset-map" command, so the detail pane shows the logical/public/source
+ * paths and imports of the selected asset.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class AssetMapperDebugSection extends AbstractDebugSection
+{
+    public function __construct(
+        private readonly AssetMapperInterface $assetMapper,
+        private readonly string $projectDir,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Assets';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Assets';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        $asset = $this->assetMapper->getAsset($item->value);
+        if (!$asset) {
+            return \sprintf('Asset "%s" does not exist.', $item->value);
+        }
+
+        return $this->describeToBuffer(function (SymfonyStyle $io) use ($asset): void {
+            $rows = [['Logical path' => $asset->logicalPath]];
+            if (isset($asset->sourcePath)) {
+                $rows[] = ['Source path' => $this->relativizePath($asset->sourcePath)];
+            }
+            if (isset($asset->publicPath)) {
+                $rows[] = ['Public path' => $asset->publicPath];
+            }
+            if (isset($asset->publicExtension)) {
+                $rows[] = ['Extension' => $asset->publicExtension];
+            }
+            $rows[] = ['Vendor' => $asset->isVendor ? 'yes' : 'no'];
+            if (isset($asset->digest)) {
+                $rows[] = ['Digest' => $asset->digest];
+            }
+
+            $io->definitionList(...$rows);
+
+            if ($imports = $asset->getJavaScriptImports()) {
+                $io->section('JavaScript imports');
+                $io->listing(array_map(
+                    static fn (JavaScriptImport $import): string => $import->importName.($import->isLazy ? ' (lazy)' : ''),
+                    $imports,
+                ));
+            }
+        });
+    }
+
+    /**
+     * Builds the full, unfiltered item list once. Recomputing it on every keystroke
+     * would be costly on large applications.
+     *
+     * @return list<DebugItem>
+     */
+    protected function buildItems(): array
+    {
+        $items = [];
+        foreach ($this->assetMapper->allAssets() as $asset) {
+            $items[] = new DebugItem('asset', $asset->logicalPath, $asset->logicalPath, searchText: implode("\n", array_filter([
+                $asset->sourcePath ?? '',
+                $asset->publicExtension ?? '',
+                $asset->isVendor ? 'vendor' : '',
+            ])) ?: null);
+        }
+
+        return $items;
+    }
+
+    private function relativizePath(string $path): string
+    {
+        return str_replace($this->projectDir.'/', '', $path);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/ConfigDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/ConfigDebugSection.php
@@ -1,0 +1,327 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * The "Config" tab of the interactive "debug" command.
+ *
+ * Reuses the same data sources and rendering as the "debug:config" and
+ * "debug:dotenv" commands. Search results are split into two groups: the
+ * bundle/extension configuration and the dotenv environment variables. The
+ * detail pane dumps the current configuration of the selected extension, or the
+ * value of the selected variable.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class ConfigDebugSection extends AbstractDebugSection
+{
+    private const string GROUP_CONFIG = 'Config';
+    private const string GROUP_ENV = 'Env Var';
+
+    private ?ContainerBuilder $container = null;
+
+    public function __construct(
+        private readonly KernelInterface $kernel,
+        private readonly ?ContainerInterface $envVarProcessors = null,
+        private readonly string $kernelEnvironment = 'dev',
+        private readonly string $projectDir = '',
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Config';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Config';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        return $item->detail ?? $this->describeToString($item->type, $item->value);
+    }
+
+    private function describeToString(string $type, string $value): string
+    {
+        $buffer = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $io = new SymfonyStyle(new ArrayInput([]), $buffer);
+
+        try {
+            if ('extension' === $type) {
+                $this->describeExtension($io, $value);
+            } else {
+                $this->describeDotenvVariable($io, $value);
+            }
+        } catch (\Throwable $e) {
+            return $this->formatError($value, $e);
+        }
+
+        return $buffer->fetch();
+    }
+
+    private function formatError(string $value, \Throwable $e): string
+    {
+        return \sprintf("\e[91mError while loading \"%s\"\e[39m\n\n%s", $value, $e->getMessage());
+    }
+
+    protected function buildItems(): array
+    {
+        $items = [];
+
+        $aliasToBundle = [];
+        foreach ($this->kernel->getBundles() as $bundle) {
+            if ($extension = $bundle->getContainerExtension()) {
+                $aliasToBundle[$extension->getAlias()] = $bundle->getName();
+            }
+        }
+
+        $aliases = array_keys($this->getContainer()->getExtensions());
+        sort($aliases);
+        foreach ($aliases as $alias) {
+            $detail = $this->describeToString('extension', $alias);
+            $items[] = new DebugItem('extension', $alias, $alias, self::GROUP_CONFIG, $detail, searchText: implode("\n", array_filter([$aliasToBundle[$alias] ?? '', $detail])));
+        }
+
+        $vars = array_keys($this->getDotenvVariables());
+        sort($vars);
+        foreach ($vars as $var) {
+            $items[] = new DebugItem('dotenv', $var, $var, self::GROUP_ENV);
+        }
+
+        return $items;
+    }
+
+    private function describeExtension(SymfonyStyle $io, string $alias): void
+    {
+        $container = $this->getContainer();
+
+        if (!$container->hasExtension($alias)) {
+            throw new \LogicException(\sprintf('No extension with alias "%s" is enabled.', $alias));
+        }
+
+        $config = $this->getConfig($container->getExtension($alias), $container);
+
+        $io->title(\sprintf('Current configuration for "%s"', $alias));
+        $io->writeln($this->dump([$alias => $config]));
+    }
+
+    private function describeDotenvVariable(SymfonyStyle $io, string $var): void
+    {
+        $io->title($var);
+        $io->definitionList(['Value' => (string) ($_SERVER[$var] ?? $_ENV[$var] ?? '')]);
+
+        $perFile = [];
+        foreach ($this->getAvailableEnvFiles() as $file) {
+            $values = $this->loadValues($file);
+            if (\array_key_exists($var, $values)) {
+                $perFile[] = \sprintf('%s: %s', $this->getRelativeName($file), $values[$var]);
+            }
+        }
+
+        if ($perFile) {
+            $io->section('Defined in (descending priority)');
+            $io->listing($perFile);
+        }
+
+        $io->comment('Note that values might be different between web and CLI.');
+    }
+
+    /**
+     * Compiles the container once and caches it. Cloning + booting the kernel and
+     * compiling the container is expensive, so it must not run on every keystroke.
+     *
+     * Deliberately mirrors ConfigDebugCommand::compileContainer() instead of using
+     * BuildDebugContainerTrait: the trait's cached path restores the dumped container
+     * without running registerContainerConfiguration() or the ValidateEnvPlaceholdersPass,
+     * so the actual (non-default) extension configuration would not be available.
+     */
+    private function getContainer(): ContainerBuilder
+    {
+        if (null !== $this->container) {
+            return $this->container;
+        }
+
+        $kernel = clone $this->kernel;
+        $kernel->boot();
+
+        $method = new \ReflectionMethod($kernel, 'buildContainer');
+        $container = $method->invoke($kernel);
+        if ($this->envVarProcessors) {
+            $container->set('container.env_var_processors_locator', $this->envVarProcessors);
+        }
+        $container->getCompiler()->compile($container);
+
+        return $this->container = $container;
+    }
+
+    private function getConfig(ExtensionInterface $extension, ContainerBuilder $container): mixed
+    {
+        return $container->resolveEnvPlaceholders(
+            $container->getParameterBag()->resolveValue(
+                $this->getConfigForExtension($extension, $container)
+            ), null
+        );
+    }
+
+    private function getConfigForExtension(ExtensionInterface $extension, ContainerBuilder $container): array
+    {
+        $extensionAlias = $extension->getAlias();
+
+        $extensionConfig = [];
+        foreach ($container->getCompilerPassConfig()->getPasses() as $pass) {
+            if ($pass instanceof ValidateEnvPlaceholdersPass) {
+                $extensionConfig = $pass->getExtensionConfig();
+                break;
+            }
+        }
+
+        if (isset($extensionConfig[$extensionAlias])) {
+            return $extensionConfig[$extensionAlias];
+        }
+
+        // Fall back to default config if the extension has one
+        $configs = $container->getExtensionConfig($extensionAlias);
+
+        if ($extension instanceof ConfigurationInterface) {
+            $configuration = $extension;
+        } elseif ($extension instanceof ConfigurationExtensionInterface) {
+            $configuration = $extension->getConfiguration($configs, $container);
+        } else {
+            throw new \LogicException(\sprintf('The extension with alias "%s" does not have configuration.', $extensionAlias));
+        }
+
+        if (!$configuration instanceof ConfigurationInterface) {
+            throw new \LogicException(\sprintf('The extension with alias "%s" does not have its getConfiguration() method setup.', $extensionAlias));
+        }
+
+        return (new Processor())->processConfiguration($configuration, $configs);
+    }
+
+    private function dump(mixed $config): string
+    {
+        if (class_exists(Yaml::class)) {
+            return Yaml::dump($config, 10);
+        }
+
+        $dump = json_encode($config, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+
+        return false === $dump ? '' : $dump;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getDotenvVariables(): array
+    {
+        $variables = [];
+        foreach ($this->getAvailableEnvFiles() as $file) {
+            $variables += $this->loadValues($file);
+        }
+
+        return $variables;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getAvailableEnvFiles(): array
+    {
+        return array_values(array_filter($this->getEnvFiles($this->getDotenvPath()), 'is_file'));
+    }
+
+    private function getDotenvPath(): string
+    {
+        $config = [];
+        $projectDir = $this->projectDir;
+
+        if (is_file($projectDir)) {
+            $config = ['dotenv_path' => basename($projectDir)];
+            $projectDir = \dirname($projectDir);
+        }
+
+        $composerFile = $projectDir.'/composer.json';
+        $config += $_SERVER['APP_RUNTIME_OPTIONS'] ?? (is_file($composerFile) ? json_decode(file_get_contents($composerFile), true) : [])['extra']['runtime'] ?? [];
+
+        return $projectDir.'/'.($config['dotenv_path'] ?? '.env');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getEnvFiles(string $filePath): array
+    {
+        $files = [
+            \sprintf('%s.local.php', $filePath),
+            \sprintf('%s.%s.local', $filePath, $this->kernelEnvironment),
+            \sprintf('%s.%s', $filePath, $this->kernelEnvironment),
+        ];
+
+        if ('test' !== $this->kernelEnvironment) {
+            $files[] = \sprintf('%s.local', $filePath);
+        }
+
+        if (!is_file($filePath) && is_file(\sprintf('%s.dist', $filePath))) {
+            $files[] = \sprintf('%s.dist', $filePath);
+        } else {
+            $files[] = $filePath;
+        }
+
+        return $files;
+    }
+
+    private function getRelativeName(string $filePath): string
+    {
+        $projectDir = is_file($this->projectDir) ? \dirname($this->projectDir) : $this->projectDir;
+
+        if (str_starts_with($filePath, $projectDir.'/') || str_starts_with($filePath, $projectDir.\DIRECTORY_SEPARATOR)) {
+            return substr($filePath, \strlen($projectDir) + 1);
+        }
+
+        return basename($filePath);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function loadValues(string $filePath): array
+    {
+        if (str_ends_with($filePath, '.php')) {
+            return include $filePath;
+        }
+
+        if (!class_exists(Dotenv::class)) {
+            return [];
+        }
+
+        return (new Dotenv())->parse(file_get_contents($filePath));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/ContainerDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/ContainerDebugSection.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Command\BuildDebugContainerTrait;
+use Symfony\Bundle\FrameworkBundle\Console\Helper\DescriptorHelper;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * The "Container" tab of the interactive "debug" command.
+ *
+ * Reuses the same data source ({@see BuildDebugContainerTrait}) and the same
+ * descriptors ({@see DescriptorHelper}) as the "debug:container" command, so the
+ * detail pane shows exactly what "debug:container <id>", "--parameter" and
+ * "--tag" already produce.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class ContainerDebugSection extends AbstractDebugSection
+{
+    use BuildDebugContainerTrait;
+
+    private const string GROUP_SERVICES = 'Services';
+    private const string GROUP_PARAMETERS = 'Parameters';
+    private const string GROUP_TAGS = 'Tags';
+
+    public function __construct(
+        private readonly KernelInterface $kernel,
+        private readonly ?FileLinkFormatter $fileLinkFormatter = null,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Container';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'DI';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        $container = $this->getContainerBuilder($this->kernel);
+
+        $options = match ($item->type) {
+            'service' => ['id' => $item->value],
+            'parameter' => ['parameter' => $item->value],
+            'tag' => ['tag' => $item->value],
+            default => [],
+        };
+
+        $buffer = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $io = new SymfonyStyle(new ArrayInput([]), $buffer);
+
+        $options['format'] = 'txt';
+        $options['output'] = $io;
+        $options['is_debug'] = $this->kernel->isDebug();
+        $options['show_hidden'] = false;
+
+        (new DescriptorHelper($this->fileLinkFormatter))->describe($io, $container, $options);
+
+        return $buffer->fetch();
+    }
+
+    protected function buildItems(): array
+    {
+        $container = $this->getContainerBuilder($this->kernel);
+
+        $services = array_filter(
+            $container->getServiceIds(),
+            static fn (string $id): bool => !str_starts_with($id, '.'),
+        );
+        sort($services);
+
+        $parameters = array_keys($container->getParameterBag()->all());
+        sort($parameters);
+
+        $tags = $container->findTags();
+        sort($tags);
+
+        $items = [];
+        foreach ($services as $id) {
+            $items[] = new DebugItem('service', $id, $id, self::GROUP_SERVICES);
+        }
+        foreach ($parameters as $name) {
+            $items[] = new DebugItem('parameter', $name, '%'.$name.'%', self::GROUP_PARAMETERS);
+        }
+        foreach ($tags as $tag) {
+            $items[] = new DebugItem('tag', $tag, '#'.$tag, self::GROUP_TAGS);
+        }
+
+        return $items;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/EventDispatcherDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/EventDispatcherDebugSection.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Helper\DescriptorHelper;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/**
+ * The "Events" tab of the interactive "debug" command.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class EventDispatcherDebugSection extends AbstractDebugSection
+{
+    private const string DEFAULT_DISPATCHER = 'event_dispatcher';
+
+    public function __construct(
+        private readonly ContainerInterface $dispatchers,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Events';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Events';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        [$dispatcherName, $event] = explode(self::VALUE_SEPARATOR, $item->value, 2);
+
+        if (!$this->dispatchers->has($dispatcherName)) {
+            return \sprintf('Event dispatcher "%s" is not available.', $dispatcherName);
+        }
+
+        $dispatcher = $this->dispatchers->get($dispatcherName);
+        if (!$dispatcher instanceof EventDispatcherInterface) {
+            return \sprintf('Service "%s" is not an event dispatcher.', $dispatcherName);
+        }
+
+        return $this->describeToBuffer(static function (SymfonyStyle $io) use ($dispatcher, $dispatcherName, $event): void {
+            $options = [
+                'event' => $event,
+                'format' => 'txt',
+                'output' => $io,
+            ];
+
+            if (self::DEFAULT_DISPATCHER !== $dispatcherName) {
+                $options['dispatcher_service_name'] = $dispatcherName;
+            }
+
+            (new DescriptorHelper())->describe($io, $dispatcher, $options);
+        });
+    }
+
+    /**
+     * Builds the full, unfiltered item list once. Recomputing it on every keystroke
+     * would be costly on large applications.
+     *
+     * @return list<DebugItem>
+     */
+    protected function buildItems(): array
+    {
+        $items = [];
+        $dispatcherNames = $this->getDispatcherNames();
+        foreach ($dispatcherNames as $dispatcherName) {
+            if (!$this->dispatchers->has($dispatcherName)) {
+                continue;
+            }
+
+            $dispatcher = $this->dispatchers->get($dispatcherName);
+            if (!$dispatcher instanceof EventDispatcherInterface) {
+                continue;
+            }
+
+            $events = $dispatcher->getListeners();
+            ksort($events);
+
+            foreach ($events as $event => $listeners) {
+                $label = self::DEFAULT_DISPATCHER === $dispatcherName ? $event : \sprintf('%s (%s)', $event, $dispatcherName);
+                $items[] = new DebugItem('event', $dispatcherName.self::VALUE_SEPARATOR.$event, $label, searchText: $this->buildSearchText($dispatcher, $event, $listeners));
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getDispatcherNames(): array
+    {
+        if ($this->dispatchers instanceof ServiceProviderInterface) {
+            $names = array_keys($this->dispatchers->getProvidedServices());
+        } else {
+            $names = $this->dispatchers->has(self::DEFAULT_DISPATCHER) ? [self::DEFAULT_DISPATCHER] : [];
+        }
+
+        usort($names, static fn (string $a, string $b): int => (self::DEFAULT_DISPATCHER === $b) <=> (self::DEFAULT_DISPATCHER === $a) ?: $a <=> $b);
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * The dispatcher name and event are omitted here because they are already
+     * matched through the item's value and label (see DebugItem::matches()).
+     *
+     * @param callable[] $listeners
+     */
+    private function buildSearchText(EventDispatcherInterface $dispatcher, string $event, array $listeners): ?string
+    {
+        $parts = [];
+
+        foreach ($listeners as $listener) {
+            $parts[] = $this->formatCallable($listener);
+            $parts[] = (string) $dispatcher->getListenerPriority($event, $listener);
+        }
+
+        return $parts ? implode("\n", $parts) : null;
+    }
+
+    private function formatCallable(callable $callable): string
+    {
+        if (\is_array($callable)) {
+            $class = \is_object($callable[0]) ? $callable[0]::class : $callable[0];
+
+            return $class.'::'.$callable[1];
+        }
+
+        if (\is_object($callable)) {
+            return $callable::class;
+        }
+
+        return (string) $callable;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/FormDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/FormDebugSection.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
+use Symfony\Component\Form\Console\Helper\DescriptorHelper;
+use Symfony\Component\Form\Extension\Core\CoreExtension;
+use Symfony\Component\Form\FormRegistryInterface;
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormTypeInterface;
+
+/**
+ * The "Form" tab of the interactive "debug" command.
+ *
+ * Reuses the same data sources ({@see FormRegistryInterface} plus the type,
+ * extension and guesser lists injected by the FormPass) and the same descriptor
+ * ({@see DescriptorHelper}) as the "debug:form" command, so the detail pane shows
+ * exactly what "debug:form <class>" already produces.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class FormDebugSection extends AbstractDebugSection
+{
+    private const string GROUP_CORE_TYPES = 'Core Types';
+    private const string GROUP_SERVICE_TYPES = 'Service Types';
+    private const string GROUP_EXTENSIONS = 'Type Extensions';
+    private const string GROUP_GUESSERS = 'Type Guessers';
+
+    /**
+     * @param list<string> $types
+     * @param list<string> $extensions
+     * @param list<string> $guessers
+     */
+    public function __construct(
+        private readonly FormRegistryInterface $formRegistry,
+        private readonly array $types = [],
+        private readonly array $extensions = [],
+        private readonly array $guessers = [],
+        private readonly ?FileLinkFormatter $fileLinkFormatter = null,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Form';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Form';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        $buffer = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $io = new SymfonyStyle(new ArrayInput([]), $buffer);
+
+        if ('type' === $item->type) {
+            $resolvedType = $this->formRegistry->getType($item->value);
+
+            (new DescriptorHelper($this->fileLinkFormatter))->describe($io, $resolvedType, [
+                'format' => 'txt',
+                'show_deprecated' => false,
+            ]);
+
+            return $buffer->fetch();
+        }
+
+        $io->title($item->value);
+
+        if ('extension' === $item->type) {
+            $io->text('Form type extension.');
+
+            if (is_subclass_of($item->value, FormTypeExtensionInterface::class)) {
+                $extendedTypes = [];
+                foreach ($item->value::getExtendedTypes() as $extendedType) {
+                    $extendedTypes[] = $extendedType;
+                }
+
+                if ($extendedTypes) {
+                    $io->section('Extended types');
+                    $io->listing($extendedTypes);
+                }
+            }
+        } else {
+            $io->text('Form type guesser.');
+        }
+
+        return $buffer->fetch();
+    }
+
+    protected function buildItems(): array
+    {
+        $coreTypes = $this->getCoreTypes();
+        $serviceTypes = array_values(array_diff($this->types, $coreTypes));
+        sort($serviceTypes);
+
+        $extensions = $this->extensions;
+        sort($extensions);
+
+        $guessers = $this->guessers;
+        sort($guessers);
+
+        $items = [];
+        foreach ($serviceTypes as $class) {
+            $items[] = new DebugItem('type', $class, $class, self::GROUP_SERVICE_TYPES);
+        }
+        foreach ($coreTypes as $class) {
+            $items[] = new DebugItem('type', $class, $class, self::GROUP_CORE_TYPES);
+        }
+        foreach ($extensions as $class) {
+            $items[] = new DebugItem('extension', $class, $class, self::GROUP_EXTENSIONS);
+        }
+        foreach ($guessers as $class) {
+            $items[] = new DebugItem('guesser', $class, $class, self::GROUP_GUESSERS);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getCoreTypes(): array
+    {
+        $coreExtension = new CoreExtension();
+        $loadTypesRefMethod = (new \ReflectionObject($coreExtension))->getMethod('loadTypes');
+        $coreTypes = $loadTypesRefMethod->invoke($coreExtension);
+        $coreTypes = array_map(static fn (FormTypeInterface $type): string => $type::class, $coreTypes);
+        sort($coreTypes);
+
+        return $coreTypes;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/MappedClassesTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/MappedClassesTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+/**
+ * Collects the classes mapped by Serializer/Validator metadata loaders.
+ *
+ * @internal
+ */
+trait MappedClassesTrait
+{
+    /**
+     * @param list<object> $loaders
+     *
+     * @return list<class-string>
+     */
+    private function getMappedClasses(array $loaders): array
+    {
+        $classes = [];
+        foreach ($loaders as $loader) {
+            if (method_exists($loader, 'getMappedClasses')) {
+                foreach ($loader->getMappedClasses() as $class) {
+                    $classes[$class] = true;
+                }
+            }
+
+            if (method_exists($loader, 'getLoaders')) {
+                foreach ($this->getMappedClasses($loader->getLoaders()) as $class) {
+                    $classes[$class] = true;
+                }
+            }
+        }
+
+        $classes = array_keys($classes);
+        sort($classes);
+
+        return $classes;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/MessengerDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/MessengerDebugSection.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * The "Messenger" tab of the interactive "debug" command.
+ *
+ * Reuses the same data source (the bus/message/handler mapping built by the
+ * MessengerPass) as the "debug:messenger" command, so the detail pane shows the
+ * handlers of the selected message exactly like "debug:messenger" does.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class MessengerDebugSection extends AbstractDebugSection
+{
+    /**
+     * @param array<string, array<string, list<array{0: string, 1: array<string, mixed>}>>> $mapping
+     */
+    public function __construct(
+        private readonly array $mapping,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Messenger';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Bus';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        [$bus, $message] = explode(self::VALUE_SEPARATOR, $item->value, 2);
+
+        if (!isset($this->mapping[$bus][$message])) {
+            return \sprintf('Message "%s" is not handled by bus "%s".', $message, $bus);
+        }
+
+        $handlers = $this->mapping[$bus][$message];
+
+        return $this->describeToBuffer(function (SymfonyStyle $io) use ($bus, $message, $handlers): void {
+            $io->section($bus);
+
+            $tableRows = [];
+            if ($description = self::getClassDescription($message)) {
+                $tableRows[] = [\sprintf('<comment>%s</>', $description)];
+            }
+
+            $tableRows[] = [\sprintf('<fg=cyan>%s</fg=cyan>', $message)];
+            foreach ($handlers as $handler) {
+                $tableRows[] = [\sprintf('    handled by <info>%s</>', $handler[0]).$this->formatConditions($handler[1])];
+                if ($handlerDescription = self::getClassDescription($handler[0])) {
+                    $tableRows[] = [\sprintf('               <comment>%s</>', $handlerDescription)];
+                }
+            }
+
+            $io->table([], $tableRows);
+        });
+    }
+
+    /**
+     * Builds the full, unfiltered item list once. Recomputing it on every keystroke
+     * would be costly on large applications.
+     *
+     * @return list<DebugItem>
+     */
+    protected function buildItems(): array
+    {
+        $singleBus = 1 === \count($this->mapping);
+
+        $items = [];
+        foreach ($this->mapping as $bus => $handlersByMessage) {
+            foreach ($handlersByMessage as $message => $handlers) {
+                $label = $singleBus ? $message : \sprintf('%s (%s)', $message, $bus);
+                $searchText = [];
+                foreach ($handlers as $handler) {
+                    $searchText[] = $handler[0];
+                }
+
+                $items[] = new DebugItem('message', $bus.self::VALUE_SEPARATOR.$message, $label, searchText: $searchText ? implode("\n", $searchText) : null);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function formatConditions(array $options): string
+    {
+        if (!$options) {
+            return '';
+        }
+
+        $optionsMapping = [];
+        foreach ($options as $key => $value) {
+            $optionsMapping[] = $key.'='.$value;
+        }
+
+        return ' (when '.implode(', ', $optionsMapping).')';
+    }
+
+    private static function getClassDescription(string $class): string
+    {
+        try {
+            $r = new \ReflectionClass($class);
+
+            if ($docComment = $r->getDocComment()) {
+                $docComment = preg_split('#\n\s*\*\s*[\n@]#', substr($docComment, 3, -2), 2)[0];
+
+                return trim(preg_replace('#\s*\n\s*\*\s*#', ' ', $docComment));
+            }
+        } catch (\ReflectionException) {
+        }
+
+        return '';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/PlaceholderDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/PlaceholderDebugSection.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+
+/**
+ * Temporary placeholder for debug sections whose shell/menu entry exists before
+ * their data providers are implemented.
+ *
+ * @internal
+ *
+ * @experimental
+ */
+final class PlaceholderDebugSection extends AbstractDebugSection
+{
+    public function __construct(
+        private readonly string $label,
+        private readonly string $shortLabel,
+        private readonly string $summary,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getShortLabel(): string
+    {
+        return $this->shortLabel;
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        return \sprintf(
+            "The %s section is reserved for the unified debug command.\n\nIt will list %s once its data provider is implemented.",
+            $this->label,
+            lcfirst($this->summary),
+        );
+    }
+
+    protected function buildItems(): array
+    {
+        return [
+            new DebugItem('section', $this->label, $this->summary),
+        ];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/RouterDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/RouterDebugSection.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Command\BuildDebugContainerTrait;
+use Symfony\Bundle\FrameworkBundle\Console\Helper\DescriptorHelper;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * The "Routes" tab of the interactive "debug" command.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class RouterDebugSection extends AbstractDebugSection
+{
+    use BuildDebugContainerTrait;
+
+    public function __construct(
+        private readonly RouterInterface $router,
+        private readonly KernelInterface $kernel,
+        private readonly ?FileLinkFormatter $fileLinkFormatter = null,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Routes';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Routes';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        $route = $this->router->getRouteCollection()->get($item->value);
+        if (!$route) {
+            return \sprintf('Route "%s" does not exist.', $item->value);
+        }
+
+        return $this->describeToBuffer(function (SymfonyStyle $io) use ($route, $item): void {
+            (new DescriptorHelper($this->fileLinkFormatter))->describe($io, $route, [
+                'format' => 'txt',
+                'name' => $item->value,
+                'output' => $io,
+                'container' => $this->fileLinkFormatter ? fn () => $this->getContainerBuilder($this->kernel) : null,
+            ]);
+        });
+    }
+
+    /**
+     * Builds the full, unfiltered item list once. Recomputing it on every keystroke
+     * would be costly on large applications.
+     *
+     * @return list<DebugItem>
+     */
+    protected function buildItems(): array
+    {
+        $routes = $this->router->getRouteCollection();
+        $items = [];
+
+        foreach ($routes->all() as $name => $route) {
+            $items[] = new DebugItem('route', $name, $name, searchText: implode("\n", array_filter([
+                $route->getPath(),
+                $route->getHost(),
+                implode(' ', $route->getMethods()),
+                $route->getDefault('_controller'),
+            ], static fn (mixed $value): bool => \is_scalar($value) && '' !== (string) $value)) ?: null);
+        }
+
+        foreach ($routes->getAliases() as $name => $alias) {
+            $route = $routes->get($name);
+            if (!$route) {
+                continue;
+            }
+
+            $items[] = new DebugItem('route', $name, $name, searchText: implode("\n", array_filter([
+                $alias->getId(),
+                $route->getPath(),
+                $route->getHost(),
+                implode(' ', $route->getMethods()),
+                $route->getDefault('_controller'),
+            ], static fn (mixed $value): bool => \is_scalar($value) && '' !== (string) $value)) ?: null);
+        }
+
+        return $items;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/SchedulerDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/SchedulerDebugSection.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/**
+ * The "Scheduler" tab of the interactive "debug" command.
+ *
+ * Reuses the same data source (the schedule providers) as the "debug:scheduler"
+ * command, so the detail pane shows the trigger, provider and next run date of
+ * the selected recurring message exactly like "debug:scheduler" does.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class SchedulerDebugSection extends AbstractDebugSection
+{
+    public function __construct(
+        private readonly ServiceProviderInterface $schedules,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Scheduler';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Sched';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        [$name, $id] = explode(self::VALUE_SEPARATOR, $item->value, 2);
+
+        if (!$this->schedules->has($name)) {
+            return \sprintf('Schedule "%s" does not exist.', $name);
+        }
+
+        $schedule = $this->schedules->get($name)->getSchedule();
+
+        $message = null;
+        foreach ($schedule->getRecurringMessages() as $recurringMessage) {
+            if ($id === $recurringMessage->getId()) {
+                $message = $recurringMessage;
+
+                break;
+            }
+        }
+
+        if (!$message instanceof RecurringMessage) {
+            return \sprintf('The selected recurring message no longer exists in schedule "%s".', $name);
+        }
+
+        return $this->describeToBuffer(static function (SymfonyStyle $io) use ($name, $schedule, $message): void {
+            $io->section($name);
+
+            $date = new \DateTimeImmutable('now');
+            if (null !== $checkpoint = self::getStatefulCheckpointTime($schedule, $name)) {
+                $date = $checkpoint;
+                $io->comment(\sprintf('Schedule "%s" is stateful: next run date computed from stored checkpoint %s.', $name, $date->format('r')));
+            }
+
+            $row = self::renderRecurringMessage($message, $date);
+
+            $io->table(
+                ['Trigger', 'Provider', 'Next Run'],
+                [[$row[0], $row[1], $row[2]?->format('r') ?? '-']],
+            );
+        });
+    }
+
+    protected function buildItems(): array
+    {
+        $names = array_keys($this->schedules->getProvidedServices());
+        $singleSchedule = 1 === \count($names);
+
+        $items = [];
+        foreach ($names as $name) {
+            if (!$this->schedules->has($name)) {
+                continue;
+            }
+
+            foreach ($this->schedules->get($name)->getSchedule()->getRecurringMessages() as $message) {
+                $row = self::renderRecurringMessage($message, new \DateTimeImmutable('now'));
+                $label = \sprintf('%s — %s', $row[0], $row[1]);
+                if (!$singleSchedule) {
+                    $label = \sprintf('%s (%s)', $label, $name);
+                }
+
+                $items[] = new DebugItem('message', $name.self::VALUE_SEPARATOR.$message->getId(), $label, searchText: $name);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Returns a stateful schedule's last-run time, read from its cache without populating it.
+     *
+     * Mirrors {@see \Symfony\Component\Scheduler\Command\DebugCommand}: a best-effort base date
+     * for the displayed next run; anything unexpected falls back to `null` so the detail keeps
+     * using `now` instead of crashing.
+     */
+    private static function getStatefulCheckpointTime(Schedule $schedule, string $name): ?\DateTimeImmutable
+    {
+        if (!$state = $schedule->getState()) {
+            return null;
+        }
+
+        $checkpoint = $state->get('scheduler_checkpoint_'.$name, static function (ItemInterface $item, bool &$save) {
+            $save = false;
+
+            return null;
+        });
+
+        if (!\is_array($checkpoint)) {
+            return null;
+        }
+
+        return ($checkpoint[0] ?? null) instanceof \DateTimeImmutable ? $checkpoint[0] : null;
+    }
+
+    /**
+     * @return array{0:string,1:string,2:\DateTimeImmutable|null}
+     */
+    private static function renderRecurringMessage(RecurringMessage $recurringMessage, \DateTimeImmutable $date): array
+    {
+        $trigger = $recurringMessage->getTrigger();
+        $next = $trigger->getNextRunDate($date);
+
+        $provider = $recurringMessage->getProvider();
+        $description = $provider instanceof \Stringable ? (string) $provider : $provider->getId();
+
+        return [(string) $trigger, $description, $next];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/SerializerDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/SerializerDebugSection.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Serializer\Command\DebugCommand as SerializerDebugCommand;
+use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
+use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+
+/**
+ * The "Serializer" tab of the interactive "debug" command.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class SerializerDebugSection extends AbstractDebugSection
+{
+    use MappedClassesTrait;
+
+    private const string GROUP_METADATA = 'Metadata';
+    private const string GROUP_NAMED_SERIALIZERS = 'Named Serializers';
+    private const string GROUP_NORMALIZERS = 'Normalizers';
+    private const string GROUP_ENCODERS = 'Encoders';
+
+    /**
+     * @param list<object>                                                          $metadataLoaders
+     * @param list<array{id: string, class: string, priority: int, built_in: bool}> $normalizers
+     * @param list<array{id: string, class: string, priority: int, built_in: bool}> $encoders
+     * @param array<string, array<string, mixed>>                                   $namedSerializers
+     */
+    public function __construct(
+        private readonly ClassMetadataFactoryInterface $serializer,
+        private readonly array $metadataLoaders = [],
+        private readonly array $normalizers = [],
+        private readonly array $encoders = [],
+        private readonly array $namedSerializers = [],
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Serializer';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Ser';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        if ('metadata' === $item->type) {
+            $buffer = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+
+            (new SerializerDebugCommand($this->serializer))->run(new ArrayInput(['class' => $item->value]), $buffer);
+
+            return $buffer->fetch();
+        }
+
+        if (null !== $item->detail) {
+            return $item->detail;
+        }
+
+        return \sprintf('Serializer item "%s" does not exist.', $item->value);
+    }
+
+    protected function buildItems(): array
+    {
+        $items = [];
+
+        foreach ($this->getMetadataClasses() as $class) {
+            $items[] = new DebugItem('metadata', $class, $class, self::GROUP_METADATA);
+        }
+
+        foreach ($this->namedSerializers as $name => $config) {
+            $items[] = new DebugItem('named_serializer', $name, $name, self::GROUP_NAMED_SERIALIZERS, $this->renderNamedSerializerDetail($name, $config), searchText: implode("\n", array_keys($config)));
+        }
+
+        foreach ($this->normalizers as $normalizer) {
+            $items[] = new DebugItem('normalizer', $normalizer['id'], $normalizer['class'], self::GROUP_NORMALIZERS, $this->renderTaggedServiceDetail('Normalizer', $normalizer), searchText: implode("\n", [$normalizer['priority'], $normalizer['built_in']]));
+        }
+
+        foreach ($this->encoders as $encoder) {
+            $items[] = new DebugItem('encoder', $encoder['id'], $encoder['class'], self::GROUP_ENCODERS, $this->renderTaggedServiceDetail('Encoder', $encoder), searchText: implode("\n", [$encoder['priority'], $encoder['built_in']]));
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function getMetadataClasses(): array
+    {
+        $metadataClasses = [];
+        foreach ($this->getMappedClasses($this->metadataLoaders) as $class) {
+            if (!class_exists($class)) {
+                continue;
+            }
+
+            try {
+                $metadata = $this->serializer->getMetadataFor($class);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if ($this->hasMetadata($metadata)) {
+                $metadataClasses[] = $class;
+            }
+        }
+
+        return $metadataClasses;
+    }
+
+    private function hasMetadata(ClassMetadataInterface $metadata): bool
+    {
+        if (null !== $metadata->getClassDiscriminatorMapping()) {
+            return true;
+        }
+
+        foreach ($metadata->getAttributesMetadata() as $attributeMetadata) {
+            if ($this->hasAttributeMetadata($attributeMetadata)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasAttributeMetadata(AttributeMetadataInterface $metadata): bool
+    {
+        return [] !== $metadata->getGroups()
+            || null !== $metadata->getMaxDepth()
+            || null !== $metadata->getSerializedName()
+            || null !== $metadata->getSerializedPath()
+            || $metadata->isIgnored()
+            || [] !== $metadata->getNormalizationContexts()
+            || [] !== $metadata->getDenormalizationContexts();
+    }
+
+    /**
+     * @param array{id: string, class: string, priority: int, built_in: bool} $service
+     */
+    private function renderTaggedServiceDetail(string $type, array $service): string
+    {
+        return $this->describeToBuffer(static function (SymfonyStyle $io) use ($type, $service): void {
+            $io->title($service['class']);
+            $io->table(['Option', 'Value'], [
+                ['Type', $type],
+                ['Service ID', $service['id']],
+                ['Priority', (string) $service['priority']],
+                ['Built-in', $service['built_in'] ? 'yes' : 'no'],
+            ]);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function renderNamedSerializerDetail(string $name, array $config): string
+    {
+        return $this->describeToBuffer(function (SymfonyStyle $io) use ($name, $config): void {
+            $io->title($name);
+
+            $rows = [];
+            foreach ($config as $key => $value) {
+                $rows[] = [$key, $this->formatValue($value)];
+            }
+
+            $io->table(['Option', 'Value'], $rows ?: [['Configuration', 'default']]);
+        });
+    }
+
+    private function formatValue(mixed $value): string
+    {
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (null === $value) {
+            return 'null';
+        }
+
+        if (\is_scalar($value)) {
+            return (string) $value;
+        }
+
+        return json_encode($value, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE) ?: get_debug_type($value);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/TranslationDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/TranslationDebugSection.php
@@ -1,0 +1,469 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Intl\Languages;
+use Symfony\Component\Translation\Catalogue\MergeOperation;
+use Symfony\Component\Translation\DataCollectorTranslator;
+use Symfony\Component\Translation\Extractor\ExtractorInterface;
+use Symfony\Component\Translation\LoggingTranslator;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Reader\TranslationReaderInterface;
+use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The "I18N" tab of the interactive "debug" command.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class TranslationDebugSection extends AbstractDebugSection
+{
+    private const int MESSAGE_MISSING = 0;
+    private const int MESSAGE_UNUSED = 1;
+    private const int MESSAGE_EQUALS_FALLBACK = 2;
+
+    /** @var array<string, array{extracted: MessageCatalogue, current: MessageCatalogue, fallbacks: list<MessageCatalogue>}> */
+    private array $catalogues = [];
+
+    /** @var array<string, array<string, mixed>>|null */
+    private ?array $extractedMessages = null;
+
+    /** @var array<string, MessageCatalogue> */
+    private array $extractedCatalogues = [];
+
+    /** @var array<string, MessageCatalogue> */
+    private array $currentCatalogues = [];
+
+    /** @var array<string, array{domain: string, id: string, translations: array<string, array{defined: bool, value: string, states: list<int>, fallbacks: array<string, string>}>}>|null */
+    private ?array $messages = null;
+
+    /** @var array<string, int>|null */
+    private ?array $localeMessageCounts = null;
+
+    /** @var list<string> */
+    private readonly array $enabledLocales;
+
+    /**
+     * @param list<string> $transPaths
+     * @param list<string> $codePaths
+     * @param list<string> $enabledLocales
+     */
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly TranslationReaderInterface $reader,
+        private readonly ExtractorInterface $extractor,
+        private readonly ?string $defaultTransPath = null,
+        private readonly ?string $defaultViewsPath = null,
+        private readonly array $transPaths = [],
+        private readonly array $codePaths = [],
+        array $enabledLocales = [],
+        private readonly ?KernelInterface $kernel = null,
+    ) {
+        $this->enabledLocales = array_values(array_filter($enabledLocales));
+    }
+
+    public function getLabel(): string
+    {
+        return 'I18N';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'I18N';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        if (null !== $item->detail) {
+            return $item->detail;
+        }
+
+        return \sprintf('I18N item "%s" does not exist.', $item->value);
+    }
+
+    /**
+     * Extracting and reading the catalogues of every enabled locale is costly,
+     * so the precomputed detail is baked into each item as it is built.
+     */
+    protected function buildItems(): array
+    {
+        $messages = $this->getMessages();
+        $localeMessageCounts = $this->getLocaleMessageCounts();
+        $domainMessageCounts = $this->getDomainMessageCounts($messages);
+
+        $items = [];
+        foreach ($domainMessageCounts as $domain => $count) {
+            $domainMessages = array_filter($messages, static fn (array $message): bool => $message['domain'] === $domain);
+            $detail = $this->renderAllDetail($domainMessages);
+            $label = \sprintf('%s (%d)', $domain, $count);
+
+            $items[] = new DebugItem('domain', $domain, $label, group: 'Domains', detail: $detail, searchText: $detail);
+        }
+
+        $allDetail = $this->renderAllDetail($messages);
+        $items[] = new DebugItem('all', 'all', \sprintf('All (%d)', \count($messages)), group: 'Contents', detail: $allDetail, searchText: $allDetail);
+
+        foreach ($this->enabledLocales as $locale) {
+            $detail = $this->renderLocaleDetail($locale, $messages);
+            $label = \sprintf('%s (%d)', $this->getLocaleName($locale), $localeMessageCounts[$locale] ?? 0);
+
+            $items[] = new DebugItem('locale', $locale, $label, group: 'Contents', detail: $detail, searchText: $detail);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string, array{domain: string, id: string, translations: array<string, array{defined: bool, value: string, states: list<int>, fallbacks: array<string, string>}>}>
+     */
+    private function getMessages(): array
+    {
+        if (null !== $this->messages) {
+            return $this->messages;
+        }
+
+        $messages = [];
+        $localeMessageCounts = [];
+
+        foreach ($this->enabledLocales as $locale) {
+            $catalogues = $this->getCatalogues($locale);
+            $mergeOperation = new MergeOperation($catalogues['extracted'], $catalogues['current']);
+            $localeMessageCounts[$locale] = 0;
+
+            foreach ($mergeOperation->getResult()->all() as $domain => $domainMessages) {
+                foreach (array_keys($domainMessages) as $id) {
+                    $key = $domain.self::VALUE_SEPARATOR.$id;
+                    $messages[$key] ??= [
+                        'domain' => $domain,
+                        'id' => $id,
+                        'translations' => [],
+                    ];
+                    ++$localeMessageCounts[$locale];
+
+                    $messages[$key]['translations'][$locale] = [
+                        'defined' => $catalogues['current']->defines($id, $domain),
+                        'value' => $catalogues['current']->defines($id, $domain) ? $catalogues['current']->get($id, $domain) : '',
+                        'states' => $this->computeStates($catalogues, $domain, $id),
+                        'fallbacks' => $this->getFallbackValues($catalogues['fallbacks'], $domain, $id),
+                    ];
+                }
+            }
+        }
+
+        uasort($messages, static fn (array $a, array $b): int => [$a['domain'], $a['id']] <=> [$b['domain'], $b['id']]);
+
+        $this->localeMessageCounts = $localeMessageCounts;
+
+        return $this->messages = $messages;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getLocaleMessageCounts(): array
+    {
+        if (null === $this->localeMessageCounts) {
+            $this->getMessages();
+        }
+
+        return $this->localeMessageCounts ?? [];
+    }
+
+    /**
+     * @param array<string, array{domain: string, id: string, translations: array<string, array{defined: bool, value: string, states: list<int>, fallbacks: array<string, string>}>}> $messages
+     *
+     * @return array<string, int>
+     */
+    private function getDomainMessageCounts(array $messages): array
+    {
+        $domainMessageCounts = [];
+        foreach ($messages as $message) {
+            $domainMessageCounts[$message['domain']] = ($domainMessageCounts[$message['domain']] ?? 0) + 1;
+        }
+
+        ksort($domainMessageCounts);
+
+        return $domainMessageCounts;
+    }
+
+    /**
+     * @param array<string, array{domain: string, id: string, translations: array<string, array{defined: bool, value: string, states: list<int>, fallbacks: array<string, string>}>}> $messages
+     */
+    private function renderAllDetail(array $messages): string
+    {
+        if (!$messages) {
+            return "No translations were found.\n";
+        }
+
+        $lines = [];
+        foreach ($messages as $message) {
+            $lines[] = \sprintf("\e[33m%s\e[39m", $message['id']);
+            $lines[] = \sprintf('  domain: %s', $message['domain']);
+
+            foreach ($this->enabledLocales as $locale) {
+                $translation = $message['translations'][$locale] ?? null;
+                if (!$translation || !$translation['defined']) {
+                    continue;
+                }
+
+                $lines[] = \sprintf('  %s: %s', $this->getLocaleName($locale), $this->indentValue($translation['value'], 4));
+            }
+
+            $lines[] = '';
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<string, array{domain: string, id: string, translations: array<string, array{defined: bool, value: string, states: list<int>, fallbacks: array<string, string>}>}> $messages
+     */
+    private function renderLocaleDetail(string $locale, array $messages): string
+    {
+        $lines = [
+            \sprintf("\e[33m%s\e[39m", $this->getLocaleName($locale)),
+            str_repeat('=', \strlen($this->getLocaleName($locale))),
+            '',
+        ];
+
+        foreach ($messages as $message) {
+            $translation = $message['translations'][$locale] ?? null;
+            if (!$translation) {
+                continue;
+            }
+
+            $lines[] = \sprintf("\e[33m%s\e[39m", $message['id']);
+            $lines[] = \sprintf('  domain: %s', $message['domain']);
+            $lines[] = \sprintf('  state: %s', '' !== ($states = $this->formatStates($translation['states'])) ? $states : 'defined');
+            $lines[] = \sprintf('  translation: %s', $translation['defined'] ? $this->indentValue($translation['value'], 4) : '<missing>');
+
+            foreach ($translation['fallbacks'] as $fallbackLocale => $fallbackValue) {
+                $lines[] = \sprintf('  fallback (%s): %s', $this->getLocaleName($fallbackLocale), $this->indentValue($fallbackValue, 4));
+            }
+
+            $lines[] = '';
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @return array{extracted: MessageCatalogue, current: MessageCatalogue, fallbacks: list<MessageCatalogue>}
+     */
+    private function getCatalogues(string $locale): array
+    {
+        if (isset($this->catalogues[$locale])) {
+            return $this->catalogues[$locale];
+        }
+
+        $transPaths = $this->getRootTransPaths();
+        $codePaths = $this->getRootCodePaths();
+
+        return $this->catalogues[$locale] = [
+            'extracted' => $this->extractMessages($locale, $codePaths),
+            'current' => $this->loadCurrentMessages($locale, $transPaths),
+            'fallbacks' => $this->loadFallbackCatalogues($locale, $transPaths),
+        ];
+    }
+
+    /**
+     * @param array{extracted: MessageCatalogue, current: MessageCatalogue, fallbacks: list<MessageCatalogue>} $catalogues
+     *
+     * @return list<int>
+     */
+    private function computeStates(array $catalogues, string $domain, string $id): array
+    {
+        $states = [];
+        $defined = $catalogues['current']->defines($id, $domain);
+        $value = $defined ? $catalogues['current']->get($id, $domain) : null;
+
+        if ($catalogues['extracted']->defines($id, $domain)) {
+            if (!$defined) {
+                $states[] = self::MESSAGE_MISSING;
+            }
+        } elseif ($defined) {
+            $states[] = self::MESSAGE_UNUSED;
+        }
+
+        if (null !== $value) {
+            foreach ($catalogues['fallbacks'] as $fallbackCatalogue) {
+                if ($fallbackCatalogue->defines($id, $domain) && $value === $fallbackCatalogue->get($id, $domain)) {
+                    $states[] = self::MESSAGE_EQUALS_FALLBACK;
+
+                    break;
+                }
+            }
+        }
+
+        return $states;
+    }
+
+    /**
+     * @param list<MessageCatalogue> $fallbackCatalogues
+     *
+     * @return array<string, string>
+     */
+    private function getFallbackValues(array $fallbackCatalogues, string $domain, string $id): array
+    {
+        $values = [];
+        foreach ($fallbackCatalogues as $fallbackCatalogue) {
+            if ($fallbackCatalogue->defines($id, $domain)) {
+                $values[$fallbackCatalogue->getLocale()] = $fallbackCatalogue->get($id, $domain);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param list<int> $states
+     */
+    private function formatStates(array $states): string
+    {
+        $result = [];
+        foreach ($states as $state) {
+            $result[] = match ($state) {
+                self::MESSAGE_MISSING => 'missing',
+                self::MESSAGE_UNUSED => 'unused',
+                self::MESSAGE_EQUALS_FALLBACK => 'same as fallback',
+                default => (string) $state,
+            };
+        }
+
+        return implode(', ', $result);
+    }
+
+    /**
+     * @param list<string> $codePaths
+     */
+    private function extractMessages(string $locale, array $codePaths): MessageCatalogue
+    {
+        if (isset($this->extractedCatalogues[$locale])) {
+            return $this->extractedCatalogues[$locale];
+        }
+
+        if (null === $this->extractedMessages) {
+            $extractedCatalogue = new MessageCatalogue($locale);
+            foreach ($codePaths as $path) {
+                if (is_dir($path) || is_file($path)) {
+                    $this->extractor->extract($path, $extractedCatalogue);
+                }
+            }
+
+            $this->extractedMessages = $extractedCatalogue->all();
+        }
+
+        $extractedCatalogue = new MessageCatalogue($locale);
+        foreach ($this->extractedMessages as $domain => $messages) {
+            $extractedCatalogue->add($messages, $domain);
+        }
+
+        return $this->extractedCatalogues[$locale] = $extractedCatalogue;
+    }
+
+    /**
+     * @param list<string> $transPaths
+     */
+    private function loadCurrentMessages(string $locale, array $transPaths): MessageCatalogue
+    {
+        if (isset($this->currentCatalogues[$locale])) {
+            return $this->currentCatalogues[$locale];
+        }
+
+        $currentCatalogue = new MessageCatalogue($locale);
+        foreach ($transPaths as $path) {
+            if (is_dir($path)) {
+                $this->reader->read($path, $currentCatalogue);
+            }
+        }
+
+        return $this->currentCatalogues[$locale] = $currentCatalogue;
+    }
+
+    /**
+     * @param list<string> $transPaths
+     *
+     * @return list<MessageCatalogue>
+     */
+    private function loadFallbackCatalogues(string $locale, array $transPaths): array
+    {
+        $fallbackCatalogues = [];
+        if ($this->translator instanceof Translator || $this->translator instanceof DataCollectorTranslator || $this->translator instanceof LoggingTranslator) {
+            foreach ($this->translator->getFallbackLocales() as $fallbackLocale) {
+                if ($fallbackLocale === $locale) {
+                    continue;
+                }
+
+                $fallbackCatalogues[] = $this->loadCurrentMessages($fallbackLocale, $transPaths);
+            }
+        }
+
+        return $fallbackCatalogues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getRootTransPaths(): array
+    {
+        $transPaths = $this->transPaths;
+        if ($this->defaultTransPath) {
+            $transPaths[] = $this->defaultTransPath;
+        }
+
+        return $transPaths;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getRootCodePaths(): array
+    {
+        $codePaths = $this->codePaths;
+        if ($this->kernel) {
+            $codePaths[] = $this->kernel->getProjectDir().'/src';
+        }
+        if ($this->defaultViewsPath) {
+            $codePaths[] = $this->defaultViewsPath;
+        }
+
+        return $codePaths;
+    }
+
+    private function getLocaleName(string $locale): string
+    {
+        if (class_exists(Languages::class)) {
+            try {
+                return Languages::getName(str_replace('-', '_', $locale), 'en');
+            } catch (\Throwable) {
+            }
+        }
+
+        return $locale;
+    }
+
+    private function indentValue(string $value, int $indent): string
+    {
+        $value = str_replace(["\r\n", "\r"], "\n", $value);
+
+        if (!str_contains($value, "\n")) {
+            return $value;
+        }
+
+        return "\n".str_repeat(' ', $indent).str_replace("\n", "\n".str_repeat(' ', $indent), $value);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/Section/ValidatorDebugSection.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/Section/ValidatorDebugSection.php
@@ -1,0 +1,334 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug\Section;
+
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Component\Console\Helper\Dumper;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Mapping\AutoMappingStrategy;
+use Symfony\Component\Validator\Mapping\CascadingStrategy;
+use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
+use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
+use Symfony\Component\Validator\Mapping\GenericMetadata;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
+use Symfony\Component\Validator\Mapping\TraversalStrategy;
+use Symfony\Component\Validator\ValidatorBuilder;
+
+/**
+ * The "Validator" tab of the interactive "debug" command.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @experimental
+ */
+final class ValidatorDebugSection extends AbstractDebugSection
+{
+    use MappedClassesTrait;
+
+    /**
+     * @param list<class-string> $candidateClasses
+     */
+    public function __construct(
+        private readonly MetadataFactoryInterface $validator,
+        private readonly ValidatorBuilder $validatorBuilder,
+        private readonly array $candidateClasses = [],
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return 'Validator';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Valid';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        $buffer = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $io = new SymfonyStyle(new ArrayInput([]), $buffer);
+        $dump = new Dumper($buffer);
+
+        /** @var ClassMetadataInterface $metadata */
+        $metadata = $this->validator->getMetadataFor($item->value);
+
+        $io->title($metadata->getClassName());
+
+        if ($metadata->getConstraints()) {
+            $io->section('Class constraints');
+
+            foreach ($metadata->getConstraints() as $constraint) {
+                $this->renderConstraint($io, $dump, $constraint);
+            }
+        }
+
+        if ($metadata->getConstrainedProperties()) {
+            $io->section('Properties');
+
+            foreach ($metadata->getConstrainedProperties() as $property) {
+                $io->writeln(\sprintf('<info>%s</info>', $property));
+
+                foreach ($metadata->getPropertyMetadata($property) as $propertyMetadata) {
+                    $this->renderPropertyOptions($io, $propertyMetadata);
+
+                    foreach ($propertyMetadata->getConstraints() as $constraint) {
+                        $this->renderConstraint($io, $dump, $constraint, 2);
+                    }
+                }
+
+                $io->newLine();
+            }
+        }
+
+        if (!$metadata->getConstraints() && !$metadata->getConstrainedProperties()) {
+            $io->text('No validators were found for this class.');
+        }
+
+        return $buffer->fetch();
+    }
+
+    protected function buildItems(): array
+    {
+        $items = [];
+        foreach ($this->getCandidateClasses() as $class) {
+            if (!class_exists($class)) {
+                continue;
+            }
+
+            try {
+                /** @var ClassMetadataInterface $metadata */
+                $metadata = $this->validator->getMetadataFor($class);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if (!$metadata->getConstraints() && !$metadata->getConstrainedProperties()) {
+                continue;
+            }
+
+            $items[] = new DebugItem('class', $class, $class, searchText: $this->buildHaystack($metadata));
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function getCandidateClasses(): array
+    {
+        $classes = array_fill_keys($this->candidateClasses, true);
+
+        foreach ($this->getMappedClasses($this->validatorBuilder->getLoaders()) as $class) {
+            $classes[$class] = true;
+        }
+
+        $classes = array_keys($classes);
+        sort($classes);
+
+        return $classes;
+    }
+
+    private function buildHaystack(ClassMetadataInterface $metadata): string
+    {
+        $haystack = [];
+
+        foreach ($metadata->getConstraints() as $constraint) {
+            $haystack[] = $this->formatConstraint($constraint);
+        }
+
+        foreach ($metadata->getConstrainedProperties() as $property) {
+            $haystack[] = $property;
+
+            foreach ($metadata->getPropertyMetadata($property) as $propertyMetadata) {
+                $haystack[] = $this->formatSearchValue($this->getPropertyOptions($propertyMetadata));
+
+                foreach ($propertyMetadata->getConstraints() as $constraint) {
+                    $haystack[] = $this->formatConstraint($constraint);
+                }
+            }
+        }
+
+        return implode("\n", array_filter($haystack));
+    }
+
+    private function formatConstraint(Constraint $constraint): string
+    {
+        return implode("\n", array_filter([
+            $constraint::class,
+            $this->getShortClassName($constraint::class),
+            implode("\n", $constraint->groups),
+            $this->formatSearchValue($this->getConstraintOptions($constraint)),
+        ]));
+    }
+
+    private function renderConstraint(SymfonyStyle $io, Dumper $dump, Constraint $constraint, int $indent = 0): void
+    {
+        $prefix = str_repeat(' ', $indent);
+
+        $io->writeln(\sprintf('%s<comment>%s</comment>', $prefix, $this->getShortClassName($constraint::class)));
+        $io->writeln(\sprintf('%s  class: %s', $prefix, $constraint::class));
+        $io->writeln(\sprintf('%s  groups: %s', $prefix, implode(', ', $constraint->groups)));
+
+        $options = $this->getConstraintOptions($constraint);
+        if (!$options) {
+            return;
+        }
+
+        $io->writeln(\sprintf('%s  options:', $prefix));
+        foreach ($options as $name => $value) {
+            $io->writeln(\sprintf('%s    %s: %s', $prefix, $name, $this->indentDump($dump($value), $indent + 6)));
+        }
+    }
+
+    private function renderPropertyOptions(SymfonyStyle $io, MetadataInterface $metadata): void
+    {
+        foreach ($this->getPropertyOptions($metadata) as $name => $value) {
+            $io->writeln(\sprintf('  %s: %s', $name, $value));
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getPropertyOptions(MetadataInterface $metadata): array
+    {
+        $options = [];
+
+        if (CascadingStrategy::CASCADE === $metadata->getCascadingStrategy()) {
+            $options['cascade'] = 'yes';
+        }
+
+        if (TraversalStrategy::TRAVERSE === $metadata->getTraversalStrategy()) {
+            $options['traversal'] = 'traverse';
+        } elseif (TraversalStrategy::IMPLICIT === $metadata->getTraversalStrategy()) {
+            $options['traversal'] = 'implicit';
+        }
+
+        if ($metadata instanceof GenericMetadata) {
+            $autoMapping = match ($metadata->getAutoMappingStrategy()) {
+                AutoMappingStrategy::ENABLED => 'enabled',
+                AutoMappingStrategy::DISABLED => 'disabled',
+                AutoMappingStrategy::NONE => null,
+            };
+
+            if (null !== $autoMapping) {
+                $options['auto mapping'] = $autoMapping;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getConstraintOptions(Constraint $constraint): array
+    {
+        $options = [];
+
+        foreach (array_keys(get_object_vars($constraint)) as $propertyName) {
+            if ('groups' === $propertyName || 'payload' === $propertyName) {
+                continue;
+            }
+
+            $options[$propertyName] = $constraint->$propertyName;
+        }
+
+        if (null !== $constraint->payload) {
+            $options['payload'] = $constraint->payload;
+        }
+
+        ksort($options);
+
+        return $options;
+    }
+
+    private function indentDump(string $dump, int $indent): string
+    {
+        $dump = trim($dump);
+
+        if (!str_contains($dump, "\n")) {
+            return $dump;
+        }
+
+        return "\n".str_repeat(' ', $indent).str_replace("\n", "\n".str_repeat(' ', $indent), $dump);
+    }
+
+    private function formatSearchValue(mixed $value): string
+    {
+        if (null === $value) {
+            return 'null';
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (\is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (\is_array($value)) {
+            $values = [];
+            foreach ($value as $key => $nestedValue) {
+                $values[] = (string) $key;
+                $values[] = $this->formatSearchValue($nestedValue);
+            }
+
+            return implode("\n", array_filter($values));
+        }
+
+        if ($value instanceof Constraint) {
+            return $this->formatConstraint($value);
+        }
+
+        if ($value instanceof \BackedEnum) {
+            return implode("\n", [$value::class, $value->name, (string) $value->value]);
+        }
+
+        if ($value instanceof \UnitEnum) {
+            return implode("\n", [$value::class, $value->name]);
+        }
+
+        if (\is_object($value)) {
+            $values = [$value::class];
+
+            if ($value instanceof \Stringable) {
+                $values[] = (string) $value;
+            }
+
+            return implode("\n", $values);
+        }
+
+        if (\is_resource($value)) {
+            return get_resource_type($value);
+        }
+
+        return get_debug_type($value);
+    }
+
+    private function getShortClassName(string $class): string
+    {
+        if (false === $position = strrpos($class, '\\')) {
+            return $class;
+        }
+
+        return substr($class, $position + 1);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/SpacerWidget.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/SpacerWidget.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Debug;
+
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Widget\AbstractWidget;
+
+/**
+ * @internal
+ */
+final class SpacerWidget extends AbstractWidget
+{
+    public function __construct(
+        private int $rows = 0,
+    ) {
+    }
+
+    public function setRows(int $rows): void
+    {
+        $rows = max(0, $rows);
+
+        if ($rows === $this->rows) {
+            return;
+        }
+
+        $this->rows = $rows;
+        $this->invalidate();
+    }
+
+    public function render(RenderContext $context): array
+    {
+        return array_fill(0, $this->rows, '');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/DebugSectionNamesPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/DebugSectionNamesPass.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * Collects the machine names of the "debug.section" tagged services so that the
+ * "debug" command can declare one input option per section without instantiating
+ * the (lazy) sections when the command is merely listed or described.
+ *
+ * @internal
+ */
+final class DebugSectionNamesPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    /**
+     * Option names that are reserved by the console application or the command itself.
+     */
+    private const array RESERVED_NAMES = ['help', 'quiet', 'verbose', 'version', 'ansi', 'no-ansi', 'no-interaction', 'silent', 'env', 'no-debug', 'profile', 'query'];
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('console.command.debug')) {
+            return;
+        }
+
+        $sections = $this->findAndSortTaggedServices(new TaggedIteratorArgument('debug.section', 'name', needsIndexes: true), $container);
+
+        $names = [];
+        foreach (array_keys($sections) as $name) {
+            if (!preg_match('/^[a-z][a-z0-9-]*$/', $name)) {
+                throw new InvalidArgumentException(\sprintf('The "name" attribute of the "debug.section" tag must match "[a-z][a-z0-9-]*", got "%s". Add a valid "name" attribute to the tag (it is used as the "--%s" option of the "debug" command).', $name, $name));
+            }
+
+            if (\in_array($name, self::RESERVED_NAMES, true)) {
+                throw new InvalidArgumentException(\sprintf('The "name" attribute of the "debug.section" tag cannot be "%1$s", it conflicts with the built-in "--%1$s" option of the "debug" command.', $name));
+            }
+
+            $names[] = $name;
+        }
+
+        $container->getDefinition('console.command.debug')->replaceArgument(1, $names);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/DebugValidatorClassCandidatesPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/DebugValidatorClassCandidatesPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class DebugValidatorClassCandidatesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('console.command.debug.section.validator')) {
+            return;
+        }
+
+        $classes = [];
+        foreach ($container->getDefinitions() as $definition) {
+            if ($definition->isAbstract() || $definition->isSynthetic()) {
+                continue;
+            }
+
+            $class = $container->getParameterBag()->resolveValue($definition->getClass());
+
+            if (!\is_string($class) || !$reflectionClass = $container->getReflectionClass($class, false)) {
+                continue;
+            }
+
+            if ($reflectionClass->isInternal() || $reflectionClass->isInterface() || $reflectionClass->isTrait()) {
+                continue;
+            }
+
+            $classes[$reflectionClass->name] = true;
+        }
+
+        $classes = array_keys($classes);
+        sort($classes);
+
+        $container->getDefinition('console.command.debug.section.validator')->setArgument(2, $classes);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -49,6 +49,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'controller.service_arguments',
         'controller.targeted_value_resolver',
         'data_collector',
+        'debug.section',
         'event_dispatcher.dispatcher',
         'form.type',
         'form.type_extension',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -456,6 +456,7 @@ class FrameworkExtension extends Extension
                 ->clearTag('kernel.event_subscriber');
 
             $container->removeDefinition('console.command.serializer_debug');
+            $container->removeDefinition('console.command.debug.section.serializer');
         }
 
         if ($typeInfoEnabled = $this->readConfigEnabled('type_info', $container, $config['type_info'])) {
@@ -551,6 +552,7 @@ class FrameworkExtension extends Extension
             }
         } else {
             $container->removeDefinition('console.command.form_debug');
+            $container->removeDefinition('console.command.debug.section.form');
         }
 
         // validation depends on form, annotations being registered
@@ -566,6 +568,7 @@ class FrameworkExtension extends Extension
         } else {
             $container->removeDefinition('cache.scheduler');
             $container->removeDefinition('console.command.scheduler_debug');
+            $container->removeDefinition('console.command.debug.section.scheduler');
         }
 
         // messenger depends on validation, and lock being registered
@@ -575,6 +578,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('console.command.messenger_consume_messages');
             $container->removeDefinition('console.command.messenger_stats');
             $container->removeDefinition('console.command.messenger_debug');
+            $container->removeDefinition('console.command.debug.section.messenger');
             $container->removeDefinition('console.command.messenger_stop_workers');
             $container->removeDefinition('console.command.messenger_setup_transports');
             $container->removeDefinition('console.command.messenger_failed_messages_retry');
@@ -1237,6 +1241,7 @@ class FrameworkExtension extends Extension
         if (!$this->readConfigEnabled('router', $container, $config)) {
             $container->removeDefinition('console.command.router_debug');
             $container->removeDefinition('console.command.router_match');
+            $container->removeDefinition('console.command.debug.section.router');
             $container->removeDefinition('messenger.middleware.router_context');
 
             return;
@@ -1541,6 +1546,7 @@ class FrameworkExtension extends Extension
     {
         if (!$this->readConfigEnabled('translator', $container, $config)) {
             $container->removeDefinition('console.command.translation_debug');
+            $container->removeDefinition('console.command.debug.section.i18n');
             $container->removeDefinition('console.command.translation_extract');
             $container->removeDefinition('console.command.translation_pull');
             $container->removeDefinition('console.command.translation_push');
@@ -1616,6 +1622,10 @@ class FrameworkExtension extends Extension
 
         if ($container->hasDefinition('console.command.translation_debug')) {
             $container->getDefinition('console.command.translation_debug')->replaceArgument(5, $transPaths);
+        }
+
+        if ($container->hasDefinition('console.command.debug.section.i18n')) {
+            $container->getDefinition('console.command.debug.section.i18n')->replaceArgument(5, $transPaths);
         }
 
         if ($container->hasDefinition('console.command.translation_extract')) {
@@ -1740,6 +1750,7 @@ class FrameworkExtension extends Extension
     {
         if (!$this->readConfigEnabled('validation', $container, $config)) {
             $container->removeDefinition('console.command.validator_debug');
+            $container->removeDefinition('console.command.debug.section.validator');
             $container->removeDefinition('.console.validate_question_input_listener');
 
             return;
@@ -2100,6 +2111,9 @@ class FrameworkExtension extends Extension
 
         $chainLoader->replaceArgument(0, $serializerLoaders);
         $container->getDefinition('serializer.mapping.cache_warmer')->replaceArgument(0, $serializerLoaders);
+        if ($container->hasDefinition('console.command.debug.section.serializer')) {
+            $container->getDefinition('console.command.debug.section.serializer')->replaceArgument(1, $serializerLoaders);
+        }
 
         if ($config['name_converter'] ?? false) {
             $container->setParameter('.serializer.name_converter', $config['name_converter']);
@@ -2366,6 +2380,7 @@ class FrameworkExtension extends Extension
 
         if (!$this->hasConsole()) {
             $container->removeDefinition('console.command.scheduler_debug');
+            $container->removeDefinition('console.command.debug.section.scheduler');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -15,6 +15,8 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProcessorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DebugSectionNamesPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DebugValidatorClassCandidatesPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DeprecateJsonStreamerValueTransformerTagPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ErrorLoggerCompilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonPathPass;
@@ -177,6 +179,8 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
         $this->addCompilerPassIfExists($container, AttributeMetadataPass::class);
+        $container->addCompilerPass(new DebugValidatorClassCandidatesPass());
+        $container->addCompilerPass(new DebugSectionNamesPass());
         $container->addCompilerPass(new TranslationLintCommandPass(), PassConfig::TYPE_BEFORE_REMOVING, 10);
         // must be registered as late as possible to get access to all Twig paths registered in
         // twig.template_iterator definition

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\FrameworkBundle\Debug\Section\AssetMapperDebugSection;
 use Symfony\Component\AssetMapper\AssetMapper;
 use Symfony\Component\AssetMapper\AssetMapperCompiler;
 use Symfony\Component\AssetMapper\AssetMapperDevServerSubscriber;
@@ -137,6 +138,13 @@ return static function (ContainerConfigurator $container) {
                     param('kernel.project_dir'),
                 ])
                 ->tag('console.command')
+
+            ->set('console.command.debug.section.assets', AssetMapperDebugSection::class)
+                ->args([
+                    service('asset_mapper'),
+                    param('kernel.project_dir'),
+                ])
+                ->tag('debug.section', ['name' => 'assets', 'priority' => 100])
 
         ->set('asset_mapper_compiler', AssetMapperCompiler::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -25,6 +25,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ConfigDumpReferenceCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerLintCommand;
 use Symfony\Bundle\FrameworkBundle\Command\DebugAutowiringCommand;
+use Symfony\Bundle\FrameworkBundle\Command\DebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\EventDispatcherDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand;
@@ -39,11 +40,22 @@ use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationExtractCommand;
 use Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\ConfigDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\ContainerDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\EventDispatcherDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\FormDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\MessengerDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\PlaceholderDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\RouterDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\SchedulerDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\SerializerDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\TranslationDebugSection;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\ValidatorDebugSection;
 use Symfony\Bundle\FrameworkBundle\EventListener\SuggestMissingPackageSubscriber;
 use Symfony\Component\Console\EventListener\ValidateQuestionInputListener;
 use Symfony\Component\Console\Messenger\RunCommandMessageHandler;
 use Symfony\Component\ErrorHandler\Command\ErrorDumpCommand;
-use Symfony\Component\Form\Command\DebugCommand;
+use Symfony\Component\Form\Command\DebugCommand as FormDebugCommand;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
 use Symfony\Component\Messenger\Command\DebugCommand as MessengerDebugCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand;
@@ -140,6 +152,105 @@ return static function (ContainerConfigurator $container) {
 
         ->set('console.command.container_lint', ContainerLintCommand::class)
             ->tag('console.command')
+
+        ->set('console.command.debug', DebugCommand::class)
+            ->args([
+                tagged_iterator('debug.section', 'name'),
+                abstract_arg('debug section names'),
+            ])
+            ->tag('console.command')
+
+        ->set('console.command.debug.section.container', ContainerDebugSection::class)
+            ->args([
+                service('kernel'),
+                service('debug.file_link_formatter')->nullOnInvalid(),
+            ])
+            ->tag('debug.section', ['name' => 'container', 'priority' => 1200])
+
+        ->set('console.command.debug.section.router', RouterDebugSection::class)
+            ->args([
+                service('router'),
+                service('kernel'),
+                service('debug.file_link_formatter')->nullOnInvalid(),
+            ])
+            ->tag('debug.section', ['name' => 'routes', 'priority' => 1100])
+
+        ->set('console.command.debug.section.config', ConfigDebugSection::class)
+            ->args([
+                service('kernel'),
+                service('container.env_var_processors_locator')->nullOnInvalid(),
+                param('kernel.environment'),
+                param('kernel.project_dir'),
+            ])
+            ->tag('debug.section', ['name' => 'config', 'priority' => 1000])
+
+        ->set('console.command.debug.section.events', EventDispatcherDebugSection::class)
+            ->args([
+                tagged_locator('event_dispatcher.dispatcher', 'name'),
+            ])
+            ->tag('debug.section', ['name' => 'events', 'priority' => 900])
+
+        ->set('console.command.debug.section.security', PlaceholderDebugSection::class)
+            ->args(['Security', 'Sec', 'firewalls, authenticators, access rules, voters and role hierarchy'])
+            ->tag('debug.section', ['name' => 'security', 'priority' => 800])
+
+        ->set('console.command.debug.section.messenger', MessengerDebugSection::class)
+            ->args([
+                abstract_arg('Message to handlers mapping'),
+            ])
+            ->tag('debug.section', ['name' => 'messenger', 'priority' => 700])
+
+        ->set('console.command.debug.section.twig', PlaceholderDebugSection::class)
+            ->args(['Twig', 'Twig', 'Twig functions, filters, tests, globals and components'])
+            ->tag('debug.section', ['name' => 'twig', 'priority' => 600])
+
+        ->set('console.command.debug.section.form', FormDebugSection::class)
+            ->args([
+                service('form.registry'),
+                abstract_arg('Form types'),
+                abstract_arg('Form type extensions'),
+                abstract_arg('Form type guessers'),
+                service('debug.file_link_formatter')->nullOnInvalid(),
+            ])
+            ->tag('debug.section', ['name' => 'form', 'priority' => 500])
+
+        ->set('console.command.debug.section.validator', ValidatorDebugSection::class)
+            ->args([
+                service('validator'),
+                service('validator.builder'),
+                abstract_arg('Validator candidate classes'),
+            ])
+            ->tag('debug.section', ['name' => 'validator', 'priority' => 400])
+
+        ->set('console.command.debug.section.serializer', SerializerDebugSection::class)
+            ->args([
+                service('serializer.mapping.class_metadata_factory'),
+                abstract_arg('Serializer metadata loaders'),
+                abstract_arg('Serializer normalizers'),
+                abstract_arg('Serializer encoders'),
+                abstract_arg('Named serializers'),
+            ])
+            ->tag('debug.section', ['name' => 'serializer', 'priority' => 300])
+
+        ->set('console.command.debug.section.i18n', TranslationDebugSection::class)
+            ->args([
+                service('translator'),
+                service('translation.reader'),
+                service('translation.extractor'),
+                param('translator.default_path'),
+                null, // twig.default_path
+                abstract_arg('Translator paths'),
+                [], // Twig paths appended by TranslatorPathsPass
+                param('kernel.enabled_locales'),
+                service('kernel'),
+            ])
+            ->tag('debug.section', ['name' => 'translations', 'priority' => 200])
+
+        ->set('console.command.debug.section.scheduler', SchedulerDebugSection::class)
+            ->args([
+                tagged_locator('scheduler.schedule_provider', 'name'),
+            ])
+            ->tag('debug.section', ['name' => 'scheduler', 'priority' => 0])
 
         ->set('console.command.debug_autowiring', DebugAutowiringCommand::class)
             ->args([
@@ -323,7 +434,7 @@ return static function (ContainerConfigurator $container) {
             ])
             ->tag('console.command')
 
-        ->set('console.command.form_debug', DebugCommand::class)
+        ->set('console.command.form_debug', FormDebugCommand::class)
             ->args([
                 service('form.registry'),
                 [], // All form types namespaces are stored here by FormPass

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/DebugCommandTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\DebugCommand;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\AbstractDebugSection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DebugCommandTest extends TestCase
+{
+    public function testSingleMatchPrintsItsDetail()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute(['--container' => 'http_client']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Detail of http_client', $tester->getDisplay());
+        // ANSI codes are stripped when the output is not decorated
+        $this->assertStringNotContainsString("\e[", $tester->getDisplay());
+    }
+
+    public function testSingleMatchKeepsAnsiCodesWhenDecorated()
+    {
+        $tester = $this->createCommandTester();
+
+        $tester->execute(['--container' => 'http_client'], ['decorated' => true]);
+
+        $this->assertStringContainsString("\e[32mDetail of http_client\e[39m", $tester->getDisplay());
+    }
+
+    public function testMultipleMatchesAskToPickOne()
+    {
+        $tester = $this->createCommandTester();
+        $tester->setInputs(['router.default']);
+
+        $exitCode = $tester->execute(['--container' => 'r'], ['interactive' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Found 2 matching items', $tester->getDisplay());
+        $this->assertStringContainsString('Detail of router.default', $tester->getDisplay());
+    }
+
+    public function testMultipleMatchesNonInteractiveListsThem()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute(['--container' => 'r'], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertSame("router.default\nmailer.transports\n", $tester->getDisplay());
+        $this->assertStringContainsString('Found 2 matching items', $tester->getErrorOutput());
+    }
+
+    public function testSectionOptionWithoutValueListsAllItems()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute(['--container' => null], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertSame("http_client\nrouter.default\nmailer.transports\n", $tester->getDisplay());
+    }
+
+    public function testNoMatchesFailsWithSuggestions()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute(['--container' => 'http_clyent'], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $this->assertStringContainsString('No items match "http_clyent"', $tester->getErrorOutput());
+        $this->assertStringContainsString('http_client', $tester->getErrorOutput());
+    }
+
+    public function testPassingSeveralSectionOptionsIsInvalid()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute(['--container' => 'foo', '--routes' => 'bar'], ['capture_stderr_separately' => true]);
+
+        $this->assertSame(Command::INVALID, $exitCode);
+        $this->assertStringContainsString('Pass only one section option at a time', $tester->getErrorOutput());
+    }
+
+    public function testBareQuerySearchesAllSections()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute(['query' => 'user'], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertSame("Container › mailer.transports\nRoutes › user_show\nRoutes › user_edit\n", $tester->getDisplay());
+    }
+
+    public function testSectionOptionWithoutValueFallsBackToTheQueryArgument()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute(['query' => 'user_show', '--routes' => null]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Detail of user_show', $tester->getDisplay());
+    }
+
+    public function testBrokenSectionDoesNotPreventSearchingTheOthers()
+    {
+        $sections = [
+            'container' => new StubDebugSection('Container', [new DebugItem('service', 'user_provider', 'user_provider')]),
+            'broken' => new BrokenDebugSection(),
+        ];
+        $tester = new CommandTester(new DebugCommand($sections, ['container', 'broken']));
+
+        $exitCode = $tester->execute(['query' => 'user'], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        // the only match (from the healthy section) is printed directly
+        $this->assertStringContainsString('Detail of user_provider', $tester->getDisplay());
+        $this->assertStringContainsString('Searching the "Broken" section failed', $tester->getErrorOutput());
+    }
+
+    public function testNonInteractiveInputWithoutQueryFails()
+    {
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute([], ['interactive' => false, 'capture_stderr_separately' => true]);
+
+        $this->assertSame(Command::INVALID, $exitCode);
+        $this->assertStringContainsString('interactive terminal', $tester->getErrorOutput());
+    }
+
+    public function testCompleteSuggestsSectionItemLabels()
+    {
+        $tester = new CommandCompletionTester($this->createCommand());
+
+        $suggestions = $tester->complete(['--container', 'r']);
+
+        $this->assertSame(['router.default', 'mailer.transports'], $suggestions);
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        return new CommandTester($this->createCommand());
+    }
+
+    private function createCommand(): DebugCommand
+    {
+        $sections = [
+            'container' => new StubDebugSection('Container', [
+                new DebugItem('service', 'http_client', 'http_client'),
+                new DebugItem('service', 'router.default', 'router.default'),
+                new DebugItem('service', 'mailer.transports', 'mailer.transports', searchText: 'user'),
+            ]),
+            'routes' => new StubDebugSection('Routes', [
+                new DebugItem('route', 'user_show', 'user_show'),
+                new DebugItem('route', 'user_edit', 'user_edit'),
+            ]),
+        ];
+
+        return new DebugCommand($sections, ['container', 'routes']);
+    }
+}
+
+class StubDebugSection extends AbstractDebugSection
+{
+    /**
+     * @param list<DebugItem> $items
+     */
+    public function __construct(
+        private readonly string $label,
+        private readonly array $items,
+    ) {
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getShortLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        return \sprintf("\e[32mDetail of %s\e[39m (width %d)", $item->value, $width);
+    }
+
+    protected function buildItems(): array
+    {
+        return $this->items;
+    }
+}
+
+class BrokenDebugSection extends AbstractDebugSection
+{
+    public function getLabel(): string
+    {
+        return 'Broken';
+    }
+
+    public function getShortLabel(): string
+    {
+        return 'Broken';
+    }
+
+    public function describe(DebugItem $item, int $width): string
+    {
+        throw new \RuntimeException('This section cannot describe anything.');
+    }
+
+    protected function buildItems(): array
+    {
+        throw new \RuntimeException('This section cannot load its items.');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Debug/DebugItemTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Debug/DebugItemTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Debug;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+
+class DebugItemTest extends TestCase
+{
+    #[DataProvider('provideMatches')]
+    public function testMatches(bool $expected, string $query)
+    {
+        $item = new DebugItem('route', 'user_show', 'User Profile', searchText: '/users/{id} App\Controller\UserController');
+
+        $this->assertSame($expected, $item->matches($query));
+    }
+
+    public static function provideMatches(): iterable
+    {
+        yield 'empty query matches everything' => [true, ''];
+        yield 'matches the label' => [true, 'profile'];
+        yield 'matches the label case-insensitively' => [true, 'PROFILE'];
+        yield 'matches the value' => [true, 'user_show'];
+        yield 'matches the extra search text' => [true, 'usercontroller'];
+        yield 'matches the path in the search text' => [true, '/users/'];
+        yield 'no match' => [false, 'mailer'];
+    }
+
+    public function testMatchesWithoutSearchText()
+    {
+        $item = new DebugItem('service', 'http_client', 'http_client');
+
+        $this->assertTrue($item->matches('http'));
+        $this->assertFalse($item->matches('controller'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Debug/Section/AbstractDebugSectionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Debug/Section/AbstractDebugSectionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Debug\Section;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Debug\DebugItem;
+use Symfony\Bundle\FrameworkBundle\Debug\Section\AbstractDebugSection;
+
+class AbstractDebugSectionTest extends TestCase
+{
+    public function testEmptyQueryReturnsTheFullSet()
+    {
+        $section = $this->createSection(
+            new DebugItem('t', 'one', 'one'),
+            new DebugItem('t', 'two', 'two'),
+        );
+
+        $this->assertCount(2, $section->search(''));
+    }
+
+    public function testItemListIsBuiltOnlyOnce()
+    {
+        $section = $this->createSection(new DebugItem('t', 'one', 'one'));
+
+        $section->search('');
+        $section->search('one');
+
+        $this->assertSame(1, $section->buildCount);
+    }
+
+    public function testLabelMatchesRankBeforeSearchTextMatches()
+    {
+        $section = $this->createSection(
+            new DebugItem('t', 'aaa', 'aaa', searchText: 'kernel'),
+            new DebugItem('t', 'kernel.listener', 'kernel.listener'),
+        );
+
+        $this->assertSame(['kernel.listener', 'aaa'], array_column($section->search('kernel'), 'label'));
+    }
+
+    public function testRankingPreservesGroupContiguity()
+    {
+        $section = $this->createSection(
+            new DebugItem('t', 'a1', 'a1', 'Group A', searchText: 'kernel'),
+            new DebugItem('t', 'a2', 'kernel.a2', 'Group A'),
+            new DebugItem('t', 'b1', 'b1', 'Group B', searchText: 'kernel'),
+            new DebugItem('t', 'b2', 'kernel.b2', 'Group B'),
+        );
+
+        $this->assertSame(
+            ['kernel.a2', 'a1', 'kernel.b2', 'b1'],
+            array_column($section->search('kernel'), 'label'),
+        );
+    }
+
+    public function testFilterIsConsistentWithSearch()
+    {
+        $items = [
+            new DebugItem('t', 'one', 'one'),
+            new DebugItem('t', 'two', 'two'),
+        ];
+        $section = $this->createSection(...$items);
+
+        $this->assertEquals($section->search('two'), $section->filter($items, 'two'));
+    }
+
+    private function createSection(DebugItem ...$items): AbstractDebugSection
+    {
+        return new class(array_values($items)) extends AbstractDebugSection {
+            public int $buildCount = 0;
+
+            public function __construct(
+                private readonly array $fixtures,
+            ) {
+            }
+
+            public function getLabel(): string
+            {
+                return 'Test';
+            }
+
+            public function getShortLabel(): string
+            {
+                return 'Test';
+            }
+
+            public function describe(DebugItem $item, int $width): string
+            {
+                return $item->value;
+            }
+
+            protected function buildItems(): array
+            {
+                ++$this->buildCount;
+
+                return $this->fixtures;
+            }
+        };
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DebugSectionNamesPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/DebugSectionNamesPassTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DebugSectionNamesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+class DebugSectionNamesPassTest extends TestCase
+{
+    public function testCollectsSectionNamesSortedByPriority()
+    {
+        $container = $this->createContainer();
+        $container->register('section.low', \stdClass::class)->addTag('debug.section', ['name' => 'low', 'priority' => 10]);
+        $container->register('section.high', \stdClass::class)->addTag('debug.section', ['name' => 'high', 'priority' => 20]);
+
+        (new DebugSectionNamesPass())->process($container);
+
+        $this->assertSame(['high', 'low'], $container->getDefinition('console.command.debug')->getArgument(1));
+    }
+
+    public function testMissingNameAttributeThrows()
+    {
+        $container = $this->createContainer();
+        $container->register('console.command.debug.section.foo', \stdClass::class)->addTag('debug.section', ['priority' => 10]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Add a valid "name" attribute to the tag/');
+
+        (new DebugSectionNamesPass())->process($container);
+    }
+
+    public function testReservedNameThrows()
+    {
+        $container = $this->createContainer();
+        $container->register('section.help', \stdClass::class)->addTag('debug.section', ['name' => 'help', 'priority' => 10]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/cannot be "help"/');
+
+        (new DebugSectionNamesPass())->process($container);
+    }
+
+    public function testNoopWithoutTheDebugCommand()
+    {
+        $container = new ContainerBuilder();
+        $container->register('some.section', \stdClass::class)->addTag('debug.section', ['name' => '!!invalid!!']);
+
+        (new DebugSectionNamesPass())->process($container);
+
+        $this->assertFalse($container->hasDefinition('console.command.debug'));
+    }
+
+    private function createContainer(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->register('console.command.debug', \stdClass::class)->setArguments([null, []]);
+
+        return $container;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -72,6 +72,7 @@
         "symfony/stopwatch": "^7.4|^8.0",
         "symfony/string": "^7.4|^8.0",
         "symfony/translation": "^7.4|^8.0",
+        "symfony/tui": "^8.1",
         "symfony/twig-bundle": "^7.4|^8.0",
         "symfony/type-info": "^7.4.1|^8.0.1",
         "symfony/uid": "^7.4|^8.0",

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -67,6 +67,10 @@ class FormPass implements CompilerPassInterface
             $commandDefinition->setArgument(2, array_keys($servicesMap));
         }
 
+        if ($container->hasDefinition('console.command.debug.section.form')) {
+            $container->getDefinition('console.command.debug.section.form')->setArgument(1, array_keys($servicesMap));
+        }
+
         if ($csrfTokenIds && $container->hasDefinition('form.type_extension.csrf')) {
             $csrfExtension = $container->getDefinition('form.type_extension.csrf');
 
@@ -117,6 +121,10 @@ class FormPass implements CompilerPassInterface
             $commandDefinition->setArgument(3, $typeExtensionsClasses);
         }
 
+        if ($container->hasDefinition('console.command.debug.section.form')) {
+            $container->getDefinition('console.command.debug.section.form')->setArgument(2, $typeExtensionsClasses);
+        }
+
         return $typeExtensions;
     }
 
@@ -134,6 +142,10 @@ class FormPass implements CompilerPassInterface
         if ($container->hasDefinition('console.command.form_debug')) {
             $commandDefinition = $container->getDefinition('console.command.form_debug');
             $commandDefinition->setArgument(4, $guessersClasses);
+        }
+
+        if ($container->hasDefinition('console.command.debug.section.form')) {
+            $container->getDefinition('console.command.debug.section.form')->setArgument(3, $guessersClasses);
         }
 
         return new IteratorArgument($guessers);

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -197,7 +197,11 @@ class MessengerPass implements CompilerPassInterface
             }
         }
 
-        if ($container->hasDefinition('console.command.messenger_debug')) {
+        $debugConsumers = array_filter(
+            ['console.command.messenger_debug', 'console.command.debug.section.messenger'],
+            $container->hasDefinition(...),
+        );
+        if ($debugConsumers) {
             $debugCommandMapping = $handlersByBusAndMessage;
             foreach ($busIds as $bus) {
                 if (!isset($debugCommandMapping[$bus])) {
@@ -210,7 +214,10 @@ class MessengerPass implements CompilerPassInterface
                     }
                 }
             }
-            $container->getDefinition('console.command.messenger_debug')->replaceArgument(0, $debugCommandMapping);
+
+            foreach ($debugConsumers as $debugConsumer) {
+                $container->getDefinition($debugConsumer)->replaceArgument(0, $debugCommandMapping);
+            }
         }
     }
 

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -64,6 +64,13 @@ class SerializerPass implements CompilerPassInterface
             $container->getDefinition('serializer')->setArgument('$defaultContext', $defaultContext);
         }
 
+        if ($container->hasDefinition('console.command.debug.section.serializer')) {
+            $debugSectionDefinition = $container->getDefinition('console.command.debug.section.serializer');
+            $debugSectionDefinition->setArgument(2, $this->getTaggedServicesData($container, $normalizers, 'serializer.normalizer.default'));
+            $debugSectionDefinition->setArgument(3, $this->getTaggedServicesData($container, $encoders, 'serializer.encoder.default'));
+            $debugSectionDefinition->setArgument(4, $namedSerializers);
+        }
+
         /** @var ?string $circularReferenceHandler */
         $circularReferenceHandler = $container->hasParameter('.serializer.circular_reference_handler')
             ? $container->getParameter('.serializer.circular_reference_handler') : null;
@@ -151,6 +158,30 @@ class SerializerPass implements CompilerPassInterface
         $serializerDefinition = $container->getDefinition($id);
         $serializerDefinition->replaceArgument(0, $normalizers);
         $serializerDefinition->replaceArgument(1, $encoders);
+    }
+
+    /**
+     * @param Reference[] $services
+     *
+     * @return list<array{id: string, class: string, priority: int, built_in: bool}>
+     */
+    private function getTaggedServicesData(ContainerBuilder $container, array $services, string $tagName): array
+    {
+        $data = [];
+        foreach ($services as $service) {
+            $serviceId = (string) $service;
+            $definition = $container->getDefinition($serviceId);
+            $tag = $definition->getTag($tagName)[0] ?? [];
+
+            $data[] = [
+                'id' => $serviceId,
+                'class' => $container->getParameterBag()->resolveValue($definition->getClass()) ?: $serviceId,
+                'priority' => $tag['priority'] ?? 0,
+                'built_in' => $tag['built_in'] ?? false,
+            ];
+        }
+
+        return $data;
     }
 
     private function configureNamedSerializers(ContainerBuilder $container, ?string $circularReferenceHandler, ?string $maxDepthHandler): void

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
@@ -73,6 +73,10 @@ class TranslatorPathsPass extends AbstractRecursivePass
                     $definition = $container->getDefinition('console.command.translation_debug');
                     $definition->replaceArgument(6, array_merge($definition->getArgument(6), $paths));
                 }
+                if ($container->hasDefinition('console.command.debug.section.i18n')) {
+                    $definition = $container->getDefinition('console.command.debug.section.i18n');
+                    $definition->replaceArgument(6, array_merge($definition->getArgument(6), $paths));
+                }
                 if ($container->hasDefinition('console.command.translation_extract')) {
                     $definition = $container->getDefinition('console.command.translation_extract');
                     $definition->replaceArgument(7, array_merge($definition->getArgument(7), $paths));


### PR DESCRIPTION
This PR proposes adding a new `debug` command to inspect every part of your application. It can replace all existing `debug:*` commands and it's built using Symfony's TUI component.

Here's a breakdown of the interface:

<img width="6720" height="3780" alt="debug-command-ui" src="https://github.com/user-attachments/assets/97ea5564-22e7-4344-b596-bf8add4d5028" />

The main idea behind this command is to **keep the interface extremely simple**. Navigation only requires the arrow keys, text keys, Escape, and PgUp/PgDown, making it trivial to learn and easy to use. The UI also adapts automatically when you resize the terminal window.

Here's the command in action inside the Symfony Demo application:

https://github.com/user-attachments/assets/4e59cbba-f411-4b48-8160-9370ac14d143

### Direct (non-interactive) mode

Besides the full-screen UI, the command supports a direct search mode for when you already know what you're looking for. Pass a per-section option (one exists for each registered section) and/or a search term:

```bash
# search one section (prints the item directly when there's a single match)
$ php bin/console debug --container http_client
$ php bin/console debug --routes user_
$ php bin/console debug --config framework

# list everything in a section
$ php bin/console debug --routes

# search across ALL sections at once
$ php bin/console debug csrf
```

* When several items match, an interactive prompt (with autocompletion) asks which one to display.
* When the output is piped or `--no-interaction` is passed, matches are printed as a plain, `grep`-friendly list and ANSI codes are stripped automatically (`bin/console debug --routes | grep login`).
* Shell completion suggests real item names: `bin/console debug --container http_<TAB>`.
* This mode doesn't require the TUI component at all, so it also works on Windows and in CI.

### Things to do

* [x] Add tests
* [ ] Review the contents of each panel. Some are identical to the existing `debug:*` command output, while others have been redesigned. We can still tweak all
of them.
* [ ] Add the missing panels: Security and Twig

This is how the available panels look today:

#### Container

<img width="2125" height="1572" alt="debug-container" src="https://github.com/user-attachments/assets/ac0d35d9-33aa-4ba4-a366-2740fdf2e916" />

#### Routes

<img width="2125" height="1572" alt="debug-routes" src="https://github.com/user-attachments/assets/3472ac13-47a4-40ad-845c-430a2d7877f7" />

#### Config

<img width="2125" height="1572" alt="debug-config" src="https://github.com/user-attachments/assets/acb970c2-cfca-4291-917a-ce32da41b2a5" />

#### Events

<img width="2125" height="1572" alt="debug-events" src="https://github.com/user-attachments/assets/c2c80d3e-8885-4e90-b2c6-a69344322a1c" />

#### Form

<img width="2125" height="1572" alt="debug-form" src="https://github.com/user-attachments/assets/f501a779-5842-4130-ad87-af6be92bca20" />

#### Validator

<img width="2125" height="1572" alt="debug-validator" src="https://github.com/user-attachments/assets/5a0f910d-8b21-4ae2-9813-e6278a92b0b2" />

#### I18N

<img width="2125" height="1572" alt="debug-i18n" src="https://github.com/user-attachments/assets/3455ad26-b1d0-4a3b-851b-bfe1b384124e" />

#### Assets

<img width="2125" height="1572" alt="debug-assets" src="https://github.com/user-attachments/assets/f85acb46-d1fb-463d-b497-517d91a6a0d7" />
