### PR TITLE
[DependencyInjection] Add supported literal option `not_found` for `imports.[*].ignore_errors` in `services.schema` and `AppReference`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -31,7 +31,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type ImportsConfig = list<string|array{
  *     resource: string,
  *     type?: string|null,
- *     ignore_errors?: bool,
+ *     ignore_errors?: bool|'not_found',
  * }>
  * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AppReference.php
@@ -40,7 +40,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
  * @psalm-type ImportsConfig = list<string|array{
  *     resource: string,
  *     type?: string|null,
- *     ignore_errors?: bool,
+ *     ignore_errors?: bool|'not_found',
  * }>
  * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|\Symfony\Component\Config\Loader\ParamConfigurator|null>|\Symfony\Component\Config\Loader\ParamConfigurator|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
@@ -17,7 +17,12 @@
             "properties": {
               "resource": { "type": "string" },
               "type": { "type": ["string", "null"] },
-              "ignore_errors": { "type": "boolean" }
+              "ignore_errors": {
+                "oneOf": [
+                  { "type": "boolean" },
+                  { "const": "not_found" }
+                ]
+              }
             },
             "required": ["resource"],
             "additionalProperties": false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Add supported literal option `not_found` for `imports.[*].ignore_errors` in `services.schema` and `AppReference`

Implemented by `FileLoader`
https://github.com/symfony/symfony/blob/8fb3ab0dc7c5e0f0a0c34278cd5589118554dc3c/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php#L63-L74