### PR TITLE
[Console] Fix SymfonyStyle questions when using output sections

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -357,10 +357,15 @@ class SymfonyStyle extends OutputStyle
             if ($this->output instanceof ConsoleSectionOutput) {
                 // add the new line of the `return` to submit the input to ConsoleSectionOutput, because ConsoleSectionOutput is holding all it's lines.
                 // this is relevant when a `ConsoleSectionOutput::clear` is called.
+                // the section already renders the prompt as a whole line, so an extra
+                // newLine() here would leave a doubled blank line below the answer; only
+                // keep the buffer in sync so autoPrependBlock() spaces the next block.
                 $this->output->addNewLineOfInputSubmit();
+                $this->bufferedOutput->write("\n\n");
+            } else {
+                $this->newLine();
+                $this->bufferedOutput->write("\n");
             }
-            $this->newLine();
-            $this->bufferedOutput->write("\n");
         }
 
         return $answer;

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -228,11 +228,41 @@ class SymfonyStyleTest extends TestCase
             'start'.\PHP_EOL. // write start
             'foo'.\PHP_EOL. // write foo
             "\x1b[1A\x1b[0Jfoo and bar".\PHP_EOL. // complete line
-            \PHP_EOL." \033[32mDummy question?\033[39m:".\PHP_EOL.' > '.\PHP_EOL.\PHP_EOL. // question
+            \PHP_EOL." \033[32mDummy question?\033[39m:".\PHP_EOL.' > '.\PHP_EOL. // question
             'foo2'.\PHP_EOL. // write foo2
             'bar2'.\PHP_EOL. // write bar
-            "\033[9A\033[0J"), // clear 9 lines (8 output lines and one from the answer input return)
+            "\033[8A\033[0J"), // clear 8 lines (7 output lines and one from the answer input return)
             escapeshellcmd(stream_get_contents($output->getStream()))
         );
+    }
+
+    public function testAskQuestionInSectionMatchesNonSectionOutput()
+    {
+        // asking a question inside a ConsoleSectionOutput must not leave an extra
+        // blank line below the answer: the output must match a regular StreamOutput.
+        $render = function (StreamOutput $output): string {
+            $inputStream = fopen('php://memory', 'r+');
+            fwrite($inputStream, 'Answer'.\PHP_EOL);
+            rewind($inputStream);
+            $input = $this->createStub(Input::class);
+            $input->method('isInteractive')->willReturn(true);
+            $input->method('getStream')->willReturn($inputStream);
+
+            $style = new SymfonyStyle($input, $output);
+            $style->writeln('before');
+            $style->ask('Dummy question?');
+            $style->writeln('after');
+
+            rewind($output->getStream());
+
+            return stream_get_contents($output->getStream());
+        };
+
+        $sections = [];
+        $sectionOutput = $render(new ConsoleSectionOutput(fopen('php://memory', 'r+', false), $sections, StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter()));
+        $streamOutput = $render(new StreamOutput(fopen('php://memory', 'r+', false), StreamOutput::VERBOSITY_NORMAL, true, new OutputFormatter()));
+
+        $this->assertSame($streamOutput, $sectionOutput);
+        $this->assertStringNotContainsString(' > '.\PHP_EOL.\PHP_EOL, $sectionOutput);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | –
| License       | MIT

Asking a question with `SymfonyStyle` (`ask()`, `askHidden()`, `confirm()`, `choice()`) inside a `ConsoleSectionOutput` leaves a **doubled blank line** below the answer. The same helpers behave correctly with a regular output.

**Cause.** `SymfonyQuestionHelper::writePrompt()` writes the ` > ` prompt with `write()` (no trailing newline), expecting the answer + <kbd>Enter</kbd> to complete that line. But `ConsoleSectionOutput` force-terminates every write as a whole line, so ` > ` already gets its own newline — and then `askQuestion()` unconditionally calls `newLine()`, adding a second one.

**Fix.** Skip that redundant `newLine()` when writing to a `ConsoleSectionOutput`, while keeping `addNewLineOfInputSubmit()` (needed for `clear()` line accounting) and the buffer state in sync so `autoPrependBlock()` still spaces the next block. Normal output is untouched (guarded by `instanceof`).

Only `askQuestion()` is affected; `title()`, `section()`, `block()` (and `success`/`error`/`warning`/`note`/`comment`/`info`/`caution`), `listing()` and `table()` render identically in a section: they finish with `writeln()` + `newLine()`, which sections handle natively.

Before / after (`ask()` in a console output section):

```bash
# before
Question?:
> 
The answer<Enter>

# after
Question?:
> The answer<Enter>
```
