### PR TITLE
[HttpKernel] Keep converting scalars of a form payload that carries an uploaded file

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -348,7 +348,9 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             foreach (array_pop($stack) as $v) {
                 if (\is_array($v)) {
                     $stack[] = $v;
-                } elseif (!\is_string($v)) {
+                } elseif (!\is_string($v) && !\is_object($v)) {
+                    // uploaded files are merged into the payload of a "form" request; being objects,
+                    // they are not scalars and must not make the payload look like a typed one
                     return true;
                 }
             }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -1215,6 +1215,54 @@ class RequestPayloadValueResolverTest extends TestCase
         $this->assertEquals([$payload], $event->getArguments());
     }
 
+    public function testMapRequestPayloadWithUploadedFileConvertsScalars()
+    {
+        $image = new UploadedFile(self::FIXTURES_BASE_PATH.'/file-small.txt', 'file-small.txt');
+
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new ReflectionExtractor())]);
+        $validator = $this->createStub(ValidatorInterface::class);
+        $validator->method('validate')->willReturn(new ConstraintViolationList());
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $argument = new ArgumentMetadata('data', RequestPayloadWithFileAndScalars::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = Request::create('/', 'POST', ['skuNumber' => '42', 'published' => 'true'], [], ['image' => $image]);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $payload = $event->getArguments()[0];
+        $this->assertSame(42, $payload->skuNumber);
+        $this->assertTrue($payload->published);
+    }
+
+    public function testMapRequestPayloadWithoutUploadedFileConvertsScalars()
+    {
+        $serializer = new Serializer([new ObjectNormalizer(null, null, null, new ReflectionExtractor())]);
+        $validator = $this->createStub(ValidatorInterface::class);
+        $validator->method('validate')->willReturn(new ConstraintViolationList());
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $argument = new ArgumentMetadata('data', RequestPayloadWithFileAndScalars::class, false, false, null, false, [
+            MapRequestPayload::class => new MapRequestPayload(),
+        ]);
+        $request = Request::create('/', 'POST', ['skuNumber' => '42', 'published' => 'true']);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $payload = $event->getArguments()[0];
+        $this->assertSame(42, $payload->skuNumber);
+        $this->assertTrue($payload->published);
+    }
+
     public function testExpressionAsValidationGroup()
     {
         $content = '{"price": 24}';
@@ -1462,6 +1510,13 @@ class RequestPayload
 class RequestPayloadWithFile extends RequestPayload
 {
     public ?UploadedFile $image = null;
+}
+
+class RequestPayloadWithFileAndScalars
+{
+    public ?UploadedFile $image = null;
+    public int $skuNumber = 0;
+    public bool $published = false;
 }
 
 interface SerializerDenormalizer extends SerializerInterface, DenormalizerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64773
| License       | MIT

A `form` payload only ever holds strings, so `RequestPayloadValueResolver` already denormalizes it as `csv` to turn the type conversion on:

```php
return $this->serializer->denormalize($data, $type, self::hasNonStringScalar($data) ? $format : 'csv', ...);
```

But `mergeParamsAndFiles()` puts the uploaded files into `$data` right before, and `hasNonStringScalar()` returns `true` for anything that is not a string — an `UploadedFile` included. So the payload looked like a typed one, the format stayed `form`, and the conversion never ran.

The consequence is the one reported in #64773: as soon as a file is actually uploaded, the `int`, `bool` and `float` properties of the DTO fail to denormalize.

```php
class ProductDto
{
    public ?UploadedFile $image = null;
    public int $skuNumber = 0;
    public bool $published = false;
}
```

An object is not a scalar, so it must not be taken into account by `hasNonStringScalar()`.

### Why not add `form` to the converted formats

The issue suggests adding `'form'` next to `xml` and `csv` in `AbstractObjectNormalizer::denormalize()`. That would change the Serializer's behaviour globally for a format it doesn't own, while the resolver already had the mechanism — it was simply defeated by the uploaded files.

### Note on the trigger

The bug only shows up when a file is really uploaded. Without a file the payload is all strings, `hasNonStringScalar()` returns `false`, and the conversion works. The two added tests differ only by that file:

- `testMapRequestPayloadWithUploadedFileConvertsScalars` fails without the patch (`ValidationFailedException: skuNumber`)
- `testMapRequestPayloadWithoutUploadedFileConvertsScalars` passes before and after, and pins the case down

Both need a `ReflectionExtractor` on the `ObjectNormalizer`: without a type extractor no type is enforced at all and PHP silently coerces the values, which is what makes this bug invisible in a naive test.

`HttpKernel` goes from 1663 to 1665 tests, no other change.

### Base branch

`hasNonStringScalar()` exists since 6.4, but `mergeParamsAndFiles()` — which puts the objects into the payload — landed in 8.1. No object reached that function before, hence 8.1.
