### PR TITLE
[Security] fix Brazilian Portuguese singular login-throttling message

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.pt_BR.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.pt_BR.xlf
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-                <target>Muitas tentativas de login inválidas, por favor, tente novamente em um minuto.</target>
+                <target>Muitas tentativas de login inválidas, por favor, tente novamente em %minutes% minuto.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`security.pt_BR.xlf` id 19 (login-throttling singular message) hardcoded
"em um minuto" (in one minute) instead of the `%minutes%` placeholder.

`TooManyLoginAttemptsAuthenticationException::getMessageData()` always
supplies `%minutes%` via `strtr` regardless of the actual threshold. The
sibling plural message (id 20, already correct in this file) reads "tente
novamente em %minutes% minutos", confirming the intended pattern for the
singular slot.

Before:
```
Muitas tentativas de login inválidas, por favor, tente novamente em um minuto.
```
After:
```
Muitas tentativas de login inválidas, por favor, tente novamente em %minutes% minuto.
```
