### PR TITLE
[Security] Add `path` and CSRF options to `switch_user`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -80,6 +80,7 @@ Security
    carries a 403 status, instead of `Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException`, which
    extends `AuthenticationException`. The firewall no longer turns the failure into a login redirect or a 401, and
    code catching the `Security\Core` exception for this case must catch the `Security\Http` one instead
+ * Add argument `$targetUri` to `ImpersonateUrlGenerator::generateImpersonationPath()` and `ImpersonateUrlGenerator::generateImpersonationUrl()`
 
 SecurityBundle
 --------------

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add the `logout_form()` function to build a form that logs the user out with a POST
  * Add the `normalize` filter to normalize values with the Serializer component
+ * Add the `impersonation_form()` and `impersonation_exit_form()` functions to build a form that switches the user with a POST
 
 8.1
 ---

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -58,7 +58,7 @@ final class SecurityExtension extends AbstractExtension
     public function getAccessDecision(mixed $role, mixed $object = null, ?string $field = null): AccessDecision
     {
         if (!class_exists(AccessDecision::class)) {
-            throw new \LogicException(\sprintf('Using the "access_decision()" function requires symfony/security-core >= 7.3. Try running "composer %s symfony/security-core".', $this->securityChecker ? 'update' : 'require'));
+            throw new \LogicException(\sprintf('Using the "access_decision()" function requires symfony/security-core >= 7.3. Try running "%s".', $this->securityChecker ? 'composer update symfony/security-core' : 'composer require symfony/security-core'));
         }
 
         $accessDecision = new AccessDecision();
@@ -95,7 +95,7 @@ final class SecurityExtension extends AbstractExtension
     public function getAccessDecisionForUser(UserInterface $user, mixed $attribute, mixed $subject = null, ?string $field = null): AccessDecision
     {
         if (!class_exists(AccessDecision::class)) {
-            throw new \LogicException(\sprintf('Using the "access_decision_for_user()" function requires symfony/security-core >= 7.3. Try running "composer %s symfony/security-core".', $this->securityChecker ? 'update' : 'require'));
+            throw new \LogicException(\sprintf('Using the "access_decision_for_user()" function requires symfony/security-core >= 7.3. Try running "%s".', $this->securityChecker ? 'composer update symfony/security-core' : 'composer require symfony/security-core'));
         }
 
         $accessDecision = new AccessDecision();
@@ -122,22 +122,46 @@ final class SecurityExtension extends AbstractExtension
         return $this->impersonateUrlGenerator->generateExitPath($exitTo);
     }
 
-    public function getImpersonateUrl(string $identifier): string
+    public function getImpersonateUrl(string $identifier, ?string $targetUri = null): string
     {
         if (null === $this->impersonateUrlGenerator) {
             return '';
         }
 
-        return $this->impersonateUrlGenerator->generateImpersonationUrl($identifier);
+        return $this->impersonateUrlGenerator->generateImpersonationUrl($identifier, $targetUri);
     }
 
-    public function getImpersonatePath(string $identifier): string
+    public function getImpersonatePath(string $identifier, ?string $targetUri = null): string
     {
         if (null === $this->impersonateUrlGenerator) {
             return '';
         }
 
-        return $this->impersonateUrlGenerator->generateImpersonationPath($identifier);
+        return $this->impersonateUrlGenerator->generateImpersonationPath($identifier, $targetUri);
+    }
+
+    /**
+     * @return array{action: string, fields: array<string, string>}
+     */
+    public function getImpersonateForm(string $identifier, ?string $targetUri = null): array
+    {
+        if (null === $this->impersonateUrlGenerator) {
+            return ['action' => '', 'fields' => []];
+        }
+
+        return $this->impersonateUrlGenerator->generateImpersonationForm($identifier, $targetUri);
+    }
+
+    /**
+     * @return array{action: string, fields: array<string, string>}
+     */
+    public function getImpersonateExitForm(?string $targetUri = null): array
+    {
+        if (null === $this->impersonateUrlGenerator) {
+            return ['action' => '', 'fields' => []];
+        }
+
+        return $this->impersonateUrlGenerator->generateExitForm($targetUri);
     }
 
     public function getFunctions(): array
@@ -149,6 +173,8 @@ final class SecurityExtension extends AbstractExtension
             new TwigFunction('impersonation_exit_path', $this->getImpersonateExitPath(...)),
             new TwigFunction('impersonation_url', $this->getImpersonateUrl(...)),
             new TwigFunction('impersonation_path', $this->getImpersonatePath(...)),
+            new TwigFunction('impersonation_form', $this->getImpersonateForm(...)),
+            new TwigFunction('impersonation_exit_form', $this->getImpersonateExitForm(...)),
         ];
 
         if ($this->securityChecker instanceof UserAuthorizationCheckerInterface) {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SecurityExtensionTest.php
@@ -34,6 +34,14 @@ class SecurityExtensionTest extends TestCase
         ClassExistsMock::withMockedClasses([FieldVote::class => true, AccessDecision::class => true]);
     }
 
+    public function testImpersonationFormsAreEmptyWithoutAnImpersonateUrlGenerator()
+    {
+        $extension = new SecurityExtension();
+
+        $this->assertSame(['action' => '', 'fields' => []], $extension->getImpersonateForm('kuba'));
+        $this->assertSame(['action' => '', 'fields' => []], $extension->getImpersonateExitForm());
+    }
+
     #[DataProvider('provideObjectFieldAclCases')]
     public function testIsGrantedCreatesFieldVoteObjectWhenFieldNotNull($object, $field, $expectedSubject)
     {

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -43,7 +43,7 @@
         "symfony/security-acl": "^2.8|^3.0",
         "symfony/security-core": "^7.4|^8.0",
         "symfony/security-csrf": "^7.4|^8.0",
-        "symfony/security-http": "^7.4|^8.0",
+        "symfony/security-http": "^8.2",
         "symfony/serializer": "^7.4|^8.0",
         "symfony/stopwatch": "^7.4|^8.0",
         "symfony/translation": "^7.4|^8.0",
@@ -59,7 +59,8 @@
         "phpdocumentor/reflection-docblock": "<5.2|>=7",
         "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/form": "<7.4.4|>8.0,<8.0.4",
-        "symfony/mime": "<7.4.9|>8.0,<8.0.9"
+        "symfony/mime": "<7.4.9|>8.0,<8.0.9",
+        "symfony/security-http": "<8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Twig\\": "" },

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add the `ldap_users_only` option to the LDAP authenticators, to bind only `LdapUser` instances against the LDAP server
  * Show the deauthentication reason and the responsible user providers in the security profiler panel
  * Serve the CSRF token id of a firewall through the `csrf_token_manager` it configures, so that `csrf_token()` no longer mints a token the firewall rejects
+ * Add `path`, `enable_csrf`, `csrf_token_id`, `csrf_parameter` and `csrf_token_manager` options to the `switch_user` firewall configuration to restrict user switching to a dedicated (POST-only) route protected by a CSRF token
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -25,8 +25,8 @@ use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager
 use Symfony\Component\Security\Core\Authorization\Voter\TraceableVoter;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
-use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 use Symfony\Component\Security\Http\FirewallMapInterface;
+use Symfony\Component\Security\Http\Impersonate\ImpersonateUrlGenerator;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -48,6 +48,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         private ?AccessDecisionManagerInterface $accessDecisionManager = null,
         private ?FirewallMapInterface $firewallMap = null,
         private ?TraceableFirewallListener $firewall = null,
+        private ?ImpersonateUrlGenerator $impersonateUrlGenerator = null,
     ) {
         $this->hasVarDumper = class_exists(ClassStub::class);
     }
