### PR TITLE
[Validator] fix Arabic ratio placeholder in image ratio-too-small message

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -284,7 +284,7 @@
             </trans-unit>
             <trans-unit id="74">
                 <source>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target>نسبة العرض على الارتفاع للصورة صغيرة جدا ({{ ratio }}). الحد الأدنى للنسبة المسموح به هو {{ max_ratio }}.</target>
+                <target>نسبة العرض على الارتفاع للصورة صغيرة جدا ({{ ratio }}). الحد الأدنى للنسبة المسموح به هو {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="75">
                 <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`validators.ar.xlf` id 74 (image ratio-too-small message) bound
`{{ max_ratio }}` in the target text instead of `{{ min_ratio }}`.

`ImageValidator` only supplies `{{ min_ratio }}` for this message key — the
sibling id 73 (ratio-too-big, same file) correctly uses `{{ max_ratio }}`,
which is what makes the swap obvious. The wrong parameter name was both
backwards for the sentence and never substituted at runtime.

Only the placeholder token changed; the rest of the Arabic text is
untouched.
