### PR TITLE
[AssetMapper] Ignore compiled assets in debug mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -99,6 +99,7 @@ return static function (ContainerConfigurator $container) {
         ->set('asset_mapper.compiled_asset_mapper_config_reader', CompiledAssetMapperConfigReader::class)
             ->args([
                 abstract_arg('public assets directory'),
+                param('kernel.debug'),
             ])
 
         ->set('asset_mapper.asset_package', MapperAwareAssetPackage::class)

--- a/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/AssetMapperCompileCommand.php
@@ -88,8 +88,8 @@ final class AssetMapperCompileCommand extends Command
         $io->comment(\sprintf('Entrypoint metadata written for <comment>%d</> entrypoints (%s).', \count($entrypointFiles), implode(', ', $styledEntrypointNames)));
 
         if ($this->isDebug) {
-            $io->warning(\sprintf(
-                'Debug mode is enabled in your project: Symfony will not serve any changed assets until you delete the files in the "%s" directory again.',
+            $io->note(\sprintf(
+                'Debug mode is enabled: the compiled files in "%s" are ignored and only used when debug is off (e.g. in production).',
                 $this->shortenPath(\dirname($manifestPath))
             ));
         }

--- a/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/CompiledAssetMapperConfigReader.php
@@ -23,12 +23,20 @@ class CompiledAssetMapperConfigReader
 
     public function __construct(
         private readonly string $directory,
+        private readonly bool $debug = false,
     ) {
         $this->filesystem = new Filesystem();
     }
 
     public function configExists(string $filename): bool
     {
+        // In debug mode, the compiled config is ignored so the dev environment always
+        // recomputes assets from source instead of reading metadata that another
+        // environment (e.g. a prior "asset-map:compile" run) may have left behind.
+        if ($this->debug) {
+            return false;
+        }
+
         return is_file(Path::join($this->directory, $filename));
     }
 

--- a/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/AssetMapperTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\AssetMapper\AssetMapperRepository;
 use Symfony\Component\AssetMapper\CompiledAssetMapperConfigReader;
 use Symfony\Component\AssetMapper\Factory\MappedAssetFactoryInterface;
 use Symfony\Component\AssetMapper\MappedAsset;
+use Symfony\Component\Filesystem\Filesystem;
 
 class AssetMapperTest extends TestCase
 {
@@ -52,6 +53,29 @@ class AssetMapperTest extends TestCase
 
         // check the manifest is used
         $this->assertSame('/final-assets/file4.checksumfrommanifest.js', $assetMapper->getPublicPath('file4.js'));
+    }
+
+    public function testCompiledManifestIsIgnoredInDebugMode()
+    {
+        $repository = new AssetMapperRepository(['dir1' => '', 'dir2' => '', 'dir3' => ''], __DIR__.'/Fixtures');
+
+        $filesystem = new Filesystem();
+        $writableRoot = __DIR__.'/Fixtures/debug_compiled_manifest';
+        $filesystem->dumpFile($writableRoot.'/manifest.json', json_encode(['file1.css' => '/from-manifest/file1.css']));
+
+        try {
+            $factory = $this->createStub(MappedAssetFactoryInterface::class);
+            $factory->method('createMappedAsset')
+                ->willReturn(new MappedAsset('file1.css', publicPath: '/dynamically-computed/file1.css'));
+
+            // debug: true -> the compiled manifest is ignored, the public path is computed dynamically
+            $debugReader = new CompiledAssetMapperConfigReader($writableRoot, true);
+            $assetMapper = new AssetMapper($repository, $factory, $debugReader);
+
+            $this->assertSame('/dynamically-computed/file1.css', $assetMapper->getPublicPath('file1.css'));
+        } finally {
+            $filesystem->remove($writableRoot);
+        }
     }
 
     public function testAllAssets()

--- a/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/CompiledAssetMapperConfigReaderTest.php
@@ -44,6 +44,18 @@ class CompiledAssetMapperConfigReaderTest extends TestCase
         $this->assertTrue($reader->configExists('foo.json'));
     }
 
+    public function testConfigExistsIsIgnoredInDebugMode()
+    {
+        $this->filesystem->touch($this->writableRoot.'/foo.json');
+
+        $prodReader = new CompiledAssetMapperConfigReader($this->writableRoot, false);
+        $this->assertTrue($prodReader->configExists('foo.json'));
+
+        // in debug, compiled config must be ignored so dev computes assets dynamically
+        $debugReader = new CompiledAssetMapperConfigReader($this->writableRoot, true);
+        $this->assertFalse($debugReader->configExists('foo.json'));
+    }
+
     public function testLoadConfig()
     {
         $reader = new CompiledAssetMapperConfigReader($this->writableRoot);

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -273,6 +273,42 @@ class ImportMapGeneratorTest extends TestCase
         $this->assertEquals($expectedData, $manager->getRawImportMapData());
     }
 
+    public function testGetRawImportMapDataUsesCompiledFileWhenNotDebug()
+    {
+        $compiledData = ['app' => ['path' => '/assets/app-compiled.js', 'type' => 'js']];
+
+        $this->compiledConfigReader = new CompiledAssetMapperConfigReader(self::$writableRoot, debug: false);
+        $this->compiledConfigReader->saveConfig(ImportMapGenerator::IMPORT_MAP_CACHE_FILENAME, $compiledData);
+
+        $manager = $this->createImportMapGenerator();
+        // the live configuration resolves to a different path; the compiled file must win
+        $this->mockImportMap([self::createLocalEntry('app', path: 'app.js')]);
+        $this->mockAssetMapper([new MappedAsset('app.js', publicPath: '/assets/app-live.js')]);
+
+        $this->assertSame($compiledData, $manager->getRawImportMapData());
+    }
+
+    public function testGetRawImportMapDataIgnoresCompiledFileInDebug()
+    {
+        $compiledData = ['app' => ['path' => '/assets/app-compiled.js', 'type' => 'js']];
+
+        $this->compiledConfigReader = new CompiledAssetMapperConfigReader(self::$writableRoot, debug: true);
+        $this->compiledConfigReader->saveConfig(ImportMapGenerator::IMPORT_MAP_CACHE_FILENAME, $compiledData);
+
+        $manager = $this->createImportMapGenerator();
+        $this->mockImportMap([self::createLocalEntry('app', path: 'app.js')]);
+        $this->mockAssetMapper([new MappedAsset('app.js', publicPath: '/assets/app-live.js')]);
+        $this->configReader
+            ->method('convertPathToFilesystemPath')
+            ->willReturnCallback(static fn (string $path) => str_starts_with($path, '.') ? Path::join('/fake/root', $path) : $path);
+
+        // debug ignores the compiled importmap.json and recomputes from source
+        $this->assertSame(
+            ['app' => ['path' => '/assets/app-live.js', 'type' => 'js']],
+            $manager->getRawImportMapData(),
+        );
+    }
+
     public static function getRawImportMapDataTests(): iterable
     {
         yield 'it returns remote downloaded entry' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #...
| License       | MIT

AssetMapper resolves assets in two ways:

* in debug, from source, with the importmap computed per request and files served by the dev server;
* in production, from compiled metadata generated by `asset-map:compile`.

In that case, the app serves the compiled build instead of resolving assets from source, and source changes no longer appear until `public/assets/` metadata files are cleared, as currently [documented](https://symfony.com/doc/current/frontend/asset_mapper.html#serving-assets-in-dev-vs-prod).

<img width="837" height="163" alt="screen capture of the documentation part mentioning this problem" src="https://github.com/user-attachments/assets/c99cb424-1359-4195-b89a-bfac2ff220a3" />

## Ignore compiled metadata in debug

This PR makes `CompiledAssetMapperConfigReader::configExists()` return `false` in debug, so compiled metadata is ignored and assets are resolved from source.

`asset-map:compile` and production behavior are unchanged.
 