### PR TITLE
[Config] Escape comment-closing sequence in generated config builders

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -450,7 +450,7 @@ public function NAME($value): static
             $comment .= '@deprecated '.$node->getDeprecation($node->getName(), $node->getParent()->getName())['message']."\n";
         }
 
-        return $comment ? ' * '.str_replace("\n", "\n * ", rtrim($comment, "\n"))."\n" : '';
+        return $comment ? ' * '.str_replace(['*/', "\n"], ['*\/', "\n * "], rtrim($comment, "\n"))."\n" : '';
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeWithCommentEnd.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeWithCommentEnd.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Builder\Fixtures;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class NodeWithCommentEnd implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tb = new TreeBuilder('node_with_comment_end');
+        $rootNode = $tb->getRootNode();
+        $rootNode
+            ->children()
+                ->scalarNode('schedule')
+                    ->info('Cron expression for when syncs should run, e.g. */30 * * * *')
+                    ->example('*/30 * * * *')
+                    ->defaultValue('*/30 * * * *')
+                ->end()
+            ->end()
+        ;
+
+        return $tb;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Builder\ConfigBuilderInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Tests\Builder\Fixtures\AddToList;
 use Symfony\Component\Config\Tests\Builder\Fixtures\NodeInitialValues;
+use Symfony\Component\Config\Tests\Builder\Fixtures\NodeWithCommentEnd;
 use Symfony\Component\DependencyInjection\Loader\Configurator\AbstractConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Filesystem\Filesystem;
@@ -149,6 +150,27 @@ class GeneratedConfigTest extends TestCase
         $configBuilder = $this->generateConfigBuilder(NodeInitialValues::class);
         $this->expectException(InvalidConfigurationException::class);
         $configBuilder->someCleverName(['not_exists' => 'foo']);
+    }
+
+    /**
+     * A node comment (info, example, default value...) may contain a comment-closing
+     * sequence, which must not prematurely close the generated docblock and break the file.
+     */
+    public function testCommentEndInNodeCommentDoesNotBreakGeneratedFile()
+    {
+        $outputDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('sf_config_builder', true);
+        $this->tempDir[] = $outputDir;
+
+        (new ConfigBuilderGenerator($outputDir))->build(new NodeWithCommentEnd());
+
+        $generatedFile = $outputDir.'/Symfony/Config/NodeWithCommentEndConfig.php';
+        $this->assertFileExists($generatedFile);
+        $generatedCode = file_get_contents($generatedFile);
+
+        // token_get_all() with TOKEN_PARSE throws a ParseError on invalid PHP, which is
+        // exactly what an unescaped comment-closing sequence in a docblock would produce.
+        $this->assertIsArray(token_get_all($generatedCode, \TOKEN_PARSE));
+        $this->assertStringContainsString('*\/30 * * * *', $generatedCode);
     }
 
     public function testSetExtraKeyMethodIsNotGeneratedWhenAllowExtraKeysIsFalse()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64817
| License       | MIT

`ConfigBuilderGenerator` inlines a node's `info`, `@example`, `@default` and `@deprecated` text into the generated `/** ... */` docblock without escaping it. When any of those values contains a comment-closing sequence (`*/`) — e.g. a default cron expression such as `*/30 * * * *`, or an `info` string mentioning one — the docblock is closed prematurely and the generated config-builder class becomes invalid PHP (fatal parse error).

#### How to reproduce

```php
$treeBuilder->getRootNode()
    ->children()
        ->scalarNode('schedule')
            ->info('Cron expression, e.g. */30 * * * *')
            ->defaultValue('*/30 * * * *')
        ->end()
    ->end()
;
```

#### Before

The generated `Config` class contains a broken docblock (the `*/` inside `@default` ends the comment early, leaking the rest as PHP):

```
/**
 * Cron expression, e.g. */30 * * * *
 * @default '*/30 * * * *'
 * @param ParamConfigurator|scalar $value
 *
 * @return $this
 */
public function schedule($value): static
```

→ `PHP Parse error: syntax error ...`

#### After

The comment-closing sequence is escaped, so it can no longer terminate the docblock and the generated file is valid PHP:

```
/**
 * Cron expression, e.g. * /30 * * * *
 * @default '* /30 * * * *'
 * @param ParamConfigurator|scalar $value
 *
 * @return $this
 */
public function schedule($value): static
```

The fix lives in `getComment()`, the single place where the comment body is assembled. The generator never legitimately emits `*/` in its own annotations, so the change is safe and only affects the text of generated comments.

A regression test generates a builder from a node whose `info`/`example`/`default` contain `*/` and asserts the generated file parses as valid PHP.
