### PR TITLE
[Lock] Add MysqlStore for advisory locking

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -251,6 +251,9 @@ jobs:
           php .github/sync-translations.php
           git diff --exit-code src/ || (echo '::error::Run "php .github/sync-translations.php" to fix XLIFF files.' && exit 1)
 
+      - name: Start MySQL
+        run: sudo systemctl start mysql.service
+
       - name: Run tests
         run: ./phpunit --group integration
         env:
@@ -270,3 +273,6 @@ jobs:
           KAFKA_BROKER: 127.0.0.1:9092
           POSTGRES_HOST: localhost
           PGBOUNCER_HOST: localhost:6432
+          MYSQL_DSN: mysql:host=localhost
+          MYSQL_USERNAME: root
+          MYSQL_PASSWORD: root

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `MysqlStore` based on MySQL `GET_LOCK()` functionality, usable with the `mysql+advisory:` DSN
+
 8.1
 ---
 

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Store;
+
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\SharedLockStoreInterface;
+
+/**
+ * MysqlStore is a PersistingStoreInterface implementation using advisory locks.
+ *
+ * The advisory locking functions used by this class are supported by both MySQL and MariaDB.
+ * It requires MySQL 5.7.5 or MariaDB 10.0.2, the versions that let a session hold several
+ * named locks at once. On older servers, acquiring a lock releases the previous one.
+ *
+ * @author Ryan Pon <me@ryanpon.com>
+ * @author rtek
+ * @author Jérôme TAMARELLE <jerome@tamarelle.net>
+ */
+class MysqlStore implements PersistingStoreInterface
+{
+    private \PDO $conn;
+
+    private string $dsn;
+
+    private array $options;
+
+    private \PDOStatement $saveStmt;
+
+    private \PDOStatement $existsStmt;
+
+    private \PDOStatement $deleteStmt;
+
+    /**
+     * You can either pass an existing database connection as PDO instance or
+     * a DSN string that will be used to lazy-connect to the database when the
+     * lock is actually used.
+     *
+     * List of available options:
+     *  * db_username: The username when lazy-connect [default: '']
+     *  * db_password: The password when lazy-connect [default: '']
+     *  * db_connection_options: An array of driver-specific connection options [default: []]
+     *
+     * @param array $options An associative array of options
+     *
+     * @throws InvalidArgumentException When PDO error mode is not PDO::ERRMODE_EXCEPTION
+     * @throws InvalidArgumentException When driver is not mysql
+     */
+    public function __construct(#[\SensitiveParameter] \PDO|string $connOrDsn, #[\SensitiveParameter] array $options = [])
+    {
+        if ($connOrDsn instanceof \PDO) {
+            $this->conn = $connOrDsn;
+            $this->assertMysqlDriver();
+            if (\PDO::ERRMODE_EXCEPTION !== $this->conn->getAttribute(\PDO::ATTR_ERRMODE)) {
+                throw new InvalidArgumentException(\sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION)).', __METHOD__));
+            }
+        } else {
+            $this->dsn = $connOrDsn;
+        }
+
+        $this->options = $options;
+    }
+
+    public function save(Key $key): void
+    {
+        $this->getInternalStore()->save($key);
+
+        $lockAcquired = false;
+
+        try {
+            $stmt = $this->saveStmt ??
+                $this->saveStmt = $this->getConnection()->prepare('SELECT IF(IS_USED_LOCK(:name1) = CONNECTION_ID(), -1, GET_LOCK(:name2, 0))');
+            $name = self::getHashedKey($key);
+            $stmt->execute(['name1' => $name, 'name2' => $name]);
+            $maybeResult = $stmt->fetchColumn();
+            if (null === $maybeResult) {
+                throw new LockAcquiringException('Failed to acquire lock due to mysql error.');
+            }
+
+            $result = (int) $maybeResult;
+
+            // 1 means lock was acquired, -1 means it was already acquired on this conn
+            if (1 === $result || -1 === $result) {
+                $key->markUnserializable();
+                $lockAcquired = true;
+
+                return;
+            }
+
+            if (0 === $result) {
+                throw new LockConflictedException('Lock already acquired by other connection.');
+            }
+
+            // We only expect to receive 1, 0, -1
+            throw new LockAcquiringException('Failed to acquire lock due to mysql error.');
+        } finally {
+            if (!$lockAcquired) {
+                $this->getInternalStore()->delete($key);
+            }
+        }
+    }
+
+    public function putOffExpiration(Key $key, float $ttl): void
+    {
+        // mysql locks forever.
+        // check if lock still exists
+        if (!$this->exists($key)) {
+            throw new LockConflictedException();
+        }
+    }
+
+    public function delete(Key $key): void
+    {
+        // Prevent deleting locks own by an other key in the same connection
+        if ($this->exists($key)) {
+            $stmt = $this->deleteStmt ??
+                $this->deleteStmt = $this->getConnection()->prepare('DO RELEASE_LOCK(:name)');
+
+            $stmt->execute(['name' => self::getHashedKey($key)]);
+        }
+
+        // the internal store is cleared even when the server already dropped the lock,
+        // otherwise the resource would stay taken for the rest of the process
+        $this->getInternalStore()->delete($key);
+    }
+
+    public function exists(Key $key): bool
+    {
+        $stmt = $this->existsStmt ??
+            $this->existsStmt = $this->getConnection()->prepare('SELECT IS_USED_LOCK(:name) = CONNECTION_ID()');
+
+        $stmt->execute(['name' => self::getHashedKey($key)]);
+        $result = (int) $stmt->fetchColumn();
+
+        if (1 === $result) {
+            return $this->getInternalStore()->exists($key);
+        }
+
+        return false;
+    }
+
+    private function getConnection(): \PDO
+    {
+        if (!isset($this->conn)) {
+            $this->conn = new \PDO(
+                $this->dsn,
+                $this->options['db_username'] ?? null,
+                $this->options['db_password'] ?? null,
+                $this->options['db_connection_options'] ?? null
+            );
+            $this->conn->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            $this->assertMysqlDriver();
+        }
+
+        return $this->conn;
+    }
+
+    private function assertMysqlDriver(): void
+    {
+        if ('mysql' !== $driver = $this->conn->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+            throw new InvalidArgumentException(\sprintf('The adapter "%s" does not support the "%s" driver.', __CLASS__, $driver));
+        }
+    }
+
+    private static function getHashedKey(Key $key): string
+    {
+        // mysql limits lock name length to 64 chars
+        // mariadb compares locks in a case insensitive fashion
+        // we mostly get around these limitations by always hashing the key
+        return hash('sha256', (string) $key);
+    }
+
+    private function getInternalStore(): SharedLockStoreInterface
+    {
+        static $storeRegistry = new \WeakMap();
+
+        return $storeRegistry[$this->getConnection()] ??= new InMemoryStore();
+    }
+}

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -118,6 +118,11 @@ class StoreFactory
             case str_starts_with($connection, 'pgsql+advisory:'):
                 return new PostgreSqlStore(preg_replace('/^([^:+]+)\+advisory/', '$1', $connection));
 
