### PR TITLE
[Mailer][BrevoMailer] Allow configuring the SMTP port through the DSN

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+* Allow configuring the SMTP port through the DSN
+
 6.4
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/README.md
@@ -10,12 +10,19 @@ Configuration example:
 # SMTP
 MAILER_DSN=brevo+smtp://USERNAME:PASSWORD@default
 
+# SMTP on a specific port
+MAILER_DSN=brevo+smtp://USERNAME:PASSWORD@default:587
+
 # API
 MAILER_DSN=brevo+api://KEY@default
 ```
 
 where:
  - `KEY` is your Brevo API Key
+
+The SMTP port defaults to 465, which uses implicit TLS. On any other port the
+connection starts in clear text and is upgraded with STARTTLS when the server
+offers it.
 
 With API, you can use custom headers.
 

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoTransportFactoryTest.php
@@ -71,6 +71,11 @@ class BrevoTransportFactoryTest extends AbstractTransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('brevo+smtp', 'default', self::USER, self::PASSWORD, 587),
+            new BrevoSmtpTransport(self::USER, self::PASSWORD, null, new NullLogger(), 587),
+        ];
+
+        yield [
             new Dsn('brevo+api', 'default', self::USER),
             new BrevoApiTransport(self::USER, new MockHttpClient(), null, new NullLogger()),
         ];

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoSmtpTransport.php
@@ -20,9 +20,9 @@ use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
  */
 final class BrevoSmtpTransport extends EsmtpTransport
 {
-    public function __construct(string $username, #[\SensitiveParameter] string $password, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null)
+    public function __construct(string $username, #[\SensitiveParameter] string $password, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null, ?int $port = null)
     {
-        parent::__construct('smtp-relay.brevo.com', 465, true, $dispatcher, $logger);
+        parent::__construct('smtp-relay.brevo.com', $port ?? 465, null, $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoTransportFactory.php
@@ -40,7 +40,7 @@ final class BrevoTransportFactory extends AbstractTransportFactory
                 ;
         }
 
-        return new $transport($this->getUser($dsn), $this->getPassword($dsn), $this->dispatcher, $this->logger);
+        return new $transport($this->getUser($dsn), $this->getPassword($dsn), $this->dispatcher, $this->logger, $dsn->getPort());
     }
 
     protected function getSupportedSchemes(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

`BrevoTransportFactory::create()` hardcoded port 465 and ignored the DSN port, so reaching Brevo on 587 with STARTTLS meant dropping the bridge and falling back to a generic `smtp://smtp-relay.brevo.com:587` DSN.

Retargeted from 7.4 to 8.2 during review, as @alexandre-daubois asked. This is a new capability, not a bugfix: the factory has never read `Dsn::getPort()` for the SMTP schemes, on any branch, and the port was never documented. Sixteen of the seventeen `*SmtpTransport` bridges hardcode their provider's port; only Sweego takes one, and only because its DSN documents it.

Behaviour with no port in the DSN is unchanged: port 465 with implicit TLS. Any other port starts in clear text and is upgraded with STARTTLS when the server offers it, which is what Brevo recommends for 587.

Changed during review:

* the port parameter is nullable, so the default lives in one place and the `?int` returned by `Dsn::getPort()` matches the parameter type;
* `465 === $port ? true : null` is dropped. `EsmtpTransport::__construct()` already maps a null TLS flag to implicit TLS on 465 and opportunistic STARTTLS elsewhere, so the ternary was dead. A sweep over 8 ports gives identical host, port and TLS state before and after;
* added the bridge CHANGELOG entry and a README example, including a note that the TLS mode changes with the port.

Note on the test: it cannot fail on the base branch, because PHP silently drops the extra constructor argument there, so both sides of the comparison end up as 465-with-TLS objects. That is inherent to adding an optional parameter. Reverting only the factory does make it fail, with `'port' => 587` against `'port' => 465`, so it does pin the factory-to-transport wiring going forward.
