### PR TITLE
[Console] Do not dispatch ConsoleEvents::ERROR when describing a namespace

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -285,6 +285,23 @@ class Application implements ResetInterface
 
                 $command = $this->find($alternative);
             } else {
+                // describing a namespace is not an error: do not dispatch ConsoleEvents::ERROR for it
+                try {
+                    if ($e instanceof CommandNotFoundException && $namespace = $this->findNamespace($name)) {
+                        $helper = new DescriptorHelper();
+                        $helper->describe($output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output, $this, [
+                            'format' => 'txt',
+                            'raw_text' => false,
+                            'namespace' => $namespace,
+                            'short' => false,
+                        ]);
+
+                        return 1;
+                    }
+                } catch (NamespaceNotFoundException) {
+                    // no namespace matches the given name, report the original error below
+                }
+
                 if (null !== $this->dispatcher) {
                     $event = new ConsoleErrorEvent($input, $output, $e);
                     $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
@@ -296,23 +313,7 @@ class Application implements ResetInterface
                     $e = $event->getError();
                 }
 
-                try {
-                    if ($e instanceof CommandNotFoundException && $namespace = $this->findNamespace($name)) {
-                        $helper = new DescriptorHelper();
-                        $helper->describe($output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output, $this, [
-                            'format' => 'txt',
-                            'raw_text' => false,
-                            'namespace' => $namespace,
-                            'short' => false,
-                        ]);
-
-                        return isset($event) ? $event->getExitCode() : 1;
-                    }
-
-                    throw $e;
-                } catch (NamespaceNotFoundException) {
-                    throw $e;
-                }
+                throw $e;
             }
         }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -593,6 +593,46 @@ class ApplicationTest extends TestCase
         $this->assertStringContainsString('The foo:bar1 command', $display);
     }
 
+    public function testRunNamespaceDoesNotDispatchTheErrorEvent()
+    {
+        putenv('COLUMNS=120');
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add(new \FooCommand());
+
+        $dispatched = false;
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('console.error', static function () use (&$dispatched) {
+            $dispatched = true;
+        });
+        $application->setDispatcher($dispatcher);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'foo'], ['decorated' => false]);
+
+        $this->assertStringContainsString('Available commands for the "foo" namespace:', trim($tester->getDisplay(true)));
+        $this->assertFalse($dispatched, '->run() does not dispatch ConsoleEvents::ERROR when it describes a namespace');
+    }
+
+    public function testRunUnknownCommandDispatchesTheErrorEvent()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add(new \FooCommand());
+
+        $dispatched = false;
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('console.error', static function () use (&$dispatched) {
+            $dispatched = true;
+        });
+        $application->setDispatcher($dispatcher);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'unknown'], ['decorated' => false]);
+
+        $this->assertTrue($dispatched, '->run() dispatches ConsoleEvents::ERROR when the command does not exist');
+    }
+
     public function testFindAlternativeExceptionMessageMultiple()
     {
         putenv('COLUMNS=120');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64830
| License       | MIT

`Application::doRun()` dispatches `ConsoleEvents::ERROR` as soon as `find()` throws, and only afterwards figures out that the given name is in fact a namespace to describe:

```php
} else {
    if (null !== $this->dispatcher) {
        $event = new ConsoleErrorEvent($input, $output, $e);
        $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);   // <- too early
        ...
    }

    try {
        if ($e instanceof CommandNotFoundException && $namespace = $this->findNamespace($name)) {
            // ... describe the namespace, this is not an error
```

So `bin/console secrets --list` prints the expected listing, while `ErrorListener` has already logged `console.CRITICAL: Error thrown while running command "secrets --list". Message: "Command "secrets" is not defined."`.

The error event is now dispatched only once we know we are not describing a namespace. A name that matches no namespace still goes through the error path, so a command that really does not exist keeps being reported:

|                             | before        | after         |
| --------------------------- | ------------- | ------------- |
| `secrets --list`            | CRITICAL logged | no log      |
| `secrets`                   | CRITICAL logged | no log      |
| `nope --list` (unknown)     | CRITICAL logged | CRITICAL logged |

### Behaviour changes worth a look

Dispatching the event on that path had three side effects that go away:

- the namespace listing returned `$event->getExitCode()`, it now always returns `1`. In practice this was already `1` (`CommandNotFoundException` has code `0`, so `ConsoleErrorEvent` falls back to `1`), but a listener could change it.
- a listener setting the exit code to `0` used to make `doRun()` return `0` *before* describing anything; the listing is now printed.
- a listener replacing the exception through `$event->setError()` could make the `$e instanceof CommandNotFoundException` check fail and suppress the listing.

### Tests

`testRunNamespaceDoesNotDispatchTheErrorEvent` fails without the fix. `testRunUnknownCommandDispatchesTheErrorEvent` guards the other direction, so that "fixing" this by never dispatching the event would not go unnoticed.
