### PR TITLE
[JsonStreamer] Add UID value object support

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -25,3 +25,8 @@ parameters:
         -
             message: '#^Negated boolean expression is always true\.$#'
             path: src/Symfony/Component/Messenger/Worker.php
+        # @implements binds the transformer to one class, but the generated code calls transform()
+        # with whatever the property holds, so each guard is reachable
+        -
+            message: '#^Instanceof between .+ and .+ will always evaluate to true\.$#'
+            path: src/Symfony/Component/JsonStreamer/Transformer/*ValueObjectTransformer.php

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/json_streamer.php
@@ -25,6 +25,8 @@ use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransforme
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\GmpNumberValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\UlidValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\UuidValueObjectTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\DateTimeToStringValueTransformer;
 use Symfony\Component\JsonStreamer\ValueTransformer\StringToDateTimeValueTransformer;
 
@@ -121,6 +123,12 @@ return static function (ContainerConfigurator $container) {
             ->tag('json_streamer.value_object_transformer')
 
         ->set('.json_streamer.value_object_transformer.gmp_number', GmpNumberValueObjectTransformer::class)
+            ->tag('json_streamer.value_object_transformer')
+
+        ->set('.json_streamer.value_object_transformer.uuid', UuidValueObjectTransformer::class)
+            ->tag('json_streamer.value_object_transformer')
+
+        ->set('.json_streamer.value_object_transformer.ulid', UlidValueObjectTransformer::class)
             ->tag('json_streamer.value_object_transformer')
 
         // cache

--- a/src/Symfony/Component/JsonStreamer/CHANGELOG.md
+++ b/src/Symfony/Component/JsonStreamer/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add `BcMath\Number` value object support with `BcMathNumberValueObjectTransformer`
  * Add `GMP` value object support with `GmpNumberValueObjectTransformer`
  * Add a `cache_variant` option that partitions the generated code cache, so a custom property metadata loader can produce several payload shapes for the same PHP type
+ * Add `Uuid` and `Ulid` value object support with `UuidValueObjectTransformer` and `UlidValueObjectTransformer`
+ * Add a `uid_format` option to control the written UID representation
 
 8.1
 ---

--- a/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamReader.php
@@ -27,11 +27,15 @@ use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\GmpNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
+use Symfony\Component\JsonStreamer\Transformer\UlidValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\UuidValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
@@ -40,6 +44,7 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
  *     date_time_format?: string,
  *     date_time_timezone?: string|\DateTimeZone,
  *     date_interval_format?: string,
+ *     uid_format?: string,
  *     cache_variant?: string,
  *     ...<string, mixed>,
  * }
@@ -98,6 +103,8 @@ final class JsonStreamReader implements StreamReaderInterface
             \DateTimeZone::class => new DateTimeZoneValueObjectTransformer(),
             \BcMath\Number::class => new BcMathNumberValueObjectTransformer(),
             \GMP::class => new GmpNumberValueObjectTransformer(),
+            Uuid::class => new UuidValueObjectTransformer(),
+            Ulid::class => new UlidValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
+++ b/src/Symfony/Component/JsonStreamer/JsonStreamWriter.php
@@ -24,12 +24,16 @@ use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeZoneValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\GmpNumberValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
+use Symfony\Component\JsonStreamer\Transformer\UlidValueObjectTransformer;
+use Symfony\Component\JsonStreamer\Transformer\UuidValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 use Symfony\Component\JsonStreamer\Write\StreamWriterGenerator;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Mathias Arlaud <mathias.arlaud@gmail.com>
@@ -38,6 +42,7 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
  *     date_time_format?: string,
  *     date_time_timezone?: string|\DateTimeZone,
  *     date_interval_format?: string,
+ *     uid_format?: string,
  *     include_null_properties?: bool,
  *     cache_variant?: string,
  *     ...<string, mixed>,
@@ -120,6 +125,8 @@ final class JsonStreamWriter implements StreamWriterInterface
             \DateTimeZone::class => new DateTimeZoneValueObjectTransformer(),
             \BcMath\Number::class => new BcMathNumberValueObjectTransformer(),
             \GMP::class => new GmpNumberValueObjectTransformer(),
+            Uuid::class => new UuidValueObjectTransformer(),
+            Ulid::class => new UlidValueObjectTransformer(),
         ];
 
         $transformersContainer = new class($transformers) implements ContainerInterface {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithUids.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithUids.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV7;
+
+class DummyWithUids
+{
+    public Uuid $uuid;
+    public UuidV7 $uuidV7;
+    public Ulid $ulid;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUids;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueObjects;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\DivideStringAndCastToIntValueTransformer;
@@ -36,6 +37,9 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\StringToBooleanVal
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueObject\Height;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeIdentifier;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV7;
 
 class JsonStreamReaderTest extends TestCase
 {
@@ -245,6 +249,34 @@ class JsonStreamReaderTest extends TestCase
             $this->assertInstanceOf(DummyWithGmpNumber::class, $read);
             $this->assertEquals(new \GMP('99999999999999999999'), $read->gmp);
         }, '{"gmp":"99999999999999999999"}', Type::object(DummyWithGmpNumber::class));
+    }
+
+    public function testReadObjectWithUids()
+    {
+        $reader = JsonStreamReader::create([], $this->streamReadersDir);
+
+        $this->assertRead($reader, function (mixed $read) {
+            $this->assertInstanceOf(DummyWithUids::class, $read);
+            $this->assertEquals(Uuid::fromString('a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40'), $read->uuid);
+            $this->assertEquals(UuidV7::fromString('018f7a5e-3c1e-7a4e-8b1a-2c3d4e5f6a7b'), $read->uuidV7);
+            $this->assertEquals(Ulid::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV'), $read->ulid);
+        }, '{"uuid":"a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40","uuidV7":"018f7a5e-3c1e-7a4e-8b1a-2c3d4e5f6a7b","ulid":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}', Type::object(DummyWithUids::class));
+    }
+
+    public function testReadObjectWithUidsUsingNonCanonicalFormat()
+    {
+        $reader = JsonStreamReader::create([], $this->streamReadersDir);
+
+        $uuid = Uuid::fromString('a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40');
+        $uuidV7 = UuidV7::fromString('018f7a5e-3c1e-7a4e-8b1a-2c3d4e5f6a7b');
+        $ulid = Ulid::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+
+        $this->assertRead($reader, function (mixed $read) use ($uuid, $uuidV7, $ulid) {
+            $this->assertInstanceOf(DummyWithUids::class, $read);
+            $this->assertEquals($uuid, $read->uuid);
+            $this->assertEquals($uuidV7, $read->uuidV7);
+            $this->assertEquals($ulid, $read->ulid);
+        }, \sprintf('{"uuid":"%s","uuidV7":"%s","ulid":"%s"}', $uuid->toBase58(), $uuidV7->toBase58(), $ulid->toBase58()), Type::object(DummyWithUids::class));
     }
 
     public function testReadUnion()

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullablePropert
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSelfReferencingDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUids;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueObjects;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
@@ -52,8 +53,12 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueObject\Height;
 use Symfony\Component\JsonStreamer\Transformer\DateIntervalValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\DateTimeValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\PropertyValueTransformerInterface;
+use Symfony\Component\JsonStreamer\Transformer\UuidValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Transformer\ValueObjectTransformerInterface;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV7;
 
 class JsonStreamWriterTest extends TestCase
 {
@@ -397,6 +402,31 @@ class JsonStreamWriterTest extends TestCase
         $dummy->gmp = new \GMP('99999999999999999999');
 
         $this->assertWritten('{"gmp":"99999999999999999999"}', $dummy, Type::object(DummyWithGmpNumber::class));
+    }
+
+    public function testWriteObjectWithUids()
+    {
+        $dummy = new DummyWithUids();
+        $dummy->uuid = Uuid::fromString('a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40');
+        $dummy->uuidV7 = UuidV7::fromString('018f7a5e-3c1e-7a4e-8b1a-2c3d4e5f6a7b');
+        $dummy->ulid = Ulid::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+
+        $this->assertWritten('{"uuid":"a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40","uuidV7":"018f7a5e-3c1e-7a4e-8b1a-2c3d4e5f6a7b","ulid":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}', $dummy, Type::object(DummyWithUids::class));
+    }
+
+    public function testWriteObjectWithUidsUsingFormat()
+    {
+        $dummy = new DummyWithUids();
+        $dummy->uuid = Uuid::fromString('a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40');
+        $dummy->uuidV7 = UuidV7::fromString('018f7a5e-3c1e-7a4e-8b1a-2c3d4e5f6a7b');
+        $dummy->ulid = Ulid::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+
+        $this->assertWritten(
+            \sprintf('{"uuid":"%s","uuidV7":"%s","ulid":"%s"}', $dummy->uuid->toBase32(), $dummy->uuidV7->toBase32(), $dummy->ulid->toBase32()),
+            $dummy,
+            Type::object(DummyWithUids::class),
+            options: [UuidValueObjectTransformer::FORMAT_KEY => UuidValueObjectTransformer::FORMAT_BASE32],
+        );
     }
 
     public function testWriteObjectWithDollarNamedProperties()

--- a/src/Symfony/Component/JsonStreamer/Tests/Transformer/UlidValueObjectTransformerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Transformer/UlidValueObjectTransformerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Transformer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\JsonStreamer\Transformer\UlidValueObjectTransformer;
+use Symfony\Component\Uid\Ulid;
+
+class UlidValueObjectTransformerTest extends TestCase
+{
+    private const ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+
+    public function testTransform()
+    {
+        $transformer = new UlidValueObjectTransformer();
+        $ulid = Ulid::fromString(self::ULID);
+
+        $this->assertSame(self::ULID, $transformer->transform($ulid));
+        $this->assertSame((string) $ulid, $transformer->transform($ulid, [UlidValueObjectTransformer::FORMAT_KEY => UlidValueObjectTransformer::FORMAT_CANONICAL]));
+        $this->assertSame($ulid->toRfc4122(), $transformer->transform($ulid, [UlidValueObjectTransformer::FORMAT_KEY => UlidValueObjectTransformer::FORMAT_RFC4122]));
+        $this->assertSame($ulid->toBase58(), $transformer->transform($ulid, [UlidValueObjectTransformer::FORMAT_KEY => UlidValueObjectTransformer::FORMAT_BASE58]));
+        $this->assertSame($ulid->toBase32(), $transformer->transform($ulid, [UlidValueObjectTransformer::FORMAT_KEY => UlidValueObjectTransformer::FORMAT_BASE32]));
+    }
+
+    public function testTransformThrowWhenInvalidNativeValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The native value must be an instance of "Symfony\Component\Uid\Ulid".');
+
+        (new UlidValueObjectTransformer())->transform(new \stdClass());
+    }
+
+    public function testTransformThrowWhenInvalidFormat()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "invalid" format is not valid.');
+
+        (new UlidValueObjectTransformer())->transform(Ulid::fromString(self::ULID), [UlidValueObjectTransformer::FORMAT_KEY => 'invalid']);
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new UlidValueObjectTransformer();
+        $ulid = Ulid::fromString(self::ULID);
+
+        $this->assertInstanceOf(Ulid::class, $transformer->reverseTransform(self::ULID));
+        $this->assertEquals($ulid, $transformer->reverseTransform(self::ULID));
+    }
+
+    public function testReverseTransformThrowWhenInvalidJsonValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value must be a string, "int" given.');
+
+        (new UlidValueObjectTransformer())->reverseTransform(42);
+    }
+
+    public function testReverseTransformThrowWhenInvalidUlidString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The string "not a ulid" is not a valid ULID.');
+
+        (new UlidValueObjectTransformer())->reverseTransform('not a ulid');
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Transformer/UuidValueObjectTransformerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Transformer/UuidValueObjectTransformerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Transformer;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\JsonStreamer\Transformer\UuidValueObjectTransformer;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Uid\UuidV7;
+
+class UuidValueObjectTransformerTest extends TestCase
+{
+    private const UUID = 'a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40';
+
+    public function testTransform()
+    {
+        $transformer = new UuidValueObjectTransformer();
+        $uuid = Uuid::fromString(self::UUID);
+
+        $this->assertSame(self::UUID, $transformer->transform($uuid));
+        $this->assertSame((string) $uuid, $transformer->transform($uuid, [UuidValueObjectTransformer::FORMAT_KEY => UuidValueObjectTransformer::FORMAT_CANONICAL]));
+        $this->assertSame($uuid->toRfc4122(), $transformer->transform($uuid, [UuidValueObjectTransformer::FORMAT_KEY => UuidValueObjectTransformer::FORMAT_RFC4122]));
+        $this->assertSame($uuid->toBase58(), $transformer->transform($uuid, [UuidValueObjectTransformer::FORMAT_KEY => UuidValueObjectTransformer::FORMAT_BASE58]));
+        $this->assertSame($uuid->toBase32(), $transformer->transform($uuid, [UuidValueObjectTransformer::FORMAT_KEY => UuidValueObjectTransformer::FORMAT_BASE32]));
+    }
+
+    public function testTransformThrowWhenInvalidNativeValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The native value must be an instance of "Symfony\Component\Uid\Uuid".');
+
+        (new UuidValueObjectTransformer())->transform(new \stdClass());
+    }
+
+    public function testTransformThrowWhenInvalidFormat()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "invalid" format is not valid.');
+
+        (new UuidValueObjectTransformer())->transform(Uuid::fromString(self::UUID), [UuidValueObjectTransformer::FORMAT_KEY => 'invalid']);
+    }
+
+    /**
+     * @param class-string<Uuid> $expectedClass
+     */
+    #[DataProvider('reverseTransformDataProvider')]
+    public function testReverseTransform(string $expectedClass, string $string)
+    {
+        $transformer = new UuidValueObjectTransformer();
+
+        $this->assertInstanceOf($expectedClass, $transformer->reverseTransform($string));
+        $this->assertEquals(Uuid::fromString($string), $transformer->reverseTransform($string));
+    }
+
+    public static function reverseTransformDataProvider(): iterable
+    {
+        yield [UuidV4::class, 'a7613e0a-5986-4f29-b3f8-3b6f8e5e6b40'];
+        yield [UuidV7::class, '018f7a5e-3c1e-7a4e-8b1a-2c3d4e5f6a7b'];
+    }
+
+    public function testReverseTransformThrowWhenInvalidJsonValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JSON value must be a string, "int" given.');
+
+        (new UuidValueObjectTransformer())->reverseTransform(42);
+    }
+
+    public function testReverseTransformThrowWhenInvalidUuidString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The string "not a uuid" is not a valid UUID.');
+
+        (new UuidValueObjectTransformer())->reverseTransform('not a uuid');
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Transformer/UlidValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/UlidValueObjectTransformer.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Transformer;
+
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+use Symfony\Component\Uid\Exception\InvalidArgumentException as UidInvalidArgumentException;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * Transforms a {@see Ulid} to a string and vice versa.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @psalm-type Options = array{
+ *     uid_format?: self::FORMAT_*,
+ *     ...<string, mixed>,
+ * }
+ *
+ * @implements ValueObjectTransformerInterface<Ulid, string>
+ */
+final class UlidValueObjectTransformer implements ValueObjectTransformerInterface
+{
+    public const FORMAT_KEY = 'uid_format';
+
+    public const FORMAT_CANONICAL = 'canonical';
+    public const FORMAT_BASE58 = 'base58';
+    public const FORMAT_BASE32 = 'base32';
+    public const FORMAT_RFC4122 = 'rfc4122';
+    public const FORMAT_RFC9562 = self::FORMAT_RFC4122; // RFC 9562 obsoleted RFC 4122 but the format is the same
+
+    /**
+     * @param Options $options
+     */
+    public function transform(object $object, array $options = []): string
+    {
+        if (!$object instanceof Ulid) {
+            throw new InvalidArgumentException(\sprintf('The native value must be an instance of "%s".', Ulid::class));
+        }
+
+        $format = $options[self::FORMAT_KEY] ?? self::FORMAT_CANONICAL;
+
+        return match ($format) {
+            self::FORMAT_CANONICAL => (string) $object,
+            self::FORMAT_BASE58 => $object->toBase58(),
+            self::FORMAT_BASE32 => $object->toBase32(),
+            self::FORMAT_RFC4122 => $object->toRfc4122(),
+            default => throw new InvalidArgumentException(\sprintf('The "%s" format is not valid.', $format)),
+        };
+    }
+
+    /**
+     * @return Ulid
+     */
+    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): object
+    {
+        if (!\is_string($scalar)) {
+            throw new InvalidArgumentException(\sprintf('The JSON value must be a string, "%s" given.', get_debug_type($scalar)));
+        }
+
+        try {
+            return Ulid::fromString($scalar);
+        } catch (UidInvalidArgumentException $e) {
+            throw new InvalidArgumentException(\sprintf('The string "%s" is not a valid ULID.', $scalar), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::STRING>
+     */
+    public static function getStreamValueType(): BuiltinType
+    {
+        return Type::string();
+    }
+
+    public static function getValueObjectClassName(): string
+    {
+        return Ulid::class;
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/Transformer/UuidValueObjectTransformer.php
+++ b/src/Symfony/Component/JsonStreamer/Transformer/UuidValueObjectTransformer.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Transformer;
+
+use Symfony\Component\JsonStreamer\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+use Symfony\Component\Uid\Exception\InvalidArgumentException as UidInvalidArgumentException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Transforms a {@see Uuid} to a string and vice versa.
+ *
+ * @author Mathias Arlaud <mathias.arlaud@gmail.com>
+ *
+ * @psalm-type Options = array{
+ *     uid_format?: self::FORMAT_*,
+ *     ...<string, mixed>,
+ * }
+ *
+ * @implements ValueObjectTransformerInterface<Uuid, string>
+ */
+final class UuidValueObjectTransformer implements ValueObjectTransformerInterface
+{
+    public const FORMAT_KEY = 'uid_format';
+
+    public const FORMAT_CANONICAL = 'canonical';
+    public const FORMAT_BASE58 = 'base58';
+    public const FORMAT_BASE32 = 'base32';
+    public const FORMAT_RFC4122 = 'rfc4122';
+    public const FORMAT_RFC9562 = self::FORMAT_RFC4122; // RFC 9562 obsoleted RFC 4122 but the format is the same
+
+    /**
+     * @param Options $options
+     */
+    public function transform(object $object, array $options = []): string
+    {
+        if (!$object instanceof Uuid) {
+            throw new InvalidArgumentException(\sprintf('The native value must be an instance of "%s".', Uuid::class));
+        }
+
+        $format = $options[self::FORMAT_KEY] ?? self::FORMAT_CANONICAL;
+
+        return match ($format) {
+            self::FORMAT_CANONICAL => (string) $object,
+            self::FORMAT_BASE58 => $object->toBase58(),
+            self::FORMAT_BASE32 => $object->toBase32(),
+            self::FORMAT_RFC4122 => $object->toRfc4122(),
+            default => throw new InvalidArgumentException(\sprintf('The "%s" format is not valid.', $format)),
+        };
+    }
+
+    /**
+     * @return Uuid
+     */
+    public function reverseTransform(int|float|string|bool|null $scalar, array $options = []): object
+    {
+        if (!\is_string($scalar)) {
+            throw new InvalidArgumentException(\sprintf('The JSON value must be a string, "%s" given.', get_debug_type($scalar)));
+        }
+
+        try {
+            return Uuid::fromString($scalar);
+        } catch (UidInvalidArgumentException $e) {
+            throw new InvalidArgumentException(\sprintf('The string "%s" is not a valid UUID.', $scalar), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @return BuiltinType<TypeIdentifier::STRING>
+     */
+    public static function getStreamValueType(): BuiltinType
+    {
+        return Type::string();
+    }
+
+    public static function getValueObjectClassName(): string
+    {
+        return Uuid::class;
+    }
+}

--- a/src/Symfony/Component/JsonStreamer/composer.json
+++ b/src/Symfony/Component/JsonStreamer/composer.json
@@ -43,7 +43,8 @@
         "phpstan/phpdoc-parser": "^1.0",
         "symfony/config": "^7.4|^8.0",
         "symfony/dependency-injection": "^7.4|^8.0",
-        "symfony/http-kernel": "^7.4|^8.0"
+        "symfony/http-kernel": "^7.4|^8.0",
+        "symfony/uid": "^7.4|^8.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\JsonStreamer\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds `Uuid` and `Ulid` value object support, with a `uid_format` option (`canonical` by default, plus `base58`, `base32` and `rfc4122`).

`PhpGeneratorTrait::getValueObjectTransformerId()` walks the parent chain, so `UuidV1` to `UuidV8`, `NilUuid`, `MaxUuid`, `NilUlid` and `MaxUlid` resolve without being registered.

Changed during review:

* **`composer require symfony/json-streamer` fatalled without `symfony/uid`.** That package is a `require-dev`, so it is optional, but both new classes declared a native concrete return type. PHP has to resolve `Uuid` when the class is loaded, to check variance against the interface's `: object`, and that is a hard fatal rather than a catchable error:

  ```
  PHP Fatal error:  Could not check compatibility between
    ...UuidValueObjectTransformer::reverseTransform(...): Symfony\Component\Uid\Uuid
  and ...ValueObjectTransformerInterface::reverseTransform(...): object,
  because class Symfony\Component\Uid\Uuid is not available
  ```

  Two paths reached it on a default install. `JsonStreamReader::create()` and `JsonStreamWriter::create()` instantiate every built-in transformer unconditionally, and `TransformerPass::process()` calls `is_a($class, ValueObjectTransformerInterface::class, true)` on every tagged service at container compile time, so a plain cache warmup was enough.

  `GmpNumberValueObjectTransformer` and `BcMathNumberValueObjectTransformer` have the same problem with `ext-gmp` and `ext-bcmath`, and solve it by declaring `: object` with an `@return` docblock. Both new classes now do the same. Verified with an autoloader that never maps `Symfony\Component\Uid\`: `is_a()` returns `true` for both classes and `JsonStreamWriter::create()` succeeds, where both fatalled before. `GmpNumberValueObjectTransformer` and `DateTimeValueObjectTransformer` load fine under the same autoloader, so the fatal was the return type and not the missing prefix;

* **PHPStan was red.** `Instanceof between Symfony\Component\Uid\Uuid and Symfony\Component\Uid\Uuid will always evaluate to true`, and the same for `Ulid`. `@implements ValueObjectTransformerInterface<Uuid, string>` binds the inherited `@param T $object` to the concrete class, so the guard in `transform()` reads as dead. It is not dead: the generated code calls `transform()` through the transformer container with whatever object the property holds.

  This is not specific to the two new classes. `GmpNumberValueObjectTransformer`, `BcMathNumberValueObjectTransformer` and the date transformers all have the same shape; they are invisible today only because the CI job diffs PHPStan on the base branch against the PR, so pre-existing errors are filtered out. Annotating `@param object $object` does silence it, but `no_superfluous_phpdoc_tags` strips the line straight back out, so `phpstan.dist.neon` carries the exemption instead, scoped to the transformer directory and covering the older ones too;

* **CHANGELOG wording.** `` `Uid` `` is not a class, while every neighbouring entry names one. It now reads `` Add `Uuid` and `Ulid` value object support with `UuidValueObjectTransformer` and `UlidValueObjectTransformer` ``, plus a line for the option.

Rebased on 8.2, which resolves the one-line `@psalm-type` conflict with #64190 in `JsonStreamReader.php`. Both options are kept, ordered as `JsonStreamWriter.php` already had them.

Suites: JsonStreamer 588, Uid 209, FrameworkBundle DependencyInjection 516, and the `JsonStreamerTest` functional test, all green.

### Known limitations, not addressed here

* **A user subclass writes and cannot be read back.** `reverseTransform()` calls `Uuid::fromString()`, which returns the version subclass rather than the declared property type:

  ```
  final class OrderId extends UuidV7
  written {"v":"019fa28e-bfce-708e-a3d5-825064aec727"}
  read    Cannot assign Symfony\Component\Uid\UuidV7 to property $v of type OrderId
  ```

  `Uuid::fromString()` already honours late static binding, so the information exists; what is missing is the target class at reverse-transform time, and `ValueObjectTransformerInterface::reverseTransform()` does not receive it. This is the one place where the comparison with `UidNormalizer` does not hold, since that one calls `$type::fromString($data)`. Worth stating in the docs at least;

* **a property typed `AbstractUid` writes `{}` and reads back a raw `\Error`.** `AbstractUid` resolves to no transformer, so the generic "unsupported object" path applies. `UidNormalizer` advertises `AbstractUid` in `getSupportedTypes()`, so people coming from the Serializer will type properties that way;

* **a non-string `uid_format` warns before throwing.** `sprintf('The "%s" format is not valid.', $format)` emits `Array to string conversion` when the option is an array. Guarding with `is_string()` makes PHPStan flag the branch as dead, because `@psalm-type Options` documents `uid_format` as a union of the format constants, so the `default` arm is unreachable on paper. Fixing it means loosening the documented type, which is a call for another day;

* **the invalid-input exception echoes the whole value.** `The string "%s" is not a valid UUID.` reproduces an arbitrary payload verbatim. The Uid component's own `InvalidArgumentException` deliberately keeps that value out of the message and in a separate property, with a docblock saying it "is typically untrusted user input of arbitrary size or content". `DateIntervalValueObjectTransformer` echoes too, so there is precedent both ways.

A symfony-docs PR is due for `uid_format` and its four values.
