### PR TITLE
[WebProfilerBundle] Make the profiler panels keyboard and screen reader accessible

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -162,6 +162,10 @@
             background: var(--tree-active-background);
             font-weight: bold;
         }
+        .tree .tree-inner:focus-visible {
+            outline: 1px solid var(--color-link);
+            outline-offset: -1px;
+        }
         .tree-details .toggle-icon {
             width: 16px;
             height: 16px;
@@ -224,20 +228,25 @@
                 const treeItems = document.querySelectorAll('.tree .tree-inner');
                 treeItems.forEach((treeItem) => {
                     const targetId = treeItem.getAttribute('data-tab-target-id');
-                    const target = document.getElementById(targetId);
 
-                    if (!target) {
+                    if (!document.getElementById(targetId)) {
                         throw `Tab target ${targetId} does not exist`;
                     }
 
                     treeItem.addEventListener('click', (e) => {
                         this.#selectTreeItem(treeItem);
+                        this.#setRovingTabindex(treeItem);
+                        treeItem.focus();
 
                         e.stopPropagation();
                         return false;
                     });
 
-                    target.classList.add('hidden');
+                    /* left/right/up/down/home/end move focus and selection through the tree */
+                    /* (www.w3.org/WAI/ARIA/apg/patterns/treeview/#keyboardinteraction) */
+                    treeItem.addEventListener('keydown', (e) => {
+                        this.#handleTreeKeydown(e, treeItem);
+                    });
                 });
 
                 if (treeItems.length > 0) {
@@ -255,6 +264,7 @@
 
                 if (this.#activeTreeItem) {
                     this.#activeTreeItem.classList.remove('active');
+                    this.#activeTreeItem.setAttribute('aria-selected', 'false');
                 }
 
                 if (this.#activeTreePanel) {
@@ -262,10 +272,94 @@
                 }
 
                 treeItem.classList.add('active');
+                treeItem.setAttribute('aria-selected', 'true');
                 treePanel.classList.remove('hidden');
 
                 this.#activeTreeItem = treeItem;
                 this.#activeTreePanel = treePanel;
+            }
+
+            #hasChildren(treeItem) {
+                return null !== this.#getChildrenGroup(treeItem);
+            }
+
+            #getChildrenGroup(treeItem) {
+                return treeItem.parentElement.querySelector(':scope > ul[role=group]');
+            }
+
+            #isExpanded(treeItem) {
+                const group = this.#getChildrenGroup(treeItem);
+
+                return null !== group && !group.classList.contains('hidden');
+            }
+
+            #getParentTreeItem(treeItem) {
+                const group = treeItem.closest('ul[role=group]');
+                const parentLi = group ? group.closest('li') : null;
+
+                return parentLi ? parentLi.querySelector(':scope > .tree-inner') : null;
+            }
+
+            #getVisibleTreeItems() {
+                return Array.from(document.querySelectorAll('.tree .tree-inner')).filter((treeItem) => {
+                    const group = treeItem.closest('ul[role=group]');
+
+                    return !group || !group.classList.contains('hidden');
+                });
+            }
+
+            #setRovingTabindex(treeItem) {
+                document.querySelectorAll('.tree .tree-inner').forEach((item) => {
+                    item.setAttribute('tabindex', item === treeItem ? '0' : '-1');
+                });
+            }
+
+            #handleTreeKeydown(e, treeItem) {
+                const key = e.key;
+                const visibleItems = this.#getVisibleTreeItems();
+                const currentIndex = visibleItems.indexOf(treeItem);
+                let newItem = null;
+
+                if ('ArrowDown' === key || 'ArrowUp' === key) {
+                    e.preventDefault();
+                    const newIndex = (currentIndex + ('ArrowDown' === key ? 1 : -1) + visibleItems.length) % visibleItems.length;
+                    newItem = visibleItems[newIndex];
+                } else if ('ArrowRight' === key) {
+                    e.preventDefault();
+                    if (this.#hasChildren(treeItem) && !this.#isExpanded(treeItem)) {
+                        this.#expandToggler(treeItem.querySelector('.toggle-button'));
+                        newItem = treeItem;
+                    } else if (this.#hasChildren(treeItem)) {
+                        newItem = visibleItems[currentIndex + 1] || treeItem;
+                    }
+                } else if ('ArrowLeft' === key) {
+                    e.preventDefault();
+                    if (this.#hasChildren(treeItem) && this.#isExpanded(treeItem)) {
+                        this.#collapseToggler(treeItem.querySelector('.toggle-button'));
+                        newItem = treeItem;
+                    } else {
+                        newItem = this.#getParentTreeItem(treeItem) || treeItem;
+                    }
+                } else if ('Home' === key) {
+                    e.preventDefault();
+                    newItem = visibleItems[0];
+                } else if ('End' === key) {
+                    e.preventDefault();
+                    newItem = visibleItems[visibleItems.length - 1];
+                } else if (' ' === key || 'Enter' === key) {
+                    e.preventDefault();
+                    this.#selectTreeItem(treeItem);
+
+                    return;
+                } else {
+                    return;
+                }
+
+                if (newItem) {
+                    this.#selectTreeItem(newItem);
+                    this.#setRovingTabindex(newItem);
+                    newItem.focus();
+                }
             }
 
             #initTogglerButtons() {
