### PR TITLE
[FrameworkBundle] Fix `debug:container --tag` not showing priority of `#[AsTaggedItem]`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -300,7 +300,7 @@ class JsonDescriptor extends Descriptor
 
         if (!$omitTags) {
             $data['tags'] = [];
-            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $data['tags'][] = ['name' => $tagName, 'parameters' => $parameters];
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -260,7 +260,7 @@ class MarkdownDescriptor extends Descriptor
         }
 
         if (!(isset($options['omit_tags']) && $options['omit_tags'])) {
-            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $output .= "\n".'- Tag: `'.$tagName.'`';
                     foreach ($parameters as $name => $value) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -197,9 +197,16 @@ class TextDescriptor extends Descriptor
 
         $options['output']->title($title);
 
-        $serviceIds = isset($options['tag']) && $options['tag']
-            ? $this->sortTaggedServicesByPriority($container->findTaggedServiceIds($options['tag']))
-            : $this->sortServiceIds($container->getServiceIds());
+        if (isset($options['tag']) && $options['tag']) {
+            $services = [];
+            foreach ($container->findTaggedServiceIds($options['tag']) as $serviceId => $tags) {
+                $definition = $container->getDefinition($serviceId);
+                $services[$serviceId] = $this->resolvePriorityServiceTags($container, $definition, $options['tag']);
+            }
+            $serviceIds = $this->sortTaggedServicesByPriority($services);
+        } else {
+            $serviceIds = $this->sortServiceIds($container->getServiceIds());
+        }
         $maxTags = [];
 
         if (isset($options['filter'])) {
@@ -221,7 +228,7 @@ class TextDescriptor extends Descriptor
                     continue;
                 }
                 if ($showTag) {
-                    $tags = $definition->getTag($showTag);
+                    $tags = $services[$serviceId];
                     foreach ($tags as $tag) {
                         foreach ($tag as $key => $value) {
                             if (!isset($maxTags[$key])) {
@@ -252,7 +259,7 @@ class TextDescriptor extends Descriptor
             $styledServiceId = $rawOutput ? $serviceId : \sprintf('<fg=cyan>%s</fg=cyan>', OutputFormatter::escape($serviceId));
             if ($definition instanceof Definition) {
                 if ($showTag) {
-                    foreach ($this->sortByPriority($definition->getTag($showTag)) as $key => $tag) {
+                    foreach ($this->sortByPriority($services[$serviceId]) as $key => $tag) {
                         $tagValues = [];
                         foreach ($tagsNames as $tagName) {
                             if (\is_array($tagValue = $tag[$tagName] ?? '')) {
@@ -297,7 +304,7 @@ class TextDescriptor extends Descriptor
         $tableRows[] = ['Class', $definition->getClass() ?: '-'];
 
         $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
-        if (!$omitTags && ($tags = $definition->getTags())) {
+        if (!$omitTags && ($tags = $container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags())) {
             $tagInformation = [];
             foreach ($tags as $tagName => $tagData) {
                 foreach ($tagData as $tagParameters) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -311,7 +311,7 @@ class XmlDescriptor extends Descriptor
                 continue;
             }
 
-            $serviceXML = $this->getContainerServiceDocument($service, $serviceId, null, $showArguments);
+            $serviceXML = $this->getContainerServiceDocument($service, $serviceId, $service instanceof Definition ? $container : null, $showArguments);
             $containerXML->appendChild($containerXML->ownerDocument->importNode($serviceXML->childNodes->item(0), true));
         }
 
@@ -385,7 +385,7 @@ class XmlDescriptor extends Descriptor
         }
 
         if (!$omitTags) {
-            if ($tags = $this->sortTagsByPriority($definition->getTags())) {
+            if ($tags = $this->sortTagsByPriority($container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags())) {
                 $serviceXML->appendChild($tagsXML = $dom->createElement('tags'));
                 foreach ($tags as $tagName => $tagData) {
                     foreach ($tagData as $parameters) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
@@ -361,4 +361,25 @@ abstract class AbstractDescriptorTestCase extends TestCase
 
         return $data;
     }
+
+    /** @dataProvider getDescribeContainerBuilderWithTaggedItemPriorityTestData */
+    public function testDescribeContainerBuilderWithTaggedItemPriority(ContainerBuilder $builder, $expectedDescription, array $options)
+    {
+        $this->assertDescription($expectedDescription, $builder, $options);
+    }
+
+    public static function getDescribeContainerBuilderWithTaggedItemPriorityTestData(): array
+    {
+        $variations = ['tagged_item_priority' => ['tag' => 'app.handler']];
+        $data = [];
+        foreach (ObjectsProvider::getContainerBuildersWithTaggedItemPriority() as $name => $object) {
+            foreach ($variations as $suffix => $options) {
+                $file = \sprintf('%s_%s.%s', trim($name, '.'), $suffix, static::getFormat());
+                $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
+                $data[] = [$object, $description, $options];
+            }
+        }
+
+        return $data;
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -13,6 +13,9 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\FooUnitEnum;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Suit;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerHigh;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerLow;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerYaml;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -196,6 +199,29 @@ class ObjectsProvider
         $builder->setDefinitions(self::getContainerDefinitionsWithPriorityTags());
 
         return ['builder' => $builder];
+    }
+
+    public static function getContainerBuildersWithTaggedItemPriority()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setDefinitions(self::getContainerDefinitionsWithTaggedItemPriority());
+
+        return ['builder' => $builder];
+    }
+
+    public static function getContainerDefinitionsWithTaggedItemPriority()
+    {
+        return [
+            'handler_high' => (new Definition(TaggedItemHandlerHigh::class))
+                ->setPublic(true)
+                ->addTag('app.handler'),
+            'handler_yaml' => (new Definition(TaggedItemHandlerYaml::class))
+                ->setPublic(true)
+                ->addTag('app.handler', ['priority' => 50]),
+            'handler_low' => (new Definition(TaggedItemHandlerLow::class))
+                ->setPublic(true)
+                ->addTag('app.handler'),
+        ];
     }
 
     public static function getContainerDefinitionsWithPriorityTags()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.json
@@ -1,0 +1,69 @@
+{
+    "definitions": {
+        "handler_yaml": {
+            "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Fixtures\\TaggedItemHandlerYaml",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "deprecated": false,
+            "file": null,
+            "tags": [
+                {
+                    "name": "app.handler",
+                    "parameters": {
+                        "priority": 50
+                    }
+                }
+            ],
+            "usages": []
+        },
+        "handler_high": {
+            "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Fixtures\\TaggedItemHandlerHigh",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "deprecated": false,
+            "file": null,
+            "tags": [
+                {
+                    "name": "app.handler",
+                    "parameters": {
+                        "priority": 100
+                    }
+                }
+            ],
+            "usages": []
+        },
+        "handler_low": {
+            "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Fixtures\\TaggedItemHandlerLow",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "deprecated": false,
+            "file": null,
+            "tags": [
+                {
+                    "name": "app.handler",
+                    "parameters": {
+                        "priority": -100
+                    }
+                }
+            ],
+            "usages": []
+        }
+    },
+    "aliases": [],
+    "services": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.md
@@ -1,0 +1,50 @@
+Services with tag `app.handler`
+===============================
+
+Definitions
+-----------
+
+### handler_yaml
+
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerYaml`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Deprecated: no
+- Tag: `app.handler`
+    - Priority: 50
+- Usages: none
+
+### handler_high
+
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerHigh`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Deprecated: no
+- Tag: `app.handler`
+    - Priority: 100
+- Usages: none
+
+### handler_low
+
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerLow`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Deprecated: no
+- Tag: `app.handler`
+    - Priority: -100
+- Usages: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.txt
@@ -1,0 +1,11 @@
+
+[33mSymfony Container Services Tagged with "app.handler" Tag[39m
+[33m========================================================[39m
+
+ -------------- ---------- --------------------------------------------------------------------- 
+ [32m Service ID   [39m [32m priority [39m [32m Class name                                                          [39m 
+ -------------- ---------- --------------------------------------------------------------------- 
+  handler_high   100        Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerHigh  
+  handler_yaml   50         Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerYaml  
+  handler_low    -100       Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerLow   
+ -------------- ---------- ---------------------------------------------------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+  <definition id="handler_yaml" class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerYaml" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">
+    <tags>
+      <tag name="app.handler">
+        <parameter name="priority">50</parameter>
+      </tag>
+    </tags>
+  </definition>
+  <definition id="handler_high" class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerHigh" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">
+    <tags>
+      <tag name="app.handler">
+        <parameter name="priority">100</parameter>
+      </tag>
+    </tags>
+  </definition>
+  <definition id="handler_low" class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItemHandlerLow" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">
+    <tags>
+      <tag name="app.handler">
+        <parameter name="priority">-100</parameter>
+      </tag>
+    </tags>
+  </definition>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItemHandlerHigh.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItemHandlerHigh.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem(priority: 100)]
+class TaggedItemHandlerHigh
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItemHandlerLow.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItemHandlerLow.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem(priority: -100)]
+class TaggedItemHandlerLow
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItemHandlerYaml.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItemHandlerYaml.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class TaggedItemHandlerYaml
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64593
| License       | MIT

`debug:container --tag` sorts and displays tag metadata coming from `findTaggedServiceIds()` only, which ignores priorities declared via `#[AsTaggedItem]`. As a result, the displayed order and the `priority` column don't match the actual runtime injection order — while YAML-declared priorities work fine.

This is a backport of #63028, which fixed the same bug but was merged on `8.1` only and never reached the maintained `7.x`/`6.x` branches. `#[AsTaggedItem]` has been available [since 5.3](https://github.com/symfony/dependency-injection/blob/5.3/CHANGELOG.md), so the bug is present here too.

The fix resolves the `#[AsTaggedItem]` priority by reflection (`resolvePriorityServiceTags()`) and merges it into the tag metadata, so all descriptors (text/json/markdown/xml) reflect the real injection order for both YAML and attribute declarations.

**Before** (`debug:container --tag=app.handler`):

```
  Service ID       priority   Class name
  AlphaHandler     200        ...
  BetaHandler      100        ...
  GammaHandler                ...   <- #[AsTaggedItem(priority: 300)], shown last, no priority
  ...
  DeltaHandler                ...   <- #[AsTaggedItem(priority: -100)], no priority
```

**After**:

```
  Service ID       priority   Class name
  GammaHandler     300        ...
  AlphaHandler     200        ...
  BetaHandler      100        ...
  ...
  DeltaHandler     -100       ...
```

Note: I targeted `6.4` as the oldest maintained branch where the bug exists (the merge-up will carry it to `7.4`/`8.x`); happy to retarget to `7.4` if you prefer. I also added a regression test covering all four descriptor formats, which the original `8.1` PR did not include.

Adaptation vs `8.1`: `XmlDescriptor` keeps its `$showArguments` argument that doesn't exist on `8.1`.
