### PR TITLE
[Translation] Make `CrowdinProvider::read()` fetch every locale when passed none

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `$projectId` constructor parameter to `CrowdinProvider`
+ * Make `CrowdinProvider::read()` fetch every locale when passed none
 
 5.4
 ---

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -65,7 +65,7 @@ final class CrowdinProvider implements ProviderInterface
     public function write(TranslatorBagInterface $translatorBag): void
     {
         $fileList = $this->getFileList();
-        $languageMapping = $this->getLanguageMapping();
+        [$languageIds, $sourceLanguageId] = $this->getLanguageIds();
 
         $defaultLocaleCatalogue = $translatorBag->getCatalogue($this->defaultLocale);
         foreach ($defaultLocaleCatalogue->getDomains() as $domain) {
@@ -100,6 +100,14 @@ final class CrowdinProvider implements ProviderInterface
             if ($locale === $this->defaultLocale) {
                 continue;
             }
+            if (!isset($languageIds[$locale])) {
+                $this->logger->warning(\sprintf('Ignored "%s" locale because it is not configured or mapped in the project.', $locale));
+
+                continue;
+            }
+            if ($sourceLanguageId === $languageIds[$locale]) {
+                continue;
+            }
 
             foreach ($catalogue->getDomains() as $domain) {
                 if (!$catalogue->all($domain)) {
@@ -111,7 +119,7 @@ final class CrowdinProvider implements ProviderInterface
                         $fileId,
                         $domain,
                         $this->xliffFileDumper->formatCatalogue($catalogue, $domain, ['default_locale' => $this->defaultLocale]),
-                        $languageMapping[$locale] ?? $locale,
+                        $languageIds[$locale],
                     );
                 }
             }
@@ -188,7 +196,17 @@ final class CrowdinProvider implements ProviderInterface
     public function read(array $domains, array $locales): TranslatorBag
     {
         $fileList = $this->getFileList();
-        $languageMapping = $this->getLanguageMapping();
+        [$languageIds, $sourceLanguageId] = $this->getLanguageIds();
+
+        // flipping keeps one locale per language, the mapped one when there is a mapping
+        $locales = $locales ?: array_values(array_flip($languageIds));
+        foreach ($locales as $i => $locale) {
+            if (!isset($languageIds[$locale])) {
+                $this->logger->warning(\sprintf('Ignored "%s" locale because it is not configured or mapped in the project.', $locale));
+
+                unset($locales[$i]);
+            }
+        }
 
         $translatorBag = new TranslatorBag();
         $responses = [];
@@ -201,10 +219,10 @@ final class CrowdinProvider implements ProviderInterface
             }
 
             foreach ($locales as $locale) {
-                if ($locale !== $this->defaultLocale) {
-                    $response = $this->exportProjectTranslations($languageMapping[$locale] ?? $locale, $fileId);
-                } else {
+                if ($sourceLanguageId === $languageIds[$locale]) {
                     $response = $this->downloadSourceFile($fileId);
+                } else {
+                    $response = $this->exportProjectTranslations($languageIds[$locale], $fileId);
                 }
 
                 $responses[] = [$response, $locale, $domain];
@@ -349,12 +367,12 @@ final class CrowdinProvider implements ProviderInterface
      * @see https://support.crowdin.com/developer/api/v2/#tag/Translations/operation/api.projects.translations.imports (Crowdin API)
      * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Translations/operation/api.projects.translations.enterprise.imports (Crowdin Enterprise API)
      */
-    private function importTranslations(int $fileId, string $domain, string $content, string $locale): ResponseInterface
+    private function importTranslations(int $fileId, string $domain, string $content, string $languageId): ResponseInterface
     {
         return $this->client->request('POST', $this->getProjectEndpoint('translations/imports'), [
             'json' => [
                 'storageId' => $this->addStorage($domain, $content),
-                'languageIds' => [str_replace('_', '-', $locale)],
+                'languageIds' => [$languageId],
                 'fileId' => $fileId,
             ],
         ]);
@@ -377,7 +395,7 @@ final class CrowdinProvider implements ProviderInterface
     {
         return $this->client->request('POST', $this->getProjectEndpoint('translations/exports'), [
             'json' => [
-                'targetLanguageId' => str_replace('_', '-', $languageId),
+                'targetLanguageId' => $languageId,
                 'fileIds' => [$fileId],
             ],
         ]);
@@ -435,24 +453,43 @@ final class CrowdinProvider implements ProviderInterface
     }
 
     /**
+     * @return array{array<string, string>, string} The language IDs indexed by locale, then the source language ID
+     *
      * @see https://support.crowdin.com/developer/api/v2/#tag/Projects/operation/api.projects.get (Crowdin API)
      * @see https://support.crowdin.com/developer/enterprise/api/v2/#tag/Projects-and-Groups/operation/api.projects.get (Crowdin Enterprise API)
      */
-    private function getLanguageMapping(): array
+    private function getLanguageIds(): array
     {
         $response = $this->client->request('GET', $this->getProjectEndpoint());
 
         if (200 !== $response->getStatusCode()) {
-            throw new ProviderException('Unable to get project info.', $response);
+            throw new ProviderException('Unable to get project settings.', $response);
         }
 
         $projectInfo = $response->toArray()['data'];
-        $mapping = [];
-        foreach ($projectInfo['languageMapping'] ?? [] as $key => $value) {
-            $mapping[$value['locale']] = $key;
+
+        $languageIds = [$projectInfo['sourceLanguageId'], ...$projectInfo['targetLanguageIds']];
+        $languageIds = array_combine(
+            array_map(static fn (string $languageId) => str_replace('-', '_', $languageId), $languageIds),
+            $languageIds,
+        );
+
+        if (!isset($projectInfo['languageMapping'])) {
+            $this->logger->warning('API key does not allow to access language mapping.');
+
+            return [$languageIds, $projectInfo['sourceLanguageId']];
         }
 
-        return $mapping;
+        foreach ($projectInfo['languageMapping'] as $languageId => $mapping) {
+            if (isset($mapping['locale'])) {
+                // a language keeps its ID as an alias, so both spellings are accepted
+                $languageIds[str_replace('-', '_', $mapping['locale'])] = $languageId;
+            } else {
+                $this->logger->warning(\sprintf('Ignored "%s" mapping because it has no "locale" placeholder.', $languageId));
+            }
+        }
+
+        return [$languageIds, $projectInfo['sourceLanguageId']];
     }
 
     private function getProjectEndpoint(string $endpoint = ''): string

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Bridge\Crowdin\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -121,7 +122,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => [],
+                    'languageMapping' => [],
+                ]]);
             },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -205,7 +210,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => [],
+                    'languageMapping' => [],
+                ]]);
             },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -305,7 +314,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => [],
