### PR TITLE
[Mime] Fix dropped whitespace between multiple encoded words

### DIFF
--- a/src/Symfony/Component/Mime/Header/AbstractHeader.php
+++ b/src/Symfony/Component/Mime/Header/AbstractHeader.php
@@ -188,17 +188,18 @@ abstract class AbstractHeader implements HeaderInterface
             $tokens[] = $encodedToken;
         }
 
-        foreach ($tokens as $i => $token) {
-            // whitespace(s) between 2 encoded tokens
-            if (
-                0 < $i
-                && isset($tokens[$i + 1])
-                && preg_match('~^[\t ]+$~', $token)
-                && $this->tokenNeedsEncoding($tokens[$i - 1])
-                && $this->tokenNeedsEncoding($tokens[$i + 1])
-            ) {
-                $tokens[$i - 1] .= $token.$tokens[$i + 1];
-                array_splice($tokens, $i, 2);
+        $i = 1;
+        while (isset($tokens[$i + 1])) {
+            // whitespace-only token(s) between 2 encoded tokens; a gap of N spaces yields N - 1 of them
+            $j = $i;
+            while (preg_match('~^[\t ]+$~', $tokens[$j] ?? '')) {
+                ++$j;
+            }
+            if ($j > $i && isset($tokens[$j]) && $this->tokenNeedsEncoding($tokens[$i - 1]) && $this->tokenNeedsEncoding($tokens[$j])) {
+                $tokens[$i - 1] .= implode('', \array_slice($tokens, $i, 1 + $j - $i));
+                array_splice($tokens, $i, 1 + $j - $i);
+            } else {
+                ++$i;
             }
         }
 

--- a/src/Symfony/Component/Mime/Tests/Header/MailboxHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/MailboxHeaderTest.php
@@ -72,6 +72,21 @@ class MailboxHeaderTest extends TestCase
         $this->assertSame('=?utf-8?Q?Fab=C3=AFen__P=C3=B6tencier?= <fabïen@symfony.com>', $header->getBodyAsString());
     }
 
+    public function testSpacesBetweenEncodedWordsAreNotDropped()
+    {
+        // decoders ignore linear whitespace between two adjacent encoded words (RFC 2047 section 6.2),
+        // so the whitespace must be folded into the encoded words themselves
+        $header = new MailboxHeader('Sender', new Address('fabïen@symfony.com', 'Fabïen  Pötencier  Länge'));
+        $this->assertSame('=?utf-8?Q?Fab=C3=AFen__P=C3=B6tencier__L=C3=A4nge?= <fabïen@symfony.com>', $header->getBodyAsString());
+
+        $header = new MailboxHeader('Sender', new Address('fabïen@symfony.com', 'Fabïen   Pötencier'));
+        $this->assertSame('=?utf-8?Q?Fab=C3=AFen___P=C3=B6tencier?= <fabïen@symfony.com>', $header->getBodyAsString());
+
+        // whitespace adjacent to unencoded text is significant and stays out of the encoded words
+        $header = new MailboxHeader('Sender', new Address('fabïen@symfony.com', 'Fabïen  Pötencier and  Länge  Grüße'));
+        $this->assertSame('=?utf-8?Q?Fab=C3=AFen__P=C3=B6tencier?= and  =?utf-8?Q?L=C3=A4nge__Gr=C3=BC=C3=9Fe?= <fabïen@symfony.com>', $header->getBodyAsString());
+    }
+
     public function testToString()
     {
         $header = new MailboxHeader('Sender', new Address('fabien@symfony.com'));

--- a/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
@@ -204,6 +204,17 @@ class UnstructuredHeaderTest extends TestCase
         );
     }
 
+    public function testWhitespaceRunsBetweenEncodedWordsAreEncodedTogether()
+    {
+        // decoders ignore linear whitespace between two adjacent encoded words (RFC 2047 section 6.2),
+        // so whitespace runs of any length must be folded into the encoded words themselves
+        $header = new UnstructuredHeader('Subject', 'Fabïen  Pötencier  Länge');
+        $this->assertSame('=?utf-8?Q?Fab=C3=AFen__P=C3=B6tencier__L=C3=A4nge?=', $header->getBodyAsString());
+
+        $header = new UnstructuredHeader('Subject', "Fabïen \t Pötencier");
+        $this->assertSame('=?utf-8?Q?Fab=C3=AFen_=09_P=C3=B6tencier?=', $header->getBodyAsString());
+    }
+
     public function testLanguageInformationAppearsInEncodedWords()
     {
         /* -- RFC 2231, 5.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The double-space handling from #58593 folds only the first whitespace gap between encoded words. With three or more words that each need encoding, like `Fabïen  Pötencier  Länge`, the later gaps are emitted as literal whitespace between separate encoded words. RFC 2047 decoders drop that whitespace, so those spaces are lost when the header is decoded.

The merge pass iterated the token list with `foreach` while `array_splice()` reindexed it, so every gap after the first was skipped. It now walks the live array with a `while` loop and folds all the gaps into one encoded word.
