### PR TITLE
[Console] Fix #[MapDateTime] arguments resolved as strings by BuiltinTypeValueResolver

### DIFF
--- a/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/BuiltinTypeValueResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/BuiltinTypeValueResolver.php
@@ -25,6 +25,8 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 final class BuiltinTypeValueResolver implements ValueResolverInterface
 {
+    private const BUILTIN_TYPES = ['string', 'bool', 'int', 'float', 'array'];
+
     public function resolve(string $argumentName, InputInterface $input, ReflectionMember $member): iterable
     {
         if ($member->isVariadic()) {
@@ -32,7 +34,7 @@ final class BuiltinTypeValueResolver implements ValueResolverInterface
         }
 
         if ($argument = Argument::tryFrom($member->getMember())) {
-            if (is_subclass_of($argument->typeName, \BackedEnum::class)) {
+            if (!\in_array($argument->typeName, self::BUILTIN_TYPES, true)) {
                 return [];
             }
 
@@ -40,7 +42,7 @@ final class BuiltinTypeValueResolver implements ValueResolverInterface
         }
 
         if ($option = Option::tryFrom($member->getMember())) {
-            if (is_subclass_of($option->typeName, \BackedEnum::class)) {
+            if (!\in_array($option->typeName, self::BUILTIN_TYPES, true) && !\in_array($option->typeName, Option::ALLOWED_UNION_TYPES, true)) {
                 return [];
             }
 

--- a/src/Symfony/Component/Console/Tests/ArgumentResolver/ValueResolver/BuiltinTypeValueResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/ArgumentResolver/ValueResolver/BuiltinTypeValueResolverTest.php
@@ -121,6 +121,56 @@ class BuiltinTypeValueResolverTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function testDelegatesToDateTimeValueResolverForDateTimeArgument()
+    {
+        $resolver = new BuiltinTypeValueResolver();
+
+        $input = new ArrayInput(['date' => '2026-01-15'], new InputDefinition([
+            new InputArgument('date'),
+        ]));
+
+        $command = new class {
+            public function __invoke(
+                #[Argument]
+                \DateTimeImmutable $date,
+            ) {
+            }
+        };
+        $reflection = new \ReflectionMethod($command, '__invoke');
+        $parameter = $reflection->getParameters()[0];
+        $member = new ReflectionMember($parameter);
+
+        $result = $resolver->resolve('date', $input, $member);
+
+        // BuiltinTypeValueResolver returns empty for \DateTimeInterface types - DateTimeValueResolver handles them
+        $this->assertSame([], $result);
+    }
+
+    public function testDelegatesToDateTimeValueResolverForDateTimeOption()
+    {
+        $resolver = new BuiltinTypeValueResolver();
+
+        $input = new ArrayInput(['--date' => '2026-01-15'], new InputDefinition([
+            new InputOption('date', mode: InputOption::VALUE_REQUIRED),
+        ]));
+
+        $command = new class {
+            public function __invoke(
+                #[Option]
+                ?\DateTimeImmutable $date = null,
+            ) {
+            }
+        };
+        $reflection = new \ReflectionMethod($command, '__invoke');
+        $parameter = $reflection->getParameters()[0];
+        $member = new ReflectionMember($parameter);
+
+        $result = $resolver->resolve('date', $input, $member);
+
+        // BuiltinTypeValueResolver returns empty for \DateTimeInterface types - DateTimeValueResolver handles them
+        $this->assertSame([], $result);
+    }
+
     public function testResolveBoolOption()
     {
         $resolver = new BuiltinTypeValueResolver();

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\ArgumentResolver\ArgumentResolver;
 use Symfony\Component\Console\ArgumentResolver\ValueResolver\ValueResolverInterface;
 use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\MapDateTime;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Command\Command;
@@ -495,6 +496,25 @@ class InvokableCommandTest extends TestCase
 
         $tester = new CommandTester($command);
         $tester->execute(['name' => 'test']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testDefaultArgumentResolversWithMapDateTimeArgument()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (
+            #[Argument, MapDateTime]
+            \DateTimeImmutable $date,
+        ): int {
+            Assert::assertInstanceOf(\DateTimeImmutable::class, $date);
+            Assert::assertSame('2026-01-15', $date->format('Y-m-d'));
+
+            return 0;
+        });
+
+        $tester = new CommandTester($command);
+        $tester->execute(['date' => '2026-01-15']);
 
         $tester->assertCommandIsSuccessful();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64759
| License       | MIT

The `#[MapDateTime]` [documentation example](https://symfony.com/doc/current/console/value_resolver.html#datetimevalueresolver) throws:

```php
public function __invoke(
    #[Argument, MapDateTime]
    \DateTimeImmutable $date,
): int {
```

```
TestCommand::__invoke(): Argument #1 ($date) must be of type DateTimeImmutable, string given
```

`BuiltinTypeValueResolver` yields the raw input value for `#[Argument]`/`#[Option]` parameters whatever their type, and it runs before `DateTimeValueResolver`, so the chain stops before the date is mapped. Lowering the service priority would not cover `ArgumentResolver::getDefaultArgumentValueResolvers()`, where the order is hardcoded.

Following @chalasr's suggestions in the issue and the review, this patches the resolver instead: it now handles an allow list of built-in types (`string`, `bool`, `int`, `float`,  `array`, plus the allowed union types for options) and defers any other type - including `\DateTimeInterface` - to the next resolver in the chain.

This also fixes `#[Argument] \DateTime $date` without the attribute, and an invalid date now fails with the `RuntimeException` suggesting `#[MapDateTime(format: ...)]` instead of a `TypeError`.
