### PR TITLE
[FrameworkBundle] Keep transport decorators when mock_response_factory is set

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2833,8 +2833,17 @@ class FrameworkExtension extends Extension
             $defaultTransportId = 'http_client.mock_transport';
         }
 
+        $realTransportId = 'http_client.transport';
+
         if ('http_client.transport' !== $defaultTransportId) {
-            $container->getDefinition('http_client')->setArgument(0, [new Reference($defaultTransportId)]);
+            // Decorate "http_client.transport" instead of replacing it as the transport of "http_client", so that
+            // decorators registered on "http_client.transport" remain in the chain when a mock factory is configured.
+            // The highest priority makes the mock the innermost decorator: decorators keep running around it whatever
+            // their own priority. The undecorated transport stays available under "http_client.transport.real" for
+            // scoped clients that opt out with "mock_response_factory: false".
+            $container->getDefinition($defaultTransportId)
+                ->setDecoratedService('http_client.transport', $realTransportId = 'http_client.transport.real', \PHP_INT_MAX);
+            $defaultTransportId = 'http_client.transport';
         }
 
         foreach ($config['scoped_clients'] as $name => $scopeConfig) {
@@ -2852,7 +2861,7 @@ class FrameworkExtension extends Extension
             unset($scopeConfig['retry_failed']);
 
             if (false === $mockResponseFactory = $scopeConfig['mock_response_factory'] ?? $defaultMockResponseFactory) {
-                $transportId = 'http_client.transport';
+                $transportId = $realTransportId;
             } elseif ($mockResponseFactory === $defaultMockResponseFactory) {
                 $transportId = $defaultTransportId;
             } elseif (\is_string($mockResponseFactory)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2578,13 +2578,15 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($container->hasDefinition('.http_client.mock_transport.my_factory'));
         $this->assertTrue($container->hasDefinition('.http_client.mock_transport.my_other_factory'));
 
+        // opted-out clients point at the undecorated real transport, renamed by the mock decoration
         $definition = $container->getDefinition('notMocked');
         $arguments = $definition->getArgument(0);
-        $this->assertSame('http_client.transport', (string) $arguments[0]);
+        $this->assertSame('http_client.transport.real', (string) $arguments[0]);
 
+        // "mocked" inherits the top-level factory, which decorates "http_client.transport" in place
         $definition = $container->getDefinition('mocked');
         $arguments = $definition->getArgument(0);
-        $this->assertSame('.http_client.mock_transport.my_factory', (string) $arguments[0]);
+        $this->assertSame('http_client.transport', (string) $arguments[0]);
 
         $definition = $container->getDefinition('mocked_custom_factory');
         $arguments = $definition->getArgument(0);
@@ -2598,13 +2600,15 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($container->hasDefinition('http_client.mock_transport'));
         $this->assertTrue($container->hasDefinition('.http_client.mock_transport.my_response_factory'));
 
+        // opted-out clients point at the undecorated real transport, renamed by the mock decoration
         $definition = $container->getDefinition('notMocked');
         $arguments = $definition->getArgument(0);
-        $this->assertSame('http_client.transport', (string) $arguments[0]);
+        $this->assertSame('http_client.transport.real', (string) $arguments[0]);
 
+        // "mocked" inherits the top-level boolean factory, which decorates "http_client.transport" in place
         $definition = $container->getDefinition('mocked');
         $arguments = $definition->getArgument(0);
-        $this->assertSame('http_client.mock_transport', (string) $arguments[0]);
+        $this->assertSame('http_client.transport', (string) $arguments[0]);
 
         $definition = $container->getDefinition('mocked_with_factory');
         $arguments = $definition->getArgument(0);
@@ -2615,11 +2619,18 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('http_client_mock_response_factory');
 
+        // The root client keeps using "http_client.transport"; the mock decorates it in place so decorators
+        // registered on "http_client.transport" are preserved.
         $definition = $container->getDefinition('http_client');
         $arguments = $definition->getArgument(0);
         $this->assertCount(1, $arguments);
         $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('.http_client.mock_transport.my_factory', (string) $arguments[0]);
+        $this->assertSame('http_client.transport', (string) $arguments[0]);
+
+        $decoratedService = $container->getDefinition('.http_client.mock_transport.my_factory')->getDecoratedService();
+        $this->assertSame('http_client.transport', $decoratedService[0]);
+        $this->assertSame('http_client.transport.real', $decoratedService[1]);
+        $this->assertSame(\PHP_INT_MAX, $decoratedService[2]);
     }
 
     public function testHttpClientRootClientMockedFromBooleanTopLevel()
@@ -2630,7 +2641,33 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $arguments = $definition->getArgument(0);
         $this->assertCount(1, $arguments);
         $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('http_client.mock_transport', (string) $arguments[0]);
+        $this->assertSame('http_client.transport', (string) $arguments[0]);
+
+        $decoratedService = $container->getDefinition('http_client.mock_transport')->getDecoratedService();
+        $this->assertSame('http_client.transport', $decoratedService[0]);
+        $this->assertSame('http_client.transport.real', $decoratedService[1]);
+        $this->assertSame(\PHP_INT_MAX, $decoratedService[2]);
+    }
+
+    /**
+     * Configuring a mock response factory must decorate "http_client.transport" in place, not replace it as the
+     * transport referenced by "http_client". Otherwise any decorator registered on "http_client.transport" (a
+     * common way to add cross-cutting behavior, e.g. dispatching an event per request) is silently removed from
+     * the chain as soon as a mock factory is configured.
+     */
+    public function testHttpClientMockResponseFactoryKeepsTransportDecoratable()
+    {
+        $container = $this->createContainerFromFile('http_client_mock_response_factory');
+
+        // "http_client" keeps using "http_client.transport", so decorators registered on it stay in the chain.
+        $this->assertSame('http_client.transport', (string) $container->getDefinition('http_client')->getArgument(0)[0]);
+
+        // The mock is wired as the innermost decorator of "http_client.transport", not as its replacement, so
+        // decorators registered with any priority keep wrapping it.
+        $decoratedService = $container->getDefinition('.http_client.mock_transport.my_factory')->getDecoratedService();
+        $this->assertNotNull($decoratedService, 'The mock transport must decorate "http_client.transport".');
+        $this->assertSame('http_client.transport', $decoratedService[0]);
+        $this->assertSame(\PHP_INT_MAX, $decoratedService[2]);
     }
 
     public function testHttpClientRootClientNotMockedByDefault()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Tests/TransportDecorator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Tests/TransportDecorator.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Tests;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Decorates "http_client.transport" with the default decoration priority and records the requests it sees.
