### PR TITLE
[Notifier] Add the WhatsApp bridge

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -155,6 +155,7 @@
         "twitter-notifier": "src/Symfony/Component/Notifier/Bridge/Twitter",
         "unifonic-notifier": "src/Symfony/Component/Notifier/Bridge/Unifonic",
         "vonage-notifier": "src/Symfony/Component/Notifier/Bridge/Vonage",
+        "whats-app-notifier": "src/Symfony/Component/Notifier/Bridge/WhatsApp",
         "yunpian-notifier": "src/Symfony/Component/Notifier/Bridge/Yunpian",
         "zendesk-notifier": "src/Symfony/Component/Notifier/Bridge/Zendesk",
         "zulip-notifier": "src/Symfony/Component/Notifier/Bridge/Zulip",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3314,6 +3314,7 @@ class FrameworkExtension extends Extension
             NotifierBridge\Twitter\TwitterTransportFactory::class => ['symfony/twitter-notifier', 'notifier.transport_factory.twitter'],
             NotifierBridge\Unifonic\UnifonicTransportFactory::class => ['symfony/unifonic-notifier', 'notifier.transport_factory.unifonic'],
             NotifierBridge\Vonage\VonageTransportFactory::class => ['symfony/vonage-notifier', 'notifier.transport_factory.vonage'],