+                    'languageMapping' => [],
+                ]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -430,7 +443,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => ['fr'],
+                    'languageMapping' => [],
+                ]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -573,7 +590,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => ['fr'],
+                    'languageMapping' => [],
+                ]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -722,7 +743,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => [],
+                    'languageMapping' => [],
+                ]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -759,7 +784,7 @@ class CrowdinProviderTest extends ProviderTestCase
             'messages' => ['a' => 'trans_en_a', 'b' => 'trans_en_b'],
         ]));
 
-        $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
+        $provider = self::createProvider($httpClient = (new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
@@ -826,15 +851,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse([
-                    'data' => [
-                        'languageMapping' => [
-                            'pt-PT' => [
-                                'locale' => 'pt',
-                            ],
-                        ],
-                    ],
-                ]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => ['fr', 'uk', 'en-GB'],
+                    'languageMapping' => ['pt-PT' => ['locale' => 'pt'], 'uk' => ['locale' => 'uk-UA']],
+                ]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -888,12 +909,14 @@ class CrowdinProviderTest extends ProviderTestCase
             },
         ];
 
-        $provider = self::createProvider((new MockHttpClient($responses))->withOptions([
+        $provider = self::createProvider($httpClient = (new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/',
             'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
 
         $provider->write($translatorBag);
+
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
     }
 
     public static function getResponsesForProcessAddFileAndUploadTranslations(): \Generator
@@ -934,6 +957,34 @@ class CrowdinProviderTest extends ProviderTestCase
         $translatorBagPt->addCatalogue($arrayLoader->load([
             'a' => 'trans_pt_a',
         ], 'pt'));
+
+        $translatorBagUk = new TranslatorBag();
+        $translatorBagUk->addCatalogue($arrayLoader->load([
+            'a' => 'trans_en_a',
+        ], 'en'));
+        $translatorBagUk->addCatalogue($arrayLoader->load([
+            'a' => 'trans_uk_a',
+        ], 'uk_UA'));
+
+        // the "uk" language is mapped to the "uk-UA" locale, which Symfony spells "uk_UA"
+        yield [$translatorBagUk, 'uk', <<<'XLIFF'
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="uk-UA" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="%s" resname="a">
+                    <source>a</source>
+                    <target>trans_uk_a</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF
+        ];
 
         yield [$translatorBagPt, 'pt-PT', <<<'XLIFF'
             <?xml version="1.0" encoding="utf-8"?>
@@ -1039,7 +1090,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse(['data' => ['languageMapping' => []]]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => ['fr'],
+                    'languageMapping' => [],
+                ]]);
             },
             'addStorage' => function (string $method, string $url, array $options = []) use ($expectedMessagesFileContent): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -1115,19 +1170,15 @@ class CrowdinProviderTest extends ProviderTestCase
                     ],
                 ]);
             },