+ */
+class TransportDecorator implements HttpClientInterface
+{
+    /** @var list<string> */
+    public static array $requests = [];
+
+    public function __construct(
+        private HttpClientInterface $inner,
+    ) {
+    }
+
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        self::$requests[] = $method.' '.$url;
+
+        return $this->inner->request($method, $url, $options);
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        return $this->inner->stream($responses, $timeout);
+    }
+
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->inner = $this->inner->withOptions($options);
+
+        return $clone;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Tests\TransportDecorator;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -44,5 +45,61 @@ class HttpClientTest extends AbstractWebTestCase
         $browser->request('GET', '/http_client_mock');
 
         self::assertSame($mockedContent, $browser->getResponse()->getContent());
+    }
+
+    public function testTransportDecoratorsKeepRunningWhenMockResponseFactoryIsSet()
+    {
+        TransportDecorator::$requests = [];
+        $client = $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
+
+        $client->request('GET', '/http_client_call');
+
+        $this->assertNotSame([], TransportDecorator::$requests, 'A decorator of "http_client.transport" with the default priority must be invoked while the mock factory is active.');
+
+        $chain = self::collectTransportChain(static::getContainer()->get('http_client'));
+        $this->assertContains(TransportDecorator::class, $chain);
+        $this->assertSame(MockHttpClient::class, end($chain), 'The mock must be the innermost part of the transport chain.');
+    }
+
+    public function testScopedClientCanOptOutFromTheMockResponseFactory()
+    {
+        $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
+
+        $chain = self::collectTransportChain(static::getContainer()->get('test.not_mocked.http_client'));
+        $this->assertNotContains(MockHttpClient::class, $chain, 'A scoped client with "mock_response_factory: false" must not end up on the mock transport.');
+
+        $chain = self::collectTransportChain(static::getContainer()->get('symfony.http_client'));
+        $this->assertSame(MockHttpClient::class, end($chain), 'A scoped client inheriting the top-level factory must end up on the mock transport.');
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private static function collectTransportChain(object $client): array
+    {
+        $chain = [];
+
+        while (true) {
+            $chain[] = $client::class;
+            $inner = null;
+
+            for ($r = new \ReflectionObject($client); $r; $r = $r->getParentClass()) {
+                foreach ($r->getProperties() as $property) {
+                    if ($property->isStatic() || !$property->isInitialized($client)) {
+                        continue;
+                    }
+                    $value = $property->getValue($client);
+                    if ($value instanceof HttpClientInterface) {
+                        $inner = $value;
+                        break 2;
+                    }
+                }
+            }
+
+            if (null === $inner) {
+                return $chain;
+            }
+            $client = $inner;
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/HttpClient/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/HttpClient/config.yml
@@ -9,3 +9,6 @@ framework:
         scoped_clients:
             symfony.http_client:
                 base_uri: 'https://symfony.com'
+            not_mocked.http_client:
+                base_uri: 'https://symfony.com'
+                mock_response_factory: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/HttpClient/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/HttpClient/services.yml
@@ -10,3 +10,13 @@ services:
 
     Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Tests\MockClientCallback:
         class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Tests\MockClientCallback
+
+    # decorates the transport with the default priority; must keep running when the mock factory is active
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Tests\TransportDecorator:
+        decorates: http_client.transport
+        arguments: ['@.inner']
+
+    # keeps the otherwise unreferenced opted-out client alive for the tests
+    test.not_mocked.http_client:
+        alias: not_mocked.http_client
+        public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since #52265, configuring `framework.http_client.mock_response_factory` registers a dedicated mock transport service and repoints `http_client` at it instead of decorating `http_client.transport`. As a side effect, any service decorating `http_client.transport` is silently dropped from the chain once a mock factory is configured: it keeps working in production but stops being invoked as soon as tests set a mock factory, with no error or deprecation. Only user decorators are affected; the built-in retry/caching/scoping/uri-template/throttling/profiler decorators wrap the client services, not the transport.

The mock is now wired as a decorator of `http_client.transport` with the highest priority. Decoration priorities run lower-is-outermost, so this makes the mock the innermost link of the chain: decorators keep running around it whatever their own priority (a plain revert to the pre-#52265 shape, decorating at priority -10, would only preserve decorators registered below -10, and `MockHttpClient` never forwards to `.inner`, so anything inside it is unused code). The undecorated transport stays available under `http_client.transport.real`, and scoped clients declaring `mock_response_factory: false` now reference it, so the opt-out introduced by #52265 keeps hitting the real transport; per-scoped-client factories remain standalone services, unaffected. Note that opted-out clients reach the undecorated transport: the compiled container holds a single decoration chain over `http_client.transport`, so a "user decorators without the mock" variant of it does not exist.

Besides the wiring assertions, the behavior is pinned by functional tests on a fully compiled kernel, where `DecoratorServicePass` actually runs (the DI test harness strips optimization passes, which is why wiring-level tests alone cannot catch these defects): a transport decorator registered with the default priority is invoked while the mock factory is active and the transport chain of the mocked clients ends in `MockHttpClient`, while the chain of the opted-out scoped client never contains it. Both tests fail on the current 8.1 base (the decorator one; the opt-out passes there) and both fail with the mock decorating at -10.
