### PR TITLE
[Messenger] Add messenger:show command to inspect pending messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -123,6 +123,7 @@ use Symfony\Component\Mercure\HubRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessage;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Bridge as MessengerBridge;
+use Symfony\Component\Messenger\Command\ShowMessagesCommand;
 use Symfony\Component\Messenger\EventListener\ReleaseDeduplicationLockOnFailureListener;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
@@ -586,6 +587,7 @@ class FrameworkExtension extends Extension
         } else {
             $container->removeDefinition('console.command.messenger_consume_messages');
             $container->removeDefinition('console.command.messenger_stats');
+            $container->removeDefinition('console.command.messenger_show');
             $container->removeDefinition('console.command.messenger_debug');
             $container->removeDefinition('console.command.messenger_stop_workers');
             $container->removeDefinition('console.command.messenger_setup_transports');
@@ -2448,6 +2450,10 @@ class FrameworkExtension extends Extension
 
         if (!$this->hasConsole()) {
             $container->removeDefinition('console.command.messenger_stats');
+        }
+
+        if (!class_exists(ShowMessagesCommand::class)) {
+            $container->removeDefinition('console.command.messenger_show');
         }
 
         $loader->load('messenger.php');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -50,6 +50,7 @@ use Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 use Symfony\Component\Messenger\Command\SetupTransportsCommand;
+use Symfony\Component\Messenger\Command\ShowMessagesCommand;
 use Symfony\Component\Messenger\Command\StatsCommand;
 use Symfony\Component\Messenger\Command\StopWorkersCommand;
 use Symfony\Component\Scheduler\Command\DebugCommand as SchedulerDebugCommand;
@@ -222,6 +223,14 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('messenger.receiver_locator'),
                 abstract_arg('Receivers names'),
+            ])
+            ->tag('console.command')
+
+        ->set('console.command.messenger_show', ShowMessagesCommand::class)
+            ->args([
+                service('messenger.receiver_locator'),
+                abstract_arg('Receivers names'),
+                service('.messenger.transport.native_php_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1107,6 +1107,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $this->assertSame([], $messengerDefinitions);
         $this->assertFalse($container->hasDefinition('console.command.messenger_consume_messages'));
+        $this->assertFalse($container->hasDefinition('console.command.messenger_show'));
         $this->assertFalse($container->hasDefinition('console.command.messenger_debug'));
         $this->assertFalse($container->hasDefinition('console.command.messenger_stop_workers'));
         $this->assertFalse($container->hasDefinition('console.command.messenger_setup_transports'));

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Allow prioritizing receivers so that `messenger:consume --all` consumes receivers in a predefined order
  * Add an optional `extra` key to the encoded envelope passed to `SerializerInterface::decode()`, holding metadata added by the receiving transport
  * Add an optional `LoggingMiddleware` logging the processing time and memory usage of each message
+ * Add the `messenger:show` command to list and inspect pending messages of a transport
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Command/ShowMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ShowMessagesCommand.php
@@ -1,0 +1,262 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Command;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Helper\Dumper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+
+/**
+ * @author Payene Denis Kombate <denis.kombate@gmail.com>
+ */
+#[AsCommand(name: 'messenger:show', description: 'Show one or more pending messages from a transport')]
+class ShowMessagesCommand extends Command
+{
+    public function __construct(
+        private ContainerInterface $receiverLocator,
+        private array $receiverNames = [],
+        private ?PhpSerializer $phpSerializer = null,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([
+                new InputArgument('transport', InputArgument::OPTIONAL, 'Name of the transport to inspect'),
+                new InputArgument('id', InputArgument::OPTIONAL, 'Specific message id to show'),
+                new InputOption('max', null, InputOption::VALUE_REQUIRED, 'Maximum number of messages to list', 50),
+                new InputOption('stats', null, InputOption::VALUE_NONE, 'Display the message count by class'),
+                new InputOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by a specific class name'),
+            ])
+            ->setHelp(<<<'EOF'
+                The <info>%command.name%</info> command shows messages that are pending in a transport:
+
+                    <info>php %command.full_name% <transport></info>
+
+                Or look at a specific message by its id:
+
+                    <info>php %command.full_name% <transport> {id}</info>
+
+                The listing can be narrowed down to a specific message class:
+
+                    <info>php %command.full_name% <transport> --class-filter='App\Message\SendEmail'</info>
+
+                Use the <info>--stats</info> option to display the message count by class instead:
+
+                    <info>php %command.full_name% <transport> --stats</info>
+                EOF
+            )
+        ;
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if ($this->receiverNames && !$input->getArgument('transport')) {
+            $io = new SymfonyStyle($input, $output);
+            $question = new ChoiceQuestion('Which transport do you want to inspect?', $this->receiverNames, 0);
+            $input->setArgument('transport', $io->getErrorStyle()->askQuestion($question));
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $io->getErrorStyle();
+
+        $id = $input->getArgument('id');
+        $classFilter = $input->getOption('class-filter');
+
+        if (null !== $id && (null !== $classFilter || $input->getOption('stats'))) {
+            throw new RuntimeException('You cannot specify a message id when using the "--stats" or "--class-filter" options.');
+        }
+
+        if (!$transportName = $input->getArgument('transport')) {
+            throw new RuntimeException('Please pass the name of the transport to inspect.');
+        }
+
+        if (!$this->receiverLocator->has($transportName)) {
+            $message = \sprintf('The "%s" transport does not exist.', $transportName);
+            if ($this->receiverNames) {
+                $message .= \sprintf(' Valid transports are: %s.', implode(', ', $this->receiverNames));
+            }
+
+            throw new RuntimeException($message);
+        }
+
+        $receiver = $this->receiverLocator->get($transportName);
+
+        if (!$receiver instanceof ListableReceiverInterface) {
+            throw new RuntimeException(\sprintf('The "%s" transport does not support listing or showing specific messages.', $transportName));
+        }
+
+        if ($input->getOption('stats')) {
+            $max = $input->hasParameterOption(['--max'], true) ? $input->getOption('max') : null;
+            $this->listMessagesPerClass($receiver, $io, $max, $classFilter);
+        } elseif (null === $id) {
+            $this->listMessages($receiver, $transportName, $io, $errorIo, $input->getOption('max'), $classFilter);
+        } else {
+            $this->showMessage($receiver, $id, $io, $errorIo);
+        }
+
+        return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('transport')) {
+            $suggestions->suggestValues($this->receiverNames);
+        }
+    }
+
+    private function listMessages(ListableReceiverInterface $receiver, string $transportName, SymfonyStyle $io, SymfonyStyle $errorIo, int $max, ?string $classFilter): void
+    {
+        $envelopes = $receiver->all($max);
+
+        $rows = [];
+
+        if ($classFilter) {
+            $errorIo->comment(\sprintf('Displaying only \'%s\' messages', $classFilter));
+        }
+
+        $this->phpSerializer?->acceptPhpIncompleteClass();
+        try {
+            foreach ($envelopes as $envelope) {
+                $currentClassName = $envelope->getMessage()::class;
+
+                if ($classFilter && $classFilter !== $currentClassName) {
+                    continue;
+                }
+
+                $rows[] = [$this->getMessageId($envelope), $currentClassName];
+            }
+        } finally {
+            $this->phpSerializer?->rejectPhpIncompleteClass();
+        }
+
+        $rowsCount = \count($rows);
+
+        if (0 === $rowsCount) {
+            $io->success('No pending messages were found.');
+
+            return;
+        }
+
+        $io->table(['Id', 'Class'], $rows);
+
+        if ($rowsCount === $max) {
+            $errorIo->comment(\sprintf('Showing first %d messages.', $max));
+        } elseif ($classFilter) {
+            $errorIo->comment(\sprintf('Showing %d message(s).', $rowsCount));
+        }
+
+        $errorIo->comment(\sprintf('Run <comment>messenger:show %s {id} -vv</comment> to see message details.', $transportName));
+    }
+
+    private function listMessagesPerClass(ListableReceiverInterface $receiver, SymfonyStyle $io, ?int $max, ?string $classFilter): void
+    {
+        $envelopes = $receiver->all($max);
+
+        $countPerClass = [];
+
+        $this->phpSerializer?->acceptPhpIncompleteClass();
+        try {
+            foreach ($envelopes as $envelope) {
+                $c = $envelope->getMessage()::class;
+
+                if ($classFilter && $classFilter !== $c) {
+                    continue;
+                }
+
+                if (!isset($countPerClass[$c])) {
+                    $countPerClass[$c] = [$c, 0];
+                }
+
+                ++$countPerClass[$c][1];
+            }
+        } finally {
+            $this->phpSerializer?->rejectPhpIncompleteClass();
+        }
+
+        if (!$countPerClass) {
+            $io->success('No pending messages were found.');
+
+            return;
+        }
+
+        $io->table(['Class', 'Count'], $countPerClass);
+    }
+
+    private function showMessage(ListableReceiverInterface $receiver, string $id, SymfonyStyle $io, SymfonyStyle $errorIo): void
+    {
+        $this->phpSerializer?->acceptPhpIncompleteClass();
+        try {
+            $envelope = $receiver->find($id);
+        } finally {
+            $this->phpSerializer?->rejectPhpIncompleteClass();
+        }
+        if (null === $envelope) {
+            throw new RuntimeException(\sprintf('The message "%s" was not found.', $id));
+        }
+
+        $io->title('Message Details');
+
+        $messageClass = $envelope->getMessage()::class;
+        $lastMessageDecodingFailed = MessageDecodingFailedException::class === $messageClass || $envelope->last(MessageDecodingFailedStamp::class);
+
+        $rows = [
+            ['Class', $messageClass],
+        ];
+
+        if (null !== $id = $this->getMessageId($envelope)) {
+            $rows[] = ['Message Id', $id];
+        }
+
+        $io->table([], $rows);
+
+        if ($io->isVeryVerbose()) {
+            $io->title('Message:');
+            if ($lastMessageDecodingFailed) {
+                $errorIo->error('The message could not be decoded. See below an APPROXIMATIVE representation of the class.');
+            }
+            $dump = new Dumper($io);
+            $io->writeln($dump($envelope->getMessage()));
+        } else {
+            if ($lastMessageDecodingFailed) {
+                $errorIo->error('The message could not be decoded.');
+            }
+            $io->writeln(' Re-run command with <info>-vv</info> to see more message details.');
+        }
+    }
+
+    private function getMessageId(Envelope $envelope): mixed
+    {
+        return $envelope->last(TransportMessageIdStamp::class)?->getId();
+    }
+}

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -343,6 +343,11 @@ class MessengerPass implements CompilerPassInterface
                 ->replaceArgument(1, array_values($receiverNames));
         }
 
+        if ($container->hasDefinition('console.command.messenger_show')) {
+            $container->getDefinition('console.command.messenger_show')
+                ->replaceArgument(1, array_values($receiverNames));
+        }
+
         $container->getDefinition('messenger.receiver_locator')->replaceArgument(0, $receiverMapping);
 
         $failureTransportsLocator = ServiceLocatorTagPass::register($container, $failureTransportsMap);

--- a/src/Symfony/Component/Messenger/Tests/Command/ShowMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ShowMessagesCommandTest.php
@@ -1,0 +1,277 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Command\ShowMessagesCommand;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+
+class ShowMessagesCommandTest extends TestCase
+{
+    private string|false $colSize;
+
+    protected function setUp(): void
+    {
+        $this->colSize = getenv('COLUMNS');
+        putenv('COLUMNS='.(119 + \strlen(\PHP_EOL)));
+    }
+
+    protected function tearDown(): void
+    {
+        putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
+    }
+
+    public function testListMessages()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(50)->willReturn([
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(15)]),
+            new Envelope(new DummyMessage('Hello'), [new TransportMessageIdStamp(16)]),
+        ]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]), ['async']);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async']);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('15   stdClass', $display);
+        $this->assertStringContainsString('16   '.DummyMessage::class, $display);
+        $this->assertStringContainsString('Run messenger:show async {id} -vv to see message details.', $display);
+    }
+
+    public function testListMessagesReturnsNoMessagesFound()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(50)->willReturn([]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async']);
+
+        $this->assertStringContainsString('[OK] No pending messages were found.', $tester->getDisplay(true));
+    }
+
+    public function testListMessagesReturnsPaginatedMessages()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(1)->willReturn([
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(15)]),
+        ]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', '--max' => 1]);
+
+        $this->assertStringContainsString('Showing first 1 messages.', $tester->getDisplay(true));
+    }
+
+    public function testListMessagesReturnsFilteredByClassMessage()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(50)->willReturn([
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(15)]),
+            new Envelope(new DummyMessage('Hello'), [new TransportMessageIdStamp(16)]),
+        ]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', '--class-filter' => DummyMessage::class]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString(\sprintf('Displaying only \'%s\' messages', DummyMessage::class), $display);
+        $this->assertStringContainsString('16   '.DummyMessage::class, $display);
+        $this->assertStringContainsString('Showing 1 message(s).', $display);
+        $this->assertStringNotContainsString('stdClass', $display);
+    }
+
+    public function testStatsIgnoresDefaultMaxAndCountsAllMessages()
+    {
+        $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp(15)]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(null)->willReturn([$envelope, $envelope, $envelope]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', '--stats' => true]);
+
+        $this->assertStringContainsString('stdClass   3', $tester->getDisplay(true));
+    }
+
+    public function testStatsHonorsExplicitMax()
+    {
+        $envelope = new Envelope(new \stdClass(), [new TransportMessageIdStamp(15)]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(10)->willReturn([$envelope]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', '--stats' => true, '--max' => 10]);
+
+        $this->assertStringContainsString('stdClass   1', $tester->getDisplay(true));
+    }
+
+    public function testStatsAppliesClassFilter()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(null)->willReturn([
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(15)]),
+            new Envelope(new DummyMessage('Hello'), [new TransportMessageIdStamp(16)]),
+        ]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', '--stats' => true, '--class-filter' => DummyMessage::class]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString(DummyMessage::class.'   1', $display);
+        $this->assertStringNotContainsString('stdClass', $display);
+    }
+
+    public function testShowMessage()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'), [new TransportMessageIdStamp(15)]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with(15)->willReturn($envelope);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', 'id' => 15]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('Message Details', $display);
+        $this->assertStringContainsString('Class        '.DummyMessage::class, $display);
+        $this->assertStringContainsString('Message Id   15', $display);
+        $this->assertStringContainsString('Re-run command with -vv to see more message details.', $display);
+    }
+
+    public function testShowMessageDumpsTheMessageWhenVeryVerbose()
+    {
+        $envelope = new Envelope(new DummyMessage('Hello'), [new TransportMessageIdStamp(15)]);
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with(15)->willReturn($envelope);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', 'id' => 15], ['verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('Message Details', $display);
+        $this->assertStringContainsString('-message: "Hello"', $display);
+    }
+
+    public function testThrowsWhenMessageIsNotFound()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with(15)->willReturn(null);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $this->expectExceptionMessage('The message "15" was not found.');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', 'id' => 15]);
+    }
+
+    public function testThrowsWhenTransportDoesNotExist()
+    {
+        $command = new ShowMessagesCommand(new ServiceLocator([]), ['async', 'failed']);
+
+        $this->expectExceptionMessage('The "nope" transport does not exist. Valid transports are: async, failed.');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'nope']);
+    }
+
+    public function testThrowsWhenReceiverIsNotListable()
+    {
+        $receiver = $this->createStub(ReceiverInterface::class);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]));
+
+        $this->expectExceptionMessage('The "async" transport does not support listing or showing specific messages.');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async']);
+    }
+
+    public function testThrowsWhenNoTransportIsGiven()
+    {
+        $command = new ShowMessagesCommand(new ServiceLocator([]));
+
+        $this->expectExceptionMessage('Please pass the name of the transport to inspect.');
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+    }
+
+    public function testThrowsWhenIdIsCombinedWithStats()
+    {
+        $command = new ShowMessagesCommand(new ServiceLocator([]));
+
+        $this->expectExceptionMessage('You cannot specify a message id when using the "--stats" or "--class-filter" options.');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', 'id' => 15, '--stats' => true]);
+    }
+
+    public function testThrowsWhenIdIsCombinedWithClassFilter()
+    {
+        $command = new ShowMessagesCommand(new ServiceLocator([]));
+
+        $this->expectExceptionMessage('You cannot specify a message id when using the "--stats" or "--class-filter" options.');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['transport' => 'async', 'id' => 15, '--class-filter' => 'App\Message\SendEmail']);
+    }
+
+    public function testChooseTransportInteractively()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(50)->willReturn([]);
+
+        $command = new ShowMessagesCommand(new ServiceLocator(['async' => static fn () => $receiver]), ['async', 'failed']);
+
+        $tester = new CommandTester($command);
+        $tester->setInputs([0]);
+        $tester->execute([]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('Which transport do you want to inspect?', $display);
+        $this->assertStringContainsString('[OK] No pending messages were found.', $display);
+    }
+
+    public function testCompleteTransport()
+    {
+        $command = new ShowMessagesCommand(new ServiceLocator([]), ['async', 'failed']);
+
+        $tester = new CommandCompletionTester($command);
+
+        $this->assertSame(['async', 'failed'], $tester->complete(['']));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Messenger\Command\DebugCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 use Symfony\Component\Messenger\Command\SetupTransportsCommand;
+use Symfony\Component\Messenger\Command\ShowMessagesCommand;
 use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\Envelope;
@@ -475,6 +476,23 @@ class MessengerPassTest extends TestCase
         (new MessengerPass())->process($container);
 
         $this->assertSame(['doctrine', 'amqp', 'dummy'], $container->getDefinition('console.command.messenger_setup_transports')->getArgument(1));
+    }
+
+    public function testItSetsTheReceiverNamesOnTheShowMessagesCommand()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('console.command.messenger_show', ShowMessagesCommand::class)->setArguments([
+            new Reference('messenger.receiver_locator'),
+            null,
+            null,
+        ]);
+
+        $container->register(AmqpReceiver::class, AmqpReceiver::class)->addTag('messenger.receiver', ['alias' => 'amqp']);
+        $container->register(DummyReceiver::class, DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'dummy']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame(['amqp', 'dummy'], $container->getDefinition('console.command.messenger_show')->getArgument(1));
     }
 
     public function testOnlyConsumableTransportsAreAddedToConsumeCommand()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64777
| License       | MIT

This PR introduces a new `messenger:show` command, the counterpart of `messenger:failed:show` for regular transports: it lists and inspects the pending messages of any transport whose receiver implements `ListableReceiverInterface` (the Doctrine transport does; AMQP for example does not).

```
php bin/console messenger:show async
php bin/console messenger:show async {id} -vv
php bin/console messenger:show async --class-filter='App\Message\SendEmail'
php bin/console messenger:show async --stats
```

- The transport name is an argument; when omitted, the command asks interactively among the configured transports, and shell completion suggests them.
- The listing shows the id and class of each pending message, `--max` limits it (50 by default).
- `--stats` displays the message count by class, scanning all messages unless `--max` is passed.
- `--class-filter` narrows the listing (exact class match) and also narrows `--stats`; filters cannot be combined with an id.
- Showing a single message uses the same dumper display as `messenger:failed:show`; `-vv` reveals the message content.
- An unknown transport, an unknown id, or a transport that does not support listing results in an error; the transport error lists the valid names.

For the docs: the command mirrors `messenger:failed:show` semantics; only transports implementing `ListableReceiverInterface` can be browsed.
