### PR TITLE
[FrameworkBundle] Fix valkey cache adapters ignoring `default_valkey_provider`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -141,7 +141,16 @@ return static function (ContainerConfigurator $container) {
                 'reset' => 'reset',
             ])
             ->tag('monolog.logger', ['channel' => 'cache'])
-        ->alias('cache.adapter.valkey', 'cache.adapter.redis')
+
+        ->set('cache.adapter.valkey')
+            ->parent('cache.adapter.redis')
+            ->abstract()
+            ->tag('cache.pool', [
+                'provider' => 'cache.default_valkey_provider',
+                'clearer' => 'cache.default_clearer',
+                'reset' => 'reset',
+            ])
+            ->tag('monolog.logger', ['channel' => 'cache'])
 
         ->set('cache.adapter.redis_tag_aware', RedisTagAwareAdapter::class)
             ->abstract()
@@ -158,7 +167,16 @@ return static function (ContainerConfigurator $container) {
                 'reset' => 'reset',
             ])
             ->tag('monolog.logger', ['channel' => 'cache'])
-        ->alias('cache.adapter.valkey_tag_aware', 'cache.adapter.redis_tag_aware')
+
+        ->set('cache.adapter.valkey_tag_aware')
+            ->parent('cache.adapter.redis_tag_aware')
+            ->abstract()
+            ->tag('cache.pool', [
+                'provider' => 'cache.default_valkey_provider',
+                'clearer' => 'cache.default_clearer',
+                'reset' => 'reset',
+            ])
+            ->tag('monolog.logger', ['channel' => 'cache'])
 
         ->set('cache.adapter.memcached', MemcachedAdapter::class)
             ->abstract()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -421,6 +421,7 @@
             <xsd:element name="default-doctrine-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="default-psr6-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="default-redis-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="default-valkey-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="default-memcached-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="default-pdo-provider" type="xsd:string" minOccurs="0" maxOccurs="1" />
             <xsd:element name="pool" type="cache_pool" minOccurs="0" maxOccurs="unbounded" />
@@ -431,6 +432,7 @@
         <xsd:attribute name="default-doctrine-provider" type="xsd:string" />
         <xsd:attribute name="default-psr6-provider" type="xsd:string" />
         <xsd:attribute name="default-redis-provider" type="xsd:string" />
+        <xsd:attribute name="default-valkey-provider" type="xsd:string" />
         <xsd:attribute name="default-memcached-provider" type="xsd:string" />
         <xsd:attribute name="default-pdo-provider" type="xsd:string" />
         <xsd:attribute name="default-doctrine-dbal-provider" type="xsd:string" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -6,6 +6,7 @@ $container->loadFromExtension('framework', [
     'handle_all_throwables' => true,
     'php_errors' => ['log' => true],
     'cache' => [
+        'default_valkey_provider' => 'valkey://valkey-host',
         'pools' => [
             'cache.foo' => [
                 'adapter' => 'cache.adapter.apcu',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -8,7 +8,7 @@
     <framework:config http-method-override="false" handle-all-throwables="true">
         <framework:annotations enabled="false" />
         <framework:php-errors log="true" />
-        <framework:cache>
+        <framework:cache default-valkey-provider="valkey://valkey-host">
             <framework:pool name="cache.foo" adapter="cache.adapter.apcu" default-lifetime="30" />
             <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />
             <framework:pool name="cache.foobar" adapter="cache.adapter.psr6" default-lifetime="10" provider="app.cache_pool" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -5,6 +5,7 @@ framework:
     php_errors:
         log: true
     cache:
+        default_valkey_provider: 'valkey://valkey-host'
         pools:
             cache.foo:
                 adapter: cache.adapter.apcu

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2055,6 +2055,22 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame($redisUrl, $url);
     }
 
+    public function testCacheDefaultValkeyProvider()
+    {
+        $container = $this->createContainerFromFile('cache');
+
+        foreach (['cache.adapter.valkey', 'cache.adapter.valkey_tag_aware'] as $id) {
+            $this->assertTrue($container->hasDefinition($id), \sprintf('"%s" should be a service, not an alias.', $id));
+            $this->assertSame('cache.default_valkey_provider', $container->getDefinition($id)->getTag('cache.pool')[0]['provider']);
+        }
+
+        $valkeyUrl = 'valkey://valkey-host';
+        $providerId = '.cache_connection.'.ContainerBuilder::hash($valkeyUrl);
+
+        $this->assertTrue($container->hasDefinition($providerId));
+        $this->assertSame($valkeyUrl, $container->getDefinition($providerId)->getArgument(0));
+    }
+
     public function testCachePoolServices()
     {
         $container = $this->createContainerFromFile('cache', [], true, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64826
| License       | MIT

Currently `cache.adapter.valkey` and `cache.adapter.valkey_tag_aware` are plain aliases to the redis services, so they inherit the `cache.default_redis_provider` tag and `default_valkey_provider` from the cache config is never actually used. This makes them their own services tagged with `cache.default_valkey_provider`, mirroring the existing redis service definitions.

Fixes #64826
