### PR TITLE
[Tui] Repaint the full screen on resize so multiplexer reattaches are not blank

### DIFF
--- a/src/Symfony/Component/Tui/Tests/TuiTest.php
+++ b/src/Symfony/Component/Tui/Tests/TuiTest.php
@@ -323,6 +323,25 @@ class TuiTest extends TestCase
         $this->assertStringContainsString('Hello', $terminal->getOutput());
     }
 
+    public function testSameSizeResizeRepaintsTheFullScreen()
+    {
+        // Multiplexers send SIGWINCH on reattach even at an unchanged size;
+        // the new terminal is blank, so diff-only rendering would show nothing
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+
+        $tui->add(new TextWidget('Hello'));
+        $tui->start();
+        $tui->processRender();
+
+        $terminal->clearOutput();
+
+        $terminal->simulateResize(40, 10);
+        $tui->processRender();
+
+        $this->assertStringContainsString('Hello', $terminal->getOutput());
+    }
+
     public function testInputEventCanConsumeGlobalInputBeforeFocusedWidget()
     {
         $terminal = new VirtualTerminal(40, 10);

--- a/src/Symfony/Component/Tui/Tui.php
+++ b/src/Symfony/Component/Tui/Tui.php
@@ -210,7 +210,10 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
         $this->stopped = false;
         $this->lastTickAt = null;
         $this->lastTickBusyHint = null;
-        $this->terminal->start($this->handleInput(...), $this->requestRender(...), function (): void {
+        // A resize forces a full repaint: multiplexers (dtach, tmux) send
+        // SIGWINCH on reattach, when the previous screen content cannot be
+        // trusted, even at an unchanged size
+        $this->terminal->start($this->handleInput(...), fn () => $this->requestRender(true), function (): void {
             $this->keybindings->setKittyProtocolActive(true);
         });
         $this->terminal->hideCursor();


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
