### PR TITLE
[Form][Validator] Review Brazilian Portuguese translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Por favor, informe um UUID válido.</target>
+                <target>Por favor, informe um UUID válido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Este valor não é um XML válido.</target>
+                <target>Este valor não é um XML válido.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Este valor não está em conformidade com o esquema XSD esperado.</target>
+                <target>Este valor não está em conformidade com o esquema XSD esperado.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Esta carga útil XML é muito grande ({{ size }} bytes): excede o limite de {{ limit }} bytes.</target>
+                <target>Este conteúdo XML é muito grande ({{ size }} bytes): excede o limite de {{ limit }} bytes.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Este valor não é uma expressão cron válida.</target>
+                <target>Este valor não é uma expressão cron válida.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64484
| License       | MIT

This PR reviews Brazilian Portuguese translations marked with `state="needs-review-translation"`.

It removes the review state from verified translations and updates "carga útil XML" to "conteúdo XML" to make the XML payload validation message sound more natural in Brazilian Portuguese.