### PR TITLE
[Validator] Add a `message` option to the `Callback` constraint

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -54,6 +54,7 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/Serializer/Tests/Fixtures/'):
         case false !== strpos($file, '/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectOuter.php'):
         case false !== strpos($file, '/src/Symfony/Component/TypeInfo/Tests/Fixtures/'):
+        case false !== strpos($file, '/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/CallbackTestWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/WhenTestWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/Validator/Tests/Fixtures/EntityWithHook.php'):
         case false !== strpos($file, '/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php'):

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Remove the unused `GroupSequence::$cascadedGroup` property
  * Add the `restrictGroups` option to the `Valid` constraint
  * Add the `Cron` constraint to validate cron expressions
+ * Add the `message` option to the `Callback` constraint; the callback must then return a boolean, and a violation is raised when it returns `false`
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`
  * Stop narrowing the `File` constraint's `mimeTypes` option with mime types auto-derived from the matched extension when `extensions` is configured
 

--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -16,25 +16,48 @@ use Symfony\Component\Validator\Constraint;
 /**
  * Defines custom validation rules through arbitrary callback methods.
  *
+ * The callback can build violations using the execution context passed to it.
+ * In addition, when the "message" option is set, the callback must return a
+ * boolean and a violation is built automatically with that message when it
+ * returns false. When "message" is not set, the return value is ignored:
+ *
+ *     #[Assert\Callback(
+ *         static function (\DateTimeImmutable $value) {
+ *             return $value > new \DateTimeImmutable('today');
+ *         },
+ *         message: 'The delivery date must be in the future.',
+ *     )]
+ *     public \DateTimeImmutable $deliveryDate;
+ *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Callback extends Constraint
 {
+    public const NOT_SATISFIED_ERROR = '9f986b1b-4c81-4b33-ad55-3e2cae0ea562';
+
+    protected const ERROR_NAMES = [
+        self::NOT_SATISFIED_ERROR => 'NOT_SATISFIED_ERROR',
+    ];
+
     /**
      * @var string|callable
      */
     public $callback;
 
+    public ?string $message = null;
+
     /**
      * @param string|callable|null $callback The callback definition
      * @param string[]|null        $groups
+     * @param string|null          $message  The violation message raised when the callback returns false; the callback must then return a boolean. When not set, the return value of the callback is ignored
      */
-    public function __construct(string|callable|null $callback = null, ?array $groups = null, mixed $payload = null)
+    public function __construct(string|callable|null $callback = null, ?array $groups = null, mixed $payload = null, ?string $message = null)
     {
         parent::__construct(null, $groups, $payload);
 
         $this->callback = $callback;
+        $this->message = $message;
     }
 
     public function getTargets(): string|array

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -34,7 +34,7 @@ class CallbackValidator extends ConstraintValidator
 
         $method = $constraint->callback;
         if ($method instanceof \Closure) {
-            $method($object, $this->context, $constraint->payload);
+            $return = $method($object, $this->context, $constraint->payload);
         } elseif (\is_array($method)) {
             if (!\is_callable($method)) {
                 if (isset($method[0]) && \is_object($method[0])) {
@@ -43,7 +43,7 @@ class CallbackValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException(json_encode($method).' targeted by Callback constraint is not a valid callable.');
             }
 
-            $method($object, $this->context, $constraint->payload);
+            $return = $method($object, $this->context, $constraint->payload);
         } elseif (null !== $object) {
             if (!method_exists($object, $method)) {
                 throw new ConstraintDefinitionException(\sprintf('Method "%s" targeted by Callback constraint does not exist in class "%s".', $method, get_debug_type($object)));
@@ -52,10 +52,35 @@ class CallbackValidator extends ConstraintValidator
             $reflMethod = new \ReflectionMethod($object, $method);
 
             if ($reflMethod->isStatic()) {
-                $reflMethod->invoke(null, $object, $this->context, $constraint->payload);
+                $return = $reflMethod->invoke(null, $object, $this->context, $constraint->payload);
             } else {
-                $reflMethod->invoke($object, $this->context, $constraint->payload);
+                $return = $reflMethod->invoke($object, $this->context, $constraint->payload);
             }
+        } else {
+            return;
+        }
+
+        if (null === $constraint->message) {
+            return;
+        }
+
+        if (!\is_bool($return)) {
+            $target = $this->context->getClassName();
+
+            if (null !== $target && null !== $propertyName = $this->context->getPropertyName()) {
+                $target .= '::$'.$propertyName;
+            }
+
+            $target ??= $this->context->getPropertyPath();
+
+            throw new ConstraintDefinitionException(\sprintf('The callback targeted by the Callback constraint%s must return a boolean when the "message" option is set, "%s" returned.', $target ? \sprintf(' on "%s"', $target) : '', get_debug_type($return)));
+        }
+
+        if (!$return) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($object))
+                ->setCode(Callback::NOT_SATISFIED_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -11,11 +11,16 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\CallbackValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Constraints\Fixtures\CallbackTestWithClosure;
 
 class CallbackValidatorTest_Class
 {
@@ -29,6 +34,8 @@ class CallbackValidatorTest_Class
 
 class CallbackValidatorTest_Object
 {
+    public $data;
+
     public function validate(ExecutionContextInterface $context)
     {
         $context->addViolation('My message', ['{{ value }}' => 'foobar']);
@@ -40,6 +47,11 @@ class CallbackValidatorTest_Object
     {
         $context->addViolation('Static message', ['{{ value }}' => 'baz']);
 
+        return false;
+    }
+
+    public function isNeverSatisfied(ExecutionContextInterface $context)
+    {
         return false;
     }
 }
@@ -230,5 +242,128 @@ class CallbackValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Callback(callback: $callback);
         $this->validate($object, $constraint);
         $this->assertNull($payloadCopy);
+    }
+
+    public function testMessageDefaultAndCustomValues()
+    {
+        $constraint = new Callback(static fn (): bool => true);
+
+        $this->assertNull($constraint->message);
+
+        $constraint = new Callback(static fn (): bool => true, message: 'myMessage');
+
+        $this->assertSame('myMessage', $constraint->message);
+    }
+
+    public function testSatisfiedClosure()
+    {
+        $this->validate('foobar', new Callback(static fn ($value): bool => 'foobar' === $value, message: 'myMessage'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testNotSatisfiedClosure()
+    {
+        $this->validate('foobar', new Callback(static fn ($value): bool => 'other' === $value, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"foobar"')
+            ->setCode(Callback::NOT_SATISFIED_ERROR)
+            ->assertRaised();
+    }
+
+    public function testReturnValueIsIgnoredWhenNoMessageIsConfigured()
+    {
+        $this->validate('foobar', new Callback(static fn (): bool => false));
+
+        $this->assertNoViolation();
+    }
+
+    public function testNotSatisfiedClosureWithCustomMessage()
+    {
+        $this->validate(42, new Callback(static fn (): bool => false, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '42')
+            ->setCode(Callback::NOT_SATISFIED_ERROR)
+            ->assertRaised();
+    }
+
+    public function testClosureCanUseTheObjectOfTheContext()
+    {
+        $object = new \stdClass();
+        $object->min = 10;
+        $this->setObject($object);
+
+        $constraint = new Callback(static fn ($value, ExecutionContextInterface $context): bool => $value >= $context->getObject()->min, message: 'This value is not valid.');
+
+        $this->validate(15, $constraint);
+        $this->assertNoViolation();
+
+        $this->validate(5, $constraint);
+        $this->buildViolation('This value is not valid.')
+            ->setParameter('{{ value }}', '5')
+            ->setCode(Callback::NOT_SATISFIED_ERROR)
+            ->assertRaised();
+    }
+
+    public function testNotSatisfiedMethod()
+    {
+        $object = new CallbackValidatorTest_Object();
+
+        $this->validate($object, new Callback('isNeverSatisfied', message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'object')
+            ->setCode(Callback::NOT_SATISFIED_ERROR)
+            ->assertRaised();
+    }
+
+    public function testNonBooleanReturnIsRejectedWhenMessageIsSet()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The callback targeted by the Callback constraint on "property.path" must return a boolean when the "message" option is set, "int" returned.');
+
+        $this->validator->validate(new \stdClass(), new Callback(static fn () => 0, message: 'myMessage'));
+    }
+
+    public function testNonBooleanReturnNamesTheOffendingProperty()
+    {
+        $this->setProperty(new CallbackValidatorTest_Object(), 'data');
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage(\sprintf('The callback targeted by the Callback constraint on "%s::$data" must return a boolean when the "message" option is set, "int" returned.', CallbackValidatorTest_Object::class));
+
+        $this->validator->validate(new \stdClass(), new Callback(static fn () => 0, message: 'myMessage'));
+    }
+
+    public function testNonBooleanReturnIsIgnoredWhenMessageIsNotSet()
+    {
+        $this->validator->validate(new \stdClass(), new Callback(static fn () => 0));
+
+        $this->assertNoViolation();
+    }
+
+    #[RequiresPhp('>=8.5.0')]
+    public function testClosureInAttribute()
+    {
+        $metadata = new ClassMetadata(CallbackTestWithClosure::class);
+        $loader = new AttributeLoader();
+        $this->assertTrue($loader->loadClassMetadata($metadata));
+
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
+        $this->assertInstanceOf(Callback::class, $aConstraint);
+        $this->assertInstanceOf(\Closure::class, $aConstraint->callback);
+        $this->assertNull($aConstraint->message);
+        $this->assertSame(['Default', 'CallbackTestWithClosure'], $aConstraint->groups);
+        $this->assertTrue(($aConstraint->callback)('valid'));
+        $this->assertFalse(($aConstraint->callback)('invalid'));
+
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
+        $this->assertInstanceOf(Callback::class, $bConstraint);
+        $this->assertSame('myMessage', $bConstraint->message);
+        $this->assertSame(['my_group'], $bConstraint->groups);
+        $this->assertSame('some attached data', $bConstraint->payload);
+        $this->assertTrue(($bConstraint->callback)('valid'));
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/CallbackTestWithClosure.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/CallbackTestWithClosure.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
+
+use Symfony\Component\Validator\Constraints\Callback;
+
+class CallbackTestWithClosure
+{
+    #[Callback(static function ($value) {
+        return 'valid' === $value;
+    })]
+    private $a;
+
+    #[Callback(static function ($value) {
+        return 'valid' === $value;
+    }, message: 'myMessage', groups: ['my_group'], payload: 'some attached data')]
+    private $b;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Following @xabbuh's suggestion, instead of adding a new constraint, this PR expands the existing `Callback` constraint with a `message` option, so a simple *ad hoc* rule can be expressed with a closure declared directly in the attribute instead of a separate method:

```php
use Symfony\Component\Validator\Constraints as Assert;