+            case str_starts_with($connection, 'mysql+advisory://'):
+                throw new InvalidArgumentException('The "mysql+advisory://" scheme is not supported, use a PDO DSN such as "mysql+advisory:host=localhost;dbname=app".');
+            case str_starts_with($connection, 'mysql+advisory:'):
+                return new MysqlStore(preg_replace('/^([^:+]+)\+advisory/', '$1', $connection));
+
             case str_starts_with($connection, 'zookeeper://'):
                 return new ZookeeperStore(ZookeeperStore::createConnection($connection));
 

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Store\MysqlStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
+
+#[RequiresPhpExtension('pdo_mysql')]
+#[Group('integration')]
+class MysqlStoreTest extends AbstractStoreTestCase
+{
+    protected function getEnv(): array
+    {
+        if (!$dsn = getenv('MYSQL_DSN')) {
+            $this->markTestSkipped('Missing MYSQL_DSN env variable');
+        }
+
+        if (!$user = getenv('MYSQL_USERNAME')) {
+            $this->markTestSkipped('Missing MYSQL_USERNAME env variable');
+        }
+
+        if (!$pass = getenv('MYSQL_PASSWORD')) {
+            $this->markTestSkipped('Missing MYSQL_PASSWORD env variable');
+        }
+
+        return [$dsn, $user, $pass];
+    }
+
+    protected function getPdo(): \PDO
+    {
+        [$dsn, $user, $pass] = $this->getEnv();
+
+        return new \PDO($dsn, $user, $pass);
+    }
+
+    protected function getStore(): PersistingStoreInterface
+    {
+        return new MysqlStore($this->getPdo());
+    }
+
+    public function testDriverRequirement()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new MysqlStore(new \PDO('sqlite::memory:'));
+    }
+
+    public function testExceptionModeRequirement()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $pdo = $this->getPdo();
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_SILENT);
+        new MysqlStore($pdo);
+    }
+
+    public function testOtherConnConflictException()
+    {
+        $storeA = $this->getStore();
+        $storeB = $this->getStore();
+
+        $key = new Key('foo');
+        $storeA->save($key);
+
+        $this->assertFalse($storeB->exists($key));
+
+        try {
+            $storeB->save($key);
+            $this->fail('Expected exception: '.LockConflictedException::class);
+        } catch (LockConflictedException $e) {
+            $this->assertStringContainsString('acquired by other', $e->getMessage());
+        }
+    }
+
+    public function testExistsOnKeyClone()
+    {
+        $store = $this->getStore();
+
+        $key = new Key('foo');
+        $store->save($key);
+
+        $this->assertTrue($store->exists($key));
+        $this->assertTrue($store->exists(clone $key));
+    }
+
+    public function testDeleteKeyWhileNotOwned()
+    {
+        $store = $this->getStore();
+
+        $keyA = new Key('foo');
+        $keyB = new Key('foo');
+
+        $store->save($keyA); // OK
+        try {
+            $store->save($keyB); // Conflict
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+        }
+
+        $store->delete($keyB);
+        $this->assertTrue($store->exists($keyA));
+        $this->assertFalse($store->exists($keyB));
+    }
+
+    public function testStoresAreStateless()
+    {
+        $pdo = $this->getPdo();
+
+        $storeA = new MysqlStore($pdo);
+        $storeB = new MysqlStore($pdo);
+        $key = new Key('foo');
+
+        $storeA->save($key);
+        $this->assertTrue($storeA->exists($key));
+        $this->assertTrue($storeB->exists($key));
+
+        $storeB->delete($key);
+        $this->assertFalse($storeB->exists($key));
+        $this->assertFalse($storeA->exists($key));
+    }
+
+    public function testDsnConstructor()
+    {
+        $this->expectNotToPerformAssertions();
+
+        [$dsn, $user, $pass] = $this->getEnv();
+        $store = new MysqlStore("$dsn", ['db_username' => $user, 'db_password' => $pass]);
+        $store->save(new Key('foo'));
+    }
+
+    public function testStringifiedFetches()
+    {
+        [$dsn, $user, $pass] = $this->getEnv();
+        $pdo = new \PDO($dsn, $user, $pass, [\PDO::ATTR_STRINGIFY_FETCHES => true]);
+        $store = new MysqlStore($pdo);
+
+        $key = new Key('foo');
+        $store->save($key);
+        $this->assertTrue($store->exists($key));
+        $store->delete($key);
+        $this->assertFalse($store->exists($key));
+    }
+
+    public function testNativePreparedStatements()
+    {
+        [$dsn, $user, $pass] = $this->getEnv();
+        $pdo = new \PDO($dsn, $user, $pass, [\PDO::ATTR_EMULATE_PREPARES => false]);
+        $store = new MysqlStore($pdo);
+
+        $key = new Key('foo');
+        $store->save($key);
+        $this->assertTrue($store->exists($key));
+        $store->delete($key);
+        $this->assertFalse($store->exists($key));
+    }
+
+    public function testPutOffExpirationWhenLockIsLost()
+    {
+        $pdo = $this->getPdo();
+        $store = new MysqlStore($pdo);
+
+        $key = new Key('foo');
+        $store->save($key);
+
+        $hashedKey = hash('sha256', (string) $key);
+
+        $pdo->exec("DO RELEASE_LOCK('$hashedKey')");
+
+        $this->expectException(LockConflictedException::class);
+        $store->putOffExpiration($key, 300.0);
+    }
+
+    public function testDeleteReleasesTheResourceWhenLockIsLost()
+    {
+        $pdo = $this->getPdo();
+        $store = new MysqlStore($pdo);
+
+        $key = new Key('foo');
+        $store->save($key);
+
+        $pdo->exec(\sprintf("DO RELEASE_LOCK('%s')", hash('sha256', (string) $key)));
+        $store->delete($key);
+
+        $newKey = new Key('foo');
+        $store->save($newKey);
+
+        $this->assertTrue($store->exists($newKey));
+    }
+
+    public function testResourcesDifferingOnlyByCase()
+    {
+        $store = $this->getStore();
+
+        $keyLower = new Key('foo');
+        $keyUpper = new Key('FOO');
+
+        $store->save($keyLower);
+
+        $store->save($keyUpper);
+        $this->assertTrue($store->exists($keyUpper));
+        $store->delete($keyUpper);
+
+        $this->assertFalse($store->exists($keyUpper));
+        $this->assertTrue($store->exists($keyLower));
+
+        $storeB = $this->getStore();
+        try {
+            $storeB->save(new Key('foo'));
+            $this->fail('The lock held by $keyLower was released by another key');
+        } catch (LockConflictedException) {
+            $this->addToAssertionCount(1);
+        }
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -19,11 +19,13 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Lock\Store\MemcachedStore;
+use Symfony\Component\Lock\Store\MysqlStore;
 use Symfony\Component\Lock\Store\NullStore;
 use Symfony\Component\Lock\Store\PdoStore;
 use Symfony\Component\Lock\Store\PostgreSqlStore;
@@ -42,6 +44,14 @@ class StoreFactoryTest extends TestCase
         $store = StoreFactory::createStore($connection);
 
         $this->assertInstanceOf($expectedStoreClass, $store);
+    }
+
+    public function testCreateStoreRejectsMysqlAdvisoryUrl()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "mysql+advisory://" scheme is not supported, use a PDO DSN such as "mysql+advisory:host=localhost;dbname=app".');
+
+        StoreFactory::createStore('mysql+advisory://user:pass@localhost:3306/test');
     }
 
     #[RequiresPhpExtension('sysvsem')]
