### PR TITLE
[FrameworkBundle] Make `WebTestCase` enable web mode by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -23,10 +23,17 @@ abstract class WebTestCase extends KernelTestCase
 {
     use WebTestAssertionsTrait;
 
+    private static bool $runtimeModeSet = false;
+
     protected function tearDown(): void
     {
         parent::tearDown();
         self::getClient(null);
+
+        if (self::$runtimeModeSet) {
+            unset($_SERVER['APP_RUNTIME_MODE']);
+            self::$runtimeModeSet = false;
+        }
     }
 
     /**
@@ -39,6 +46,11 @@ abstract class WebTestCase extends KernelTestCase
     {
         if (static::$booted) {
             throw new \LogicException(\sprintf('Booting the kernel before calling "%s()" is not supported, the kernel should only be booted once.', __METHOD__));
+        }
+
+        if (!isset($_SERVER['APP_RUNTIME_MODE'])) {
+            $_SERVER['APP_RUNTIME_MODE'] = 'web=1';
+            self::$runtimeModeSet = true;
         }
 
         $kernel = static::bootKernel($options);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ErrorHandler/config.yml
@@ -1,5 +1,2 @@
 imports:
     - { resource: ../config/default.yml }
-
-parameters:
-    kernel.runtime_mode.web: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64705
| License       | MIT

From https://github.com/symfony/symfony/pull/60033#pullrequestreview-3377148894:

> shouldn't web test cases run in "web" mode?