### PR TITLE
[Validator] Add return type annotations to `Validation::createCallable()`

### DIFF
--- a/src/Symfony/Component/Validator/Validation.php
+++ b/src/Symfony/Component/Validator/Validation.php
@@ -23,6 +23,10 @@ final class Validation
 {
     /**
      * Creates a callable chain of constraints.
+     *
+     * @phpstan-return callable<T>(T $value): T
+     *
+     * @psalm-return callable(mixed $value): mixed
      */
     public static function createCallable(Constraint|ValidatorInterface|null $constraintOrValidator = null, Constraint ...$constraints): callable
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Adds `@phpstan-return` / `@psalm-return` annotations to `Validation::createCallable()` so static analysis knows the returned callable passes the validated value through unchanged (`callable<T>(T $value): T`).
