### PR TITLE
[Security] fix German singular login-throttling message to keep %minutes%

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.de.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.de.xlf
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in einer Minute noch einmal.</target>
+                <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in %minutes% Minute noch einmal.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`security.de.xlf` id 19 (login-throttling singular message) hardcoded
"einer Minute" (one minute) instead of keeping the `%minutes%` placeholder.

`TooManyLoginAttemptsAuthenticationException::getMessageData()` always
supplies `%minutes%` via `strtr` regardless of the actual threshold, so a
hardcoded "one" is wrong whenever the configured threshold isn't 1. The
sibling plural message (id 20, already correct in this file) keeps
`%minutes%` literally: "in %minutes% Minuten". German "Minute" doesn't take
a plural -s in the singular, so "%minutes% Minute" is grammatically correct
as the singular form.

Before:
```
Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in einer Minute noch einmal.
```
After:
```
Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in %minutes% Minute noch einmal.
```
