### PR TITLE
[Form][Security][Validator] Review Bosnian (bs) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Molim upišite ispravan UUID.</target>
+                <target>Molim upišite ispravan UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.bs.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.bs.xlf
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minut.|Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minuta.</target>
+                <target>Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minutu.|Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minute.|Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minuta.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjana IP adresa.</target>
+                <target>Ova vrijednost nije ispravna IP adresa.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target state="needs-review-translation">Privremeni direktorij nije konfiguriran u php.ini, ili konfigurirani direktorij ne postoji.</target>
+                <target>Privremeni direktorij nije konfiguriran u php.ini, ili konfigurirani direktorij ne postoji.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjan Međunarodni broj bankovnog računa (IBAN).</target>
+                <target>Ova vrijednost nije ispravan međunarodni broj bankovnog računa (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjan Poslovni identifikacijski kod (BIC).</target>
+                <target>Ova vrijednost nije ispravan poslovni identifikacijski kod (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83" resname="This is not a valid UUID.">
                 <source>This value is not a valid UUID.</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjan UUID.</target>
+                <target>Ova vrijednost nije ispravan UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -428,147 +428,147 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-review-translation">Ekstenzija datoteke je nevažeća ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
+                <target>Ekstenzija datoteke je nevažeća ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-review-translation">Otkriveno kodiranje karaktera je nevažeće ({{ detected }}). Dozvoljena kodiranja su {{ encodings }}.</target>
+                <target>Otkriveno kodiranje znakova je nevažeće ({{ detected }}). Dozvoljena kodiranja su {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjana MAC adresa.</target>
+                <target>Ova vrijednost nije ispravna MAC adresa.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target state="needs-review-translation">Ovom URL-u nedostaje domena najvišeg nivoa.</target>
+                <target>Ovom URL-u nedostaje domena najvišeg nivoa.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target state="needs-review-translation">Ova vrijednost je prekratka. Trebala bi sadržavati barem jednu riječ.|Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječi.</target>
+                <target>Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječ.|Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječi.|Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječi.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target state="needs-review-translation">Ova vrijednost je predugačka. Trebala bi sadržavati samo jednu riječ.|Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječi ili manje.</target>
+                <target>Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječ ili manje.|Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječi ili manje.|Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječi ili manje.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target state="needs-review-translation">Ova vrijednost ne predstavlja valjani tjedan u ISO 8601 formatu.</target>
+                <target>Ova vrijednost ne predstavlja ispravnu sedmicu u ISO 8601 formatu.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeća sedmica.</target>
+                <target>Ova vrijednost nije važeća sedmica.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target state="needs-review-translation">Ova vrijednost ne smije biti prije tjedna "{{ min }}".</target>
+                <target>Ova vrijednost ne smije biti prije sedmice "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target state="needs-review-translation">Ova vrijednost ne bi trebala biti nakon sedmice "{{ max }}".</target>
+                <target>Ova vrijednost ne smije biti nakon sedmice "{{ max }}".</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeći Twig šablon.</target>
+                <target>Ova vrijednost nije važeći Twig šablon.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Ova datoteka nije važeći video.</target>
+                <target>Ova datoteka nije važeći video.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Veličina videa nije mogla biti utvrđena.</target>
+                <target>Veličina videa nije mogla biti utvrđena.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
+                <target>Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je premala ({{ width }}px). Minimalna očekivana širina je {{ min_width }}px.</target>
+                <target>Širina videa je premala ({{ width }}px). Minimalna očekivana širina je {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
+                <target>Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je premala ({{ height }}px). Očekivana minimalna visina je {{ min_height }}px.</target>
+                <target>Visina videa je premala ({{ height }}px). Minimalna očekivana visina je {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video ima premalo piksela ({{ pixels }}). Očekivana minimalna količina je {{ min_pixels }}.</target>
+                <target>Video ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video ima previše piksela ({{ pixels }}). Očekivana maksimalna količina je {{ max_pixels }}.</target>
+                <target>Video ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Omjer videa je prevelik ({{ ratio }}). Dozvoljeni maksimalni omjer je {{ max_ratio }}.</target>
+                <target>Razmjera videa je prevelika ({{ ratio }}). Maksimalna dozvoljena razmjera je {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Omjer videa je premali ({{ ratio }}). Minimalni očekivani omjer je {{ min_ratio }}.</target>
+                <target>Razmjera videa je premala ({{ ratio }}). Minimalna očekivana razmjera je {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Video je kvadratan ({{ width }}x{{ height }}px). Kvadratni video zapisi nisu dozvoljeni.</target>
+                <target>Video je kvadratan ({{ width }}x{{ height }}px). Kvadratni video zapisi nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video je vodoravne orijentacije ({{ width }}x{{ height }} px). Vodoravni video zapisi nisu dozvoljeni.</target>
+                <target>Video je orijentisan horizontalno (landscape) ({{ width }}x{{ height }}px). Horizontalno orijentisani video zapisi nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video je uspravno orijentisan ({{ width }}x{{ height }}px). Video zapisi uspravne orijentacije nisu dozvoljeni.</target>
+                <target>Video je orijentisan vertikalno (portrait) ({{ width }}x{{ height }}px). Vertikalno orijentisani video zapisi nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Video datoteka je oštećena.</target>
+                <target>Video datoteka je oštećena.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Video sadrži više tokova. Dozvoljen je samo jedan tok.</target>
+                <target>Video sadrži više tokova. Dozvoljen je samo jedan tok.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Nepodržani video kodek "{{ codec }}".</target>
+                <target>Nepodržani video kodek "{{ codec }}".</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Nepodržani video kontejner "{{ container }}".</target>
+                <target>Nepodržani video kontejner "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Datoteka slike je oštećena.</target>
+                <target>Datoteka slike je oštećena.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Slika ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
+                <target>Slika ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Slika ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
+                <target>Slika ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Naziv ove datoteke ne odgovara očekivanom skupu znakova.</target>
+                <target>Naziv ove datoteke ne odgovara očekivanom skupu znakova.</target>
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeći XML.</target>
+                <target>Ova vrijednost nije važeći XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Ova vrijednost ne odgovara očekivanoj XSD shemi.</target>
+                <target>Ova vrijednost ne odgovara očekivanoj XSD shemi.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Ovaj XML sadržaj je prevelik ({{ size }} bajtova): premašuje ograničenje od {{ limit }} bajtova.</target>
+                <target>Ovaj XML sadržaj je prevelik ({{ size }} B): premašuje ograničenje od {{ limit }} B.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeći cron izraz.</target>
+                <target>Ova vrijednost nije važeći cron izraz.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A          |
| ------------- | ---------- |
| Branch?       | 6.4        |
| Bug fix?      | no         |
| New feature?  | no         |
| Deprecations? | no         |
| Issues        | Fix #53014 |
| License       | MIT        |

Finalizes the remaining Bosnian (`bs`) translations flagged `needs-review-translation` across the **Validator** (41 units), **Form** (1) and **Security** (1) components, as requested in #53014.

All review markers are removed and the wording is aligned to the vocabulary already used in the finalized parts of the same files:

- `valjan` → `ispravan` for format validations (IP, IBAN, BIC, UUID, MAC), matching the existing `ispravan` used for date/email/URL/ISBN/currency
- `tjedan` → `sedmica` for "week"
- lowercased the spelled-out acronyms (`međunarodni broj bankovnog računa`, `poslovni identifikacijski kod`) — they are common-noun phrases, not proper names
- the Security "too many login attempts" message and the word-count messages were given the three Bosnian plural forms (e.g. `minutu|minute|minuta`)
- a few consistency fixes across the video/image messages (`razmjera`, orientation wording, etc.)

Note on review: I'm a native **Croatian** speaker, not Bosnian. Given how close the two languages are I'm comfortable reviewing these strings, and I cross-checked every unit against the already-finalized **Croatian** translations in the same files for consistency. A review from a native Bosnian speaker is of course still very welcome.
