### PR TITLE
[Validator] fix Galician placeholder name in collection divisible-by message

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -372,7 +372,7 @@
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-                <target>O número de elementos desta colección debería ser múltiplo de {{compare_value}}.</target>
+                <target>O número de elementos desta colección debería ser múltiplo de {{ compared_value }}.</target>
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`validators.gl.xlf` id 96 (collection divisible-by message) used
`{{compare_value}}` in the target text (also missing the internal spaces
the rest of the file uses).

`Count`'s `divisibleByMessage` is always substituted through
`{{ compared_value }}` — with the "d". Same wrong-parameter-name bug as the
one already confirmed in the az and tr translations of this identical
message.

Only the placeholder token changed; the rest of the Galician text is
untouched.