-            'getProject' => function (string $method, string $url): ResponseInterface {
+            'getProject' => function (string $method, string $url) use ($locale): ResponseInterface {
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse([
-                    'data' => [
-                        'languageMapping' => [
-                            'pt-PT' => [
-                                'locale' => 'pt',
-                            ],
-                        ],
-                    ],
-                ]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => [str_replace('_', '-', $locale)],
+                    'languageMapping' => [],
+                ]]);
             },
             'exportProjectTranslations' => function (string $method, string $url, array $options = []) use ($expectedTargetLanguageId): ResponseInterface {
                 $this->assertSame('POST', $method);
@@ -1239,19 +1290,15 @@ class CrowdinProviderTest extends ProviderTestCase
                     ],
                 ]);
             },
-            'getProject' => function (string $method, string $url): ResponseInterface {
+            'getProject' => function (string $method, string $url) use ($locale): ResponseInterface {
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse([
-                    'data' => [
-                        'languageMapping' => [
-                            'pt-PT' => [
-                                'locale' => 'pt',
-                            ],
-                        ],
-                    ],
-                ]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => $locale,
+                    'targetLanguageIds' => [],
+                    'languageMapping' => [],
+                ]]);
             },
             'downloadSource' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('GET', $method);
@@ -1316,6 +1363,220 @@ class CrowdinProviderTest extends ProviderTestCase
         ];
     }
 
