### PR TITLE
[Validator] Make `Validation` invokable for use with the pipe operator

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Make `Validation` instantiable and invokable, so it can be used as a validation step with the pipe operator (`$value |> new Validation(new NotBlank())`)
  * Add the `Cron` constraint to validate cron expressions
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`
 

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Blank;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validation;
@@ -41,6 +42,39 @@ class ValidationTest extends TestCase
             $this->assertCount(1, $violations);
             $this->assertEquals('This value should be blank.', $violations->get(0)->getMessage());
         }
+    }
+
+    public function testInvokableValid()
+    {
+        $validation = new Validation(new NotBlank(), new Email());
+        $this->assertEquals('test@example.com', $validation('test@example.com'));
+    }
+
+    public function testInvokableInvalid()
+    {
+        $validation = new Validation(new Blank());
+        try {
+            $validation('test');
+            $this->fail('No ValidationFailedException thrown');
+        } catch (ValidationFailedException $e) {
+            $this->assertEquals('test', $e->getValue());
+
+            $violations = $e->getViolations();
+            $this->assertCount(1, $violations);
+            $this->assertEquals('This value should be blank.', $violations->get(0)->getMessage());
+        }
+    }
+
+    public function testInvokableWithValidator()
+    {
+        $validation = new Validation(Validation::createValidator(), new NotBlank());
+        $this->assertEquals('test@example.com', $validation('test@example.com'));
+    }
+
+    public function testInvokableWithoutConstraints()
+    {
+        $validation = new Validation();
+        $this->assertEquals('test', $validation('test'));
     }
 
     public function testCreateIsValidCallableValid()

--- a/src/Symfony/Component/Validator/Validation.php
+++ b/src/Symfony/Component/Validator/Validation.php
@@ -22,7 +22,47 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final class Validation
 {
     /**
+     * @var Constraint[]
+     */
+    private array $constraints;
+
+    private ?\Closure $validate = null;
+
+    /**
+     * Instances of this class are invokable and validate the value they are called with,
+     * which makes them suitable for use with the pipe operator:
+     *
+     *     $email = $input |> new Validation(new NotBlank(), new Email());
+     */
+    public function __construct(
+        private readonly Constraint|ValidatorInterface|null $constraintOrValidator = null,
+        Constraint ...$constraints,
+    ) {
+        $this->constraints = $constraints;
+    }
+
+    /**
+     * Validates the value against the constraints and returns it.
+     *
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return T The $value
+     */
+    public function __invoke(mixed $value): mixed
+    {
+        $this->validate ??= self::createCallable($this->constraintOrValidator, ...$this->constraints);
+
+        return ($this->validate)($value);
+    }
+
+    /**
      * Creates a callable chain of constraints.
+     *
+     * @phpstan-return callable<T>(T $value): T
+     *
+     * @psalm-return callable(mixed $value): mixed
      */
     public static function createCallable(Constraint|ValidatorInterface|null $constraintOrValidator = null, Constraint ...$constraints): callable
     {
@@ -77,12 +117,5 @@ final class Validation
     public static function createValidatorBuilder(): ValidatorBuilder
     {
         return new ValidatorBuilder();
-    }
-
-    /**
-     * This class cannot be instantiated.
-     */
-    private function __construct()
-    {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

PHP 8.5 introduced the pipe operator (`|>`), which accepts any callable on its right-hand side — including invokable objects. The Validator component already provides a pipe-friendly helper via the static factory:

```php
$email = $dto->getEmail() |> Validation::createCallable(new NotBlank(), new Email());
```

This PR makes `Validation` itself instantiable and invokable, so the same intent reads more naturally:

```php
$email = $dto->getEmail() |> new Validation(new NotBlank(), new Email());
```

The constructor mirrors `createCallable()`: the first argument may also be a configured `ValidatorInterface`:

```php
$email = $dto->getEmail() |> new Validation($this->validator, new NotBlank(), new Email());
```

Invoking the instance exposes the same behavior as the `createCallable()`  closure does - it validates the value, returning it if valid, or throwing a `ValidationFailedException` if invalid. The closure is created lazily and cached on first invocation.

Notes:
- BC-safe: the class is `final` and its constructor was private ("This class cannot be instantiated"), so no existing code could instantiate or extend it.
- Tests do not use `|>` literally since the monorepo supports PHP >= 8.4.1, where it is a parse error; they call the instance directly, which is exactly what the pipe operator does.