+            NotifierBridge\WhatsApp\WhatsAppTransportFactory::class => ['symfony/whats-app-notifier', 'notifier.transport_factory.whats-app'],
             NotifierBridge\Yunpian\YunpianTransportFactory::class => ['symfony/yunpian-notifier', 'notifier.transport_factory.yunpian'],
             NotifierBridge\Zendesk\ZendeskTransportFactory::class => ['symfony/zendesk-notifier', 'notifier.transport_factory.zendesk'],
             NotifierBridge\Zulip\ZulipTransportFactory::class => ['symfony/zulip-notifier', 'notifier.transport_factory.zulip'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -45,6 +45,7 @@ return static function (ContainerConfigurator $container) {
         'slack' => Bridge\Slack\SlackTransportFactory::class,
         'telegram' => Bridge\Telegram\TelegramTransportFactory::class,
         'twitter' => Bridge\Twitter\TwitterTransportFactory::class,
+        'whats-app' => Bridge\WhatsApp\WhatsAppTransportFactory::class,
         'zendesk' => Bridge\Zendesk\ZendeskTransportFactory::class,
         'zulip' => Bridge\Zulip\ZulipTransportFactory::class,
     ];

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/README.md
@@ -1,0 +1,78 @@
+WhatsApp Notifier
+==================
+
+Provides [Meta WhatsApp Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api)
+integration for Symfony Notifier, as a `Chatter` transport.
+
+> **Note**
+> This bridge talks directly to Meta's own Graph API `POST /{phone_number_id}/messages`
+> endpoint. If you're looking for WhatsApp support through a third-party gateway instead,
+> the `Twilio` bridge can also send WhatsApp messages, by prefixing its `From` number with
+> `whatsapp:`.
+
+DSN example
+-----------
+
+```
+WHATSAPP_DSN=whatsapp://TOKEN@default?phone_number_id=PHONE_NUMBER_ID&api_version=v26.0
+```
+
+where:
+
+- `TOKEN` is a WhatsApp Business permanent access token (system user token recommended)
+- `PHONE_NUMBER_ID` is the sending number's `phone_number_id`, from the WhatsApp Business
+  Account (WABA) configuration
+- `api_version` is optional (defaults to `v26.0`)
+
+The DSN carries no default recipient, so every message must set one through
+`WhatsAppOptions::recipientPhoneNumber()`. The transport does not claim messages without
+it, which leaves them to any other chatter transport that can deliver them.
+
+Sending a template message
+---------------------------
+
+Business-initiated messages (reminders, confirmations) require a pre-approved message
+template (Meta calls these HSM, for Highly Structured Messages). Use `WhatsAppOptions` to
+select one and set its body parameters:
+
+```php
+use Symfony\Component\Notifier\Bridge\WhatsApp\WhatsAppOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$options = (new WhatsAppOptions())
+    ->recipientPhoneNumber('5491112345678')
+    ->template('recordatorio_turno', 'es_AR', ['Ana', 'Corte de pelo', '10/07/2026', '15:00']);
+
+$chatMessage = new ChatMessage('Recordatorio de tu turno', $options);
+
+$chatter->send($chatMessage);
+```
+
+Sending a free-form session message
+------------------------------------
+
+Inside WhatsApp's 24h customer service window (i.e. after the recipient has messaged the
+business), free-form text is allowed without a template:
+
+```php
+use Symfony\Component\Notifier\Bridge\WhatsApp\WhatsAppOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$options = (new WhatsAppOptions())->recipientPhoneNumber('5491112345678');
+
+$chatMessage = new ChatMessage('Tu turno para mañana sigue en pie, ¡te esperamos!', $options);
+
+$chatter->send($chatMessage);
+```
+
+Quick-reply buttons on a template are configured on the template itself in Meta's WhatsApp
+Manager (Message Templates), not via this bridge. The API call only supplies the template
+name, language, and body parameters.
+
+Resources
+---------
+
+- [Contributing](https://symfony.com/doc/current/contributing/index.html)
+- [Report issues](https://github.com/symfony/symfony/issues) and
+  [send Pull Requests](https://github.com/symfony/symfony/pulls)
+  in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/Tests/WhatsAppOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/Tests/WhatsAppOptionsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\WhatsApp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\WhatsApp\WhatsAppOptions;
+
+/**
+ * @author Piero Recchia <piero.recchia@gmail.com>
+ */
+final class WhatsAppOptionsTest extends TestCase
+{
+    public function testGetRecipientIdReturnsTheConfiguredPhoneNumber()
+    {
+        $options = (new WhatsAppOptions())->recipientPhoneNumber('5491112345678');
+
+        self::assertSame('5491112345678', $options->getRecipientId());
+    }
+
+    public function testGetRecipientIdIsNullByDefault()
+    {
+        self::assertNull((new WhatsAppOptions())->getRecipientId());
+    }
+
+    public function testGetTemplateIsNullByDefault()
+    {
+        self::assertNull((new WhatsAppOptions())->getTemplate());
+    }
+
+    public function testGetTemplateReturnsTheConfiguredTemplate()
+    {
+        $options = (new WhatsAppOptions())->template('recordatorio_turno', 'es_AR', ['Ana']);
+
+        self::assertSame([
+            'name' => 'recordatorio_turno',
+            'languageCode' => 'es_AR',
+            'bodyParameters' => ['Ana'],
+        ], $options->getTemplate());
+    }
+
+    public function testToArrayWithoutATemplate()
+    {
+        $options = (new WhatsAppOptions())->recipientPhoneNumber('5491112345678');
+
+        self::assertSame([
+            'recipientPhoneNumber' => '5491112345678',
+            'template' => null,
+        ], $options->toArray());
+    }
+
+    public function testToArrayWithATemplate()
+    {
+        $options = (new WhatsAppOptions())
+            ->recipientPhoneNumber('5491112345678')
+            ->template('recordatorio_turno', 'es_AR', ['Ana', 'Corte de pelo']);
+
+        self::assertSame([
+            'recipientPhoneNumber' => '5491112345678',
+            'template' => [
+                'name' => 'recordatorio_turno',
+                'languageCode' => 'es_AR',
+                'bodyParameters' => ['Ana', 'Corte de pelo'],
+            ],
+        ], $options->toArray());
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/Tests/WhatsAppTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/Tests/WhatsAppTransportFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\WhatsApp\Tests;
+
+use Symfony\Component\Notifier\Bridge\WhatsApp\WhatsAppTransportFactory;
+use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Notifier\Test\MissingRequiredOptionTestTrait;
+
+/**
+ * @author Piero Recchia <piero.recchia@gmail.com>
+ */
+final class WhatsAppTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+    use MissingRequiredOptionTestTrait;
+
+    public function createFactory(): WhatsAppTransportFactory
+    {
+        return new WhatsAppTransportFactory();
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            'whatsapp://graph.facebook.com?phone_number_id=123456789&api_version=v26.0',
+            'whatsapp://token@default?phone_number_id=123456789',
+        ];
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [true, 'whatsapp://token@host.test?phone_number_id=123456789'];
+        yield [false, 'somethingElse://token@default?phone_number_id=123456789'];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield 'missing token' => ['whatsapp://host.test?phone_number_id=123456789'];
+    }
+
+    public static function missingRequiredOptionProvider(): iterable
+    {
+        yield 'missing option: phone_number_id' => ['whatsapp://token@host.test'];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://login:apiKey@default'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/Tests/WhatsAppTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/Tests/WhatsAppTransportTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\WhatsApp\Tests;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\WhatsApp\WhatsAppOptions;
+use Symfony\Component\Notifier\Bridge\WhatsApp\WhatsAppTransport;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Piero Recchia <piero.recchia@gmail.com>
+ */
+final class WhatsAppTransportTest extends TransportTestCase
+{
+    public static function createTransport(?HttpClientInterface $client = null): WhatsAppTransport
+    {
+        return new WhatsAppTransport('access-token', '123456789', 'v26.0', $client ?? new MockHttpClient());
+    }
+
+    public static function toStringProvider(): iterable
+    {
+        yield ['whatsapp://graph.facebook.com?phone_number_id=123456789&api_version=v26.0', self::createTransport()];
+    }
+
+    public static function supportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!', (new WhatsAppOptions())->recipientPhoneNumber('5491112345678'))];
+    }
+
+    public static function unsupportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+        yield [new DummyMessage()];
+    }
+
+    public function testSupportsRequiresARecipient()
+    {
+        $transport = self::createTransport();
+
+        self::assertFalse($transport->supports(new ChatMessage('Hello!')));
+        self::assertFalse($transport->supports(new ChatMessage('Hello!', new WhatsAppOptions())));
+    }
+
+    public function testSendFreeFormTextMessageWhenNoTemplateIsSet()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('POST', $method);
+            self::assertSame('https://graph.facebook.com/v26.0/123456789/messages', $url);
+            self::assertContains('Authorization: Bearer access-token', $options['headers']);
+
+            $payload = json_decode($options['body'], true);
+            self::assertSame('whatsapp', $payload['messaging_product']);
+            self::assertSame('individual', $payload['recipient_type']);
+            self::assertSame('5491112345678', $payload['to']);
+            self::assertSame('text', $payload['type']);
+            self::assertSame('Hello!', $payload['text']['body']);
+
+            return new MockResponse(json_encode(['messages' => [['id' => 'wamid.42']]]));
+        });
+
+        $message = new ChatMessage('Hello!', (new WhatsAppOptions())->recipientPhoneNumber('5491112345678'));
+
+        $sentMessage = self::createTransport($client)->send($message);
+
+        self::assertInstanceOf(SentMessage::class, $sentMessage);
+        self::assertSame('wamid.42', $sentMessage->getMessageId());
+    }
+
+    public function testSendTemplateMessageWithBodyParameters()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            self::assertContains('Authorization: Bearer access-token', $options['headers']);
+
+            $payload = json_decode($options['body'], true);
+            self::assertSame('whatsapp', $payload['messaging_product']);
+            self::assertSame('individual', $payload['recipient_type']);
+            self::assertSame('template', $payload['type']);
+            self::assertSame('recordatorio_turno', $payload['template']['name']);
+            self::assertSame('es_AR', $payload['template']['language']['code']);
+            self::assertSame('Ana', $payload['template']['components'][0]['parameters'][0]['text']);
+
+            return new MockResponse(json_encode(['messages' => [['id' => 'wamid.43']]]));
+        });
+
+        $options = (new WhatsAppOptions())
+            ->recipientPhoneNumber('5491112345678')
+            ->template('recordatorio_turno', 'es_AR', ['Ana', 'Corte de pelo']);
+
+        $sentMessage = self::createTransport($client)->send(new ChatMessage('fallback', $options));
+
+        self::assertSame('wamid.43', $sentMessage->getMessageId());
+    }
+
+    public function testSendThrowsWithoutARecipientPhoneNumber()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('recipient phone number');
+
+        self::createTransport()->send(new ChatMessage('Hello!'));
+    }
+
+    public function testSendThrowsOnNonSuccessfulResponse()
+    {
+        $client = new MockHttpClient(new MockResponse(
+            json_encode(['error' => ['message' => 'Invalid parameter']]),
+            ['http_code' => 400],
+        ));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Invalid parameter');
+
+        $message = new ChatMessage('Hello!', (new WhatsAppOptions())->recipientPhoneNumber('5491112345678'));
+        self::createTransport($client)->send($message);
+    }
+
+    public function testSendThrowsTransportExceptionOnNonJsonErrorResponse()
+    {
+        $client = new MockHttpClient(new MockResponse('<html><body>502 Bad Gateway</body></html>', ['http_code' => 502]));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('502 Bad Gateway');
+
+        $message = new ChatMessage('Hello!', (new WhatsAppOptions())->recipientPhoneNumber('5491112345678'));
+        self::createTransport($client)->send($message);
+    }
+
+    public function testSendThrowsTransportExceptionOnNonJsonSuccessfulResponse()
+    {
+        $client = new MockHttpClient(new MockResponse(''));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Unable to send the WhatsApp message: malformed response from the WhatsApp Cloud API.');
+
+        $message = new ChatMessage('Hello!', (new WhatsAppOptions())->recipientPhoneNumber('5491112345678'));
+        self::createTransport($client)->send($message);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppOptions.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\WhatsApp;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * WhatsApp Cloud API messages are either a pre-approved template (required for
+ * business-initiated messages outside the 24h customer service window) or free-form text
+ * (only allowed inside that window). {@see template()} selects the former; omitting it
+ * sends the {@see \Symfony\Component\Notifier\Message\ChatMessage} subject as free text.
+ *
+ * @author Piero Recchia <piero.recchia@gmail.com>
+ */
+final class WhatsAppOptions implements MessageOptionsInterface
+{
+    private ?string $recipientPhoneNumber = null;
+
+    /**
+     * @var array{name: string, languageCode: string, bodyParameters: list<string>}|null
+     */
+    private ?array $template = null;
+
+    public function getRecipientId(): ?string
+    {
+        return $this->recipientPhoneNumber;
+    }
+
+    /**
+     * @param string $phoneNumber recipient phone number in E.164 format, with or without a leading "+"
+     */
+    public function recipientPhoneNumber(string $phoneNumber): static
+    {
+        $this->recipientPhoneNumber = $phoneNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return array{name: string, languageCode: string, bodyParameters: list<string>}|null
+     */
+    public function getTemplate(): ?array
+    {
+        return $this->template;
+    }
+
+    /**
+     * @param list<string> $bodyParameters positional values for the template's {{1}}, {{2}}, … body variables
+     */
+    public function template(string $name, string $languageCode, array $bodyParameters = []): static
+    {
+        $this->template = [
+            'name' => $name,
+            'languageCode' => $languageCode,
+            'bodyParameters' => $bodyParameters,
+        ];
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'recipientPhoneNumber' => $this->recipientPhoneNumber,
+            'template' => $this->template,
+        ];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransport.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\WhatsApp;
+
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Piero Recchia <piero.recchia@gmail.com>
+ */
+final class WhatsAppTransport extends AbstractTransport
+{
+    protected const HOST = 'graph.facebook.com';
+
+    public function __construct(
+        #[\SensitiveParameter] private string $accessToken,
+        private string $phoneNumberId,
+        private string $apiVersion,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+    ) {
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('whatsapp://%s?phone_number_id=%s&api_version=%s', $this->getEndpoint(), $this->phoneNumberId, $this->apiVersion);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ChatMessage
+            && (null === $message->getOptions() || $message->getOptions() instanceof WhatsAppOptions)
+            && '' !== ($message->getRecipientId() ?? '');
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof ChatMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
+        }
+
+        $options = $message->getOptions();
+        $options = $options instanceof WhatsAppOptions ? $options : null;
+        $to = $message->getRecipientId();
+
+        if (null === $to || '' === $to) {
+            throw new InvalidArgumentException('Unable to send a WhatsApp message without a recipient phone number set via WhatsAppOptions::recipientPhoneNumber().');
+        }
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'recipient_type' => 'individual',
+            'to' => $to,
+            ...$this->messageBody($options, $message->getSubject()),
+        ];
+
+        $endpoint = \sprintf('https://%s/%s/%s/messages', $this->getEndpoint(), $this->apiVersion, $this->phoneNumberId);
+
+        $response = $this->client->request('POST', $endpoint, [
+            'auth_bearer' => $this->accessToken,
+            'json' => $payload,
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Meta WhatsApp Cloud API server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            try {
+                $errorMessage = $response->toArray(false)['error']['message'] ?? null;
+            } catch (DecodingExceptionInterface) {
+                $errorMessage = $response->getContent(false);
+            }
+
+            throw new TransportException(\sprintf('Unable to send the WhatsApp message: error %d ("%s").', $statusCode, $errorMessage ?: 'unknown error'), $response);
+        }
+
+        try {
+            $content = $response->toArray(false);
+        } catch (DecodingExceptionInterface $e) {
+            throw new TransportException('Unable to send the WhatsApp message: malformed response from the WhatsApp Cloud API.', $response, 0, $e);
+        }
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId((string) ($content['messages'][0]['id'] ?? ''));
+
+        return $sentMessage;
+    }
+
+    /**
+     * @return array{type: string, template?: array<string, mixed>, text?: array{body: string}}
+     */
+    private function messageBody(?WhatsAppOptions $options, string $subject): array
+    {
+        $template = $options?->getTemplate();
+
+        if (null === $template) {
+            return [
+                'type' => 'text',
+                'text' => ['body' => $subject],
+            ];
+        }
+
+        $parameters = array_map(
+            static fn (string $value): array => ['type' => 'text', 'text' => $value],
+            $template['bodyParameters'],
+        );
+
+        return [
+            'type' => 'template',
+            'template' => [
+                'name' => $template['name'],
+                'language' => ['code' => $template['languageCode']],
+                'components' => [] === $parameters ? [] : [
+                    ['type' => 'body', 'parameters' => $parameters],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransportFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\WhatsApp;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+/**
+ * @author Piero Recchia <piero.recchia@gmail.com>
+ */
+final class WhatsAppTransportFactory extends AbstractTransportFactory
+{
+    private const DEFAULT_API_VERSION = 'v26.0';
+
+    public function create(Dsn $dsn): WhatsAppTransport
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('whatsapp' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'whatsapp', $this->getSupportedSchemes());
+        }
+
+        $accessToken = $this->getUser($dsn);
+        $phoneNumberId = $dsn->getRequiredOption('phone_number_id');
+        $apiVersion = $dsn->getOption('api_version', self::DEFAULT_API_VERSION);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new WhatsAppTransport($accessToken, $phoneNumberId, $apiVersion, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['whatsapp'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "symfony/whats-app-notifier",
+    "type": "symfony-notifier-bridge",
+    "description": "Symfony WhatsApp Notifier Bridge, via Meta's WhatsApp Cloud API",
+    "keywords": ["whatsapp", "meta", "notifier", "chat"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Piero Recchia",
+            "email": "piero.recchia@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/notifier": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symfony\\Component\\Notifier\\Bridge\\WhatsApp\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony WhatsApp Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -336,6 +336,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Vonage\VonageTransportFactory::class,
             'package' => 'symfony/vonage-notifier',
         ],
+        'whatsapp' => [
+            'class' => Bridge\WhatsApp\WhatsAppTransportFactory::class,
+            'package' => 'symfony/whats-app-notifier',
+        ],
         'yunpian' => [
             'class' => Bridge\Yunpian\YunpianTransportFactory::class,
             'package' => 'symfony/yunpian-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -105,6 +105,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             Bridge\Twitter\TwitterTransportFactory::class => false,
             Bridge\Unifonic\UnifonicTransportFactory::class => false,
             Bridge\Vonage\VonageTransportFactory::class => false,
+            Bridge\WhatsApp\WhatsAppTransportFactory::class => false,
             Bridge\Yunpian\YunpianTransportFactory::class => false,
             Bridge\Zendesk\ZendeskTransportFactory::class => false,
             Bridge\Zulip\ZulipTransportFactory::class => false,
@@ -196,6 +197,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['twitter', 'symfony/twitter-notifier'];
         yield ['unifonic', 'symfony/unifonic-notifier'];
         yield ['vonage', 'symfony/vonage-notifier'];
+        yield ['whatsapp', 'symfony/whats-app-notifier'];
         yield ['yunpian', 'symfony/yunpian-notifier'];
         yield ['zendesk', 'symfony/zendesk-notifier'];
         yield ['zulip', 'symfony/zulip-notifier'];

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -106,6 +106,7 @@ final class Transport
         Bridge\Twitter\TwitterTransportFactory::class,
         Bridge\Unifonic\UnifonicTransportFactory::class,
         Bridge\Vonage\VonageTransportFactory::class,
+        Bridge\WhatsApp\WhatsAppTransportFactory::class,
         Bridge\Yunpian\YunpianTransportFactory::class,
         Bridge\Zendesk\ZendeskTransportFactory::class,
         Bridge\Zulip\ZulipTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This adds a Notifier bridge for the [WhatsApp Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api),
Meta's own hosted WhatsApp Business API. It registers a `Chatter` transport that posts to
`POST https://graph.facebook.com/{api_version}/{phone_number_id}/messages`.

Unlike the `Twilio` bridge, which reaches WhatsApp through a Business Solution Provider by prefixing
its `From` number with `whatsapp:`, this bridge talks to Meta directly, so it needs no third-party
gateway account.

### DSN

```
WHATSAPP_DSN=whatsapp://TOKEN@default?phone_number_id=PHONE_NUMBER_ID&api_version=v26.0
```

`api_version` is optional and defaults to `v26.0`, the current Graph API version. Meta retires a
Graph API version roughly two years after the following one ships, so the option is there to let
applications move ahead of, or stay behind, the bridge's default.

### Getting the credentials

Both values come from an app in the [Meta developer console](https://developers.facebook.com/apps):

1. Create an app of type *Business* and add the **WhatsApp** product to it.
2. Under **WhatsApp > API Setup**, connect a WhatsApp Business Account (WABA). The page then shows
   the sending number's **Phone number ID**, which is the `phone_number_id` DSN option. This is the
   numeric ID, not the phone number itself.
3. The same page issues a temporary access token, which is fine to try the bridge out but expires
   within 24 hours. For anything else, create a **System User** in **Business Settings > Users >
   System Users**, assign it to the app and to the WABA, and generate a token with the
   `whatsapp_business_messaging`, `whatsapp_business_management` and `business_management` scopes.
   That token is the `TOKEN` part of the DSN and does not expire.

### Sending messages

A recipient is always required and is set through `WhatsAppOptions`. The DSN carries the sending
number only, so a `ChatMessage` without options cannot be delivered; the transport reports it as
unsupported rather than claiming it, which leaves it to any other chatter transport that can
deliver it.

Meta allows two kinds of outbound message, and which one applies depends on the customer service
window. Per Meta's documentation, a 24 hour window opens (or refreshes) every time the user messages
the business. Inside it, free-form messages are allowed; once it closes, a pre-approved template is
the only kind of message that can still be sent.

Free-form, inside the window, sends the `ChatMessage` subject as text:

```php
use Symfony\Component\Notifier\Bridge\WhatsApp\WhatsAppOptions;
use Symfony\Component\Notifier\Message\ChatMessage;

$options = (new WhatsAppOptions())->recipientPhoneNumber('5491112345678');

$chatter->send(new ChatMessage('Your appointment tomorrow is confirmed.', $options));
```

Outside the window, or for any business-initiated message, select a template approved beforehand in
Meta's WhatsApp Manager and pass its positional body parameters:

```php
$options = (new WhatsAppOptions())
    ->recipientPhoneNumber('5491112345678')
    ->template('appointment_reminder', 'en_US', ['Ana', 'Haircut', '10/07/2026', '15:00']);

$chatter->send(new ChatMessage('Appointment reminder', $options));
```

The subject is unused in that case, since the wording comes from the approved template. Quick-reply
buttons are configured on the template itself in WhatsApp Manager, not through this bridge.

### Possible follow-up

A DSN-level default recipient option would let a transport be dedicated to a single destination and
would remove the need for `WhatsAppOptions` in the simplest cases. It is deliberately out of scope
here, since it changes what a bare `ChatMessage` means for this transport.

### Documentation

A symfony-docs pull request should cover:

* the new `whatsapp` scheme and its row in the chatter transports table of `notifier.rst`, with the
  DSN format and the `symfony/whats-app-notifier` package name;
* the two DSN options, `phone_number_id` (required) and `api_version` (optional), and where the
  phone number ID comes from in the Meta developer console;
* the System User token and the three scopes it needs, contrasted with the temporary token;
* `WhatsAppOptions::recipientPhoneNumber()` as mandatory, and the fact that the transport does not
  support a `ChatMessage` without one;
* `WhatsAppOptions::template()` and the 24 hour customer service window that makes templates
  necessary outside it;
* the note that this bridge uses Meta's Cloud API directly, whereas `Twilio` reaches WhatsApp
  through a Business Solution Provider.
