### PR TITLE
[Console] Improve FileInputHelper paste detection read performance

### DIFF
--- a/src/Symfony/Component/Console/Helper/FileInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/FileInputHelper.php
@@ -102,18 +102,25 @@ final class FileInputHelper
         $buffer = '';
         $inPaste = false;
         $pasteBuffer = '';
+        $chunk = '';
+        $chunkPos = 0;
 
-        while (!feof($inputStream)) {
-            $inputHelper->waitForInput();
-            $char = fread($inputStream, 1);
+        while (true) {
+            if ($chunkPos >= \strlen($chunk)) {
+                $inputHelper->waitForInput();
+                $chunk = fread($inputStream, 8192);
 
-            if (false === $char || '' === $char) {
-                if ('' === $buffer && '' === $pasteBuffer) {
-                    throw new MissingInputException('Aborted.');
+                if (false === $chunk || '' === $chunk) {
+                    if ('' === $buffer && '' === $pasteBuffer) {
+                        throw new MissingInputException('Aborted.');
+                    }
+                    break;
                 }
-                break;
+
+                $chunkPos = 0;
             }
 
+            $char = $chunk[$chunkPos++];
             $buffer .= $char;
 
             if (\strlen($buffer) > self::MAX_PASTE_BYTES) {

--- a/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
@@ -75,4 +75,39 @@ class FileInputHelperTest extends TestCase
             fclose($stream);
         }
     }
+
+    public function testReadWithPasteDetectionReassemblesPasteSpanningMultipleReadChunks()
+    {
+        $pasteStart = (new \ReflectionClassConstant(FileInputHelper::class, 'PASTE_START'))->getValue();
+        $pasteEnd = (new \ReflectionClassConstant(FileInputHelper::class, 'PASTE_END'))->getValue();
+
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'sf_console_'.bin2hex(random_bytes(4)).'.txt';
+        file_put_contents($path, 'x');
+
+        // Pad so that the path itself straddles the internal 8192-byte read buffer: part of
+        // it lands in the first fread() call, the rest in the second. If the buffered read
+        // dropped or corrupted bytes at the chunk boundary, the reassembled path would differ
+        // from the original and the assertion below would fail.
+        $padding = str_repeat(' ', 8192 - \strlen($pasteStart) - 5);
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $pasteStart.$padding.$path.$pasteEnd);
+        rewind($stream);
+
+        $helper = new FileInputHelper();
+        $method = (new \ReflectionClass(FileInputHelper::class))->getMethod('readWithPasteDetection');
+
+        $terminalReflection = new \ReflectionClass(TerminalInputHelper::class);
+        $inputHelper = $terminalReflection->newInstanceWithoutConstructor();
+        foreach (['isStdin' => false, 'withStty' => false] as $name => $value) {
+            $terminalReflection->getProperty($name)->setValue($inputHelper, $value);
+        }
+
+        try {
+            $file = $method->invoke($helper, $stream, new BufferedOutput(), new FileQuestion('?'), $inputHelper);
+            $this->assertSame($path, $file->getPathname());
+        } finally {
+            fclose($stream);
+            @unlink($path);
+        }
+    }
 }


### PR DESCRIPTION
Replace per-byte fread() calls with 8192-byte buffered reads to reduce syscall overhead by up to ~8192x when processing large pasted input.

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

**Problem**: 
`fread($inputStream, 1)` in the paste-detection loop issued one fread syscall (plus one stream_select via waitForInput()) per byte. For a pasted base64-encoded image approaching the 16 MB limit, that's up to ~22 read iterations.

**Fix**: 
Introduced a small read buffer `fread($inputStream, 8192)` per fill, with `$chunk/$chunkPos` tracking position within the buffer. waitForInput() is now called only when the buffer is exhausted, reducing syscalls by up to ~8192×. The character-by-character processing logic (BPM marker detection, newline detection, size check) is unchanged.

Symfony test of this feature had been silenced in the php-src repository because of this issue. The Symfony tests have hung since the introduction of this code. https://github.com/php/php-src/commit/1182b14b7f1be71b4c62f1d47410db5c142785ff
