### PR TITLE
 RFC: Console Sub-Commands

### DIFF
--- a/src/Symfony/Component/Console/AbstractCommand.php
+++ b/src/Symfony/Component/Console/AbstractCommand.php
@@ -445,9 +445,6 @@ abstract class AbstractCommand
         }
 
         $command->setApplication($this->getApplication());
-        foreach ($command->commands as $subCommand) {
-            $subCommand->setApplication($this->getApplication());
-        }
 
         if (!$command->isEnabled()) {
             $command->setApplication(null);

--- a/src/Symfony/Component/Console/AbstractCommand.php
+++ b/src/Symfony/Component/Console/AbstractCommand.php
@@ -697,4 +697,16 @@ abstract class AbstractCommand
     }
 
     abstract public function getApplication(): ?Application;
+
+    /**
+     * Returns the namespace part of the command name.
+     *
+     * This method is not part of public API and should not be used directly.
+     */
+    public function extractNamespace(string $name, ?int $limit = null): string
+    {
+        $parts = explode(':', $name, -1);
+
+        return implode(':', null === $limit ? $parts : \array_slice($parts, 0, $limit));
+    }
 }

--- a/src/Symfony/Component/Console/AbstractCommand.php
+++ b/src/Symfony/Component/Console/AbstractCommand.php
@@ -517,7 +517,11 @@ abstract class AbstractCommand
             $command = new Command(null, $command);
         }
 
-        $command->setApplication($this);
+
+        $command->setApplication($this->getApplication());
+        foreach ($command->commands as $command) {
+            $command->setApplication($this->getApplication());
+        }
 
         if (!$command->isEnabled()) {
             $command->setApplication(null);
@@ -766,4 +770,6 @@ abstract class AbstractCommand
     {
         return '    '.implode("\n    ", $abbrevs);
     }
+
+    abstract public function getApplication(): ?Application;
 }

--- a/src/Symfony/Component/Console/AbstractCommand.php
+++ b/src/Symfony/Component/Console/AbstractCommand.php
@@ -36,8 +36,8 @@ abstract class AbstractCommand
     protected ?InputDefinition $definition = null;
     protected ?CommandLoaderInterface $commandLoader = null;
     protected ?ArgumentResolverInterface $argumentResolver = null;
-    private ?EventDispatcherInterface $dispatcher = null;
-    private array $commands = [];
+    protected ?EventDispatcherInterface $dispatcher = null;
+    protected array $commands = [];
     protected bool $wantHelps = false;
     protected string $defaultCommand;
     private Terminal $terminal;
@@ -124,89 +124,16 @@ abstract class AbstractCommand
      */
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        try {
-            // Makes ArgvInput::getFirstArgument() able to distinguish an option from an argument.
-            $input->bind($this->getDefinition());
-        } catch (ExceptionInterface) {
-            // Errors must be ignored, full binding/validation happens later when the command is known.
-        }
-
         $name = $this->getCommandName($input);
-        if (true === $input->hasParameterOption(['--help', '-h'], true)) {
-            if (!$name) {
-                $name = 'help';
-                $input = new ArrayInput(['command_name' => $this->defaultCommand]);
-            } else {
-                $this->wantHelps = true;
-            }
-        }
 
         if (!$name) {
-            $name = $this->defaultCommand;
-            $definition = $this->getDefinition();
-            $definition->setArguments(array_merge(
-                $definition->getArguments(),
-                [
-                    'command' => new InputArgument('command', InputArgument::OPTIONAL, $definition->getArgument('command')->getDescription(), $name),
-                ]
-            ));
+            throw new \RuntimeException(
+                'Command name cannot be determined from input'
+            );
         }
 
-        try {
-            $this->runningCommand = null;
-            // the command name MUST be the first element of the input
-            $command = $this->find($name);
-        } catch (\Throwable $e) {
-            if (($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException) && 1 === \count($alternatives = $e->getAlternatives()) && $input->isInteractive()) {
-                $alternative = $alternatives[0];
+        $command = $this->find($name);
 
-                $style = new SymfonyStyle($input, $output);
-                $output->writeln('');
-                $formattedBlock = (new FormatterHelper())->formatBlock(\sprintf('Command "%s" is not defined.', $name), 'error', true);
-                $output->writeln($formattedBlock);
-                if (!$style->confirm(\sprintf('Do you want to run "%s" instead? ', $alternative), false)) {
-                    if (null !== $this->dispatcher) {
-                        $event = new ConsoleErrorEvent($input, $output, $e);
-                        $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
-
-                        return $event->getExitCode();
-                    }
-
-                    return 1;
-                }
-
-                $command = $this->find($alternative);
-            } else {
-                if (null !== $this->dispatcher) {
-                    $event = new ConsoleErrorEvent($input, $output, $e);
-                    $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
-
-                    if (0 === $event->getExitCode()) {
-                        return 0;
-                    }
-
-                    $e = $event->getError();
-                }
-
-                try {
-                    if ($e instanceof CommandNotFoundException && $namespace = $this->findNamespace($name)) {
-                        $helper = new DescriptorHelper();
-                        $helper->describe($output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output, $this, [
-                            'format' => 'txt',
-                            'raw_text' => false,
-                            'namespace' => $namespace,
-                            'short' => false,
-                        ]);
-
-                        return isset($event) ? $event->getExitCode() : 1;
-                    }
-
-                    throw $e;
-                } catch (NamespaceNotFoundException) {
-                    throw $e;
-                }
-            }
-        }
 
         if ($command instanceof LazyCommand) {
             $command = $command->getCommand();
@@ -517,10 +444,9 @@ abstract class AbstractCommand
             $command = new Command(null, $command);
         }
 
-
         $command->setApplication($this->getApplication());
