### PR TITLE
[HttpClient] Remove unused code in `AsyncResponse::__destruct()`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -190,7 +190,7 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
 
         if ($this->initializer && null === $this->getInfo('error') && !$this->hasThrown) {
             try {
-                self::initialize($this, -0.0);
+                self::initialize($this);
                 $this->getHeaders(true);
             } catch (HttpExceptionInterface $httpException) {
                 // no-op


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT
