### PR TITLE
[ExpressionLanguage] Add the native PHP `count()` function to the ExpressionLanguage component

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
+++ b/src/Symfony/Component/ExpressionLanguage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `count()` function to ExpressionLanguage
+
 8.1
 ---
 

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -140,7 +140,7 @@ class ExpressionLanguage
 
     protected function registerFunctions(): void
     {
-        $basicPhpFunctions = ['constant', 'min', 'max'];
+        $basicPhpFunctions = ['constant', 'min', 'max', 'count'];
         foreach ($basicPhpFunctions as $function) {
             $this->addFunction(ExpressionFunction::fromPhp($function));
         }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -533,4 +533,11 @@ class ExpressionLanguageTest extends TestCase
         $parsed = $el->parse('1 + 1', []);
         $this->assertSame($parsed, $el->parse($parsed, []));
     }
+
+    public function testCountFunction()
+    {
+        $language = new ExpressionLanguage();
+        $this->assertSame(3, $language->evaluate('count([1, 2, 3])'));
+        $this->assertSame(0, $language->evaluate('count([])'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64802 
| License       | MIT

**Description**
This PR adds the native PHP `count()` function to the ExpressionLanguage component. This allows developers to use `count(items)` directly in expressions, simplifying code and making expressions more powerful.

**Usage example**
```php
$language = new ExpressionLanguage();
$result = $language->evaluate('count([1,2,3]) > 2'); // true
$result = $language->evaluate('count(items) > 2', ['items' => ['a', 'b', 'c']]); // true