### PR TITLE
[Serializer] Skip `XmlEncoderTest::testEncodeException()` when using libxml ≥ 2.13

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -414,6 +414,10 @@ class XmlEncoderTest extends TestCase
 
     public function testEncodeException()
     {
+        if (\LIBXML_LOADED_VERSION >= 21300) {
+            $this->markTestSkipped('libxml outputs a replacement character reference (&#xFFFD;) instead of failing.');
+        }
+
         $this->expectException(NotEncodableValueException::class);
         $this->encoder->encode('Invalid character: '.\chr(7), 'xml');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

```console
$ php -i | grep 'libxml2 Version'
libxml2 Version => 2.15.3

$ ./phpunit src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php --filter=testEncodeException
PHPUnit 13.2.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.7
Configuration: /home/mathieu/PhpstormProjects/symfony/phpunit.xml.dist

F                                                                   1 / 1 (100%)

Time: 00:00.006, Memory: 20.00 MB

There was 1 failure:

1) Symfony\Component\Serializer\Tests\Encoder\XmlEncoderTest::testEncodeException
Failed asserting that exception of type "Symfony\Component\Serializer\Exception\NotEncodableValueException" is thrown.

/home/mathieu/PhpstormProjects/symfony/.phpunit/phpunit-13-0/phpunit:104
/home/mathieu/PhpstormProjects/symfony/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php:458
/home/mathieu/PhpstormProjects/symfony/vendor/symfony/phpunit-bridge/bin/simple-phpunit:13

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

I think it comes from https://gitlab.gnome.org/GNOME/libxml2/-/commit/4dcc2d743eb83b8aaec0d91660d615fdb024dad0