### PR TITLE
 Add additional IP ranges for RFC2544 and RFC5180

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -27,6 +27,7 @@ class IpUtils
         '203.0.113.0/24', // Documentation Ranges TEST-NET-3 (RFC 5737)
         '172.16.0.0/12',  // RFC1918
         '169.254.0.0/16', // RFC3927
+        '198.18.0.0/15',  // IPv4 Benchmarking (RFC 2544)
         '0.0.0.0/8',      // RFC5735
         '240.0.0.0/4',    // RFC1112
         '100.64.0.0/10',  // RFC6598
@@ -39,6 +40,7 @@ class IpUtils
         '2002::/16',      // 6to4 (RFC 3056)
         '2001::/32',      // Teredo tunneling (RFC 4380)
         '2001:db8::/32',  // Documentation Ranges (RFC 3849)
+        '2001:0002::/48', // IPv6 Benchmarking (RFC 5180 and corrections)
         '64:ff9b::/96',   // NAT64 well-known prefix (RFC 6052)
         '64:ff9b:1::/48', // NAT64 local-use prefix (RFC 8215)
     ];

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -188,6 +188,7 @@ class IpUtilsTest extends TestCase
             ['203.0.113.1',     true],
             ['172.16.0.1',      true],
             ['169.254.0.1',     true],
+            ['198.18.0.1',      true],
             ['0.0.0.1',         true],
             ['240.0.0.1',       true],
             ['100.64.0.1',      true],
@@ -200,6 +201,7 @@ class IpUtilsTest extends TestCase
             ['2002:7f00:1::',      true],
             ['2001::1',            true],
             ['2001:db8::1',        true],
+            ['2001:0002::1',       true],
             ['64:ff9b::7f00:1',    true],
             ['64:ff9b:1::7f00:1',  true],
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no
| License       | MIT

Adding the IPv4 and IPv6 ranges for the IP Benchmarks: 
- [RFC 2544](https://datatracker.ietf.org/doc/html/rfc2544)
- [RFC 5180](https://datatracker.ietf.org/doc/html/rfc5180) → including errata [1752](https://errata.rfc-editor.org/search/?errata_id=1752)

Not sure if this is a new feature, or bugfix for a missing range?
Help is welcome :-) 