@@ -83,6 +93,7 @@ class StoreFactoryTest extends TestCase
             yield ['mysql:host=localhost;dbname=test;', PdoStore::class];
             yield ['pgsql:host=localhost;dbname=test;', PdoStore::class];
             yield ['pgsql+advisory:host=localhost;dbname=test;', PostgreSqlStore::class];
+            yield ['mysql+advisory:host=localhost;dbname=test;', MysqlStore::class];
             yield ['oci:host=localhost;dbname=test;', PdoStore::class];
             yield ['sqlsrv:server=localhost;Database=test', PdoStore::class];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT
| Doc PR        | symfony/symfony-docs#22440

Adds `MysqlStore`, a session-backed lock store built on MySQL user-level locks (`GET_LOCK`, `RELEASE_LOCK`, `IS_USED_LOCK`, `CONNECTION_ID`), reachable through the `mysql+advisory:` DSN. It is to `PdoStore` what `PostgreSqlStore` is to `DoctrineDbalStore`: no `lock_keys` table, no TTL, and the server drops every lock when the session ends, so a crashed client cannot leave a resource locked forever.

`save()` runs a single statement:

```sql
SELECT IF(IS_USED_LOCK(:name1) = CONNECTION_ID(), -1, GET_LOCK(:name2, 0))
```

