### PR TITLE
[Mailer] Reject control characters in SmtpTransport::setLocalDomain()

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -140,6 +140,30 @@ class SmtpTransportTest extends TestCase
         $this->assertContains("RCPT TO:<recipient2@example.org>\r\n", $stream->getCommands());
     }
 
+    /**
+     * @dataProvider provideLocalDomainsWithControlCharacters
+     */
+    public function testSetLocalDomainRejectsControlCharacters(string $domain)
+    {
+        $transport = new SmtpTransport(new DummyStream());
+
+        $this->expectException(\Symfony\Component\Mailer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The local domain name must not contain control characters.');
+
+        $transport->setLocalDomain($domain);
+    }
+
+    public static function provideLocalDomainsWithControlCharacters(): iterable
+    {
+        yield 'CRLF' => ["evil\r\nMAIL FROM:<injected@example.org>"];
+        yield 'CR only' => ["example.org\r"];
+        yield 'LF only' => ["example.org\n"];
+        yield 'NUL byte' => ["example.org\x00"];
+        yield 'HTAB' => ["example.org\t"];
+        yield 'DEL (0x7F)' => ["example.org\x7F"];
+        yield 'control char in the middle' => ["exam\x01ple.org"];
+    }
+
     public function testMessageIdFromServerIsEmbeddedInSentMessageEvent()
     {
         $calls = 0;

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Transport\Smtp;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -107,6 +108,10 @@ class SmtpTransport extends AbstractTransport
      */
     public function setLocalDomain(string $domain): static
     {
+        if (preg_match('/[\x00-\x1F\x7F]/', $domain)) {
+            throw new InvalidArgumentException('The local domain name must not contain control characters.');
+        }
+
         if ('' !== $domain && '[' !== $domain[0]) {
             if (filter_var($domain, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {
                 $domain = '['.$domain.']';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SmtpTransport::setLocalDomain()` stores the domain unchanged, and it's later interpolated straight into the greeting: `sprintf("HELO %s\r\n", $this->domain)` (and the `EHLO` variants in `EsmtpTransport`). A domain that contains CR/LF therefore writes extra lines onto the SMTP connection, smuggling additional commands, e.g. `setLocalDomain("evil\r\nMAIL FROM:<injected@example.org>")` puts an attacker-chosen `MAIL FROM` on the wire ahead of the real envelope.

`local_domain` comes from operator/DSN config, so this is hardening rather than a remotely-triggerable bug. But the value reaches the wire unescaped, and `Address` already rejects the same control characters for email addresses, so the setter should be consistent. The guard uses the same pattern (`/[\x00-\x1F\x7F]/`) and throws `InvalidArgumentException`.

Targeted at 6.4: the same unescaped HELO/EHLO interpolation exists on all maintained branches, and the identical guard in `Mime\Address` was applied down to the lowest branches as part of CVE-2026-45067.

Unit tests cover the rejection with a data provider matching the `Address` one (CRLF, CR, LF, NUL, HTAB, DEL, control character in the middle).
