### PR TITLE
[ObjectMapper] Add test coverage for mapping a source property with a non-throwing PropertyAccessor

### DIFF
--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformSourceProperty/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformSourceProperty/Source.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformSourceProperty;
+
+class Source
+{
+    public string $id = '123';
+    public string $sourceProperty = 'ABC';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformSourceProperty/Target.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/TransformSourceProperty/Target.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\TransformSourceProperty;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Source::class)]
+class Target
+{
+    #[Map(source: 'sourceProperty', transform: [self::class, 'transformProperty'])]
+    public string $targetProperty;
+
+    public static function transformProperty(string $value): string
+    {
+        return $value;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -115,6 +115,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformC
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionD;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformSourceProperty\Source as TransformSourcePropertySource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformSourceProperty\Target as TransformSourcePropertyTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized\Post;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Uninitialized\PostView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Unreadable\Order;
@@ -917,5 +919,17 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(MappedChildEntityDto::class, $target);
         $this->assertSame('Test', $target->name);
         $this->assertNull($target->secret);
+    }
+
+    public function testTransformReceivesMappedSourceValueWithNonThrowingPropertyAccessor()
+    {
+        $mapper = new ObjectMapper(propertyAccessor: PropertyAccess::createPropertyAccessorBuilder()->disableExceptionOnInvalidPropertyPath()->getPropertyAccessor());
+
+        $target = $mapper->map(new TransformSourcePropertySource(), TransformSourcePropertyTarget::class);
+
+        // a non-throwing property accessor must not make the unrelated target property name look readable on the
+        // source, otherwise the #[Map(source: ...)] property is read as null and the transform receives null
+        $this->assertInstanceOf(TransformSourcePropertyTarget::class, $target);
+        $this->assertSame('ABC', $target->targetProperty);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Related to #64818 (fixed by #64848)
| License       | MIT

This PR originally fixed #64818: with a `PropertyAccessor` configured not to throw (`disableExceptionOnInvalidPropertyPath()` / `DO_NOT_THROW`), `isReadable()` returns `true` for any property name, so the source-name resolution introduced in 1e1542f38ba (v7.4.14) ignored explicit `#[Map(source:)]` names and transforms received `null`.

That resolution logic has since been rewritten by #64848, which stops consulting `isReadable()` entirely and fixes #64818 as well. This PR is now rebased on top of it and reduced to what remains valuable: a regression test for the non-throwing-accessor scenario, which the tests of #64848 do not cover. The test errors with the original `TypeError` when run against the pre-#64848 code and passes since.
