### PR TITLE
[DoctrineBridge] Filter non-.php files in ProxyCacheWarmer::warmUp() to avoid CacheWarmerAggregate exception

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
@@ -60,7 +60,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
             $em->getProxyFactory()->generateProxyClasses($classes);
 
             foreach (scandir($proxyCacheDir) as $file) {
-                if (!is_dir($file = $proxyCacheDir.'/'.$file)) {
+                if (str_ends_with($file, '.php') && !is_dir($file = $proxyCacheDir.'/'.$file)) {
                     $files[] = $file;
                 }
             }

--- a/src/Symfony/Bridge/Doctrine/Tests/CacheWarmer/ProxyCacheWarmerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/CacheWarmer/ProxyCacheWarmerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\CacheWarmer;
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Proxy\ProxyFactory;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer;
+
+class ProxyCacheWarmerTest extends TestCase
+{
+    public function testWarmUpFiltersNonPhpFiles()
+    {
+        $proxyDir = sys_get_temp_dir().'/doctrine_proxy_test_'.uniqid();
+        mkdir($proxyDir, 0o777, true);
+
+        try {
+            // simulate the atomic-write temp file left by ProxyFactory::generateProxyClasses()
+            file_put_contents($proxyDir.'/__CG__Foo.php', '<?php // proxy');
+            file_put_contents($proxyDir.'/__CG__Foo.php.2eb37f8174836c6595d337b3', '<?php // temp');
+
+            $proxyFactory = $this->createMock(ProxyFactory::class);
+            $proxyFactory->expects($this->once())
+                ->method('generateProxyClasses')
+                ->willReturn(1);
+
+            $configuration = $this->createStub(Configuration::class);
+            $configuration->method('getProxyDir')->willReturn($proxyDir);
+            $configuration->method('getAutoGenerateProxyClasses')->willReturn(0);
+
+            $metadataFactory = $this->createStub(ClassMetadataFactory::class);
+            $metadataFactory->method('getAllMetadata')->willReturn([]);
+
+            $em = $this->createStub(EntityManagerInterface::class);
+            $em->method('getConfiguration')->willReturn($configuration);
+            $em->method('getProxyFactory')->willReturn($proxyFactory);
+            $em->method('getMetadataFactory')->willReturn($metadataFactory);
+
+            $registry = $this->createStub(ManagerRegistry::class);
+            $registry->method('getManagers')->willReturn([$em]);
+
+            $result = (new ProxyCacheWarmer($registry))->warmUp('/cache');
+
+            $this->assertContains($proxyDir.'/__CG__Foo.php', $result);
+            $this->assertNotContains($proxyDir.'/__CG__Foo.php.2eb37f8174836c6595d337b3', $result, 'warmUp() must not return atomic-write temp files that do not end in .php');
+        } finally {
+            array_map('unlink', glob($proxyDir.'/*'));
+            rmdir($proxyDir);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64846
| License       | MIT

## Problem

`ProxyCacheWarmer::warmUp()` collects proxy files via `scandir()` without filtering by extension. `doctrine/orm`'s `ProxyFactory` uses an atomic write pattern: it writes to a temp file (`Proxy.php.{random_hex}`) then renames it to the final `.php` path:

```php
$tmpFileName = $fileName . '.' . bin2hex(random_bytes(12));
file_put_contents($tmpFileName, $proxyCode);
rename($tmpFileName, $fileName);
```

If such a temp path ends up in the array returned by `warmUp()`, two distinct failures can happen:

1. **Transient race** (concurrent PHP workers): the temp file disappears again between `scandir()` and the validation that `CacheWarmerAggregate` performs since Symfony 6.3 (6d905904d77) on every returned preload item, which then throws:

   ```
   "Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer::warmUp()" should return a list of files or classes
   but "/var/cache/prod/doctrine/orm/Proxies/__CG__SomeEntity.php.2eb37f8174836c6595d337b3" is none of them.
   ```

2. **Persistent temp file** (e.g. `rename()` failed silently): the file still exists, so it passes that validation and is written into the generated preload file as a `require_once`, loading the same proxy class twice and making opcache preloading fail at startup.

The first error is **intermittent** because in normal conditions the `rename()` completes before `scandir()` is called; it surfaces under concurrent deploys.

## Fix

Add a `str_ends_with($file, '.php')` guard in the `scandir()` loop:

```diff
  foreach (scandir($proxyCacheDir) as $file) {
-     if (!is_dir($file = $proxyCacheDir.'/'.$file)) {
+     if (str_ends_with($file, '.php') && !is_dir($file = $proxyCacheDir.'/'.$file)) {
          $files[] = $file;
      }
  }
```

This makes the warmer robust against leftover temp files in both scenarios, regardless of whether the race occurs or `rename()` succeeds.

