### PR TITLE
[Form][Security][Validator] Improve Croatian translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hr.xlf
@@ -8,23 +8,23 @@
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file.</source>
-                <target>Prenesena datoteka je prevelika. Molim pokušajte prenijeti manju datoteku.</target>
+                <target>Prenesena datoteka je prevelika. Pokušajte prenijeti manju datoteku.</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF vrijednost nije ispravna. Pokušajte ponovo poslati obrazac.</target>
+                <target>CSRF token nije valjan. Pokušajte ponovno poslati obrazac.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>
-                <target>Ova vrijednost nije važeća HTML5 boja.</target>
+                <target>Ova vrijednost nije valjana HTML5 boja.</target>
             </trans-unit>
             <trans-unit id="100">
                 <source>Please enter a valid birthdate.</source>
-                <target>Molim upišite ispravan datum rođenja.</target>
+                <target>Unesite ispravan datum rođenja.</target>
             </trans-unit>
             <trans-unit id="101">
                 <source>The selected choice is invalid.</source>
-                <target>Odabrani izbor nije ispravan.</target>
+                <target>Odabrani izbor nije valjan.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>The collection is invalid.</source>
@@ -32,31 +32,31 @@
             </trans-unit>
             <trans-unit id="103">
                 <source>Please select a valid color.</source>
-                <target>Molim odaberite ispravnu boju.</target>
+                <target>Odaberite ispravnu boju.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>Please select a valid country.</source>
-                <target>Molim odaberite ispravnu državu.</target>
+                <target>Odaberite ispravnu državu.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>Please select a valid currency.</source>
-                <target>Molim odaberite ispravnu valutu.</target>
+                <target>Odaberite ispravnu valutu.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>Please choose a valid date interval.</source>
-                <target>Molim odaberite ispravni vremenski interval.</target>
+                <target>Odaberite ispravan vremenski interval.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Please enter a valid date and time.</source>
-                <target>Molim unesite ispravni datum i vrijeme.</target>
+                <target>Unesite ispravan datum i vrijeme.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Please enter a valid date.</source>
-                <target>Molim odaberite ispravan datum.</target>
+                <target>Unesite ispravan datum.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Please select a valid file.</source>
-                <target>Molim odaberite ispravnu datoteku.</target>
+                <target>Odaberite ispravnu datoteku.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The hidden field is invalid.</source>
@@ -64,23 +64,23 @@
             </trans-unit>
             <trans-unit id="111">
                 <source>Please enter an integer.</source>
-                <target>Molim unesite cijeli broj.</target>
+                <target>Unesite cijeli broj.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>Please select a valid language.</source>
-                <target>Molim odaberite ispravan jezik.</target>
+                <target>Odaberite ispravan jezik.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>Please select a valid locale.</source>
-                <target>Molim odaberite ispravnu lokalizaciju.</target>
+                <target>Odaberite ispravnu regionalnu oznaku.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>Please enter a valid money amount.</source>
-                <target>Molim unesite ispravan iznos novca.</target>
+                <target>Unesite ispravan novčani iznos.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>Please enter a number.</source>
-                <target>Molim unesite broj.</target>
+                <target>Unesite broj.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>The password is invalid.</source>
@@ -88,31 +88,31 @@
             </trans-unit>
             <trans-unit id="117">
                 <source>Please enter a percentage value.</source>
-                <target>Molim unesite vrijednost postotka.</target>
+                <target>Unesite postotnu vrijednost.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>The values do not match.</source>
-                <target>Ove vrijednosti se ne poklapaju.</target>
+                <target>Vrijednosti se ne podudaraju.</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>Please enter a valid time.</source>
-                <target>Molim unesite ispravno vrijeme.</target>
+                <target>Unesite ispravno vrijeme.</target>
             </trans-unit>
             <trans-unit id="120">
                 <source>Please select a valid timezone.</source>