@@ -193,13 +194,12 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                     'authenticators' => $firewallConfig->getAuthenticators(),
                 ];
 
-                // generate exit impersonation path from current request
-                if ($this->data['impersonated'] && null !== $switchUserConfig = $firewallConfig->getSwitchUser()) {
-                    $exitPath = $request->getRequestUri();
-                    $exitPath .= null === $request->getQueryString() ? '?' : '&';
-                    $exitPath .= \sprintf('%s=%s', urlencode($switchUserConfig['parameter']), SwitchUserListener::EXIT_VALUE);
-
-                    $this->data['impersonation_exit_path'] = $exitPath;
+                if ($this->data['impersonated'] && null !== $firewallConfig->getSwitchUser()) {
+                    try {
+                        $this->data['impersonation_exit_path'] = $this->impersonateUrlGenerator?->generateExitPath();
+                    } catch (\Exception) {
+                        // fail silently when the exit impersonation path cannot be generated
+                    }
                 }
             }
         }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -267,11 +267,32 @@ class MainConfiguration implements ConfigurationInterface
             ->end()
             ->arrayNode('switch_user')
                 ->canBeUnset()
+                ->beforeNormalization()
+                    ->ifArray()
+                    ->then(static function ($v) {
+                        if (isset($v['csrf_token_manager'])) {
+                            $v['enable_csrf'] ??= true;
+                        } elseif ($v['enable_csrf'] ?? false) {
+                            $v['csrf_token_manager'] = 'security.csrf.token_manager';
+                        }
+
+                        return $v;
+                    })
+                ->end()
                 ->children()
                     ->scalarNode('provider')->end()
                     ->scalarNode('parameter')->defaultValue('_switch_user')->end()
                     ->scalarNode('role')->defaultValue('ROLE_ALLOWED_TO_SWITCH')->end()
                     ->scalarNode('target_route')->defaultValue(null)->end()
+                    ->scalarNode('path')
+                        ->defaultNull()
+                        ->cannotBeEmpty()
+                        ->info('Restrict user switching to this path (a path or route name). Declaring the route POST-only is up to the application. The parameter is no longer read from the request headers in this mode.')
+                    ->end()
+                    ->booleanNode('enable_csrf')->defaultNull()->end()
+                    ->scalarNode('csrf_token_id')->defaultValue('switch_user')->end()
+                    ->scalarNode('csrf_parameter')->defaultValue('_csrf_token')->end()
+                    ->scalarNode('csrf_token_manager')->end()
                 ->end()
             ->end()
             ->arrayNode('required_badges', 'required_badge')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -943,6 +943,15 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $listener->replaceArgument(7, $config['role']);
         $listener->replaceArgument(9, $stateless);
         $listener->replaceArgument(11, $config['target_route']);
+        $listener->replaceArgument(13, $config['path']);
+
+        if ($config['enable_csrf'] ?? false) {
+            $listener->replaceArgument(14, new Reference($config['csrf_token_manager']));
+            $listener->replaceArgument(15, $config['csrf_parameter']);
+            $listener->replaceArgument(16, $config['csrf_token_id']);
+
+            $this->registerCsrfTokenManager($container, $id, $config['csrf_token_id'], $config['csrf_token_manager']);
+        }
 
         return $switchUserListenerId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.php
@@ -24,6 +24,7 @@ return static function (ContainerConfigurator $container) {
                 service('security.access.decision_manager'),
                 service('security.firewall.map'),
                 service('debug.security.firewall')->nullOnInvalid(),
+                service('security.impersonate_url_generator')->nullOnInvalid(),
             ])
             ->tag('data_collector', [
                 'template' => '@Security/Collector/security.html.twig',

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -191,6 +191,8 @@ return static function (ContainerConfigurator $container) {
             service('request_stack'),
             service('security.firewall.map'),
             service('security.token_storage'),
+            service('router')->nullOnInvalid(),
+            service('security.csrf.token_manager')->nullOnInvalid(),
         ])
 
         // Firewall related services

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
@@ -157,6 +157,11 @@ return static function (ContainerConfigurator $container) {
                 false, // Stateless
                 service('router')->nullOnInvalid(),
                 abstract_arg('Target Route'),
+                service('security.http_utils'),
+                null, // Path
+                null, // CSRF Token Manager
+                '_csrf_token', // CSRF Parameter
+                'switch_user', // CSRF Token ID
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -22,6 +22,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -36,8 +37,11 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
 use Symfony\Component\Security\Http\Firewall\AbstractListener;
+use Symfony\Component\Security\Http\Impersonate\ImpersonateUrlGenerator;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -187,6 +191,39 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertSame(['ROLE_USER'], $collector->getRoles()->getValue(true));
         $this->assertSame([], $collector->getInheritedRoles()->getValue(true));
         $this->assertSame('hhamon', $collector->getUser());
+    }
+
+    public function testCollectImpersonationExitPathFromTheUrlGenerator()
+    {
+        $adminToken = new UsernamePasswordToken(new InMemoryUser('yceruto', 'P4$$w0rD', ['ROLE_ADMIN']), 'provider', ['ROLE_ADMIN']);
+
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new SwitchUserToken(new InMemoryUser('hhamon', 'P4$$w0rD', ['ROLE_USER']), 'provider', ['ROLE_USER'], $adminToken));
+
+        $switchUser = [
+            'parameter' => '_switch_user',
+            'path' => '/switch-user',
+            'enable_csrf' => true,
+            'csrf_parameter' => '_csrf_token',
+            'csrf_token_id' => 'switch_user',
+        ];
+
+        $firewallMap = $this->createStub(FirewallMap::class);
+        $firewallMap->method('getFirewallConfig')->willReturn(new FirewallConfig('dummy', 'security.user_checker.dummy', switchUser: $switchUser));
+
+        $request = Request::create('/profile');
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $csrfTokenManager = $this->createStub(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->method('getToken')->willReturn(new CsrfToken('switch_user', 'T0K3N'));
+
+        $impersonateUrlGenerator = new ImpersonateUrlGenerator($requestStack, $firewallMap, $tokenStorage, null, $csrfTokenManager);
+
+        $collector = new SecurityDataCollector($tokenStorage, null, null, null, $firewallMap, null, $impersonateUrlGenerator);
+        $collector->collect($request, new Response());
+
+        $this->assertSame('/switch-user?_switch_user=_exit&_csrf_token=T0K3N&_target_path=%2Fprofile', $collector->getImpersonationExitPath());
     }
 
     public function testGetFirewall()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -173,6 +173,10 @@ abstract class CompleteConfigurationTestCase extends TestCase
                     'parameter' => '_switch_user',
                     'role' => 'ROLE_ALLOWED_TO_SWITCH',
                     'target_route' => null,
+                    'path' => null,
+                    'enable_csrf' => null,
+                    'csrf_token_id' => 'switch_user',
+                    'csrf_parameter' => '_csrf_token',
                 ],
                 [
                     'csrf_parameter' => '_csrf_token',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -145,6 +145,22 @@ class MainConfigurationTest extends TestCase
         }
     }
 
