### PR TITLE
[Messenger] Add messenger:show command to inspect pending messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -52,6 +52,7 @@ use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 use Symfony\Component\Messenger\Command\SetupTransportsCommand;
 use Symfony\Component\Messenger\Command\StatsCommand;
+use Symfony\Component\Messenger\Command\ShowMessagesCommand;
 use Symfony\Component\Messenger\Command\StopWorkersCommand;
 use Symfony\Component\Scheduler\Command\DebugCommand as SchedulerDebugCommand;
 use Symfony\Component\Serializer\Command\DebugCommand as SerializerDebugCommand;
@@ -221,6 +222,14 @@ return static function (ContainerConfigurator $container) {
                 service('messenger.transport.native_php_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
+
+        ->set('console.command.messenger_show', ShowMessagesCommand::class)
+            ->args([
+                service('messenger.receiver_locator'),
+            ])
+            ->tag('console.command')
+        ;
+
 
         ->set('console.command.messenger_stats', StatsCommand::class)
             ->args([

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -74,12 +74,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '7.3.11';
-    public const VERSION_ID = 70311;
+    public const VERSION = '7.3.12-DEV';
+    public const VERSION_ID = 70312;
     public const MAJOR_VERSION = 7;
     public const MINOR_VERSION = 3;
-    public const RELEASE_VERSION = 11;
-    public const EXTRA_VERSION = '';
+    public const RELEASE_VERSION = 12;
+    public const EXTRA_VERSION = 'DEV';
 
     public const END_OF_MAINTENANCE = '01/2026';
     public const END_OF_LIFE = '01/2026';

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `--class-filter` option to the `messenger:failed:remove` command
  * Add `$stamps` parameter to `HandleTrait::handle`
  * Add `Symfony\Component\Messenger\EventListener\ResetMemoryUsageListener` to reset PHP's peak memory usage for each processed message
+ * Add a `messenger:show` command to inspect pending messages on a given transport
 
 7.2
 ---

--- a/src/Symfony/Component/Messenger/Command/ShowMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ShowMessagesCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+
+/**
+ * @author Payene Denis Kombate <denis.kombate@gmail.com>
+ */
+#[AsCommand( name: 'messenger:show', description: 'Affiche les messages en attente dans un transport spécifique.',)]
+class ShowMessagesCommand extends Command
+{
+    // On injecte le locator qui contient TOUS les transports de l'application
+    public function __construct(
+        private ContainerInterface $receiverLocator
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('id', InputArgument::OPTIONAL, 'The message ID to show')
+            ->addOption('transport', 't', InputOption::VALUE_REQUIRED, 'The transport name to inspect')
+            ->addOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by message class name')
+            ->addOption('max', null, InputOption::VALUE_REQUIRED, 'Maximum number of messages to display', 50)
+            ->addOption('stats', null, InputOption::VALUE_NONE, 'Display only statistics about the queue');
+    }
+
+
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $transportName = $input->getOption('transport');
+
+        if (!$transportName) {
+            $io->error('The --transport option is required.');
+            return Command::FAILURE;
+        }
+
+        if (!$this->receiverLocator->has($transportName)) {
+            $io->error(sprintf('The transport "%s" does not exist.', $transportName));
+            return Command::FAILURE;
+        }
+
+        $receiver = $this->receiverLocator->get($transportName);
+
+        if (!$receiver instanceof ListableReceiverInterface) {
+            $io->error(sprintf('The transport "%s" does not support browsing messages.', $transportName));
+            return Command::FAILURE;
+        }
+
+        $id = $input->getArgument('id');
+        $classFilter = $input->getOption('class-filter');
+
+        // Cas 1 : Affichage d'un message unique par ID
+        if (null !== $id) {
+            $envelope = $receiver->find($id);
+            if (null === $envelope) {
+                $io->warning(sprintf('Message with ID "%s" not found in transport "%s".', $id, $transportName));
+                return Command::SUCCESS;
+            }
+            
+            $this->displaySingleMessage($io, $envelope, $id);
+            return Command::SUCCESS;
+        }
+
+        // Cas 2 : Récupération d'une liste de messages
+        $max = (int) $input->getOption('max');
+        $envelopes = $receiver->all($max);
+
+        if (empty($envelopes)) {
+            $io->success(sprintf('No pending messages found in transport "%s".', $transportName));
+            return Command::SUCCESS;
+        }
+
+        // Filtrage par classe si option spécifiée
+        if ($classFilter) {
+            $envelopes = array_filter($envelopes, function ($envelope) use ($classFilter) {
+                return str_contains(get_class($envelope->getMessage()), $classFilter);
+            });
+        }
+
+        // Cas 3 : Affichage simple des statistiques (--stats)
+        if ($input->getOption('stats')) {
+            $io->info(sprintf('Pending messages count listed (max %d): %d', $max, count($envelopes)));
+            return Command::SUCCESS;
+        }
+
+        // Cas 4 : Rendu du tableau graphique standard
+        $rows = [];
+        foreach ($envelopes as $envelope) {
+            // Recherche de l'ID via le TransportMessageIdStamp s'il existe
+            $idStamp = $envelope->last(\Symfony\Component\Messenger\Stamp\TransportMessageIdStamp::class);
+            $messageId = $idStamp ? $idStamp->getId() : 'N/A';
+            
+            $rows[] = [
+                $messageId,
+                get_class($envelope->getMessage()),
+            ];
+        }
+
+        $io->table(['ID', 'Message Class'], $rows);
+        return Command::SUCCESS;
+    }
+
+    private function displaySingleMessage(SymfonyStyle $io, Envelope $envelope, string $id): void
+    {
+        $io->title(sprintf('Message ID: %s', $id));
+        $io->text(sprintf('**Class:** %s', get_class($envelope->getMessage())));
+        
+        // Dump propre du contenu du message
+        $io->section('Message Content');
+        if (class_exists(\Symfony\Component\VarDumper\Dumper\CliDumper::class)) {
+            $io->writeln(dump($envelope->getMessage()));
+        } else {
+            $io->writeln(print_r($envelope->getMessage(), true));
+        }
+    }
+
+
+}

--- a/src/Symfony/Component/Messenger/Tests/Command/ShowMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ShowMessagesCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Command;
+
+use Symfony\Component\Messenger\Command\ShowMessagesCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+
+/**
+ * @author Payene Denis Kombate <denis.kombate@gmail.com>
+ */
+class ShowMessagesCommandTest extends TestCase
+{
+    
+    public function testExecuteDisplaysMessagesSuccessfully(): void
+    {
+        // 1. On crée un faux message PHP
+        $mockMessage = new \stdClass();
+        $envelope = new Envelope($mockMessage, [new TransportMessageIdStamp('123')]);
+
+        // 2. On simule (mock) le Receiver qui implémente ListableReceiverInterface
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())
+            ->method('all')
+            ->with(50)
+            ->willReturn([$envelope]);
+
+        // 3. On simule le ServiceLocator qui contient notre faux transport "async"
+        $transportLocator = $this->createMock(ServiceLocator::class);
+        $transportLocator->expects($this->once())
+            ->method('has')
+            ->with('async')
+            ->willReturn(true);
+            
+        $transportLocator->expects($this->once())
+            ->method('get')
+            ->with('async')
+            ->willReturn($receiver);
+
+        // 4. On instancie la commande et on fusionne la définition pour valider les options graphiques
+        $command = new ShowMessagesCommand($transportLocator);
+        $command->mergeApplicationDefinition(); 
+        $commandTester = new CommandTester($command);
+        
+        $commandTester->execute([
+            '--transport' => 'async',
+        ]);
+
+        // 5. Assertions : On vérifie que la commande s'est bien exécutée et affiche l'ID
+        $commandTester->assertCommandIsSuccessful();
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('123', $output);
+        $this->assertStringContainsString('stdClass', $output);
+    }
+
+    public function testExecuteOutputsTableOfMessages(): void
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        
+        // On simule une enveloppe contenant un message générique
+        $envelope = new Envelope(new \stdClass());
+        $receiver->method('all')->with(50)->willReturn([$envelope]);
+
+        $locator = $this->createMock(ServiceLocator::class);
+        $locator->method('has')->with('async')->willReturn(true);
+        $locator->method('get')->with('async')->willReturn($receiver);
+
+        // CORRECTION : On passe uniquement le $locator (1 seul argument attendu par le constructeur)
+        $command = new ShowMessagesCommand($locator);
+        $command->mergeApplicationDefinition(); 
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--transport' => 'async']);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        
+        // On vérifie les entêtes du tableau SymfonyStyle dans la sortie console
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('ID', $display);
+        $this->assertStringContainsString('Message Class', $display);
+        $this->assertStringContainsString('stdClass', $display);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| Issues        | Fix #64777
| License       | MIT

### Description
This PR introduces a new `messenger:show` command to the Messenger component, as proposed in #64777. 
While `messenger:failed:show` provides a great experience for inspecting failed messages, there was currently no equivalent command to inspect pending messages on regular, active transports.

### Lifecycle & Usage
The command lists or displays pending messages for a given transport, provided that the transport implements `ListableReceiverInterface`:

```bash
php bin/console messenger:show --transport=async
php bin/console messenger:show --transport=async <id>
php bin/console messenger:show --transport=async --class-filter=MyMessage --max=20 --stats
```
If a transport does not support browsing queued messages, the command safely reports that browsing is not supported and exits with a `Command::FAILURE` status.

### Todo
- [x] Implement the `ShowMessagesCommand`
- [x] Add comprehensive unit tests (`ShowMessagesCommandTest`)
- [x] Register service in FrameworkBundle DIC (`console.php`)
