### PR TITLE
[Mailer] Add RemoteTemplateEmail to send emails rendered from provider-hosted templates

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -198,6 +198,11 @@ SecurityBundle
    as `DefaultAuthenticationSuccessHandler` and `DefaultAuthenticationFailureHandler` do. Without forwarding,
    the authenticator options and the session target path are lost, and a successful login redirects to `/`
 
+Mailer
+------
+
+ * Deprecate the "templateid" and "params" email headers in the Brevo bridge, use a `RemoteTemplateEmail` instead
+
 Serializer
 ----------
 

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
 * Allow configuring the SMTP port through the DSN
+* Add support for `RemoteTemplateEmail` to `BrevoApiTransport`
+* Deprecate the "templateid" and "params" email headers, use a `RemoteTemplateEmail` instead
 
 6.4
 ---

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -12,16 +12,21 @@
 namespace Symfony\Component\Mailer\Bridge\Brevo\Tests\Transport;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Mailer\Bridge\Brevo\Transport\BrevoApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -29,6 +34,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class BrevoApiTransportTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     #[DataProvider('getTransportData')]
     public function testToString(BrevoApiTransport $transport, string $expected)
     {
@@ -55,15 +62,12 @@ class BrevoApiTransportTest extends TestCase
 
     public function testCustomHeader()
     {
-        $params = ['param1' => 'foo', 'param2' => 'bar'];
         $json = json_encode(['"custom_header_1' => 'custom_value_1']);
 
         $email = new Email();
         $email->getHeaders()
             ->add(new MetadataHeader('custom', $json))
             ->add(new TagHeader('TagInHeaders'))
-            ->addTextHeader('templateId', 1)
-            ->addParameterizedHeader('params', 'params', $params)
             ->addTextHeader('foo', 'bar');
         $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
 
@@ -76,13 +80,61 @@ class BrevoApiTransportTest extends TestCase
 
         $this->assertArrayHasKey('tags', $payload);
         $this->assertEquals('TagInHeaders', current($payload['tags']));
-        $this->assertArrayHasKey('templateId', $payload);
-        $this->assertEquals(1, $payload['templateId']);
-        $this->assertArrayHasKey('params', $payload);
-        $this->assertEquals('foo', $payload['params']['param1']);
-        $this->assertEquals('bar', $payload['params']['param2']);
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testRemoteTemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('42', ['param1' => 'foo', 'param2' => 'bar']);
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame(42, $payload['templateId']);
+        $this->assertSame(['param1' => 'foo', 'param2' => 'bar'], $payload['params']);
+        $this->assertArrayNotHasKey('subject', $payload);
+        $this->assertArrayNotHasKey('textContent', $payload);
+        $this->assertArrayNotHasKey('htmlContent', $payload);
+    }
+
+    public function testRemoteTemplateWithNonNumericReference()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('welcome');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Brevo API expects a numeric template id, "welcome" given.');
+
+        $method->invoke($transport, $email, $envelope);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDeprecatedTemplateHeaders()
+    {
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/brevo-mailer 8.2: Using the "templateid" email header to select a Brevo template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class));
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/brevo-mailer 8.2: Using the "params" email header to define the variables of a Brevo template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class));
+
+        $email = new Email();
+        $email->getHeaders()
+            ->addTextHeader('templateId', 1)
+            ->addParameterizedHeader('params', 'params', ['param1' => 'foo', 'param2' => 'bar']);
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame(1, $payload['templateId']);
+        $this->assertSame(['param1' => 'foo', 'param2' => 'bar'], $payload['params']);
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -15,11 +15,14 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
@@ -31,7 +34,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Pierre TANGUY
  */
