### PR TITLE
[CI] Check GitHub Actions workflows for security issues with zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,34 @@
+name: GitHub Actions security analysis
+
+on:
+  push:
+    paths:
+      - ".github/**.yml"
+      - ".github/**.yaml"
+  pull_request:
+    paths:
+      - ".github/**.yml"
+      - ".github/**.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

[zizmor](https://docs.zizmor.sh/) is a static analysis tool for GitHub Actions which finds security issues in GitHub Actions configuration files.

https://github.com/symfony/symfony/pull/64325 by @Kocal and https://github.com/symfony/symfony/pull/64457 already hardened workflows in this repository based on the output of zizmor, and `zizmor` currently reports no findings.
However, without checking new changes to the workflows, there is a risk that new security issues could be introduced in the future.

This PR adds a new workflow which runs zizmor, similar to [symfony/ux](https://github.com/symfony/ux/blob/3.x/.github/workflows/zizmor.yaml) and [Composer](https://github.com/composer/composer/blob/main/.github/workflows/zizmor.yml).
The workflow is configured to run only on pushes and pull requests that make changes to files in the `.github` directory, to avoid running it on unrelated changes (which would be the majority of PRs).

I have stripped the emoji's from the workflow, job and step names to stay consistent with other workflows in this repository, happy to put them back in (which would be consistent with `symfony/ux`).

According to [a comment by @nicolas-grekas  in PR #64325](https://github.com/symfony/symfony/pull/64325#issuecomment-4630168516) adding a zizmor workflow was originally part of the PR but later dropped as it had to be discussed separately.

@edorian [commented](https://github.com/symfony/symfony/pull/64325#issuecomment-4630356341):

> For Zizmor I mainly mentioned that it is a lot of warnings and needs a complementing strategy to keep updating things (like dependabot) and that some things I'm also ok with ignoring. The recently implementations on Composer and PHPUnit are good examples.

> So introducing Zizmor makes sense to me, but given the amount of changes I can see why it should be a separate discussion.

As `zizmor` currently reports no findings (using the default persona, so not in "pedantic" mode), and Dependabot was already enabled as part of #64325, I believe this allows us to turn on zizmor to prevent regressions in the future.