-        foreach ($command->commands as $command) {
-            $command->setApplication($this->getApplication());
+        foreach ($command->commands as $subCommand) {
+            $subCommand->setApplication($this->getApplication());
         }
 
         if (!$command->isEnabled()) {
@@ -560,7 +486,9 @@ abstract class AbstractCommand
 
         // When the command has a different name than the one used at the command loader level
         if (!isset($this->commands[$name])) {
-            throw new CommandNotFoundException(\sprintf('The "%s" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".', $name));
+            throw new CommandNotFoundException(\sprintf(
+                'The "%s" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".', $name
+            ));
         }
 
         $command = $this->commands[$name];

--- a/src/Symfony/Component/Console/AbstractCommand.php
+++ b/src/Symfony/Component/Console/AbstractCommand.php
@@ -1,0 +1,769 @@
+<?php
+
+namespace Symfony\Component\Console;
+use Symfony\Component\Console\ArgumentResolver\ArgumentResolverInterface;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
+use Symfony\Component\Console\Event\ConsoleAlarmEvent;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleSignalEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Exception\NamespaceNotFoundException;
+use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputAwareInterface;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\SignalRegistry\SignalRegistry;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+abstract class AbstractCommand
+{
+    protected ?Command $runningCommand = null;
+    protected ?InputDefinition $definition = null;
+    protected ?CommandLoaderInterface $commandLoader = null;
+    protected ?ArgumentResolverInterface $argumentResolver = null;
+    private ?EventDispatcherInterface $dispatcher = null;
+    private array $commands = [];
+    protected bool $wantHelps = false;
+    protected string $defaultCommand;
+    private Terminal $terminal;
+    private ?SignalRegistry $signalRegistry = null;
+    private array $signalsToDispatchEvent = [];
+    private ?int $alarmInterval = null;
+
+    protected function __construct(
+    ){
+        $this->defaultCommand = 'list';
+        $this->terminal = new Terminal();
+        if (\defined('SIGINT') && SignalRegistry::isSupported()) {
+            $this->signalRegistry = new SignalRegistry();
+            $this->signalsToDispatchEvent = [\SIGINT, \SIGQUIT, \SIGTERM, \SIGUSR1, \SIGUSR2, \SIGALRM];
+        }
+    }
+
+    public function getSignalRegistry(): SignalRegistry
+    {
+        if (!$this->signalRegistry) {
+            throw new RuntimeException('Signals are not supported. Make sure that the "pcntl" extension is installed and that "pcntl_*" functions are not disabled by your php.ini\'s "disable_functions" directive.');
+        }
+
+        return $this->signalRegistry;
+    }
+
+    public function setSignalsToDispatchEvent(int ...$signalsToDispatchEvent): void
+    {
+        $this->signalsToDispatchEvent = $signalsToDispatchEvent;
+    }
+
+    /**
+     * Sets the interval to schedule a SIGALRM signal in seconds.
+     */
+    public function setAlarmInterval(?int $seconds): void
+    {
+        $this->alarmInterval = $seconds;
+        $this->scheduleAlarm();
+    }
+
+    /**
+     * Gets the interval in seconds on which a SIGALRM signal is dispatched.
+     */
+    public function getAlarmInterval(): ?int
+    {
+        return $this->alarmInterval;
+    }
+
+    private function scheduleAlarm(): void
+    {
+        if (null !== $this->alarmInterval) {
+            $this->getSignalRegistry()->scheduleAlarm($this->alarmInterval);
+        }
+    }
+
+
+    /**
+     * @final
+     */
+    public function setArgumentResolver(ArgumentResolverInterface $argumentResolver): void
+    {
+        $this->argumentResolver = $argumentResolver;
+    }
+
+    public function getArgumentResolver(): ?ArgumentResolverInterface
+    {
+        return $this->argumentResolver;
+    }
+
+    public function setCommandLoader(CommandLoaderInterface $commandLoader): void
+    {
+        $this->commandLoader = $commandLoader;
+    }
+
+    public function getDefinition(): InputDefinition
+    {
+        return $this->definition;
+    }
+
+    /**
+     * Runs the a command
+     *
+     * @return int 0 if everything went fine, or an error code
+     */
+    public function doRun(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            // Makes ArgvInput::getFirstArgument() able to distinguish an option from an argument.
+            $input->bind($this->getDefinition());
+        } catch (ExceptionInterface) {
+            // Errors must be ignored, full binding/validation happens later when the command is known.
+        }
+
+        $name = $this->getCommandName($input);
+        if (true === $input->hasParameterOption(['--help', '-h'], true)) {
+            if (!$name) {
+                $name = 'help';
+                $input = new ArrayInput(['command_name' => $this->defaultCommand]);
+            } else {
+                $this->wantHelps = true;
+            }
+        }
+
+        if (!$name) {
+            $name = $this->defaultCommand;
+            $definition = $this->getDefinition();
+            $definition->setArguments(array_merge(
+                $definition->getArguments(),
+                [
+                    'command' => new InputArgument('command', InputArgument::OPTIONAL, $definition->getArgument('command')->getDescription(), $name),
+                ]
+            ));
+        }
+
+        try {
+            $this->runningCommand = null;
+            // the command name MUST be the first element of the input
+            $command = $this->find($name);
+        } catch (\Throwable $e) {
+            if (($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException) && 1 === \count($alternatives = $e->getAlternatives()) && $input->isInteractive()) {
+                $alternative = $alternatives[0];
+
+                $style = new SymfonyStyle($input, $output);
+                $output->writeln('');
+                $formattedBlock = (new FormatterHelper())->formatBlock(\sprintf('Command "%s" is not defined.', $name), 'error', true);
+                $output->writeln($formattedBlock);
+                if (!$style->confirm(\sprintf('Do you want to run "%s" instead? ', $alternative), false)) {
+                    if (null !== $this->dispatcher) {
+                        $event = new ConsoleErrorEvent($input, $output, $e);
+                        $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
+
+                        return $event->getExitCode();
+                    }
+
+                    return 1;
+                }
+
+                $command = $this->find($alternative);
+            } else {
+                if (null !== $this->dispatcher) {
+                    $event = new ConsoleErrorEvent($input, $output, $e);
+                    $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
+
+                    if (0 === $event->getExitCode()) {
+                        return 0;
+                    }
+
+                    $e = $event->getError();
+                }
+
+                try {
+                    if ($e instanceof CommandNotFoundException && $namespace = $this->findNamespace($name)) {
+                        $helper = new DescriptorHelper();
+                        $helper->describe($output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output, $this, [
+                            'format' => 'txt',
+                            'raw_text' => false,
+                            'namespace' => $namespace,
+                            'short' => false,
+                        ]);
+
+                        return isset($event) ? $event->getExitCode() : 1;
+                    }
+
+                    throw $e;
+                } catch (NamespaceNotFoundException) {
+                    throw $e;
+                }
+            }
+        }
+
+        if ($command instanceof LazyCommand) {
+            $command = $command->getCommand();
+        }
+
+        $this->runningCommand = $command;
+        $exitCode = $this->doRunCommand($command, $input, $output);
+        $this->runningCommand = null;
+
+        return $exitCode;
+    }
+
+    /**
+     * Gets the name of the command based on input.
+     */
+    protected function getCommandName(InputInterface $input): ?string
+    {
+        return $input->getFirstArgument();
+    }
+
+    /**
+     * Finds a command by name or alias.
+     *
+     * Contrary to get, this command tries to find the best
+     * match if you give it an abbreviation of a name or alias.
+     *
+     * @throws CommandNotFoundException When command name is incorrect or ambiguous
+     */
+    public function find(string $name): Command
+    {
+        $aliases = [];
+
+        foreach ($this->commands as $command) {
+            foreach ($command->getAliases() as $alias) {
+                if (!$this->has($alias)) {
+                    $this->commands[$alias] = $command;
+                }
+            }
+        }
+
+        if ($this->has($name)) {
+            return $this->get($name);
+        }
+
+        $allCommands = $this->commandLoader ? array_merge($this->commandLoader->getNames(), array_keys($this->commands)) : array_keys($this->commands);
+        $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $name))).'[^:]*';
+        $commands = preg_grep('{^'.$expr.'}', $allCommands);
+
+        if (!$commands) {
+            $commands = preg_grep('{^'.$expr.'}i', $allCommands);
+        }
+
+        sort($commands);
+
+        // if no commands matched or we just matched namespaces
+        if (!$commands || \count(preg_grep('{^'.$expr.'$}i', $commands)) < 1) {
+            if (false !== $pos = strrpos($name, ':')) {
+                // check if a namespace exists and contains commands
+                $this->findNamespace(substr($name, 0, $pos));
+            }
+
+            $message = \sprintf('Command "%s" is not defined.', $name);
+
+            if ($alternatives = $this->findAlternatives($name, $allCommands)) {
+                $wantHelps = $this->wantHelps;
+
+                $this->wantHelps = false;
+
+                // // remove hidden commands
+                if ($alternatives = array_filter($alternatives, fn ($name) => !$this->get($name)->isHidden())) {
+                     $message .= \sprintf("\n\nDid you mean %s?\n    %s", 1 === \count($alternatives) ? 'this' : 'one of these', implode("\n    ", $alternatives));
+                }
+                $this->wantHelps = $wantHelps;
+            }
+
+            throw new CommandNotFoundException($message, array_values($alternatives));
+        }
+
+        // filter out aliases for commands which are already on the list
+        if (\count($commands) > 1) {
+            $commandList = $this->commandLoader ? array_merge(array_flip($this->commandLoader->getNames()), $this->commands) : $this->commands;
+            $commands = array_unique(array_filter($commands, function ($nameOrAlias) use (&$commandList, $commands, &$aliases) {
+                if (!$commandList[$nameOrAlias] instanceof Command) {
+                    $commandList[$nameOrAlias] = $this->commandLoader->get($nameOrAlias);
+                }
+
+                $commandName = $commandList[$nameOrAlias]->getName();
+
+                $aliases[$nameOrAlias] = $commandName;
+
+                return $commandName === $nameOrAlias || !\in_array($commandName, $commands, true);
+            }));
+        }
+
+        // check whether all commands left are aliases to the same one
+        if (\count($commands) > 1) {
+            $uniqueCommands = array_unique(array_map(function ($nameOrAlias) use (&$commandList) {
+                if (!$commandList[$nameOrAlias] instanceof Command) {
+                    $commandList[$nameOrAlias] = $this->commandLoader->get($nameOrAlias);
+                }
+
+                return $commandList[$nameOrAlias]->getName();
+            }, $commands));
+
+            if (1 === \count($uniqueCommands)) {
+                $commands = [reset($uniqueCommands)];
+            }
+        }
+
+        if (\count($commands) > 1) {
+            sort($commands);
+            $usableWidth = $this->terminal->getWidth() - 10;
+            $abbrevs = array_values($commands);
+            $maxLen = 0;
+            foreach ($abbrevs as $abbrev) {
+                $maxLen = max(Helper::width($abbrev), $maxLen);
+            }
+            $abbrevs = array_map(static function ($cmd) use ($commandList, $usableWidth, $maxLen, &$commands) {
+                if ($commandList[$cmd]->isHidden()) {
+                    unset($commands[array_search($cmd, $commands)]);
+
+                    return false;
+                }
+
+                $abbrev = str_pad($cmd, $maxLen, ' ').' '.$commandList[$cmd]->getDescription();
+
+                return Helper::width($abbrev) > $usableWidth ? Helper::substr($abbrev, 0, $usableWidth - 3).'...' : $abbrev;
+            }, array_values($commands));
+
+            if (\count($commands) > 1) {
+                $suggestions = $this->getAbbreviationSuggestions(array_filter($abbrevs));
+
+                throw new CommandNotFoundException(\sprintf("Command \"%s\" is ambiguous.\nDid you mean one of these?\n%s", $name, $suggestions), array_values($commands));
+            }
+        }
+
+        $command = $commands ? $this->get(reset($commands)) : null;
+
+        if (!$command || $command->isHidden()) {
+            throw new CommandNotFoundException(\sprintf('The command "%s" does not exist.', $name));
+        }
+
+        return $command;
+    }
+
+    /**
+     * Runs the current command.
+     *
+     * If an event dispatcher has been attached to the application,
+     * events are also dispatched during the life-cycle of the command.
+     *
+     * @return int 0 if everything went fine, or an error code
+     */
+    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
+    {
+        foreach ($command->getHelperSet() as $helper) {
+            if ($helper instanceof InputAwareInterface) {
+                $helper->setInput($input);
+            }
+        }
+
+        $registeredSignals = false;
+        if (($commandSignals = $command->getSubscribedSignals()) || $this->dispatcher && $this->signalsToDispatchEvent) {
+            $signalRegistry = $this->getSignalRegistry();
+
+            $registeredSignals = true;
+            $this->getSignalRegistry()->pushCurrentHandlers();
+
+            if ($this->dispatcher) {
+                // We register application signals, so that we can dispatch the event
+                foreach ($this->signalsToDispatchEvent as $signal) {
+                    $signalEvent = new ConsoleSignalEvent($command, $input, $output, $signal);
+                    $alarmEvent = \SIGALRM === $signal ? new ConsoleAlarmEvent($command, $input, $output) : null;
+
+                    $signalRegistry->register($signal, function ($signal) use ($signalEvent, $alarmEvent, $command, $commandSignals, $input, $output) {
+                        $this->dispatcher->dispatch($signalEvent, ConsoleEvents::SIGNAL);
+                        $exitCode = $signalEvent->getExitCode();
+
+                        if (null !== $alarmEvent) {
+                            if (false !== $exitCode) {
+                                $alarmEvent->setExitCode($exitCode);
+                            } else {
+                                $alarmEvent->abortExit();
+                            }
+                            $this->dispatcher->dispatch($alarmEvent);
+                            $exitCode = $alarmEvent->getExitCode();
+                        }
+
+                        // If the command is signalable, we call the handleSignal() method
+                        if (\in_array($signal, $commandSignals, true)) {
+                            $exitCode = $command->handleSignal($signal, $exitCode);
+                        }
+
+                        if (\SIGALRM === $signal) {
+                            $this->scheduleAlarm();
+                        }
+
+                        if (false !== $exitCode) {
+                            $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode, $signal);
+                            $this->dispatcher->dispatch($event, ConsoleEvents::TERMINATE);
+
+                            exit($event->getExitCode());
+                        }
+                    });
+                }
+
+                // then we register command signals, but not if already handled after the dispatcher
+                $commandSignals = array_diff($commandSignals, $this->signalsToDispatchEvent);
+            }
+
+            foreach ($commandSignals as $signal) {
+                $signalRegistry->register($signal, function (int $signal) use ($command): void {
+                    if (\SIGALRM === $signal) {
+                        $this->scheduleAlarm();
+                    }
+
+                    if (false !== $exitCode = $command->handleSignal($signal)) {
+                        exit($exitCode);
+                    }
+                });
+            }
+        }
+
+        if (null === $this->dispatcher) {
+            try {
+                return $command->run($input, $output);
+            } finally {
+                if ($registeredSignals) {
+                    $this->getSignalRegistry()->popPreviousHandlers();
+                }
+            }
+        }
+
+        // bind before the console.command event, so the listeners have access to input options/arguments
+        try {
+            $command->mergeApplicationDefinition();
+            $input->bind($command->getDefinition());
+        } catch (ExceptionInterface) {
+            // ignore invalid options/arguments for now, to allow the event listeners to customize the InputDefinition
+        }
+
+        $event = new ConsoleCommandEvent($command, $input, $output);
+        $e = null;
+
+        try {
+            $this->dispatcher->dispatch($event, ConsoleEvents::COMMAND);
+
+            if ($event->commandShouldRun()) {
+                $exitCode = $command->run($input, $output);
+            } else {
+                $exitCode = ConsoleCommandEvent::RETURN_CODE_DISABLED;
+            }
+        } catch (\Throwable $e) {
+            $event = new ConsoleErrorEvent($input, $output, $e, $command);
+            $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
+            $e = $event->getError();
+
+            if (0 === $exitCode = $event->getExitCode()) {
+                $e = null;
+            }
+        } finally {
+            if ($registeredSignals) {
+                $this->getSignalRegistry()->popPreviousHandlers();
+            }
+        }
+
+        $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode);
+        $this->dispatcher->dispatch($event, ConsoleEvents::TERMINATE);
+
+        if (null !== $e) {
+            throw $e;
+        }
+
+        return $event->getExitCode();
+    }
+
+    /**
+     * Registers a new command.
+     */
+    public function register(string $name): Command
+    {
+        return $this->addCommand(new Command($name));
+    }
+
+    /**
+     * Adds an array of command objects.
+     *
+     * If a Command is not enabled it will not be added.
+     *
+     * @param callable[]|Command[] $commands An array of commands
+     */
+    public function addCommands(array $commands): void
+    {
+        foreach ($commands as $command) {
+            $this->addCommand($command);
+        }
+    }
+
+    /**
+     * Adds a command object.
+     *
+     * If a command with the same name already exists, it will be overridden.
+     * If the command is not enabled it will not be added.
+     */
+    public function addCommand(callable|Command $command): ?Command
+    {
+        if (!$command instanceof Command) {
+            $command = new Command(null, $command);
+        }
+
+        $command->setApplication($this);
+
+        if (!$command->isEnabled()) {
+            $command->setApplication(null);
+
+            return null;
+        }
+
+        if (!$command instanceof LazyCommand) {
+            // Will throw if the command is not correctly initialized.
+            $command->getDefinition();
+        }
+
+        if (!$command->getName()) {
+            throw new LogicException(\sprintf('The command defined in "%s" cannot have an empty name.', get_debug_type($command)));
+        }
+
+        $this->commands[$command->getName()] = $command;
+
+        foreach ($command->getAliases() as $alias) {
+            $this->commands[$alias] = $command;
+        }
+
+        return $command;
+    }
+
+    /**
+     * Returns a registered command by name or alias.
+     *
+     * @throws CommandNotFoundException When given command name does not exist
+     */
+    public function get(string $name): Command
+    {
+        if (!$this->has($name)) {
+            throw new CommandNotFoundException(\sprintf('The command "%s" does not exist.', $name));
+        }
+
+        // When the command has a different name than the one used at the command loader level
+        if (!isset($this->commands[$name])) {
+            throw new CommandNotFoundException(\sprintf('The "%s" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".', $name));
+        }
+
+        $command = $this->commands[$name];
+
+        return $command;
+    }
+
+    /**
+     * Returns true if the command exists, false otherwise.
+     */
+    public function has(string $name): bool
+    {
+        return isset($this->commands[$name]) || ($this->commandLoader?->has($name) && $this->addCommand($this->commandLoader->get($name)));
+    }
+
+    /**
+     * @final
+     */
+    public function setDispatcher(EventDispatcherInterface $dispatcher): void
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function getDispatcher(): ?EventDispatcherInterface
+    {
+        return $this->dispatcher;
+    }
+
+    /**
+     * Gets the commands (registered in the given namespace if provided).
+     *
+     * The array keys are the full names and the values the command instances.
+     *
+     * @return Command[]
+     */
+    public function all(?string $namespace = null): array
+    {
+        if (null === $namespace) {
+            if (!$this->commandLoader) {
+                return $this->commands;
+            }
+
+            $commands = $this->commands;
+            foreach ($this->commandLoader->getNames() as $name) {
+                if (!isset($commands[$name]) && $this->has($name)) {
+                    $commands[$name] = $this->get($name);
+                }
+            }
+
+            return $commands;
+        }
+
+        $commands = [];
+        foreach ($this->commands as $name => $command) {
+            if ($namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1)) {
+                $commands[$name] = $command;
+            }
+        }
+
+        if ($this->commandLoader) {
+            foreach ($this->commandLoader->getNames() as $name) {
+                if (!isset($commands[$name]) && $namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1) && $this->has($name)) {
+                    $commands[$name] = $this->get($name);
+                }
+            }
+        }
+
+        return $commands;
+    }
+
+    /**
+     * Finds alternative of $name among $collection,
+     * if nothing is found in $collection, try in $abbrevs.
+     *
+     * @return string[]
+     */
+    private function findAlternatives(string $name, iterable $collection): array
+    {
+        $threshold = 1e3;
+        $alternatives = [];
+
+        $collectionParts = [];
+        foreach ($collection as $item) {
+            $collectionParts[$item] = explode(':', $item);
+        }
+
+        foreach (explode(':', $name) as $i => $subname) {
+            foreach ($collectionParts as $collectionName => $parts) {
+                $exists = isset($alternatives[$collectionName]);
+                if (!isset($parts[$i]) && $exists) {
+                    $alternatives[$collectionName] += $threshold;
+                    continue;
+                } elseif (!isset($parts[$i])) {
+                    continue;
+                }
+
+                $lev = levenshtein($subname, $parts[$i]);
+                if ($lev <= \strlen($subname) / 3 || '' !== $subname && str_contains($parts[$i], $subname)) {
+                    $alternatives[$collectionName] = $exists ? $alternatives[$collectionName] + $lev : $lev;
+                } elseif ($exists) {
+                    $alternatives[$collectionName] += $threshold;
+                }
+            }
+        }
+
+        foreach ($collection as $item) {
+            $lev = levenshtein($name, $item);
+            if ($lev <= \strlen($name) / 3 || str_contains($item, $name)) {
+                $alternatives[$item] = isset($alternatives[$item]) ? $alternatives[$item] - $lev : $lev;
+            }
+        }
+
+        $alternatives = array_filter($alternatives, static fn ($lev) => $lev < 2 * $threshold);
+        ksort($alternatives, \SORT_NATURAL | \SORT_FLAG_CASE);
+
+        return array_keys($alternatives);
+    }
+
+    /**
+     * Finds a registered namespace by a name or an abbreviation.
+     *
+     * @throws NamespaceNotFoundException When namespace is incorrect or ambiguous
+     */
+    public function findNamespace(string $namespace): string
+    {
+        $allNamespaces = $this->getNamespaces();
+        $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $namespace))).'[^:]*';
+        $namespaces = preg_grep('{^'.$expr.'}', $allNamespaces);
+
+        if (!$namespaces) {
+            $message = \sprintf('There are no commands defined in the "%s" namespace.', $namespace);
+
+            if ($alternatives = $this->findAlternatives($namespace, $allNamespaces)) {
+                if (1 == \count($alternatives)) {
+                    $message .= "\n\nDid you mean this?\n    ";
+                } else {
+                    $message .= "\n\nDid you mean one of these?\n    ";
+                }
+
+                $message .= implode("\n    ", $alternatives);
+            }
+
+            throw new NamespaceNotFoundException($message, $alternatives);
+        }
+
+        $exact = \in_array($namespace, $namespaces, true);
+        if (\count($namespaces) > 1 && !$exact) {
+            sort($namespaces);
+
+            throw new NamespaceNotFoundException(\sprintf("The namespace \"%s\" is ambiguous.\nDid you mean one of these?\n%s.", $namespace, $this->getAbbreviationSuggestions(array_values($namespaces))), array_values($namespaces));
+        }
+
+        return $exact ? $namespace : reset($namespaces);
+    }
+
+    /**
+     * Returns an array of all unique namespaces used by currently registered commands.
+     *
+     * It does not return the global namespace which always exists.
+     *
+     * @return string[]
+     */
+    public function getNamespaces(): array
+    {
+        $namespaces = [];
+        foreach ($this->all() as $command) {
+            if ($command->isHidden()) {
+                continue;
+            }
+
+            $namespaces[] = $this->extractAllNamespaces($command->getName());
+
+            foreach ($command->getAliases() as $alias) {
+                $namespaces[] = $this->extractAllNamespaces($alias);
+            }
+        }
+
+        return array_values(array_unique(array_filter(array_merge([], ...$namespaces))));
+    }
+
+    /**
+     * Returns all namespaces of the command name.
+     *
+     * @return string[]
+     */
+    private function extractAllNamespaces(string $name): array
+    {
+        // -1 as third argument is needed to skip the command short name when exploding
+        $parts = explode(':', $name, -1);
+        $namespaces = [];
+
+        foreach ($parts as $part) {
+            if (\count($namespaces)) {
+                $namespaces[] = end($namespaces).':'.$part;
+            } else {
+                $namespaces[] = $part;
+            }
+        }
+
+        return $namespaces;
+    }
+
+    /**
+     * Returns abbreviated suggestions in string format.
+     */
+    private function getAbbreviationSuggestions(array $abbrevs): string
+    {
+        return '    '.implode("\n    ", $abbrevs);
+    }
+}

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -201,7 +201,99 @@ class Application extends AbstractCommand implements ResetInterface
             return 0;
         }
 
