### PR TITLE
[Validator] fix Welsh height placeholder in image constraint messages

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
@@ -168,11 +168,11 @@
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target>Mae uchder y ddelwedd yn rhy fawr ({{ width }}px). Yr uchder mwyaf â ganiateir yw {{ max_height }}px.</target>
+                <target>Mae uchder y ddelwedd yn rhy fawr ({{ height }}px). Yr uchder mwyaf â ganiateir yw {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="46">
                 <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target>Mae uchder y ddelwedd yn rhy fach ({{ width }}px). Yr uchder lleiaf â ganiateir yw {{ min_height }}px.</target>
+                <target>Mae uchder y ddelwedd yn rhy fach ({{ height }}px). Yr uchder lleiaf â ganiateir yw {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user's current password.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

The height-too-big and height-too-small messages (trans-unit ids 45 and 46)
in `validators.cy.xlf` had `{{ width }}` in the target text where the
message is about height. So the number shown to the user was the wrong
dimension.

`ImageValidator` only calls `setParameter('{{ height }}', ...)` for these
two message keys, never `{{ width }}`. The sibling width messages (ids 43
and 44, same file) already use `{{ width }}` correctly, which is what gave
this away in the first place — the height messages were clearly copy-pasted
from the width ones and the placeholder never got updated.

Before:
```
Mae uchder y ddelwedd yn rhy fawr ({{ width }}px). Yr uchder mwyaf â ganiateir yw {{ max_height }}px.
```
After:
```
Mae uchder y ddelwedd yn rhy fawr ({{ height }}px). Yr uchder mwyaf â ganiateir yw {{ max_height }}px.
```

Only the placeholder token changed; the rest of the Welsh text is untouched.
