### PR TITLE
[Mailer][Messenger] Wrap AsyncAws exceptions into TransportException in the AmazonSqs and SES transports

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -142,4 +142,21 @@ class SesHttpAsyncAwsTransportTest extends TestCase
         $this->expectExceptionMessage('Unable to send an email: i\'m a teapot (code 418).');
         $transport->send($mail);
     }
+
+    public function testSendThrowsTransportExceptionOnNetworkFailure()
+    {
+        $client = new MockHttpClient(static fn (): ResponseInterface => new MockResponse('', ['error' => 'Connection timed out']));
+
+        $transport = new SesHttpAsyncAwsTransport(new SesClient(Configuration::create([]), new NullProvider(), $client));
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Could not reach the remote Amazon server.');
+        $transport->send($mail);
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Ses\Input\SendEmailRequest;
 use AsyncAws\Ses\SesClient;
 use AsyncAws\Ses\ValueObject\Destination;
@@ -64,6 +65,8 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
             $exception->appendDebug($e->getResponse()->getInfo('debug') ?? '');
 
             throw $exception;
+        } catch (NetworkException $e) {
+            throw new HttpTransportException('Could not reach the remote Amazon server.', $response, 0, $e);
         }
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsReceiverTest.php
@@ -11,11 +11,16 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
+use AsyncAws\Core\Exception\Http\NetworkException;
+use AsyncAws\Core\Exception\UnparsableResponse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceivedStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceiver;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Serializer as SerializerComponent;
@@ -54,6 +59,32 @@ class AmazonSqsReceiverTest extends TestCase
         iterator_to_array($receiver->get());
     }
 
+    public function testItConvertsNetworkExceptionDuringGetIntoTransportException()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('get')->willThrowException(new NetworkException('Could not contact remote server.'));
+
+        $receiver = new AmazonSqsReceiver($connection, $this->createSerializer());
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not contact remote server.');
+
+        iterator_to_array($receiver->get());
+    }
+
+    public function testItConvertsNetworkExceptionDuringAckIntoTransportException()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('delete')->willThrowException(new NetworkException('Could not contact remote server.'));
+
+        $receiver = new AmazonSqsReceiver($connection, $this->createSerializer());
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not contact remote server.');
+
+        $receiver->ack(new Envelope(new DummyMessage('Hi'), [new AmazonSqsReceivedStamp('1')]));
+    }
+
     private function createSqsEnvelope()
     {
         return [
@@ -63,6 +94,45 @@ class AmazonSqsReceiverTest extends TestCase
                 'type' => DummyMessage::class,
             ],
         ];
+    }
+
+    public function testItConvertsNetworkExceptionDuringRejectIntoTransportException()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('delete')->willThrowException(new NetworkException('Could not contact remote server.'));
+
+        $receiver = new AmazonSqsReceiver($connection, $this->createSerializer());
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not contact remote server.');
+
+        $receiver->reject(new Envelope(new DummyMessage('Oops'), [new AmazonSqsReceivedStamp('id')]));
+    }
+
+    public function testItConvertsNetworkExceptionDuringGetMessageCountIntoTransportException()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getMessageCount')->willThrowException(new NetworkException('Could not contact remote server.'));
+
+        $receiver = new AmazonSqsReceiver($connection, $this->createSerializer());
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not contact remote server.');
+
+        $receiver->getMessageCount();
+    }
+
+    public function testItConvertsUnparsableResponseIntoTransportException()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('get')->willThrowException(new UnparsableResponse('Could not parse response as array.'));
+
+        $receiver = new AmazonSqsReceiver($connection, $this->createSerializer());
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not parse response as array.');
+
+        iterator_to_array($receiver->get());
     }
 
     private function createSerializer(): Serializer

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
+use AsyncAws\Core\Exception\Http\NetworkException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp;
@@ -18,6 +19,7 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsSender;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsXrayTraceHeaderStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class AmazonSqsSenderTest extends TestCase
@@ -85,6 +87,25 @@ class AmazonSqsSenderTest extends TestCase
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
         $sender = new AmazonSqsSender($connection, $serializer);