`-1` means this session already holds the lock, so it is not re-acquired. That keeps MySQL's per-session lock counter at 1 and makes a single `RELEASE_LOCK` enough. Lock names are always `hash('sha256', (string) $key)`, which sidesteps both the 64-character name limit and any collation question.

Per-connection concurrency uses the same static `WeakMap` of `InMemoryStore` as `PostgreSqlStore`.

Added during review:

* the minimum server versions are now stated on the class. The store holds several named locks per session, which MySQL only allows from 5.7.5 and MariaDB from 10.0.2. On an older server `GET_LOCK` releases the previously held lock, and the store would report both as held while the server holds one;
* `mysql+advisory://user:pass@host/db` is now rejected. It used to match the new case, get rewritten to a Doctrine URL that `\PDO` cannot parse, and fail on the first `acquire()` in production with `could not find driver` and no DSN in the message. Anyone copying the `pgsql+advisory://` shape from the docs landed here. Covered by `StoreFactoryTest::testCreateStoreRejectsMysqlAdvisoryUrl`;
* `delete()` no longer leaves a resource wedged after the server drops a lock underneath the store. It used to return early when `exists()` was false, keeping the `InMemoryStore` entry, so no other `Key` on that connection could take the resource again even though MySQL was free. `testPutOffExpirationWhenLockIsLost` already built that state; `testDeleteReleasesTheResourceWhenLockIsLost` now carries it one step further. The release itself is still guarded by `exists()`, so a key still cannot release a lock owned by another key on the same connection;
* the comment about case-insensitive comparison now names MariaDB. MySQL 5.7+ compares user-level lock names byte-wise; MariaDB is the case-insensitive one. The sha256 hex hash is lowercase either way, so the mitigation was already correct.

Note for the merger: the `Fabbot / Checks` failure is a false positive. Fabbot re-lints whole touched files and flags a pre-existing `StoreFactory::requireBridgeClass()` exception message that this PR does not change; its suggested fix produces broken nested quotes, which is why that hunk was reverted earlier in the review.

Not covered by CI: MariaDB, and any MySQL older than the runner's 8.0.
