### PR TITLE
[ObjectMapper] Keep the class-level transform/if of the target's #[Map] in the reverse class-map factory

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ReverseClassObjectMapperMetadataFactory.php
@@ -15,7 +15,7 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 use Symfony\Component\ObjectMapper\ClassHierarchyTrait;
 
 /**
- * Maps classes based on attributes found on the target's properties.
+ * Maps classes based on attributes found on the target class and its properties.
  *
  * @author Florent Blaison <florent.blaison@gmail.com>
  */
@@ -55,7 +55,20 @@ final class ReverseClassObjectMapperMetadataFactory implements ObjectMapperMetad
 
         if (!$property) {
             foreach ($targetClasses as $targetClass) {
-                if (!array_any($mappings, static fn (Mapping $m): bool => $m->target === $targetClass)) {
+                if (array_any($mappings, static fn (Mapping $m): bool => $m->target === $targetClass)) {
+                    continue;
+                }
+
+                $matched = false;
+                foreach ((new \ReflectionClass($targetClass))->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                    $map = $attribute->newInstance();
+                    if ($map->source && is_a($class, $map->source, true)) {
+                        $matched = true;
+                        $mappings[] = new Mapping($targetClass, null, $map->if, $map->transform);
+                    }
+                }
+
+                if (!$matched) {
                     $mappings[] = new Mapping($targetClass);
                 }
             }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Amount.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Amount.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class Amount
+{
+    public function __construct(
+        public int $cents,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/BasePayment.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/BasePayment.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+class BasePayment
+{
+    public function __construct(
+        public Amount $amount,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/BasePaymentView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/BasePaymentView.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: BasePayment::class, transform: [self::class, 'fromPayment'])]
+final class BasePaymentView
+{
+    public function __construct(
+        public readonly int $amountCents,
+    ) {
+    }
+
+    public static function fromPayment(mixed $value, object $source, ?object $target): self
+    {
+        return new self($source->amount->cents);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Invoice.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Invoice.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class Invoice
+{
+    public function __construct(
+        public int $total,
+        public string $currency,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/InvoiceView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/InvoiceView.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Invoice::class, if: [self::class, 'isEuro'], transform: [self::class, 'fromEuro'])]
+#[Map(source: Invoice::class, if: [self::class, 'isDollar'], transform: [self::class, 'fromDollar'])]
+final class InvoiceView
+{
+    public function __construct(
+        public readonly string $label,
+    ) {
+    }
+
+    public static function isEuro(mixed $value, object $source, ?object $target): bool
+    {
+        return 'EUR' === $source->currency;
+    }
+
+    public static function isDollar(mixed $value, object $source, ?object $target): bool
+    {
+        return 'USD' === $source->currency;
+    }
+
+    public static function fromEuro(mixed $value, object $source, ?object $target): self
+    {
+        return new self($source->total.' EUR');
+    }
+
+    public static function fromDollar(mixed $value, object $source, ?object $target): self
+    {
+        return new self($source->total.' USD');
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Payment.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/Payment.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class Payment
+{
+    public function __construct(
+        public Amount $amount,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PaymentView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/PaymentView.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Payment::class, transform: [self::class, 'fromPayment'])]
+final class PaymentView
+{
+    public function __construct(
+        public readonly int $amountCents,
+    ) {
+    }
+
+    public static function fromPayment(mixed $value, object $source, ?object $target): self
+    {
+        return new self($source->amount->cents);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RefundPayment.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ClassMap/RefundPayment.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap;
+
+final class RefundPayment extends BasePayment
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -30,20 +30,28 @@ use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Amount;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedFlatTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedInnerSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedOtherTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedOuterSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\BasePayment;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\BasePaymentView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Cost;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceAndAutoMappedView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\CostRequestWithSourceView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\ExtensibleTargetChild;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Invoice;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\InvoiceView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\ExtensibleTargetParent;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Payment;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PaymentView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PreMappedSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PreMappedTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\PrivateMappedChildView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RefundPayment;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RichDomainUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\RichDomainUserView;
@@ -1035,6 +1043,55 @@ final class ObjectMapperTest extends TestCase
         $withoutTransform = $mapper->map(new SharedSource(), SharedTargetWithoutTransform::class);
         $this->assertInstanceOf(SharedTargetWithoutTransform::class, $withoutTransform);
         $this->assertSame(21, $withoutTransform->value);
+    }
+
+    public function testClassMapKeepsClassLevelTransformDeclaredOnTarget()
+    {
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(
+            new ReflectionObjectMapperMetadataFactory(),
+            [Payment::class => PaymentView::class],
+        ));
+
+        $view = $mapper->map(new Payment(new Amount(4200)));
+
+        $this->assertInstanceOf(PaymentView::class, $view);
+        $this->assertSame(4200, $view->amountCents);
+
+        $view = $mapper->map(new Payment(new Amount(100)), PaymentView::class);
+
+        $this->assertInstanceOf(PaymentView::class, $view);
+        $this->assertSame(100, $view->amountCents);
+    }
+
+    public function testClassMapKeepsClassLevelTransformDeclaredForAParentSourceClass()
+    {
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(
+            new ReflectionObjectMapperMetadataFactory(),
+            [RefundPayment::class => BasePaymentView::class],
+        ));
+
+        $view = $mapper->map(new RefundPayment(new Amount(500)));
+
+        $this->assertInstanceOf(BasePaymentView::class, $view);
+        $this->assertSame(500, $view->amountCents);
+    }
+
+    public function testClassMapKeepsEveryConditionalClassLevelMapDeclaredOnTarget()
+    {
+        $mapper = new ObjectMapper(new ReverseClassObjectMapperMetadataFactory(
+            new ReflectionObjectMapperMetadataFactory(),
+            [Invoice::class => InvoiceView::class],
+        ));
+
+        $view = $mapper->map(new Invoice(100, 'EUR'));
+
+        $this->assertInstanceOf(InvoiceView::class, $view);
+        $this->assertSame('100 EUR', $view->label);
+
+        $view = $mapper->map(new Invoice(50, 'USD'));
+
+        $this->assertInstanceOf(InvoiceView::class, $view);
+        $this->assertSame('50 USD', $view->label);
     }
 
     public function testClassMapWithMultipleTargetsSharingOneSourceRequiresAnExplicitTarget()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a target class declares `#[Map(source: SomeSource::class, transform: ...)]` and the reverse class-map factory is used, `ObjectMapper::map(new SomeSource(), Target::class)` never runs the transformer: the resulting object is built by calling the constructor with the raw source values, causing a `TypeError` whenever a source value doesn't match the target's constructor parameter type.

**Root cause:** in `ReverseClassObjectMapperMetadataFactory::create()`, the class-level branch builds `new Mapping($targetClass)` without copying the `transform`/`if` declared on the target's `#[Map(source: ...)]` attribute. Because this reverse mapping is injected into the source metadata, the metadata becomes non-empty, so `ObjectMapper::doMap()` skips the fallback that would otherwise read the transform from the target's own metadata. The transform is therefore lost on both paths, and `doMap()` calls the target constructor with unmapped values.

**Fix:** in the class-level branch, resolve the target class's `#[Map]` attribute whose `source` matches the source class and carry its `transform`/`if` into the created `Mapping`.

The added test reproduces the reported failure on 8.1 without the fix:

```
TypeError: PaymentView::__construct(): Argument #1 ($amountCents) must be of type int, null given
```


## Follow-up changes after review

Two sibling gaps in the same class-level branch are fixed here as well, both aligning the class-map behavior with the attribute-only fallback path and with the factory's own property-level branch:

- Subclass sources are matched with `is_a()` instead of a strict `===`, so a `#[Map(source: Parent, transform: ...)]` also applies when the class map registers a child class. Previously the transform was dropped and the constructor received raw values.
- One `Mapping` is synthesized per matching `#[Map]` attribute instead of keeping only the first one, so a target declaring several conditional maps (`if` with exclusive conditions) from the same source keeps all of its branches. This also exercises the `if` half of the title, which had no test before.

Both cases are covered by new tests with dedicated fixtures (a parent/child payment pair, and an invoice mapped through two conditional class-level maps).