-        return parent::doRun($input, $output);
+        try {
+            // Makes ArgvInput::getFirstArgument() able to distinguish an option from an argument.
+            $input->bind($this->getDefinition());
+        } catch (ExceptionInterface) {
+            // Errors must be ignored, full binding/validation happens later when the command is known.
+        }
+
+        $name = $this->getCommandName($input);
+        if (true === $input->hasParameterOption(['--help', '-h'], true)) {
+            if (!$name) {
+                $name = 'help';
+                $input = new ArrayInput(['command_name' => $this->defaultCommand]);
+            } else {
+                $this->wantHelps = true;
+            }
+        }
+
+        if (!$name) {
+            $name = $this->defaultCommand;
+            $definition = $this->getDefinition();
+            $definition->setArguments(array_merge(
+                $definition->getArguments(),
+                [
+                    'command' => new InputArgument('command', InputArgument::OPTIONAL, $definition->getArgument('command')->getDescription(), $name),
+                ]
+            ));
+        }
+
+        try {
+            $this->runningCommand = null;
+            // the command name MUST be the first element of the input
+            $command = $this->find($name);
+        } catch (\Throwable $e) {
+            if (($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException) && 1 === \count($alternatives = $e->getAlternatives()) && $input->isInteractive()) {
+                $alternative = $alternatives[0];
+
+                $style = new SymfonyStyle($input, $output);
+                $output->writeln('');
+                $formattedBlock = (new FormatterHelper())->formatBlock(\sprintf('Command "%s" is not defined.', $name), 'error', true);
+                $output->writeln($formattedBlock);
+                if (!$style->confirm(\sprintf('Do you want to run "%s" instead? ', $alternative), false)) {
+                    if (null !== $this->dispatcher) {
+                        $event = new ConsoleErrorEvent($input, $output, $e);
+                        $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
+
+                        return $event->getExitCode();
+                    }
+
+                    return 1;
+                }
+
+                $command = $this->find($alternative);
+            } else {
+                if (null !== $this->dispatcher) {
+                    $event = new ConsoleErrorEvent($input, $output, $e);
+                    $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
+
+                    if (0 === $event->getExitCode()) {
+                        return 0;
+                    }
+
+                    $e = $event->getError();
+                }
+
+                try {
+                    if ($e instanceof CommandNotFoundException && $namespace = $this->findNamespace($name)) {
+                        $helper = new DescriptorHelper();
+                        $helper->describe($output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output, $this, [
+                            'format' => 'txt',
+                            'raw_text' => false,
+                            'namespace' => $namespace,
+                            'short' => false,
+                        ]);
+
+                        return isset($event) ? $event->getExitCode() : 1;
+                    }
+
+                    throw $e;
+                } catch (NamespaceNotFoundException) {
+                    throw $e;
+                }
+            }
+        }
+
+        if ($command instanceof LazyCommand) {
+            $command = $command->getCommand();
+        }
+
+        $this->runningCommand = $command;
+        $exitCode = $this->doRunCommand($command, $input, $output);
+        $this->runningCommand = null;
+
+        return $exitCode;
     }
 
     public function reset(): void

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -414,6 +414,7 @@ class Application extends AbstractCommand implements ResetInterface
     public function addCommand(callable|Command $command): ?Command
     {
         $this->init();
+
         return parent::addCommand($command);
     }
 
