### PR TITLE
[ObjectMapper] Fix explicit #[Map(target:)] being overwritten by a same-name source property

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -132,6 +132,8 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         $mapToProperties = [];
+        $explicitTargets = [];
+        $implicitValues = [];
         foreach ($this->getAllProperties($refl) as $property) {
             if ($property->isStatic()) {
                 continue;
@@ -174,6 +176,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 }
 
                 $value = $this->getSourceValue($source, $mappedTarget, $value, $objectMap, $mapping);
+                $explicitTargets[$targetPropertyName] = true;
                 $this->storeValue($targetPropertyName, $mapToProperties, $ctorArguments, $value);
             }
 
@@ -187,7 +190,12 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $value = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap);
+                $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap);
+            }
+        }
+
+        foreach ($implicitValues as $propertyName => $value) {
+            if (!isset($explicitTargets[$propertyName])) {
                 $this->storeValue($propertyName, $mapToProperties, $ctorArguments, $value);
             }
         }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/BaseSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/BaseSource.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority;
+
+class BaseSource
+{
+    public string $email = 'from-email';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/ChildSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/ChildSource.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Target::class)]
+class ChildSource extends BaseSource
+{
+    #[Map(target: 'email')]
+    public string $customerEmail = 'from-customerEmail';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/ConditionalSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/ConditionalSource.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Target::class)]
+class ConditionalSource
+{
+    #[Map(target: 'email', if: [self::class, 'never'])]
+    public string $customerEmail = 'from-customerEmail';
+
+    public string $email = 'from-email';
+
+    public static function never(mixed $value): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/ReversedSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/ReversedSource.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Target::class)]
+class ReversedSource
+{
+    public string $email = 'from-email';
+    #[Map(target: 'email')]
+    public string $customerEmail = 'from-customerEmail';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/Source.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Target::class)]
+class Source
+{
+    #[Map(target: 'email')]
+    public string $customerEmail = 'from-customerEmail';
+    public string $email = 'from-email';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/Target.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitTargetPriority/Target.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority;
+
+class Target
+{
+    public string $email = '';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -48,6 +48,10 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\NestedSource as
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\NestedTarget as ExplicitSourceNestedTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\Source as ExplicitSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\Target as ExplicitSourceTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority\ChildSource as ExplicitTargetPriorityChildSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority\ConditionalSource as ExplicitTargetPriorityConditionalSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority\ReversedSource as ExplicitTargetPriorityReversedSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitTargetPriority\Source as ExplicitTargetPrioritySource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
@@ -813,6 +817,39 @@ final class ObjectMapperTest extends TestCase
         $source = new MultipleTargetPropertyA();
         $mapper = new ObjectMapper();
         $mapper->map($source);
+    }
+
+    public function testExplicitMappingTakesPriorityOverImplicitSameNameProperty()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new ExplicitTargetPrioritySource());
+        $this->assertSame('from-customerEmail', $target->email);
+    }
+
+    public function testExplicitMappingTakesPriorityRegardlessOfDeclarationOrder()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new ExplicitTargetPriorityReversedSource());
+        $this->assertSame('from-customerEmail', $target->email);
+    }
+
+    public function testSkippedConditionalMappingKeepsImplicitValue()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new ExplicitTargetPriorityConditionalSource());
+        $this->assertSame('from-email', $target->email);
+    }
+
+    public function testExplicitMappingTakesPriorityOverInheritedImplicitProperty()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new ExplicitTargetPriorityChildSource());
+
+        $this->assertSame('from-customerEmail', $target->email);
     }
 
     public function testConditionalMappingAppliedToConstructorArguments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64769
| License       | MIT

In `doMap()`, explicit `#[Map(target:)]` mappings and implicit same-name mappings store their values into the same array, keyed by target property, in source-property iteration order (own properties first, then parents). The last writer wins, so an unmapped source property whose name matches an explicit mapping's target silently overwrites it. The inheritance variant is always broken: a parent property with the same name as a child's explicit target is iterated last and wins unconditionally.

The fix tracks which target properties were claimed by an explicit mapping and buffers implicit same-name values, flushing them after the loop only for unclaimed targets. Explicit mappings now win deterministically, regardless of declaration order or inheritance.

Notes:
- A target is only claimed when a value is actually stored: an explicit mapping skipped by a runtime `if` callable, a non-matching `TargetClass` condition, or an unreadable source property does not suppress the implicit fallback. This is covered by a dedicated test.
- One edge becomes deterministic: with a literal `if: false` on a constructor argument, the outcome previously depended on declaration order; the implicit value now always applies.
