### PR TITLE
[String] Fix splice() on multibyte strings

### DIFF
--- a/src/Symfony/Component/String/CodePointString.php
+++ b/src/Symfony/Component/String/CodePointString.php
@@ -202,7 +202,7 @@ class CodePointString extends AbstractUnicodeString
 
         $str = clone $this;
         $start = $start ? \strlen(mb_substr($this->string, 0, $start, 'UTF-8')) : 0;
-        $length = $length ? \strlen(mb_substr($this->string, $start, $length, 'UTF-8')) : $length;
+        $length = $length ? \strlen(mb_substr(substr($this->string, $start), 0, $length, 'UTF-8')) : $length;
         $str->string = substr_replace($this->string, $replacement, $start, $length ?? \PHP_INT_MAX);
 
         return $str;

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -629,4 +629,25 @@ END'],
             ]
         );
     }
+
+    /**
+     * @dataProvider provideSpliceMultibyte
+     */
+    public function testSpliceMultibyte(string $expected, string $origin, string $replacement, int $start, ?int $length = null)
+    {
+        $this->assertEquals(
+            static::createFromString($expected),
+            static::createFromString($origin)->splice($replacement, $start, $length)
+        );
+    }
+
+    public static function provideSpliceMultibyte()
+    {
+        return [
+            ['aαb_c', 'aαbβc', '_', 3, 1],
+            ['αXc', 'ααbc', 'X', 1, 2],
+            ['α_δ', 'αβγδ', '_', 1, -1],
+            ['αβ_δ', 'αβγδ', '_', -2, 1],
+        ];
+    }
 }

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -286,7 +286,7 @@ class UnicodeString extends AbstractUnicodeString
         $str = clone $this;
 
         $start = $start ? \strlen(grapheme_substr($this->string, 0, $start)) : 0;
-        $length = $length ? \strlen(grapheme_substr($this->string, $start, $length ?? 2147483647)) : $length;
+        $length = $length ? \strlen(grapheme_substr(substr($this->string, $start), 0, $length)) : $length;
         $str->string = substr_replace($this->string, $replacement, $start, $length ?? 2147483647);
 
         if (normalizer_is_normalized($str->string)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`UnicodeString::splice()` and `CodePointString::splice()` convert `$start` from a character offset to a byte offset, then pass that byte offset back to `grapheme_substr()`/`mb_substr()` as a character offset when measuring the replaced length. With a multibyte character before `$start`, that measures the wrong region. `CodePointString` then returns a broken byte sequence, and `UnicodeString` throws "Invalid UTF-8 string." on valid input. The fix takes the length from the substring starting at the byte offset, which is already on a character boundary.