@@ -796,5 +797,10 @@ class Application extends AbstractCommand implements ResetInterface
     protected function getCommandName(InputInterface $input): ?string
     {
         return $this->singleCommand ? $this->defaultCommand : $input->getFirstArgument();
+    }
+
+    public function getApplication(): ?Application
+    {
+        return $this;
     }
 }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -32,7 +32,6 @@ use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\NamespaceNotFoundException;
-use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\DebugFormatterHelper;
 use Symfony\Component\Console\Helper\DescriptorHelper;
@@ -55,7 +54,6 @@ use Symfony\Component\Console\SignalRegistry\SignalRegistry;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\ErrorHandler\ErrorHandler;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -73,107 +71,23 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Application implements ResetInterface
+class Application extends AbstractCommand implements ResetInterface
 {
-    private array $commands = [];
-    private bool $wantHelps = false;
-    private ?Command $runningCommand = null;
-    private ?CommandLoaderInterface $commandLoader = null;
     private bool $catchExceptions = true;
     private bool $catchErrors = false;
     private bool $autoExit = true;
-    private InputDefinition $definition;
     private HelperSet $helperSet;
-    private ?EventDispatcherInterface $dispatcher = null;
-    private ?ArgumentResolverInterface $argumentResolver = null;
     private Terminal $terminal;
-    private string $defaultCommand;
     private bool $singleCommand = false;
     private bool $initialized = false;
-    private ?SignalRegistry $signalRegistry = null;
-    private array $signalsToDispatchEvent = [];
-    private ?int $alarmInterval = null;
 
     public function __construct(
         private string $name = 'UNKNOWN',
         private string $version = 'UNKNOWN',
         private ?ContainerInterface $container = null,
     ) {
+        parent::__construct();
         $this->terminal = new Terminal();
-        $this->defaultCommand = 'list';
-        if (\defined('SIGINT') && SignalRegistry::isSupported()) {
-            $this->signalRegistry = new SignalRegistry();
-            $this->signalsToDispatchEvent = [\SIGINT, \SIGQUIT, \SIGTERM, \SIGUSR1, \SIGUSR2, \SIGALRM];
-        }
-    }
-
-    /**
-     * @final
-     */
-    public function setDispatcher(EventDispatcherInterface $dispatcher): void
-    {
-        $this->dispatcher = $dispatcher;
-    }
-
-    public function getDispatcher(): ?EventDispatcherInterface
-    {
-        return $this->dispatcher;
-    }
-
-    /**
-     * @final
-     */
-    public function setArgumentResolver(ArgumentResolverInterface $argumentResolver): void
-    {
-        $this->argumentResolver = $argumentResolver;
-    }
-
-    public function getArgumentResolver(): ?ArgumentResolverInterface
-    {
-        return $this->argumentResolver;
-    }
-
-    public function setCommandLoader(CommandLoaderInterface $commandLoader): void
-    {
-        $this->commandLoader = $commandLoader;
-    }
-
-    public function getSignalRegistry(): SignalRegistry
-    {
-        if (!$this->signalRegistry) {
-            throw new RuntimeException('Signals are not supported. Make sure that the "pcntl" extension is installed and that "pcntl_*" functions are not disabled by your php.ini\'s "disable_functions" directive.');
-        }
-
-        return $this->signalRegistry;
-    }
-
-    public function setSignalsToDispatchEvent(int ...$signalsToDispatchEvent): void
-    {
-        $this->signalsToDispatchEvent = $signalsToDispatchEvent;
-    }
-
-    /**
-     * Sets the interval to schedule a SIGALRM signal in seconds.
-     */
-    public function setAlarmInterval(?int $seconds): void
-    {
-        $this->alarmInterval = $seconds;
-        $this->scheduleAlarm();
-    }
-
-    /**
-     * Gets the interval in seconds on which a SIGALRM signal is dispatched.
-     */
-    public function getAlarmInterval(): ?int
-    {
-        return $this->alarmInterval;
-    }
-
-    private function scheduleAlarm(): void
-    {
-        if (null !== $this->alarmInterval) {
-            $this->getSignalRegistry()->scheduleAlarm($this->alarmInterval);
-        }
     }
 
     /**
@@ -287,99 +201,7 @@ class Application implements ResetInterface
             return 0;
         }
 
-        try {
-            // Makes ArgvInput::getFirstArgument() able to distinguish an option from an argument.
-            $input->bind($this->getDefinition());
-        } catch (ExceptionInterface) {
-            // Errors must be ignored, full binding/validation happens later when the command is known.
-        }
-
-        $name = $this->getCommandName($input);
-        if (true === $input->hasParameterOption(['--help', '-h'], true)) {
-            if (!$name) {
-                $name = 'help';
-                $input = new ArrayInput(['command_name' => $this->defaultCommand]);
-            } else {
-                $this->wantHelps = true;
-            }
-        }
-
-        if (!$name) {
-            $name = $this->defaultCommand;
-            $definition = $this->getDefinition();
-            $definition->setArguments(array_merge(
-                $definition->getArguments(),
-                [
-                    'command' => new InputArgument('command', InputArgument::OPTIONAL, $definition->getArgument('command')->getDescription(), $name),
-                ]
-            ));
-        }
-
-        try {
-            $this->runningCommand = null;
-            // the command name MUST be the first element of the input
-            $command = $this->find($name);
-        } catch (\Throwable $e) {
-            if (($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException) && 1 === \count($alternatives = $e->getAlternatives()) && $input->isInteractive()) {
-                $alternative = $alternatives[0];
-
-                $style = new SymfonyStyle($input, $output);
-                $output->writeln('');
-                $formattedBlock = (new FormatterHelper())->formatBlock(\sprintf('Command "%s" is not defined.', $name), 'error', true);
-                $output->writeln($formattedBlock);
-                if (!$style->confirm(\sprintf('Do you want to run "%s" instead? ', $alternative), false)) {
-                    if (null !== $this->dispatcher) {
-                        $event = new ConsoleErrorEvent($input, $output, $e);
-                        $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
-
-                        return $event->getExitCode();
-                    }
-
-                    return 1;
-                }
-
-                $command = $this->find($alternative);
-            } else {
-                if (null !== $this->dispatcher) {
-                    $event = new ConsoleErrorEvent($input, $output, $e);
-                    $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
-
-                    if (0 === $event->getExitCode()) {
-                        return 0;
-                    }
-
-                    $e = $event->getError();
-                }
-
-                try {
-                    if ($e instanceof CommandNotFoundException && $namespace = $this->findNamespace($name)) {
-                        $helper = new DescriptorHelper();
-                        $helper->describe($output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output, $this, [
-                            'format' => 'txt',
-                            'raw_text' => false,
-                            'namespace' => $namespace,
-                            'short' => false,
-                        ]);
-
-                        return isset($event) ? $event->getExitCode() : 1;
-                    }
-
-                    throw $e;
-                } catch (NamespaceNotFoundException) {
-                    throw $e;
-                }
-            }
-        }
-
-        if ($command instanceof LazyCommand) {
-            $command = $command->getCommand();
-        }
-
-        $this->runningCommand = $command;
-        $exitCode = $this->doRunCommand($command, $input, $output);
-        $this->runningCommand = null;
-
-        return $exitCode;
+        return parent::doRun($input, $output);
     }
 
     public function reset(): void
@@ -563,106 +385,6 @@ class Application implements ResetInterface
     /**
      * Registers a new command.
      */
-    public function register(string $name): Command
-    {
-        return $this->addCommand(new Command($name));
-    }
-
-    /**
-     * Adds an array of command objects.
-     *
-     * If a Command is not enabled it will not be added.
-     *
-     * @param callable[]|Command[] $commands An array of commands
-     */
-    public function addCommands(array $commands): void
-    {
-        foreach ($commands as $command) {
-            $this->addCommand($command);
-        }
-    }
-
-    /**
-     * Adds a command object.
-     *
-     * If a command with the same name already exists, it will be overridden.
-     * If the command is not enabled it will not be added.
-     */
-    public function addCommand(callable|Command $command): ?Command
-    {
-        $this->init();
-
-        if (!$command instanceof Command) {
-            $command = new Command(null, $command);
-        }
-
-        $command->setApplication($this);
-
-        if (!$command->isEnabled()) {
-            $command->setApplication(null);
-
-            return null;
-        }
-
-        if (!$command instanceof LazyCommand) {
-            // Will throw if the command is not correctly initialized.
-            $command->getDefinition();
-        }
-
-        if (!$command->getName()) {
-            throw new LogicException(\sprintf('The command defined in "%s" cannot have an empty name.', get_debug_type($command)));
-        }
-
-        $this->commands[$command->getName()] = $command;
-
-        foreach ($command->getAliases() as $alias) {
-            $this->commands[$alias] = $command;
-        }
-
-        return $command;
-    }
-
-    /**
-     * Returns a registered command by name or alias.
-     *
-     * @throws CommandNotFoundException When given command name does not exist
-     */
-    public function get(string $name): Command
-    {
-        $this->init();
-
-        if (!$this->has($name)) {
-            throw new CommandNotFoundException(\sprintf('The command "%s" does not exist.', $name));
-        }
-
-        // When the command has a different name than the one used at the command loader level
-        if (!isset($this->commands[$name])) {
-            throw new CommandNotFoundException(\sprintf('The "%s" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".', $name));
-        }
-
-        $command = $this->commands[$name];
-
-        if ($this->wantHelps) {
-            $this->wantHelps = false;
-
-            $helpCommand = $this->get('help');
-            $helpCommand->setCommand($command);
-
-            return $helpCommand;
-        }
-
-        return $command;
-    }
-
-    /**
-     * Returns true if the command exists, false otherwise.
-     */
-    public function has(string $name): bool
-    {
-        $this->init();
-
-        return isset($this->commands[$name]) || ($this->commandLoader?->has($name) && $this->addCommand($this->commandLoader->get($name)));
-    }
 
     /**
      * Returns an array of all unique namespaces used by currently registered commands.
@@ -689,211 +411,47 @@ class Application implements ResetInterface
         return array_values(array_unique(array_filter(array_merge([], ...$namespaces))));
     }
 
-    /**
-     * Finds a registered namespace by a name or an abbreviation.
-     *
-     * @throws NamespaceNotFoundException When namespace is incorrect or ambiguous
-     */
-    public function findNamespace(string $namespace): string
+    public function addCommand(callable|Command $command): ?Command
     {
-        $allNamespaces = $this->getNamespaces();
-        $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $namespace))).'[^:]*';
-        $namespaces = preg_grep('{^'.$expr.'}', $allNamespaces);
-
-        if (!$namespaces) {
-            $message = \sprintf('There are no commands defined in the "%s" namespace.', $namespace);
-
-            if ($alternatives = $this->findAlternatives($namespace, $allNamespaces)) {
-                if (1 == \count($alternatives)) {
-                    $message .= "\n\nDid you mean this?\n    ";
-                } else {
-                    $message .= "\n\nDid you mean one of these?\n    ";
-                }
-
-                $message .= implode("\n    ", $alternatives);
-            }
-
-            throw new NamespaceNotFoundException($message, $alternatives);
-        }
-
-        $exact = \in_array($namespace, $namespaces, true);
-        if (\count($namespaces) > 1 && !$exact) {
-            sort($namespaces);
-
-            throw new NamespaceNotFoundException(\sprintf("The namespace \"%s\" is ambiguous.\nDid you mean one of these?\n%s.", $namespace, $this->getAbbreviationSuggestions(array_values($namespaces))), array_values($namespaces));
-        }
-
-        return $exact ? $namespace : reset($namespaces);
+        $this->init();
+        return parent::addCommand($command);
     }
 
