### PR TITLE
 Fix/webprofiler mailer macros 6.4

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -260,218 +260,219 @@
         {{ _self.render_transport_details(collector, events.transports|first, true) }}
     {% endif %}
 
-    {% macro render_transport_details(collector, transport, show_transport_name = false) %}
-        <div class="card">
-            {% set num_emails = collector.events.events(transport)|length %}
-            {% if num_emails > 1 %}
-                <div class="mailer-email-summary-table-wrapper">
-                    <table class="mailer-email-summary-table">
-                        <thead>
-                            <tr>
-                                <th>#</th>
-                                <th>Subject</th>
-                                <th>To</th>
-                                <th class="visually-hidden">Actions</th>
+{% endblock %}
+
+{% macro render_transport_details(collector, transport, show_transport_name = false) %}
+    <div class="card">
+        {% set num_emails = collector.events.events(transport)|length %}
+        {% if num_emails > 1 %}
+            <div class="mailer-email-summary-table-wrapper">
+                <table class="mailer-email-summary-table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Subject</th>
+                            <th>To</th>
+                            <th class="visually-hidden">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for event in collector.events.events(transport) %}
+                            <tr class="mailer-email-summary-table-row {{ loop.first ? 'active' }}" data-target="#email-{{ loop.index }}">
+                                <td>{{ loop.index }}</td>
+                                <td>{{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}</td>
+                                <td>{{ event.message.headers.get('to').bodyAsString()|default(event.envelope.recipients|map(addr => addr.toString())|join(', ')) }}</td>
+                                <td class="visually-hidden"><button class="mailer-email-summary-table-row-button" data-target="#email-{{ loop.index }}">View email details</button></td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            {% for event in collector.events.events(transport) %}
-                                <tr class="mailer-email-summary-table-row {{ loop.first ? 'active' }}" data-target="#email-{{ loop.index }}">
-                                    <td>{{ loop.index }}</td>
-                                    <td>{{ event.message.headers.get('subject').bodyAsString()|default('(No subject)') }}</td>
-                                    <td>{{ event.message.headers.get('to').bodyAsString()|default(event.envelope.recipients|map(addr => addr.toString())|join(', ')) }}</td>
-                                    <td class="visually-hidden"><button class="mailer-email-summary-table-row-button" data-target="#email-{{ loop.index }}">View email details</button></td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            {% for event in collector.events.events(transport) %}
+                <div class="mailer-email-details {{ loop.first ? 'active' }}" id="email-{{ loop.index }}">
+                    {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
                 </div>
-
-                {% for event in collector.events.events(transport) %}
-                    <div class="mailer-email-details {{ loop.first ? 'active' }}" id="email-{{ loop.index }}">
-                        {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
-                    </div>
-                {% endfor %}
-            {% else %}
-                {% set event = (collector.events.events(transport)|first) %}
-                {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
-            {% endif %}
-        </div>
-    {% endmacro %}
-
-    {% macro render_email_details(collector, transport, message, message_is_queued, show_transport_name = false) %}
-        {% if show_transport_name %}
-            <p class="mailer-transport-information">
-                <strong>Status:</strong> <span class="badge badge-{{ message_is_queued ? 'warning' : 'success' }}">{{ message_is_queued ? 'Queued' : 'Sent' }}</span>
-                &bull;
-                <strong>Transport:</strong> <code>{{ transport }}</code>
-            </p>
-        {% endif %}
-
-        {% if message.headers is not defined %}
-            {# render the raw message contents #}
-            <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
-                {{ source('@WebProfiler/Icon/download.svg') }}
-                Download as EML file
-            </a>
-
-            <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+            {% endfor %}
         {% else %}
-            <div class="sf-tabs">
-                <div class="tab">
-                    <h3 class="tab-title">Email contents</h3>
-                    <div class="tab-content">
-                        <div class="card-block">
-                            <p class="mailer-message-subject">
-                                {{ message.headers.get('subject').bodyAsString()|default('(No subject)') }}
+            {% set event = (collector.events.events(transport)|first) %}
+            {{ _self.render_email_details(collector, transport, event.message, event.isQueued, show_transport_name) }}
+        {% endif %}
+    </div>
+{% endmacro %}
+
+{% macro render_email_details(collector, transport, message, message_is_queued, show_transport_name = false) %}
+    {% if show_transport_name %}
+        <p class="mailer-transport-information">
+            <strong>Status:</strong> <span class="badge badge-{{ message_is_queued ? 'warning' : 'success' }}">{{ message_is_queued ? 'Queued' : 'Sent' }}</span>
+            &bull;
+            <strong>Transport:</strong> <code>{{ transport }}</code>
+        </p>
+    {% endif %}
+
+    {% if message.headers is not defined %}
+        {# render the raw message contents #}
+        <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
+            {{ source('@WebProfiler/Icon/download.svg') }}
+            Download as EML file
+        </a>
+
+        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+    {% else %}
+        <div class="sf-tabs">
+            <div class="tab">
+                <h3 class="tab-title">Email contents</h3>
+                <div class="tab-content">
+                    <div class="card-block">
+                        <p class="mailer-message-subject">
+                            {{ message.headers.get('subject').bodyAsString()|default('(No subject)') }}
+                        </p>
+                        <div class="mailer-message-headers">
+                            <p>
+                                <strong>From:</strong>
+                                {{ message.headers.get('from').bodyAsString()|default('(empty)') }}
                             </p>
-                            <div class="mailer-message-headers">
-                                <p>
-                                    <strong>From:</strong>
-                                    {{ message.headers.get('from').bodyAsString()|default('(empty)') }}
-                                </p>
-                                <p>
-                                    <strong>To:</strong>
-                                    {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
-                                </p>
-                                {% for header in message.headers.all|filter(header => (header.name ?? '')|lower not in ['subject', 'from', 'to']) %}
-                                    <p class="mailer-message-header-secondary">{{ header.toString }}</p>
-                                {% endfor %}
-                            </div>
+                            <p>
+                                <strong>To:</strong>
+                                {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
+                            </p>
+                            {% for header in message.headers.all|filter(header => (header.name ?? '')|lower not in ['subject', 'from', 'to']) %}
+                                <p class="mailer-message-header-secondary">{{ header.toString }}</p>
+                            {% endfor %}
                         </div>
+                    </div>
 
-                        {% if message.attachments is defined and message.attachments %}
-                            <div class="card-block">
-                                {% set num_of_attachments = message.attachments|length %}
-                                {% set total_attachments_size_in_bytes = message.attachments|reduce((total_size, attachment) => total_size + attachment.body|length, 0) %}
-                                <p class="mailer-message-attachments-title">
-                                    {{ source('@WebProfiler/Icon/attachment.svg') }}
-                                    Attachments <span>({{ num_of_attachments }} file{{ num_of_attachments > 1 ? 's' }} / {{ _self.render_file_size_humanized(total_attachments_size_in_bytes) }})</span>
-                                </p>
-
-                                <ul class="mailer-message-attachments-list">
-                                    {% for attachment in message.attachments %}
-                                        <li>
-                                            {{ source('@WebProfiler/Icon/file.svg') }}
-
-                                            {% if attachment.filename|default %}
-                                                {{ attachment.filename }}
-                                            {% else %}
-                                                <em>(no filename)</em>
-                                            {% endif %}
-
-                                            ({{ _self.render_file_size_humanized(attachment.body|length) }})
-
-                                            <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">Download</a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                        {% endif %}
-
+                    {% if message.attachments is defined and message.attachments %}
                         <div class="card-block">
-                            <div class="sf-tabs sf-tabs-sm">
-                            {% if message.htmlBody is defined %}
-                                {% set textBody = message.textBody %}
-                                {% set htmlBody = message.htmlBody %}
-                                <div class="tab {{ not textBody ? 'disabled' }} {{ textBody ? 'active' }}">
-                                    <h3 class="tab-title">Text content</h3>
-                                    <div class="tab-content">
-                                        {% if textBody %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
-                                                {%- if message.textCharset() %}
-                                                    {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
-                                                {%- else %}
-                                                    {{- textBody }}
-                                                {%- endif -%}
-                                            </pre>
-                                        {% else %}
-                                            <div class="mailer-empty-email-body">
-                                                <p>The text body is empty.</p>
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                </div>
+                            {% set num_of_attachments = message.attachments|length %}
+                            {% set total_attachments_size_in_bytes = message.attachments|reduce((total_size, attachment) => total_size + attachment.body|length, 0) %}
+                            <p class="mailer-message-attachments-title">
+                                {{ source('@WebProfiler/Icon/attachment.svg') }}
+                                Attachments <span>({{ num_of_attachments }} file{{ num_of_attachments > 1 ? 's' }} / {{ _self.render_file_size_humanized(total_attachments_size_in_bytes) }})</span>
+                            </p>
 
-                                {% if htmlBody %}
-                                    <div class="tab">
-                                        <h3 class="tab-title">HTML preview</h3>
-                                        <div class="tab-content">
-                                            <pre class="prewrap" style="max-height: 600px"><iframe src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}" style="height: 80vh;width: 100%;"></iframe>
-                                            </pre>
+                            <ul class="mailer-message-attachments-list">
+                                {% for attachment in message.attachments %}
+                                    <li>
+                                        {{ source('@WebProfiler/Icon/file.svg') }}
+
+                                        {% if attachment.filename|default %}
+                                            {{ attachment.filename }}
+                                        {% else %}
+                                            <em>(no filename)</em>
+                                        {% endif %}
+
+                                        ({{ _self.render_file_size_humanized(attachment.body|length) }})
+
+                                        <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">Download</a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+
+                    <div class="card-block">
+                        <div class="sf-tabs sf-tabs-sm">
+                        {% if message.htmlBody is defined %}
+                            {% set textBody = message.textBody %}
+                            {% set htmlBody = message.htmlBody %}
+                            <div class="tab {{ not textBody ? 'disabled' }} {{ textBody ? 'active' }}">
+                                <h3 class="tab-title">Text content</h3>
+                                <div class="tab-content">
+                                    {% if textBody %}
+                                        <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            {%- if message.textCharset() %}
+                                                {{- textBody|convert_encoding('UTF-8', message.textCharset()) }}
+                                            {%- else %}
+                                                {{- textBody }}
+                                            {%- endif -%}
+                                        </pre>
+                                    {% else %}
+                                        <div class="mailer-empty-email-body">
+                                            <p>The text body is empty.</p>
                                         </div>
-                                    </div>
-                                {% endif %}
-
-                                <div class="tab {{ not htmlBody ? 'disabled' }} {{ not textBody and htmlBody ? 'active' }}">
-                                    <h3 class="tab-title">HTML content</h3>
-                                    <div class="tab-content">
-                                        {% if htmlBody %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
-                                                {%- if message.htmlCharset() %}
-                                                    {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
-                                                {%- else %}
-                                                    {{- htmlBody }}
-                                                {%- endif -%}
-                                            </pre>
-                                        {% else %}
-                                            <div class="mailer-empty-email-body">
-                                                <p>The HTML body is empty.</p>
-                                            </div>
-                                        {% endif %}
-                                    </div>
+                                    {% endif %}
                                 </div>
-                            {% else %}
-                                {% set body = message.body ? message.body.toString() : null %}
-                                <div class="tab {{ not body ? 'disabled' }} {{ body ? 'active' }}">
-                                    <h3 class="tab-title">Content</h3>
+                            </div>
+
+                            {% if htmlBody %}
+                                <div class="tab">
+                                    <h3 class="tab-title">HTML preview</h3>
                                     <div class="tab-content">
-                                        {% if body %}
-                                            <pre class="mailer-email-body prewrap" style="max-height: 600px">
-                                                {{- body }}
-                                            </pre>
-                                        {% else %}
-                                            <div class="mailer-empty-email-body">
-                                                <p>The body is empty.</p>
-                                            </div>
-                                        {% endif %}
+                                        <pre class="prewrap" style="max-height: 600px"><iframe src="data:text/html;charset=utf-8;base64,{{ collector.base64Encode(htmlBody) }}" style="height: 80vh;width: 100%;"></iframe>
+                                        </pre>
                                     </div>
                                 </div>
                             {% endif %}
+
+                            <div class="tab {{ not htmlBody ? 'disabled' }} {{ not textBody and htmlBody ? 'active' }}">
+                                <h3 class="tab-title">HTML content</h3>
+                                <div class="tab-content">
+                                    {% if htmlBody %}
+                                        <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            {%- if message.htmlCharset() %}
+                                                {{- htmlBody|convert_encoding('UTF-8', message.htmlCharset()) }}
+                                            {%- else %}
+                                                {{- htmlBody }}
+                                            {%- endif -%}
+                                        </pre>
+                                    {% else %}
+                                        <div class="mailer-empty-email-body">
+                                            <p>The HTML body is empty.</p>
+                                        </div>
+                                    {% endif %}
+                                </div>
                             </div>
+                        {% else %}
+                            {% set body = message.body ? message.body.toString() : null %}
+                            <div class="tab {{ not body ? 'disabled' }} {{ body ? 'active' }}">
+                                <h3 class="tab-title">Content</h3>
+                                <div class="tab-content">
+                                    {% if body %}
+                                        <pre class="mailer-email-body prewrap" style="max-height: 600px">
+                                            {{- body }}
+                                        </pre>
+                                    {% else %}
+                                        <div class="mailer-empty-email-body">
+                                            <p>The body is empty.</p>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% endif %}
                         </div>
                     </div>
                 </div>
+            </div>
 
-                <div class="tab">
-                    <h3 class="tab-title">MIME parts</h3>
-                    <div class="tab-content">
-                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.body().asDebugString() }}</pre>
-                    </div>
-                </div>
-
-                <div class="tab">
-                    <h3 class="tab-title">Raw Message</h3>
-                    <div class="tab-content">
-                        <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
-                            {{ source('@WebProfiler/Icon/download.svg') }}
-                            Download as EML file
-                        </a>
-
-                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
-                    </div>
+            <div class="tab">
+                <h3 class="tab-title">MIME parts</h3>
+                <div class="tab-content">
+                    <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.body().asDebugString() }}</pre>
                 </div>
             </div>
-        {% endif %}
-    {% endmacro %}
 
-    {% macro render_file_size_humanized(bytes) %}
-        {%- if bytes < 1000 -%}
-            {{- bytes ~ ' bytes' -}}
-        {%- elseif bytes < 1000 ** 2 -%}
-            {{- (bytes / 1000)|number_format(2) ~ ' kB' -}}
-        {%- else -%}
-            {{- (bytes / 1000 ** 2)|number_format(2) ~ ' MB' -}}
-        {%- endif -%}
-    {% endmacro %}
-{% endblock %}
+            <div class="tab">
+                <h3 class="tab-title">Raw Message</h3>
+                <div class="tab-content">
+                    <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
+                        {{ source('@WebProfiler/Icon/download.svg') }}
+                        Download as EML file
+                    </a>
+
+                    <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro render_file_size_humanized(bytes) %}
+    {%- if bytes < 1000 -%}
+        {{- bytes ~ ' bytes' -}}
+    {%- elseif bytes < 1000 ** 2 -%}
+        {{- (bytes / 1000)|number_format(2) ~ ' kB' -}}
+    {%- else -%}
+        {{- (bytes / 1000 ** 2)|number_format(2) ~ ' MB' -}}
+    {%- endif -%}
+{% endmacro %}


### PR DESCRIPTION
Macros defined inside `{% block panel %}` trigger `E_USER_DEPRECATED` with Twig 3.27+ (`CorrectnessNodeVisitor`). Other collector templates (`cache`, `form`, `logger`, etc.) already define macros at template root.

| Q             | A                                        |
| ------------- | ---------------------------------------- |
| Branch?       | 6.4                                      |
| Bug fix?      | yes                                      |
| New feature?  | no                                       |
| BC breaks?    | no                                       |
| Deprecations? | no (fixes Twig 3.27 deprecation)         |
| Tickets       | Fixes #64871                             |
| License       | MIT                                      |

Moves `{% macro %}` definitions in `mailer.html.twig` from inside `{% block panel %}` to the template root,
matching the pattern already used in `cache.html.twig`, `form.html.twig`, `logger.html.twig`, etc.

## Problem

With Twig 3.27+, opening the Mailer panel in the Web Profiler triggers:

```
User Deprecated: Since twig/twig 3.27: Using the "macro" tag outside the root of a template is deprecated
in @WebProfiler/Collector/mailer.html.twig at line 267.
```

(and lines 306, 472 for the other two macros).

## Solution

Relocate the three macros after the panel block's `{% endblock %}`. Calls via `_self.render_*()` inside the panel block are unchanged.

## How to test

1. Install a Symfony 6.4 app with `symfony/web-profiler-bundle` and `twig/twig` ^3.27.
2. Send an email in `dev`.
3. Open `/_profiler/{token}?panel=mailer`.
4. Confirm no Twig 3.27 macro deprecation warnings appear.

## Notes

- Rebased cleanly on `6.4` as requested by @fabpot.
- Supersedes #64872.