### PR TITLE
[Tui] Add `multiselect` option to `SelectListWidget`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -92,6 +92,11 @@ Translation
 
  * `FilteringProvider::read()` now returns an empty `TranslatorBag` when none of the requested locales match the configured ones, and a bag of empty catalogues when no requested domain matches, instead of delegating to the wrapped provider
 
+Tui
+---
+
+ * [BC BREAK] Add argument `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
+
 Validator
 ---------
 

--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
+ * Add multi-select support to `SelectListWidget`
+ * [BC BREAK] Add `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
 
 8.1
 ---

--- a/src/Symfony/Component/Tui/Event/MultiSelectEvent.php
+++ b/src/Symfony/Component/Tui/Event/MultiSelectEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Event;
+
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+/**
+ * Event dispatched when items are selected in a multi-select SelectList.
+ *
+ * @experimental
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class MultiSelectEvent extends AbstractEvent
+{
+    /**
+     * @param list<array{value: string, label: string, description?: string, checked?: bool}> $items
+     */
+    public function __construct(
+        SelectListWidget $target,
+        private readonly array $items,
+    ) {
+        parent::__construct($target);
+    }
+
+    /**
+     * Get the full selected item arrays.
+     *
+     * @return list<array{value: string, label: string, description?: string, checked?: bool}>
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * Get the selected item values.
+     *
+     * @return list<string>
+     */
+    public function getValues(): array
+    {
+        return array_column($this->items, 'value');
+    }
+
+    public function isEmpty(): bool
+    {
+        return !$this->items;
+    }
+}

