### PR TITLE
[VarExporter] Adapt ProxyHelper tests to PHP 8.6 null byte rendering in default values

### DIFF
--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -40,6 +40,10 @@ class ProxyHelperTest extends TestCase
             $expected = str_replace('self', '\\'.TestForProxyHelper::class, $expected);
             $expected = str_replace('= [namespace\M_PI, new M_PI()]', '= [\M_PI, new \Symfony\Component\VarExporter\Tests\M_PI()]', $expected);
 
+            if (\PHP_VERSION_ID >= 80600) {
+                $expected = str_replace('"a\0b"', '"a\000b"', $expected);
+            }
+
             yield [$expected, $method];
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT
