### PR TITLE
[HttpFoundation] Add RFC5737 and RFC3849 to IpUtils::PRIVATE_SUBNETS

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -22,6 +22,9 @@ class IpUtils
         '127.0.0.0/8',    // RFC1700 (Loopback)
         '10.0.0.0/8',     // RFC1918
         '192.168.0.0/16', // RFC1918
+        '192.0.2.0/24',   // Documentation Ranges TEST-NET-1 (RFC 5737)
+        '198.51.100.0/24',// Documentation Ranges TEST-NET-2 (RFC 5737)
+        '203.0.113.0/24', // Documentation Ranges TEST-NET-3 (RFC 5737)
         '172.16.0.0/12',  // RFC1918
         '169.254.0.0/16', // RFC3927
         '0.0.0.0/8',      // RFC5735
@@ -35,6 +38,7 @@ class IpUtils
         '::/96',          // IPv4-compatible IPv6 addresses (RFC 4291 section 2.5.5.1)
         '2002::/16',      // 6to4 (RFC 3056)
         '2001::/32',      // Teredo tunneling (RFC 4380)
+        '2001:db8::/32',  // Documentation Ranges (RFC 3849)
         '64:ff9b::/96',   // NAT64 well-known prefix (RFC 6052)
         '64:ff9b:1::/48', // NAT64 local-use prefix (RFC 8215)
     ];

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -183,6 +183,9 @@ class IpUtilsTest extends TestCase
             ['127.0.0.1',       true],
             ['10.0.0.1',        true],
             ['192.168.0.1',     true],
+            ['192.0.2.1',       true],
+            ['198.51.100.1',    true],
+            ['203.0.113.1',     true],
             ['172.16.0.1',      true],
             ['169.254.0.1',     true],
             ['0.0.0.1',         true],
@@ -196,6 +199,7 @@ class IpUtilsTest extends TestCase
             ['::7f00:1',           true],
             ['2002:7f00:1::',      true],
             ['2001::1',            true],
+            ['2001:db8::1',        true],
             ['64:ff9b::7f00:1',    true],
             ['64:ff9b:1::7f00:1',  true],
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/pull/64783#issuecomment-4874443849
| License       | MIT


Adding the IPv4 and IPv6 ranges for "Address Blocks Reserved for Documentation":

- [RFC 5737 - IPv4 Address Blocks Reserved for Documentation](https://datatracker.ietf.org/doc/html/5737)
- [RFC 3849 - IPv6 Address Prefix Reserved for Documentation](https://datatracker.ietf.org/doc/html/rfc3849)