### PR TITLE
[ErrorHandler] page aria and semantic improvements

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -265,6 +265,18 @@ thead.sf-toggle-content.sf-toggle-visible, tbody.sf-toggle-content.sf-toggle-vis
     text-align: inherit;
     cursor: pointer;
 }
+/* wraps the open/close icons (see createToggles() in exception.js); block avoids the empty */
+/* inline-block "strut" height that would otherwise push the content down */
+.sf-toggle-button {
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    display: block;
+    font-size: 0;
+    line-height: 0;
+}
 .filter-list { position: absolute; border: var(--border); box-shadow: var(--shadow); margin: 0; padding: 0; display: flex; flex-direction: column; }
 .filter-list :after { content: ''; }
 .filter-list li {

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -250,8 +250,21 @@ thead.sf-toggle-content.sf-toggle-visible, tbody.sf-toggle-content.sf-toggle-vis
 [data-filters] { position: relative; }
 [data-filtered] { cursor: pointer; }
 [data-filtered]:after { content: '\00a0\25BE'; }
-[data-filtered]:hover .filter-list li { display: inline-flex; }
+[data-filtered]:hover .filter-list li,
+[data-filtered].filter-open .filter-list li { display: inline-flex; }
 [class*="filter-hidden-"] { display: none; }
+
+.filter-toggle {
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    font: inherit;
+    font-weight: inherit;
+    color: inherit;
+    text-align: inherit;
+    cursor: pointer;
+}
 .filter-list { position: absolute; border: var(--border); box-shadow: var(--shadow); margin: 0; padding: 0; display: flex; flex-direction: column; }
 .filter-list :after { content: ''; }
 .filter-list li {
@@ -261,9 +274,23 @@ thead.sf-toggle-content.sf-toggle-visible, tbody.sf-toggle-content.sf-toggle-vis
     display: none;
     list-style: none;
     margin: 0;
-    padding: 5px 10px;
+    padding: 0;
+    position: relative;
     text-align: left;
     font-weight: normal;
+}
+.filter-list li label {
+    display: block;
+    padding: 5px 10px;
+    cursor: inherit;
+}
+/* hidden but still focusable via its <label>; the coloured "chip" look comes from the <li>/<label> */
+.filter-list li input[type="checkbox"] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    opacity: 0;
 }
 .filter-list li.active {
     background: var(--tab-background);
@@ -277,8 +304,9 @@ thead.sf-toggle-content.sf-toggle-visible, tbody.sf-toggle-content.sf-toggle-vis
 .filter-list-level li { cursor: s-resize; }
 .filter-list-level li.active { cursor: n-resize; }
 .filter-list-level li.last-active { cursor: default; }
-.filter-list-level li.last-active:before { content: '\2714\00a0'; }
-.filter-list-choice li:before { content: '\2714\00a0'; color: transparent; }
+/* the "/ ''" alt text keeps screen readers from reading the checkmark as part of the label */
+.filter-list-level li.last-active:before { content: '\2714\00a0' / ''; }
+.filter-list-choice li:before { content: '\2714\00a0' / ''; color: transparent; }
 .filter-list-choice li.active:before { color: unset; }
 
 .container { max-width: 1024px; margin: 0 auto; padding: 0 15px; }

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -216,8 +216,9 @@ thead.sf-toggle-content.sf-toggle-visible, tbody.sf-toggle-content.sf-toggle-vis
     text-align: center;
     white-space: nowrap;
 }
