### PR TITLE
[HttpFoundation] re-allow the _version URL parameter for signed non-single-use URLs

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
@@ -256,13 +256,20 @@ class UriSignerTest extends TestCase
         $signer->sign('http://example.com/foo?_hash=bar', new \DateTimeImmutable('2099-01-01 00:00:00'));
     }
 
-    public function testSignWithReservedVersionParameter()
+    public function testSignWithReservedVersionParameterWithoutVersion()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?_version=valid', new \DateTimeImmutable('2099-01-01 00:00:00'))));
+    }
+
+    public function testSignWithReservedVersionParameterWithVersion()
     {
         $signer = new UriSigner('foobar');
 
         $this->expectException(LogicException::class);
 
-        $signer->sign('http://example.com/foo?_version=valid', new \DateTimeImmutable('2099-01-01 00:00:00'));
+        $signer->sign('http://example.com/foo?_version=valid', new \DateTimeImmutable('2099-01-01 00:00:00'), 'v1');
     }
 
     public function testSignDoesNotExposeVersion()

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -92,7 +92,7 @@ class UriSigner
             throw new LogicException(\sprintf('URI query parameter conflict: parameter name "%s" is reserved.', $this->expirationParameter));
         }
 
-        if (isset($params[$this->versionParameter])) {
+        if (null !== $version && isset($params[$this->versionParameter])) {
             throw new LogicException(\sprintf('URI query parameter conflict: parameter name "%s" is reserved.', $this->versionParameter));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | see https://github.com/symfony/symfony/pull/64408#discussion_r3485870854
| License       | MIT
