### PR TITLE
[SecurityBundle] Add leeway to OIDC token handler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add the `leeway` option to the OIDC token handler configuration
  * Add support for the `clientHints`, `prefetchCache`, and `prerenderCache` `ClearSite-Data` directives
  * Add support for `#[AsTaggedItem]` attribute to configure voter priority
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -31,6 +31,7 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
             ->replaceArgument(2, $config['audience'])
             ->replaceArgument(3, $config['issuers'])
             ->replaceArgument(4, $config['claim'])
+            ->replaceArgument('$leeway', $config['leeway'])
             ->addTag('container.reversible')
         );
 
@@ -148,6 +149,11 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                     ->scalarNode('claim')
                         ->info('Claim which contains the user identifier (e.g.: sub, email..).')
                         ->defaultValue('sub')
+                    ->end()
+                    ->integerNode('leeway')
+                        ->info('Leeway in seconds allowed when validating the "iat", "nbf" and "exp" claims.')
+                        ->defaultValue(0)
+                        ->min(0)
                     ->end()
                     ->scalarNode('audience')
                         ->info('Audience set in the token, for validation purpose.')

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -91,6 +91,7 @@ return static function (ContainerConfigurator $container) {
                 'sub',
                 service('logger')->nullOnInvalid(),
                 service('clock'),
+                '$leeway' => 0,
             ])
 
         ->set('security.access_token_handler.oidc_discovery.http_client', HttpClientInterface::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -141,6 +141,27 @@ class AccessTokenFactoryTest extends TestCase
         $this->processConfig($config, $factory);
     }
 
+    public function testInvalidOidcTokenHandlerConfigurationWithNegativeLeeway()
+    {
+        $config = [
+            'token_handler' => [
+                'oidc' => [
+                    'algorithms' => ['RS256'],
+                    'issuers' => ['https://www.example.com'],
+                    'audience' => 'audience',
+                    'keyset' => 'keyset',
+                    'leeway' => -1,
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig($config, $factory);
+    }
+
     public function testOidcTokenHandlerConfigurationWithMultipleAlgorithms()
     {
         $container = new ContainerBuilder();
@@ -151,6 +172,7 @@ class AccessTokenFactoryTest extends TestCase
                     'algorithms' => ['RS256', 'ES256'],
                     'issuers' => ['https://www.example.com'],
                     'audience' => 'audience',
+                    'leeway' => 60,
                     'keyset' => $jwkset,
                 ],
             ],
@@ -172,6 +194,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_2' => 'audience',
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
+            '$leeway' => 60,
         ];
         $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
     }
@@ -292,6 +315,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_2' => 'audience',
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
+            '$leeway' => 0,
         ];
         $expectedCalls = [
             [
@@ -347,6 +371,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_2' => 'audience',
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
+            '$leeway' => 0,
         ];
         $expectedCalls = [
             [

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -62,7 +62,11 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         private string $claim = 'sub',
         private ?LoggerInterface $logger = null,
         private ClockInterface $clock = new Clock(),
+        private int $leeway = 0,
     ) {
+        if (0 > $leeway) {
+            throw new \InvalidArgumentException('The "$leeway" argument must be greater than or equal to 0.');
+        }
     }
 
     public function enableJweSupport(JWKSet $decryptionKeyset, AlgorithmManager $decryptionAlgorithms, bool $enforceEncryption): void
@@ -223,9 +227,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
     {
         // Verify the claims
         $checkers = [
-            new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-            new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-            new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+            new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: $this->leeway, protectedHeaderOnly: true),
+            new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: $this->leeway, protectedHeaderOnly: true),
+            new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: $this->leeway, protectedHeaderOnly: true),
             new Checker\AudienceChecker($this->audience),
             new Checker\IssuerChecker($this->issuers),
         ];
@@ -248,9 +252,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
                 new Checker\AlgorithmChecker($this->decryptionAlgorithms->list()),
                 new Checker\CallableChecker('enc', fn ($value) => \in_array($value, $this->decryptionAlgorithms->list())),
                 new Checker\CallableChecker('cty', static fn ($value) => 'JWT' === $value),
-                new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-                new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
-                new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: 0, protectedHeaderOnly: true),
+                new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: $this->leeway, protectedHeaderOnly: true),
+                new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: $this->leeway, protectedHeaderOnly: true),
+                new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: $this->leeway, protectedHeaderOnly: true),
             ],
             [new JWETokenSupport()]
         );

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add configurable leeway to `OidcTokenHandler`
  * Add support for the `clientHints`, `prefetchCache`, and `prerenderCache` `ClearSite-Data` directives
 
 8.0

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -126,6 +127,47 @@ class OidcTokenHandlerTest extends TestCase
                 'email' => 'foo@example.com',
             ])),
         ];
+    }
+
+    public function testGetsUserIdentifierFromExpiredTokenWithinConfiguredLeeway()
+    {
+        $clock = new MockClock('2026-06-06T12:00:00+00:00');
+        $time = $clock->now()->getTimestamp();
+        $claims = [
+            'iat' => $time - 3600,
+            'nbf' => $time - 3600,
+            'exp' => $time - 30,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+            'email' => 'foo@example.com',
+        ];
+        $token = self::buildJWS(json_encode($claims));
+
+        $userBadge = (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            clock: $clock,
+            leeway: 60,
+        ))->getUserBadgeFrom($token);
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+    }
+
+    public function testRejectsNegativeLeeway()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "$leeway" argument must be greater than or equal to 0.');
+
+        (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            leeway: -1,
+        ))->getUserBadgeFrom('invalid');
     }
 
     public function testThrowsAnErrorIfUserPropertyIsMissing()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds a configurable `leeway` option to the OIDC token handler.

The leeway is used when validating temporal JWT claims (`iat`, `nbf` and `exp`) to account for small clock skews between systems. The default remains `0`, so the current strict validation behavior is preserved unless users explicitly configure a leeway.

Example:

```yaml
security:
    firewalls:
        main:
            access_token:
                token_handler:
                    oidc:
                        algorithms: ['RS256']
                        issuers: ['https://issuer.example.com']
                        audience: 'api'
                        keyset: '%env(OIDC_JWKSET)%'
                        leeway: 60