### PR TITLE
[PhpUnitBridge] fix finding given config file name

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -44,6 +44,12 @@ $getEnvVar = static function ($name, $default = false) use ($argv) {
                 }
             }
 
+            // probe the verbatim name last so that the default "phpunit" lookup keeps
+            // resolving to phpunit.xml(.dist) when an extensionless "phpunit" file exists
+            if (file_exists($probableConfig)) {
+                return $probableConfig;
+            }
+
             return null;
         };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Commit bc1124c (#63039) introduced support for the `.dist.xml` suffix and rewrote the config lookup of `simple-phpunit`. The rewrite dropped the check for the supplied filename itself, so an explicitly given config (`-c custom.xml`) is only probed as `custom.xml.xml`, `custom.xml.xml.dist` and `custom.xml.dist.xml`, never as `custom.xml`. The wrapper then silently ignores the `SYMFONY_PHPUNIT_*` settings from that file; the breakage is subtle because phpunit itself still receives `-c` through passthrough and runs normally.

This restores the verbatim-name check, probing it after the suffixed candidates. Probing it first would introduce a new collision: the default lookup probes `phpunit`, so an extensionless `phpunit` binary or shim in the working directory (as in symfony/symfony itself) would shadow `phpunit.xml.dist`, emit a `DOMDocument::load()` warning and drop every `<php><env>` setting.

Verified against a config-discovery matrix (each scenario's config carries a distinct `SYMFONY_PHPUNIT_DIR` marker, so the run proves which file was read): `-c custom.xml`, `-ccustom.xml`, `--configuration custom.xml`, paths with spaces, absolute paths, the suffix-less `-c custom` form, `-c <dir>` and default discovery all resolve to the right file, with and without a `phpunit` shim next to `phpunit.xml.dist`. On the unpatched 8.1 the explicit-filename forms fall back to `phpunit.xml.dist`; with the check probed first instead, the shim scenario consumes the shim and loses the config.
