### PR TITLE
[ObjectMapper] Fix per-property #[Map(source:)] being ignored when the target property name also exists on the source

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -127,7 +127,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         $refl = $this->getSourceReflectionClass($source) ?? $targetRefl;
 
         // When source contains no metadata, we read metadata on the target instead
-        if ($refl === $targetRefl) {
+        if ($readMetadataFromTarget = $refl === $targetRefl) {
             $readMetadataFrom = $mappedTarget;
         }
 
@@ -140,10 +140,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             $propertyName = $property->getName();
             $mappings = $this->metadataFactory->create($readMetadataFrom, $propertyName);
             foreach ($mappings as $mapping) {
-                $sourcePropertyName = $propertyName;
-                if ($mapping->source && !$this->isReadable($source, $propertyName)) {
-                    $sourcePropertyName = $mapping->source;
-                }
+                // when metadata is read from the source, $mapping->source describes the
+                // reverse mapping and must not be resolved against $source
+                $sourcePropertyName = $readMetadataFromTarget ? $mapping->source ?? $propertyName : $propertyName;
 
                 $targetPropertyName = $mapping->target ?? $propertyName;
                 if (false === $if = $mapping->if) {

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/NestedSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/NestedSource.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource;
+
+class NestedSource
+{
+    public Reason $reason;
+
+    public function __construct()
+    {
+        $this->reason = new Reason();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/NestedTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/NestedTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: NestedSource::class)]
+class NestedTarget
+{
+    public function __construct(#[Map(source: 'reason.description')] public string $reason)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/Reason.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/Reason.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource;
+
+class Reason
+{
+    public function __construct(public string $description = 'from-nested-description')
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/Source.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource;
+
+class Source
+{
+    public string $reason = 'from-reason';
+    public string $reasonText = 'from-reasonText';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/Target.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/ExplicitSource/Target.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Source::class)]
+class Target
+{
+    public function __construct(#[Map(source: 'reasonText')] public string $reason)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapTargetToSource/C.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapTargetToSource/C.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: B::class)]
+class C
+{
+    public function __construct(public string $target)
+    {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -44,6 +44,10 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultValueStdClass\TargetDto
 use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\Address;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\User as UserEmbeddedMapping;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\UserDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\NestedSource as ExplicitSourceNestedSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\NestedTarget as ExplicitSourceNestedTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\Source as ExplicitSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ExplicitSource\Target as ExplicitSourceTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
@@ -67,6 +71,7 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Target;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\A as MapTargetToSourceA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\B as MapTargetToSourceB;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapTargetToSource\C as MapTargetToSourceC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\A as MultipleTargetPropertyA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as MultipleTargetPropertyB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
@@ -409,6 +414,29 @@ final class ObjectMapperTest extends TestCase
         $b = $mapper->map($a, MapTargetToSourceB::class);
         $this->assertInstanceOf(MapTargetToSourceB::class, $b);
         $this->assertSame('str', $b->target);
+    }
+
+    public function testMapTargetToSourceIsIgnoredWhenMappingFromTheSource()
+    {
+        $b = new MapTargetToSourceB('str');
+        $mapper = new ObjectMapper();
+        $c = $mapper->map($b, MapTargetToSourceC::class);
+        $this->assertInstanceOf(MapTargetToSourceC::class, $c);
+        $this->assertSame('str', $c->target);
+    }
+
+    public function testExplicitSourceTakesPrecedenceOverSameNamedProperty()
+    {
+        $mapper = new ObjectMapper();
+        $target = $mapper->map(new ExplicitSource(), ExplicitSourceTarget::class);
+        $this->assertSame('from-reasonText', $target->reason);
+    }
+
+    public function testExplicitSourceSupportsPropertyPath()
+    {
+        $mapper = new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), PropertyAccess::createPropertyAccessor());
+        $target = $mapper->map(new ExplicitSourceNestedSource(), ExplicitSourceNestedTarget::class);
+        $this->assertSame('from-nested-description', $target->reason);
     }
 
     public function testMultipleTargetMapProperty()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64762
| License       | MIT

A per-property `#[Map(source: '...')]` was only honored when the target property name was *not* readable on the source object:

```php
$sourcePropertyName = $propertyName;
if ($mapping->source && !$this->isReadable($source, $propertyName)) {
    $sourcePropertyName = $mapping->source;
}
```

So when the source happened to expose a property with the same name as the target one, the explicit `source` was silently discarded and the same-named property was read instead. This also meant a property path such as `#[Map(source: 'reason.description')]` never got a chance to be resolved by the `PropertyAccessor` whenever the source had a `reason` property.

```php
class Source
{
    public string $reason = 'from-reason';
    public string $reasonText = 'from-reasonText';
}

#[Map(source: Source::class)]
class Target
{
    public function __construct(#[Map(source: 'reasonText')] public string $reason)
    {
    }
}

(new ObjectMapper())->map(new Source(), Target::class)->reason; // 'from-reason', expected 'from-reasonText'
```

### Why not give `source` unconditional precedence

The issue suggests `$sourcePropertyName = $mapping->source ?? $propertyName;`. That passes the whole existing test suite, but it breaks the reverse direction, which is currently untested: when the metadata is read from the *source* object, `source` describes the reverse mapping and must not be resolved against the source itself. Taking the existing `MapTargetToSource` fixtures, mapping `B` (which carries `#[Map(source: 'source')]` on its own `$target` property) to another class then fails with `NoSuchPropertyException: The property "source" does not exist on "B"`.

So the fix keys off the distinction the code already makes — whether metadata was read from the target or from the source:

```php
$readMetadataFromTarget = $refl === $targetRefl;
...
$sourcePropertyName = $readMetadataFromTarget ? $mapping->source ?? $propertyName : $propertyName;
```

### Tests

- `testExplicitSourceTakesPrecedenceOverSameNamedProperty` and `testExplicitSourceSupportsPropertyPath` fail without the fix.
- `testMapTargetToSourceIsIgnoredWhenMappingFromTheSource` passes both before and after; it is there to lock the reverse-mapping behaviour, which the naive one-liner would silently break.

### Note

One visible behaviour change: `#[Map(source: 'a.b')]` used without a `PropertyAccessor` now throws an explicit `NoSuchPropertyException`, where it previously read the same-named property and typically blew up later with a `TypeError` in the target constructor.

I could not confirm the regression between `symfony/object-mapper` v8.0.9 and v8.0.14 mentioned in the issue: the reproducer fails identically on v8.0.9, so this looks like a long-standing bug rather than a recent regression.
