### PR TITLE
[AssetMapper] Fix crash when a remote package depends on a locally-mapped importmap entry

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapVersionChecker.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapVersionChecker.php
@@ -86,7 +86,14 @@ class ImportMapVersionChecker
                     continue;
                 }
 
-                $dependencyPackageName = $entries->get($dependencyName)->getPackageName();
+                $dependencyEntry = $entries->get($dependencyName);
+
+                // local entries have no version to check and no package name to resolve
+                if (!$dependencyEntry->isRemotePackage()) {
+                    continue;
+                }
+
+                $dependencyPackageName = $dependencyEntry->getPackageName();
 
                 if (!isset($packageDependencies[$dependencyPackageName])) {
                     continue;
@@ -94,8 +101,8 @@ class ImportMapVersionChecker
 
                 $dependencyVersionConstraint = $packageDependencies[$dependencyPackageName];
 
-                if (!$this->isVersionSatisfied($dependencyVersionConstraint, $entries->get($dependencyName)->version)) {
-                    $problems[] = new PackageVersionProblem($packageName, $dependencyPackageName, $dependencyVersionConstraint, $entries->get($dependencyName)->version);
+                if (!$this->isVersionSatisfied($dependencyVersionConstraint, $dependencyEntry->version)) {
+                    $problems[] = new PackageVersionProblem($packageName, $dependencyPackageName, $dependencyVersionConstraint, $dependencyEntry->version);
                 }
             }
         }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapVersionCheckerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapVersionCheckerTest.php
@@ -35,7 +35,7 @@ class ImportMapVersionCheckerTest extends TestCase
             ->willReturn(new ImportMapEntries($importMapEntries));
 
         $remoteDownloader = $this->createMock(RemotePackageDownloader::class);
-        $remoteDownloader->expects($this->exactly(\count($importMapEntries)))
+        $remoteDownloader->expects($this->exactly(\count(array_filter($importMapEntries, static fn (ImportMapEntry $entry) => $entry->isRemotePackage()))))
             ->method('getDependencies')
             ->with($this->callback(static function ($importName) use ($importMapEntries) {
                 foreach ($importMapEntries as $entry) {
@@ -281,6 +281,25 @@ class ImportMapVersionCheckerTest extends TestCase
             ],
             [],
         ];
+
+        yield 'remote package with a locally-mapped dependency' => [
+            [
+                self::createRemoteEntry('foo', version: '1.0.0'),
+                self::createLocalEntry('bar'),
+            ],
+            [
+                'foo' => ['bar'],
+            ],
+            [
+                [
+                    'url' => '/foo/1.0.0',
+                    'response' => [
+                        'dependencies' => ['bar' => '^2.0.0'],
+                    ],
+                ],
+            ],
+            [],
+        ];
     }
 
     /**
@@ -430,5 +449,10 @@ class ImportMapVersionCheckerTest extends TestCase
         $packageModuleSpecifier ??= $importName;
 
         return ImportMapEntry::createRemote($importName, ImportMapType::JS, '/path/to/'.$importName, $version, $packageModuleSpecifier, false);
+    }
+
+    private static function createLocalEntry(string $importName): ImportMapEntry
+    {
+        return ImportMapEntry::createLocal($importName, ImportMapType::JS, '/path/to/'.$importName, false);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64699
| License       | MIT

`ImportMapVersionChecker::checkVersions()` calls `getPackageName()` on a dependency entry without first checking `isRemotePackage()`. When a remote package declares a dependency whose name is mapped to a **local** (path-based) importmap entry, that entry's `packageModuleSpecifier` is `null`, so `getPackageName()` → `splitPackageNameAndFilePath(null)` throws a `TypeError`:

```
ImportMapEntry::splitPackageNameAndFilePath(): Argument #1 ($packageModuleSpecifier) must be of type string, null given
```

This breaks every `importmap:require` (and, through Flex recipes, plain `composer require`/`update`) for the whole project.

The outer loop already guards local entries with `isRemotePackage()`; this applies the same guard in the dependency loop. A local entry has no version constraint to check against the remote dependency anyway, so it is simply skipped.

Thanks to @ghisleouf for the detailed report and root-cause analysis. 🙏