-    /**
-     * Finds a command by name or alias.
-     *
-     * Contrary to get, this command tries to find the best
-     * match if you give it an abbreviation of a name or alias.
-     *
-     * @throws CommandNotFoundException When command name is incorrect or ambiguous
-     */
+    public function get(string $name): Command
+    {
+        $this->init();
+        $command = parent::get($name);
+
+        if ($this->wantHelps) {
+            $this->wantHelps = false;
+
+            $helpCommand = $this->get('help');
+            $helpCommand->setCommand($command);
+
+            return $helpCommand;
+        }
+
+        return $command;
+
+    }
+
+    public function has(string $name): bool
+    {
+        $this->init();
+        return parent::has($name);
+    }
+
     public function find(string $name): Command
     {
         $this->init();
 
-        $aliases = [];
-
-        foreach ($this->commands as $command) {
-            foreach ($command->getAliases() as $alias) {
-                if (!$this->has($alias)) {
-                    $this->commands[$alias] = $command;
-                }
-            }
-        }
-
-        if ($this->has($name)) {
-            return $this->get($name);
-        }
-
-        $allCommands = $this->commandLoader ? array_merge($this->commandLoader->getNames(), array_keys($this->commands)) : array_keys($this->commands);
-        $expr = implode('[^:]*:', array_map('preg_quote', explode(':', $name))).'[^:]*';
-        $commands = preg_grep('{^'.$expr.'}', $allCommands);
-
-        if (!$commands) {
-            $commands = preg_grep('{^'.$expr.'}i', $allCommands);
-        }
-
-        sort($commands);
-
-        // if no commands matched or we just matched namespaces
-        if (!$commands || \count(preg_grep('{^'.$expr.'$}i', $commands)) < 1) {
-            if (false !== $pos = strrpos($name, ':')) {
-                // check if a namespace exists and contains commands
-                $this->findNamespace(substr($name, 0, $pos));
-            }
-
-            $message = \sprintf('Command "%s" is not defined.', $name);
-
-            if ($alternatives = $this->findAlternatives($name, $allCommands)) {
-                $wantHelps = $this->wantHelps;
-                $this->wantHelps = false;
-
-                // remove hidden commands
-                if ($alternatives = array_filter($alternatives, fn ($name) => !$this->get($name)->isHidden())) {
-                    $message .= \sprintf("\n\nDid you mean %s?\n    %s", 1 === \count($alternatives) ? 'this' : 'one of these', implode("\n    ", $alternatives));
-                }
-                $this->wantHelps = $wantHelps;
-            }
-
-            throw new CommandNotFoundException($message, array_values($alternatives));
-        }
-
-        // filter out aliases for commands which are already on the list
-        if (\count($commands) > 1) {
-            $commandList = $this->commandLoader ? array_merge(array_flip($this->commandLoader->getNames()), $this->commands) : $this->commands;
-            $commands = array_unique(array_filter($commands, function ($nameOrAlias) use (&$commandList, $commands, &$aliases) {
-                if (!$commandList[$nameOrAlias] instanceof Command) {
-                    $commandList[$nameOrAlias] = $this->commandLoader->get($nameOrAlias);
-                }
-
-                $commandName = $commandList[$nameOrAlias]->getName();
-
-                $aliases[$nameOrAlias] = $commandName;
-
-                return $commandName === $nameOrAlias || !\in_array($commandName, $commands, true);
-            }));
-        }
-
-        // check whether all commands left are aliases to the same one
-        if (\count($commands) > 1) {
-            $uniqueCommands = array_unique(array_map(function ($nameOrAlias) use (&$commandList) {
-                if (!$commandList[$nameOrAlias] instanceof Command) {
-                    $commandList[$nameOrAlias] = $this->commandLoader->get($nameOrAlias);
-                }
-
-                return $commandList[$nameOrAlias]->getName();
-            }, $commands));
-
-            if (1 === \count($uniqueCommands)) {
-                $commands = [reset($uniqueCommands)];
-            }
-        }
-
-        if (\count($commands) > 1) {
-            sort($commands);
-            $usableWidth = $this->terminal->getWidth() - 10;
-            $abbrevs = array_values($commands);
-            $maxLen = 0;
-            foreach ($abbrevs as $abbrev) {
-                $maxLen = max(Helper::width($abbrev), $maxLen);
-            }
-            $abbrevs = array_map(static function ($cmd) use ($commandList, $usableWidth, $maxLen, &$commands) {
-                if ($commandList[$cmd]->isHidden()) {
-                    unset($commands[array_search($cmd, $commands)]);
-
-                    return false;
-                }
-
-                $abbrev = str_pad($cmd, $maxLen, ' ').' '.$commandList[$cmd]->getDescription();
-
-                return Helper::width($abbrev) > $usableWidth ? Helper::substr($abbrev, 0, $usableWidth - 3).'...' : $abbrev;
-            }, array_values($commands));
-
-            if (\count($commands) > 1) {
-                $suggestions = $this->getAbbreviationSuggestions(array_filter($abbrevs));
-
-                throw new CommandNotFoundException(\sprintf("Command \"%s\" is ambiguous.\nDid you mean one of these?\n%s", $name, $suggestions), array_values($commands));
-            }
-        }
-
-        $command = $commands ? $this->get(reset($commands)) : null;
-
-        if (!$command || $command->isHidden()) {
-            throw new CommandNotFoundException(\sprintf('The command "%s" does not exist.', $name));
-        }
-
-        return $command;
+        return parent::find($name);
     }
 
