### PR TITLE
[DependencyInjection] Write a CACHEDIR.TAG file in the cache and build directories

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
  * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
  * Add support for injecting a service as a lazy proxy on a per-argument basis, using the `!lazy_proxy` YAML tag, the `@~` reference prefix or the `lazy_proxy()` function in the PHP-DSL
+ * Write a `CACHEDIR.TAG` file in the cache and build directories so backup tools can skip them
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
@@ -295,6 +295,11 @@ trait KernelTrait
             } elseif (!is_writable($dir)) {
                 throw new \RuntimeException(\sprintf('Unable to write in the "%s" directory (%s).', $name, $dir));
             }
+
+            // Tag the directory so backup tools can skip it; see https://bford.info/cachedir/
+            if (!is_file($tag = $dir.'/CACHEDIR.TAG')) {
+                @file_put_contents($tag, "Signature: 8a477f597d28d172789f06886806bc55\n# This file is a cache directory tag created by Symfony.\n# For information about cache directory tags, see https://bford.info/cachedir/\n");
+            }
         }
 
         $container = $this->getContainerBuilder();

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -116,6 +116,18 @@ class KernelTest extends TestCase
         $this->assertFileDoesNotExist($legacyContainerDir.'.legacy');
     }
 
+    public function testBuildContainerWritesCachedirTag()
+    {
+        $kernel = new CustomProjectDirKernel();
+        $kernel->boot();
+
+        foreach ([$kernel->getCacheDir(), $kernel->getBuildDir()] as $dir) {
+            $cachedirTag = $dir.'/CACHEDIR.TAG';
+            $this->assertFileExists($cachedirTag);
+            $this->assertStringStartsWith('Signature: 8a477f597d28d172789f06886806bc55', file_get_contents($cachedirTag));
+        }
+    }
+
     public function testBootInitializesBundlesAndContainer()
     {
         $kernel = $this->getKernel(['initializeBundles']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This writes a [`CACHEDIR.TAG`](https://bford.info/cachedir/) file into the cache and build directories, where `KernelTrait::buildContainer()` prepares them.

Both directories hold generated, reproducible files, so there is no reason to back them up. `CACHEDIR.TAG` is a small convention that lets backup tools skip such directories. GNU `tar` honors it with `--exclude-caches`, and `rsync`, `borg` and `restic` support it too.

The file is the signature line required by the spec plus two comment lines:

```
Signature: 8a477f597d28d172789f06886806bc55
# This file is a cache directory tag created by Symfony.
# For information about cache directory tags, see https://bford.info/cachedir/
```

The write is guarded by `is_file()`, so it happens once and an existing tag is never rewritten. It runs where the container is built, not on every boot.

I took this from Shopware, which has been doing the same in its kernel for a while, on `var/cache`.

Scope. This tags the two directories the kernel itself creates. Tagging individual cache pool directories, so that a `FilesystemAdapter` pointed outside `var/` gets the same treatment, is a separate change and can follow if wanted.
