### PR TITLE
 jitter shouldn't make scheduler miss runs

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Scheduler\Tests\Trigger;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Scheduler\Trigger\JitterTrigger;
+use Symfony\Component\Scheduler\Trigger\PeriodicalTrigger;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 class JitterTriggerTest extends TestCase
@@ -38,5 +39,22 @@ class JitterTriggerTest extends TestCase
         $values = array_unique($values);
 
         $this->assertGreaterThan(1, \count($values));
+    }
+
+    public function testDoesNotSkipRunsWithJitter()
+    {
+        $from = new \DateTimeImmutable('2026-07-07 16:30:00');
+        $inner = new PeriodicalTrigger(10, $from);
+        $trigger = new JitterTrigger($inner, 15);
+
+        // The first run at 16:30:00 was executed at 16:30:12 due to a 12s jitter.
+        $run = $from->modify('+12 seconds');
+
+        $nextRun = $trigger->getNextRunDate($run);
+
+        $this->assertNotNull($nextRun);
+        // The slot at 16:30:10 is already ran, so the next scheduled run is 16:30:20 + a random jitter up to 15s.
+        $this->assertGreaterThanOrEqual($from->modify('+20 seconds')->getTimestamp(), $nextRun->getTimestamp());
+        $this->assertLessThanOrEqual($from->modify('+35 seconds')->getTimestamp(), $nextRun->getTimestamp());
     }
 }

--- a/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
@@ -31,8 +31,25 @@ final class JitterTrigger extends AbstractDecoratedTrigger
 
     public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
     {
-        if (!$nextRun = $this->trigger->getNextRunDate($run)) {
+        // the provided execution time includes jitter, try to get back to the actual time
+        $runWithoutJitter = $run->sub(new \DateInterval(\sprintf('PT%sS', $this->maxSeconds)));
+
+        if (!$nextRun = $this->trigger->getNextRunDate($runWithoutJitter)) {
             return null;
+        }
+
+        // if we get the run that just ran, proceed to the next one
+        while ($nextRun <= $run) {
+            if (!$advanced = $this->trigger->getNextRunDate($nextRun)) {
+                return null;
+            }
+
+            // the decorated trigger no longer advances: stop to avoid an infinite loop
+            if ($advanced <= $nextRun) {
+                break;
+            }
+
+            $nextRun = $advanced;
         }
 
         return $nextRun->add(new \DateInterval(\sprintf('PT%sS', random_int(0, $this->maxSeconds))));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Issues        | Fix #64780 
| License       | MIT

This tries to address the issue where using jitter on scheduled tasks skips runs : the next run date is computed using the actual previous run date instead of the planned time without jitter. 

This change tries to fix it by substracting the max jitter time from the provided datetime before calling the decorated trigger to get the next planned run.

A better fix could be to use the planned time instead of the actual run time, but that might be too big a change.