-    /**
-     * Gets the commands (registered in the given namespace if provided).
-     *
-     * The array keys are the full names and the values the command instances.
-     *
-     * @return Command[]
-     */
     public function all(?string $namespace = null): array
     {
         $this->init();
-
-        if (null === $namespace) {
-            if (!$this->commandLoader) {
-                return $this->commands;
-            }
-
-            $commands = $this->commands;
-            foreach ($this->commandLoader->getNames() as $name) {
-                if (!isset($commands[$name]) && $this->has($name)) {
-                    $commands[$name] = $this->get($name);
-                }
-            }
-
-            return $commands;
-        }
-
-        $commands = [];
-        foreach ($this->commands as $name => $command) {
-            if ($namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1)) {
-                $commands[$name] = $command;
-            }
-        }
-
-        if ($this->commandLoader) {
-            foreach ($this->commandLoader->getNames() as $name) {
-                if (!isset($commands[$name]) && $namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1) && $this->has($name)) {
-                    $commands[$name] = $this->get($name);
-                }
-            }
-        }
-
-        return $commands;
+        return parent::all($namespace);
     }
 
     /**
@@ -1039,145 +597,6 @@ class Application implements ResetInterface
     }
 
     /**
-     * Runs the current command.
-     *
-     * If an event dispatcher has been attached to the application,
-     * events are also dispatched during the life-cycle of the command.
-     *
-     * @return int 0 if everything went fine, or an error code
-     */
-    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
-    {
-        foreach ($command->getHelperSet() as $helper) {
-            if ($helper instanceof InputAwareInterface) {
-                $helper->setInput($input);
-            }
-        }
-
-        $registeredSignals = false;
-        if (($commandSignals = $command->getSubscribedSignals()) || $this->dispatcher && $this->signalsToDispatchEvent) {
-            $signalRegistry = $this->getSignalRegistry();
-
-            $registeredSignals = true;
-            $this->getSignalRegistry()->pushCurrentHandlers();
-
-            if ($this->dispatcher) {
-                // We register application signals, so that we can dispatch the event
-                foreach ($this->signalsToDispatchEvent as $signal) {
-                    $signalEvent = new ConsoleSignalEvent($command, $input, $output, $signal);
-                    $alarmEvent = \SIGALRM === $signal ? new ConsoleAlarmEvent($command, $input, $output) : null;
-
-                    $signalRegistry->register($signal, function ($signal) use ($signalEvent, $alarmEvent, $command, $commandSignals, $input, $output) {
-                        $this->dispatcher->dispatch($signalEvent, ConsoleEvents::SIGNAL);
-                        $exitCode = $signalEvent->getExitCode();
-
-                        if (null !== $alarmEvent) {
-                            if (false !== $exitCode) {
-                                $alarmEvent->setExitCode($exitCode);
-                            } else {
-                                $alarmEvent->abortExit();
-                            }
-                            $this->dispatcher->dispatch($alarmEvent);
-                            $exitCode = $alarmEvent->getExitCode();
-                        }
-
-                        // If the command is signalable, we call the handleSignal() method
-                        if (\in_array($signal, $commandSignals, true)) {
-                            $exitCode = $command->handleSignal($signal, $exitCode);
-                        }
-
-                        if (\SIGALRM === $signal) {
-                            $this->scheduleAlarm();
-                        }
-
-                        if (false !== $exitCode) {
-                            $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode, $signal);
-                            $this->dispatcher->dispatch($event, ConsoleEvents::TERMINATE);
-
-                            exit($event->getExitCode());
-                        }
-                    });
-                }
-
-                // then we register command signals, but not if already handled after the dispatcher
-                $commandSignals = array_diff($commandSignals, $this->signalsToDispatchEvent);
-            }
-
-            foreach ($commandSignals as $signal) {
-                $signalRegistry->register($signal, function (int $signal) use ($command): void {
-                    if (\SIGALRM === $signal) {
-                        $this->scheduleAlarm();
-                    }
-
-                    if (false !== $exitCode = $command->handleSignal($signal)) {
-                        exit($exitCode);
-                    }
-                });
-            }
-        }
-
-        if (null === $this->dispatcher) {
-            try {
-                return $command->run($input, $output);
-            } finally {
-                if ($registeredSignals) {
-                    $this->getSignalRegistry()->popPreviousHandlers();
-                }
-            }
-        }
-
-        // bind before the console.command event, so the listeners have access to input options/arguments
-        try {
-            $command->mergeApplicationDefinition();
-            $input->bind($command->getDefinition());
-        } catch (ExceptionInterface) {
-            // ignore invalid options/arguments for now, to allow the event listeners to customize the InputDefinition
-        }
-
-        $event = new ConsoleCommandEvent($command, $input, $output);
-        $e = null;
-
-        try {
-            $this->dispatcher->dispatch($event, ConsoleEvents::COMMAND);
-
-            if ($event->commandShouldRun()) {
-                $exitCode = $command->run($input, $output);
-            } else {
-                $exitCode = ConsoleCommandEvent::RETURN_CODE_DISABLED;
-            }
-        } catch (\Throwable $e) {
-            $event = new ConsoleErrorEvent($input, $output, $e, $command);
-            $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
-            $e = $event->getError();
-
-            if (0 === $exitCode = $event->getExitCode()) {
-                $e = null;
-            }
-        } finally {
-            if ($registeredSignals) {
-                $this->getSignalRegistry()->popPreviousHandlers();
-            }
-        }
-
-        $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode);
-        $this->dispatcher->dispatch($event, ConsoleEvents::TERMINATE);
-
-        if (null !== $e) {
-            throw $e;
-        }
-
-        return $event->getExitCode();
-    }
-
-    /**
-     * Gets the name of the command based on input.
-     */
-    protected function getCommandName(InputInterface $input): ?string
-    {
-        return $this->singleCommand ? $this->defaultCommand : $input->getFirstArgument();
-    }
-
-    /**
      * Gets the default input definition.
      */
     protected function getDefaultInputDefinition(): InputDefinition
@@ -1235,54 +654,6 @@ class Application implements ResetInterface
         $parts = explode(':', $name, -1);
 
         return implode(':', null === $limit ? $parts : \array_slice($parts, 0, $limit));