+    public function testSwitchUserPathCannotBeEmpty()
+    {
+        $config = array_merge(static::$minimalConfig, [
+            'firewalls' => [
+                'main' => [
+                    'switch_user' => ['path' => ''],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The path "security.firewalls.main.switch_user.path" cannot contain an empty value, but got "".');
+
+        (new Processor())->processConfiguration(new MainConfiguration([], []), [$config]);
+    }
+
     public function testLogoutDeleteCookies()
     {
         $config = [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -444,6 +444,63 @@ class SecurityExtensionTest extends TestCase
         $this->assertTrue($container->getDefinition('security.authentication.switchuser_listener.some_firewall')->getArgument(9));
     }
 
+    public function testSwitchUserCsrfTokenManagersAreRegisteredForTheirTokenId()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'default' => ['id' => 'foo'],
+            ],
+
+            'firewalls' => [
+                'custom_manager' => [
+                    'http_basic' => null,
+                    'switch_user' => ['csrf_token_manager' => 'app.csrf_token_manager'],
+                ],
+                'default_manager' => [
+                    'http_basic' => null,
+                    'switch_user' => ['enable_csrf' => true, 'csrf_token_id' => 'other_switch_user'],
+                ],
+                'no_csrf' => [
+                    'http_basic' => null,
+                    'switch_user' => true,
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertEquals(
+            ['switch_user' => new ServiceClosureArgument(new Reference('app.csrf_token_manager'))],
+            $container->getDefinition('security.csrf_token_manager_locator')->getArgument(0)
+        );
+    }
+
+    public function testSwitchUserAndLogoutCannotMapTheSameTokenIdToDifferentCsrfTokenManagers()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'default' => ['id' => 'foo'],
+            ],
+
+            'firewalls' => [
+                'main' => [
+                    'http_basic' => null,
+                    'logout' => ['csrf_token_id' => 'shared', 'csrf_token_manager' => 'app.csrf_token_manager'],
+                    'switch_user' => ['csrf_token_id' => 'shared', 'csrf_token_manager' => 'app.other_csrf_token_manager'],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "main" firewall configures a "csrf_token_manager" for the "shared" token id, but another firewall already configured a different one. Give them distinct "csrf_token_id" values.');
+
+        $container->compile();
+    }
+
     public function testRoleHierarchyDumpCommandIsRegisteredWithRoleHierarchy()
     {
         $container = $this->getRawContainer();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Environment;
@@ -60,6 +61,23 @@ class LoginController implements ServiceSubscriberInterface
         return new Response($this->container->get('twig')->render('@FormLogin/Login/logout_form.html.twig'));
     }
 
+    public function impersonationFormAction()
+    {
+        $csrfToken = $this->container->get('csrf')->getToken('switch_user')->getValue();
+
+        return new Response($this->container->get('twig')->render('@FormLogin/Login/impersonate.html.twig', ['csrf_token' => $csrfToken]));
+    }
+
+    public function impersonationLinkAction()
+    {
+        return new Response($this->container->get('twig')->render('@FormLogin/Login/impersonation_link.html.twig'));
+    }
+
+    public function impersonationFormHelperAction()
+    {
+        return new Response($this->container->get('twig')->render('@FormLogin/Login/impersonation_form.html.twig'));
+    }
+
     public function secureAction()
     {
         throw new \Exception('Wrapper', 0, new \Exception('Another Wrapper', 0, new AccessDeniedException()));
@@ -69,6 +87,7 @@ class LoginController implements ServiceSubscriberInterface
     {
         return [
             'twig' => Environment::class,
+            'csrf' => CsrfTokenManagerInterface::class,
         ];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/impersonate.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/impersonate.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <form action="{{ path('switch_user_route') }}" method="post">
+        <input type="hidden" name="_switch_user" value="" />
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+
+        <input type="submit" name="switch" />
+    </form>
+{% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/impersonation_form.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/impersonation_form.html.twig
@@ -1,0 +1,23 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    {% set impersonate = impersonation_form('user_cannot_switch_1') %}
+    <form method="post" action="{{ impersonate.action }}">
+        {% for name, value in impersonate.fields %}
+            <input type="hidden" name="{{ name }}" value="{{ value }}" />
+        {% endfor %}
+
+        <input type="submit" name="switch" />
+    </form>
+
+    {% set exit = impersonation_exit_form() %}
+    {% if exit.action %}
+        <form method="post" action="{{ exit.action }}">
+            {% for name, value in exit.fields %}
+                <input type="hidden" name="{{ name }}" value="{{ value }}" />
+            {% endfor %}
+
+            <input type="submit" name="exit" />
+        </form>
+    {% endif %}
+{% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/impersonation_link.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/impersonation_link.html.twig
@@ -1,0 +1,1 @@
+{{ impersonation_path('user_cannot_switch_1')|raw }}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -50,6 +50,124 @@ class SwitchUserTest extends AbstractWebTestCase
         $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());
     }
 
+    public function testSwitchUserViaPostOnlyRouteRejectsGet()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_path.yml']);
+
+        // the route is declared POST-only, so a GET is rejected by routing before
+        // it can ever reach the switch-user listener
+        $client->request('GET', '/switch-user?_switch_user=user_cannot_switch_1');
+
+        $this->assertSame(405, $client->getResponse()->getStatusCode());
+    }
+
+    public function testSwitchUserViaPostOnlyRoute()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_path.yml']);
+
+        $client->request('POST', '/switch-user', ['_switch_user' => 'user_cannot_switch_1']);
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_cannot_switch_1', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testSwitchUserViaPathWithoutCsrfTokenIsDenied()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_csrf.yml']);
+
+        $client->request('POST', '/switch-user', ['_switch_user' => 'user_cannot_switch_1']);
+
+        $this->assertSame(403, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testSwitchUserViaPathWithValidCsrfToken()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_csrf.yml']);
+
+        // render a form carrying a valid session-bound CSRF token, then submit it
+        $crawler = $client->request('GET', '/impersonation-form');
+        $form = $crawler->selectButton('switch')->form();
+        $form['_switch_user'] = 'user_cannot_switch_1';
+        $client->submit($form);
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_cannot_switch_1', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testExitImpersonationPathTargetsTheConfiguredPath()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_path.yml']);
+
+        $client->request('POST', '/switch-user', ['_switch_user' => 'user_cannot_switch_1', '_target_path' => '/profile']);
+
+        $this->assertSame('/switch-user?_switch_user=_exit&_target_path=%2Fprofile', $client->getProfile()->getCollector('security')->getImpersonationExitPath());
+    }
+
+    public function testExitImpersonationPathCarriesACsrfToken()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_csrf.yml']);
+
+        $crawler = $client->request('GET', '/impersonation-form');
+        $form = $crawler->selectButton('switch')->form();
+        $form['_switch_user'] = 'user_cannot_switch_1';
+        $client->submit($form);
+
+        $exitPath = $client->getProfile()->getCollector('security')->getImpersonationExitPath();
+        $this->assertMatchesRegularExpression('#^/switch-user\?_switch_user=_exit&_csrf_token=.+&_target_path=%2F$#', $exitPath);
+
+        // the route is declared POST-only, so the generated URL is submitted as a POST
+        $client->request('POST', $exitPath);
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testImpersonationPathCarriesACsrfToken()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_csrf.yml']);
+
+        $client->request('GET', '/impersonation-link');
+        $client->request('POST', trim($client->getResponse()->getContent()));
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_cannot_switch_1', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testImpersonationPathCarriesATokenOfTheCsrfTokenManagerOfTheFirewall()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_csrf_custom_manager.yml']);
+
+        $client->request('GET', '/impersonation-link');
+        $client->request('POST', trim($client->getResponse()->getContent()));
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_cannot_switch_1', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testTheImpersonationFormHelperBuildsAFormTheListenerAccepts()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_csrf_custom_manager.yml']);
+
+        $crawler = $client->request('GET', '/impersonation-form-helper');
+        $client->submit($crawler->selectButton('switch')->form());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_cannot_switch_1', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testTheExitFormHelperBuildsAFormTheListenerAccepts()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch', ['root_config' => 'switchuser_csrf_custom_manager.yml']);
+
+        $crawler = $client->request('GET', '/impersonation-form-helper');
+        $crawler = $client->submit($crawler->selectButton('switch')->form());
+        $client->submit($crawler->selectButton('exit')->form());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());
+    }
+
     public function testSwitchUserStateless()
     {
         $client = $this->createClient(['test_case' => 'JsonLogin', 'root_config' => 'switchuser_stateless.yml']);
@@ -74,7 +192,7 @@ class SwitchUserTest extends AbstractWebTestCase
 
     protected function createAuthenticatedClient($username, array $options = [])
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'switchuser.yml'] + $options);
+        $client = $this->createClient($options + ['test_case' => 'StandardFormLogin', 'root_config' => 'switchuser.yml']);
         $client->followRedirects(true);
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routing.yml
@@ -11,3 +11,20 @@ logout_form:
 app_logout:
     path:     /logout
     methods:  [POST]