--- a/src/Symfony/Component/Tui/Event/SelectEvent.php
+++ b/src/Symfony/Component/Tui/Event/SelectEvent.php
@@ -23,7 +23,7 @@ use Symfony\Component\Tui\Widget\SelectListWidget;
 class SelectEvent extends AbstractEvent
 {
     /**
-     * @param array{value: string, label: string, description?: string} $item
+     * @param array{value: string, label: string, description?: string, checked?: bool} $item
      */
     public function __construct(
         SelectListWidget $target,
@@ -35,7 +35,7 @@ class SelectEvent extends AbstractEvent
     /**
      * Get the full selected item array.
      *
-     * @return array{value: string, label: string, description?: string}
+     * @return array{value: string, label: string, description?: string, checked?: bool}
      */
     public function getItem(): array
     {

--- a/src/Symfony/Component/Tui/Event/SelectionToggleEvent.php
+++ b/src/Symfony/Component/Tui/Event/SelectionToggleEvent.php
@@ -14,29 +14,29 @@ namespace Symfony\Component\Tui\Event;
 use Symfony\Component\Tui\Widget\SelectListWidget;
 
 /**
- * Event dispatched when the highlighted item changes in a SelectList.
- *
- * This fires when the user moves the cursor (arrow keys, scroll), not
- * when they confirm a selection (that's {@see SelectEvent}).
+ * Event dispatched when an item is checked or unchecked in a multi-select SelectList.
  *
  * @experimental
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SelectionChangeEvent extends AbstractEvent
+class SelectionToggleEvent extends AbstractEvent
 {
     /**
-     * @param array{value: string, label: string, description?: string, checked?: bool} $item
+     * @param array{value: string, label: string, description?: string, checked?: bool}       $item
+     * @param list<array{value: string, label: string, description?: string, checked?: bool}> $selectedItems
      */
     public function __construct(
         SelectListWidget $target,
         private readonly array $item,
+        private readonly bool $checked,
+        private readonly array $selectedItems,
     ) {
         parent::__construct($target);
     }
 
     /**
-     * Get the full highlighted item array.
+     * Get the toggled item.
      *
      * @return array{value: string, label: string, description?: string, checked?: bool}
      */
@@ -46,26 +46,25 @@ class SelectionChangeEvent extends AbstractEvent
     }
 
     /**
-     * Get the highlighted item's value.
+     * Get the toggled item value.
      */
     public function getValue(): string
     {
         return $this->item['value'];
     }
 
-    /**
-     * Get the highlighted item's label.
-     */
-    public function getLabel(): string
+    public function isChecked(): bool
     {
-        return $this->item['label'];
+        return $this->checked;
     }
 
     /**
-     * Get the highlighted item's description, if any.
+     * Get the currently selected item arrays after the toggle.
+     *
+     * @return list<array{value: string, label: string, description?: string, checked?: bool}>
      */
-    public function getDescription(): ?string
+    public function getSelectedItems(): array
     {
-        return $this->item['description'] ?? null;
+        return $this->selectedItems;
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
@@ -15,8 +15,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Event\CancelEvent;
+use Symfony\Component\Tui\Event\MultiSelectEvent;
 use Symfony\Component\Tui\Event\SelectEvent;
 use Symfony\Component\Tui\Event\SelectionChangeEvent;
+use Symfony\Component\Tui\Event\SelectionToggleEvent;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Terminal\VirtualTerminal;
 use Symfony\Component\Tui\Tui;
@@ -230,7 +232,148 @@ class SelectListTest extends TestCase
         $this->assertTrue($cancelled);
     }
 
-    private function createTestList(): SelectListWidget
+    public function testMultiselectRendersInitialCheckedItems()
+    {
+        $list = new SelectListWidget([
+            ['value' => 'opt1', 'label' => 'Option 1', 'description' => 'First option'],
+            ['value' => 'opt2', 'label' => 'Option 2', 'description' => 'Second option', 'checked' => true],
+        ], multiselect: true);
+
+        $lines = $list->render(new RenderContext(80, 24));
+
+        $this->assertStringContainsString('[ ] Option 1', $lines[0]);
+        $this->assertStringContainsString('[x] Option 2', $lines[1]);
+        $this->assertSame([
+            ['value' => 'opt2', 'label' => 'Option 2', 'description' => 'Second option', 'checked' => true],
+        ], $list->getSelectedItems());
+    }
+
+    public function testMultiselectTogglesCurrentItem()
+    {
+        $list = $this->createTestList(multiselect: true);
+
+        $list->handleInput(' ');
+
+        $this->assertSame([
+            ['value' => 'opt1', 'label' => 'Option 1', 'description' => 'First option', 'checked' => true],
+        ], $list->getSelectedItems());
+        $this->assertStringContainsString('[x] Option 1', $list->render(new RenderContext(80, 24))[0]);
+
+        $list->handleInput(' ');
+
+        $this->assertSame([], $list->getSelectedItems());
+        $this->assertStringContainsString('[ ] Option 1', $list->render(new RenderContext(80, 24))[0]);
+    }
+
+    public function testSingleSelectIgnoresSpaceToggle()
+    {
+        $list = $this->createTestList();
+
+        $list->handleInput(' ');
+        $lines = $list->render(new RenderContext(80, 24));
+
+        $this->assertSame([], $list->getSelectedItems());
+        $this->assertStringNotContainsString('[ ]', $lines[0]);
+        $this->assertStringNotContainsString('[x]', $lines[0]);
+    }
+
+    public function testMultiselectPreservesTogglesAcrossFilter()
+    {
+        $list = $this->createTestList(multiselect: true);
+
+        $list->setFilter('opt2');
+        $list->handleInput(' ');
+        $list->setFilter('');
+
+        $this->assertSame([
+            ['value' => 'opt2', 'label' => 'Option 2', 'description' => 'Second option', 'checked' => true],
+        ], $list->getSelectedItems());
+
+        $lines = $list->render(new RenderContext(80, 24));
+        $this->assertStringContainsString('[ ] Option 1', $lines[0]);
+        $this->assertStringContainsString('[x] Option 2', $lines[1]);
+    }
+
+    public function testOnSelectionToggleCallback()
+    {
+        [$list, $tui] = $this->createTestListWithTui(multiselect: true);
+
+        $toggle = null;
+        $tui->addListener(static function (SelectionToggleEvent $e) use (&$toggle) {
+            $toggle = [
+                'value' => $e->getValue(),
+                'checked' => $e->isChecked(),
+                'selectedItems' => $e->getSelectedItems(),
+                'item' => $e->getItem(),
+            ];
+        });
+
+        $list->handleInput(' ');
+
+        $this->assertSame([
+            'value' => 'opt1',
+            'checked' => true,
+            'selectedItems' => [
+                ['value' => 'opt1', 'label' => 'Option 1', 'description' => 'First option', 'checked' => true],
+            ],
+            'item' => ['value' => 'opt1', 'label' => 'Option 1', 'description' => 'First option', 'checked' => true],
+        ], $toggle);
+    }
+
+    public function testOnMultiSelectCallback()
+    {
+        [$list, $tui] = $this->createTestListWithTui(multiselect: true);
+
+        $event = null;
+        $tui->addListener(static function (MultiSelectEvent $e) use (&$event) {
+            $event = $e;
+        });
+
+        $list->handleInput(' ');
+        $list->handleInput("\r");
+
+        $this->assertInstanceOf(MultiSelectEvent::class, $event);
+        $this->assertFalse($event->isEmpty());
+        $this->assertSame(['opt1'], $event->getValues());
+        $this->assertSame([
+            ['value' => 'opt1', 'label' => 'Option 1', 'description' => 'First option', 'checked' => true],
+        ], $event->getItems());
+    }
+
+    public function testMultiSelectEventDispatchesWhenEmpty()
+    {
+        [$list, $tui] = $this->createTestListWithTui(multiselect: true);
+
+        $event = null;
+        $tui->addListener(static function (MultiSelectEvent $e) use (&$event) {
+            $event = $e;
+        });
+
+        $list->handleInput("\r");
+
+        $this->assertInstanceOf(MultiSelectEvent::class, $event);
+        $this->assertTrue($event->isEmpty());
+        $this->assertSame([], $event->getValues());
+        $this->assertSame([], $event->getItems());
+    }
+
+    public function testMultiselectRendersWithinWidth()
+    {
+        $list = $this->createTestList(multiselect: true);
+        $width = 60;
+        $lines = $list->render(new RenderContext($width, 24));
+
+        foreach ($lines as $i => $line) {
+            $lineWidth = AnsiUtils::visibleWidth($line);
+            $this->assertLessThanOrEqual(
+                $width,
+                $lineWidth,
+                \sprintf('Line %d exceeds width: %d > %d', $i, $lineWidth, $width),
+            );
+        }
+    }
+
+    private function createTestList(bool $multiselect = false): SelectListWidget
     {
         $items = [
             ['value' => 'opt1', 'label' => 'Option 1', 'description' => 'First option'],
@@ -238,17 +381,17 @@ class SelectListTest extends TestCase
             ['value' => 'opt3', 'label' => 'Option 3', 'description' => 'Third option'],
         ];
 
-        return new SelectListWidget($items, 5);
+        return new SelectListWidget($items, 5, multiselect: $multiselect);
     }
 
     /**
      * @return array{SelectListWidget, Tui}
      */
-    private function createTestListWithTui(): array
+    private function createTestListWithTui(bool $multiselect = false): array
     {
         $terminal = new VirtualTerminal(80, 24);
         $tui = new Tui(terminal: $terminal);
-        $list = $this->createTestList();
+        $list = $this->createTestList($multiselect);
         $tui->add($list);
 
         return [$list, $tui];

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -13,14 +13,20 @@ namespace Symfony\Component\Tui\Widget;
 
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Event\CancelEvent;
+use Symfony\Component\Tui\Event\MultiSelectEvent;
 use Symfony\Component\Tui\Event\SelectEvent;
 use Symfony\Component\Tui\Event\SelectionChangeEvent;
+use Symfony\Component\Tui\Event\SelectionToggleEvent;
 use Symfony\Component\Tui\Input\Key;
 use Symfony\Component\Tui\Input\Keybindings;
 use Symfony\Component\Tui\Render\RenderContext;
 
 /**
  * Interactive selection list with keyboard navigation.
+ *
+ * In single-select mode (default), Enter confirms the highlighted item.
+ * In multiselect mode, Space toggles the highlighted item and Enter confirms
+ * all checked items.
  *
  * Item `label`, `description`, and `value` are rendered to the terminal
  * as-is and are not sanitized. See {@see TextWidget} for the raw-passthrough
@@ -36,35 +42,36 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
     use FocusableTrait;
     use KeybindingsTrait;
 
-    /** @var array<array{value: string, label: string, description?: string}> */
-    private array $filteredItems;
+    /** @var list<int> */
+    private array $filteredItemIndices;
 
     private int $selectedIndex = 0;
     private bool $selected = false;
 
     /**
-     * @param array<array{value: string, label: string, description?: string}> $items
+     * @param list<array{value: string, label: string, description?: string, checked?: bool}> $items
      */
     public function __construct(
         private array $items,
         private int $maxVisible = 5,
+        private bool $multiselect = false,
         ?Keybindings $keybindings = null,
     ) {
-        $this->filteredItems = $items;
+        $this->resetFilteredItems();
         if (null !== $keybindings) {
             $this->setKeybindings($keybindings);
         }
     }
 
     /**
-     * @param array<array{value: string, label: string}> $items
+     * @param list<array{value: string, label: string, description?: string, checked?: bool}> $items
      *
      * @return $this
      */
     public function setItems(array $items): static
     {
         $this->items = $items;
-        $this->filteredItems = $items;
+        $this->resetFilteredItems();
         $this->selectedIndex = 0;
         $this->invalidate();
 
@@ -78,13 +85,13 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
     {
         $filter = strtolower($filter);
 
-        $filteredItems = array_values(array_filter(
+        $filteredItemIndices = array_keys(array_filter(
             $this->items,
             static fn ($item) => str_starts_with(strtolower($item['value']), $filter),
         ));
 
-        if ($filteredItems !== $this->filteredItems) {
-            $this->filteredItems = $filteredItems;
+        if ($filteredItemIndices !== $this->filteredItemIndices) {
+            $this->filteredItemIndices = $filteredItemIndices;
             $this->selectedIndex = 0;
             $this->invalidate();
         }
@@ -97,7 +104,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
      */
     public function setSelectedIndex(int $index): static
     {
-        $index = max(0, min($index, \count($this->filteredItems) - 1));
+        $index = max(0, min($index, \count($this->filteredItemIndices) - 1));
         if ($this->selectedIndex !== $index) {
             $this->selectedIndex = $index;
             $this->invalidate();
@@ -109,11 +116,25 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
     /**
      * Get the currently selected item.
      *
-     * @return array{value: string, label: string, description?: string}|null
+     * @return array{value: string, label: string, description?: string, checked?: bool}|null
      */
     public function getSelectedItem(): ?array
     {
-        return $this->filteredItems[$this->selectedIndex] ?? null;
+        return $this->getFilteredItem($this->selectedIndex);
+    }
+
+    /**
+     * @return list<array{value: string, label: string, description?: string, checked?: bool}>
+     */
+    public function getSelectedItems(): array
+    {
+        if (!$this->multiselect) {
+            return [];
+        }
+
+        return array_values(
+            array_filter($this->items, static fn (array $item) => $item['checked'] ?? false)
+        );
     }
 
     /**
@@ -132,6 +153,26 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
     public function onSelect(callable $callback): static
     {
         return $this->on(SelectEvent::class, $callback);
+    }
+
+    /**
+     * @param callable(MultiSelectEvent): void $callback
+     *
+     * @return $this
+     */
+    public function onMultiSelect(callable $callback): static
+    {
+        return $this->on(MultiSelectEvent::class, $callback);
+    }
+
+    /**
+     * @param callable(SelectionToggleEvent): void $callback
+     *
+     * @return $this
+     */
+    public function onSelectionToggle(callable $callback): static
+    {
+        return $this->on(SelectionToggleEvent::class, $callback);
     }
 
     /**
@@ -162,10 +203,10 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
 
         $kb = $this->getKeybindings();
 
-        if ($this->filteredItems) {
+        if ($this->filteredItemIndices) {
             // Up - wrap to bottom when at top
             if ($kb->matches($data, 'select_up')) {
-                $this->selectedIndex = 0 === $this->selectedIndex ? \count($this->filteredItems) - 1 : $this->selectedIndex - 1;
+                $this->selectedIndex = 0 === $this->selectedIndex ? \count($this->filteredItemIndices) - 1 : $this->selectedIndex - 1;
                 $this->notifySelectionChange();
 
                 return;
@@ -173,7 +214,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
 
             // Down - wrap to top when at bottom
             if ($kb->matches($data, 'select_down')) {
-                $this->selectedIndex = $this->selectedIndex === \count($this->filteredItems) - 1 ? 0 : $this->selectedIndex + 1;
+                $this->selectedIndex = $this->selectedIndex === \count($this->filteredItemIndices) - 1 ? 0 : $this->selectedIndex + 1;
                 $this->notifySelectionChange();
 
                 return;
@@ -187,8 +228,14 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
             }
 
             if ($kb->matches($data, 'select_page_down') || $kb->matches($data, 'cursor_right')) {
-                $this->selectedIndex = min(\count($this->filteredItems) - 1, $this->selectedIndex + $this->maxVisible);
+                $this->selectedIndex = min(\count($this->filteredItemIndices) - 1, $this->selectedIndex + $this->maxVisible);
                 $this->notifySelectionChange();
+
+                return;
+            }
+
+            if ($this->multiselect && $kb->matches($data, 'choice_toggle')) {
+                $this->toggleCurrentItem();
 
                 return;
             }
@@ -217,7 +264,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
         $lines = [];
 
         // No items match filter
-        if (!$this->filteredItems) {
+        if (!$this->filteredItemIndices) {
             $line = $this->applyElement('no-match', '  No matching items');
             $lines[] = $line;
 
@@ -229,21 +276,21 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
             0,
             min(
                 $this->selectedIndex - (int) floor($this->maxVisible / 2),
-                \count($this->filteredItems) - $this->maxVisible,
+                \count($this->filteredItemIndices) - $this->maxVisible,
             ),
         );
-        $endIndex = min($startIndex + $this->maxVisible, \count($this->filteredItems));
+        $endIndex = min($startIndex + $this->maxVisible, \count($this->filteredItemIndices));
 
         // Compute max label width from visible items for alignment
         $maxLabelWidth = 0;
         for ($i = $startIndex; $i < $endIndex; ++$i) {
-            $maxLabelWidth = max($maxLabelWidth, AnsiUtils::visibleWidth($this->filteredItems[$i]['label']));
+            $maxLabelWidth = max($maxLabelWidth, AnsiUtils::visibleWidth($this->getFilteredItem($i)['label']));
         }
         $labelColumnWidth = min(30, $maxLabelWidth);
 
         // Render visible items
         for ($i = $startIndex; $i < $endIndex; ++$i) {
-            $item = $this->filteredItems[$i];
+            $item = $this->getFilteredItem($i);
             $isSelected = $i === $this->selectedIndex;
             $description = isset($item['description']) ? $this->normalizeDescription($item['description']) : null;
             $line = $this->renderItem($item, $isSelected, $description, $columns, $labelColumnWidth);
@@ -251,8 +298,8 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
         }
 
         // Add scroll indicator if needed
-        if ($startIndex > 0 || $endIndex < \count($this->filteredItems)) {
-            $scrollText = \sprintf('  (%d/%d)', $this->selectedIndex + 1, \count($this->filteredItems));
+        if ($startIndex > 0 || $endIndex < \count($this->filteredItemIndices)) {
+            $scrollText = \sprintf('  (%d/%d)', $this->selectedIndex + 1, \count($this->filteredItemIndices));
             $line = $this->applyElement('scroll-info', AnsiUtils::truncateToWidth($scrollText, $columns - 2, ''));
             $lines[] = $line;
         }
@@ -274,19 +321,21 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
             'select_cancel' => [Key::ESCAPE, 'ctrl+c'],
             'cursor_left' => [Key::LEFT, 'ctrl+b'],
             'cursor_right' => [Key::RIGHT, 'ctrl+f'],
+            'choice_toggle' => [Key::SPACE],
         ];
     }
 
     /**
-     * @param array{value: string, label: string, description?: string} $item
+     * @param array{value: string, label: string, description?: string, checked?: bool} $item
      */
     private function renderItem(array $item, bool $isSelected, ?string $description, int $columns, int $labelColumnWidth): string
     {
         $displayValue = $item['label'];
+        $checkbox = $this->multiselect ? (($item['checked'] ?? false) ? '[x] ' : '[ ] ') : '';
         $alignedWidth = $labelColumnWidth + 2;
 
         if ($isSelected) {
-            $prefix = '→ ';
+            $prefix = '→ '.$checkbox;
             $selectedStyle = $this->resolveElement('selected');
 
             if (null !== $description && $columns > 40) {
@@ -300,7 +349,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
                 if ($remainingColumns > 10) {
                     $truncatedDesc = AnsiUtils::truncateToWidth($description, $remainingColumns, '');
 
-                    return $selectedStyle->apply("→ {$truncatedValue}{$spacing}{$truncatedDesc}");
+                    return $selectedStyle->apply("→ {$checkbox}{$truncatedValue}{$spacing}{$truncatedDesc}");
                 }
             }
 
@@ -310,7 +359,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
         }
 
         // Non-selected item
-        $prefix = '  ';
+        $prefix = '  '.$checkbox;
 
         if (null !== $description && $columns > 40) {
             $maxValueColumns = min($labelColumnWidth, $columns - \strlen($prefix) - 4);
@@ -334,16 +383,44 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
         return $prefix.AnsiUtils::truncateToWidth($displayValue, $maxColumns, '');
     }
 
+    private function resetFilteredItems(): void
+    {
+        $this->filteredItemIndices = array_keys($this->items);
+    }
+
     private function normalizeDescription(string $description): string
     {
         // Convert multiline to single line
         return trim(preg_replace('/[\r\n]+/', ' ', $description));
     }
 
+    private function toggleCurrentItem(): void
+    {
+        if (!$this->multiselect) {
+            return;
+        }
+
+        if (null === $itemIndex = $this->filteredItemIndices[$this->selectedIndex] ?? null) {
+            return;
+        }
+
+        $this->items[$itemIndex]['checked'] = $checked = !($this->items[$itemIndex]['checked'] ?? false);
+
+        $this->invalidate();
+        $this->dispatch(new SelectionToggleEvent($this, $this->items[$itemIndex], $checked, $this->getSelectedItems()));
+    }
+
     private function confirmSelection(): void
     {
         $this->selected = true;
-        if (null !== $selectedItem = $this->filteredItems[$this->selectedIndex] ?? null) {
+
+        if ($this->multiselect) {
+            $this->dispatch(new MultiSelectEvent($this, $this->getSelectedItems()));
+
+            return;
+        }
+
+        if (null !== $selectedItem = $this->getFilteredItem($this->selectedIndex)) {
             $this->dispatch(new SelectEvent($this, $selectedItem));
         }
     }
@@ -351,8 +428,16 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
     private function notifySelectionChange(): void
     {
         $this->invalidate();
-        if (null !== $selectedItem = $this->filteredItems[$this->selectedIndex] ?? null) {
+        if (null !== $selectedItem = $this->getFilteredItem($this->selectedIndex)) {
             $this->dispatch(new SelectionChangeEvent($this, $selectedItem));
         }
+    }
+
+    /**
+     * @return array{value: string, label: string, description?: string, checked?: bool}|null
+     */
+    private function getFilteredItem(int $index): ?array
+    {
+        return isset($this->filteredItemIndices[$index]) ? $this->items[$this->filteredItemIndices[$index]] : null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds a `multiselect` option to the `SelectListWidget`:

<img width="498" height="298" alt="screen" src="https://github.com/user-attachments/assets/109e4bbf-f83c-462d-b2fa-59046987b638" />