### PR TITLE
[WebProfilerBundle] Move mailer panel macros to template root for Twig 3.27+

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -58,6 +58,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -260,218 +260,219 @@
         {{ _self.render_transport_details(collector, events.transports|first, true) }}
     {% endif %}
 
-    {% macro render_transport_details(collector, transport, show_transport_name = false) %}
-        <div class="card">
-            {% set num_emails = collector.events.events(transport)|length %}
-            {% if num_emails > 1 %}
-                <div class="mailer-email-summary-table-wrapper">
-                    <table class="mailer-email-summary-table">
-                        <thead>
-                            <tr>
-                                <th>#</th>
-                                <th>Subject</th>
-                                <th>To</th>
-                                <th class="visually-hidden">Actions</th>
+{% endblock %}
+
+{% macro render_transport_details(collector, transport, show_transport_name = false) %}
+    <div class="card">
+        {% set num_emails = collector.events.events(transport)|length %}
+        {% if num_emails > 1 %}
+            <div class="mailer-email-summary-table-wrapper">
+                <table class="mailer-email-summary-table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Subject</th>
+                            <th>To</th>
+                            <th class="visually-hidden">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for event in collector.events.events(transport) %}
+                            <tr class="mailer-email-summary-table-row {{ loop.first ? 'active' }}" data-target="#email-{{ loop.index }}">
+                                <td>{{ loop.index }}</td>
+                                <td>{{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}</td>
+                                <td>{{ event.message.headers.get('to').bodyAsString()|default(event.envelope.recipients|map(addr => addr.toString())|join(', ')) }}</td>
+                                <td class="visually-hidden"><button class="mailer-email-summary-table-row-button" data-target="#email-{{ loop.index }}">View email details</button></td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            {% for event in collector.events.events(transport) %}
-                                <tr class="mailer-email-summary-table-row {{ loop.first ? 'active' }}" data-target="#email-{{ loop.index }}">
-                                    <td>{{ loop.index }}</td>
-                                    <td>{{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}</td>
-                                    <td>{{ event.message.headers.get('to').bodyAsString()|default(event.envelope.recipients|map(addr => addr.toString())|join(', ')) }}</td>
-                                    <td class="visually-hidden"><button class="mailer-email-summary-table-row-button" data-target="#email-{{ loop.index }}">View email details</button></td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            {% for event in collector.events.events(transport) %}
+                <div class="mailer-email-details {{ loop.first ? 'active' }}" id="email-{{ loop.index }}">
+                    {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
                 </div>
-
-                {% for event in collector.events.events(transport) %}
-                    <div class="mailer-email-details {{ loop.first ? 'active' }}" id="email-{{ loop.index }}">
-                        {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
-                    </div>
-                {% endfor %}
-            {% else %}
-                {% set event = (collector.events.events(transport)|first) %}
-                {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
-            {% endif %}
-        </div>
-    {% endmacro %}
-
-    {% macro render_email_details(collector, transport, message, message_is_queued, show_transport_name = false) %}
-        {% if show_transport_name %}
-            <p class="mailer-transport-information">
-                <strong>Status:</strong> <span class="badge badge-{{ message_is_queued ? 'warning' : 'success' }}">{{ message_is_queued ? 'Queued' : 'Sent' }}</span>
-                &bull;
-                <strong>Transport:</strong> <code>{{ transport }}</code>
-            </p>
-        {% endif %}
-
-        {% if message.headers is not defined %}
-            {# render the raw message contents #}
-            <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
-                {{ source('@WebProfiler/Icon/download.svg') }}
-                Download as EML file
-            </a>
-
-            <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+            {% endfor %}
         {% else %}
-            <div class="sf-tabs">
-                <div class="tab">
-                    <h3 class="tab-title">Email contents</h3>
-                    <div class="tab-content">
-                        <div class="card-block">
-                            <p class="mailer-message-subject">
-                                {{ message.headers.get('subject').bodyAsString()|default('(No subject)') }}
+            {% set event = (collector.events.events(transport)|first) %}
+            {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
+        {% endif %}
+    </div>
+{% endmacro %}
+
+{% macro render_email_details(collector, transport, message, message_is_queued, show_transport_name = false) %}
+    {% if show_transport_name %}
+        <p class="mailer-transport-information">
+            <strong>Status:</strong> <span class="badge badge-{{ message_is_queued ? 'warning' : 'success' }}">{{ message_is_queued ? 'Queued' : 'Sent' }}</span>
+            &bull;
+            <strong>Transport:</strong> <code>{{ transport }}</code>
+        </p>
+    {% endif %}
+
+    {% if message.headers is not defined %}
+        {# render the raw message contents #}
+        <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
+            {{ source('@WebProfiler/Icon/download.svg') }}
+            Download as EML file
+        </a>
+
+        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+    {% else %}
+        <div class="sf-tabs">
+            <div class="tab">
+                <h3 class="tab-title">Email contents</h3>
+                <div class="tab-content">
+                    <div class="card-block">
+                        <p class="mailer-message-subject">
+                            {{ message.headers.get('subject').bodyAsString()|default('(No subject)') }}
+                        </p>
+                        <div class="mailer-message-headers">
+                            <p>
+                                <strong>From:</strong>
+                                {{ message.headers.get('from').bodyAsString()|default('(empty)') }}
                             </p>
-                            <div class="mailer-message-headers">
-                                <p>
-                                    <strong>From:</strong>
-                                    {{ message.headers.get('from').bodyAsString()|default('(empty)') }}
-                                </p>
-                                <p>
-                                    <strong>To:</strong>
-                                    {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
-                                </p>
-                                {% for header in message.headers.all|filter(header => (header.name ?? '')|lower not in ['subject', 'from', 'to']) %}
-                                    <p class="mailer-message-header-secondary">{{ header.toString }}</p>
-                                {% endfor %}
-                            </div>
+                            <p>
+                                <strong>To:</strong>
+                                {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
+                            </p>
+                            {% for header in message.headers.all|filter(header => (header.name ?? '')|lower not in ['subject', 'from', 'to']) %}
+                                <p class="mailer-message-header-secondary">{{ header.toString }}</p>
+                            {% endfor %}
                         </div>
+                    </div>
 
-                        {% if message.attachments is defined and message.attachments %}
-                            <div class="card-block">
-                                {% set num_of_attachments = message.attachments|length %}
-                                {% set total_attachments_size_in_bytes = message.attachments|reduce((total_size, attachment) => total_size + attachment.body|length, 0) %}
-                                <p class="mailer-message-attachments-title">
-                                    {{ source('@WebProfiler/Icon/attachment.svg') }}
-                                    Attachments <span>({{ num_of_attachments }} file{{ num_of_attachments > 1 ? 's' }} / {{ _self.render_file_size_humanized(total_attachments_size_in_bytes) }})</span>
-                                </p>
-
-                                <ul class="mailer-message-attachments-list">
-                                    {% for attachment in message.attachments %}
-                                        <li>
-                                            {{ source('@WebProfiler/Icon/file.svg') }}
-
-                                            {% if attachment.filename|default %}
-                                                {{ attachment.filename }}
-                                            {% else %}
-                                                <em>(no filename)</em>
-                                            {% endif %}
-
-                                            ({{ _self.render_file_size_humanized(attachment.body|length) }})
-
-                                            <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">Download</a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                        {% endif %}
-
+                    {% if message.attachments is defined and message.attachments %}
                         <div class="card-block">
-                            <div class="sf-tabs sf-tabs-sm">
-                            {% if message.htmlBody is defined %}
-                                {% set textBody = message.textBody %}
-                                {% set htmlBody = message.htmlBody %}
-                                <div class="tab {{ not textBody ? 'disabled' }} {{ textBody ? 'active' }}">
-                                    <h3 class="tab-title">Text content</h3>
-                                    <div class="tab-content">
-                                        {% if textBody %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
-                                                {%- if message.textCharset() %}
-                                                    {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
-                                                {%- else %}
-                                                    {{- textBody }}
-                                                {%- endif -%}
-                                            </pre>
-                                        {% else %}
-                                            <div class="mailer-empty-email-body">
-                                                <p>The text body is empty.</p>
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                </div>
+                            {% set num_of_attachments = message.attachments|length %}
+                            {% set total_attachments_size_in_bytes = message.attachments|reduce((total_size, attachment) => total_size + attachment.body|length, 0) %}
+                            <p class="mailer-message-attachments-title">
+                                {{ source('@WebProfiler/Icon/attachment.svg') }}
+                                Attachments <span>({{ num_of_attachments }} file{{ num_of_attachments > 1 ? 's' }} / {{ _self.render_file_size_humanized(total_attachments_size_in_bytes) }})</span>
+                            </p>
 
-                                {% if htmlBody %}
-                                    <div class="tab">
-                                        <h3 class="tab-title">HTML preview</h3>
-                                        <div class="tab-content">
-                                            <pre class="prewrap" style="max-height: 600px"><iframe src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}" style="height: 80vh;width: 100%;"></iframe>
-                                            </pre>
+                            <ul class="mailer-message-attachments-list">
+                                {% for attachment in message.attachments %}
+                                    <li>
+                                        {{ source('@WebProfiler/Icon/file.svg') }}
+
+                                        {% if attachment.filename|default %}
+                                            {{ attachment.filename }}
+                                        {% else %}
+                                            <em>(no filename)</em>
+                                        {% endif %}
+
+                                        ({{ _self.render_file_size_humanized(attachment.body|length) }})
+
+                                        <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">Download</a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+
+                    <div class="card-block">
+                        <div class="sf-tabs sf-tabs-sm">
+                        {% if message.htmlBody is defined %}
+                            {% set textBody = message.textBody %}
+                            {% set htmlBody = message.htmlBody %}
+                            <div class="tab {{ not textBody ? 'disabled' }} {{ textBody ? 'active' }}">
+                                <h3 class="tab-title">Text content</h3>
+                                <div class="tab-content">
+                                    {% if textBody %}
+                                        <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            {%- if message.textCharset() %}
+                                                {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
+                                            {%- else %}
+                                                {{- textBody }}
+                                            {%- endif -%}
+                                        </pre>
+                                    {% else %}
+                                        <div class="mailer-empty-email-body">
+                                            <p>The text body is empty.</p>
                                         </div>
-                                    </div>
-                                {% endif %}
-
-                                <div class="tab {{ not htmlBody ? 'disabled' }} {{ not textBody and htmlBody ? 'active' }}">
-                                    <h3 class="tab-title">HTML content</h3>
-                                    <div class="tab-content">
-                                        {% if htmlBody %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
-                                                {%- if message.htmlCharset() %}
-                                                    {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
-                                                {%- else %}
-                                                    {{- htmlBody }}
-                                                {%- endif -%}
-                                            </pre>
-                                        {% else %}
-                                            <div class="mailer-empty-email-body">
-                                                <p>The HTML body is empty.</p>
-                                            </div>
-                                        {% endif %}
-                                    </div>
+                                    {% endif %}
                                 </div>
-                            {% else %}
-                                {% set body = message.body ? message.body.toString() : null %}
-                                <div class="tab {{ not body ? 'disabled' }} {{ body ? 'active' }}">
-                                    <h3 class="tab-title">Content</h3>
+                            </div>
+
+                            {% if htmlBody %}
+                                <div class="tab">
+                                    <h3 class="tab-title">HTML preview</h3>
                                     <div class="tab-content">
-                                        {% if body %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
-                                                {{- body }}
-                                            </pre>
-                                        {% else %}
-                                            <div class="mailer-empty-email-body">
-                                                <p>The body is empty.</p>
-                                            </div>
-                                        {% endif %}
+                                        <pre class="prewrap" style="max-height: 600px"><iframe src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}" style="height: 80vh;width: 100%;"></iframe>
+                                        </pre>
                                     </div>
                                 </div>
                             {% endif %}
+
+                            <div class="tab {{ not htmlBody ? 'disabled' }} {{ not textBody and htmlBody ? 'active' }}">
+                                <h3 class="tab-title">HTML content</h3>
+                                <div class="tab-content">
+                                    {% if htmlBody %}
+                                        <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            {%- if message.htmlCharset() %}
+                                                {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
+                                            {%- else %}
+                                                {{- htmlBody }}
+                                            {%- endif -%}
+                                        </pre>
+                                    {% else %}
+                                        <div class="mailer-empty-email-body">
+                                            <p>The HTML body is empty.</p>
+                                        </div>
+                                    {% endif %}
+                                </div>
                             </div>
+                        {% else %}
+                            {% set body = message.body ? message.body.toString() : null %}
+                            <div class="tab {{ not body ? 'disabled' }} {{ body ? 'active' }}">
+                                <h3 class="tab-title">Content</h3>
+                                <div class="tab-content">
+                                    {% if body %}
+                                        <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            {{- body }}
+                                        </pre>
+                                    {% else %}
+                                        <div class="mailer-empty-email-body">
+                                            <p>The body is empty.</p>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% endif %}
                         </div>
                     </div>
                 </div>
+            </div>
 
-                <div class="tab">
-                    <h3 class="tab-title">MIME parts</h3>
-                    <div class="tab-content">
-                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.body().asDebugString() }}</pre>
-                    </div>
-                </div>
-
-                <div class="tab">
-                    <h3 class="tab-title">Raw Message</h3>
-                    <div class="tab-content">
-                        <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
-                            {{ source('@WebProfiler/Icon/download.svg') }}
-                            Download as EML file
-                        </a>
-
-                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
-                    </div>
+            <div class="tab">
+                <h3 class="tab-title">MIME parts</h3>
+                <div class="tab-content">
+                    <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.body().asDebugString() }}</pre>
                 </div>
             </div>
-        {% endif %}
-    {% endmacro %}
 
-    {% macro render_file_size_humanized(bytes) %}
-        {%- if bytes < 1000 -%}
-            {{- bytes ~ ' bytes' -}}
-        {%- elseif bytes < 1000 ** 2 -%}
-            {{- (bytes / 1000)|number_format(2) ~ ' kB' -}}
-        {%- else -%}
-            {{- (bytes / 1000 ** 2)|number_format(2) ~ ' MB' -}}
-        {%- endif -%}
-    {% endmacro %}
-{% endblock %}
+            <div class="tab">
+                <h3 class="tab-title">Raw Message</h3>
+                <div class="tab-content">
+                    <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
+                        {{ source('@WebProfiler/Icon/download.svg') }}
+                        Download as EML file
+                    </a>
+
+                    <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro render_file_size_humanized(bytes) %}
+    {%- if bytes < 1000 -%}
+        {{- bytes ~ ' bytes' -}}
+    {%- elseif bytes < 1000 ** 2 -%}
+        {{- (bytes / 1000)|number_format(2) ~ ' kB' -}}
+    {%- else -%}
+        {{- (bytes / 1000 ** 2)|number_format(2) ~ ' MB' -}}
+    {%- endif -%}
+{% endmacro %}

--- a/src/Symfony/Component/Console/Helper/TerminalInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/TerminalInputHelper.php
@@ -59,7 +59,7 @@ final class TerminalInputHelper
                 throw new \RuntimeException('Unable to read the terminal settings.');
             }
 
-            $this->initialState = $state;
+            $this->initialState = trim($state);
 
             $this->createSignalHandlers();
         }
@@ -96,7 +96,13 @@ final class TerminalInputHelper
 
         // Safeguard in case an unhandled kill signal exists
         $this->checkForKillSignal();
-        shell_exec('stty '.$this->initialState);
+
+        // The captured "stty -g" state is not guaranteed to be accepted back by "stty" on every
+        // platform/terminal (e.g. some nested pty implementations reject it with "invalid argument"),
+        // and shell_exec() gives no way to detect that failure. Try the exact restore first so
+        // any custom terminal settings survive, but always fall back to "stty sane" so the
+        // terminal is left in a usable state even when the exact restore silently fails.
+        shell_exec('stty '.$this->initialState.' 2>/dev/null || stty sane');
         $this->signalToKill = 0;
 
         foreach ($this->signalHandlers as $signal => $originalHandler) {
@@ -119,9 +125,12 @@ final class TerminalInputHelper
             $this->signalHandlers[$signal] = pcntl_signal_get_handler($signal);
 
             pcntl_signal($signal, function ($signal) {
-                // Save current state, then restore to initial state
+                // Save current state, then restore to initial state. The original signal
+                // handler is about to run, so fall back to "stty sane" if the exact restore
+                // is rejected by "stty" (see the same fallback in finish()), to make sure it
+                // runs with a usable terminal.
                 $currentState = shell_exec('stty -g');
-                shell_exec('stty '.$this->initialState);
+                shell_exec('stty '.$this->initialState.' 2>/dev/null || stty sane');
                 $originalHandler = $this->signalHandlers[$signal];
 
                 if (\is_callable($originalHandler)) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/terminal_input_helper_bad_state.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/terminal_input_helper_bad_state.php
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\Component\Console\Helper\TerminalInputHelper;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = \dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+$helper = new TerminalInputHelper(\STDIN);
+
+// Simulate a captured state that "stty" refuses to parse back (as can happen with some
+// nested pty implementations), to exercise the "stty sane" fallback in finish().
+$property = new ReflectionProperty(TerminalInputHelper::class, 'initialState');
+$property->setValue($helper, 'not-a-valid-stty-state');
+
+// Put the terminal in the raw-ish state the question helpers use while reading keypresses.
+shell_exec('stty -icanon -echo');
+
+$helper->finish();

--- a/src/Symfony/Component/Console/Tests/Helper/TerminalInputHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TerminalInputHelperTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Terminal;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+
+class TerminalInputHelperTest extends TestCase
+{
+    /**
+     * @group tty
+     */
+    public function testFinishFallsBackToSttySaneWhenInitialStateIsInvalid()
+    {
+        if (!Terminal::hasSttyAvailable()) {
+            $this->markTestSkipped('stty not available');
+        }
+
+        $previousSttyMode = shell_exec('stty -g');
+
+        $p = new Process(['php', __DIR__.'/../Fixtures/terminal_input_helper_bad_state.php']);
+        try {
+            $p->setTty(true);
+            $p->run();
+        } catch (RuntimeException $e) {
+            if (str_contains($e->getMessage(), '/dev/tty')) {
+                $this->markTestSkipped('/dev/tty is not read/writable in this environment.');
+            }
+
+            throw $e;
+        }
+
+        // Tokenize instead of matching substrings: "-echo" is also a substring of the
+        // unrelated flags "-echonl" and "-echoprt", which are off by default.
+        $flags = preg_split('/\s+/', trim(shell_exec('stty -a')));
+
+        // Restore the terminal to how it was before running the test, now that we have read
+        // the state left by the fixture script.
+        shell_exec('stty '.trim($previousSttyMode).' 2>/dev/null || stty sane');
+
+        $this->assertSame(0, $p->getExitCode());
+        $this->assertContains('echo', $flags);
+        $this->assertContains('icanon', $flags);
+    }
+}

--- a/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bs.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Molim upišite ispravan UUID.</target>
+                <target>Molim upišite ispravan UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/JitterTriggerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Scheduler\Tests\Trigger;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Scheduler\Trigger\JitterTrigger;
+use Symfony\Component\Scheduler\Trigger\PeriodicalTrigger;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
 
 class JitterTriggerTest extends TestCase
@@ -38,5 +39,22 @@ class JitterTriggerTest extends TestCase
         $values = array_unique($values);
 
         $this->assertGreaterThan(1, \count($values));
+    }
+
+    public function testDoesNotSkipRunsWithJitter()
+    {
+        $from = new \DateTimeImmutable('2026-07-07 16:30:00');
+        $inner = new PeriodicalTrigger(10, $from);
+        $trigger = new JitterTrigger($inner, 15);
+
+        // The first run at 16:30:00 was executed at 16:30:12 due to a 12s jitter.
+        $run = $from->modify('+12 seconds');
+
+        $nextRun = $trigger->getNextRunDate($run);
+
+        $this->assertNotNull($nextRun);
+        // The slot at 16:30:10 is already ran, so the next scheduled run is 16:30:20 + a random jitter up to 15s.
+        $this->assertGreaterThanOrEqual($from->modify('+20 seconds')->getTimestamp(), $nextRun->getTimestamp());
+        $this->assertLessThanOrEqual($from->modify('+35 seconds')->getTimestamp(), $nextRun->getTimestamp());
     }
 }

--- a/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/JitterTrigger.php
@@ -31,8 +31,25 @@ final class JitterTrigger extends AbstractDecoratedTrigger
 
     public function getNextRunDate(\DateTimeImmutable $run): ?\DateTimeImmutable
     {
-        if (!$nextRun = $this->trigger->getNextRunDate($run)) {
+        // the provided execution time includes jitter, try to get back to the actual time
+        $runWithoutJitter = $run->sub(new \DateInterval(\sprintf('PT%sS', $this->maxSeconds)));
+
+        if (!$nextRun = $this->trigger->getNextRunDate($runWithoutJitter)) {
             return null;
+        }
+
+        // if we get the run that just ran, proceed to the next one
+        while ($nextRun <= $run) {
+            if (!$advanced = $this->trigger->getNextRunDate($nextRun)) {
+                return null;
+            }
+
+            // the decorated trigger no longer advances: stop to avoid an infinite loop
+            if ($advanced <= $nextRun) {
+                break;
+            }
+
+            $nextRun = $advanced;
         }
 
         return $nextRun->add(new \DateInterval(\sprintf('PT%sS', random_int(0, $this->maxSeconds))));

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.bs.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.bs.xlf
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minut.|Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minuta.</target>
+                <target>Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minutu.|Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minute.|Previše neuspješnih pokušaja prijave, pokušajte ponovo za %minutes% minuta.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -89,8 +89,17 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
             throw new BadMethodCallException(\sprintf('The nested denormalizer needs to be set to allow "%s()" to be used.', __METHOD__));
         }
 
-        return str_ends_with($type, '[]')
-            && $this->denormalizer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
+        if (!str_ends_with($type, '[]') || !\is_array($data)) {
+            return false;
+        }
+
+        $itemType = substr($type, 0, -2);
+
+        foreach ($data as $item) {
+            return $this->denormalizer->supportsDenormalization($item, $itemType, $format, $context);
+        }
+
+        return true;
     }
 
     /**
@@ -103,9 +112,6 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
         return $this->denormalizer instanceof CacheableSupportsMethodInterface && $this->denormalizer->hasCacheableSupportsMethod();
     }
 
-    /**
-     * @param mixed $key
-     */
     private function validateKeyType(array $builtinTypes, $key, string $path): void
     {
         if (!$builtinTypes) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -59,7 +59,7 @@ class ArrayDenormalizerTest extends TestCase
         $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
         $nestedDenormalizer->expects($this->once())
             ->method('supportsDenormalization')
-            ->with($this->anything(), ArrayDummy::class, 'json', ['con' => 'text'])
+            ->with(['foo' => 'one', 'bar' => 'two'], ArrayDummy::class, 'json', ['con' => 'text'])
             ->willReturn(true);
         $denormalizer = new ArrayDenormalizer();
         $denormalizer->setDenormalizer($nestedDenormalizer);
@@ -107,6 +107,19 @@ class ArrayDenormalizerTest extends TestCase
                 ['foo' => 'one', 'bar' => 'two'],
                 ArrayDummy::class
             )
+        );
+    }
+
+    public function testSupportsEmptyArray()
+    {
+        $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
+        $nestedDenormalizer->expects($this->never())
+            ->method('supportsDenormalization');
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($nestedDenormalizer);
+
+        $this->assertTrue(
+            $denormalizer->supportsDenormalization([], __NAMESPACE__.'\ArrayDummy[]')
         );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -1118,10 +1118,10 @@ class SerializerTest extends TestCase
             ],
             [
                 'currentType' => 'null',
-                'expectedTypes' => ['array'],
+                'expectedTypes' => ['Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]'],
                 'path' => 'anotherCollection',
                 'useMessageForUser' => false,
-                'message' => 'Data expected to be "Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]", "null" given.',
+                'message' => 'The type of the "anotherCollection" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\Php74Full" must be one of "Symfony\Component\Serializer\Tests\Fixtures\Php74Full[]" ("null" given).',
             ],
         ];
 

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjana IP adresa.</target>
+                <target>Ova vrijednost nije ispravna IP adresa.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target state="needs-review-translation">Privremeni direktorij nije konfiguriran u php.ini, ili konfigurirani direktorij ne postoji.</target>
+                <target>Privremeni direktorij nije konfiguriran u php.ini, ili konfigurirani direktorij ne postoji.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjan Međunarodni broj bankovnog računa (IBAN).</target>
+                <target>Ova vrijednost nije ispravan međunarodni broj bankovnog računa (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjan Poslovni identifikacijski kod (BIC).</target>
+                <target>Ova vrijednost nije ispravan poslovni identifikacijski kod (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83" resname="This is not a valid UUID.">
                 <source>This value is not a valid UUID.</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjan UUID.</target>
+                <target>Ova vrijednost nije ispravan UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -428,147 +428,147 @@
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-review-translation">Ekstenzija datoteke je nevažeća ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
+                <target>Ekstenzija datoteke je nevažeća ({{ extension }}). Dozvoljene ekstenzije su {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-review-translation">Otkriveno kodiranje karaktera je nevažeće ({{ detected }}). Dozvoljena kodiranja su {{ encodings }}.</target>
+                <target>Otkriveno kodiranje znakova je nevažeće ({{ detected }}). Dozvoljena kodiranja su {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
-                <target state="needs-review-translation">Ova vrijednost nije valjana MAC adresa.</target>
+                <target>Ova vrijednost nije ispravna MAC adresa.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target state="needs-review-translation">Ovom URL-u nedostaje domena najvišeg nivoa.</target>
+                <target>Ovom URL-u nedostaje domena najvišeg nivoa.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target state="needs-review-translation">Ova vrijednost je prekratka. Trebala bi sadržavati barem jednu riječ.|Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječi.</target>
+                <target>Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječ.|Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječi.|Ova vrijednost je prekratka. Trebala bi sadržavati barem {{ min }} riječi.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target state="needs-review-translation">Ova vrijednost je predugačka. Trebala bi sadržavati samo jednu riječ.|Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječi ili manje.</target>
+                <target>Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječ ili manje.|Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječi ili manje.|Ova vrijednost je predugačka. Trebala bi sadržavati {{ max }} riječi ili manje.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target state="needs-review-translation">Ova vrijednost ne predstavlja valjani tjedan u ISO 8601 formatu.</target>
+                <target>Ova vrijednost ne predstavlja ispravnu sedmicu u ISO 8601 formatu.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeća sedmica.</target>
+                <target>Ova vrijednost nije važeća sedmica.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target state="needs-review-translation">Ova vrijednost ne smije biti prije tjedna "{{ min }}".</target>
+                <target>Ova vrijednost ne smije biti prije sedmice "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target state="needs-review-translation">Ova vrijednost ne bi trebala biti nakon sedmice "{{ max }}".</target>
+                <target>Ova vrijednost ne smije biti nakon sedmice "{{ max }}".</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeći Twig šablon.</target>
+                <target>Ova vrijednost nije važeći Twig šablon.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Ova datoteka nije važeći video.</target>
+                <target>Ova datoteka nije važeći video.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Veličina videa nije mogla biti utvrđena.</target>
+                <target>Veličina videa nije mogla biti utvrđena.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
+                <target>Širina videa je prevelika ({{ width }}px). Dozvoljena maksimalna širina je {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Širina videa je premala ({{ width }}px). Minimalna očekivana širina je {{ min_width }}px.</target>
+                <target>Širina videa je premala ({{ width }}px). Minimalna očekivana širina je {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
+                <target>Visina videa je prevelika ({{ height }}px). Dozvoljena maksimalna visina je {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Visina videa je premala ({{ height }}px). Očekivana minimalna visina je {{ min_height }}px.</target>
+                <target>Visina videa je premala ({{ height }}px). Minimalna očekivana visina je {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video ima premalo piksela ({{ pixels }}). Očekivana minimalna količina je {{ min_pixels }}.</target>
+                <target>Video ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Video ima previše piksela ({{ pixels }}). Očekivana maksimalna količina je {{ max_pixels }}.</target>
+                <target>Video ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Omjer videa je prevelik ({{ ratio }}). Dozvoljeni maksimalni omjer je {{ max_ratio }}.</target>
+                <target>Razmjera videa je prevelika ({{ ratio }}). Maksimalna dozvoljena razmjera je {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Omjer videa je premali ({{ ratio }}). Minimalni očekivani omjer je {{ min_ratio }}.</target>
+                <target>Razmjera videa je premala ({{ ratio }}). Minimalna očekivana razmjera je {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Video je kvadratan ({{ width }}x{{ height }}px). Kvadratni video zapisi nisu dozvoljeni.</target>
+                <target>Video je kvadratan ({{ width }}x{{ height }}px). Kvadratni video zapisi nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video je vodoravne orijentacije ({{ width }}x{{ height }} px). Vodoravni video zapisi nisu dozvoljeni.</target>
+                <target>Video je orijentisan horizontalno (landscape) ({{ width }}x{{ height }}px). Horizontalno orijentisani video zapisi nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Video je uspravno orijentisan ({{ width }}x{{ height }}px). Video zapisi uspravne orijentacije nisu dozvoljeni.</target>
+                <target>Video je orijentisan vertikalno (portrait) ({{ width }}x{{ height }}px). Vertikalno orijentisani video zapisi nisu dozvoljeni.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Video datoteka je oštećena.</target>
+                <target>Video datoteka je oštećena.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Video sadrži više tokova. Dozvoljen je samo jedan tok.</target>
+                <target>Video sadrži više tokova. Dozvoljen je samo jedan tok.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Nepodržani video kodek "{{ codec }}".</target>
+                <target>Nepodržani video kodek "{{ codec }}".</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Nepodržani video kontejner "{{ container }}".</target>
+                <target>Nepodržani video kontejner "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Datoteka slike je oštećena.</target>
+                <target>Datoteka slike je oštećena.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Slika ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
+                <target>Slika ima premalo piksela ({{ pixels }}). Očekivani minimalni broj je {{ min_pixels }}.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Slika ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
+                <target>Slika ima previše piksela ({{ pixels }}). Očekivani maksimalni broj je {{ max_pixels }}.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Naziv ove datoteke ne odgovara očekivanom skupu znakova.</target>
+                <target>Naziv ove datoteke ne odgovara očekivanom skupu znakova.</target>
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeći XML.</target>
+                <target>Ova vrijednost nije važeći XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Ova vrijednost ne odgovara očekivanoj XSD shemi.</target>
+                <target>Ova vrijednost ne odgovara očekivanoj XSD shemi.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Ovaj XML sadržaj je prevelik ({{ size }} bajtova): premašuje ograničenje od {{ limit }} bajtova.</target>
+                <target>Ovaj XML sadržaj je prevelik ({{ size }} B): premašuje ograničenje od {{ limit }} B.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Ova vrijednost nije važeći cron izraz.</target>
+                <target>Ova vrijednost nije važeći cron izraz.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -568,7 +568,7 @@
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Cette valeur n'est pas une expression cron valide.</target>
+                <target>Cette valeur n'est pas une expression cron valide.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -48,11 +48,11 @@
             </trans-unit>
             <trans-unit id="12">
                 <source>This value is not a valid datetime.</source>
-                <target>Cette valeur n'est pas une date valide.</target>
+                <target>Cette valeur n'est pas une date/heure valide.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>This value is not a valid email address.</source>
-                <target>Cette valeur n'est pas une adresse email valide.</target>
+                <target>Cette valeur n'est pas une adresse e-mail valide.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>The file could not be found.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Cette chaîne est trop longue. Elle doit avoir au maximum {{ limit }} caractère.|Cette chaîne est trop longue. Elle doit avoir au maximum {{ limit }} caractères.</target>
+                <target>Cette chaîne est trop longue. Elle doit contenir au maximum {{ limit }} caractère.|Cette chaîne est trop longue. Elle doit contenir au maximum {{ limit }} caractères.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,7 +84,7 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Cette chaîne est trop courte. Elle doit avoir au minimum {{ limit }} caractère.|Cette chaîne est trop courte. Elle doit avoir au minimum {{ limit }} caractères.</target>
+                <target>Cette chaîne est trop courte. Elle doit contenir au minimum {{ limit }} caractère.|Cette chaîne est trop courte. Elle doit contenir au minimum {{ limit }} caractères.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
@@ -128,7 +128,7 @@
             </trans-unit>
             <trans-unit id="35">
                 <source>This value should be a valid number.</source>
-                <target>Cette valeur doit être un nombre.</target>
+                <target>Cette valeur doit être un nombre valide.</target>
             </trans-unit>
             <trans-unit id="36">
                 <source>This file is not a valid image.</source>
@@ -180,7 +180,7 @@
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-                <target>Cette chaîne doit avoir exactement {{ limit }} caractère.|Cette chaîne doit avoir exactement {{ limit }} caractères.</target>
+                <target>Cette chaîne doit contenir exactement {{ limit }} caractère.|Cette chaîne doit contenir exactement {{ limit }} caractères.</target>
             </trans-unit>
             <trans-unit id="49">
                 <source>The file was only partially uploaded.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target>Cette valeur n'est pas un Code Identifiant de Business (BIC) valide.</target>
+                <target>Cette valeur n'est pas un Code d'Identification Bancaire (BIC) valide.</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -328,7 +328,7 @@
             </trans-unit>
             <trans-unit id="85">
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
-                <target>Ce code d'identification d'entreprise (BIC) n'est pas associé à l'IBAN {{ iban }}.</target>
+                <target>Ce Code d'Identification Bancaire (BIC) n'est pas associé à l'IBAN {{ iban }}.</target>
             </trans-unit>
             <trans-unit id="86">
                 <source>This value should be valid JSON.</source>
@@ -472,11 +472,11 @@
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target>Ce fichier n’est pas une vidéo valide.</target>
+                <target>Ce fichier n'est pas une vidéo valide.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target>La taille de la vidéo n’a pas pu être détectée.</target>
+                <target>La taille de la vidéo n'a pas pu être détectée.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
@@ -544,11 +544,11 @@
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target>L’image comporte trop peu de pixels ({{ pixels }}). La quantité minimale attendue est de {{ min_pixels }} pixels.</target>
+                <target>L'image comporte trop peu de pixels ({{ pixels }}). La quantité minimale attendue est de {{ min_pixels }} pixels.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target>L’image contient trop de pixels ({{ pixels }}). La quantité maximale attendue est de {{ max_pixels }} pixels.</target>
+                <target>L'image contient trop de pixels ({{ pixels }}). La quantité maximale attendue est de {{ max_pixels }} pixels.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>


### PR DESCRIPTION
Macros defined inside {% block panel %} trigger E_USER_DEPRECATED with Twig 3.27+ (CorrectnessNodeVisitor). Other collector templates (cache, form, logger, etc.) already define macros at template root.

| Q             | A |
|---------------|---|
| Bug fix?      | yes |
| New feature?  | no |
| BC breaks?    | no |
| Deprecations? | no (fixes Twig 3.27 deprecation) |
| Tickets       | Fixes #64871 |
| License       | MIT |

Moves `{% macro %}` definitions in `mailer.html.twig` from inside `{% block panel %}` to the template root,
matching the pattern already used in `cache.html.twig`, `form.html.twig`, `logger.html.twig`, etc.

## Problem

With Twig 3.27+, opening the Mailer panel in the Web Profiler triggers:

```
User Deprecated: Since twig/twig 3.27: Using the "macro" tag outside the root of a template is deprecated
in @WebProfiler/Collector/mailer.html.twig at line 267.
```

(and lines 306, 472 for the other two macros).

## Solution

Relocate the three macros after the panel block's `{% endblock %}`. Calls via `_self.render_*()` inside the panel block are unchanged.

## How to test

1. Install a Symfony 8.1 app with `symfony/web-profiler-bundle` and `twig/twig` ^3.27.
2. Send an email in `dev`.
3. Open `/_profiler/{token}?panel=mailer`.
4. Confirm no Twig 3.27 macro deprecation warnings appear.

## PR links

- **Compare:** https://github.com/symfony/symfony/compare/8.1...nowo-tech:symfony:fix/webprofiler-mailer-macros-twig327?expand=1
- **Fork branch:** `nowo-tech:fix/webprofiler-mailer-macros-twig327`
- **Target:** `symfony/symfony` → `8.1`