### PR TITLE
[Validator] fix Azerbaijani placeholder name in divisible-by message

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
@@ -324,7 +324,7 @@
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
-                <target>Bu dəyər {{ compare_value }} dəyərinin bölənlərindən biri olmalıdır.</target>
+                <target>Bu dəyər {{ compared_value }} dəyərinin bölənlərindən biri olmalıdır.</target>
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`validators.az.xlf` id 84 (divisible-by message) used `{{ compare_value }}`
in the target text.

`AbstractComparisonValidator` always calls
`setParameter('{{ compared_value }}', ...)` — with the "d". The mismatched
name meant the number was never substituted, so the raw `{{ compare_value }}`
text would leak straight into the message shown to the user.

Only the placeholder token changed; the rest of the Azerbaijani text is
untouched.
