### PR TITLE
[DependencyInjection] Fix lazy + factory service with a leading-backslash class on PHP 8.4

### DIFF
--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/LazyServiceInstantiator.php
@@ -38,7 +38,7 @@ final class LazyServiceInstantiator implements InstantiatorInterface
             eval($dumper->getProxyCode($definition, $id));
         }
 
-        if ($definition->getClass() === $proxyClass) {
+        if (ltrim($definition->getClass(), '\\') === $proxyClass) {
             return $class->newLazyProxy($realInstantiator);
         }
 

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/LazyServiceDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/LazyServiceDumper.php
@@ -88,7 +88,7 @@ final class LazyServiceDumper implements DumperInterface
         $proxyClass = $this->getProxyClass($definition, $asGhostObject);
 
         if (!$asGhostObject) {
-            if ($definition->getClass() === $proxyClass) {
+            if (ltrim($definition->getClass(), '\\') === $proxyClass) {
                 return <<<EOF
                             if (true === \$lazyLoad) {
                                 $instantiation new \ReflectionClass('$proxyClass')->newLazyProxy(static fn () => $factoryCode);
@@ -149,7 +149,7 @@ final class LazyServiceDumper implements DumperInterface
             }
         }
 
-        if ($definition->getClass() === $proxyClass) {
+        if (ltrim($definition->getClass(), '\\') === $proxyClass) {
             return '';
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/Instantiator/LazyServiceInstantiatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/Instantiator/LazyServiceInstantiatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\LazyProxy\Instantiator;
 
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Definition;
@@ -41,5 +42,33 @@ class LazyServiceInstantiatorTest extends TestCase
         $this->assertSame(0, $instance->calls);
         $this->assertSame('Hello from the abstract class!', $proxy->say());
         $this->assertSame(1, $instance->calls);
+    }
+
+    #[RequiresPhp('>=8.4.0')]
+    public function testInstantiateProxyWithFactoryAndLeadingBackslashClassName()
+    {
+        $instantiator = new LazyServiceInstantiator();
+
+        $definition = (new Definition('\\'.LazyProxiedTestService::class))
+            ->setFactory([LazyProxiedTestService::class, 'create'])
+            ->setLazy(true);
+
+        $proxy = $instantiator->instantiateProxy(new Container(), $definition, 'foo', static fn () => LazyProxiedTestService::create());
+
+        $this->assertInstanceOf(LazyProxiedTestService::class, $proxy);
+        $this->assertSame('hello', $proxy->say());
+    }
+}
+
+class LazyProxiedTestService
+{
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function say(): string
+    {
+        return 'hello';
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
@@ -75,6 +75,35 @@ class LazyServiceDumperTest extends TestCase
         $this->assertTrue($dumper->isProxyCandidate($definition));
         $this->assertStringContainsString(\PHP_VERSION_ID >= 80400 ? '' : 'readonly class ReadOnlyClassGhost', $dumper->getProxyCode($definition));
     }
+
+    #[RequiresPhp('>=8.4.0')]
+    public function testFactoryWithLeadingBackslashClass()
+    {
+        $dumper = new LazyServiceDumper();
+        $definition = (new Definition('\\'.LazyProxiedService::class))
+            ->setFactory([LazyProxiedService::class, 'create'])
+            ->setLazy(true);
+
+        // getProxyClass() returns the reflection-normalized name, i.e. without the leading backslash
+        $this->assertSame(LazyProxiedService::class, $dumper->getProxyClass($definition, false));
+
+        // a leading backslash on the class name must still take the native lazy path:
+        // no decorated proxy class is generated...
+        $this->assertSame('', $dumper->getProxyCode($definition));
+
+        // ...and the factory code relies on newLazyProxy() instead of the broken decorator
+        $factoryCode = $dumper->getProxyFactoryCode($definition, 'svc', 'self::getSvcService($container, false)');
+        $this->assertStringContainsString('newLazyProxy', $factoryCode);
+        $this->assertStringNotContainsString('createLazyProxy', $factoryCode);
+    }
+}
+
+class LazyProxiedService
+{
+    public static function create(): self
+    {
+        return new self();
+    }
 }
 
 final class TestContainer implements ContainerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64673
| License       | MIT

A **lazy** + **factory**-created service whose `class` is a root-namespace name written **with a leading backslash** (`class: \Foo`) produces a broken dumped container on PHP 8.4: `Cannot redeclare class Foo` (single-file dump) or `Call to undefined method Foo::createLazyProxy()` (`as_files`).

`getProxyClass()` returns the reflection-normalized class name (`Foo`), while `Definition::getClass()` keeps the leading backslash (`\Foo`). The strict `===` comparison in `getProxyFactoryCode()` (and `getProxyCode()`) therefore fails, so the dumper falls back to the decorator branch instead of the native `newLazyProxy()` path — emitting a proxy class that reuses the root-namespace name and calls `createLazyProxy()` on the real class.

This normalizes the leading backslash (`ltrim(..., '\\')`) in both comparisons, so such a service takes the native lazy path as it does without the backslash (and as it does on PHP 8.2/8.3).

Thanks to @ghisleouf for the precise report, reproducer and root-cause analysis. 🙏
