### PR TITLE
[Translation] i18n(fr): improve Symfony Validator French translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -48,11 +48,11 @@
             </trans-unit>
             <trans-unit id="12">
                 <source>This value is not a valid datetime.</source>
-                <target>Cette valeur n'est pas une date valide.</target>
+                <target>Cette valeur n'est pas une date/heure valides.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>This value is not a valid email address.</source>
-                <target>Cette valeur n'est pas une adresse email valide.</target>
+                <target>Cette valeur n'est pas une adresse e-mail valide.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>The file could not be found.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Cette chaîne est trop longue. Elle doit avoir au maximum {{ limit }} caractère.|Cette chaîne est trop longue. Elle doit avoir au maximum {{ limit }} caractères.</target>
+                <target>Cette chaîne est trop longue. Elle doit contenir au maximum {{ limit }} caractère.|Cette chaîne est trop longue. Elle doit contenir au maximum {{ limit }} caractères.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,7 +84,7 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Cette chaîne est trop courte. Elle doit avoir au minimum {{ limit }} caractère.|Cette chaîne est trop courte. Elle doit avoir au minimum {{ limit }} caractères.</target>
+                <target>Cette chaîne est trop courte. Elle doit contenir au minimum {{ limit }} caractère.|Cette chaîne est trop courte. Elle doit contenir au minimum {{ limit }} caractères.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
@@ -128,7 +128,7 @@
             </trans-unit>
             <trans-unit id="35">
                 <source>This value should be a valid number.</source>
-                <target>Cette valeur doit être un nombre.</target>
+                <target>Cette valeur doit être un nombre valide.</target>
             </trans-unit>
             <trans-unit id="36">
                 <source>This file is not a valid image.</source>
@@ -180,7 +180,7 @@
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-                <target>Cette chaîne doit avoir exactement {{ limit }} caractère.|Cette chaîne doit avoir exactement {{ limit }} caractères.</target>
+                <target>Cette chaîne doit contenir exactement {{ limit }} caractère.|Cette chaîne doit contenir exactement {{ limit }} caractères.</target>
             </trans-unit>
             <trans-unit id="49">
                 <source>The file was only partially uploaded.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target>Cette valeur n'est pas un Code Identifiant de Business (BIC) valide.</target>
+                <target>Cette valeur n'est pas un Code d'Identification Bancaire (BIC) valide.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -328,7 +328,7 @@
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
-                <target>Ce code d'identification d'entreprise (BIC) n'est pas associé à l'IBAN {{ iban }}.</target>
+                <target>Ce Code d'Identification bancaire (BIC) n'est pas associé à l'IBAN {{ iban }}.</target>
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>
@@ -472,11 +472,11 @@
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target>Ce fichier n’est pas une vidéo valide.</target>
+                <target>Ce fichier n'est pas une vidéo valide.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target>La taille de la vidéo n’a pas pu être détectée.</target>
+                <target>La taille de la vidéo n'a pas pu être détectée.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
@@ -544,11 +544,11 @@
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target>L’image comporte trop peu de pixels ({{ pixels }}). La quantité minimale attendue est de {{ min_pixels }} pixels.</target>
+                <target>L'image comporte trop peu de pixels ({{ pixels }}). La quantité minimale attendue est de {{ min_pixels }} pixels.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target>L’image contient trop de pixels ({{ pixels }}). La quantité maximale attendue est de {{ max_pixels }} pixels.</target>
+                <target>L'image contient trop de pixels ({{ pixels }}). La quantité maximale attendue est de {{ max_pixels }} pixels.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #64680 
| License       | MIT

This PR improves French translations for the Symfony Validator component.

It refines the wording of existing validation messages to ensure consistency with the current French translation style used across Symfony.

No functional changes are introduced, only translation improvements in:
- validators.fr.xlf
