### PR TITLE
[Validator] fix Traditional Chinese min/max placeholder swap in image messages

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -164,7 +164,7 @@
             </trans-unit>
             <trans-unit id="44">
                 <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target>圖片寬度過小 ({{ width }}px)。允許的最小寬度為 {{ max_width }}px。</target>
+                <target>圖片寬度過小 ({{ width }}px)。允許的最小寬度為 {{ min_width }}px。</target>
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
@@ -172,7 +172,7 @@
             </trans-unit>
             <trans-unit id="46">
                 <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target>圖片高度過小 ({{ height }}px)。允許的最小高度為 {{ max_height }}px。</target>
+                <target>圖片高度過小 ({{ height }}px)。允許的最小高度為 {{ min_height }}px。</target>
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user's current password.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

Two messages in `validators.zh_TW.xlf` had a min/max parameter swap: the
translated text correctly reads as a minimum-value message, but the bound
placeholder was the maximum one.

- id 44 (width-too-small): target bound `{{ max_width }}`, should be
  `{{ min_width }}`.
- id 46 (height-too-small): target bound `{{ max_height }}`, should be
  `{{ min_height }}`.

`ImageValidator` calls `setParameter('{{ min_width }}', ...)` and
`setParameter('{{ min_height }}', ...)` specifically for these two message
keys, so the wrong parameter name meant the number shown never matched what
the sentence said.

Only the placeholder tokens changed in both units; the rest of the Chinese
text is untouched.