-                <target>Molim odaberite ispravnu vremensku zonu.</target>
+                <target>Odaberite ispravnu vremensku zonu.</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>Please enter a valid URL.</source>
-                <target>Molim unesite ispravan URL.</target>
+                <target>Unesite ispravan URL.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>Please enter a valid search term.</source>
-                <target>Molim unesite ispravan pojam za pretraživanje.</target>
+                <target>Unesite ispravan pojam za pretraživanje.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>Please provide a valid phone number.</source>
-                <target>Molim navedite ispravan telefonski broj.</target>
+                <target>Navedite ispravan telefonski broj.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The checkbox has an invalid value.</source>
@@ -120,23 +120,23 @@
             </trans-unit>
             <trans-unit id="125">
                 <source>Please enter a valid email address.</source>
-                <target>Molim unesite valjanu adresu elektronske pošte.</target>
+                <target>Unesite ispravnu adresu e-pošte.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>Please select a valid option.</source>
-                <target>Molim odaberite ispravnu opciju.</target>
+                <target>Odaberite ispravnu opciju.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>Please select a valid range.</source>
-                <target>Molim odaberite ispravan raspon.</target>
+                <target>Odaberite ispravan raspon.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>Please enter a valid week.</source>
-                <target>Molim unesite ispravni tjedan.</target>
+                <target>Unesite ispravan tjedan.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target>Molim unesite ispravan UUID.</target>
+                <target>Unesite ispravan UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.hr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.hr.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
-                <target>Dogodila se autentifikacijske iznimka.</target>
+                <target>Došlo je do autentifikacijske iznimke.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>Authentication credentials could not be found.</source>
@@ -12,19 +12,19 @@
             </trans-unit>
             <trans-unit id="3">
                 <source>Authentication request could not be processed due to a system problem.</source>
-                <target>Autentifikacijski zahtjev nije moguće provesti uslijed sistemskog problema.</target>
+                <target>Autentifikacijski zahtjev nije moguće obraditi zbog problema u sustavu.</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>Invalid credentials.</source>
-                <target>Neispravni akreditacijski podaci.</target>
+                <target>Neispravni autentifikacijski podaci.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
-                <target>Cookie je već netko drugi iskoristio.</target>
+                <target>Netko drugi već je upotrijebio kolačić.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>Not privileged to request the resource.</source>
-                <target>Nemate privilegije zahtijevati resurs.</target>
+                <target>Nemate ovlasti zatražiti ovaj resurs.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>Invalid CSRF token.</source>
@@ -32,11 +32,11 @@
             </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
-                <target>Nije pronađen autentifikacijski provider koji bi podržao autentifikacijski token.</target>
+                <target>Nije pronađen pružatelj autentifikacije koji podržava autentifikacijski token.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>No session available, it either timed out or cookies are not enabled.</source>
-                <target>Sesija nije dostupna, ili je istekla ili cookies nisu omogućeni.</target>
+                <target>Sesija nije dostupna, istekla je ili kolačići nisu omogućeni.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>No token could be found.</source>
@@ -48,11 +48,11 @@
             </trans-unit>
             <trans-unit id="13">
                 <source>Account has expired.</source>
-                <target>Račun je isteko.</target>
+                <target>Račun je istekao.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>Credentials have expired.</source>
-                <target>Akreditacijski podaci su istekli.</target>
+                <target>Autentifikacijski podaci su istekli.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>Account is disabled.</source>
@@ -64,19 +64,19 @@
             </trans-unit>
             <trans-unit id="17">
                 <source>Too many failed login attempts, please try again later.</source>
-                <target>Previše neuspjelih pokušaja prijave, molim pokušajte ponovo kasnije.</target>
+                <target>Previše neuspjelih pokušaja prijave, pokušajte ponovno kasnije.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>Invalid or expired login link.</source>
-                <target>Link za prijavu je isteako ili je neispravan.</target>
+                <target>Poveznica za prijavu je istekla ili nije ispravna.</target>
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Previše neuspjelih pokušaja prijave, molim pokušajte ponovo za %minutes% minutu.</target>
+                <target>Previše neuspjelih pokušaja prijave, pokušajte ponovno za %minutes% minutu.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>Previše neuspjelih pokušaja prijave, pokušajte ponovo za %minutes% minutu.|Previše neuspjelih pokušaja prijave, pokušajte ponovo za %minutes% minute.|Previše neuspjelih pokušaja prijave, pokušajte ponovo za %minutes% minuta.</target>
+                <target>Previše neuspjelih pokušaja prijave, pokušajte ponovno za %minutes% minutu.|Previše neuspjelih pokušaja prijave, pokušajte ponovno za %minutes% minute.|Previše neuspjelih pokušaja prijave, pokušajte ponovno za %minutes% minuta.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="1">
                 <source>This value should be false.</source>
