### PR TITLE
[FrameworkBundle] Add a command to dump information of the Symfony Profiler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
  * Allow prefixing entries with `!` in `framework.workflows.<name>.events_to_dispatch` to permanently disable an event; e.g. `events_to_dispatch: ['!workflow.announce']` fires every event except `workflow.announce`. The GuardEvent can never be disabled; `!workflow.guard` is rejected at config compile time. Mixing allow-list and block-list entries in the same list is rejected at config compile time too.
  * Add support for the HttpClient `max_connect_duration` option to the `http_client` configuration
+ * Add `profiler:dump` command to get profiler information in machine-readable formats
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ProfilerDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ProfilerDumpCommand.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\Profiler\ProfileDumper;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+/**
+ * Get profiler information in machine-readable formats.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @final
+ */
+#[AsCommand(name: 'profiler:dump', description: 'Get profiler information for a given profile in Markdown or JSON format')]
+class ProfilerDumpCommand extends Command
+{
+    public function __construct(
+        private Profiler $profiler,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([
+                new InputArgument('token', InputArgument::OPTIONAL, 'The profile token', 'latest'),
+                new InputOption('list', null, InputOption::VALUE_NONE, 'List recent profiles instead of dumping one'),
+                new InputOption('panel', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Dump only the given panel(s), e.g. "db" or "logger"'),
+                new InputOption('type', null, InputOption::VALUE_REQUIRED, 'The profile type ("request" or "command") [default: "request"]'),
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, \sprintf('The output format ("%s")', implode('", "', $this->getAvailableFormatOptions())), 'md'),
+                new InputOption('full', null, InputOption::VALUE_NONE, 'Do not truncate long values in the output'),
+                new InputOption('limit', null, InputOption::VALUE_REQUIRED, 'The maximum number of profiles to list', 20),
+                new InputOption('url', null, InputOption::VALUE_REQUIRED, 'Filter profiles by URL'),
+                new InputOption('method', null, InputOption::VALUE_REQUIRED, 'Filter profiles by HTTP method'),
+                new InputOption('status-code', null, InputOption::VALUE_REQUIRED, 'Filter profiles by HTTP status code'),
+            ])
+            ->setHelp(<<<'EOF'
+                The <info>%command.name%</info> command dumps the data collected by the profiler
+                for a given profile in a format suitable for terminal consumers such as AI agents
+                (long values are truncated in the output unless the <info>--full</info> option is used):
+
+                  <info>php %command.full_name%</info>                   # dump the most recent HTTP profile
+                  <info>php %command.full_name% dd93a8</info>            # dump the profile for the given token
+                  <info>php %command.full_name% --panel=db</info>        # dump only the database panel
+                  <info>php %command.full_name% --status-code=500</info> # dump the most recent failed request
+                  <info>php %command.full_name% --type=command</info>    # dump the most recent profiled console command
+                  <info>php %command.full_name% --format=json</info>     # machine-readable output
+                  <info>php %command.full_name% --panel=request --full</info> # dump the request panel without truncating values
+
+                Use the <info>--list</info> option to list the most recent profiles:
+
+                  <info>php %command.full_name% --list</info>
+                  <info>php %command.full_name% --list --limit=50 --method=POST</info>
+
+                Beware that the output may contain sensitive data collected from the requests
+                (headers, cookies, query parameters, etc.).
+                EOF
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = $input->getOption('format');
+        if (!\in_array($format, $this->getAvailableFormatOptions(), true)) {
+            throw new InvalidArgumentException(\sprintf('Supported formats are "%s".', implode('", "', $this->getAvailableFormatOptions())));
+        }
+
+        if ($input->getOption('list')) {
+            return $this->listProfiles($input, $output, $io, $format);
+        }
+
+        $type = $input->getOption('type') ?? 'request';
+        $token = $input->getArgument('token');
+        if ('latest' === $token) {
+            $latest = current($this->profiler->find(null, $input->getOption('url'), 1, $input->getOption('method'), null, null, $input->getOption('status-code'), static fn (array $profile) => $type === ($profile['virtual_type'] ?? 'request')));
+            if (!$latest) {
+                $io->error(\sprintf('No profiles found for type "%s". Make some requests to the application first, or profile console commands by running them with the --profile option.', $type));
+
+                return Command::FAILURE;
+            }
+
+            $token = $latest['token'];
+        }
+
+        if (!$profile = $this->profiler->loadProfile($token)) {
+            $io->error(\sprintf('No profile found for token "%s". Run this command with the --list option to list the available profiles.', $token));
+
+            return Command::FAILURE;
+        }
+
+        $panels = $input->getOption('panel') ?: null;
+        $dumper = $input->getOption('full') ? new ProfileDumper(\PHP_INT_MAX, \PHP_INT_MAX, \PHP_INT_MAX, \PHP_INT_MAX) : new ProfileDumper();
+
+        try {
+            $dump = 'json' === $format
+                ? json_encode($dumper->toArray($profile, $panels), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE)
+                : $dumper->toMarkdown($profile, $panels);
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln($dump, OutputInterface::OUTPUT_RAW);
+
+        return Command::SUCCESS;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('token')) {
+            $suggestions->suggestValue('latest');
+            foreach ($this->profiler->find(null, null, 20, null, null, null) as $profile) {
+                $suggestions->suggestValue($profile['token']);
+            }
+        }
+
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $suggestions->suggestValues($this->getAvailableFormatOptions());
+        }
+
+        if ($input->mustSuggestOptionValuesFor('type')) {
+            $suggestions->suggestValues(['request', 'command']);
+        }
+    }
+
+    private function listProfiles(InputInterface $input, OutputInterface $output, SymfonyStyle $io, string $format): int
+    {
+        $type = $input->getOption('type');
+        $profiles = $this->profiler->find(
+            null,
+            $input->getOption('url'),
+            $input->getOption('limit'),
+            $input->getOption('method'),
+            null,
+            null,
+            $input->getOption('status-code'),
+            null !== $type ? static fn (array $profile) => $type === ($profile['virtual_type'] ?? 'request') : null,
+        );
+
+        $profiles = array_map(static fn (array $profile) => [
+            'token' => $profile['token'],
+            'time' => $profile['time'] ? \DateTimeImmutable::createFromFormat('U', (string) $profile['time'])->format(\DateTimeInterface::RFC3339) : null,
+            'method' => $profile['method'],
+            'url' => $profile['url'],
+            'status_code' => $profile['status_code'] ?? null,
+            'type' => $profile['virtual_type'] ?? 'request',
+            'has_errors' => (bool) ($profile['has_errors'] ?? false),
+        ], $profiles);
+
+        if ('json' === $format) {
+            $output->writeln(json_encode($profiles, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE), OutputInterface::OUTPUT_RAW);
+
+            return Command::SUCCESS;
+        }
+
+        if (!$profiles) {
+            $io->error('No profiles found. Make some requests to the application first, or profile console commands by running them with the --profile option.');
+
+            return Command::FAILURE;
+        }
+
+        $rows = ['| TOKEN | TIME | METHOD | URL | STATUS | TYPE | ERRORS |', '| ----- | ---- | ------ | --- | ------ | ---- | ------ |'];
+        foreach ($profiles as $profile) {
+            $rows[] = \sprintf('| %s | %s | %s | %s | %s | %s | %s |', $profile['token'], $profile['time'] ?? 'n/a', $profile['method'], $profile['url'], $profile['status_code'] ?? 'n/a', $profile['type'], $profile['has_errors'] ? 'yes' : 'no');
+        }
+        $rows[] = '';
+        $rows[] = 'Run "profiler:dump <token>" to inspect any of these profiles.';
+
+        $output->writeln($rows, OutputInterface::OUTPUT_RAW);
+
+        return Command::SUCCESS;
+    }
+
+    /** @return string[] */
+    private function getAvailableFormatOptions(): array
+    {
+        return ['md', 'json'];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -911,6 +911,8 @@ class FrameworkExtension extends Extension
             // this is needed for the WebProfiler to work even if the profiler is disabled
             $container->setParameter('data_collector.templates', []);
 
+            $container->removeDefinition('console.command.profiler_dump');
+
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -26,6 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerLintCommand;
 use Symfony\Bundle\FrameworkBundle\Command\DebugAutowiringCommand;
 use Symfony\Bundle\FrameworkBundle\Command\EventDispatcherDebugCommand;
+use Symfony\Bundle\FrameworkBundle\Command\ProfilerDumpCommand;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand;
 use Symfony\Bundle\FrameworkBundle\Command\SecretsDecryptToLocalCommand;
@@ -227,6 +228,12 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.scheduler_debug', SchedulerDebugCommand::class)
             ->args([
                 tagged_locator('scheduler.schedule_provider', 'name'),
+            ])
+            ->tag('console.command')
+
+        ->set('console.command.profiler_dump', ProfilerDumpCommand::class)
+            ->args([
+                service('profiler'),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/ProfilerDumpCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/ProfilerDumpCommandTest.php
@@ -1,0 +1,292 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\ProfilerDumpCommand;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector;
+use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+class ProfilerDumpCommandTest extends TestCase
+{
+    private string $storageDir;
+    private Profiler $profiler;
+
+    protected function setUp(): void
+    {
+        $this->storageDir = sys_get_temp_dir().'/sf_profiler_dump_command_test'.uniqid();
+        $this->profiler = new Profiler(new FileProfilerStorage('file:'.$this->storageDir));
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->storageDir);
+    }
+
+    public function testDumpByToken()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+        $this->saveProfile('bbbbbb', 'http://example.com/bar');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['token' => 'aaaaaa']);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('# Profile aaaaaa — GET http://example.com/foo → 200', $tester->getDisplay());
+        $this->assertStringContainsString('## memory', $tester->getDisplay());
+    }
+
+    public function testDumpLatest()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+        $this->saveProfile('bbbbbb', 'http://example.com/bar');
+        // profiles of other types are ignored when resolving the "latest" token
+        $this->saveProfile('cccccc', 'http://example.com/some-command', virtualType: 'command');
+
+        $tester = $this->createCommandTester();
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('# Profile bbbbbb', $tester->getDisplay());
+    }
+
+    public function testDumpLatestOfCommandType()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+        $this->saveProfile('cccccc', 'http://example.com/some-command', virtualType: 'command');
+        $this->saveProfile('bbbbbb', 'http://example.com/bar');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['--type' => 'command']);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('# Profile cccccc', $tester->getDisplay());
+    }
+
+    public function testDumpLatestWithFilters()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo', statusCode: 500);
+        $this->saveProfile('bbbbbb', 'http://example.com/bar');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['--status-code' => '500']);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('# Profile aaaaaa', $tester->getDisplay());
+    }
+
+    public function testDumpLatestWhenNoProfiles()
+    {
+        $tester = $this->createCommandTester();
+
+        $this->assertSame(1, $tester->execute([]));
+        $this->assertStringContainsString('No profiles found for type "request".', $tester->getDisplay());
+    }
+
+    public function testDumpUnknownToken()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+
+        $tester = $this->createCommandTester();
+
+        $this->assertSame(1, $tester->execute(['token' => 'zzzzzz']));
+        $this->assertStringContainsString('No profile found for token "zzzzzz".', $tester->getDisplay());
+    }
+
+    public function testDumpUnknownPanel()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+
+        $tester = $this->createCommandTester();
+
+        $this->assertSame(1, $tester->execute(['token' => 'aaaaaa', '--panel' => ['foobar']]));
+        $this->assertStringContainsString('Available panels: "memory".', $tester->getDisplay());
+    }
+
+    public function testDumpPanel()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['token' => 'aaaaaa', '--panel' => ['memory']]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('## memory', $tester->getDisplay());
+    }
+
+    public function testDumpFull()
+    {
+        $profile = new Profile('aaaaaa');
+        $profile->setUrl('http://example.com/foo');
+        $profile->setMethod('GET');
+        $profile->setStatusCode(200);
+        $profile->setTime(time());
+        $profile->addCollector(new LongValueStubCollector());
+        $this->profiler->saveProfile($profile);
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['token' => 'aaaaaa']);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('… (truncated)', $tester->getDisplay());
+
+        $tester->execute(['token' => 'aaaaaa', '--full' => true]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString(str_repeat('a', 3000), $tester->getDisplay());
+        $this->assertStringNotContainsString('… (truncated)', $tester->getDisplay());
+    }
+
+    public function testDumpJsonFormat()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['token' => 'aaaaaa', '--format' => 'json']);
+
+        $tester->assertCommandIsSuccessful();
+        $data = json_decode($tester->getDisplay(), true);
+        $this->assertSame('aaaaaa', $data['token']);
+        $this->assertSame('http://example.com/foo', $data['url']);
+        $this->assertArrayHasKey('memory', $data['collectors']);
+    }
+
+    public function testInvalidFormat()
+    {
+        $tester = $this->createCommandTester();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Supported formats are "md", "json".');
+
+        $tester->execute(['--format' => 'xml']);
+    }
+
+    public function testListProfiles()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo', statusCode: 500);
+        $this->saveProfile('bbbbbb', 'http://example.com/bar', method: 'POST');
+        $this->saveProfile('cccccc', 'http://example.com/some-command', virtualType: 'command');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['--list' => true]);
+
+        $tester->assertCommandIsSuccessful();
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('| TOKEN | TIME | METHOD | URL | STATUS | TYPE | ERRORS |', $display);
+        $this->assertStringContainsString('| aaaaaa |', $display);
+        $this->assertStringContainsString('| bbbbbb |', $display);
+        // profiles of all types are listed by default
+        $this->assertStringContainsString('| cccccc |', $display);
+        // the newest profile is listed first
+        $this->assertLessThan(strpos($display, '| aaaaaa |'), strpos($display, '| cccccc |'));
+    }
+
+    public function testListProfilesWithFilters()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+        $this->saveProfile('bbbbbb', 'http://example.com/bar', method: 'POST');
+        $this->saveProfile('cccccc', 'http://example.com/some-command', virtualType: 'command');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['--list' => true, '--method' => 'POST']);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('| bbbbbb |', $tester->getDisplay());
+        $this->assertStringNotContainsString('| aaaaaa |', $tester->getDisplay());
+
+        $tester->execute(['--list' => true, '--type' => 'command']);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('| cccccc |', $tester->getDisplay());
+        $this->assertStringNotContainsString('| aaaaaa |', $tester->getDisplay());
+
+        $tester->execute(['--list' => true, '--limit' => 1]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('| cccccc |', $tester->getDisplay());
+        $this->assertStringNotContainsString('| bbbbbb |', $tester->getDisplay());
+    }
+
+    public function testListProfilesJsonFormat()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['--list' => true, '--format' => 'json']);
+
+        $tester->assertCommandIsSuccessful();
+        $data = json_decode($tester->getDisplay(), true);
+        $this->assertCount(1, $data);
+        $this->assertSame('aaaaaa', $data[0]['token']);
+        $this->assertSame('request', $data[0]['type']);
+    }
+
+    public function testComplete()
+    {
+        $this->saveProfile('aaaaaa', 'http://example.com/foo');
+
+        $tester = new CommandCompletionTester(new ProfilerDumpCommand($this->profiler));
+
+        $this->assertSame(['latest', 'aaaaaa'], $tester->complete(['']));
+        $this->assertSame(['md', 'json'], $tester->complete(['--format', '']));
+        $this->assertSame(['request', 'command'], $tester->complete(['--type', '']));
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        return new CommandTester(new ProfilerDumpCommand($this->profiler));
+    }
+
+    private function saveProfile(string $token, string $url, string $method = 'GET', int $statusCode = 200, ?string $virtualType = null): Profile
+    {
+        $collector = new MemoryDataCollector();
+        $collector->collect(Request::create($url), new Response());
+
+        $profile = new Profile($token);
+        $profile->setUrl($url);
+        $profile->setMethod($method);
+        $profile->setStatusCode($statusCode);
+        $profile->setTime(time());
+        $profile->setVirtualType($virtualType);
+        $profile->addCollector($collector);
+
+        $this->profiler->saveProfile($profile);
+
+        return $profile;
+    }
+}
+
+class LongValueStubCollector extends DataCollector
+{
+    public function __construct()
+    {
+        $this->data = ['long_string' => str_repeat('a', 3000)];
+    }
+
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'long_value_stub';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerDumpCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerDumpCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[Group('functional')]
+class ProfilerDumpCommandTest extends AbstractWebTestCase
+{
+    public function testDumpProfile()
+    {
+        $client = $this->createClient(['test_case' => 'Profiler', 'root_config' => 'config.yml']);
+
+        $client->enableProfiler();
+        $client->request('GET', '/profiler');
+        $token = $client->getProfile()->getToken();
+
+        $application = new Application(static::$kernel);
+        $tester = new CommandTester($application->find('profiler:dump'));
+        $tester->execute(['token' => $token], ['decorated' => false]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('# Profile '.$token, $tester->getDisplay());
+        $this->assertStringContainsString('## request', $tester->getDisplay());
+    }
+
+    public function testCommandIsUnregisteredWhenProfilerIsDisabled()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml']);
+
+        $application = new Application(static::$kernel);
+
+        $this->assertFalse($application->has('profiler:dump'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/filesystem": "^7.4|^8.0",
         "symfony/finder": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
-        "symfony/http-kernel": "^8.1",
+        "symfony/http-kernel": "^8.2",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php85": "^1.33",
         "symfony/routing": "^7.4|^8.0",

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `ProfileDumper` to dump `Profile` data as Markdown or as an array
  * Add `#[AsControllerAttributeListener]` attribute to declare event listeners for controller attributes
  * Add the `$expiration` argument to `FragmentUriGenerator::__construct()` and sign fragment URIs with a 5-year expiration by default
  * Add `hasDump()` method to `Profile` to track profiles with dump

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfileDumper.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfileDumper.php
@@ -1,0 +1,258 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Profiler;
+
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * Dumps the data collected in a Profile as Markdown or as an array.
+ *
+ * The output is meant to be consumed from the terminal, e.g. by AI agents
+ * inspecting the last requests made to the application. Long values are
+ * truncated by default, so the dump is a summary of the profile rather than
+ * a faithful export; pass \PHP_INT_MAX as the limits to disable truncation.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class ProfileDumper
+{
+    private const MAX_INLINE_JSON_LENGTH = 120;
+
+    public function __construct(
+        private int $maxStringLength = 2048,
+        private int $maxDepth = 4,
+        private int $maxItemsPerLevel = 50,
+        private int $maxTraceFrames = 10,
+    ) {
+    }
+
+    /**
+     * @param string[]|null $panels The names of the panels to dump, or null to dump all non-empty panels
+     *
+     * @throws \InvalidArgumentException When one of the requested panels doesn't exist in the profile
+     */
+    public function toArray(Profile $profile, ?array $panels = null): array
+    {
+        $time = $profile->getTime() ? \DateTimeImmutable::createFromFormat('U', (string) $profile->getTime())->format(\DateTimeInterface::RFC3339) : null;
+
+        return [
+            'token' => $profile->getToken(),
+            'type' => $profile->getVirtualType() ?? 'request',
+            'method' => $profile->getMethod(),
+            'url' => $profile->getUrl(),
+            'status_code' => $profile->getStatusCode(),
+            'time' => $time,
+            'has_errors' => $profile->hasErrors(),
+            'collectors' => $this->extract($profile, $panels),
+        ];
+    }
+
+    /**
+     * @param string[]|null $panels The names of the panels to dump, or null to dump all non-empty panels
+     *
+     * @throws \InvalidArgumentException When one of the requested panels doesn't exist in the profile
+     */
+    public function toMarkdown(Profile $profile, ?array $panels = null): string
+    {
+        $data = $this->toArray($profile, $panels);
+
+        $title = \sprintf('# Profile %s', $data['token']);
+        if (null !== $data['method'] || null !== $data['url']) {
+            $title .= \sprintf(' — %s', trim($data['method'].' '.$data['url']));
+        }
+        if (null !== $data['status_code']) {
+            $title .= \sprintf(' → %d', $data['status_code']);
+        }
+
+        $output = $title."\n";
+        $output .= \sprintf("- time: %s | type: %s | errors: %s\n", $data['time'] ?? 'n/a', $data['type'], $data['has_errors'] ? 'yes' : 'no');
+
+        foreach ($data['collectors'] as $name => $collectorData) {
+            $output .= "\n".$this->renderPanel($name, $collectorData);
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param string[]|null $panels
+     */
+    private function extract(Profile $profile, ?array $panels): array
+    {
+        $collectors = $profile->getCollectors();
+
+        if (null !== $panels && $unknownPanels = array_diff($panels, array_keys($collectors))) {
+            throw new \InvalidArgumentException(\sprintf('The following panels are not available in this profile: "%s". Available panels: "%s".', implode('", "', $unknownPanels), implode('", "', array_keys($collectors))));
+        }
+
+        $data = [];
+        foreach ($collectors as $name => $collector) {
+            if (null !== $panels && !\in_array($name, $panels, true)) {
+                continue;
+            }
+
+            try {
+                if (!$collector instanceof DataCollector) {
+                    $collectorData = null !== $panels ? \sprintf('The "%s" collector does not expose its data.', get_debug_type($collector)) : null;
+                } else {
+                    $collectorData = $this->normalize($collector->__serialize()['data'] ?? []);
+                }
+            } catch (\Throwable $e) {
+                $collectorData = ['error' => \sprintf('Unable to dump this panel: %s', $e->getMessage())];
+            }
+
+            // omit empty panels, except when explicitly requested
+            if (null === $panels && (null === $collectorData || [] === $collectorData)) {
+                continue;
+            }
+
+            $data[$name] = $collectorData;
+        }
+
+        // the exception panel is the most valuable one when debugging, show it first
+        if (isset($data['exception'])) {
+            $data = ['exception' => $data['exception']] + $data;
+        }
+
+        return $data;
+    }
+
+    private function normalize(mixed $value, int $depth = 0): mixed
+    {
+        if ($value instanceof Data) {
+            $value = $value->getValue(true);
+        }
+
+        if (\is_array($value)) {
+            if ($depth >= $this->maxDepth) {
+                return '…';
+            }
+
+            $normalized = [];
+            $i = 0;
+            foreach ($value as $k => $v) {
+                if (++$i > $this->maxItemsPerLevel) {
+                    $normalized[] = \sprintf('… %d more items', \count($value) - $this->maxItemsPerLevel);
+                    break;
+                }
+                // objects cast to arrays mangle the property names ("\0ClassName\0name" for
+                // private, "\0*\0name" for protected, etc.); replace that by the visibility
+                // notation used by VarDumper ("-name" for private, "#name" for protected,
+                // "+name" for dynamic and the bare name for virtual properties)
+                if (\is_string($k) && str_starts_with($k, "\0") && false !== $pos = strrpos($k, "\0")) {
+                    $prefix = substr($k, 1, $pos - 1);
+                    $k = match (true) {
+                        '*' === $prefix => '#',
+                        '+' === $prefix => '+',
+                        str_starts_with($prefix, '~') => '',
+                        default => '-',
+                    }.substr($k, 1 + $pos);
+                }
+                $normalized[$k] = $this->normalize($v, 1 + $depth);
+            }
+
+            return $normalized;
+        }
+
+        if (\is_string($value)) {
+            return \strlen($value) > $this->maxStringLength ? substr($value, 0, $this->maxStringLength).'… (truncated)' : $value;
+        }
+
+        if ($value instanceof FlattenException) {
+            return $this->normalizeException($value, $depth);
+        }
+
+        if ($value instanceof \UnitEnum) {
+            return $value instanceof \BackedEnum ? $value->value : $value->name;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(\DateTimeInterface::RFC3339);
+        }
+
+        if ($value instanceof \Stringable) {
+            return $this->normalize((string) $value, $depth);
+        }
+
+        if (\is_object($value)) {
+            return \sprintf('(object) %s', get_debug_type($value));
+        }
+
+        return $value;
+    }
+
+    private function normalizeException(FlattenException $exception, int $depth): array
+    {
+        $data = [
+            'class' => $exception->getClass(),
+            'message' => $this->normalize($exception->getMessage(), $depth),
+            'at' => $exception->getFile().':'.$exception->getLine(),
+        ];
+
+        $trace = [];
+        foreach ($exception->getTrace() as $i => $frame) {
+            if ($i >= $this->maxTraceFrames) {
+                $trace[] = \sprintf('… %d more frames', \count($exception->getTrace()) - $this->maxTraceFrames);
+                break;
+            }
+            $trace[] = \sprintf('%s%s%s() (%s:%d)', $frame['class'], $frame['type'], $frame['function'], $frame['file'], $frame['line']);
+        }
+        $data['trace'] = $trace;
+
+        if ($previous = $exception->getPrevious()) {
+            $data['previous'] = $this->normalizeException($previous, $depth);
+        }
+
+        return $data;
+    }
+
+    private function renderPanel(string $name, mixed $data): string
+    {
+        $output = \sprintf("## %s\n", $name);
+
+        if (!\is_array($data)) {
+            return $output.\sprintf("- %s\n", $this->stringify($data));
+        }
+
+        foreach ($data as $key => $value) {
+            // skip empty values to make the output more compact
+            if (null === $value || '' === $value || [] === $value) {
+                continue;
+            }
+
+            if (\is_scalar($value)) {
+                $output .= \sprintf("- %s: %s\n", $key, $this->stringify($value));
+                continue;
+            }
+
+            $json = json_encode($value, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE);
+            if (\strlen($json) <= self::MAX_INLINE_JSON_LENGTH) {
+                $output .= \sprintf("- %s: %s\n", $key, $json);
+            } else {
+                $output .= \sprintf("- %s:\n  ```json\n  %s\n  ```\n", $key, $json);
+            }
+        }
+
+        return $output;
+    }
+
+    private function stringify(string|int|float|bool|null $value): string
+    {
+        return match (true) {
+            null === $value => 'null',
+            \is_bool($value) => $value ? 'true' : 'false',
+            default => (string) $value,
+        };
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfileDumperTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfileDumperTest.php
@@ -1,0 +1,314 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Profiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\AjaxDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
+use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\ProfileDumper;
+
+class ProfileDumperTest extends TestCase
+{
+    public function testToArray()
+    {
+        $profile = $this->createProfile();
+        $data = (new ProfileDumper())->toArray($profile);
+
+        $this->assertSame('abc123', $data['token']);
+        $this->assertSame('request', $data['type']);
+        $this->assertSame('GET', $data['method']);
+        $this->assertSame('http://example.com/foo?bar=baz', $data['url']);
+        $this->assertSame(500, $data['status_code']);
+        $this->assertSame('2026-07-06T10:32:41+00:00', $data['time']);
+        $this->assertTrue($data['has_errors']);
+
+        $this->assertArrayHasKey('exception', $data['collectors']);
+        $this->assertArrayHasKey('memory', $data['collectors']);
+        $this->assertArrayHasKey('request', $data['collectors']);
+        $this->assertArrayHasKey('logger', $data['collectors']);
+
+        $exception = $data['collectors']['exception']['exception'];
+        $this->assertSame(\RuntimeException::class, $exception['class']);
+        $this->assertSame('Something went wrong', $exception['message']);
+        $this->assertSame(\LogicException::class, $exception['previous']['class']);
+
+        $this->assertNotFalse(json_encode($data));
+    }
+
+    public function testToMarkdown()
+    {
+        $profile = $this->createProfile();
+        $markdown = (new ProfileDumper())->toMarkdown($profile);
+
+        $this->assertStringContainsString('# Profile abc123 — GET http://example.com/foo?bar=baz → 500', $markdown);
+        $this->assertStringContainsString('- time: 2026-07-06T10:32:41+00:00 | type: request | errors: yes', $markdown);
+        $this->assertStringContainsString('## exception', $markdown);
+        $this->assertStringContainsString('Something went wrong', $markdown);
+        $this->assertStringContainsString('## memory', $markdown);
+        $this->assertStringContainsString('## logger', $markdown);
+        $this->assertStringContainsString('An error occurred', $markdown);
+
+        // the exception panel is always rendered first
+        $this->assertLessThan(strpos($markdown, '## memory'), strpos($markdown, '## exception'));
+
+        // keys with empty values are kept in the array output but not rendered in Markdown
+        $this->assertArrayHasKey('request_files', (new ProfileDumper())->toArray($profile)['collectors']['request']);
+        $this->assertStringNotContainsString('request_files', $markdown);
+    }
+
+    public function testEmptyPanelsAreOmitted()
+    {
+        $profile = $this->createProfile();
+        $data = (new ProfileDumper())->toArray($profile);
+
+        // the AjaxDataCollector never collects any data
+        $this->assertArrayNotHasKey('ajax', $data['collectors']);
+    }
+
+    public function testFilterPanels()
+    {
+        $profile = $this->createProfile();
+        $data = (new ProfileDumper())->toArray($profile, ['memory']);
+
+        $this->assertSame(['memory'], array_keys($data['collectors']));
+    }
+
+    public function testUnknownPanel()
+    {
+        $profile = $this->createProfile();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The following panels are not available in this profile: "foobar". Available panels: "memory", "request", "logger", "exception", "ajax".');
+
+        (new ProfileDumper())->toArray($profile, ['foobar']);
+    }
+
+    public function testValuesAreTruncated()
+    {
+        $profile = new Profile('abc123');
+        $profile->addCollector($this->roundTrip(new TruncationStubCollector()));
+
+        $data = (new ProfileDumper())->toArray($profile);
+        $stub = $data['collectors']['truncation_stub'];
+
+        $this->assertStringEndsWith('… (truncated)', $stub['long_string']);
+        $this->assertSame(2048 + \strlen('… (truncated)'), \strlen($stub['long_string']));
+        $this->assertSame('…', $stub['deep']['level1']['level2']['level3']);
+        $this->assertCount(51, $stub['many_items']);
+        $this->assertSame('… 10 more items', $stub['many_items'][50]);
+    }
+
+    public function testObjectPropertyNamesUseUmlVisibilityNotation()
+    {
+        $profile = new Profile('abc123');
+        $profile->addCollector($this->roundTrip(new ObjectStubCollector()));
+
+        $data = (new ProfileDumper())->toArray($profile);
+        $object = $data['collectors']['object_stub']['object'];
+
+        $this->assertSame(['publicProperty', '#protectedProperty', '-privateProperty', '+dynamicProperty'], array_keys($object));
+        $this->assertSame(['date'], array_keys($data['collectors']['object_stub']['virtual']));
+        $this->assertStringNotContainsString('\u0000', json_encode($data));
+    }
+
+    public function testTruncationCanBeDisabled()
+    {
+        $profile = new Profile('abc123');
+        $profile->addCollector($this->roundTrip(new TruncationStubCollector()));
+
+        $data = (new ProfileDumper(\PHP_INT_MAX, \PHP_INT_MAX, \PHP_INT_MAX, \PHP_INT_MAX))->toArray($profile);
+        $stub = $data['collectors']['truncation_stub'];
+
+        $this->assertSame(str_repeat('a', 3000), $stub['long_string']);
+        $this->assertSame('value', $stub['deep']['level1']['level2']['level3']['level4']['level5']);
+        $this->assertSame(range(1, 60), $stub['many_items']);
+    }
+
+    public function testBrokenCollector()
+    {
+        $profile = new Profile('abc123');
+        $profile->addCollector(new BrokenStubCollector());
+
+        $data = (new ProfileDumper())->toArray($profile);
+
+        $this->assertSame(['error' => 'Unable to dump this panel: This collector is broken.'], $data['collectors']['broken_stub']);
+    }
+
+    public function testCollectorNotExposingData()
+    {
+        $profile = new Profile('abc123');
+        $profile->addCollector(new NotDumpableStubCollector());
+
+        $dumper = new ProfileDumper();
+
+        $this->assertSame([], $dumper->toArray($profile)['collectors']);
+        $this->assertSame(
+            \sprintf('The "%s" collector does not expose its data.', NotDumpableStubCollector::class),
+            $dumper->toArray($profile, ['not_dumpable_stub'])['collectors']['not_dumpable_stub']
+        );
+    }
+
+    private function createProfile(): Profile
+    {
+        $request = Request::create('http://example.com/foo?bar=baz');
+        $response = new Response('', 500);
+        $exception = new \RuntimeException('Something went wrong', previous: new \LogicException('Root cause'));
+
+        $exceptionCollector = new ExceptionDataCollector();
+        $exceptionCollector->collect($request, $response, $exception);
+
+        $memoryCollector = new MemoryDataCollector();
+        $memoryCollector->collect($request, $response);
+        $memoryCollector->lateCollect();
+
+        $requestCollector = new RequestDataCollector();
+        $requestCollector->collect($request, $response);
+        $requestCollector->lateCollect();
+
+        $loggerCollector = new LoggerDataCollector(new class implements DebugLoggerInterface {
+            public function getLogs(?Request $request = null): array
+            {
+                return [
+                    ['message' => 'An error occurred', 'context' => ['foo' => 'bar'], 'priority' => 400, 'priorityName' => 'ERROR', 'channel' => 'app', 'timestamp' => 1783333961, 'timestamp_rfc3339' => '2026-07-06T10:32:41.000+00:00'],
+                    ['message' => 'Some info', 'context' => [], 'priority' => 200, 'priorityName' => 'INFO', 'channel' => 'app', 'timestamp' => 1783333961, 'timestamp_rfc3339' => '2026-07-06T10:32:41.000+00:00'],
+                ];
+            }
+
+            public function countErrors(?Request $request = null): int
+            {
+                return 1;
+            }
+
+            public function clear(): void
+            {
+            }
+        });
+        $loggerCollector->collect($request, $response);
+        $loggerCollector->lateCollect();
+
+        $ajaxCollector = new AjaxDataCollector();
+
+        $profile = new Profile('abc123');
+        $profile->setUrl('http://example.com/foo?bar=baz');
+        $profile->setMethod('GET');
+        $profile->setStatusCode(500);
+        $profile->setTime(1783333961);
+        $profile->setHasErrors(true);
+
+        // serialize/unserialize the collectors to reproduce how profiles are stored
+        foreach ([$memoryCollector, $requestCollector, $loggerCollector, $exceptionCollector, $ajaxCollector] as $collector) {
+            $profile->addCollector($this->roundTrip($collector));
+        }
+
+        return $profile;
+    }
+
+    private function roundTrip(DataCollectorInterface $collector): DataCollectorInterface
+    {
+        return unserialize(serialize($collector));
+    }
+}
+
+class TruncationStubCollector extends DataCollector
+{
+    public function __construct()
+    {
+        $this->data = [
+            'long_string' => str_repeat('a', 3000),
+            'deep' => ['level1' => ['level2' => ['level3' => ['level4' => ['level5' => 'value']]]]],
+            'many_items' => range(1, 60),
+        ];
+    }
+
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'truncation_stub';
+    }
+}
+
+class ObjectStubCollector extends DataCollector
+{
+    public function __construct()
+    {
+        $object = new StubObject();
+        $object->dynamicProperty = 'dynamic value';
+
+        $this->data = [
+            'object' => $this->cloneVar($object),
+            // the DateTime caster exposes the date as a virtual property
+            'virtual' => $this->cloneVar(new \DateTimeImmutable('2026-07-07')),
+        ];
+    }
+
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'object_stub';
+    }
+}
+
+#[\AllowDynamicProperties]
+class StubObject
+{
+    public string $publicProperty = 'public value';
+    protected string $protectedProperty = 'protected value';
+    private string $privateProperty = 'private value';
+}
+
+class BrokenStubCollector extends DataCollector
+{
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'broken_stub';
+    }
+
+    public function __serialize(): array
+    {
+        throw new \LogicException('This collector is broken.');
+    }
+}
+
+class NotDumpableStubCollector implements DataCollectorInterface
+{
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'not_dumpable_stub';
+    }
+
+    public function reset(): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

I was recently working on improving the performance of Twig Components in a Symfony application. I was using AI, and the agent could acess Symfony Profiler data via Playwright, but that approach is highly inefficient. Instead, I propose adding a new `profiler:dump` command to get Symfony Profiler data programmatically, in either Markdown or JSON format, making it easy to consume from AI agents and other external tools.

It works like this:

```bash
$ php bin/console profiler:dump                   # dump the most recent HTTP profile in Markdown format
$ php bin/console profiler:dump dd93a8            # dump the profile for the given token
$ php bin/console profiler:dump --panel=db        # dump only the database panel
$ php bin/console profiler:dump --status-code=500 # dump the most recent failed request
$ php bin/console profiler:dump --type=command    # dump the most recent profiled console command
$ php bin/console profiler:dump --format=json     # machine-readable output
$ php bin/console profiler:dump --panel=request --full # dump the request panel without truncating long values
```

Use the `--list` option to list the most recent profiles:

```bash
$ php bin/console profiler:dump --list
$ php bin/console profiler:dump --list --limit=50 --method=POST
```

Why not use an MCP server? Because using a command requires zero setup or maintenance. It's also much faster and works with any external tool, not just MCP-compatible AI tools.