+    public function testReadWithoutLocales()
+    {
+        $responses = [
+            'listFiles' => new JsonMockResponse(['data' => [
+                ['data' => [
+                    'id' => 12,
+                    'name' => 'messages.xlf',
+                ]],
+            ]]),
+            'getProject' => new JsonMockResponse(['data' => [
+                'sourceLanguageId' => 'en',
+                'targetLanguageIds' => ['fr-BE'],
+                'languageMapping' => [],
+            ]]),
+            'exportSource' => new JsonMockResponse(['data' => ['url' => 'https://file.en']]),
+            'exportTranslations' => new JsonMockResponse(['data' => ['url' => 'https://file.fr']]),
+            'downloadSource' => new MockResponse(<<<'XLIFF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                    <body></body>
+                  </file>
+                </xliff>
+                XLIFF),
+            'downloadTranslations' => new MockResponse(<<<'XLIFF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file source-language="en" target-language="fr-BE" datatype="plaintext" original="file.ext">
+                    <body></body>
+                  </file>
+                </xliff>
+                XLIFF),
+        ];
+
+        $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
+            'auth_bearer' => 'API_TOKEN',
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
+
+        $translatorBag = $crowdinProvider->read(['messages'], []);
+
+        $this->assertEqualsCanonicalizing(
+            ['en', 'fr_BE'],
+            array_map(static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(), $translatorBag->getCatalogues()),
+        );
+    }
+
+    public function testMappedLanguageIdCanStillBeRead()
+    {
+        $responses = [
+            'listFiles' => new JsonMockResponse(['data' => [
+                ['data' => [
+                    'id' => 12,
+                    'name' => 'messages.xlf',
+                ]],
+            ]]),
+            'getProject' => new JsonMockResponse(['data' => [
+                'sourceLanguageId' => 'fr',
+                'targetLanguageIds' => [],
+                'languageMapping' => ['fr' => ['locale' => 'fr_FR']],
+            ]]),
+            'exportSource' => new JsonMockResponse(['data' => ['url' => 'https://file.fr']]),
+            'downloadSource' => new MockResponse(<<<'XLIFF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file source-language="fr" target-language="fr" datatype="plaintext" original="file.ext">
+                    <body></body>
+                  </file>
+                </xliff>
+                XLIFF),
+        ];
+
+        $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
+            'auth_bearer' => 'API_TOKEN',
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
+
+        $translatorBag = $crowdinProvider->read(['messages'], ['fr']);
+
+        $this->assertCount(1, $catalogues = $translatorBag->getCatalogues());
+        $this->assertSame('fr', $catalogues[0]->getLocale());
+    }
+
+    #[TestWith(['uk'])]
+    #[TestWith(['uk_UA'])]
+    public function testMappedLanguageCanBeReadUnderBothNames(string $locale)
+    {
+        $responses = [
+            'listFiles' => new JsonMockResponse(['data' => [
+                ['data' => [
+                    'id' => 12,
+                    'name' => 'messages.xlf',
+                ]],
+            ]]),
+            'getProject' => new JsonMockResponse(['data' => [
+                'sourceLanguageId' => 'en',
+                'targetLanguageIds' => ['uk'],
+                'languageMapping' => ['uk' => ['locale' => 'uk-UA']],
+            ]]),
+            'exportTranslations' => function (string $method, string $url, array $options = []): ResponseInterface {
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/translations/exports', $url);
+                $this->assertSame(json_encode(['targetLanguageId' => 'uk', 'fileIds' => [12]]), $options['body']);
+
+                return new JsonMockResponse(['data' => ['url' => 'https://file.uk']]);
+            },
+            'downloadTranslations' => new MockResponse(<<<'XLIFF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file source-language="en" target-language="uk-UA" datatype="plaintext" original="file.ext">
+                    <body></body>
+                  </file>
+                </xliff>
+                XLIFF),
+        ];
+
+        $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
+            'auth_bearer' => 'API_TOKEN',
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
+
+        $translatorBag = $crowdinProvider->read(['messages'], [$locale]);
+
+        $this->assertCount(1, $catalogues = $translatorBag->getCatalogues());
+        $this->assertSame($locale, $catalogues[0]->getLocale());
+    }
+
+    public function testReadWithoutLocalesReadsMappedLanguagesOnce()
+    {
+        $responses = [
+            'listFiles' => new JsonMockResponse(['data' => [
+                ['data' => [
+                    'id' => 12,
+                    'name' => 'messages.xlf',
+                ]],
+            ]]),
+            'getProject' => new JsonMockResponse(['data' => [
+                'sourceLanguageId' => 'en',
+                'targetLanguageIds' => ['uk'],
+                'languageMapping' => ['uk' => ['locale' => 'uk-UA']],
+            ]]),
+            'downloadSource' => new JsonMockResponse(['data' => ['url' => 'https://file.en']]),
+            'exportTranslations' => new JsonMockResponse(['data' => ['url' => 'https://file.uk']]),
+            'getSourceFile' => new MockResponse(<<<'XLIFF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                    <body></body>
+                  </file>
+                </xliff>
+                XLIFF),
+            'getTranslationsFile' => new MockResponse(<<<'XLIFF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file source-language="en" target-language="uk-UA" datatype="plaintext" original="file.ext">
+                    <body></body>
+                  </file>
+                </xliff>
+                XLIFF),
+        ];
+
+        $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
+            'auth_bearer' => 'API_TOKEN',
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com', '1');
+
+        $translatorBag = $crowdinProvider->read(['messages'], []);
+
+        $this->assertEqualsCanonicalizing(
+            ['en', 'uk_UA'],
+            array_map(static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(), $translatorBag->getCatalogues()),
+        );
+    }
+
+    public function testSourceLanguageIsNeverExported()
+    {
+        $responses = [
+            'listFiles' => new JsonMockResponse(['data' => [
+                ['data' => [
+                    'id' => 12,
+                    'name' => 'messages.xlf',
+                ]],
+            ]]),
+            'getProject' => new JsonMockResponse(['data' => [
+                'sourceLanguageId' => 'en',
+                'targetLanguageIds' => [],
+                'languageMapping' => [],
+            ]]),
+            'downloadSource' => function (string $method, string $url): ResponseInterface {
+                $this->assertSame('https://api.crowdin.com/api/v2/projects/1/files/12/download', $url);
+
+                return new JsonMockResponse(['data' => ['url' => 'https://file.en']]);
+            },
+            'getSourceFile' => new MockResponse(<<<'XLIFF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+                    <body></body>
+                  </file>
+                </xliff>
+                XLIFF),
+        ];
+
+        // the project source language is not the application default locale
+        $crowdinProvider = self::createProvider((new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.crowdin.com/api/v2/',
+            'auth_bearer' => 'API_TOKEN',
+        ]), $this->getLoader(), $this->getLogger(), 'en_US', 'api.crowdin.com', '1');
+
+        $translatorBag = $crowdinProvider->read(['messages'], []);
+
+        $this->assertCount(1, $catalogues = $translatorBag->getCatalogues());
+        $this->assertSame('en', $catalogues[0]->getLocale());
+    }
+
     public function testReadServerException()
     {
         $responses = [
@@ -1336,17 +1597,13 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse([
-                    'data' => [
-                        'languageMapping' => [
-                            'pt-PT' => [
-                                'locale' => 'pt',
-                            ],
-                        ],
-                    ],
-                ]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => ['fr'],
+                    'languageMapping' => [],
+                ]]);
             },
-            'exportProjectTranslations' => function (string $method, string $url, array $options = []): ResponseInterface {
+            'exportProjectTranslations' => function (string $method, string $url): ResponseInterface {
                 $this->assertSame('POST', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1/translations/exports', $url);
 
@@ -1385,15 +1642,11 @@ class CrowdinProviderTest extends ProviderTestCase
                 $this->assertSame('GET', $method);
                 $this->assertSame('https://api.crowdin.com/api/v2/projects/1', $url);
 
-                return new JsonMockResponse([
-                    'data' => [
-                        'languageMapping' => [
-                            'pt-PT' => [
-                                'locale' => 'pt',
-                            ],
-                        ],
-                    ],
-                ]);
+                return new JsonMockResponse(['data' => [
+                    'sourceLanguageId' => 'en',
+                    'targetLanguageIds' => ['fr'],
+                    'languageMapping' => [],
+                ]]);
             },
             'exportProjectTranslations' => function (string $method, string $url, array $options = []): ResponseInterface {
                 $this->assertSame('POST', $method);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Another stab at #64155: same as #64594, but for Crowdin.