### PR TITLE
[Security][Validator] fix broken Armenian placeholders

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.hy.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.hy.xlf
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Մուտքի չափազանց շատ անհաջող փորձեր: Խնդրում ենք կրկին փորձել %minutes րոպե:</target>
+                <target>Մուտքի չափազանց շատ անհաջող փորձեր: Խնդրում ենք կրկին փորձել %minutes% րոպե:</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -164,7 +164,7 @@
             </trans-unit>
             <trans-unit id="44">
                 <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target>Նկարի լայնությունը չափազանց փոքր է ({{ width }}px). Մինիմալ չափն է {{ min_ width }}px։</target>
+                <target>Նկարի լայնությունը չափազանց փոքր է ({{ width }}px). Մինիմալ չափն է {{ min_width }}px։</target>
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

Two separate broken-placeholder bugs in Armenian translations, both in
files touched by this PR:

`validators.hy.xlf` id 44 (image width-too-small message): the target had
a stray space inside the placeholder, `{{ min_ width }}` instead of
`{{ min_width }}`. `ImageValidator` calls
`setParameter('{{ min_width }}', ...)`, so the space meant it never
matched and the raw placeholder text would leak into the message.

`security.hy.xlf` id 19 (login-throttling singular message): the target
was missing the closing percent sign, `%minutes` instead of `%minutes%`.
`TooManyLoginAttemptsAuthenticationException::getMessageData()` always
supplies `%minutes%` via `strtr`, so the same problem applied — the raw
placeholder text would leak into the message shown to the user. The
sibling id 20 (plural, already correct in this file) uses the properly
closed `%minutes%` token.

Both fixes only change the placeholder token itself; the surrounding
Armenian text is untouched in both files.