+
+switch_user_route:
+    path:     /switch-user
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller\LoginController::afterLoginAction }
+    methods:  [POST]
+
+impersonation_form:
+    path:     /impersonation-form
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller\LoginController::impersonationFormAction }
+
+impersonation_link:
+    path:     /impersonation-link
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller\LoginController::impersonationLinkAction }
+
+impersonation_form_helper:
+    path:     /impersonation-form-helper
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller\LoginController::impersonationFormHelperAction }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_csrf.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_csrf.yml
@@ -1,0 +1,15 @@
+imports:
+    - { resource: ./base_config.yml }
+
+security:
+    providers:
+        in_memory:
+            memory:
+                users:
+                    user_can_switch:      { password: test, roles: [ROLE_USER, ROLE_ALLOWED_TO_SWITCH] }
+                    user_cannot_switch_1: { password: test, roles: [ROLE_USER] }
+    firewalls:
+        default:
+            switch_user:
+                path: switch_user_route
+                enable_csrf: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_csrf_custom_manager.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_csrf_custom_manager.yml
@@ -1,0 +1,20 @@
+imports:
+    - { resource: ./base_config.yml }
+
+services:
+    app.switch_user_csrf_token_manager:
+        class: Symfony\Component\Security\Csrf\CsrfTokenManager
+        arguments: [null, '@security.csrf.token_storage', 'impersonation-']
+
+security:
+    providers:
+        in_memory:
+            memory:
+                users:
+                    user_can_switch:      { password: test, roles: [ROLE_USER, ROLE_ALLOWED_TO_SWITCH] }
+                    user_cannot_switch_1: { password: test, roles: [ROLE_USER] }
+    firewalls:
+        default:
+            switch_user:
+                path: switch_user_route
+                csrf_token_manager: app.switch_user_csrf_token_manager

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_path.yml
@@ -1,0 +1,14 @@
+imports:
+    - { resource: ./base_config.yml }
+
+security:
+    providers:
+        in_memory:
+            memory:
+                users:
+                    user_can_switch:      { password: test, roles: [ROLE_USER, ROLE_ALLOWED_TO_SWITCH] }
+                    user_cannot_switch_1: { password: test, roles: [ROLE_USER] }
+    firewalls:
+        default:
+            switch_user:
+                path: switch_user_route

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Impersonate/ImpersonateUrlGeneratorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Impersonate/ImpersonateUrlGeneratorTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Impersonate;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Http\Impersonate\ImpersonateUrlGenerator;
+
+class ImpersonateUrlGeneratorTest extends TestCase
+{
+    private const CSRF_CONFIG = [
+        'parameter' => '_switch_user',
+        'enable_csrf' => true,
+        'csrf_parameter' => '_token',
+        'csrf_token_id' => 'impersonate',
+    ];
+
+    public function testUrlsAreBuiltFromTheCurrentUriWhenNoPathIsConfigured()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user']);
+
+        $this->assertSame('/profile?page=2&_switch_user=kuba', $generator->generateImpersonationPath('kuba'));
+        $this->assertSame('http://localhost/profile?page=2&_switch_user=kuba', $generator->generateImpersonationUrl('kuba'));
+    }
+
+    public function testUrlsAreBuiltFromTheGivenTargetWhenNoPathIsConfigured()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user']);
+
+        $this->assertSame('/dashboard?_switch_user=kuba', $generator->generateImpersonationPath('kuba', '/dashboard'));
+        $this->assertSame('http://localhost/dashboard?_switch_user=kuba', $generator->generateImpersonationUrl('kuba', '/dashboard'));
+    }
+
+    public function testExitUrlsAreBuiltFromTheGivenTargetWhenNoPathIsConfigured()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user'], true);
+
+        $this->assertSame('/dashboard?_switch_user=_exit', $generator->generateExitPath('/dashboard'));
+        $this->assertSame('http://localhost/dashboard?_switch_user=_exit', $generator->generateExitUrl('/dashboard'));
+        $this->assertSame('/profile?page=2&_switch_user=_exit', $generator->generateExitPath());
+    }
+
+    public function testUrlsAreBuiltFromTheConfiguredPath()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user']);
+
+        $this->assertSame('/switch-user?_switch_user=kuba&_target_path=%2Fprofile%3Fpage%3D2', $generator->generateImpersonationPath('kuba'));
+        $this->assertSame('http://localhost/switch-user?_switch_user=kuba&_target_path=%2Fprofile%3Fpage%3D2', $generator->generateImpersonationUrl('kuba'));
+    }
+
+    public function testUrlsAreBuiltFromTheGivenTargetWhenAPathIsConfigured()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user']);
+
+        $this->assertSame('/switch-user?_switch_user=kuba&_target_path=%2Fdashboard', $generator->generateImpersonationPath('kuba', '/dashboard'));
+        $this->assertSame('http://localhost/switch-user?_switch_user=kuba&_target_path=%2Fdashboard', $generator->generateImpersonationUrl('kuba', '/dashboard'));
+    }
+
+    public function testUrlsAreBuiltFromTheConfiguredRoute()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => 'app_switch_user']);
+
+        $this->assertSame('/switch-user?_switch_user=kuba&_target_path=%2Fprofile%3Fpage%3D2', $generator->generateImpersonationPath('kuba'));
+        $this->assertSame('http://localhost/switch-user?_switch_user=kuba&_target_path=%2Fprofile%3Fpage%3D2', $generator->generateImpersonationUrl('kuba'));
+    }
+
+    public function testExitUrlsAreBuiltFromTheConfiguredPath()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user'], true);
+
+        $this->assertSame('/switch-user?_switch_user=_exit&_target_path=%2Fprofile%3Fpage%3D2', $generator->generateExitPath());
+        $this->assertSame('/switch-user?_switch_user=_exit&_target_path=%2Fdashboard', $generator->generateExitPath('/dashboard'));
+        $this->assertSame('http://localhost/switch-user?_switch_user=_exit&_target_path=%2Fdashboard', $generator->generateExitUrl('/dashboard'));
+    }
+
+    public function testCsrfTokenIsAppendedWhenTheFirewallEnablesIt()
+    {
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->atLeastOnce())
+            ->method('getToken')->with('impersonate')
+            ->willReturn(new CsrfToken('impersonate', 'T0K3N'));
+
+        $generator = $this->createGenerator(self::CSRF_CONFIG, true, $csrfTokenManager);
+
+        $this->assertSame('/profile?page=2&_switch_user=kuba&_token=T0K3N', $generator->generateImpersonationPath('kuba'));
+        $this->assertSame('/profile?page=2&_switch_user=_exit&_token=T0K3N', $generator->generateExitPath());
+    }
+
+    public function testCsrfTokenIsNotAppendedWhenTheFirewallDoesNotEnableIt()
+    {
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->never())->method('getToken');
+
+        $generator = $this->createGenerator(['parameter' => '_switch_user'], false, $csrfTokenManager);
+
+        $this->assertSame('/profile?page=2&_switch_user=kuba', $generator->generateImpersonationPath('kuba'));
+    }
+
+    public function testAnExceptionIsThrownWithoutACsrfTokenManager()
+    {
+        $generator = $this->createGenerator(self::CSRF_CONFIG);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to generate the impersonate URLs without a CSRF token manager.');
+
+        $generator->generateImpersonationPath('kuba');
+    }
+
+    public function testExitUrlsAreEmptyWhenNotImpersonating()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user']);
+
+        $this->assertSame('', $generator->generateExitPath());
+        $this->assertSame('', $generator->generateExitUrl());
+    }
+
+    public function testFormPartsAreBuiltFromTheCurrentUriWhenNoPathIsConfigured()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user']);
+
+        $this->assertSame([
+            'action' => '/profile?page=2',
+            'fields' => ['_switch_user' => 'kuba'],
+        ], $generator->generateImpersonationForm('kuba'));
+    }
+
+    public function testFormPartsAreBuiltFromTheConfiguredPath()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user']);
+
+        $this->assertSame([
+            'action' => '/switch-user',
+            'fields' => ['_switch_user' => 'kuba', '_target_path' => '/profile?page=2'],
+        ], $generator->generateImpersonationForm('kuba'));
+    }
+
+    public function testFormPartsAreBuiltFromTheConfiguredRoute()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => 'app_switch_user']);
+
+        $this->assertSame([
+            'action' => '/switch-user',
+            'fields' => ['_switch_user' => 'kuba', '_target_path' => '/profile?page=2'],
+        ], $generator->generateImpersonationForm('kuba'));
+    }
+
+    public function testFormFieldsCarryATokenOfTheCsrfTokenManagerOfTheFirewall()
+    {
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('getToken')->with('impersonate')
+            ->willReturn(new CsrfToken('impersonate', 'T0K3N'));
+
+        $generator = $this->createGenerator(self::CSRF_CONFIG + ['path' => '/switch-user'], false, $csrfTokenManager);
+
+        $this->assertSame([
+            'action' => '/switch-user',
+            'fields' => ['_switch_user' => 'kuba', '_token' => 'T0K3N', '_target_path' => '/profile?page=2'],
+        ], $generator->generateImpersonationForm('kuba'));
+    }
+
+    public function testFormPartsTargetTheGivenUri()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user']);
+
+        $this->assertSame([
+            'action' => '/switch-user',
+            'fields' => ['_switch_user' => 'kuba', '_target_path' => '/dashboard'],
+        ], $generator->generateImpersonationForm('kuba', '/dashboard'));
+    }
+
+    public function testExitFormPartsTargetTheGivenUri()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user'], true);
+
+        $this->assertSame([
+            'action' => '/switch-user',
+            'fields' => ['_switch_user' => '_exit', '_target_path' => '/dashboard'],
+        ], $generator->generateExitForm('/dashboard'));
+    }
+
+    public function testExitFormPartsAreEmptyWhenNotImpersonating()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => '/switch-user']);
+
+        $this->assertSame(['action' => '', 'fields' => []], $generator->generateExitForm());
+    }
+
+    public function testParametersTheRouteTakesAsPlaceholdersStayOutOfTheFormFields()
+    {
+        $generator = $this->createGenerator(['parameter' => '_switch_user', 'path' => 'app_switch_user_restful']);
+
+        $this->assertSame([
+            'action' => '/switch-user/kuba',
+            'fields' => ['_target_path' => '/profile?page=2'],
+        ], $generator->generateImpersonationForm('kuba'));
+        $this->assertSame('/switch-user/kuba?_target_path=%2Fprofile%3Fpage%3D2', $generator->generateImpersonationPath('kuba'));
+    }
+
+    private function createGenerator(array $switchUser, bool $impersonating = false, ?CsrfTokenManagerInterface $csrfTokenManager = null): ImpersonateUrlGenerator
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/profile?page=2'));
+
+        $firewallMap = $this->createStub(FirewallMap::class);
+        $firewallMap->method('getFirewallConfig')->willReturn(new FirewallConfig('main', 'security.user_checker', switchUser: $switchUser));
+
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('admin', ''), 'main');
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken($impersonating ? new SwitchUserToken(new InMemoryUser('kuba', ''), 'main', [], $originalToken) : $originalToken);
+
+        $routes = new RouteCollection();
+        $routes->add('app_switch_user', new Route('/switch-user'));
+        $routes->add('app_switch_user_restful', new Route('/switch-user/{_switch_user}'));
+
+        return new ImpersonateUrlGenerator($requestStack, $firewallMap, $tokenStorage, new UrlGenerator($routes, new RequestContext()), $csrfTokenManager);
+    }
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -9,6 +9,10 @@ CHANGELOG
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
  * Add `LogoutUrlGenerator::getLogoutForm()` to build a form that logs the user out with a POST
  * Throw the status-code-specific `HttpException` (e.g. `NotFoundHttpException`, `AccessDeniedHttpException`) instead of a generic one when `#[IsGranted]`'s `statusCode` option is set
