### PR TITLE
[Config] Escape comment-closing sequence in generated config builders

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -450,7 +450,7 @@ public function NAME($value): static
             $comment .= '@deprecated '.$node->getDeprecation($node->getName(), $node->getParent()->getName())['message']."\n";
         }
 
-        return $comment ? ' * '.str_replace("\n", "\n * ", rtrim($comment, "\n"))."\n" : '';
+        return $comment ? ' * '.str_replace(['*/', "\n"], ['* /', "\n * "], rtrim($comment, "\n"))."\n" : '';
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeWithCommentEnd.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeWithCommentEnd.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Builder\Fixtures;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class NodeWithCommentEnd implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tb = new TreeBuilder('node_with_comment_end');
+        $rootNode = $tb->getRootNode();
+        $rootNode
+            ->children()
+                ->scalarNode('schedule')
+                    ->info('Cron expression for when syncs should run, e.g. */30 * * * *')
+                    ->example('*/30 * * * *')
+                    ->defaultValue('*/30 * * * *')
+                ->end()
+            ->end()
+        ;
+
+        return $tb;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -151,6 +151,25 @@ class GeneratedConfigTest extends TestCase
         $configBuilder->someCleverName(['not_exists' => 'foo']);
     }
 
+    /**
+     * A node comment (info, example, default value...) may contain a comment-closing
+     * sequence, which must not prematurely close the generated docblock and break the file.
+     */
+    public function testCommentEndInNodeCommentDoesNotBreakGeneratedFile()
+    {
+        $outputDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('sf_config_builder', true);
+        $this->tempDir[] = $outputDir;
+
+        (new ConfigBuilderGenerator($outputDir))->build(new Fixtures\NodeWithCommentEnd());
+
+        $generatedFile = $outputDir.'/Symfony/Config/NodeWithCommentEndConfig.php';
+        $this->assertFileExists($generatedFile);
+
+        // token_get_all() with TOKEN_PARSE throws a ParseError on invalid PHP, which is
+        // exactly what an unescaped comment-closing sequence in a docblock would produce.
+        $this->assertIsArray(token_get_all(file_get_contents($generatedFile), \TOKEN_PARSE));
+    }
+
     public function testSetExtraKeyMethodIsNotGeneratedWhenAllowExtraKeysIsFalse()
     {
         /** @var AddToListConfig $configBuilder */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 for features / 6.4, 7.4, 8.0, 8.1 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
