### PR TITLE
[Console] Fall back to "stty sane" when restoring the captured terminal state fails

### DIFF
--- a/src/Symfony/Component/Console/Helper/TerminalInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/TerminalInputHelper.php
@@ -59,7 +59,7 @@ final class TerminalInputHelper
                 throw new \RuntimeException('Unable to read the terminal settings.');
             }
 
-            $this->initialState = $state;
+            $this->initialState = trim($state);
 
             $this->createSignalHandlers();
         }
@@ -96,7 +96,13 @@ final class TerminalInputHelper
 
         // Safeguard in case an unhandled kill signal exists
         $this->checkForKillSignal();
-        shell_exec('stty '.$this->initialState);
+
+        // The captured "stty -g" state is not guaranteed to be accepted back by "stty" on every
+        // platform/terminal (e.g. some nested pty implementations reject it with "invalid argument"),
+        // and shell_exec() gives no way to detect that failure. Try the exact restore first so
+        // any custom terminal settings survive, but always fall back to "stty sane" so the
+        // terminal is left in a usable state even when the exact restore silently fails.
+        shell_exec('stty '.$this->initialState.' 2>/dev/null || stty sane');
         $this->signalToKill = 0;
 
         foreach ($this->signalHandlers as $signal => $originalHandler) {
@@ -119,9 +125,12 @@ final class TerminalInputHelper
             $this->signalHandlers[$signal] = pcntl_signal_get_handler($signal);
 
             pcntl_signal($signal, function ($signal) {
-                // Save current state, then restore to initial state
+                // Save current state, then restore to initial state. The original signal
+                // handler is about to run, so fall back to "stty sane" if the exact restore
+                // is rejected by "stty" (see the same fallback in finish()), to make sure it
+                // runs with a usable terminal.
                 $currentState = shell_exec('stty -g');
-                shell_exec('stty '.$this->initialState);
+                shell_exec('stty '.$this->initialState.' 2>/dev/null || stty sane');
                 $originalHandler = $this->signalHandlers[$signal];
 
                 if (\is_callable($originalHandler)) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/terminal_input_helper_bad_state.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/terminal_input_helper_bad_state.php
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\Component\Console\Helper\TerminalInputHelper;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$helper = new TerminalInputHelper(\STDIN);
+
+// Simulate a captured state that "stty" refuses to parse back (as can happen with some
+// nested pty implementations), to exercise the "stty sane" fallback in finish().
+$property = new ReflectionProperty(TerminalInputHelper::class, 'initialState');
+$property->setValue($helper, 'not-a-valid-stty-state');
+
+// Put the terminal in the raw-ish state the question helpers use while reading keypresses.
+shell_exec('stty -icanon -echo');
+
+$helper->finish();

--- a/src/Symfony/Component/Console/Tests/Helper/TerminalInputHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TerminalInputHelperTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Terminal;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+
+class TerminalInputHelperTest extends TestCase
+{
+    /**
+     * @group tty
+     */
+    public function testFinishFallsBackToSttySaneWhenInitialStateIsInvalid()
+    {
+        if (!Terminal::hasSttyAvailable()) {
+            $this->markTestSkipped('stty not available');
+        }
+
+        $previousSttyMode = shell_exec('stty -g');
+
+        $p = new Process(['php', __DIR__.'/../Fixtures/terminal_input_helper_bad_state.php']);
+        try {
+            $p->setTty(true);
+            $p->run();
+        } catch (RuntimeException $e) {
+            if (str_contains($e->getMessage(), '/dev/tty')) {
+                $this->markTestSkipped('/dev/tty is not read/writable in this environment.');
+            }
+
+            throw $e;
+        }
+
+        // Tokenize instead of matching substrings: "-echo" is also a substring of the
+        // unrelated flags "-echonl" and "-echoprt", which are off by default.
+        $flags = preg_split('/\s+/', trim(shell_exec('stty -a')));
+
+        // Restore the terminal to how it was before running the test, now that we have read
+        // the state left by the fixture script.
+        shell_exec('stty '.trim($previousSttyMode).' 2>/dev/null || stty sane');
+
+        $this->assertSame(0, $p->getExitCode());
+        $this->assertContains('echo', $flags);
+        $this->assertContains('icanon', $flags);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT


On some terminal/pty implementations, the state string captured via
"stty -g" is rejected by "stty" when replayed, and shell_exec() gives
no way to detect that failure. This leaves the terminal in raw mode
(no echo) after a question is asked. Try the exact restore first, and
fall back to "stty sane" only when it fails, so the terminal always
ends up usable.

---

Demo, as far as you can understand, this is not easy :) 

```
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane +) cat test.php 
<?php

require __DIR__.'/vendor/autoload.php';

$question = new \Symfony\Component\Console\Question\Question('What is your name?');
$question->setAutocompleterValues(['John', 'Jane', 'Jack', 'Jill']);

$questionHelper = new \Symfony\Component\Console\Helper\QuestionHelper();
$questionHelper->ask(new \Symfony\Component\Console\Input\ArrayInput([]), new \Symfony\Component\Console\Output\ConsoleOutput(), $question);
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane +) php test.php 
What is your name?John
stty: invalid argument '2502:5:f00bf:8a3b:3:1c:7f:15:4:0:1:0:11:13:1a:0:12:f:17:16:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0'
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane +)                ## <= Here I typed `echo "...."`, but I can't see anything
I type something but I cant see my command line
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane +)                ## <= Here I typed `stty sane`, bit I can't see anything
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane +) !!
stty sane
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane +) echo "I type something but I cant see my command line"
I type something but I cant see my command line
```


Once fixed: 

```
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane) php test.php 
What is your name?John
>…ome/gregoire/dev/github.com/lyrixx/symfony(console-stty-sane) ls
CHANGELOG-6.0.md  CHANGELOG-6.3.md    CONTRIBUTING.md  README.md       UPGRADE-6.2.md  UPGRADE-7.0.md  issue.md           phpunit           splitsh.json  test.php
CHANGELOG-6.1.md  CHANGELOG-6.4.md    CONTRIBUTORS.md  UPGRADE-6.0.md  UPGRADE-6.3.md  composer.json   link               phpunit.xml.dist  src           vendor
CHANGELOG-6.2.md  CODE_OF_CONDUCT.md  LICENSE          UPGRADE-6.1.md  UPGRADE-6.4.md  composer.lock   phpstan.dist.neon  psalm.xml         templates
```