-.tab-navigation .tab-control.disabled {
+.tab-navigation .tab-control:disabled {
     color: var(--tab-disabled-color);
+    cursor: default;
 }
 .tab-navigation .tab-control.active {
     background-color: var(--tab-active-background);

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -166,12 +166,36 @@
 
             addClass(element, 'sf-toggle-content');
 
+            /* wrap just the icons in a real <button>: the row itself can contain a link, and a */
+            /* <button> can't contain one; inserted in place so nothing shifts visually */
+            var iconClose = toggles[i].querySelector('.icon-close');
+            var iconOpen = toggles[i].querySelector('.icon-open');
+            var toggleButton = document.createElement('button');
+            toggleButton.type = 'button';
+            addClass(toggleButton, 'sf-toggle-button');
+            var firstIcon = iconClose || iconOpen;
+            if (firstIcon) {
+                firstIcon.parentNode.insertBefore(toggleButton, firstIcon);
+            }
+            if (iconClose) {
+                toggleButton.appendChild(iconClose);
+            }
+            if (iconOpen) {
+                toggleButton.appendChild(iconOpen);
+            }
+            /* fixed label: the toggle's own text is read again right after as normal content, */
+            /* so reusing it as the button's name (e.g. via aria-labelledby) would repeat it twice */
+            toggleButton.setAttribute('aria-label', toggles[i].getAttribute('data-toggle-label') || 'Toggle details');
+            toggleButton.setAttribute('aria-controls', element.id);
+
             if (toggles[i].hasAttribute('data-toggle-initial') && toggles[i].getAttribute('data-toggle-initial') == 'display') {
                 addClass(toggles[i], 'sf-toggle-on');
                 addClass(element, 'sf-toggle-visible');
+                toggleButton.setAttribute('aria-expanded', 'true');
             } else {
                 addClass(toggles[i], 'sf-toggle-off');
                 addClass(element, 'sf-toggle-hidden');
+                toggleButton.setAttribute('aria-expanded', 'false');
             }
 
             addEventListener(toggles[i], 'click', function(e) {
@@ -194,6 +218,7 @@
                 toggleClass(toggle, 'sf-toggle-off');
                 toggleClass(element, 'sf-toggle-hidden');
                 toggleClass(element, 'sf-toggle-visible');
+                toggle.querySelector('.sf-toggle-button').setAttribute('aria-expanded', hasClass(toggle, 'sf-toggle-on') ? 'true' : 'false');
 
                 /* the toggle doesn't change its contents when clicking on it */
                 if (!toggle.hasAttribute('data-toggle-alt-content')) {

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -82,9 +82,12 @@
             for (j = 0; j < tabNavigation.length; j++) {
                 tabId = tabNavigation[j].getAttribute('data-tab-id');
                 var tabPanel = document.getElementById(tabId);
+                var tabPanelTitle = tabPanel.querySelector('.tab-title');
                 tabPanel.setAttribute('role', 'tabpanel');
-                tabPanel.setAttribute('aria-labelledby', tabId);
-                tabPanel.querySelector('.tab-title').className = 'hidden';
+                tabPanel.setAttribute('tabindex', '0');
+                tabPanelTitle.id = tabId + '-label';
+                tabPanel.setAttribute('aria-labelledby', tabPanelTitle.id);
+                addClass(tabPanelTitle, 'hidden');
 
                 if (hasClass(tabNavigation[j], 'active')) {
                     tabPanel.className = 'block';

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -75,6 +75,24 @@
             addClass(document.querySelector('[data-tab-id="' + selectedTabId + '"]'), 'active');
         }
 
+        /* activates a tab: shows its panel and hides the others in the same group */
+        var activateTab = function(tab) {
+            var tabsOfGroup = tab.parentNode.children;
+            for (var i = 0; i < tabsOfGroup.length; i++) {
+                var tabId = tabsOfGroup[i].getAttribute('data-tab-id');
+                document.getElementById(tabId).className = 'hidden';
+                removeClass(tabsOfGroup[i], 'active');
+                tabsOfGroup[i].removeAttribute('aria-selected');
+                tabsOfGroup[i].setAttribute('tabindex', '-1');
+            }
+
+            addClass(tab, 'active');
+            tab.setAttribute('aria-selected', 'true');
+            tab.removeAttribute('tabindex');
+            var activeTabId = tab.getAttribute('data-tab-id');
+            document.getElementById(activeTabId).className = 'block';
+        };
+
         /* display the active tab and add the 'click' event listeners */
         for (i = 0; i < tabGroups.length; i++) {
             tabNavigation = tabGroups[i].querySelectorAll(':scope > .tab-navigation .tab-control');
@@ -108,21 +126,30 @@
                         activeTab = activeTab.parentNode;
                     }
 
-                    /* get the full list of tabs through the parent of the active tab element */
-                    var tabNavigation = activeTab.parentNode.children;
-                    for (var k = 0; k < tabNavigation.length; k++) {
-                        var tabId = tabNavigation[k].getAttribute('data-tab-id');
-                        document.getElementById(tabId).className = 'hidden';
-                        removeClass(tabNavigation[k], 'active');
-                        tabNavigation[k].removeAttribute('aria-selected');
-                        tabNavigation[k].setAttribute('tabindex', '-1');
+                    activateTab(activeTab);
+                });
+
+                /* left/right arrow keys move focus to the previous/next tab and activate it */
+                /* (www.w3.org/WAI/ARIA/apg/patterns/tabs/#keyboardinteraction) */
+                tabNavigation[j].addEventListener('keydown', function(e) {
+                    var key = e.key;
+                    if ('ArrowLeft' !== key && 'ArrowRight' !== key) {
+                        return;
                     }
 
-                    addClass(activeTab, 'active');
-                    activeTab.setAttribute('aria-selected', 'true');
-                    activeTab.removeAttribute('tabindex');
-                    var activeTabId = activeTab.getAttribute('data-tab-id');
-                    document.getElementById(activeTabId).className = 'block';
+                    e.preventDefault();
+
+                    var tabsOfGroup = Array.prototype.slice.call(this.parentNode.children);
+                    var currentIndex = tabsOfGroup.indexOf(this);
+                    var newIndex = currentIndex;
+                    /* skip disabled tabs, without looping forever if they all are */
+                    do {
+                        newIndex = (newIndex + ('ArrowRight' === key ? 1 : -1) + tabsOfGroup.length) % tabsOfGroup.length;
+                    } while (tabsOfGroup[newIndex].disabled && newIndex !== currentIndex);
+
+                    var newTab = tabsOfGroup[newIndex];
+                    activateTab(newTab);
+                    newTab.focus();
                 });
             }
 

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -50,7 +50,8 @@
             tabNavigation.className = 'tab-navigation';
             tabNavigation.setAttribute('role', 'tablist');
 
-            var selectedTabId = 'tab-' + i + '-0'; /* select the first tab by default */
+            var selectedTabId = null;
+            var firstEnabledTabId = null;
             for (var j = 0; j < tabs.length; j++) {
                 var tabId = 'tab-' + i + '-' + j;
                 var tabTitle = tabs[j].querySelector('.tab-title').innerHTML;
@@ -60,10 +61,12 @@
                 tabNavigationItem.setAttribute('data-tab-id', tabId);
                 tabNavigationItem.setAttribute('role', 'tab');
                 tabNavigationItem.setAttribute('aria-controls', tabId);
-                if (hasClass(tabs[j], 'active')) { selectedTabId = tabId; }
                 if (hasClass(tabs[j], 'disabled')) {
                     tabNavigationItem.disabled = true;
+                } else if (null === firstEnabledTabId) {
+                    firstEnabledTabId = tabId;
                 }
+                if (hasClass(tabs[j], 'active')) { selectedTabId = tabId; }
                 tabNavigationItem.innerHTML = tabTitle;
                 tabNavigation.appendChild(tabNavigationItem);
 
@@ -72,7 +75,9 @@
             }
 
             tabGroups[i].insertBefore(tabNavigation, tabGroups[i].firstChild);
-            addClass(document.querySelector('[data-tab-id="' + selectedTabId + '"]'), 'active');
+            /* fall back to the first enabled tab (not necessarily the first tab) when none */
+            /* is explicitly marked active, so the default selection is never a disabled tab */
+            addClass(document.querySelector('[data-tab-id="' + (selectedTabId || firstEnabledTabId || ('tab-' + i + '-0')) + '"]'), 'active');
         }
 
         /* activates a tab: shows its panel and hides the others in the same group */

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -62,7 +62,7 @@
                 tabNavigationItem.setAttribute('aria-controls', tabId);
                 if (hasClass(tabs[j], 'active')) { selectedTabId = tabId; }
                 if (hasClass(tabs[j], 'disabled')) {
-                    addClass(tabNavigationItem, 'disabled');
+                    tabNavigationItem.disabled = true;
                 }
                 tabNavigationItem.innerHTML = tabTitle;
                 tabNavigation.appendChild(tabNavigationItem);

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -234,6 +234,8 @@
             }
             addClass(list, 'filter-list');
             addClass(list, 'filter-list-'+type);
+            list.setAttribute('role', 'menu');
+            list.setAttribute('aria-label', 'Filter by ' + name);
             values.forEach(function (value, i) {
                 if (value instanceof HTMLElement) {
                     value = value.dataset['filter'+ucName];
@@ -245,30 +247,71 @@
                     label = i in labels ? labels[i] : value,
                     active = false,
                     matches;
+                /* a real checkbox so Space toggles it and its checked state is exposed natively, */
+                /* no custom JS needed; the <li> itself is just a transparent wrapper */
+                option.setAttribute('role', 'none');
+                var checkboxId = 'filter-option-' + name + '-' + i;
+                var checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.id = checkboxId;
+                checkbox.setAttribute('role', 'menuitemcheckbox');
+                /* roving tabindex (APG menu pattern): only the first item is tabbable, the rest */
+                /* are reached with the up/down arrows below */
+                checkbox.setAttribute('tabindex', 0 === i ? '0' : '-1');
+                var optionLabel = document.createElement('label');
+                optionLabel.setAttribute('for', checkboxId);
                 if ('' === label) {
-                    option.innerHTML = '<em>(none)</em>';
+                    optionLabel.innerHTML = '<em>(none)</em>';
                 } else {
-                    option.innerText = label;
+                    optionLabel.innerText = label;
                 }
                 option.dataset.filter = value;
-                option.setAttribute('title', 1 === (matches = filters.querySelectorAll('[data-filter-'+name+'="'+value+'"]').length) ? 'Matches 1 row' : 'Matches '+matches+' rows');
+                /* set here, not on the (role="none") <li>, so it reaches assistive technologies too */
+                checkbox.setAttribute('title', 1 === (matches = filters.querySelectorAll('[data-filter-'+name+'="'+value+'"]').length) ? 'Matches 1 row' : 'Matches '+matches+' rows');
+                option.appendChild(checkbox);
+                option.appendChild(optionLabel);
                 indexed[value] = i;
                 list.appendChild(option);
-                addEventListener(option, 'click', function () {
+                addEventListener(checkbox, 'keydown', function (e) {
+                    if ('ArrowUp' !== e.key && 'ArrowDown' !== e.key) {
+                        return;
+                    }
+
+                    e.preventDefault();
+
+                    var checkboxesOfList = Array.prototype.slice.call(list.querySelectorAll('input[type=checkbox]'));
+                    var currentIndex = checkboxesOfList.indexOf(checkbox);
+                    var newIndex = currentIndex + ('ArrowDown' === e.key ? 1 : -1);
+                    newIndex = (newIndex + checkboxesOfList.length) % checkboxesOfList.length;
+
+                    checkbox.setAttribute('tabindex', '-1');
+                    checkboxesOfList[newIndex].setAttribute('tabindex', '0');
+                    checkboxesOfList[newIndex].focus();
+                });
+                addEventListener(checkbox, 'change', function () {
                     if ('choice' === type) {
                         filters.querySelectorAll('[data-filter-'+name+']').forEach(function (row) {
                             if (option.dataset.filter === row.dataset['filter'+ucName]) {
                                 toggleClass(row, 'filter-hidden-'+name);
                             }
                         });
-                        toggleClass(option, 'active');
+                        if (checkbox.checked) {
+                            addClass(option, 'active');
+                        } else {
+                            removeClass(option, 'active');
+                        }
                     } else if ('level' === type) {
-                        if (i === this.parentNode.querySelectorAll('.active').length - 1) {
+                        /* re-clicking the current threshold must not uncheck it; use "last-active" */
+                        /* (untouched by the native toggle) rather than checkbox.checked to detect that */
+                        if (hasClass(option, 'last-active')) {
+                            checkbox.checked = true;
                             return;
                         }
-                        this.parentNode.querySelectorAll('li').forEach(function (currentOption, j) {
+                        list.querySelectorAll('li').forEach(function (currentOption, j) {
+                            var currentCheckbox = currentOption.querySelector('input[type=checkbox]');
                             if (j <= i) {
                                 addClass(currentOption, 'active');
+                                currentCheckbox.checked = true;
                                 if (i === j) {
                                     addClass(currentOption, 'last-active');
                                 } else {
@@ -277,6 +320,7 @@
                             } else {
                                 removeClass(currentOption, 'active');
                                 removeClass(currentOption, 'last-active');
+                                currentCheckbox.checked = false;
                             }
                         });
                         filters.querySelectorAll('[data-filter-'+name+']').forEach(function (row) {
@@ -296,6 +340,7 @@
                         addClass(option, 'last-active');
                     }
                 }
+                checkbox.checked = active;
                 if (active) {
                     addClass(option, 'active');
                 } else {
@@ -307,6 +352,65 @@
             });
 
             if (1 < list.childNodes.length) {
+                /* lets keyboard and screen reader users open the list; mouse users keep doing */
+                /* it by hovering, as before (see :hover in the CSS) */
+                var toggle = document.createElement('button');
+                toggle.type = 'button';
+                addClass(toggle, 'filter-toggle');
+                toggle.innerHTML = filter.innerHTML;
+                toggle.setAttribute('aria-haspopup', 'menu');
+                toggle.setAttribute('aria-expanded', 'false');
+                /* the list's <li> are hidden by CSS while closed, but the <ul role="menu"> itself */
+                /* isn't; without this, screen readers can stumble on it while closed (e.g. when a */
+                /* whole hidden tabpanel becomes visible at once) */
+                list.setAttribute('aria-hidden', 'true');
+
+                var closeFilter = function () {
+                    removeClass(filter, 'filter-open');
+                    toggle.setAttribute('aria-expanded', 'false');
+                    list.setAttribute('aria-hidden', 'true');
+                };
+
+                addEventListener(toggle, 'click', function () {
+                    if (hasClass(filter, 'filter-open')) {
+                        closeFilter();
+                    } else {
+                        addClass(filter, 'filter-open');
+                        toggle.setAttribute('aria-expanded', 'true');
+                        list.removeAttribute('aria-hidden');
+                        /* opening a menu moves focus to the item with tabindex 0 (kept in sync by */
+                        /* the arrow keys below), not left on the button (APG menu-button pattern) */
+                        var firstItem = list.querySelector('[tabindex="0"]');
+                        if (firstItem) {
+                            firstItem.focus();
+                        }
+                    }
+                });
+
+                addEventListener(filter, 'keydown', function (e) {
+                    if ('Escape' === e.key && hasClass(filter, 'filter-open')) {
+                        closeFilter();
+                        toggle.focus();
+                    }
+                });
+
+                addEventListener(document, 'click', function (e) {
+                    if (hasClass(filter, 'filter-open') && !filter.contains(e.target)) {
+                        closeFilter();
+                    }
+                });
+
+                /* closes on focus leaving rather than the mouse leaving: once opened by click or */
+                /* keyboard, .filter-open keeps it open regardless of the mouse. This also closes it */
+                /* when focus moves straight to another filter's toggle */
+                addEventListener(filter, 'focusout', function (e) {
+                    if (hasClass(filter, 'filter-open') && !filter.contains(e.relatedTarget)) {
+                        closeFilter();
+                    }
+                });
+
+                filter.innerHTML = '';
+                filter.appendChild(toggle);
                 filter.appendChild(list);
                 filter.dataset.filtered = '';
             }

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php
@@ -32,7 +32,9 @@
             </header>
         <?php } ?>
 
-        <?= $this->include('views/exception.html.php', $context); ?>
+        <main>
+            <?= $this->include('views/exception.html.php', $context); ?>
+        </main>
 
         <script>
             <?= $this->include('assets/js/exception.js'); ?>

--- a/src/Symfony/Component/ErrorHandler/Resources/views/trace.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/trace.html.php
@@ -1,4 +1,4 @@
-<div class="trace-line-header break-long-words <?= $trace['file'] ? 'sf-toggle' : ''; ?>" data-toggle-selector="#trace-html-<?= $prefix; ?>-<?= $i; ?>" data-toggle-initial="<?= 'expanded' === $style ? 'display' : ''; ?>">
+<div class="trace-line-header break-long-words <?= $trace['file'] ? 'sf-toggle' : ''; ?>" data-toggle-selector="#trace-html-<?= $prefix; ?>-<?= $i; ?>" data-toggle-initial="<?= 'expanded' === $style ? 'display' : ''; ?>" data-toggle-label="Toggle code snippet">
     <?php if ($trace['file']) { ?>
         <span class="icon icon-close"><?= $this->include('assets/images/icon-minus-square.svg'); ?></span>
         <span class="icon icon-open"><?= $this->include('assets/images/icon-plus-square.svg'); ?></span>

--- a/src/Symfony/Component/ErrorHandler/Resources/views/traces.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/traces.html.php
@@ -1,7 +1,7 @@
 <div class="trace trace-as-html" id="trace-box-<?= $index; ?>">
     <div class="trace-details">
         <div class="trace-head">
-            <div class="sf-toggle" data-toggle-selector="#trace-html-<?= $index; ?>" data-toggle-initial="<?= $expand ? 'display' : ''; ?>">
+            <div class="sf-toggle" data-toggle-selector="#trace-html-<?= $index; ?>" data-toggle-initial="<?= $expand ? 'display' : ''; ?>" data-toggle-label="Toggle stack trace">
                 <span class="icon icon-close"><?= $this->include('assets/images/icon-minus-square-o.svg'); ?></span>
                 <span class="icon icon-open"><?= $this->include('assets/images/icon-plus-square-o.svg'); ?></span>
                 <?php

--- a/src/Symfony/Component/ErrorHandler/Resources/views/traces_text.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/traces_text.html.php
@@ -1,7 +1,7 @@
 <table class="trace trace-as-text">
     <thead class="trace-head">
         <tr>
-            <th class="sf-toggle" data-toggle-selector="#trace-text-<?= $index; ?>" data-toggle-initial="<?= 1 === $index ? 'display' : ''; ?>">
+            <th class="sf-toggle" data-toggle-selector="#trace-text-<?= $index; ?>" data-toggle-initial="<?= 1 === $index ? 'display' : ''; ?>" data-toggle-label="Toggle stack trace">
                 <div class="trace-class">
                     <?php if ($numExceptions > 1) { ?>
                         <span class="text-muted">[<?= $numExceptions - $index + 1; ?>/<?= $numExceptions; ?>]</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no->
| License       | MIT

This improves keyboard and screen reader accessibility of the exception page:
- Adds a `<main>` landmark around the page content, so screen reader users can jump straight to it 
- The tab panels `aria-labelledby`, pointed to themselves and could make assistive technologies read out the whole panel
- Adds left/right arrow key navigation between tabs, per the standard ARIA tabs pattern
- Marks disabled tabs (e.g. "Logs" when there are no log entries) with `aria-disabled`
- Makes the log filters (Level/Channel) keyboard and screen reader accessible: real checkboxes with labels instead of a menu that only opened on mouse hover
- Makes the stack trace toggles (show/hide code snippets) keyboard and screen reader accessible with real buttons