+ * Add `$httpUtils`, `$path`, `$csrfTokenManager`, `$csrfParameter` and `$csrfTokenId` arguments to `SwitchUserListener` to restrict user switching to a dedicated route protected by a CSRF token
+ * Add `$urlGenerator` and `$csrfTokenManager` arguments to `ImpersonateUrlGenerator` so that the generated URLs follow the `path` and CSRF configuration of the firewall
+ * Add `ImpersonateUrlGenerator::generateImpersonationForm()` and `generateExitForm()` to build a form that switches the user with a POST
+ * Add `$targetUri` argument to `ImpersonateUrlGenerator::generateImpersonationPath()` and `generateImpersonationUrl()`
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -27,7 +27,11 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\ParameterBagUtils;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -56,19 +60,42 @@ class SwitchUserListener extends AbstractListener
         private bool $stateless = false,
         private ?UrlGeneratorInterface $urlGenerator = null,
         private ?string $targetRoute = null,
+        private ?HttpUtils $httpUtils = null,
+        private ?string $path = null,
+        private ?CsrfTokenManagerInterface $csrfTokenManager = null,
+        private string $csrfParameter = '_csrf_token',
+        private string $csrfTokenId = 'switch_user',
     ) {
         if ('' === $firewallName) {
             throw new \InvalidArgumentException('$firewallName must not be empty.');
+        }
+
+        if (null !== $path && null === $httpUtils) {
+            throw new \InvalidArgumentException(\sprintf('A "%s" instance must be provided when the "path" option is set.', HttpUtils::class));
         }
     }
 
     public function supports(Request $request): ?bool
     {
-        // usernames can be falsy
-        $username = $request->query->get($this->usernameParameter) ?? (!\in_array($request->getMethod(), ['GET', 'HEAD'], true) ? $request->request->get($this->usernameParameter) : null);
+        if (null !== $this->path) {
+            // when scoped to a dedicated path, the parameter carries the target
+            // identity but no longer triggers the listener on every request
+            if (!$this->httpUtils->checkRequestPath($request, $this->path)) {
+                return false;
+            }
 
-        if (null === $username || '' === $username) {
-            $username = $request->headers->get($this->usernameParameter);
+            $username = ParameterBagUtils::getRequestParameterValue($request, $this->usernameParameter);
+
+            if (!\is_string($username)) {
+                $username = null;
+            }
+        } else {
+            // usernames can be falsy
+            $username = $request->query->get($this->usernameParameter) ?? (!\in_array($request->getMethod(), ['GET', 'HEAD'], true) ? $request->request->get($this->usernameParameter) : null);
+
+            if (null === $username || '' === $username) {
+                $username = $request->headers->get($this->usernameParameter);
+            }
         }
 
         // if it's still "empty", nothing to do.
@@ -93,6 +120,14 @@ class SwitchUserListener extends AbstractListener
         $username = $request->attributes->get('_switch_user_username');
         $request->attributes->remove('_switch_user_username');
 
+        if (null !== $this->csrfTokenManager) {
+            $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->csrfParameter);
+
+            if (!\is_string($csrfToken) || !$this->csrfTokenManager->isTokenValid(new CsrfToken($this->csrfTokenId, $csrfToken))) {
+                throw new AccessDeniedException('Invalid CSRF token.');
+            }
+        }
+
         if (null === $this->tokenStorage->getToken()) {
             throw new AuthenticationCredentialsNotFoundException('Could not find original Token object.');
         }
@@ -108,13 +143,35 @@ class SwitchUserListener extends AbstractListener
             }
         }
 
