### PR TITLE
[Security] fix Portuguese singular login-throttling message

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.pt.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.pt.xlf
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Muitas tentativas de login sem sucesso, por favor, tente novamente novamente em 1 minuto.</target>
+                <target>Muitas tentativas de login sem sucesso, por favor, tente novamente em %minutes% minuto.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`security.pt.xlf` id 19 (login-throttling singular message) had a
duplicated word ("novamente novamente") and hardcoded "em 1 minuto" instead
of the `%minutes%` placeholder.

`TooManyLoginAttemptsAuthenticationException::getMessageData()` always
supplies `%minutes%` via `strtr` regardless of the actual threshold. The
sibling plural message (id 20, already correct in this file) reads "tente
novamente em %minutes% minutos", which is the template this fix mirrors
for the singular form.

Before:
```
Muitas tentativas de login sem sucesso, por favor, tente novamente novamente em 1 minuto.
```
After:
```
Muitas tentativas de login sem sucesso, por favor, tente novamente em %minutes% minuto.
```