-    }
-
-    /**
-     * Finds alternative of $name among $collection,
-     * if nothing is found in $collection, try in $abbrevs.
-     *
-     * @return string[]
-     */
-    private function findAlternatives(string $name, iterable $collection): array
-    {
-        $threshold = 1e3;
-        $alternatives = [];
-
-        $collectionParts = [];
-        foreach ($collection as $item) {
-            $collectionParts[$item] = explode(':', $item);
-        }
-
-        foreach (explode(':', $name) as $i => $subname) {
-            foreach ($collectionParts as $collectionName => $parts) {
-                $exists = isset($alternatives[$collectionName]);
-                if (!isset($parts[$i]) && $exists) {
-                    $alternatives[$collectionName] += $threshold;
-                    continue;
-                } elseif (!isset($parts[$i])) {
-                    continue;
-                }
-
-                $lev = levenshtein($subname, $parts[$i]);
-                if ($lev <= \strlen($subname) / 3 || '' !== $subname && str_contains($parts[$i], $subname)) {
-                    $alternatives[$collectionName] = $exists ? $alternatives[$collectionName] + $lev : $lev;
-                } elseif ($exists) {
-                    $alternatives[$collectionName] += $threshold;
-                }
-            }
-        }
-
-        foreach ($collection as $item) {
-            $lev = levenshtein($name, $item);
-            if ($lev <= \strlen($name) / 3 || str_contains($item, $name)) {
-                $alternatives[$item] = isset($alternatives[$item]) ? $alternatives[$item] - $lev : $lev;
-            }
-        }
-
-        $alternatives = array_filter($alternatives, static fn ($lev) => $lev < 2 * $threshold);
-        ksort($alternatives, \SORT_NATURAL | \SORT_FLAG_CASE);
-
-        return array_keys($alternatives);
     }
 
     /**
@@ -1417,5 +788,13 @@ class Application implements ResetInterface
                 $this->addCommand($this->container->get($id));
             }
         }
+    }
+
+    /**
+     * Gets the name of the command based on input.
+     */
+    protected function getCommandName(InputInterface $input): ?string
+    {
+        return $this->singleCommand ? $this->defaultCommand : $input->getFirstArgument();
     }
 }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -738,18 +738,6 @@ class Application extends AbstractCommand implements ResetInterface
     }
 
     /**
-     * Returns the namespace part of the command name.
-     *
-     * This method is not part of public API and should not be used directly.
-     */
-    public function extractNamespace(string $name, ?int $limit = null): string
-    {
-        $parts = explode(':', $name, -1);
-
-        return implode(':', null === $limit ? $parts : \array_slice($parts, 0, $limit));
-    }
-
-    /**
      * Sets the default Command name.
      *
      * @return $this

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Override;
 use Symfony\Component\Console\AbstractCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -126,14 +127,26 @@ class Command extends AbstractCommand implements SignalableCommandInterface
         $this->definition->setTolerateExtraTokens(true);
     }
 
+    #[Override]
+    public function addCommand(callable|Command $command): ?Command
+    {
+        $this->ignoreExtraArguments();
+        return parent::addCommand($command);
+    }
+
     public function setApplication(?Application $application): void
     {
         $this->application = $application;
         if ($application) {
             $this->setHelperSet($application->getHelperSet());
+            foreach ($this->commands as $subCommand) {
+                $subCommand->setApplication($application);
+                $subCommand->setHelperSet($application->getHelperSet());
+            }
         } else {
             $this->helperSet = null;
         }
+
 
         $this->fullDefinition = null;
     }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -351,6 +351,7 @@ class Command implements SignalableCommandInterface
         $this->fullDefinition = new InputDefinition();
         $this->fullDefinition->setOptions($this->definition->getOptions());
         $this->fullDefinition->addOptions($this->application->getDefinition()->getOptions());
+        $this->fullDefinition->setTolerateExtraTokens($this->definition->getTolerateExtraTokens());
 
         if ($mergeArgs) {
             $this->fullDefinition->setArguments($this->application->getDefinition()->getArguments());

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Symfony\Component\Console\AbstractCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -32,7 +33,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Command implements SignalableCommandInterface
+class Command extends AbstractCommand implements SignalableCommandInterface
 {
     // see https://tldp.org/LDP/abs/html/exitcodes.html
     public const SUCCESS = 0;
@@ -43,7 +44,6 @@ class Command implements SignalableCommandInterface
     private ?string $name = null;
     private ?string $processTitle = null;
     private array $aliases = [];
-    private InputDefinition $definition;
     private bool $hidden = false;
     private string $help = '';
     private string $description = '';
@@ -61,6 +61,8 @@ class Command implements SignalableCommandInterface
      */
     public function __construct(?string $name = null, ?callable $code = null)
     {
+        parent::__construct();
+
         $this->definition = new InputDefinition();
 
         $attribute = $this->getCommandAttribute($code);

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -119,6 +119,11 @@ class Command implements SignalableCommandInterface
         $this->ignoreValidationErrors = true;
     }
 
