### PR TITLE
[Filesystem] Trim trailing whitespace from the tempnam() prefix

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -633,8 +633,10 @@ class Filesystem
 
         // If no scheme or scheme is "file" or "gs" (Google Cloud) create temp file in local filesystem
         if ((null === $scheme || 'file' === $scheme || 'gs' === $scheme) && '' === $suffix) {
+            // PHP's tempnam() truncates the prefix to 63 characters; trim trailing whitespace
+            // from the truncated value, as a trailing space makes the file creation fail on Windows
             // If tempnam failed or no scheme return the filename otherwise prepend the scheme
-            if ($tmpFile = self::box('tempnam', $hierarchy, $prefix)) {
+            if ($tmpFile = self::box('tempnam', $hierarchy, rtrim(substr($prefix, 0, 63)))) {
                 if (null !== $scheme && 'gs' !== $scheme) {
                     return $scheme.'://'.$tmpFile;
                 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1474,6 +1474,18 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($filename);
     }
 
+    public function testTempnamTrimsTrailingWhitespaceFromTruncatedPrefix()
+    {
+        // PHP's tempnam() truncates the prefix to 63 characters; if that leaves a
+        // trailing space, the file creation fails on Windows. See #64722.
+        $prefix = str_repeat('a', 62).' suffix';
+
+        $filename = $this->filesystem->tempnam($this->workspace, $prefix);
+
+        $this->assertFileExists($filename);
+        $this->assertStringNotContainsString(' ', basename($filename));
+    }
+
     public function testTempnamWithFileScheme()
     {
         $scheme = 'file://';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64722
| License       | MIT

PHP's `tempnam()` truncates the prefix to 63 characters. On Windows, if that 63rd character ends up being a space, file creation is denied (`tempnam(): file created in the system's temporary directory`) and `tempnam()` returns `false` — so `Filesystem::dumpFile()` fails for any target filename with a space at position 63.

This trims trailing whitespace from the truncated prefix before passing it to PHP's `tempnam()`. The `substr(..., 0, 63)` mirrors PHP's own truncation so the trim targets the character that actually becomes trailing. The temp file name is an internal detail, so this has no observable effect on other platforms.

Thanks @spackmat for the very thorough report and root-cause analysis. 🙏
