### PR TITLE
[VarExporter] Add a NO_INLINE_ARRAY flag to export each array item on its own line

### DIFF
--- a/src/Symfony/Component/VarExporter/CHANGELOG.md
+++ b/src/Symfony/Component/VarExporter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `VarExporter::NO_INLINE_ARRAY` flag to export each array item on its own line
+
 8.1
 ---
 

--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\VarExporter\Internal;
 
+use Symfony\Component\VarExporter\VarExporter;
+
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  *
@@ -18,7 +20,7 @@ namespace Symfony\Component\VarExporter\Internal;
  */
 class Exporter
 {
-    public static function export($value, $indent = '')
+    public static function export($value, $indent = '', $flags = 0)
     {
         switch (true) {
             case \is_int($value) || \is_float($value): return var_export($value, true);
@@ -79,11 +81,11 @@ class Exporter
             if (\is_array($v)) {
                 $isFlat = false;
             }
-            $code .= self::export($v, $subIndent).",\n";
+            $code .= self::export($v, $subIndent, $flags).",\n";
             ++$size;
         }
 
-        if (!$isFlat) {
+        if (!$isFlat || ($flags & VarExporter::NO_INLINE_ARRAY)) {
             return "[\n".$code.$indent.']';
         }
 
@@ -101,7 +103,7 @@ class Exporter
                 if (\is_int($k) && $k > $j) {
                     $j = $k;
                 }
-                $code .= self::export($v, $indent);
+                $code .= self::export($v, $indent, $flags);
             }
 
             return $code.']';
@@ -123,7 +125,7 @@ class Exporter
             if (\is_int($k) && $k > $j) {
                 $j = $k;
             }
-            $part .= self::export($v, $subIndent).',';
+            $part .= self::export($v, $subIndent, $flags).',';
 
             if ('' !== $line && $lineSize + $partSize > 20) {
                 $code .= $subIndent.$line."\n";

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -319,6 +319,29 @@ class VarExporterTest extends TestCase
 
         $this->assertStringContainsString("['line1'.\"\\n\"\n                .'line2']", $exported);
     }
+
+    public function testNoInlineArray()
+    {
+        $value = ['foo' => ['1', '2', '3']];
+
+        // by default, short flat arrays are inlined
+        $this->assertSame(<<<'PHP'
+            [
+                'foo' => ['1', '2', '3'],
+            ]
+            PHP, VarExporter::export($value));
+
+        // with NO_INLINE_ARRAY, each item is placed on its own line
+        $this->assertSame(<<<'PHP'
+            [
+                'foo' => [
+                    '1',
+                    '2',
+                    '3',
+                ],
+            ]
+            PHP, VarExporter::export($value, flags: VarExporter::NO_INLINE_ARRAY));
+    }
 }
 
 class MyCloneable

--- a/src/Symfony/Component/VarExporter/VarExporter.php
+++ b/src/Symfony/Component/VarExporter/VarExporter.php
@@ -28,19 +28,25 @@ use Symfony\Component\VarExporter\Internal\Exporter;
 final class VarExporter
 {
     /**
+     * Exports each array item on its own line instead of inlining short flat arrays.
+     */
+    public const NO_INLINE_ARRAY = 1;
+
+    /**
      * Exports a serializable PHP value to PHP code.
      *
      * @param bool                              &$isStaticValue Set to true after execution if the provided value is static, false otherwise
      * @param array<class-string, class-string> &$foundClasses  Classes found in the value are added to this list as both keys and values
+     * @param int                               $flags          A bitmask of self::* constants to tweak the generated code
      *
      * @throws ExceptionInterface When the provided value cannot be serialized
      */
-    public static function export(mixed $value, ?bool &$isStaticValue = null, array &$foundClasses = []): string
+    public static function export(mixed $value, ?bool &$isStaticValue = null, array &$foundClasses = [], int $flags = 0): string
     {
         $isStaticValue = true;
 
         if (!\is_object($value) && !(\is_array($value) && $value) && !\is_resource($value) || $value instanceof \UnitEnum) {
-            return Exporter::export($value);
+            return Exporter::export($value, '', $flags);
         }
 
         if (\is_resource($value)) {
@@ -54,7 +60,7 @@ final class VarExporter
         }
 
         if (\array_key_exists('value', $data)) {
-            return Exporter::export($data['value']);
+            return Exporter::export($data['value'], '', $flags);
         }
 
         $isStaticValue = false;
@@ -68,6 +74,6 @@ final class VarExporter
             $foundClasses[$classes] = $classes;
         }
 
-        return '\deepclone_from_array('.Exporter::export($data).', null, true)';
+        return '\deepclone_from_array('.Exporter::export($data, '', $flags).', null, true)';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64591
| License       | MIT

Since 8.1, `VarExporter` inlines short flat arrays on a single line (≤ 20 items), instead of placing each item on its own line:

```php
VarExporter::export(['foo' => ['1', '2', '3']]);
// [
//     'foo' => ['1', '2', '3'],
// ]
```

As reported in #64591, this is a breaking change for use cases that rely on a consistent one-item-per-line layout (e.g. generating locale files, where a stable diff matters more than saving lines).

This PR adds an **opt-in** `VarExporter::NO_INLINE_ARRAY` flag that restores the one-item-per-line layout, matching the reporter's suggested "config setting/parameter" solution:

```php
VarExporter::export(['foo' => ['1', '2', '3']], flags: VarExporter::NO_INLINE_ARRAY);
// [
//     'foo' => [
//         '1',
//         '2',
//         '3',
//     ],
// ]
```

The default behavior is unchanged (the flag defaults to `0`), so there is no BC break. The implementation reuses the one-item-per-line code path already built internally, so the change is minimal.
