### PR TITLE
[Serializer] Fix `GetSetMethodNormalizer` denormalization of constructor only objects

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -89,6 +89,11 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
         $reflection = self::$reflectionCache[$class];
 
+        // Denormalization can also populate an object through its constructor, even when it exposes no setters (immutable value objects).
+        if (!$readAttributes && ($constructor = $reflection->getConstructor()) && $constructor->isPublic() && $constructor->getNumberOfParameters() > 0) {
+            return true;
+        }
+
         foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
             if ($readAttributes ? $this->isGetMethod($reflectionMethod) : $this->isSetMethod($reflectionMethod)) {
                 return true;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -617,6 +617,20 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->assertSame($expected, $obj->$method());
     }
 
+    public function testSupportsAndDenormalizeConstructorOnlyObject()
+    {
+        $this->assertTrue($this->normalizer->supportsDenormalization(['x' => 1, 'y' => 2], ImmutableDummy::class));
+
+        $obj = $this->normalizer->denormalize(['x' => 1, 'y' => 2], ImmutableDummy::class);
+        $this->assertSame(1, $obj->getX());
+        $this->assertSame(2, $obj->getY());
+    }
+
+    public function testDoesNotSupportDenormalizationOfNonPublicConstructorOnlyObject()
+    {
+        $this->assertFalse($this->normalizer->supportsDenormalization(['x' => 1], ImmutablePrivateConstructorDummy::class));
+    }
+
     public function testDiscriminatorWithAllowExtraAttributesFalse()
     {
         // Discriminator type property should be allowed with allow_extra_attributes=false
@@ -783,6 +797,43 @@ class GetConstructorDummy
     public function otherMethod()
     {
         throw new \RuntimeException('Dummy::otherMethod() should not be called');
+    }
+}
+
+class ImmutableDummy
+{
+    public function __construct(
+        private int $x,
+        private int $y,
+    ) {
+    }
+
+    public function getX(): int
+    {
+        return $this->x;
+    }
+
+    public function getY(): int
+    {
+        return $this->y;
+    }
+}
+
+class ImmutablePrivateConstructorDummy
+{
+    private function __construct(
+        private int $x,
+    ) {
+    }
+
+    public static function create(int $x): self
+    {
+        return new self($x);
+    }
+
+    public function getX(): int
+    {
+        return $this->x;
     }
 }
 


### PR DESCRIPTION
| Q             | A          |
| ------------- | ---------- |
| Branch?       | 6.4        |
| Bug fix?      | yes        |
| New feature?  | no         |
| Deprecations? | no         |
| Issues        | Fix #64702 |
| License       | MIT        |

`GetSetMethodNormalizer` can no longer denormalize immutable value objects built only through their constructor (getters, no setters). Indeed, `supportsDenormalization()` only matches classes exposing a setter, while `denormalize()` can still build these objects via their constructor.

This makes `supports()` also accept a class with a parameterized constructor, fixing the inconsistency.