### PR TITLE
[HttpFoundation] Fold `UriSigner` version into the signature without a reserved parameter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -108,7 +108,6 @@ return static function (ContainerConfigurator $container) {
                 '_hash',
                 '_expiration',
                 service('clock')->nullOnInvalid(),
-                '_version',
             ])
             ->lazy()
         ->alias(UriSigner::class, 'uri_signer')

--- a/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
@@ -256,15 +256,6 @@ class UriSignerTest extends TestCase
         $signer->sign('http://example.com/foo?_hash=bar', new \DateTimeImmutable('2099-01-01 00:00:00'));
     }
 
-    public function testSignWithReservedVersionParameter()
-    {
-        $signer = new UriSigner('foobar');
-
-        $this->expectException(LogicException::class);
-
-        $signer->sign('http://example.com/foo?_version=valid', new \DateTimeImmutable('2099-01-01 00:00:00'));
-    }
-
     public function testSignDoesNotExposeVersion()
     {
         $signer = new UriSigner('foobar');

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -33,7 +33,6 @@ class UriSigner
     /**
      * @param string                 $hashParameter       Query string parameter to use
      * @param string                 $expirationParameter Query string parameter to use for expiration
-     * @param string                 $versionParameter    Reserved parameter name folded into the signature for versioning
      * @param \DateInterval|int|null $defaultExpiration   The expiration applied when none is passed to sign(); an int is a number of seconds
      */
     public function __construct(
@@ -41,7 +40,6 @@ class UriSigner
         private string $hashParameter = '_hash',
         private string $expirationParameter = '_expiration',
         private ?ClockInterface $clock = null,
-        private string $versionParameter = '_version',
         \DateInterval|int|null $defaultExpiration = null,
     ) {
         if (!$secret) {
@@ -92,21 +90,11 @@ class UriSigner
             throw new LogicException(\sprintf('URI query parameter conflict: parameter name "%s" is reserved.', $this->expirationParameter));
         }
 
-        if (isset($params[$this->versionParameter])) {
-            throw new LogicException(\sprintf('URI query parameter conflict: parameter name "%s" is reserved.', $this->versionParameter));
-        }
-
         if (null !== $expiration) {
             $params[$this->expirationParameter] = $this->getExpirationTime($expiration);
         }
 
-        $hashParams = $params;
-
-        if (null !== $version) {
-            $hashParams[$this->versionParameter] = $version;
-        }
-
-        $params[$this->hashParameter] = $this->computeHash($this->buildUrl($url, $hashParams));
+        $params[$this->hashParameter] = $this->computeHash($this->buildUrl($url, $params), $version);
 
         return $this->buildUrl($url, $params);
     }
@@ -159,8 +147,14 @@ class UriSigner
         };
     }
 
-    private function computeHash(string $uri): string
+    private function computeHash(string $uri, #[\SensitiveParameter] ?string $version = null): string
     {
+        if (null !== $version) {
+            // the version is folded into the signature without ever being exposed in the URI;
+            // the NUL byte safely separates it from the URI, which can never contain one
+            $uri .= "\0".$version;
+        }
+
         return strtr(rtrim(base64_encode(hash_hmac('sha256', $uri, $this->secret, true)), '='), ['/' => '_', '+' => '-']);
     }
 
@@ -219,13 +213,7 @@ class UriSigner
         $hash = $params[$this->hashParameter];
         unset($params[$this->hashParameter]);
 
-        $hashParams = $params;
-
-        if (null !== $version) {
-            $hashParams[$this->versionParameter] = $version;
-        }
-
-        if (!hash_equals($this->computeHash($this->buildUrl($url, $hashParams)), strtr(rtrim($hash, '='), ['/' => '_', '+' => '-']))) {
+        if (!hash_equals($this->computeHash($this->buildUrl($url, $params), $version), strtr(rtrim($hash, '='), ['/' => '_', '+' => '-']))) {
             return self::STATUS_INVALID;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Replaces #64753
| License       | MIT

Follow-up to #64408

The version was never written to the URI, so exposing it as a configurable `$versionParameter` (guarded by a reserved-parameter conflict check) added plumbing for no benefit. Fold it directly into the hashed message, separated by a NUL byte that the percent-encoded URI can never contain.

This also removes a collision the reservation was working around: signing "/foo?_version=v1" and signing "/foo" with version "v1" previously produced identical hash inputs. With the separator they are distinct, so `_version` becomes an ordinary signable parameter.