### PR TITLE
[ObjectMapper] Resolve a nested reverse-mapped property by the type of its destination

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -175,7 +175,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $value = $this->getSourceValue($source, $mappedTarget, $value, $objectMap, $mapping);
+                $value = $this->getSourceValue($source, $mappedTarget, $value, $objectMap, $mapping, $targetPropertyName);
                 $explicitTargets[$targetPropertyName] = true;
                 $this->storeValue($targetPropertyName, $mapToProperties, $ctorArguments, $value);
             }
@@ -190,7 +190,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap);
+                $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap, null, $propertyName);
             }
         }
 
@@ -279,7 +279,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         return $source->{$propertyName};
     }
 
-    private function getSourceValue(object $source, object $target, mixed $value, \WeakMap $objectMap, ?Mapping $mapping = null): mixed
+    private function getSourceValue(object $source, object $target, mixed $value, \WeakMap $objectMap, ?Mapping $mapping = null, ?string $targetPropertyName = null): mixed
     {
         if ($mapping?->transform) {
             $value = $this->applyTransforms($mapping, $value, $source, $target);
@@ -288,6 +288,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         if (
             \is_object($value)
             && ($innerMetadata = $this->metadataFactory->create($value))
+            && ($innerMetadata = $this->filterMetadataByPropertyType($innerMetadata, $target, $targetPropertyName))
             && ($mapTo = $this->getMapTarget($innerMetadata, $value, $source, $target, true))
             && (\is_string($mapTo->target) && class_exists($mapTo->target))
         ) {
@@ -368,6 +369,40 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         return $mapTo;
+    }
+
+    /**
+     * Narrows the mappings of a nested object to the one matching the declared type of the property it is mapped into.
+     *
+     * A nested class declaring several #[Map] targets yields one Mapping per target. When the
+     * destination property is typed, only one of them can be assigned to it, so the mapping is not ambiguous.
+     *
+     * @param Mapping[] $metadata
+     *
+     * @return Mapping[]
+     */
+    private function filterMetadataByPropertyType(array $metadata, object $target, ?string $targetPropertyName): array
+    {
+        if (null === $targetPropertyName || 2 > \count($metadata)) {
+            return $metadata;
+        }
+
+        if (!$property = $this->getPropertyFromHierarchy(new \ReflectionClass($target), $targetPropertyName)) {
+            return $metadata;
+        }
+
+        $type = $property->getType();
+        if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+            return $metadata;
+        }
+
+        $propertyClass = $type->getName();
+        $filtered = array_values(array_filter($metadata, static fn (Mapping $m): bool => \is_string($m->target)
+            && class_exists($m->target)
+            && is_a($m->target, $propertyClass, true)
+        ));
+
+        return 1 === \count($filtered) ? $filtered : $metadata;
     }
 
     private function applyTransforms(Mapping $map, mixed $value, object $source, ?object $target): mixed

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerInterface.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+interface InnerInterface
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerSource.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: InnerTargetA::class)]
+#[Map(target: InnerTargetB::class)]
+class InnerSource
+{
+    public string $value = 'inner-value';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerTargetA.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerTargetA.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+class InnerTargetA implements InnerInterface
+{
+    public string $value;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerTargetB.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/InnerTargetB.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+class InnerTargetB implements InnerInterface
+{
+    public string $value;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterSource.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: OuterTarget::class)]
+#[Map(target: OuterTargetWithUntypedProperty::class)]
+#[Map(target: OuterTargetWithInterfaceProperty::class)]
+class OuterSource
+{
+    public InnerSource $inner;
+
+    public function __construct()
+    {
+        $this->inner = new InnerSource();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterSourceWithRenamedProperty.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterSourceWithRenamedProperty.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: OuterTargetWithRenamedProperty::class)]
+class OuterSourceWithRenamedProperty
+{
+    #[Map(target: 'nested')]
+    public InnerSource $inner;
+
+    public function __construct()
+    {
+        $this->inner = new InnerSource();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+class OuterTarget
+{
+    public InnerTargetA $inner;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithInterfaceProperty.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithInterfaceProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+class OuterTargetWithInterfaceProperty
+{
+    public InnerInterface $inner;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithRenamedProperty.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithRenamedProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+class OuterTargetWithRenamedProperty
+{
+    public InnerTargetA $nested;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithUntypedProperty.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithUntypedProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+class OuterTargetWithUntypedProperty
+{
+    public $inner;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -86,6 +86,13 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransfor
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ChildWithoutClassTransformerTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\InnerTargetA;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterSource as MultiTargetOuterSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterSourceWithRenamedProperty;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTarget as MultiTargetOuterTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTargetWithInterfaceProperty;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTargetWithRenamedProperty;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTargetWithUntypedProperty;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\ChildEntity;
@@ -817,6 +824,47 @@ final class ObjectMapperTest extends TestCase
         $source = new MultipleTargetPropertyA();
         $mapper = new ObjectMapper();
         $mapper->map($source);
+    }
+
+    public function testNestedPropertyWithSeveralMapTargetsIsResolvedByItsDeclaredType()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new MultiTargetOuterSource(), MultiTargetOuterTarget::class);
+
+        $this->assertInstanceOf(InnerTargetA::class, $target->inner);
+        $this->assertSame('inner-value', $target->inner->value);
+    }
+
+    public function testNestedRenamedPropertyWithSeveralMapTargetsIsResolvedByItsDeclaredType()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new OuterSourceWithRenamedProperty());
+
+        $this->assertInstanceOf(OuterTargetWithRenamedProperty::class, $target);
+        $this->assertInstanceOf(InnerTargetA::class, $target->nested);
+        $this->assertSame('inner-value', $target->nested->value);
+    }
+
+    public function testNestedPropertyWithSeveralMapTargetsThrowsWhenUntyped()
+    {
+        $mapper = new ObjectMapper();
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Ambiguous mapping');
+
+        $mapper->map(new MultiTargetOuterSource(), OuterTargetWithUntypedProperty::class);
+    }
+
+    public function testNestedPropertyWithSeveralMapTargetsThrowsWhenTypedWithAnInterfaceBothTargetsImplement()
+    {
+        $mapper = new ObjectMapper();
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Ambiguous mapping');
+
+        $mapper->map(new MultiTargetOuterSource(), OuterTargetWithInterfaceProperty::class);
     }
 
     public function testExplicitMappingTakesPriorityOverImplicitSameNameProperty()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64761
| License       | MIT

`ObjectMapper::getSourceValue()` resolves a nested object-valued property through `getMapTarget(..., enforceUnique: true)` on the nested value's class-level metadata. When that class declares several `#[Map]` targets, the second candidate throws `Ambiguous mapping` before the declared type of the destination property is ever consulted, even though only one candidate can be assigned to it.

The fix threads the destination property name into `getSourceValue()` and narrows the candidates to the single one assignable to the property's declared named, non-builtin type. In every other case (untyped property, union, interface implemented by several candidates, zero or several assignable survivors) the metadata is returned untouched, so the existing ambiguity guard still fires; the filter never silently picks among several viable candidates.

Retargeted from 8.1 to 7.4: the issue was reported through the 8.1 reverse class map (where the synthesized mappings carry no `if`, leaving no workaround at all), but the underlying order of operations is wrong on 7.4 already with plain attributes: a nested class carrying `#[Map(target: A)] #[Map(target: B)]` mapped into a property typed `A` throws the same exception. The tests use attribute-based fixtures accordingly and cover both call sites (auto-mapped and renamed via `#[Map(target: 'nested')]`), plus two guard-preservation cases (untyped property, interface-typed property that both candidates implement). When merging up to 8.1, class-map based coverage equivalent to the previous revision of this PR can be added on top since the same code path fixes it.
