### PR TITLE
[Contracts] Set splitsh tag_skip strategy to no_commit

### DIFF
--- a/src/Symfony/Contracts/splitsh.json
+++ b/src/Symfony/Contracts/splitsh.json
@@ -8,6 +8,7 @@
         "translation-contracts": "Translation"
     },
     "defaults": {
-        "git_constraint": "<1.8.2"
+        "git_constraint": "<1.8.2",
+        "tag_skip": "no_commit"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

Contract packages like `service-contracts` are produced by splitting a repository that was itself already split. That collapses the pull-request merges whose subjects (bug #..., feature #...) the default `tag_skip` policy relies on to decide what changed. So with v3.7.1, real changes (a rename in service-contracts, an NTLM fix in http-client-contracts) looked like
nothing happened, and all six components were left untagged.

The new `no_commit` strategy tags a patch whenever a component actually received a commit, instead of looking for those merge subjects. Milestones (.0 and pre-releases) are still always tagged. Every component that changed will now get its tag, and its changelog will list the real commits.