+    public function ignoreExtraArguments(): void
+    {
+        $this->definition->setTolerateExtraTokens(true);
+    }
+
     public function setApplication(?Application $application): void
     {
         $this->application = $application;

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -124,7 +124,7 @@ class Command extends AbstractCommand implements SignalableCommandInterface
 
     public function ignoreExtraArguments(): void
     {
-        $this->definition->setTolerateExtraTokens(true);
+        $this->definition->setIgnoreExtraArguments(true);
     }
 
     #[Override]
@@ -366,7 +366,7 @@ class Command extends AbstractCommand implements SignalableCommandInterface
         $this->fullDefinition = new InputDefinition();
         $this->fullDefinition->setOptions($this->definition->getOptions());
         $this->fullDefinition->addOptions($this->application->getDefinition()->getOptions());
-        $this->fullDefinition->setTolerateExtraTokens($this->definition->getTolerateExtraTokens());
+        $this->fullDefinition->setIgnoreExtraArguments($this->definition->getIgnoreExtraArguments());
 
         if ($mergeArgs) {
             $this->fullDefinition->setArguments($this->application->getDefinition()->getArguments());

--- a/src/Symfony/Component/Console/Exception/UnexpectedArgumentException.php
+++ b/src/Symfony/Component/Console/Exception/UnexpectedArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Console\Exception;
+
+class UnexpectedArgumentException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Input;
 
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Exception\UnexpectedArgumentException;
 
 /**
  * ArgvInput represents an input coming from the CLI arguments.
@@ -74,7 +75,14 @@ class ArgvInput extends Input
         $parseOptions = true;
         $this->parsed = $this->tokens;
         while (null !== $token = array_shift($this->parsed)) {
-            $parseOptions = $this->parseToken($token, $parseOptions);
+            try {
+                $parseOptions = $this->parseToken($token, $parseOptions);
+            } catch (UnexpectedArgumentException $e) {
+                if (true === $this->definition->getTolerateExtraTokens()) {
+                    break;
+                }
+                throw $e;
+            }
         }
     }
 
@@ -196,7 +204,7 @@ class ArgvInput extends Input
                 $message = \sprintf('No arguments expected, got "%s".', $token);
             }
 
-            throw new RuntimeException($message);
+            throw new UnexpectedArgumentException($message);
         }
     }
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -122,6 +122,11 @@ class ArgvInput extends Input
         }
     }
 
+    public function getUnparsedTokens(): array
+    {
+        return $this->parsed;
+    }
+
     /**
      * Parses a short option set.
      *

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -79,6 +79,7 @@ class ArgvInput extends Input
                 $parseOptions = $this->parseToken($token, $parseOptions);
             } catch (UnexpectedArgumentException $e) {
                 if (true === $this->definition->getTolerateExtraTokens()) {
+                    $this->parsed[] = $token;
                     break;
                 }
                 throw $e;

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -95,7 +95,7 @@ class ArgvInput extends Input
             try {
                 $parseOptions = $this->parseToken($token, $parseOptions);
             } catch (UnexpectedArgumentException $e) {
-                if (true === $this->definition->getTolerateExtraTokens()) {
+                if (true === $this->definition->getIgnoreExtraArguments()) {
                     array_unshift($this->parsed, $token);
                     break;
                 }

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -125,7 +125,7 @@ class ArgvInput extends Input
 
     public function getUnparsedTokens(): array
     {
-        return $this->parsed;
+        return array_reverse($this->parsed);
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -64,6 +64,17 @@ class ArgvInput extends Input
         parent::__construct($definition);
     }
 
+    public function getSubCommandInput(): static
+    {
+        $tokens = $this->getUnparsedTokens();
+
+        // create a fake application name as it will be stripped in the ctor
+        array_unshift($tokens, '__fake_application_name__');
+        $argv = new ArgvInput($tokens);
+
+        return $argv;
+    }
+
     /** @param list<string> $tokens */
     protected function setTokens(array $tokens): void
     {

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -64,6 +64,9 @@ class ArgvInput extends Input
         parent::__construct($definition);
     }
 
+    /**
+     * Return a new Input instance for any sub-command.
+     */
     public function getSubCommandInput(): static
     {
         $tokens = $this->getUnparsedTokens();
@@ -71,6 +74,9 @@ class ArgvInput extends Input
         // create a fake application name as it will be stripped in the ctor
         array_unshift($tokens, '__fake_application_name__');
         $argv = new ArgvInput($tokens);
+
+        // the attributes are inherited
+        $argv->attributes = $this->attributes;
 
         return $argv;
     }
@@ -90,7 +96,7 @@ class ArgvInput extends Input
                 $parseOptions = $this->parseToken($token, $parseOptions);
             } catch (UnexpectedArgumentException $e) {
                 if (true === $this->definition->getTolerateExtraTokens()) {
-                    $this->parsed[] = $token;
+                    array_unshift($this->parsed, $token);
                     break;
                 }
                 throw $e;
@@ -136,7 +142,7 @@ class ArgvInput extends Input
 
     public function getUnparsedTokens(): array
     {
-        return array_reverse($this->parsed);
+        return $this->parsed;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -32,6 +32,7 @@ abstract class Input implements RawInputInterface, StreamableInputInterface
     protected $stream;
     protected array $options = [];
     protected array $arguments = [];
+    protected array $attributes = [];
     protected bool $interactive = true;
 
     public function __construct(?InputDefinition $definition = null)
@@ -42,6 +43,24 @@ abstract class Input implements RawInputInterface, StreamableInputInterface
             $this->bind($definition);
             $this->validate();
         }
+    }
+
+    public function setAttribute(string $name, mixed $value): void
+    {
+        $this->attributes[$name] = $value;
+    }
+
+    public function getAttribute(string $name): mixed
+    {
+        if (!array_key_exists($name, $this->attributes)) {
+            throw new RuntimeException(sprintf(
+                'Attribute "%s" not know, known attributes: "%s"',
+                $name,
+                implode('", "', array_keys($this->attributes))
+            ));
+        }
+
+        return $this->attributes[$name];
     }
 
     public function bind(InputDefinition $definition): void

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -35,7 +35,7 @@ class InputDefinition
     private array $options = [];
     private array $negations = [];
     private array $shortcuts = [];
-    private bool $tolerateExtraTokens = false;
+    private bool $ignoreExtraArguments = false;
 
     /**
      * @param array $definition An array of InputArgument and InputOption instance
@@ -352,14 +352,14 @@ class InputDefinition
         return $this->negations[$negation];
     }
 
-    public function getTolerateExtraTokens(): bool
+    public function getIgnoreExtraArguments(): bool
     {
-        return $this->tolerateExtraTokens;
+        return $this->ignoreExtraArguments;
     }
 
-    public function setTolerateExtraTokens(bool $tolerate): void
+    public function setIgnoreExtraArguments(bool $ignore): void
     {
-        $this->tolerateExtraTokens = $tolerate;
+        $this->ignoreExtraArguments = $ignore;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -35,6 +35,7 @@ class InputDefinition
     private array $options = [];
     private array $negations = [];
     private array $shortcuts = [];
+    private bool $tolerateExtraTokens = false;
 
     /**
      * @param array $definition An array of InputArgument and InputOption instance
@@ -349,6 +350,16 @@ class InputDefinition
         }
 
         return $this->negations[$negation];
+    }
+
+    public function getTolerateExtraTokens(): bool
+    {
+        return $this->tolerateExtraTokens;
+    }
+
+    public function setTolerateExtraTokens(bool $tolerate): void
+    {
+        $this->tolerateExtraTokens = $tolerate;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -858,5 +858,23 @@ class ArgvInputTest extends TestCase
             "A\nB'C",
             "A\nB'C",
         );
+
+        yield 'allow extra tokens' => (function () {
+            $definition = new InputDefinition();
+            $definition->setTolerateExtraTokens(true);
+            $definition->addOption(new InputOption('foo', null));
+            $definition->addArgument(new InputArgument('foo', InputArgument::REQUIRED));
+
+            return [
+                $definition,
+                new ArgvInput([
+                    'docker',
+                    'compose',
+                    'up',
+                ]),
+                null,
+                [],
+            ];
+        })();
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -861,7 +861,7 @@ class ArgvInputTest extends TestCase
 
         yield 'allow extra tokens' => (function () {
             $definition = new InputDefinition();
-            $definition->setTolerateExtraTokens(true);
+            $definition->setIgnoreExtraArguments(true);
             $definition->addOption(new InputOption('foo', null));
             $definition->addArgument(new InputArgument('foo', InputArgument::REQUIRED));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no? 
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

**NOTE: this PR is a rough proof-of-concept**

CLI applications such as `docker` or `git` make use of _sub-commands_. A sub command is appended to a parent command and is encapsulated - meaning that it options and arguments from the parent are not inherited.

For example the `docker` CLI application:

```
docker --context=foobar compose -f compose.yml --debug exec -t php bash
docker --context=foobar buildx --builder=foobar bake --check
```

The command tree might look like this:

```
                        +-------------+
                        | cmd:docker  |
                        +-------------+
                        | opt:context |
                        | opt:debug   |
                        +-------------+
                                |
                  +-------------+---------------+
                  |                             |
           +-------------+               +-------------+
           | cmd:compose |               | cmd:buildx  |
           +-------------+               +-------------+
           | opt:file    |               | opt:builder |
           +-------------+               +-------------+
                  |                             |
       +----------+--------+                    |
       |                   |                    |
+-------------+     +-------------+      +-------------+
|   cmd:up    |     |   cmd:down  |      |   cmd:bake  |
+-------------+     +-------------+      +-------------+
| arg:service |     | arg:service |      | opt:check   |
+-------------+     +-------------+      +-------------+
```

Each sub-command has its own options:

```
bin/console docker --context=foobar compose -f compose.yml exec container foobar
              ^          ^             ^          ^          ^      ^-------^
           1st cmd  1st opts        2nd cmd    2nd opts   3rd cmd    3rd args
```

This style of application is not currently possible in Symfony - essentially because it's not possible to ignore additional arguments.

Allowing additional arguments
-----------------------------

If it were possible to resolve the `docker` command and still have access to
the remaining tokens then it would be **possible** to create the example docker
application above.

```php
final class DockerCommand extends Command
{
    public function configure(): void
    {
        // ...

        $this->ignoreExtraArguments();
    }

    // ...

    public function execute(InputInterface $input, OutputInterface $output): int
    {
        $tokens = $input->getUnparsedTokens();

        $commandName = array_shift($tokens);

        // fetch the command!
        $command = $subCommandLocator->get($commandName);

        // awkward...
        array_unshift($tokens, '__fake_application_name__');
        $argv = new ArgvInput($tokens);

        return $command->run($argv, $output);
    }
}
```

For this to work we introduce the `ignoreExtraArguments` method and a method to retrieve the _unparsed_ tokens that would be left when that option is enabled.

Supporting Sub-Commands 
-----------------------

Supporting sub-commands in the console component would be _possible_ for the user with the above change, but refactoring would be required to support them natively, this PR attempts to illustrate a direction that could be taken.

Taking the docker example:

```php
#[AsCommand(name: 'docker')]
final class DockerCommnad extends Command
{
    public function configure(): void
    {
        $this->addOption('debug', null, InputOption::VALUE_NONE);
        $this->addOption('context', 'c', InputOption::VALUE_REQUIRED);

        $this->addCommand(new ComposeCommand());
    }

    public function __invoke(
        InputInterface $input,
        OutputInterface $output,
        ?string $context = null,
    ): int
    {
        assert($input instanceof ArgvInput);

        $subInput = $input->getSubCommandInput();

        $subInput->setAttribute('debug', $input->getOption('debug'));
        $subInput->setAttribute('context', $input->getOption('context'));

        return $this->doRun($subInput, $output);
    }
}

#[AsCommand(name: 'compose')]
final class ComposeCommand extends Command
{
    protected function configure(): void
    {
        $this->addCommand(new UpCommand());
        $this->addCommand(new DownCommand());
    }

    public function __invoke(
        InputInterface $input,
        OutputInterface $output,
        #[Option(shortcut: 'f')]
        ?string $file = null
    ): int
    {
        $debug = $input->getAttribute('debug');
        if ($debug && $file) {
            $output->writeln(sprintf('Using compose file: %s', $file));
        }

        return $this->doRun($input->getSubCommandInput(), $output);
    }
}

#[AsCommand(name:'up')]
final class UpCommand
{
    public function __invoke(
        InputInterface  $input,
        OutputInterface  $output,
        #[Argument]
        string $service,
    ): int
    {
        $output->writeln('running docker compose up');

        return 0;
    }
}

// etc
```

### Implementation

This POC is a rough sketch of how this could be implemented and the refactoring of the `Application` is very crude - but I think it could be done in a B/C manner eventually.

- Introduces an `AbstractCommand` class which contains everything relating to registering and running commands.
- The `Application` extends this class and therefore becomes command-like and commands become application-like.
- `$attributes` are added to the `Input` class - similar to `Request` attributes. Allowing context to be passed from "parent" to "child" commands.
- We introduce a method `getSubCommandInput()` to `ArgvInput` to take care of providing a valid input
- Commands can call `doRun($input, $output)` to execute sub-commands.

The final version would:

- Allow sub-command registration via. `#[AsCommand(name: 'compose', parent: DockerCommand::class)]` (where `parent` is a service ID).
- Not register commands with a "parent" in the main commmand locator.
- Dedicated command locators would be provided to each command that has sub-commands based on the `parent` mapping.
- Allow `Input` attributes to be injected via.  the ArgumentResolver
- Provide the expected "help" when a sub-command is attempted but cannot be found
- The `getUnparsedTokens` / `getSubCommandInput` would need to be generalized to some extent to `ArrayInput` etc.

## Next Steps

The easiest change would be to create a PR containing only the `ignoreAdditionalArguments()` and `getUnparsedTokens()` to make sub-commands _possible_ in userland and perhaps after that consider the larger refactoring proposed here.


