### PR TITLE
[Tui] Fix wrapping lines that end with whitespace followed by ANSI codes exceeding the width

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/TextWrapper.php
+++ b/src/Symfony/Component/Tui/Ansi/TextWrapper.php
@@ -254,7 +254,9 @@ final class TextWrapper
             $wrapped[] = rtrim($currentLine);
         }
 
-        return $wrapped ?: [''];
+        // Trailing whitespace kept before an ANSI reset (e.g. from a highlighted
+        // blank line) can push a line past the requested width; clamp each line.
+        return $wrapped ? array_map(static fn (string $line): string => AnsiUtils::truncateToWidth($line, $width, ''), $wrapped) : [''];
     }
 
     /**

--- a/src/Symfony/Component/Tui/Tests/Ansi/TextWrapperTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/TextWrapperTest.php
@@ -50,6 +50,19 @@ class TextWrapperTest extends TestCase
         $this->assertLessThanOrEqual(5, AnsiUtils::visibleWidth($lines[1]));
     }
 
+    public function testWrapWhitespaceOnlyLineWithTrailingAnsiCodeRespectsWidth()
+    {
+        // A syntax highlighter emits a color code around an indentation-only line
+        // and closes it with a reset. The trailing reset must not keep the
+        // whitespace from being trimmed, which would exceed the requested width.
+        $styled = "\x1b[38;5;245m".str_repeat(' ', 82)."\x1b[0m";
+        $lines = TextWrapper::wrapTextWithAnsi($styled, 79);
+
+        foreach ($lines as $i => $line) {
+            $this->assertLessThanOrEqual(79, AnsiUtils::visibleWidth($line), \sprintf('Line %d exceeds width: width=%d', $i, AnsiUtils::visibleWidth($line)));
+        }
+    }
+
     public function testWrapAnsiCodesPreservedAcrossLines()
     {
         // Bold text that wraps


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