-        if (!$this->stateless) {
-            $request->query->remove($this->usernameParameter);
-            $request->server->set('QUERY_STRING', http_build_query($request->query->all(), '', '&'));
-            $response = new RedirectResponse($this->urlGenerator && $this->targetRoute && self::EXIT_VALUE !== $username ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
-
-            $event->setResponse($response);
+        if ($this->stateless) {
+            return;
         }
+
+        if (null !== $this->path) {
+            // on a dedicated endpoint there is no "current page" to return to,
+            // so resolve an explicit target: submitted path, then target_route, then "/"
+            $targetUrl = ParameterBagUtils::getRequestParameterValue($request, '_target_path');
+
+            if (!\is_string($targetUrl) || !str_starts_with($targetUrl, '/')) {
+                $targetUrl = $this->urlGenerator && $this->targetRoute && self::EXIT_VALUE !== $username ? $this->urlGenerator->generate($this->targetRoute) : '/';
+            }
+
+            $event->setResponse($this->httpUtils->createRedirectResponse($request, $targetUrl));
+
+            return;
+        }
+
+        $request->query->remove($this->usernameParameter);
+
+        if (null !== $this->csrfTokenManager) {
+            // keep the token out of the address bar, the history, the logs and the Referer of the landing page
+            $request->query->remove($this->csrfParameter);
+        }
+
+        $request->server->set('QUERY_STRING', http_build_query($request->query->all(), '', '&'));
+        $response = new RedirectResponse($this->urlGenerator && $this->targetRoute && self::EXIT_VALUE !== $username ? $this->urlGenerator->generate($this->targetRoute) : $request->getUri(), 302);
+
+        $event->setResponse($response);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
@@ -13,8 +13,10 @@ namespace Symfony\Component\Security\Http\Impersonate;
 
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 
 /**
@@ -29,35 +31,56 @@ class ImpersonateUrlGenerator
         private RequestStack $requestStack,
         private FirewallMap $firewallMap,
         private TokenStorageInterface $tokenStorage,
+        private ?UrlGeneratorInterface $urlGenerator = null,
+        private ?CsrfTokenManagerInterface $csrfTokenManager = null,
     ) {
     }
 
-    public function generateImpersonationPath(string $identifier): string
+    public function generateImpersonationPath(string $identifier/* , ?string $targetUri = null */): string
     {
-        return $this->buildPath(null, $identifier);
+        $targetUri = 1 < \func_num_args() ? func_get_arg(1) : null;
+
+        return $this->buildUrl(UrlGeneratorInterface::ABSOLUTE_PATH, $targetUri, $identifier);
     }
 
-    public function generateImpersonationUrl(string $identifier): string
+    public function generateImpersonationUrl(string $identifier/* , ?string $targetUri = null */): string
     {
-        if (null === $request = $this->requestStack->getCurrentRequest()) {
-            return '';
-        }
+        $targetUri = 1 < \func_num_args() ? func_get_arg(1) : null;
 
-        return $request->getUriForPath($this->buildPath(null, $identifier));
+        return $this->buildUrl(UrlGeneratorInterface::ABSOLUTE_URL, $targetUri, $identifier);
     }
 
     public function generateExitPath(?string $targetUri = null): string
     {
-        return $this->buildPath($targetUri);
+        return $this->buildUrl(UrlGeneratorInterface::ABSOLUTE_PATH, $targetUri);
     }
 
     public function generateExitUrl(?string $targetUri = null): string
     {
-        if (null === $request = $this->requestStack->getCurrentRequest()) {
-            return '';
-        }
+        return $this->buildUrl(UrlGeneratorInterface::ABSOLUTE_URL, $targetUri);
+    }
 
-        return $request->getUriForPath($this->buildPath($targetUri));
+    /**
+     * Returns the action and the hidden fields of a form triggering the impersonation.
+     *
+     * Unlike the URLs, this keeps the parameters out of the address bar and works with
+     * a path restricted to POST requests.
+     *
+     * @return array{action: string, fields: array<string, string>}
+     */
+    public function generateImpersonationForm(string $identifier, ?string $targetUri = null): array
+    {
+        return $this->buildForm($targetUri, $identifier);
+    }
+
+    /**
+     * Returns the action and the hidden fields of a form exiting the impersonation.
+     *
+     * @return array{action: string, fields: array<string, string>}
+     */
+    public function generateExitForm(?string $targetUri = null): array
+    {
+        return $this->buildForm($targetUri);
     }
 
     private function isImpersonatedUser(): bool
@@ -65,24 +88,94 @@ class ImpersonateUrlGenerator
         return $this->tokenStorage->getToken() instanceof SwitchUserToken;
     }
 