-                <target>Ova vrijednost treba biti netočna (false).</target>
+                <target>Ova vrijednost mora biti false.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>This value should be true.</source>
-                <target>Ova vrijednost treba biti točna (true).</target>
+                <target>Ova vrijednost mora biti true.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>This value should be of type {{ type }}.</source>
@@ -24,15 +24,15 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-                <target>Izaberite barem {{ limit }} mogućnosti.</target>
+                <target>Odaberite barem {{ limit }} mogućnost.|Odaberite barem {{ limit }} mogućnosti.|Odaberite barem {{ limit }} mogućnosti.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-                <target>Izaberite najviše {{ limit }} mogućnosti.</target>
+                <target>Odaberite najviše {{ limit }} mogućnost.|Odaberite najviše {{ limit }} mogućnosti.|Odaberite najviše {{ limit }} mogućnosti.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid.</source>
-                <target>Jedna ili više danih vrijednosti nije ispravna.</target>
+                <target>Jedna ili više unesenih vrijednosti nisu ispravne.</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>This field was not expected.</source>
@@ -48,15 +48,15 @@
             </trans-unit>
             <trans-unit id="12">
                 <source>This value is not a valid datetime.</source>
-                <target>Ova vrijednost nije ispravnog datum-vrijeme formata.</target>
+                <target>Ova vrijednost nije u ispravnom formatu datuma i vremena.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>This value is not a valid email address.</source>
-                <target>Ova vrijednost nije ispravna e-mail adresa.</target>
+                <target>Ova vrijednost nije ispravna adresa e-pošte.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>The file could not be found.</source>
-                <target>Datoteka ne može biti pronađena.</target>
+                <target>Datoteka nije pronađena.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>The file is not readable.</source>
@@ -64,11 +64,11 @@
             </trans-unit>
             <trans-unit id="16">
                 <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Datoteka je prevelika ({{ size }} {{ suffix }}). Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
+                <target>Datoteka je prevelika ({{ size }} {{ suffix }}). Najveća dopuštena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-                <target>Mime tip datoteke nije ispravan ({{ type }}). Dozvoljeni mime tipovi su {{ types }}.</target>
+                <target>MIME vrsta datoteke nije valjana ({{ type }}). Dopuštene MIME vrste su {{ types }}.</target>
             </trans-unit>
             <trans-unit id="18">
                 <source>This value should be {{ limit }} or less.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Ova vrijednost je predugačka. Treba imati {{ limit }} znakova ili manje.</target>
+                <target>Ova vrijednost je predugačka. Treba imati {{ limit }} znak ili manje.|Ova vrijednost je predugačka. Treba imati {{ limit }} znaka ili manje.|Ova vrijednost je predugačka. Treba imati {{ limit }} znakova ili manje.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,15 +84,15 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Ova vrijednost je prekratka. Treba imati {{ limit }} znakova ili više.</target>
+                <target>Ova vrijednost je prekratka. Treba imati {{ limit }} znak ili više.|Ova vrijednost je prekratka. Treba imati {{ limit }} znaka ili više.|Ova vrijednost je prekratka. Treba imati {{ limit }} znakova ili više.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
-                <target>Ova vrijednost ne bi trebala biti prazna.</target>
+                <target>Ova vrijednost ne smije biti prazna.</target>
             </trans-unit>
             <trans-unit id="23">
                 <source>This value should not be null.</source>
-                <target>Ova vrijednost ne bi trebala biti null.</target>
+                <target>Ova vrijednost ne smije biti null.</target>
             </trans-unit>
             <trans-unit id="24">
                 <source>This value should be null.</source>
@@ -116,7 +116,7 @@
             </trans-unit>
             <trans-unit id="32">
                 <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Ova datoteka je prevelika. Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