@@ -325,6 +419,7 @@
                 if (this.#isTogglerCollapsed(button)) {
                     button.classList.remove('closed');
                     target.classList.remove('hidden');
+                    button.closest('.tree-inner')?.setAttribute('aria-expanded', 'true');
 
                     this.#togglerStates[targetId] = 1;
                     this.#saveTogglerStates();
@@ -342,6 +437,7 @@
                 if (this.#isTogglerExpanded(button)) {
                     button.classList.add('closed');
                     target.classList.add('hidden');
+                    button.closest('.tree-inner')?.setAttribute('aria-expanded', 'false');
 
                     this.#togglerStates[targetId] = 0;
                     this.#saveTogglerStates();
@@ -386,9 +482,9 @@
     {% if collector.data.forms|length %}
         <div class="tree-wrapper">
             <div id="tree-menu" class="tree">
-                <ul>
+                <ul role="tree" aria-label="Forms">
                 {% for formName, formData in collector.data.forms %}
-                    {{ _self.form_tree_entry(formName, formData, true) }}
+                    {{ _self.form_tree_entry(formName, formData, true, 1, collector.data.forms|length, loop.index, loop.first) }}
                 {% endfor %}
                 </ul>
             </div>
@@ -406,31 +502,43 @@
     {% endif %}
 {% endblock %}
 
-{% macro form_tree_entry(name, data, is_root) %}
+{% macro form_tree_entry(name, data, is_root, level, setsize, posinset, is_first) %}
     {% set has_error = data.errors is defined and data.errors|length > 0 %}
-    <li>
-        <div class="tree-inner" data-tab-target-id="{{ data.id }}-details" title="{{ name|default('(no name)') }}">
+    {% set has_descendant_error = data.has_children_error|default(false) %}
+    {% set is_expanded_initially = is_root or has_descendant_error %}
+    <li role="none">
+        <div class="tree-inner"
+            role="treeitem"
+            tabindex="{{ is_first ? '0' : '-1' }}"
+            aria-selected="{{ is_first ? 'true' : 'false' }}"
+            {% if data.children is not empty %}aria-expanded="{{ is_expanded_initially ? 'true' : 'false' }}"{% endif %}
+            data-tab-target-id="{{ data.id }}-details"
+            title="{{ name|default('(no name)') }}"
+            aria-level="{{ level }}"
+            aria-setsize="{{ setsize }}"
+            aria-posinset="{{ posinset }}"
+            aria-label="{{ name|default('(no name)') }}{% if has_error %}, {{ data.errors|length }} error{{ data.errors|length > 1 ? 's' }}{% elseif has_descendant_error %}, contains errors{% endif %}">
             {% if has_error %}
                 <div class="badge-error">{{ data.errors|length }}</div>
             {% endif %}
 
             {% if data.children is not empty %}
-                <button class="toggle-button" data-toggle-target-id="{{ data.id }}-children">
+                <button class="toggle-button" data-toggle-target-id="{{ data.id }}-children" tabindex="-1" aria-hidden="true">
                     {{ source('@WebProfiler/Icon/chevron-down.svg') }}
                 </button>
             {% else %}
                 <div class="toggle-icon empty"></div>
             {% endif %}
 
-            <span {% if has_error or data.has_children_error|default(false) %}class="has-error"{% endif %}>
+            <span {% if has_error or has_descendant_error %}class="has-error"{% endif %}>
                 {{ name|default('(no name)') }}
             </span>
         </div>
 
         {% if data.children is not empty %}
-            <ul id="{{ data.id }}-children" {% if not is_root and not data.has_children_error|default(false) %}class="hidden"{% endif %}>
+            <ul role="group" id="{{ data.id }}-children" {% if not is_expanded_initially %}class="hidden"{% endif %}>
                 {% for childName, childData in data.children %}
-                    {{ _self.form_tree_entry(childName, childData, false) }}
+                    {{ _self.form_tree_entry(childName, childData, false, level + 1, data.children|length, loop.index, false) }}
                 {% endfor %}
             </ul>
         {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -131,6 +131,7 @@
                 <th colspan="2" class="sf-toggle"
                     data-toggle-selector="#message-item-{{ discr }}-{{ loop.index0 }}-details"
                     data-toggle-initial="{{ loop.first ? 'display' }}"
+                    data-toggle-label="Toggle message details"
                 >
                     <span class="dump-inline">{{ profiler_dump(dispatchCall.message.type) }}</span>
                     {% if dispatchCall.exception is defined %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -46,7 +46,7 @@
                     tabNavigationItem.setAttribute('aria-controls', tabId);
                     if (tab.classList.contains('active')) { selectedTabId = tabId; }
                     if (tab.classList.contains('disabled')) {
-                        tabNavigationItem.classList.add('disabled');
+                        tabNavigationItem.disabled = true;
                     } else if (null === firstEnabledTabId) {
                         firstEnabledTabId = tabId;
                     }
@@ -62,15 +62,35 @@
                 document.querySelector('[data-tab-id="' + selectedTabId + '"]').classList.add('active');
             });
 
+            /* activates a tab: shows its panel and hides the others in the same group */
+            const activateTab = (tab) => {
+                Array.from(tab.parentNode.children).forEach((tabOfGroup) => {
+                    const tabId = tabOfGroup.getAttribute('data-tab-id');
+                    document.getElementById(tabId).className = 'hidden';
+                    tabOfGroup.classList.remove('active');
+                    tabOfGroup.removeAttribute('aria-selected');
+                    tabOfGroup.setAttribute('tabindex', '-1');
+                });
+
+                tab.classList.add('active');
+                tab.setAttribute('aria-selected', 'true');
+                tab.removeAttribute('tabindex');
+                const activeTabId = tab.getAttribute('data-tab-id');
+                document.getElementById(activeTabId).className = 'block';
+            };
+
             /* display the active tab and add the 'click' event listeners */
             tabGroups.forEach((tabGroup) => {
                 const tabs = tabGroup.querySelectorAll(':scope > .tab-navigation .tab-control');
                 tabs.forEach((tab) => {
                     const tabId = tab.getAttribute('data-tab-id');
                     const tabPanel = document.getElementById(tabId);
+                    const tabPanelTitle = tabPanel.querySelector('.tab-title');
                     tabPanel.setAttribute('role', 'tabpanel');
-                    tabPanel.setAttribute('aria-labelledby', tabId);
-                    tabPanel.querySelector('.tab-title').className = 'hidden';
+                    tabPanel.setAttribute('tabindex', '0');
+                    tabPanelTitle.id = `${tabId}-label`;
+                    tabPanel.setAttribute('aria-labelledby', tabPanelTitle.id);
+                    tabPanelTitle.classList.add('hidden');
 
                     if (tab.classList.contains('active')) {
                         tabPanel.className = 'block';
@@ -91,21 +111,30 @@
                             activeTab = activeTab.parentNode;
                         }
 
-                        /* get the full list of tabs through the parent of the active tab element */
-                        const tabs = Array.from(activeTab.parentNode.children);
-                        tabs.forEach((tab) => {
-                            const tabId = tab.getAttribute('data-tab-id');
-                            document.getElementById(tabId).className = 'hidden';
-                            tab.classList.remove('active');
-                            tab.removeAttribute('aria-selected');
-                            tab.setAttribute('tabindex', '-1');
-                        });
+                        activateTab(activeTab);
+                    });
 
-                        activeTab.classList.add('active');
-                        activeTab.setAttribute('aria-selected', 'true');
-                        activeTab.removeAttribute('tabindex');
-                        const activeTabId = activeTab.getAttribute('data-tab-id');
-                        document.getElementById(activeTabId).className = 'block';
+                    /* left/right arrow keys move focus to the previous/next tab and activate it */
+                    /* (www.w3.org/WAI/ARIA/apg/patterns/tabs/#keyboardinteraction) */
+                    tab.addEventListener('keydown', function(e) {
+                        const key = e.key;
+                        if ('ArrowLeft' !== key && 'ArrowRight' !== key) {
+                            return;
+                        }
+
+                        e.preventDefault();
+
+                        const tabsOfGroup = Array.from(this.parentNode.children);
+                        const currentIndex = tabsOfGroup.indexOf(this);
+                        let newIndex = currentIndex;
+                        /* skip disabled tabs, without looping forever if they all are */
+                        do {
+                            newIndex = (newIndex + ('ArrowRight' === key ? 1 : -1) + tabsOfGroup.length) % tabsOfGroup.length;
+                        } while (tabsOfGroup[newIndex].disabled && newIndex !== currentIndex);
+
+                        const newTab = tabsOfGroup[newIndex];
+                        activateTab(newTab);
+                        newTab.focus();
                     });
                 });
 
@@ -171,12 +200,42 @@
 
                 element.classList.add('sf-toggle-content');
 
+                /* some toggles are just icons with no accessible name of their own (e.g. the */
+                /* stack trace expand/collapse controls): wrap those in a real <button> so they */
+                /* get one; toggles that already have visible text (most of them) keep using */
+                /* themselves as the control, since they're already a real <a>/<button> */
+                const iconClose = toggle.querySelector('.icon-close');
+                const iconOpen = toggle.querySelector('.icon-open');
+                let toggleControl = toggle;
+                const firstIcon = iconClose || iconOpen;
+                if (firstIcon) {
+                    /* a button may already wrap the icons in the markup; reuse it instead of */
+                    /* nesting a new one inside it, which would produce invalid, broken HTML */
+                    const existingButton = firstIcon.closest('button');
+                    if (existingButton && toggle.contains(existingButton)) {
+                        toggleControl = existingButton;
+                    } else {
+                        toggleControl = document.createElement('button');
+                        toggleControl.type = 'button';
+                        toggleControl.classList.add('sf-toggle-button');
+                        firstIcon.parentNode.insertBefore(toggleControl, firstIcon);
+                        if (iconClose) { toggleControl.appendChild(iconClose); }
+                        if (iconOpen) { toggleControl.appendChild(iconOpen); }
+                    }
+                    /* fixed label: the toggle's own text is read again right after as normal */
+                    /* content, so reusing it as the button's name would repeat it twice */
+                    toggleControl.setAttribute('aria-label', toggle.getAttribute('data-toggle-label') || 'Toggle details');
+                }
+                toggleControl.setAttribute('aria-controls', element.id);
+
                 if (toggle.hasAttribute('data-toggle-initial') && 'display' === toggle.getAttribute('data-toggle-initial')) {
                     toggle.classList.add('sf-toggle-on');
                     element.classList.add('sf-toggle-visible');
+                    toggleControl.setAttribute('aria-expanded', 'true');
                 } else {
                     toggle.classList.add('sf-toggle-off');
                     element.classList.add('sf-toggle-hidden');
+                    toggleControl.setAttribute('aria-expanded', 'false');
                 }
 
                 toggle.addEventListener('click', (e) => {
@@ -199,6 +258,7 @@
                     toggle.classList.toggle('sf-toggle-off');
                     element.classList.toggle('sf-toggle-hidden');
                     element.classList.toggle('sf-toggle-visible');
+                    toggleControl.setAttribute('aria-expanded', toggle.classList.contains('sf-toggle-on') ? 'true' : 'false');
 
                     /* the toggle doesn't change its contents when clicking on it */
                     if (!toggle.hasAttribute('data-toggle-alt-content')) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -1685,8 +1685,9 @@ tr.status-warning td {
     text-align: center;
     white-space: nowrap;
 }
-.tab-navigation .tab-control.disabled {
+.tab-navigation .tab-control:disabled {
     color: var(--tab-disabled-color);
+    cursor: default;
 }
 .tab-navigation .tab-control.active {
     background-color: var(--tab-active-background);
@@ -1727,6 +1728,18 @@ tr.status-warning td {
 }
 .sf-toggle-content.sf-toggle-visible {
     display: block;
+}
+/* wraps the open/close icons (see #createToggles() in base_js.html.twig); block avoids the empty */
+/* inline-block "strut" height that would otherwise push the content down */
+.sf-toggle-button {
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    display: block;
+    font-size: 0;
+    line-height: 0;
 }
 
 {# Badges


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Makes the profiler's own interface usable with a keyboard and with a screen reader. Three areas, all of them shared by every panel.

**Tabs.** Every tab group now follows the [ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/): left and right arrows move through the tabs and activate them, with a roving `tabindex` so the group is a single tab stop. A panel is labelled by its tab title, through an `aria-labelledby` that points at the title element instead of at the panel itself, which is what it did before. Disabled tabs now carry the real `disabled` property rather than a class, so browsers expose them as unavailable, refuse the click and the arrow keys skip over them; the stylesheet matches on `:disabled` accordingly.

**Toggles.** Toggles that are only an icon, such as the expand and collapse chevrons, have no accessible name and cannot be focused. They are now wrapped in a real `<button>` that carries `aria-controls` and an `aria-expanded` kept in sync on every click. A template can name the control through `data-toggle-label`, which the Messenger panel uses for its message rows; the others fall back to "Toggle details". A toggle that already has visible text keeps using itself as the control, and a button already present in the markup is reused rather than nested inside a new one.

**Forms panel tree.** The field tree becomes a real [tree view](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/): `role="tree"`, `role="group"` and `role="treeitem"`, with `aria-level`, `aria-setsize`, `aria-posinset`, `aria-selected` and `aria-expanded` on each node. Up and down move through the visible nodes, right expands a node then walks into it, left collapses it then walks back to the parent, `Home` and `End` jump to the ends, `Enter` and `Space` select. Focus is visible through a `:focus-visible` outline, and the chevron buttons are hidden from assistive technologies since the expanded state is now carried by the node itself.

Some history, since the description said something else for a while. This started as a copy of the exception page work in #64823, on the premise that `base_js.html.twig` and `profiler.css.twig` had to stay in sync with `exception.js` and `exception.css`. That premise does not hold: inside the profiler the exception panel is rendered by ErrorHandler's own renderer, so nothing here changes it, and the exception page has since been redesigned, which is why #64823 was closed. What is left stands on its own and applies to every profiler panel.

Three bugfixes that were part of this branch went to 6.4 separately in #65423: the Session tab disabled while showing usages, the default tab selection landing on a disabled tab, and href-less `<a>` toggles that cannot be focused.

Verified with the WebProfilerBundle suite (180 tests, 509 assertions) and by parsing the four changed templates. There is no test for the added behaviour: the bundle has no harness that renders collector templates, and none at all for the JavaScript.
