### PR TITLE
[Messenger] Avoid redispatching messages from completed batches

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -18,3 +18,10 @@ parameters:
     ignoreErrors:
         # Added in PHP 8.4
         - '#^Class BcMath\\Number not found\.$#'
+        # DeferredBatchMessage::$acked aliases a bool that batch handlers flip during dispatch()
+        -
+            message: '#^If condition is always false\.$#'
+            path: src/Symfony/Component/Messenger/Worker.php
+        -
+            message: '#^Negated boolean expression is always true\.$#'
+            path: src/Symfony/Component/Messenger/Worker.php

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -41,6 +41,8 @@ use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
 use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
@@ -51,6 +53,7 @@ use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyReceiver;
 use Symfony\Component\Messenger\Tests\Fixtures\ResettableDummyReceiver;
+use Symfony\Component\Messenger\TraceableMessageBus;
 use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
@@ -602,6 +605,85 @@ class WorkerTest extends TestCase
         $worker->run();
 
         $this->assertSame($expectedMessages, $handler->processedMessages);
+    }
+
+    public function testCompletedBatchIsNotRedispatchedWhileWorkerIsIdle()
+    {
+        $expectedMessages = [];
+        $receivedEnvelopes = [];
+        for ($i = 1; $i <= 10; ++$i) {
+            $message = new DummyMessage('message'.$i);
+            $expectedMessages[] = $message;
+            $receivedEnvelopes[] = [new Envelope($message)];
+        }
+
+        $receiver = new DummyReceiver($receivedEnvelopes);
+        $handler = new DummyBatchHandler(batchSize: 10);
+        $clock = new MockClock();
+        $bus = new TraceableMessageBus(new MessageBus([
+            new HandleMessageMiddleware(new HandlersLocator([
+                DummyMessage::class => [new HandlerDescriptor($handler)],
+            ]), clock: $clock),
+        ]));
+
+        $worker = new Worker(['transport' => $receiver], $bus, clock: $clock);
+        $worker->run(['time_limit' => 30]);
+
+        $this->assertSame($expectedMessages, $handler->processedMessages);
+        $this->assertSame(10, $receiver->getAcknowledgeCount());
+        $this->assertCount(10, $bus->getDispatchedMessages());
+    }
+
+    public function testFlushFailureDoesNotRejectAlreadyAckedBatchMessage()
+    {
+        $expectedMessages = [
+            new DummyMessage('Hey'),
+        ];
+
+        $receiver = new DummyReceiver([
+            [new Envelope($expectedMessages[0])],
+            [],
+            [],
+        ]);
+
+        $handler = new DummyBatchHandler();
+
+        $clock = new MockClock();
+        $throwAfterFlush = new class implements MiddlewareInterface {
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                $envelope = $stack->next()->handle($envelope, $stack);
+
+                if ($envelope->last(FlushBatchHandlersStamp::class)) {
+                    throw new \RuntimeException('Flush dispatch failed.');
+                }
+
+                return $envelope;
+            }
+        };
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]), clock: $clock);
+
+        $bus = new MessageBus([$throwAfterFlush, $middleware]);
+        $clock = new MockClock();
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(WorkerRunningEvent::class, function (WorkerRunningEvent $event) use ($clock) {
+            static $i = 0;
+            if (1 === ++$i) {
+                $clock->sleep(30);
+            } else {
+                $event->getWorker()->stop();
+            }
+        });
+
+        $worker = new Worker([$receiver], $bus, $dispatcher, clock: $clock);
+        $worker->run();
+
+        $this->assertSame($expectedMessages, $handler->processedMessages);
+        $this->assertSame(1, $receiver->getAcknowledgeCount());
+        $this->assertSame(0, $receiver->getRejectCount());
     }
 
     public function testFlushBatchOnIdle()

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -304,20 +304,28 @@ class Worker
 
         foreach ($unacks as $handler) {
             $deferredMessage = $unacks[$handler];
+
+            if ($deferredMessage->acked) {
+                continue;
+            }
             $transportName = $deferredMessage->transportName;
             $envelope = $deferredMessage->envelope;
             try {
                 $e = null;
                 $this->bus->dispatch($envelope->with(new FlushBatchHandlersStamp(true === $force || !\is_bool($force))));
             } catch (\Throwable $e) {
-                $envelope = $envelope->withoutAll(NoAutoAckStamp::class);
-                $this->acks[] = [$transportName, $envelope, $e];
+                if (!$deferredMessage->acked) {
+                    $this->acks[] = [$transportName, $envelope->withoutAll(NoAutoAckStamp::class), $e];
+                }
                 continue;
             }
 
+            if ($deferredMessage->acked) {
+                continue;
+            }
             $noAutoAckStamp = $envelope->last(NoAutoAckStamp::class);
 
-            if (!$deferredMessage->acked && !$noAutoAckStamp) {
+            if (!$noAutoAckStamp) {
                 $this->acks[] = [$transportName, $envelope, $e];
             } elseif ($noAutoAckStamp) {
                 $this->unacks ??= new DeferredBatchMessageQueue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This fixes a loop where `Worker` keeps dispatching an envelope after its batch handler has already acknowledged or rejected the message.

## Why it happens

While a batch is waiting for more messages, `Worker` saves one envelope for its batch handler in `DeferredBatchMessageQueue`.

The saved `DeferredBatchMessage` contains two important pieces of state:

- its envelope has `NoAutoAckStamp`, which records that the handler did not acknowledge the message during its first dispatch; and
- its `acked` property refers to the boolean changed later by the message's `Acknowledger`.

When another message fills the batch, the handler processes the batch and calls `ack()` or `nack()` for every message. This changes the saved message's `acked` property to `true`, but its envelope remains in `DeferredBatchMessageQueue` with `NoAutoAckStamp`.

On the next empty worker loop, `Worker::flush()` removes that saved entry and dispatches its envelope with `FlushBatchHandlersStamp`. After the dispatch, the existing code decides whether to save the envelope again:

```php
if (!$deferredMessage->acked && !$noAutoAckStamp) {
    $this->acks[] = [$transportName, $envelope, $e];
} elseif ($noAutoAckStamp) {
    $this->unacks->add(/* ... */);
}
```

For a completed message, the first condition is false because `acked` is `true`. The second condition is still true because the saved envelope keeps `NoAutoAckStamp`. The completed envelope is therefore saved again.

The same steps repeat on every empty worker loop:

1. remove the saved envelope;
2. dispatch it;
3. see `NoAutoAckStamp`; and
4. save it again.

This is an in-process loop; the transport does not return the message again. In the reproduced idle case, the batch is empty, so its `process()` method has no jobs to run. The extra dispatches still run the message bus and its middleware.

## The fix

`Worker::flush()` now checks `DeferredBatchMessage::$acked` twice:

1. **Before dispatch:** the batch may have completed while this envelope was waiting in the flush queue. In that case, no flush dispatch is needed.
2. **After dispatch:** the flush itself may have completed the batch. In that case, the envelope must not be saved again.

A message with `acked === false` follows the existing behavior.

## Test

The regression test sends 10 messages to a batch handler with a batch size of 10. It uses `MockClock` to keep the worker running for 30 simulated seconds after the batch completes.

| Result | Before | After |
| --- | ---: | ---: |
| Messages processed | 10 | 10 |
| Transport acknowledgements | 10 | 10 |
| Message-bus dispatches | 41 | 10 |

Before this fix, the 41 dispatches are the 10 received messages, 30 idle-loop dispatches, and one final dispatch when the worker stops. After this fix, each received message is dispatched exactly once.


## Follow-up changes after review

- The failure path got the same acked guard as the happy path: when the flush dispatch throws after the handler already acked the batch (the exception comes from the middleware chain after `process()` ran), the worker no longer enqueues a reject for an envelope whose ack is already queued, which would double the transport accounting. Covered by a regression test that fails without the guard.
- The PHPStan errors reported by CI on `Worker.php` ("If condition is always false" / "Negated boolean expression is always true") are false positives: `DeferredBatchMessage::$acked` aliases a bool that batch handlers flip during `$this->bus->dispatch()`, which the analyzer cannot see when narrowing the property. Both messages are now ignored for `Worker.php` in `phpstan.dist.neon`; the one genuinely dead recheck in the re-add condition was removed.
