### PR TITLE
[HttpClient] Add support for the QUERY HTTP method to CachingHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add the `extra.cache_policy` option to `CachingHttpClient` to tag cached responses and force their lifetime
  * Allow passing a stream or a closure to `HttpOptions::buffer()`
+ * Add `QUERY` to the list of cacheable HTTP methods in `CachingHttpClient`
 
 8.1
 ---

--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -58,11 +58,11 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
     /**
      * The HTTP methods that are always cacheable.
      */
-    private const CACHEABLE_METHODS = ['GET', 'HEAD'];
+    private const CACHEABLE_METHODS = ['GET', 'HEAD', 'QUERY'];
     /**
      * The HTTP methods that are considered safe per RFC 9110.
      */
-    private const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS', 'TRACE'];
+    private const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS', 'TRACE', 'QUERY'];
     /**
      * Headers that influence the response and may affect caching behavior.
      */
@@ -151,7 +151,11 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             throw new InvalidArgumentException(\sprintf('The "extra.cache_policy" option must be a callable, "%s" given.', get_debug_type($cacheHook)));
         }
 
-        if ('' !== $options['body'] || ($options['extra']['no_cache'] ?? false) || isset($options['normalized_headers']['range']) || !\in_array($method, self::CACHEABLE_METHODS, true)) {
+        $isQuery = 'QUERY' === $method;
+        $hasDisqualifyingBody = $isQuery ? !\is_string($options['body']) : '' !== $options['body'];
+        $isMalformedQuery = $isQuery && '' === trim(substr($options['normalized_headers']['content-type'][0] ?? '', \strlen('content-type: ')));
+
+        if ($hasDisqualifyingBody || $isMalformedQuery || ($options['extra']['no_cache'] ?? false) || isset($options['normalized_headers']['range']) || !\in_array($method, self::CACHEABLE_METHODS, true)) {
             if (isset($requestCacheControl['only-if-cached'])) {
                 return self::createGatewayTimeoutResponse($method, $url, $options);
             }
@@ -186,7 +190,8 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             return new AsyncResponse($this->client, $method, $url, $options);
         }
 
-        $requestHash = self::hash($method.$fullUrl.serialize(array_intersect_key($options['normalized_headers'], self::RESPONSE_INFLUENCING_HEADERS)));
+        $influencingHeaders = $isQuery ? self::RESPONSE_INFLUENCING_HEADERS + ['content-type' => true] : self::RESPONSE_INFLUENCING_HEADERS;
+        $requestHash = self::hash($method.$fullUrl.($isQuery ? \strlen($options['body'])."\0".$options['body'] : '').serialize(array_intersect_key($options['normalized_headers'], $influencingHeaders)));
         $varyKey = "vary_{$requestHash}";
         $varyFields = $this->cache->get($varyKey, static fn ($item, &$save): array => ($save = false) ?: [], 0);
 

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -63,6 +63,129 @@ class CachingHttpClientTest extends TestCase
         $this->assertSame('non-cached response', $response->getContent(), 'Request with body should bypass cache.');
     }
 
+    public function testItCachesQueryResponses()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=300',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $options = ['body' => 'query=foo', 'headers' => ['Content-Type' => 'application/x-www-form-urlencoded']];
+        $response = $client->request('QUERY', 'http://example.com/search', $options);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', $options);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testDifferentQueryBodiesDoNotCollideInCache()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('bar', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('baz', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+        ]);
+
+        $headers = ['headers' => ['Content-Type' => 'application/x-www-form-urlencoded']];
+
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => 'foo'] + $headers);
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => 'foo'] + $headers);
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => 'bar'] + $headers);
+        $this->assertSame('bar', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/searchfoo', ['body' => ''] + $headers);
+        $this->assertSame('baz', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => 'foo'] + $headers);
+        $this->assertSame('foo', $response->getContent());
+    }
+
+    public function testQueryBodiesWithEmbeddedNullByteDoNotCollideInCache()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('bar', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+        ]);
+
+        $headers = ['headers' => ['Content-Type' => 'application/x-www-form-urlencoded']];
+
+        // bodies containing raw null bytes must still map to distinct cache entries
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => "\0foo"] + $headers);
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => "foo\0"] + $headers);
+        $this->assertSame('bar', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => "\0foo"] + $headers);
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', ['body' => "foo\0"] + $headers);
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testQueryRequestsWithDifferentContentTypeDoNotCollideInCache()
+    {
+        $client = $this->buildClient([
+            new MockResponse('foo', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('bar', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+        ]);
+
+        $formEncoded = [
+            'body' => 'query=foo',
+            'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
+        ];
+        $json = [
+            'body' => 'query=foo',
+            'headers' => ['Content-Type' => 'application/json'],
+        ];
+
+        $response = $client->request('QUERY', 'http://example.com/search', $formEncoded);
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', $formEncoded);
+        $this->assertSame('foo', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', $json);
+        $this->assertSame('bar', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', $json);
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testBypassCacheForQueryWithStreamedBody()
+    {
+        $client = $this->buildClient([
+            new MockResponse('first stream response', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('second stream response', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('string body response', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+        ]);
+
+        $streamedOptions = ['body' => static function () { yield 'query=foo'; }];
+        $response = $client->request('QUERY', 'http://example.com/search', $streamedOptions);
+        $this->assertSame('first stream response', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', $streamedOptions);
+        $this->assertSame('second stream response', $response->getContent(), 'Streamed body should bypass cache.');
+
+        $stringOptions = ['body' => 'query=foo', 'headers' => ['Content-Type' => 'application/x-www-form-urlencoded']];
+        $response = $client->request('QUERY', 'http://example.com/search', $stringOptions);
+        $this->assertSame('string body response', $response->getContent());
+
+        $response = $client->request('QUERY', 'http://example.com/search', $stringOptions);
+        $this->assertSame('string body response', $response->getContent(), 'String body should be served from cache.');
+    }
+
     public function testBypassCacheWhenRangeHeaderPresent()
     {
         // If a "range" header is present, caching is bypassed.
@@ -90,6 +213,20 @@ class CachingHttpClientTest extends TestCase
         $client->request('POST', 'http://example.com/foo-bar');
         $response = $client->request('POST', 'http://example.com/foo-bar');
         $this->assertSame('second response', $response->getContent(), 'Non-cacheable method must bypass caching.');
+    }
+
+    public function testItDoesNotCacheQueryWithoutContentType()
+    {
+        // A QUERY request without a Content-Type header is malformed per RFC 10008 §2 and must bypass caching.
+        $client = $this->buildClient([
+            new MockResponse('first response', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('second response', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+        ]);
+
+        $options = ['body' => 'query=foo'];
+        $client->request('QUERY', 'http://example.com/search', $options);
+        $response = $client->request('QUERY', 'http://example.com/search', $options);
+        $this->assertSame('second response', $response->getContent(), 'Missing Content-Type must bypass caching.');
     }
 
     public function testItServesResponseFromCache()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix -
| License       | MIT


Adds `QUERY` to the list of cacheable, safe HTTP methods in `CachingHttpClient`. 

`QUERY` carries its payload in the request body, so:

  - [x] a body no longer disqualifies a `QUERY` request from caching (only a non-string/streamed body does)
  - [x] the cache key folds in the request body and `Content-Type`, hashed with the body length-prefixed
  - [x] a `QUERY` with a missing, empty, or whitespace-only `Content-Type` is treated as non-cacheable, per RFC 10008 §2
