### PR TITLE
[Validator] fix Finnish height placeholder in image constraint message

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
@@ -168,7 +168,7 @@
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target>Kuva on liian korkea ({{ width }} px). Korkeuden tulee olla enintään {{ max_width }} px.</target>
+                <target>Kuva on liian korkea ({{ height }} px). Korkeuden tulee olla enintään {{ max_height }} px.</target>
             </trans-unit>
             <trans-unit id="46">
                 <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

The height-too-big message (trans-unit id 45) in `validators.fi.xlf` used
`{{ width }}` and `{{ max_width }}` in the target text, but this message is
about height.

`ImageValidator` calls `setParameter('{{ max_height }}', ...)` for this
message key, never `{{ max_width }}`. The sibling id 46 (height-too-small,
already correct in this same file) confirms the intended pair is
`{{ height }}` / `{{ max_height }}`.

Before:
```
Kuva on liian korkea ({{ width }} px). Korkeuden tulee olla enintään {{ max_width }} px.
```
After:
```
Kuva on liian korkea ({{ height }} px). Korkeuden tulee olla enintään {{ max_height }} px.
```

Only the two placeholder tokens changed; the rest of the Finnish text is
untouched.
