### PR TITLE
[Bridge][Monolog] Do not reset in ConsoleCommandProcessor

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
@@ -52,7 +52,8 @@ class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterfac
      */
     public function reset()
     {
-        unset($this->commandData);
+        // the command data is set once, on ConsoleEvents::COMMAND, and must outlive any reset
+        // happening while the command is still running
     }
 
     /**

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
@@ -61,6 +61,19 @@ class ConsoleCommandProcessorTest extends TestCase
         $this->assertEquals([], $record['extra']);
     }
 
+    public function testCommandDataSurvivesReset()
+    {
+        $processor = new ConsoleCommandProcessor();
+        $processor->addCommandData($this->getConsoleEvent());
+
+        $processor->reset();
+
+        $record = $processor(RecordFactory::create());
+
+        $this->assertArrayHasKey('command', $record['extra']);
+        $this->assertSame(self::TEST_NAME, $record['extra']['command']['name']);
+    }
+
     private function getConsoleEvent(): ConsoleEvent
     {
         $input = $this->createStub(InputInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

It does not make sense to reset the command name in this processor!
When the command is `messenger:consume`, as soon as messenger processes a message,
it resets the containers, so we lost valuable data.

The command data is written once, on `ConsoleEvents::COMMAND`, and nothing writes it again for the rest of the run. So any reset happening while the command is still running strips the command name from every later record. `ResetServicesListener` does exactly that after each message, and the processor is a `kernel.reset` service because it implements `ResetInterface`.

Retargeted from 8.2 to 6.4 during review. The first version removed `ResetInterface`, `Monolog\ResettableInterface` and the `reset()` method, which is a BC break and can only land on the dev branch. Emptying the method body fixes the same bug, is BC safe, and reaches every maintained branch:

* nothing is removed, so an application that hand-tagged the service `kernel.reset` with `method: reset` keeps working;
* on 7.3 and later the class also implements `Monolog\ResettableInterface`, and `Logger::reset()` cascades into the same method, so the merge-up neutralizes that second path for free. Verified on 8.2 with a test driving the real cascade;
* the service cannot simply be untagged instead, because the tag is autoconfigured from `ResetInterface`.

Removing the interfaces and the now-empty method is still worth doing on the dev branch, but as a cleanup rather than as the fix.

Added during review: `ConsoleCommandProcessorTest::testCommandDataSurvivesReset`, which fails on 6.4 with `Failed asserting that an array has the key 'command'`.

One behaviour change worth recording: log records emitted after a reset and before the next `ConsoleEvents::COMMAND` now carry the previous command's name instead of no command at all. Records emitted inside a later command are correct, because `addCommandData` overwrites at `ConsoleEvents::COMMAND` with priority 1, before the command body runs.
