### PR TITLE
[Messenger] Fix AmazonSqs connection destructor throwing on network failure

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\Sqs\Result\GetQueueUrlResult;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
@@ -289,6 +290,40 @@ class ConnectionTest extends TestCase
 
         $connection = new Connection(['queue_name' => 'queue', 'account' => 123, 'auto_setup' => false], $client);
         $connection->get();
+    }
+
+    public function testDestructDoesNotThrowOnNetworkFailure()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('', ['error' => 'Connection timed out']));
+        $client = new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => 'key', 'accessKeySecret' => 'secret'], null, $httpClient);
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, 'https://sqs.eu-west-1.amazonaws.com/123456789012/queue');
+
+        try {
+            $connection->get();
+            $this->fail('The receive should have failed.');
+        } catch (NetworkException) {
+        }
+
+        unset($connection);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testResetClearsTheFailedResponse()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('', ['error' => 'Connection timed out']));
+        $client = new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => 'key', 'accessKeySecret' => 'secret'], null, $httpClient);
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, 'https://sqs.eu-west-1.amazonaws.com/123456789012/queue');
+
+        try {
+            $connection->get();
+            $this->fail('The receive should have failed.');
+        } catch (NetworkException) {
+        }
+
+        $connection->reset();
+
+        $this->addToAssertionCount(1);
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
+use AsyncAws\Core\Exception\Exception as AsyncAwsException;
 use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use AsyncAws\Sqs\Enum\QueueAttributeName;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
@@ -77,7 +78,11 @@ class Connection
 
     public function __destruct()
     {
-        $this->reset();
+        try {
+            $this->reset();
+        } catch (AsyncAwsException) {
+            // requeuing in-flight messages on shutdown is best effort and must not throw from the destructor
+        }
     }
 
     /**
@@ -373,8 +378,14 @@ class Connection
     public function reset(): void
     {
         if (null !== $this->currentResponse) {
-            // fetch current response in order to requeue in transit messages
-            if (!$this->fetchMessage()) {
+            try {
+                // fetch current response in order to requeue in transit messages
+                if (!$this->fetchMessage()) {
+                    $this->currentResponse->cancel();
+                    $this->currentResponse = null;
+                }
+            } catch (AsyncAwsException) {
+                // the response failed (e.g. because of a network error) and cannot be reused
                 $this->currentResponse->cancel();
                 $this->currentResponse = null;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #50342 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT


When the SQS endpoint is unreachable (e.g. a TCP connect timeout), a failed ReceiveMessage poll leaves `Connection::$currentResponse` holding a response that has already been consumed and errored. `Connection::__destruct()` then calls `reset()`, which tries to resolve that same response again (in order to requeue in-transit messages). This second resolve is guaranteed to throw — and since it happens inside a destructor during script shutdown, the exception cannot be caught anywhere and the process dies with a PHP fatal error (exit code 255) instead of exiting cleanly.

How we hit this in production

We run `messenger:consume` workers on ECS consuming from SQS. I guess our infrastructure drops TCP SYN packets sometimes, so the connect timeout fires while the worker is long-polling ReceiveMessage. The failure then unfolds in two phases:

Phase 1 — the receive fails (expected): `Connection::get()` → `fetchMessage()` → `Result::resolve()` throws `AsyncAws\Core\Exception\Http\NetworkException`: Could not contact remote server.
It propagates through `Worker::run()` and the command starts terminating. So far this is the documented "transport is broken, let the worker die" behavior, and it produces a clean non-zero exit.

Phase 2 — the destructor throws again (the bug): during shutdown the Connection object is destructed while `$currentResponse` still references the failed response. `__destruct()` → `reset()` → `fetchMessage()` → `resolve()` throws again — this time from a destructor, where it is uncatchable:

```
PHP Fatal error:  Uncaught Symfony\Component\HttpClient\Exception\TransportException:                                                                                                                                                
  Instance of "Symfony\Component\HttpClient\Response\CurlResponse" is already consumed and                                                                                                                                             
  cannot be managed by "Symfony\Component\HttpClient\Response\AsyncResponse". A decorated                                                                                                                                              
  client should not call any of the response's methods in its "request()" method.                                                                                                                                                      
  in /var/www/vendor/symfony/http-client/Response/AsyncResponse.php:233                                                                                                                                                                
  #0 [internal function]: Symfony\Component\HttpClient\Response\AsyncResponse::stream()                                                                                                                                                
  #1 .../symfony/http-client/Response/ResponseStream.php(45): Generator->rewind()                                                                                                                                                      
  #2 .../async-aws/core/src/Response.php(148): ResponseStream->rewind()                                                                                                                                                                
  #3 .../async-aws/core/src/Result.php(69): AsyncAws\Core\Response->resolve()                                                                                                                                                          
  #4 .../symfony/amazon-sqs-messenger/Transport/Connection.php(247): AsyncAws\Core\Result->resolve()                                                                                                                                   
  #5 .../symfony/amazon-sqs-messenger/Transport/Connection.php(419): Connection->fetchMessage()                                                                                                                                        
  #6 .../symfony/amazon-sqs-messenger/Transport/Connection.php(85): Connection->reset()                                                                                                                                                
  #7 [internal function]: Connection->__destruct()                                                                                                                                                                                     
  #8 {main}     
```

Next
```
 AsyncAws\Core\Exception\Http\NetworkException: Could not contact remote server.                                                                                                                                                 
  in /var/www/vendor/async-aws/core/src/Response.php:160                                                                                                                                                                               
  ...                                                                                                                                                                                                                                  
  #3 .../symfony/amazon-sqs-messenger/Transport/Connection.php(85): Connection->reset()                                                                                                                                                
  #4 [internal function]: Connection->__destruct()                                                                                                                                                                                     
  #5 {main}             
```

 (The line numbers above are from symfony/amazon-sqs-messenger v7.4.6; the affected code is identical on 6.4: __destruct() calling reset(), and reset() calling fetchMessage().)  

Consequences: fatal masks the real exit code; monitoring gets a misleading Uncaught Exception pointing at the destructor; the fatal is deterministic once the receive failed (object state, not network); explicit reset() via ResetInterface can never succeed on the poisoned $currentResponse.

Reproduce: Connection::get() against a MockHttpClient response with ['error' => ...] (or a blackholed endpoint), catch the NetworkException, then unset($connection) → fatal.

Fix: __destruct() wraps reset() in try/catch (requeuing on shutdown is best effort and must never throw); reset() cancels and clears the failed response, so the connection state stays usable. Both tests fail without the fix.