### PR TITLE
[Validator] Add missing French (fr) translation for cron expression

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -568,7 +568,7 @@
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Cette valeur n'est pas une expression cron valide.</target>
+                <target>Cette valeur n'est pas une expression cron valide.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64680
| License       | MIT

Finalizes the missing French (fr) translation for the `This value is not a valid cron expression.` validator message (trans-unit id 146) by reviewing the suggested translation and removing the `needs-review-translation` state.
