### PR TITLE
[Config] Escape "*/" in generated array-shape comments

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -21,7 +21,9 @@ final class ArrayShapeGenerator
 {
     public static function generate(NodeInterface $node): string
     {
-        return str_replace("\n", "\n * ", self::doGeneratePhpDoc($node));
+        // "*/" anywhere in the shape (a comment, an enum value, a node name) would prematurely
+        // close the surrounding doc block, so the slash is escaped to keep the value readable
+        return str_replace(['*/', "\n"], ['*\/', "\n * "], self::doGeneratePhpDoc($node));
     }
 
     private static function doGeneratePhpDoc(NodeInterface $node, int $nestingLevel = 1): string

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -182,6 +182,25 @@ class ArrayShapeGeneratorTest extends TestCase
         $this->assertStringContainsString('node?: bool|\Symfony\Component\Config\Loader\ParamConfigurator, // Deprecated: The "node" option is deprecated. // This is a boolean node. Set to true to enable it. Set to false to disable it. // Default: true', ArrayShapeGenerator::generate($root));
     }
 
+    public function testPhpDocDoesNotCloseCommentBlock()
+    {
+        $child = new ScalarNode('schedule');
+        $child->setInfo('Cron expression for when normal/incremental syncs should run');
+        $child->setDefaultValue('*/30 * * * *');
+
+        $root = new ArrayNode('root');
+        $root->addChild($child);
+        $root->addChild(new EnumNode('preset', values: ['*/5 * * * *', '*/30 * * * *']));
+
+        $generated = ArrayShapeGenerator::generate($root);
+
+        // A "*/" in the info, default value or an enum value would prematurely close the surrounding doc block and generate invalid PHP.
+        $this->assertStringNotContainsString('*/', $generated);
+        // The slash is escaped so the values stay recognizable instead of being dropped.
+        $this->assertStringContainsString('*\\/30 * * * *', $generated);
+        $this->assertStringContainsString('"*\\/5 * * * *"|"*\\/30 * * * *"', $generated);
+    }
+
     public function testPhpDocShapeSingleLevel()
     {
         $root = new ArrayNode('root');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64817
| License       | MIT

A config value that contains `*/` (for example a cron expression like `*/30 * * * *`) is written as-is into the generated array-shape comment (`// Default: ...`). The `*/` closes the surrounding doc block early, so the generated `config/reference.php` becomes invalid PHP. This replaces `*/` with a space in the comment, the same way `PhpDumper` already does when embedding text into a generated doc block.