class Order
{
    #[Assert\Callback(
        static function (\DateTimeImmutable $value) {
            return $value > new \DateTimeImmutable('today');
        },
        message: 'The delivery date must be in the future.',
    )]
    public \DateTimeImmutable $deliveryDate;
}
```

> [!NOTE]
> PHP 8.5 is the first PHP version that allows static closures in constant expressions,
> so you need PHP 8.5 or higher to declare the closure inside the attribute like this.
> The `message` option itself works with any callable on any supported PHP version.

The closure receives the same arguments as before (`$value`, the `ExecutionContextInterface` and the constraint `payload`), so rules that involve other properties can read the owning object from the context:

```php
#[Assert\Callback(
    static function (int $value, ExecutionContextInterface $context) {
        return $value >= $context->getObject()->subtotal;
    },
    message: 'The total must be greater than the subtotal.',
)]
public int $total;
```

When `message` is set, the callback must return a boolean; returning anything else throws a `ConstraintDefinitionException` naming the offending property, rather than silently doing nothing:

```
The callback targeted by the Callback constraint on "App\Entity\Order::$deliveryDate"
must return a boolean when the "message" option is set, "int" returned.
```

That matters because a predicate like `preg_match(...)` returns `0`, not `false`.

## BC considerations

None. The return value is only inspected when the new `message` option is set, and it defaults to `null`, so no existing constraint can reach the new behaviour:

```
returns false, no message                    => 0 violations
returns 0, no message                        => 0 violations
void callback, no message                    => 0 violations
adds violation via $context + returns false  => 1 violation  (its own)
returns false WITH message                   => 1 violation  (automatic)
returns true WITH message                    => 0 violations
adds violation + returns false WITH message  => 2 violations (both, deliberate)
```

Callbacks that build their own violations through the context and return `null`/`void`, the documented and overwhelmingly common usage, are untouched.
