### PR TITLE
[Cache] Remove always-true method_exists() check in FilesystemCommonTrait::__destruct()

### DIFF
--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -184,9 +184,7 @@ trait FilesystemCommonTrait
 
     public function __destruct()
     {
-        if (method_exists(parent::class, '__destruct')) {
-            parent::__destruct();
-        }
+        parent::__destruct();
         if (isset($this->tmpSuffix) && is_file($this->directory.$this->tmpSuffix)) {
             unlink($this->directory.$this->tmpSuffix);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?        | 6.4
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Issues         | Fix static analysis failure on 6.4 PRs
| License        | MIT

`FilesystemCommonTrait::__destruct()` guards the call to the parent destructor with `method_exists(parent::class, '__destruct')`. Both classes that use this trait (`FilesystemAdapter`, `PhpFilesAdapter`) extend `AbstractAdapter`, which always declares `__destruct()` via `AbstractAdapterTrait`. So the check can never be false, and PHPStan flags it:

```
Call to function method_exists() with 'Symfony\Component\Cache\Adapter\AbstractAdapter' and '__destruct' will always evaluate to true.
```

This is currently failing the PHPStan check on every open 6.4 PR (checked several at random, all red on this same message).

Removed the dead check and call `parent::__destruct()` directly, same as `TagAwareAdapter::__destruct()` already does elsewhere in the same component.
