### PR TITLE
[Yaml] Improve the error message for an unterminated quoted string

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1204,7 +1204,7 @@ class Parser
             }
         } while ($this->moveToNextLine());
 
-        throw new ParseException('Malformed inline YAML string.');
+        throw new ParseException('Unterminated quoted string. If it spans multiple lines, its continuation lines must be indented at least as deeply as where it starts.');
     }
 
     private function lexUnquotedString(int &$cursor): string

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1268,6 +1268,21 @@ class ParserTest extends TestCase
         $this->parser->parse($yaml);
     }
 
+    public function testParseUnterminatedQuotedStringException()
+    {
+        $yaml = <<<'EOF'
+            foo:
+                bar: 'first line
+                    second line
+            '
+            EOF;
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Unterminated quoted string');
+
+        $this->parser->parse($yaml);
+    }
+
     public function testExplicitStringCasting()
     {
         $yaml = <<<'EOF'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | #33082
| License       | MIT

When a multi-line quoted scalar has a continuation or closing line indented less than where it starts, the closing quote falls outside the value's block and is never reached. Parsing then fails with `Malformed inline YAML string`, which gives no hint that indentation is the cause:

```yaml
foo:
    bar: 'first line
        second line
'
```

The new message names the problem instead:

> Unterminated quoted string. If it spans multiple lines, its continuation lines must be indented at least as deeply as where it starts.

The parsing is unchanged and the input stays invalid (accepting it was tried in #48022 and reverted). This only improves the error reported in #33082.