+                <target>Ova datoteka je prevelika. Najveća dopuštena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>
@@ -124,7 +124,7 @@
             </trans-unit>
             <trans-unit id="34">
                 <source>The file could not be uploaded.</source>
-                <target>Ova datoteka ne može biti prenesena.</target>
+                <target>Nije moguće prenijeti datoteku.</target>
             </trans-unit>
             <trans-unit id="35">
                 <source>This value should be a valid number.</source>
@@ -144,7 +144,7 @@
             </trans-unit>
             <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
-                <target>Ova vrijednost nije ispravana regionalna oznaka.</target>
+                <target>Ova vrijednost nije ispravna regionalna oznaka.</target>
             </trans-unit>
             <trans-unit id="40">
                 <source>This value is not a valid country.</source>
@@ -156,23 +156,23 @@
             </trans-unit>
             <trans-unit id="42">
                 <source>The size of the image could not be detected.</source>
-                <target>Veličina slike se ne može odrediti.</target>
+                <target>Nije moguće odrediti veličinu slike.</target>
             </trans-unit>
             <trans-unit id="43">
                 <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target>Širina slike je prevelika ({{ width }}px). Najveća dozvoljena širina je {{ max_width }}px.</target>
+                <target>Širina slike je prevelika ({{ width }}px). Najveća dopuštena širina je {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="44">
                 <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target>Širina slike je premala ({{ width }}px). Najmanja dozvoljena širina je {{ min_width }}px.</target>
+                <target>Širina slike je premala ({{ width }}px). Najmanja očekivana širina je {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target>Visina slike je prevelika ({{ height }}px). Najveća dozvoljena visina je {{ max_height }}px.</target>
+                <target>Visina slike je prevelika ({{ height }}px). Najveća dopuštena visina je {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="46">
                 <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target>Visina slike je premala ({{ height }}px). Najmanja dozvoljena visina je {{ min_height }}px.</target>
+                <target>Visina slike je premala ({{ height }}px). Najmanja očekivana visina je {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user's current password.</source>
@@ -180,7 +180,7 @@
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-                <target>Ova vrijednost treba imati točno {{ limit }} znakova.</target>
+                <target>Ova vrijednost treba imati točno {{ limit }} znak.|Ova vrijednost treba imati točno {{ limit }} znaka.|Ova vrijednost treba imati točno {{ limit }} znakova.</target>
             </trans-unit>
             <trans-unit id="49">
                 <source>The file was only partially uploaded.</source>
@@ -188,15 +188,15 @@
             </trans-unit>
             <trans-unit id="50">
                 <source>No file was uploaded.</source>
-                <target>Niti jedna datoteka nije prenesena.</target>
+                <target>Nijedna datoteka nije prenesena.</target>
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target>Privremena mapa nije konfigurirana u php.ini-u, ili konfigurirana mapa ne postoji.</target>
+                <target>Privremena mapa nije konfigurirana u php.ini-u ili konfigurirana mapa ne postoji.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
-                <target>Ne mogu zapisati privremenu datoteku na disk.</target>
+                <target>Privremenu datoteku nije moguće zapisati na disk.</target>
             </trans-unit>
             <trans-unit id="53">
                 <source>A PHP extension caused the upload to fail.</source>
@@ -204,11 +204,11 @@
             </trans-unit>
             <trans-unit id="54">
                 <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
-                <target>Ova kolekcija treba sadržavati {{ limit }} ili više elemenata.|Ova kolekcija treba sadržavati {{ limit }} ili više elemenata.|Ova kolekcija treba sadržavati {{ limit }} ili više elemenata.</target>
+                <target>Ova kolekcija treba sadržavati {{ limit }} element ili više.|Ova kolekcija treba sadržavati {{ limit }} elementa ili više.|Ova kolekcija treba sadržavati {{ limit }} elemenata ili više.</target>
             </trans-unit>
             <trans-unit id="55">
                 <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-                <target>Ova kolekcija treba sadržavati {{ limit }} ili manje elemenata.|Ova kolekcija treba sadržavati {{ limit }} ili manje elemenata.|Ova kolekcija treba sadržavati {{ limit }} ili manje elemenata.</target>
+                <target>Ova kolekcija treba sadržavati {{ limit }} element ili manje.|Ova kolekcija treba sadržavati {{ limit }} elementa ili manje.|Ova kolekcija treba sadržavati {{ limit }} elemenata ili manje.</target>
             </trans-unit>
             <trans-unit id="56">
                 <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
@@ -260,7 +260,7 @@
             </trans-unit>
             <trans-unit id="68">
                 <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-                <target>Ova vrijednost treba biti {{ compared_value_type }} {{ compared_value }}.</target>
+                <target>Ova vrijednost treba biti identična vrijednosti {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="69">
                 <source>This value should be less than {{ compared_value }}.</source>
@@ -276,35 +276,35 @@
             </trans-unit>
             <trans-unit id="72">
                 <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-                <target>Ova vrijednost treba biti različita od {{ compared_value_type }} {{ compared_value }}.</target>
+                <target>Ova vrijednost ne smije biti identična vrijednosti {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="73">
                 <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target>Omjer slike je prevelik ({{ ratio }}). Dozvoljeni maksimalni omjer je {{ max_ratio }}.</target>
+                <target>Omjer slike je prevelik ({{ ratio }}). Najveći dopušteni omjer je {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="74">
                 <source>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target>Omjer slike je premali ({{ ratio }}). Minimalni očekivani omjer je {{ min_ratio }}.</target>
+                <target>Omjer slike je premali ({{ ratio }}). Najmanji očekivani omjer je {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="75">
                 <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
-                <target>Slika je kvadratnog oblika ({{ width }}x{{ height }}px). Kvadratne slike nisu dozvoljene.</target>
+                <target>Slika je kvadratnog oblika ({{ width }}x{{ height }}px). Kvadratne slike nisu dopuštene.</target>
             </trans-unit>
             <trans-unit id="76">
                 <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-                <target>Slika je orijentirana horizontalno ({{ width }}x{{ height }}px). Horizontalno orijentirane slike nisu dozvoljene.</target>
+                <target>Slika je orijentirana horizontalno ({{ width }}x{{ height }}px). Horizontalno orijentirane slike nisu dopuštene.</target>
             </trans-unit>
             <trans-unit id="77">
                 <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
-                <target>Slika je orijentirana vertikalno ({{ width }}x{{ height }}px). Vertikalno orijentirane slike nisu dozvoljene.</target>
+                <target>Slika je orijentirana vertikalno ({{ width }}x{{ height }}px). Vertikalno orijentirane slike nisu dopuštene.</target>
             </trans-unit>
             <trans-unit id="78">
                 <source>An empty file is not allowed.</source>
-                <target>Prazna datoteka nije dozvoljena.</target>
+                <target>Prazna datoteka nije dopuštena.</target>
             </trans-unit>
             <trans-unit id="79">
                 <source>The host could not be resolved.</source>
-                <target>Poslužitelj ne može biti pronađen.</target>
+                <target>Nije moguće pronaći poslužitelj.</target>
             </trans-unit>
             <trans-unit id="80">
                 <source>This value does not match the expected {{ charset }} charset.</source>
@@ -324,19 +324,19 @@
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
-                <target>Ova vrijednost treba biti višekratnik od {{ compared_value }}.</target>
+                <target>Ova vrijednost treba biti višekratnik vrijednosti {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
-                <target>Poslovni identifikacijski broj (BIC) nije povezan sa IBAN brojem {{ iban }}.</target>
+                <target>Poslovni identifikacijski kod (BIC) nije povezan s IBAN brojem {{ iban }}.</target>
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>
-                <target>Ova vrijednost treba biti validan JSON.</target>
+                <target>Ova vrijednost treba biti valjani JSON.</target>
             </trans-unit>
             <trans-unit id="87">
                 <source>This collection should contain only unique elements.</source>
-                <target>Ova kolekcija treba sadržavati samo unikatne elemente.</target>
+                <target>Ova kolekcija treba sadržavati samo jedinstvene elemente.</target>
             </trans-unit>
             <trans-unit id="88">
                 <source>This value should be positive.</source>
@@ -356,11 +356,11 @@
             </trans-unit>
             <trans-unit id="92">
                 <source>This value is not a valid timezone.</source>
-                <target>Ova vrijednost nije validna vremenska zona.</target>
+                <target>Ova vrijednost nije ispravna vremenska zona.</target>
             </trans-unit>
             <trans-unit id="93">
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-                <target>Ova lozinka je procurila u nekom od sigurnosnih propusta, te je potrebno koristiti drugu lozinku.</target>
+                <target>Ova lozinka je otkrivena u povredi podataka i ne smije se upotrebljavati. Odaberite drugu lozinku.</target>
             </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
@@ -368,7 +368,7 @@
             </trans-unit>
             <trans-unit id="95">
                 <source>This value is not a valid hostname.</source>
-                <target>Ova vrijednost nije ispravno ime poslužitelja (engl. hostname).</target>
+                <target>Ova vrijednost nije valjani naziv poslužitelja (hostname).</target>
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
@@ -376,7 +376,7 @@
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
-                <target>Ova vrijednost mora zadovoljiti jedan od sljedećih ograničenja:</target>
+                <target>Ova vrijednost mora zadovoljiti barem jedno od sljedećih ograničenja:</target>
             </trans-unit>
             <trans-unit id="98">
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
@@ -384,7 +384,7 @@
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
-                <target>Ova vrijednost nije ispravan međunarodni identifikacijski broj vrijednosnih papira (ISIN).</target>
+                <target>Ova vrijednost nije valjani međunarodni identifikacijski broj vrijednosnih papira (ISIN).</target>
             </trans-unit>
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
@@ -392,7 +392,7 @@
             </trans-unit>
             <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
-                <target>Ova vrijednost nije važeća CSS boja.</target>
+                <target>Ova vrijednost nije valjana CSS boja.</target>
             </trans-unit>
             <trans-unit id="102">
                 <source>This value is not a valid CIDR notation.</source>
@@ -400,7 +400,7 @@
             </trans-unit>
             <trans-unit id="103">
                 <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-                <target>Vrijednost mrežne maske trebala bi biti između {{ min }} i {{ max }}.</target>
+                <target>Vrijednost mrežne maske treba biti između {{ min }} i {{ max }}.</target>
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
@@ -408,7 +408,7 @@
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target>Jačina lozinke je preniska. Molim koristite jaču lozinku.</target>
+                <target>Jačina lozinke je preniska. Upotrijebite jaču lozinku.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
@@ -428,11 +428,11 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target>Ekstenzija datoteke nije valjana ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
+                <target>Ekstenzija datoteke nije valjana ({{ extension }}). Dopuštene ekstenzije su {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target>Otkriveno kodiranje znakova je nevažeće ({{ detected }}). Dopuštena kodiranja su {{ encodings }}.</target>
+                <target>Otkriveno kodiranje znakova nije valjano ({{ detected }}). Dopuštena kodiranja su {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
@@ -444,11 +444,11 @@
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target>Ova vrijednost je prekratka. Trebala bi sadržavati barem jednu riječ.|Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječi.</target>
+                <target>Ova vrijednost je prekratka. Mora sadržavati barem {{ min }} riječ.|Ova vrijednost je prekratka. Mora sadržavati barem {{ min }} riječi.|Ova vrijednost je prekratka. Mora sadržavati barem {{ min }} riječi.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target>Ova vrijednost je predugačka. Trebala bi sadržavati samo jednu riječ.|Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječi ili manje.</target>
+                <target>Ova vrijednost je predugačka. Smije sadržavati najviše {{ max }} riječ.|Ova vrijednost je predugačka. Smije sadržavati najviše {{ max }} riječi.|Ova vrijednost je predugačka. Smije sadržavati najviše {{ max }} riječi.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
@@ -460,11 +460,11 @@
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target>Ova vrijednost ne bi trebala biti prije tjedna "{{ min }}".</target>
+                <target>Ova vrijednost ne smije biti prije tjedna "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target>Ova vrijednost ne bi trebala biti nakon tjedna "{{ max }}".</target>
+                <target>Ova vrijednost ne smije biti nakon tjedna "{{ max }}".</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
@@ -472,55 +472,55 @@
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target>Ova datoteka nije valjani videozapis.</target>
+                <target>Ova datoteka nije ispravan videozapis.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target>Veličina videozapisa nije mogla biti određena.</target>
+                <target>Nije moguće odrediti veličinu videozapisa.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target>Širina videozapisa je prevelika ({{ width }}px). Dopuštenа maksimalna širina je {{ max_width }}px.</target>
+                <target>Širina videozapisa je prevelika ({{ width }}px). Najveća dopuštena širina je {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target>Širina videozapisa je premala ({{ width }}px). Očekivana minimalna širina je {{ min_width }}px.</target>
+                <target>Širina videozapisa je premala ({{ width }}px). Najmanja očekivana širina je {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target>Visina videozapisa je prevelika ({{ height }}px). Dopuštena maksimalna visina je {{ max_height }}px.</target>
+                <target>Visina videozapisa je prevelika ({{ height }}px). Najveća dopuštena visina je {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target>Visina videozapisa je premala ({{ height }}px). Očekivana minimalna visina je {{ min_height }}px.</target>
+                <target>Visina videozapisa je premala ({{ height }}px). Najmanja očekivana visina je {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target>Video ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
+                <target>Videozapis ima premalo piksela ({{ pixels }}). Najmanji očekivani broj piksela je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target>Video ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
+                <target>Videozapis ima previše piksela ({{ pixels }}). Najveći očekivani broj piksela je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target>Omjer videa je prevelik ({{ ratio }}). Dopušteni maksimalni omjer je {{ max_ratio }}.</target>
+                <target>Omjer videozapisa je prevelik ({{ ratio }}). Najveći dopušteni omjer je {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target>Omjer videa je premalen ({{ ratio }}). Minimalni očekivani omjer je {{ min_ratio }}.</target>
+                <target>Omjer videozapisa je premalen ({{ ratio }}). Najmanji očekivani omjer je {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target>Video je kvadratan ({{ width }}x{{ height }}px). Kvadratni videozapisi nisu dopušteni.</target>
+                <target>Videozapis je kvadratan ({{ width }}x{{ height }}px). Kvadratni videozapisi nisu dopušteni.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target>Video je vodoravne orijentacije ({{ width }}x{{ height }} px). Vodoravni videozapisi nisu dopušteni.</target>
+                <target>Videozapis je vodoravne orijentacije ({{ width }}x{{ height }}px). Videozapisi vodoravne orijentacije nisu dopušteni.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target>Video je okomite orijentacije ({{ width }}x{{ height }} px). Videozapisi okomite orijentacije nisu dopušteni.</target>
+                <target>Videozapis je okomite orijentacije ({{ width }}x{{ height }}px). Videozapisi okomite orijentacije nisu dopušteni.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
@@ -528,7 +528,7 @@
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target>Video sadrži više tokova. Dopušten je samo jedan tok.</target>
+                <target>Videozapis sadrži više tokova. Dopušten je samo jedan tok.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
@@ -544,11 +544,11 @@
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target>Slika ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
+                <target>Slika ima premalo piksela ({{ pixels }}). Najmanji očekivani broj piksela je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target>Slika ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
+                <target>Slika ima previše piksela ({{ pixels }}). Najveći očekivani broj piksela je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
@@ -556,7 +556,7 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target>Ova vrijednost nije važeći XML.</target>
+                <target>Ova vrijednost nije valjani XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
@@ -564,11 +564,11 @@
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target>Ovaj XML sadržaj je prevelik ({{ size }} bajtova): premašuje ograničenje od {{ limit }} bajtova.</target>
+                <target>Ovaj XML sadržaj je prevelik ({{ size }} B): premašuje ograničenje od {{ limit }} B.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target>Ova vrijednost nije važeći cron izraz.</target>
+                <target>Ova vrijednost nije valjani cron izraz.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The current Croatian translations are not in great shape. There are typos, awkward phrasing, grammar issues, missing plural forms, overly literal translations, and inconsistent terminology across messages.

This PR improves those translations with more natural wording and tries to standardize recurring terminology, for example valjan / važeći / ispravan, videozapis / videodatoteka, authentication terminology, and similar repeated terms. It also fixes Croatian pluralization where Symfony provides plural forms.