-final class BrevoApiTransport extends AbstractApiTransport
+final class BrevoApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     public function __construct(
         #[\SensitiveParameter] private string $key,
@@ -90,12 +93,24 @@ final class BrevoApiTransport extends AbstractApiTransport
     private function getPayload(Email $email, Envelope $envelope): array
     {
         $tracking = $this->getTracking($email->getHeaders());
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
 
         $payload = [
             'sender' => $this->formatAddress($envelope->getSender()),
             'to' => $this->formatAddresses($this->getRecipients($email, $envelope), $tracking),
-            'subject' => $email->getSubject(),
         ];
+        if (null === $template || null !== $email->getSubject()) {
+            $payload['subject'] = $email->getSubject();
+        }
+        if (null !== $template) {
+            if (!ctype_digit($template->getReference())) {
+                throw new InvalidArgumentException(\sprintf('The Brevo API expects a numeric template id, "%s" given.', $template->getReference()));
+            }
+            $payload['templateId'] = (int) $template->getReference();
+            if ($template->getVariables()) {
+                $payload['params'] = $template->getVariables();
+            }
+        }
         if ($attachments = $this->prepareAttachments($email)) {
             $payload['attachment'] = $attachments;
         }
@@ -157,11 +172,13 @@ final class BrevoApiTransport extends AbstractApiTransport
                 continue;
             }
             if ('templateid' === $name) {
+                trigger_deprecation('symfony/brevo-mailer', '8.2', 'Using the "templateid" email header to select a Brevo template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class);
                 $headersAndTags[$header->getName()] = (int) $header->getValue();
 
                 continue;
             }
             if ('params' === $name) {
+                trigger_deprecation('symfony/brevo-mailer', '8.2', 'Using the "params" email header to define the variables of a Brevo template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class);
                 $headersAndTags[$header->getName()] = $header->getParameters();
 
                 continue;

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/mailer": "^8.2"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mailer/Bridge/Resend/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `RemoteTemplateEmail` to `ResendApiTransport`
+
 7.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Transport/ResendApiTransportTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -79,6 +80,37 @@ class ResendApiTransportTest extends TestCase
         $this->assertEquals('custom; param1=foo; param2=bar', $payload['headers']['x-custom-params']);
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testRemoteTemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('tpl_123', ['firstName' => 'Fabien']);
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new ResendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame(['id' => 'tpl_123', 'variables' => ['firstName' => 'Fabien']], $payload['template']);
+        $this->assertArrayNotHasKey('subject', $payload);
+        $this->assertArrayNotHasKey('text', $payload);
+        $this->assertArrayNotHasKey('html', $payload);
+    }
+
+    public function testRemoteTemplateWithSubject()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->subject('Hello!')
+            ->template('tpl_123');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new ResendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(ResendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('Hello!', $payload['subject']);
+        $this->assertSame(['id' => 'tpl_123'], $payload['template']);
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Transport/ResendApiTransport.php
@@ -17,8 +17,10 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
@@ -30,7 +32,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Mathieu Santostefano <msantostefano@proton.me>
  */
-final class ResendApiTransport extends AbstractApiTransport
+final class ResendApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     public function __construct(
         #[\SensitiveParameter] private readonly string $apiKey,
@@ -94,11 +96,21 @@ final class ResendApiTransport extends AbstractApiTransport
 
     private function getPayload(Email $email, Envelope $envelope): array
     {
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+
         $payload = [
             'from' => $this->formatAddress($envelope->getSender()),
             'to' => $this->formatAddresses($this->getRecipients($email, $envelope)),
-            'subject' => $email->getSubject(),
         ];
+        if (null === $template || null !== $email->getSubject()) {
+            $payload['subject'] = $email->getSubject();
+        }
+        if (null !== $template) {
+            $payload['template'] = ['id' => $template->getReference()];
+            if ($template->getVariables()) {
+                $payload['template']['variables'] = $template->getVariables();
+            }
+        }
         if ($attachments = $this->prepareAttachments($email)) {
             $payload['attachments'] = $attachments;
         }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `RemoteTemplateEmail` to `SendgridApiTransport`
+
 8.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -176,6 +177,22 @@ class SendgridApiTransportTest extends TestCase
         $this->assertArrayHasKey('headers', $payload);
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
+    }
+
+    public function testRemoteTemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('d-12345', ['firstName' => 'Fabien']);
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('d-12345', $payload['template_id']);
+        $this->assertSame(['firstName' => 'Fabien'], $payload['personalizations'][0]['dynamic_template_data']);
+        $this->assertArrayNotHasKey('content', $payload);
+        $this->assertArrayNotHasKey('subject', $payload['personalizations'][0]);
     }
 
     public function testReplyTo()

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -20,8 +20,10 @@ use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\DateHeader;
@@ -33,7 +35,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class SendgridApiTransport extends AbstractApiTransport
+class SendgridApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     private const HOST = 'api.%region_dot%sendgrid.com';
 
@@ -92,11 +94,18 @@ class SendgridApiTransport extends AbstractApiTransport
             return $stringified;
         };
 
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+
         $payload = [
             'personalizations' => [],
             'from' => $addressStringifier($envelope->getSender()),
-            'content' => $this->getContent($email),
         ];
+
+        if (null !== $template) {
+            $payload['template_id'] = $template->getReference();
+        } else {
+            $payload['content'] = $this->getContent($email);
+        }
 
         if ($email->getAttachments()) {
             $payload['attachments'] = $this->getAttachments($email);
@@ -104,8 +113,13 @@ class SendgridApiTransport extends AbstractApiTransport
 
         $personalization = [
             'to' => array_map($addressStringifier, $this->getRecipients($email, $envelope)),
-            'subject' => $email->getSubject(),
         ];
+        if (null === $template || null !== $email->getSubject()) {
+            $personalization['subject'] = $email->getSubject();
+        }
+        if (null !== $template && $template->getVariables()) {
+            $personalization['dynamic_template_data'] = $template->getVariables();
+        }
         if ($emails = array_map($addressStringifier, $email->getCc())) {
             $personalization['cc'] = $emails;
         }

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add a `rate_limiter` option to mailer transports
  * Add DSN param `timeout` to configure the connect/read/write timeout of SMTP transports
+ * Add `RemoteTemplateEmail`, `RemoteTemplate` and `RemoteTemplateTransportInterface` to send emails rendered by the mail provider from a template hosted on its side
  * Reorder EsmtpTransport authenticators to prefer PLAIN over obsolete LOGIN
  * Add `InMemorySmimeCertificateRepository` to provide recipient S/MIME certificates from a static map
  * Add a configurable behavior to `SmimeEncryptedMessageListener` when a recipient has no certificate (`send_unencrypted`, `fail`, `encrypt`, `skip`), overridable per message via the `X-SMime-Encrypt` header

--- a/src/Symfony/Component/Mailer/RemoteTemplate.php
+++ b/src/Symfony/Component/Mailer/RemoteTemplate.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer;
+
+/**
+ * The reference and variables of a template hosted by a mail provider.
+ *
+ * @author Florent Blaison <florent.blaison@gmail.com>
+ */
+final class RemoteTemplate
+{
+    /**
+     * @param string               $reference The provider-side reference of the template (an id, uuid, name or alias, depending on the provider)
+     * @param array<string, mixed> $variables The variables used by the provider to render the template
+     */
+    public function __construct(
+        private string $reference,
+        private array $variables = [],
+    ) {
+    }
+
+    public function getReference(): string
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getVariables(): array
+    {
+        return $this->variables;
+    }
+}

--- a/src/Symfony/Component/Mailer/RemoteTemplateEmail.php
+++ b/src/Symfony/Component/Mailer/RemoteTemplateEmail.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer;
+
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\Part\TextPart;
+
+/**
+ * An email rendered by the mail provider from a template hosted on its side.
+ *
+ * Such emails can only be sent through transports implementing
+ * {@see RemoteTemplateTransportInterface}; other transports refuse them.
+ *
+ * @author Florent Blaison <florent.blaison@gmail.com>
+ */
+class RemoteTemplateEmail extends Email
+{
+    private ?RemoteTemplate $template = null;
+
+    /**
+     * @param string|null          $template  The provider-side reference of the template (an id, uuid, name or alias, depending on the provider)
+     * @param array<string, mixed> $variables The variables used by the provider to render the template
+     *
+     * @return $this
+     */
+    public function template(?string $template, array $variables = []): static
+    {
+        $this->template = null === $template ? null : new RemoteTemplate($template, $variables);
+
+        return $this;
+    }
+
+    public function getRemoteTemplate(): ?RemoteTemplate
+    {
+        return $this->template;
+    }
+
+    public function getBody(): AbstractPart
+    {
+        if (null === $this->template) {
+            return parent::getBody();
+        }
+
+        return new TextPart(\sprintf('This email is rendered by the mail provider from its "%s" template.', $this->template->getReference()));
+    }
+
+    protected function ensureBodyValid(): void
+    {
+        if (null === $this->template) {
+            parent::ensureBodyValid();
+
+            return;
+        }
+
+        if (null !== $this->getTextBody() || null !== $this->getHtmlBody()) {
+            throw new LogicException('An email using a remote template cannot have a text or an HTML part; its body is rendered by the mail provider.');
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function __serialize(): array
+    {
+        return [$this->template, parent::__serialize()];
+    }
+
+    /**
+     * @internal
+     */
+    public function __unserialize(array $data): void
+    {
+        if (null !== ($data[0] ?? null) && !$data[0] instanceof RemoteTemplate) {
+            throw new \BadMethodCallException('Cannot unserialize '.self::class);
+        }
+
+        [$this->template, $parentData] = $data;
+
+        parent::__unserialize($parentData);
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/RemoteTemplateEmailTest.php
+++ b/src/Symfony/Component/Mailer/Tests/RemoteTemplateEmailTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
+use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\Part\TextPart;
+
+class RemoteTemplateEmailTestToStringGadget
+{
+    public static bool $fired = false;
+
+    public function __toString(): string
+    {
+        self::$fired = true;
+
+        return '';
+    }
+}
+
+class RemoteTemplateEmailTest extends TestCase
+{
+    public function testTemplate()
+    {
+        $email = new RemoteTemplateEmail();
+        $this->assertNull($email->getRemoteTemplate());
+
+        $email->template('welcome', ['firstName' => 'Fabien']);
+        $this->assertSame('welcome', $email->getRemoteTemplate()->getReference());
+        $this->assertSame(['firstName' => 'Fabien'], $email->getRemoteTemplate()->getVariables());
+
+        $email->template(null);
+        $this->assertNull($email->getRemoteTemplate());
+    }
+
+    public function testEnsureValidityWithTemplateAndNoBody()
+    {
+        $email = new RemoteTemplateEmail();
+        $email->from('fabien@symfony.com');
+        $email->to('you@example.com');
+        $email->template('welcome');
+
+        $email->ensureValidity();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnsureValidityWithTemplateAndTextBody()
+    {
+        $email = new RemoteTemplateEmail();
+        $email->from('fabien@symfony.com');
+        $email->to('you@example.com');
+        $email->template('welcome');
+        $email->text('some text');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('An email using a remote template cannot have a text or an HTML part; its body is rendered by the mail provider.');
+
+        $email->ensureValidity();
+    }
+
+    public function testEnsureValidityWithTemplateAndHtmlBody()
+    {
+        $email = new RemoteTemplateEmail();
+        $email->from('fabien@symfony.com');
+        $email->to('you@example.com');
+        $email->template('welcome');
+        $email->html('<b>some html</b>');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('An email using a remote template cannot have a text or an HTML part; its body is rendered by the mail provider.');
+
+        $email->ensureValidity();
+    }
+
+    public function testEnsureValidityWithoutTemplateStillRequiresABody()
+    {
+        $email = new RemoteTemplateEmail();
+        $email->from('fabien@symfony.com');
+        $email->to('you@example.com');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A message must have a text or an HTML part or attachments.');
+
+        $email->ensureValidity();
+    }
+
+    public function testGetBodyReturnsAPlaceholderWhenATemplateIsSet()
+    {
+        $email = new RemoteTemplateEmail();
+        $email->template('welcome');
+
+        $body = $email->getBody();
+
+        $this->assertInstanceOf(TextPart::class, $body);
+        $this->assertStringContainsString('welcome', $body->getBody());
+    }
+
+    public function testSerialization()
+    {
+        $email = new RemoteTemplateEmail();
+        $email->from('fabien@symfony.com');
+        $email->to('you@example.com');
+        $email->template('welcome', ['firstName' => 'Fabien']);
+
+        $email = unserialize(serialize($email));
+
+        $this->assertSame('welcome', $email->getRemoteTemplate()->getReference());
+        $this->assertSame(['firstName' => 'Fabien'], $email->getRemoteTemplate()->getVariables());
+        $this->assertSame('fabien@symfony.com', $email->getFrom()[0]->getAddress());
+    }
+
+    public function testUnserializeRejectsInvalidTemplateSlot()
+    {
+        $email = new RemoteTemplateEmail();
+        $email->template('welcome');
+        $data = $email->__serialize();
+        $data[0] = new RemoteTemplateEmailTestToStringGadget();
+        $payload = \sprintf('O:%d:"%s":%d:{', \strlen(RemoteTemplateEmail::class), RemoteTemplateEmail::class, \count($data));
+        foreach ($data as $key => $value) {
+            $payload .= serialize($key).serialize($value);
+        }
+        $payload .= '}';
+        RemoteTemplateEmailTestToStringGadget::$fired = false;
+
+        try {
+            unserialize($payload);
+            $this->fail('Expected BadMethodCallException.');
+        } catch (\BadMethodCallException $e) {
+        }
+
+        $this->assertFalse(RemoteTemplateEmailTestToStringGadget::$fired, '__toString gadget must not fire during unserialize');
+    }
+}

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractTransportTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\EventListener\MessageListener;
 use Symfony\Component\Mailer\Exception\LogicException;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport\NullTransport;
@@ -119,6 +120,42 @@ class AbstractTransportTest extends TestCase
 
         $sentMessage = $transport->send((new TemplatedEmail())->to('me@example.com')->from('me@example.com')->htmlTemplate('tpl'));
         $this->assertMatchesRegularExpression('/Some message/', $sentMessage->getMessage()->toString());
+    }
+
+    public function testSendingRemoteTemplateEmailWithUnsupportedTransport()
+    {
+        $transport = new class(new EventDispatcher()) extends AbstractTransport {
+            protected function doSend(SentMessage $message): void
+            {
+            }
+
+            public function __toString(): string
+            {
+                return 'fake://';
+            }
+        };
+
+        $email = (new RemoteTemplateEmail())
+            ->from('fabien@example.com')
+            ->to('helene@example.com')
+            ->template('welcome', ['firstName' => 'Fabien']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('does not support sending emails rendered from a remote template');
+
+        $transport->send($email);
+    }
+
+    public function testSendingRemoteTemplateEmailWithSupportedTransport()
+    {
+        $transport = new NullTransport(new EventDispatcher());
+
+        $email = (new RemoteTemplateEmail())
+            ->from('fabien@example.com')
+            ->to('helene@example.com')
+            ->template('welcome', ['firstName' => 'Fabien']);
+
+        $this->assertNotNull($transport->send($email));
     }
 
     public function testRejectMessage()

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\Event\FailedMessageEvent;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Event\SentMessageEvent;
 use Symfony\Component\Mailer\Exception\LogicException;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\BodyRendererInterface;
@@ -68,6 +69,7 @@ abstract class AbstractTransport implements TransportInterface
 
         try {
             if (!$this->dispatcher) {
+                $this->ensureRemoteTemplateSupport($message);
                 $sentMessage = new SentMessage($message, $envelope);
 
                 $rateLimiter?->consume(1)->ensureAccepted();
@@ -89,6 +91,8 @@ abstract class AbstractTransport implements TransportInterface
             if ($message instanceof TemplatedEmail && !$message->isRendered()) {
                 throw new LogicException(\sprintf('You must configure a "%s" when a "%s" instance has a text or HTML template set.', BodyRendererInterface::class, get_debug_type($message)));
             }
+
+            $this->ensureRemoteTemplateSupport($message);
 
             $sentMessage = new SentMessage($message, $envelope);
 
@@ -140,6 +144,13 @@ abstract class AbstractTransport implements TransportInterface
     protected function getLogger(): LoggerInterface
     {
         return $this->logger;
+    }
+
+    private function ensureRemoteTemplateSupport(RawMessage $message): void
+    {
+        if ($message instanceof RemoteTemplateEmail && null !== $message->getRemoteTemplate() && !$this instanceof RemoteTemplateTransportInterface) {
+            throw new LogicException(\sprintf('The "%s" transport does not support sending emails rendered from a remote template.', get_debug_type($this)));
+        }
     }
 
     private function checkThrottling(): void

--- a/src/Symfony/Component/Mailer/Transport/NullTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/NullTransport.php
@@ -18,7 +18,7 @@ use Symfony\Component\Mailer\SentMessage;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class NullTransport extends AbstractTransport
+final class NullTransport extends AbstractTransport implements RemoteTemplateTransportInterface
 {
     protected function doSend(SentMessage $message): void
     {

--- a/src/Symfony/Component/Mailer/Transport/RemoteTemplateTransportInterface.php
+++ b/src/Symfony/Component/Mailer/Transport/RemoteTemplateTransportInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Transport;
+
+use Symfony\Component\Mailer\RemoteTemplateEmail;
+
+/**
+ * Implemented by transports that can send a {@see RemoteTemplateEmail} by
+ * delegating the rendering of the email to a template hosted by the mail provider.
+ *
+ * @author Florent Blaison <florent.blaison@gmail.com>
+ */
+interface RemoteTemplateTransportInterface
+{
+}

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `AbstractPart::setContentTypeParameter()`
  * Add the `Group` class to put a group of mailboxes in a mailbox list header (RFC 5322 and RFC 6854)
  * Add `MailboxListHeader::getAddressList()` and `MailboxListHeader::createAddressList()`
+ * Make `Email::ensureBodyValid()` protected to allow subclasses adjusting the body validation
 
 8.0
 ---

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -399,7 +399,7 @@ class Email extends Message
         parent::ensureValidity();
     }
 
-    private function ensureBodyValid(): void
+    protected function ensureBodyValid(): void
     {
         if (null === $this->text && null === $this->html && !$this->attachments && null === parent::getBody()) {
             throw new LogicException('A message must have a text or an HTML part or attachments.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

## Motivation

Most transactional email providers can render an email from a **template hosted on their side**, configured with a template reference and a set of variables. Symfony Mailer currently has no abstraction for this, which has led to inconsistent, bridge-specific hacks:

- the Brevo bridge gives a special meaning to the `templateid` and `params` headers (which, as noted in https://github.com/symfony/symfony/pull/63196#issuecomment-3811130861, escaped review on the initial bridge submission);
- the Mailjet bridge maps the `X-MJ-TemplateID` / `X-MJ-TemplateLanguage` headers;
- the Mailgun bridge forwards a `template` parameter.

Previous attempts to extend this header-based approach to other bridges (#63196, #63223) were rightfully rejected: repurposing header names inside a bridge creates hidden restrictions and breaks the transport abstraction.

However, the underlying feature *is* interoperable — virtually every provider with a Symfony bridge exposes the exact same pair `{template reference, variables map}`:

| Provider | Template reference | Variables |
|---|---|---|
| Brevo | `templateId` (int) | `params` |
| Mailjet | `TemplateID` (int) | `Variables` |
| Mailgun | `template` (name) | `t:variables` |
| SendGrid | `template_id` | `dynamic_template_data` |
| Postmark | `TemplateId` / `TemplateAlias` | `TemplateModel` |
| Mandrill | `template_name` | `merge_vars` |
| MailerSend | `template_id` | `personalization` |
| Mailtrap | `template_uuid` | `template_variables` |
| Amazon SES v2 | `Template.TemplateName` | `TemplateData` |
| Resend | `template.id` | `template.variables` |

This is the same situation that led to `TagHeader` / `MetadataHeader`: one common concept, provider-specific payload mappings. This PR follows that precedent, but **without headers**.

## Design

```php
use Symfony\Component\Mailer\RemoteTemplateEmail;

$email = (new RemoteTemplateEmail())
    ->from('hello@example.com')
    ->to('user@example.com')
    ->template('welcome-v2', ['firstName' => 'Fabien', 'orderId' => 42]);

$mailer->send($email);
```

- **`RemoteTemplateEmail extends Email`** carries the template reference (a `string`; each bridge casts to its native type) and the variables. Since the body is rendered by the provider, `ensureValidity()` allows sending without a local text/HTML part — and rejects an email that defines both a local body *and* a template. A local subject remains allowed (providers support overriding it). Serialization is preserved so async sending via Messenger keeps the template.
- **`RemoteTemplateTransportInterface`** is a marker interface implemented by transports that support the feature. Each one maps the reference/variables to its native API payload.
- **Explicit failure instead of hidden behavior**: `AbstractTransport::send()` throws a `LogicException` when a `RemoteTemplateEmail` with a template is sent through a transport that does not implement the interface (SMTP transports, sendmail, not-yet-migrated bridges…). No header name is reserved, nothing is silently dropped. `NullTransport` implements the interface so `null://` setups keep working.

This addresses the concerns raised on the previous attempts:
1. *"Special meaning for header names"* → no headers involved; the feature is part of the component's API surface.
2. *"Bridges are not SDKs"* → bridges only map one interoperable concept, exactly like they already do for tags and metadata.
3. *"No interoperable common case"* → see the table above; the abstraction is limited to the `{reference, variables}` pair that all providers share. Anything provider-specific beyond that stays out of scope.

## What this PR does

- Add `RemoteTemplateEmail` and `RemoteTemplateTransportInterface` to `symfony/mailer`, with the fail-fast check in `AbstractTransport`;
- change `Email::ensureBodyValid()` from `private` to `protected` in `symfony/mime` (BC-safe) so the subclass can adjust body validation;
- implement the interface in three bridges with different payload styles to demonstrate the mapping: **Resend** (`template.id` / `template.variables`), **Brevo** (`templateId` / `params`), **SendGrid** (`template_id` / `dynamic_template_data`);
- deprecate the `templateid` and `params` magic headers of the Brevo bridge in favor of the new abstraction.

Out of scope (by design):
- per-recipient variables / batch personalizations: one message = one set of variables;
- any other provider-specific template option.

Other bridges (Mailjet, Postmark, Mailtrap, MailerSend, Mailgun, SES…) can follow in separate PRs, including SMTP transports of providers whose relay supports templates through documented headers (e.g. Mailjet's `X-MJ-TemplateID`).

## For the documentation

- `TemplatedEmail` (Twig bridge) renders the body locally; `RemoteTemplateEmail` delegates rendering to the provider. The two are mutually exclusive: a `RemoteTemplateEmail` that defines both a template and a local text or HTML part is refused.
- A local subject stays optional: when set, it overrides the subject defined in the provider-side template. Attachments remain supported alongside a template.
- Transports that do not implement `RemoteTemplateTransportInterface` (SMTP, sendmail, not-yet-migrated bridges) throw a `LogicException`. This exception is not a transport exception, so a failover chain does not fall back to its next transport: every transport of a chain should support remote templates before using them.
- The template reference is always a string; each bridge maps it to its native type. The Brevo transport only accepts numeric ids and throws an `InvalidArgumentException` otherwise.
