### PR TITLE
[Process] Prevent setPty being set to 'true' on Windows inline with setTty

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1047,6 +1047,14 @@ class Process implements \IteratorAggregate
      */
     public function setPty(bool $bool): static
     {
+        if ('\\' === \DIRECTORY_SEPARATOR && $bool) {
+            throw new RuntimeException('PTY mode is not supported on Windows platform.');
+        }
+
+        if ($bool && !self::isPtySupported()) {
+            throw new RuntimeException('PTY mode requires pty to be read/writable.');
+        }
+
         $this->pty = $bool;
 
         return $this;

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -568,6 +568,19 @@ class ProcessTest extends TestCase
         $this->assertEquals("foo\r\n", $process->getOutput());
     }
 
+    public function testPTYInWindowsEnvironment()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('PTY mode is not supported on Windows platform.');
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test is for Windows platform only');
+        }
+
+        $process = $this->getProcess('echo "foo" >> /dev/null');
+        $process->setPty(false);
+        $process->setPty(true);
+    }
+
     public function testMustRun()
     {
         $process = $this->getProcess('echo foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | -
| License       | MIT

Within the `Process` component, if you try and call `setTTY` with `true` then on Windows or if `/dev/tty` is not read/writable then an exception is thrown noting this. With `setPTY` then while `isPtySupported` exists, the setting is changed with no indication that it will actually not be set. This updates `setPTY` to be inline with `setTTY`.

I would consider this a bug as currently the behaviour is incorrect; but this does break backwards compatibility in that anyone using `setPTY` in a 'best-effort' basis will start getting an exception. As such, if this should be rebased to the 8.2 branch then just let me know.