-    private function buildPath(?string $targetUri = null, string $identifier = SwitchUserListener::EXIT_VALUE): string
+    private function buildUrl(int $referenceType, ?string $targetUri = null, string $identifier = SwitchUserListener::EXIT_VALUE): string
+    {
+        [$url, $parameters] = $this->buildParts($referenceType, $targetUri, $identifier);
+
+        if ('' === $url || !$parameters) {
+            return $url;
+        }
+
+        return $url.(str_contains($url, '?') ? '&' : '?').http_build_query($parameters, '', '&');
+    }
+
+    /**
+     * @return array{action: string, fields: array<string, string>}
+     */
+    private function buildForm(?string $targetUri = null, string $identifier = SwitchUserListener::EXIT_VALUE): array
+    {
+        [$action, $fields] = $this->buildParts(UrlGeneratorInterface::ABSOLUTE_PATH, $targetUri, $identifier);
+
+        return ['action' => $action, 'fields' => $fields];
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, string>}
+     */
+    private function buildParts(int $referenceType, ?string $targetUri, string $identifier): array
     {
         if (null === ($request = $this->requestStack->getCurrentRequest())) {
-            return '';
+            return ['', []];
         }
 
         if (!$this->isImpersonatedUser() && SwitchUserListener::EXIT_VALUE == $identifier) {
-            return '';
+            return ['', []];
         }
 
-        if (null === $switchUserConfig = $this->firewallMap->getFirewallConfig($request)->getSwitchUser()) {
+        if (null === $switchUserConfig = $this->firewallMap->getFirewallConfig($request)?->getSwitchUser()) {
             throw new \LogicException('Unable to generate the impersonate URLs without a firewall configured for the user switch.');
         }
 
-        $targetUri ??= $request->getRequestUri();
+        $parameters = [$switchUserConfig['parameter'] => $identifier];
 
-        $targetUri .= (str_contains($targetUri, '?') ? '&' : '?').http_build_query([$switchUserConfig['parameter'] => $identifier], '', '&');
+        if ($switchUserConfig['enable_csrf'] ?? false) {
+            if (null === $this->csrfTokenManager) {
+                throw new \LogicException('Unable to generate the impersonate URLs without a CSRF token manager.');
+            }
 
-        return $targetUri;
+            // the token id is served by the manager the firewall configured for it
+            $parameters[$switchUserConfig['csrf_parameter']] = $this->csrfTokenManager->getToken($switchUserConfig['csrf_token_id'])->getValue();
+        }
+
+        if (null !== $path = $switchUserConfig['path'] ?? null) {
+            // the switch happens on a dedicated endpoint, so the page to come back to is carried explicitly
+            $parameters['_target_path'] = $targetUri ?? $request->getRequestUri();
+
+            if ('/' !== $path[0]) {
+                if (null === $this->urlGenerator) {
+                    throw new \LogicException('Unable to generate the impersonate URLs from a route name without a URL generator.');
+                }
+
+                // the route may take some of the parameters as placeholders, only the others are left over
+                return self::splitQuery($this->urlGenerator->generate($path, $parameters, $referenceType));
+            }
+
+            $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($path) : $request->getBaseUrl().$path;
+        } else {
+            $url = $targetUri ?? $request->getRequestUri();
+
+            if (UrlGeneratorInterface::ABSOLUTE_URL === $referenceType) {
+                $url = $request->getUriForPath($url);
+            }
+        }
+
+        return [$url, $parameters];
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, string>}
+     */
+    private static function splitQuery(string $url): array
+    {
+        [$url, $query] = explode('?', $url, 2) + ['', ''];
+        $parameters = [];
+
+        // parse_str() cannot be used here as it turns dots and spaces in parameter names into underscores
+        foreach ('' === $query ? [] : explode('&', $query) as $pair) {
+            [$name, $value] = explode('=', $pair, 2) + ['', ''];
+            $parameters[urldecode($name)] = urldecode($value);
+        }
+
+        return [$url, $parameters];
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -28,8 +28,11 @@ use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserChecker;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
+use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -412,5 +415,261 @@ class SwitchUserListenerTest extends TestCase
         $listener = new SwitchUserListener($this->tokenStorage, $userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', $dispatcher);
         $this->assertTrue($listener->supports($this->event->getRequest()));
         $listener->authenticate($this->event);
+    }
+
+    public function testHttpUtilsIsRequiredWhenPathIsSet()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A "Symfony\Component\Security\Http\HttpUtils" instance must be provided when the "path" option is set.');
+
+        new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, path: '/impersonate');
+    }
+
+    public function testSupportsReturnsFalseWhenPathDoesNotMatch()
+    {
+        $this->request->request->set('_switch_user', 'kuba');
+
+        $httpUtils = $this->createMock(HttpUtils::class);
+        $httpUtils->expects($this->once())
+            ->method('checkRequestPath')->with($this->request, '/impersonate')
+            ->willReturn(false);
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, httpUtils: $httpUtils, path: '/impersonate');
+
+        $this->assertFalse($listener->supports($this->request));
+    }
+
+    public function testSupportsReadsParameterFromRequestBodyWhenScopedToAPath()
+    {
+        // when scoped to a path, the listener only fires on a path match and reads
+        // the target identity from the request body (as posted by a form)
+        $this->request->setMethod('POST');
+        $this->request->request->set('_switch_user', 'kuba');
+
+        $httpUtils = $this->createMock(HttpUtils::class);
+        $httpUtils->expects($this->once())
+            ->method('checkRequestPath')->with($this->request, '/impersonate')
+            ->willReturn(true);
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, httpUtils: $httpUtils, path: '/impersonate');
+
+        $this->assertTrue($listener->supports($this->request));
+        $this->assertSame('kuba', $this->request->attributes->get('_switch_user_username'));
+    }
+
+    public function testSwitchUserViaPathRedirectsToTargetPath()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('username', '', ['ROLE_FOO']), 'key', ['ROLE_FOO']);
+        $this->tokenStorage->setToken($token);
+
+        $this->request->setMethod('POST');
+        $this->request->request->set('_switch_user', 'kuba');
+        $this->request->request->set('_target_path', '/dashboard');
+
+        $httpUtils = $this->createStub(HttpUtils::class);
+        $httpUtils->method('checkRequestPath')->willReturn(true);
+        $httpUtils->method('createRedirectResponse')->willReturnCallback(static fn ($request, $path) => new RedirectResponse($path));
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
+            ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
+            ->willReturn(true);
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager, httpUtils: $httpUtils, path: '/impersonate');
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+
+        $this->assertInstanceOf(SwitchUserToken::class, $this->tokenStorage->getToken());
+        $this->assertInstanceOf(RedirectResponse::class, $this->event->getResponse());
+        $this->assertSame('/dashboard', $this->event->getResponse()->getTargetUrl());
+    }
+
+    public function testSwitchUserViaPathFallsBackToRootWhenNoTarget()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('username', '', ['ROLE_FOO']), 'key', ['ROLE_FOO']);
+        $this->tokenStorage->setToken($token);
+
+        $this->request->setMethod('POST');
+        $this->request->request->set('_switch_user', 'kuba');
+
+        $httpUtils = $this->createStub(HttpUtils::class);
+        $httpUtils->method('checkRequestPath')->willReturn(true);
+        $httpUtils->method('createRedirectResponse')->willReturnCallback(static fn ($request, $path) => new RedirectResponse($path));
+
+        $accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->method('decide')->willReturn(true);
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager, httpUtils: $httpUtils, path: '/impersonate');
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+
+        $this->assertSame('/', $this->event->getResponse()->getTargetUrl());
+    }
+
+    public function testSwitchUserViaPathNeutralizesOpenRedirectTargetPath()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('username', '', ['ROLE_FOO']), 'key', ['ROLE_FOO']);
+        $this->tokenStorage->setToken($token);
+
+        $request = Request::create('/impersonate', 'POST');
+        $request->request->set('_switch_user', 'kuba');
+        $request->request->set('_target_path', '//attacker.com');
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->method('decide')->willReturn(true);
+
+        // a real HttpUtils routes the target through getUriForPath(), keeping the current host
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager, httpUtils: new HttpUtils(), path: '/impersonate');
+        $this->assertTrue($listener->supports($request));
+        $listener->authenticate($event);
+
+        $this->assertSame('http://localhost//attacker.com', $event->getResponse()->getTargetUrl());
+    }
+
+    public function testSwitchUserFailsWithMissingCsrfToken()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('username', '', ['ROLE_ALLOWED_TO_SWITCH']), 'key', ['ROLE_ALLOWED_TO_SWITCH']);
+        $this->tokenStorage->setToken($token);
+        $this->request->query->set('_switch_user', 'kuba');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->never())->method('isTokenValid');
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, csrfTokenManager: $csrfTokenManager);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Invalid CSRF token.');
+
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+    }
+
+    public function testSwitchUserFailsWithInvalidCsrfToken()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('username', '', ['ROLE_ALLOWED_TO_SWITCH']), 'key', ['ROLE_ALLOWED_TO_SWITCH']);
+        $this->tokenStorage->setToken($token);
+        $this->request->query->set('_switch_user', 'kuba');
+        $this->request->query->set('_csrf_token', 'invalid');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')->with(new CsrfToken('switch_user', 'invalid'))
+            ->willReturn(false);
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, csrfTokenManager: $csrfTokenManager);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Invalid CSRF token.');
+
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+    }
+
+    public function testSwitchUserSucceedsWithValidCsrfToken()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('username', '', ['ROLE_FOO']), 'key', ['ROLE_FOO']);
+        $this->tokenStorage->setToken($token);
+        $this->request->query->set('_switch_user', 'kuba');
+        $this->request->query->set('_csrf_token', 'valid');
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('isTokenValid')->with(new CsrfToken('switch_user', 'valid'))
+            ->willReturn(true);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->expects($this->once())
+            ->method('decide')->with($token, ['ROLE_ALLOWED_TO_SWITCH'])
+            ->willReturn(true);
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager, csrfTokenManager: $csrfTokenManager);
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+
+        $this->assertInstanceOf(SwitchUserToken::class, $this->tokenStorage->getToken());
+    }
+
+    public function testExitUserFailsWithInvalidCsrfToken()
+    {
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('username', '', []), 'key', []);
+        $switchUserToken = new SwitchUserToken(new InMemoryUser('kuba', '', ['ROLE_USER']), 'key', ['ROLE_USER'], $originalToken);
+        $this->tokenStorage->setToken($switchUserToken);
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->never())->method('isTokenValid');
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, csrfTokenManager: $csrfTokenManager);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Invalid CSRF token.');
+
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+    }
+
+    public function testCsrfTokenIsRemovedFromTheRedirectUrl()
+    {
+        $token = new UsernamePasswordToken(new InMemoryUser('username', '', ['ROLE_FOO']), 'key', ['ROLE_FOO']);
+        $this->tokenStorage->setToken($token);
+
+        $request = Request::create('/page?_switch_user=kuba&_csrf_token=T0K3N&keep=1');
+        $event = new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $csrfTokenManager = $this->createStub(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->method('isTokenValid')->willReturn(true);
+
+        $accessDecisionManager = $this->createStub(AccessDecisionManagerInterface::class);
+        $accessDecisionManager->method('decide')->willReturn(true);
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $accessDecisionManager, csrfTokenManager: $csrfTokenManager);
+        $this->assertTrue($listener->supports($request));
+        $listener->authenticate($event);
+
+        $this->assertSame(['keep' => '1'], $request->query->all());
+        $this->assertSame('http://localhost/page?keep=1', $event->getResponse()->getTargetUrl());
+    }
+
+    public function testExitUserViaPathDoesNotRedirectToTargetRoute()
+    {
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('username', '', []), 'key', []);
+        $this->tokenStorage->setToken(new SwitchUserToken(new InMemoryUser('kuba', '', ['ROLE_USER']), 'key', ['ROLE_USER'], $originalToken));
+
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
+
+        $httpUtils = $this->createStub(HttpUtils::class);
+        $httpUtils->method('checkRequestPath')->willReturn(true);
+        $httpUtils->method('createRedirectResponse')->willReturnCallback(static fn ($request, $path) => new RedirectResponse($path));
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/after-switch');
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, urlGenerator: $urlGenerator, targetRoute: 'whatever', httpUtils: $httpUtils, path: '/impersonate');
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+
+        $this->assertSame('/', $this->event->getResponse()->getTargetUrl());
+        $this->assertSame($originalToken, $this->tokenStorage->getToken());
+    }
+
+    public function testExitUserViaPathRedirectsToTargetPath()
+    {
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('username', '', []), 'key', []);
+        $this->tokenStorage->setToken(new SwitchUserToken(new InMemoryUser('kuba', '', ['ROLE_USER']), 'key', ['ROLE_USER'], $originalToken));
+
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
+        $this->request->query->set('_target_path', '/dashboard');
+
+        $httpUtils = $this->createStub(HttpUtils::class);
+        $httpUtils->method('checkRequestPath')->willReturn(true);
+        $httpUtils->method('createRedirectResponse')->willReturnCallback(static fn ($request, $path) => new RedirectResponse($path));
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, httpUtils: $httpUtils, path: '/impersonate');
+        $this->assertTrue($listener->supports($this->request));
+        $listener->authenticate($this->event);
+
+        $this->assertSame('/dashboard', $this->event->getResponse()->getTargetUrl());
+        $this->assertSame($originalToken, $this->tokenStorage->getToken());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #27348
| License       | MIT

