### PR TITLE
[Bridge][Monolog] Implements ProcessorInterface on our processors

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Processor;
 
 use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -23,7 +24,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  *
  * @internal
  */
-abstract class AbstractTokenProcessor
+abstract class AbstractTokenProcessor implements ProcessorInterface
 {
     private bool $processing = false;
 

--- a/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Processor;
 
 use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleEvent;
@@ -23,7 +24,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @author Piotr Stankowski <git@trakos.pl>
  */
-final class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterface, ResettableInterface
+final class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterface, ResettableInterface, ProcessorInterface
 {
     private array $commandData;
 

--- a/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/RouteProcessor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Processor;
 
 use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
@@ -26,7 +27,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @final
  */
-class RouteProcessor implements EventSubscriberInterface, ResetInterface, ResettableInterface
+class RouteProcessor implements EventSubscriberInterface, ResetInterface, ResettableInterface, ProcessorInterface
 {
     private array $routeData = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no really
| Deprecations? | no
| Issues        |
| License       | MIT

ATM, Symfony builtin processors have weird configurations!

* Our web processor extends monolog one, So it has the "implements", so it's autoconfigured
* Token processor, via the bundle, is tagged explicitly: https://github.com/symfony/monolog-bundle/blob/423bc371cd5c9f95652ed01f128c0c58ab77cad7/src/DependencyInjection/MonologExtension.php#L96-L97
* Processors that implements the interface are autoconfigured
* But our processors don't implements the interface => Not registered :/ Not cool!
