### PR TITLE
[Routing] Detect circular references in object route parameters

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -282,10 +282,16 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         // add a query string if needed
         $extra = array_udiff_assoc(array_diff_key($parameters, $variables), $defaults, static fn ($a, $b) => $a == $b ? 0 : 1);
 
-        array_walk_recursive($extra, $caster = static function (&$v) use (&$caster) {
+        $seen = [];
+        array_walk_recursive($extra, $caster = static function (&$v) use (&$caster, &$seen, $name) {
             if (\is_object($v)) {
+                if (isset($seen[$id = spl_object_id($v)])) {
+                    throw new InvalidParameterException(\sprintf('Parameters for route "%s" cannot contain a circular reference (in object of class "%s").', $name, get_debug_type($v)));
+                }
                 if ($vars = get_object_vars($v)) {
+                    $seen[$id] = true;
                     array_walk_recursive($vars, $caster);
+                    unset($seen[$id]);
                     $v = $vars;
                 } elseif (method_exists($v, '__toString')) {
                     $v = (string) $v;

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -138,6 +138,12 @@ class UrlGeneratorTest extends TestCase
         $nestedStdClass = new \stdClass();
         $nestedStdClass->nested = $stdClass;
 
+        $sharedLeaf = new \stdClass();
+        $sharedLeaf->baz = 'bar';
+        $sharedObject = new \stdClass();
+        $sharedObject->left = $sharedLeaf;
+        $sharedObject->right = $sharedLeaf;
+
         return [
             'null' => ['', 'foo', null],
             'string' => ['?foo=bar', 'foo', 'bar'],
@@ -151,7 +157,24 @@ class UrlGeneratorTest extends TestCase
             'stdClass in nested stdClass' => ['?foo%5Bnested%5D%5Bbaz%5D=bar', 'foo', $nestedStdClass],
             'non stringable object' => ['', 'foo', new NonStringableObject()],
             'non stringable object but has public property' => ['?foo%5Bfoo%5D=property', 'foo', new NonStringableObjectWithPublicProperty()],
+            // a shared (acyclic) reference must not be mistaken for a circular one
+            'object with a shared acyclic reference' => ['?foo%5Bleft%5D%5Bbaz%5D=bar&foo%5Bright%5D%5Bbaz%5D=bar', 'foo', $sharedObject],
         ];
+    }
+
+    public function testGenerateWithCircularObjectReference()
+    {
+        $a = new \stdClass();
+        $b = new \stdClass();
+        $a->b = $b;
+        $b->a = $a;
+
+        $routes = $this->getRoutes('test', new Route('/testing'));
+
+        $this->expectException(InvalidParameterException::class);
+        $this->expectExceptionMessage('Parameters for route "test" cannot contain a circular reference');
+
+        $this->getGenerator($routes)->generate('test', ['foo' => $a]);
     }
 
     public function testUrlWithExtraParametersFromGlobals()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64619
| License       | MIT

`UrlGenerator::doGenerate()` casts object parameters to arrays through a recursive `array_walk_recursive` caster with no cycle guard. A self-referencing object graph runs the stack out — a raw SIGSEGV on PHP 8.2, a fatal `Maximum call stack size reached` on 8.3+ — with no usable error.

This tracks visited objects (by `spl_object_id()`) and throws an `InvalidParameterException` when a circular reference is found, as suggested in the issue. Shared but acyclic references (e.g. the same object referenced twice) are unaffected, since each object is only marked as "seen" while its own subtree is being walked.

Thanks @mihai-stancu for the report and @eyupcanakman for confirming the root cause. 🙏
