### PR TITLE
[Form][Validator] Review Uzbek (uz) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.uz.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Iltimos, haqiqiy UUID kiriting.</target>
+                <target>Iltimos, to'g'ri UUID kiriting.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Ushbu qiymat haqiqiy XML emas.</target>
+                <target>Bu qiymat haqiqiy XML emas.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Ushbu qiymat kutilgan XSD sxemasiga mos kelmaydi.</target>
+                <target>Ushbu qiymat kutilgan XSD sxemasiga mos kelmaydi.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Bu XML yuki juda katta ({{ size }} bayt): u {{ limit }} bayt chegarasidan oshib ketadi.</target>
+                <target>Bu XML yuki juda katta ({{ size }} bayt): u {{ limit }} bayt chegarasidan oshib ketadi.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Ushbu qiymat yaroqli cron ifodasi emas.</target>
+                <target>Ushbu qiymat to'g'ri cron ifodasi emas.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64522
| License       | MIT

I'm a native Uzbek (uz) speaker. Reviewed the strings and adjusted a few for consistency with the existing entries: used `to'g'ri` for "valid" in units 129 and 146 (matching the surrounding `to'g'ri URL` / `to'g'ri ifoda` wording), and aligned unit 143 with the existing `Bu qiymat haqiqiy UUID emas.` phrasing. Removed the `needs-review-translation` markers.