+        $sender->send($envelope);
+    }
+
+    public function testItConvertsNetworkExceptionDuringSendIntoTransportException()
+    {
+        $envelope = new Envelope(new DummyMessage('Oy'));
+        $encoded = ['body' => '...', 'headers' => ['type' => DummyMessage::class]];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('send')->willThrowException(new NetworkException('Could not contact remote server.'));
+
+        $serializer = $this->createStub(SerializerInterface::class);
+        $serializer->method('encode')->with($envelope)->willReturn($encoded);
+
+        $sender = new AmazonSqsSender($connection, $serializer);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not contact remote server.');
+
         $sender->send($envelope);
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Core\Exception\Http\ServerException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
@@ -148,6 +149,34 @@ class AmazonSqsTransportTest extends TestCase
             ->expects($this->once())
             ->method('reset')
             ->willThrowException($this->createHttpException());
+
+        $this->expectException(TransportException::class);
+
+        $transport->reset();
+    }
+
+    public function testItConvertsNetworkExceptionDuringSetupIntoTransportException()
+    {
+        $connection = $this->createMock(Connection::class);
+        $transport = $this->getTransport(null, $connection);
+        $connection
+            ->expects($this->once())
+            ->method('setup')
+            ->willThrowException(new NetworkException('Could not contact remote server.'));
+
+        $this->expectException(TransportException::class);
+
+        $transport->setup();
+    }
+
+    public function testItConvertsNetworkExceptionDuringResetIntoTransportException()
+    {
+        $connection = $this->createMock(Connection::class);
+        $transport = $this->getTransport(null, $connection);
+        $connection
+            ->expects($this->once())
+            ->method('reset')
+            ->willThrowException(new NetworkException('Could not contact remote server.'));
 
         $this->expectException(TransportException::class);
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
-use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Exception as AsyncAwsException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -39,7 +39,7 @@ class AmazonSqsReceiver implements ReceiverInterface, MessageCountAwareInterface
     {
         try {
             $sqsEnvelope = $this->connection->get();
-        } catch (HttpException $e) {
+        } catch (AsyncAwsException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
         if (null === $sqsEnvelope) {
@@ -64,7 +64,7 @@ class AmazonSqsReceiver implements ReceiverInterface, MessageCountAwareInterface
     {
         try {
             $this->connection->delete($this->findSqsReceivedStamp($envelope)->getId());
-        } catch (HttpException $e) {
+        } catch (AsyncAwsException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
     }
@@ -73,7 +73,7 @@ class AmazonSqsReceiver implements ReceiverInterface, MessageCountAwareInterface
     {
         try {
             $this->connection->delete($this->findSqsReceivedStamp($envelope)->getId());
-        } catch (HttpException $e) {
+        } catch (AsyncAwsException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
     }
@@ -82,7 +82,7 @@ class AmazonSqsReceiver implements ReceiverInterface, MessageCountAwareInterface
     {
         try {
             return $this->connection->getMessageCount();
-        } catch (HttpException $e) {
+        } catch (AsyncAwsException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
     }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsSender.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
-use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Exception as AsyncAwsException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
@@ -64,7 +64,7 @@ class AmazonSqsSender implements SenderInterface
                 $messageDeduplicationId,
                 $xrayTraceId
             );
-        } catch (HttpException $e) {
+        } catch (AsyncAwsException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
 
-use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Exception as AsyncAwsException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
@@ -73,7 +73,7 @@ class AmazonSqsTransport implements TransportInterface, SetupableTransportInterf
     {
         try {
             $this->connection->setup();
-        } catch (HttpException $e) {
+        } catch (AsyncAwsException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
     }
@@ -85,7 +85,7 @@ class AmazonSqsTransport implements TransportInterface, SetupableTransportInterf
     {
         try {
             $this->connection->reset();
-        } catch (HttpException $e) {
+        } catch (AsyncAwsException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`AsyncAws\Core\Exception\Http\HttpException` is an interface, implemented only by `ClientException`, `ServerException` and `RedirectionException`, that is only when the service answered with a 3xx/4xx/5xx status. When the request never completes, `Response::resolve()` stores a `NetworkException` instead, which implements the AsyncAws root exception interface but not `HttpException`. It therefore walked through every catch in the AmazonSqs bridge and escaped raw, where `ReceiverInterface` documents a `TransportException`.

Two things changed during review.

**The sender was missing.** `AmazonSqsSender::send()` was the seventh call site and the only one left unwrapped. It runs in every process that dispatches a message, not only in `messenger:consume`, so it is at least as exposed as the receiver.

**The catch is now the AsyncAws root exception rather than an enumeration.** `catch (HttpException|NetworkException)` still left `UnparsableResponse` behind, which is what you get from a proxy or load balancer answering 200 with an HTML body. Catching `AsyncAws\Core\Exception\Exception` covers every AsyncAws failure and matches what the other transports already do with their own driver exceptions: `\AMQPException` for Amqp, `DBALException` for Doctrine, the Pheanstalk root for Beanstalkd, `\RedisException|\Relay\Exception` for Redis.

The same flaw exists in the Mailer SES transport, which is the only other AsyncAws integration in the monorepo, so the second commit fixes it there too. `NetworkException` carries no response, no AWS code and no AWS message, so it needs its own catch rather than a wider one; the message matches what Mandrill and Mailgun already use.

Full call-site coverage after this PR:

| entry point | wrapped | tested |
| --- | --- | --- |
| `AmazonSqsReceiver::get()` | yes | yes |
| `AmazonSqsReceiver::ack()` | yes | yes |
| `AmazonSqsReceiver::reject()` | yes | yes |
| `AmazonSqsReceiver::getMessageCount()` | yes | yes |
| `AmazonSqsSender::send()` | yes | yes |
| `AmazonSqsTransport::setup()` | yes | yes |
| `AmazonSqsTransport::reset()` | yes | yes |
| `SesHttpAsyncAwsTransport::doSend()` | yes | yes |

All eight tests fail on a clean 6.4 and pass with the fix.

Note for whoever merges up: 7.4 and later have a ninth site, `AmazonSqsReceiver::keepalive()`, which does not exist on 6.4 and needs the same catch.
