### PR TITLE
[SecurityBundle] Deprecate the unused `remember_me` authenticator option

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -23,6 +23,11 @@ HttpFoundation
 
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()`
 
+SecurityBundle
+--------------
+
+ * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
+
 Serializer
 ----------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `allowed_time_drift` option to the OIDC token handler configuration
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
+ * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -54,7 +54,10 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
 
         $builder
             ->scalarNode('provider')->end()
-            ->booleanNode('remember_me')->defaultTrue()->end()
+            ->booleanNode('remember_me')
+                ->defaultTrue()
+                ->setDeprecated('symfony/security-bundle', '8.2', 'Setting the "%path%.%node%" configuration option has no effect and is deprecated. It will be removed in Symfony 9.0.')
+            ->end()
             ->scalarNode('success_handler')->end()
             ->scalarNode('failure_handler')->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
@@ -19,7 +19,6 @@ security:
     default:
       form_login:
         check_path: login
-        remember_me: true
       logout: ~
       stateless: false
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
@@ -15,7 +15,6 @@ security:
         default:
             form_login:
                 check_path: login
-                remember_me: true
             logout: ~
             stateless: true
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
@@ -15,7 +15,6 @@ security:
         default:
             form_login:
                 check_path: login
-                remember_me: true
             logout:
                 delete_cookies:
                     flavor: { path: null, domain: somedomain }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_enabled.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_enabled.yml
@@ -15,7 +15,6 @@ security:
         default:
             form_login:
                 check_path: login
-                remember_me: true
             logout:
                 enable_csrf: true
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -15,7 +15,6 @@ security:
         default:
             form_login:
                 check_path: login
-                remember_me: true
             remember_me:
                 always_remember_me: true
                 secret: secret

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/config.yml
@@ -16,7 +16,6 @@ security:
             logout: ~
             form_login:
                 check_path: login
-                remember_me: true
 
     access_control:
         - { path: ^/profile, roles: ROLE_USER }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
@@ -15,7 +15,6 @@ security:
         default:
             form_login:
                 check_path: login
-                remember_me: true
             remember_me:
                 always_remember_me: true
                 secret: key


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | n/a
| License       | MIT

The `remember_me` option on `form_login`, `json_login`, `login_link` and `access_token` (defined in `AbstractFactory`) is no longer read anywhere. Deprecate it for removal in Symfony 9.0.

I believe this was just missed in https://github.com/symfony/symfony/pull/33558.