Allow scoping user switching to a dedicated route/path and protecting it with a CSRF token, mirroring the logout listener. Pointing the new `path` option at a POST-only route keeps GET requests from ever changing state.

## Usage

Point `switch_user` at a dedicated, POST-only route and enable CSRF:

```yaml
# config/packages/security.yaml
security:
    firewalls:
        main:
            # ...
            switch_user:
                path: app_switch_user   # a route name (or path)
                enable_csrf: true       # csrf_token_id defaults to "switch_user"
```

```yaml
# config/routes.yaml
app_switch_user:
    path: /switch-user
    methods: [POST]                     # a GET can no longer change state
    # no controller needed: the switch_user listener handles the request
```

Trigger the switch with a form instead of a GET link. `impersonation_form()` returns the action and the hidden fields to render, both taken from the firewall configuration:

```twig
{% set impersonate = impersonation_form(user.userIdentifier, app.request.pathInfo) %}

<form method="post" action="{{ impersonate.action }}">
    {% for name, value in impersonate.fields %}
        <input type="hidden" name="{{ name }}" value="{{ value }}">
    {% endfor %}

    <button>Impersonate {{ user.userIdentifier }}</button>
</form>
```

Exiting works the same way with `impersonation_exit_form()`, which returns an empty action when the current user is not impersonating anyone:

```twig
{% set exit = impersonation_exit_form(app.request.pathInfo) %}

{% if exit.action %}
    <form method="post" action="{{ exit.action }}">
        {% for name, value in exit.fields %}
            <input type="hidden" name="{{ name }}" value="{{ value }}">
        {% endfor %}

        <button>Exit impersonation</button>
    </form>
{% endif %}
```

The fields carry the target identity under the configured `parameter`, a CSRF token under `csrf_parameter` when `enable_csrf` is on, and `_target_path` so the user lands back on the page they came from. Writing the form by hand works too, but then the parameter names and the token are yours to keep in sync with the configuration:

```twig
<form method="post" action="{{ path('app_switch_user') }}">
    <input type="hidden" name="_switch_user" value="{{ user.userIdentifier }}">
    <input type="hidden" name="_csrf_token" value="{{ csrf_token('switch_user') }}">
    {# optional: return to the current page afterwards #}
    <input type="hidden" name="_target_path" value="{{ app.request.pathInfo }}">

    <button>Impersonate {{ user.userIdentifier }}</button>
</form>
```

`impersonation_path()` and `impersonation_url()` still build a single URL carrying the same parameters in its query string. They suit a plain link, which a POST-only route rejects by design.

A firewall can also use its own CSRF token manager, and the helpers mint the token with it. Note that `csrf_token()` always reaches for the application's default manager, so a hand-written form has to be pointed at this one explicitly:

```yaml
security:
    firewalls:
        main:
            switch_user:
                path: app_switch_user
                csrf_token_manager: app.impersonation_csrf_token_manager  # implies enable_csrf: true
```

`path` can alternatively be set to just a path (`/switch-user`) instead of a route.

Leaving `path` unset keeps the existing query-parameter behavior unchanged.

## Possible Future Scope
- `use_referer` option — opt-in `Referer` fallback in the redirect chain, mirroring `form_login`'s `use_referer`.
- RESTful URLs — model impersonation as a resource:
  - `POST /switch-user/{username}` — target user via route param instead of `_switch_user` (mostly works today via the attributes fallback; the form helpers already leave such a parameter in the action rather than in the fields).
  - `DELETE /switch-user` — un-impersonate with no target param (clean exit semantics; client needs real `DELETE` via JS/`_method`).
