### PR TITLE
[Validator] fix Basque IBAN placeholder casing in BIC mismatch message

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -328,7 +328,7 @@
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
-                <target>Banku Identifikazioko Kode hau ez dago lotuta {{ IBAN }} IBAN-rekin.</target>
+                <target>Banku Identifikazioko Kode hau ez dago lotuta {{ iban }} IBAN-rekin.</target>
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`validators.eu.xlf` id 85 (BIC/IBAN mismatch message) used `{{ IBAN }}`
(uppercase) in the target text.

`BicValidator` always calls `setParameter('{{ iban }}', ...)` — lowercase.
Symfony's parameter substitution is case-sensitive, so the uppercase
placeholder was never replaced and would leak literally into the
user-facing message.

Only the placeholder casing changed; the rest of the Basque text is
untouched.
