### PR TITLE
[Console] Add input and output to `handleSignal()`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -8,6 +8,11 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/8.2/
 
 If you're upgrading from a version below 8.1, follow the [8.1 upgrade guide](UPGRADE-8.1.md) first.
 
+Console
+-------
+
+ * Add arguments `?InputInterface $input = null` and `?OutputInterface $output = null` to `SignalableCommandInterface::handleSignal()`
+
 Crowdin Translation Provider
 ----------------------------
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1083,7 +1083,7 @@ class Application implements ResetInterface
 
                         // If the command is signalable, we call the handleSignal() method
                         if (\in_array($signal, $commandSignals, true)) {
-                            $exitCode = $command->handleSignal($signal, $exitCode);
+                            $exitCode = $command->handleSignal($signal, $exitCode, $input, $output);
                         }
 
                         if (\SIGALRM === $signal) {
@@ -1104,12 +1104,12 @@ class Application implements ResetInterface
             }
 
             foreach ($commandSignals as $signal) {
-                $signalRegistry->register($signal, function (int $signal) use ($command): void {
+                $signalRegistry->register($signal, function (int $signal) use ($command, $input, $output): void {
                     if (\SIGALRM === $signal) {
                         $this->scheduleAlarm();
                     }
 
-                    if (false !== $exitCode = $command->handleSignal($signal)) {
+                    if (false !== $exitCode = $command->handleSignal($signal, 0, $input, $output)) {
                         exit($exitCode);
                     }
                 });

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add optional input and output arguments to `SignalableCommandInterface::handleSignal()`
+
 8.1
 ---
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -655,9 +655,16 @@ class Command implements SignalableCommandInterface
         return $this->code?->getSubscribedSignals() ?? [];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    /**
+     * @param ?InputInterface $input
+     * @param ?OutputInterface $output
+     */
+    public function handleSignal(int $signal, int|false $previousExitCode = 0/* , ?InputInterface $input = null, ?OutputInterface $output = null */): int|false
     {
-        return $this->code?->handleSignal($signal, $previousExitCode) ?? false;
+        $input = \func_num_args() > 2 ? func_get_arg(2) : null;
+        $output = \func_num_args() > 3 ? func_get_arg(3) : null;
+
+        return $this->code?->handleSignal($signal, $previousExitCode, $input, $output) ?? false;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -196,9 +196,9 @@ class InvokableCommand implements SignalableCommandInterface
         return $this->signalableCommand?->getSubscribedSignals() ?? [];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
-        return $this->signalableCommand?->handleSignal($signal, $previousExitCode) ?? false;
+        return $this->signalableCommand?->handleSignal($signal, $previousExitCode, $input, $output) ?? false;
     }
 
     public function isInteractive(): bool

--- a/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
+++ b/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
 /**
  * Interface for command reacting to signal.
  *
@@ -30,7 +33,10 @@ interface SignalableCommandInterface
     /**
      * The method will be called when the application is signaled.
      *
+     * @param ?InputInterface $input
+     * @param ?OutputInterface $output
+     *
      * @return int|false The exit code to return or false to continue the normal execution
      */
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false;
+    public function handleSignal(int $signal, int|false $previousExitCode = 0/* , ?InputInterface $input = null, ?OutputInterface $output = null */): int|false;
 }

--- a/src/Symfony/Component/Console/Command/TraceableCommand.php
+++ b/src/Symfony/Component/Console/Command/TraceableCommand.php
@@ -90,11 +90,11 @@ final class TraceableCommand extends Command
         return $this->command->getSubscribedSignals();
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         $event = $this->stopwatch->start($this->getName().'.handle_signal');
 
-        $exit = $this->command->handleSignal($signal, $previousExitCode);
+        $exit = $this->command->handleSignal($signal, $previousExitCode, $input, $output);
 
         $event->stop();
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -2273,9 +2273,14 @@ class ApplicationTest extends TestCase
 
         $application = $this->createSignalableApplication($command, null);
         $application->setSignalsToDispatchEvent(\SIGUSR1);
+        $input = new ArrayInput(['signal']);
+        $output = new BufferedOutput();
 
-        $this->assertSame(1, $application->run(new ArrayInput(['signal'])));
+        $this->assertSame(1, $application->run($input, $output));
         $this->assertTrue($command->signaled);
+        $this->assertSame(0, $command->previousExitCode);
+        $this->assertSame($input, $command->input);
+        $this->assertSame($output, $command->output);
     }
 
     #[RequiresPhpExtension('pcntl')]
@@ -2357,8 +2362,14 @@ class ApplicationTest extends TestCase
 
         $application = $this->createSignalableApplication($command, $dispatcher);
         $application->setSignalsToDispatchEvent(\SIGUSR1);
-        $this->assertSame(1, $application->run(new ArrayInput(['signal'])));
+        $input = new ArrayInput(['signal']);
+        $output = new BufferedOutput();
+
+        $this->assertSame(1, $application->run($input, $output));
         $this->assertSame([SignalEventSubscriber::class, SignableCommand::class], $command->signalHandlers);
+        $this->assertFalse($command->previousExitCode);
+        $this->assertSame($input, $command->input);
+        $this->assertSame($output, $command->output);
     }
 
     public function testSignalableCommandDoesNotInterruptedOnTermSignals()
@@ -2514,9 +2525,14 @@ class ApplicationTest extends TestCase
 
         $application = $this->createSignalableApplication($command, null);
         $application->setSignalsToDispatchEvent(\SIGUSR1);
+        $input = new ArrayInput(['signal-invokable']);
+        $output = new BufferedOutput();
 
-        $this->assertSame(1, $application->run(new ArrayInput(['signal-invokable'])));
+        $this->assertSame(1, $application->run($input, $output));
         $this->assertTrue($invokable->signaled);
+        $this->assertSame(0, $invokable->previousExitCode);
+        $this->assertSame($input, $invokable->input);
+        $this->assertSame($output, $invokable->output);
     }
 
     #[RequiresPhpExtension('pcntl')]
@@ -2528,7 +2544,7 @@ class ApplicationTest extends TestCase
                 return [\SIGUSR1];
             }
 
-            public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+            public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
             {
                 return false;
             }
@@ -2671,7 +2687,7 @@ class ApplicationTest extends TestCase
                 return [\SIGUSR1];
             }
 
-            public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+            public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
             {
                 return false;
             }
@@ -2695,7 +2711,7 @@ class ApplicationTest extends TestCase
                 return [\SIGUSR1];
             }
 
-            public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+            public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
             {
                 return false;
             }
@@ -3070,15 +3086,23 @@ class BaseSignableCommand extends Command
 #[AsCommand(name: 'signal')]
 class SignableCommand extends BaseSignableCommand
 {
+    public int|false|null $previousExitCode = null;
+    public ?InputInterface $input = null;
+    public ?OutputInterface $output = null;
+
     public function getSubscribedSignals(): array
     {
         return SignalRegistry::isSupported() ? [\SIGUSR1] : [];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         $this->signaled = true;
         $this->signalHandlers[] = __CLASS__;
+
+        $this->previousExitCode = $previousExitCode;
+        $this->input = $input;
+        $this->output = $output;
 
         return false;
     }
@@ -3092,7 +3116,7 @@ class TerminatableCommand extends BaseSignableCommand
         return SignalRegistry::isSupported() ? [\SIGINT] : [];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         $this->signaled = true;
         $this->signalHandlers[] = __CLASS__;
@@ -3126,7 +3150,7 @@ class TerminatableWithEventCommand extends Command implements EventSubscriberInt
         return [\SIGINT];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         $this->shouldContinue = false;
 
@@ -3172,6 +3196,9 @@ class SignalEventSubscriber implements EventSubscriberInterface
 trait SignalableInvokableCommandTrait
 {
     public bool $signaled = false;
+    public int|false|null $previousExitCode = null;
+    public ?InputInterface $input = null;
+    public ?OutputInterface $output = null;
 
     public function __invoke(): int
     {
@@ -3192,9 +3219,13 @@ trait SignalableInvokableCommandTrait
         return SignalRegistry::isSupported() ? [\SIGUSR1] : [];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         $this->signaled = true;
+
+        $this->previousExitCode = $previousExitCode;
+        $this->input = $input;
+        $this->output = $output;
 
         return false;
     }
@@ -3218,7 +3249,7 @@ class AlarmableCommand extends BaseSignableCommand
         return [\SIGALRM];
     }
 
-    public function handleSignal(int $signal, false|int $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, false|int $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         if (\SIGALRM === $signal) {
             $this->signaled = true;

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\MethodBasedTestCommand;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -459,7 +461,7 @@ class InvokableSignalableCommand implements SignalableCommandInterface
         return [];
     }
 
-    public function handleSignal(int $signal, false|int $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, false|int $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         return false;
     }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_signalable.php
@@ -17,7 +17,7 @@ require $vendor.'/vendor/autoload.php';
         return [SIGINT];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         exit(254);
     }

--- a/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/alarm/command_exit.phpt
@@ -39,7 +39,7 @@ class MyCommand extends Command
         return [\SIGALRM];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         if (\SIGALRM === $signal) {
             echo "Received alarm!";

--- a/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/signal/command_exit.phpt
@@ -35,7 +35,7 @@ class MyCommand extends Command
         return [\SIGINT];
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0, ?InputInterface $input = null, ?OutputInterface $output = null): int|false
     {
         echo "Received signal!";
 

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -346,7 +346,11 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
         return $this->signals ?? (SignalRegistry::isSupported() ? [\SIGTERM, \SIGINT, \SIGQUIT, \SIGALRM] : []);
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    /**
+     * @param ?InputInterface $input
+     * @param ?OutputInterface $output
+     */
+    public function handleSignal(int $signal, int|false $previousExitCode = 0/* , ?InputInterface $input = null, ?OutputInterface $output = null */): int|false
     {
         if (!$this->worker) {
             return false;

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -146,7 +146,11 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         return $this->signals ?? (\extension_loaded('pcntl') ? [\SIGTERM, \SIGINT, \SIGQUIT, \SIGALRM] : []);
     }
 
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    /**
+     * @param ?InputInterface $input
+     * @param ?OutputInterface $output
+     */
+    public function handleSignal(int $signal, int|false $previousExitCode = 0/* , ?InputInterface $input = null, ?OutputInterface $output = null */): int|false
     {
         if (!$this->worker) {
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Currently, when `handleSignal()` needs access to the input or output, you first need to store the objects in properties because they are not passed to the method, for example:

```php 
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Command\SignalableCommandInterface;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

#[AsCommand(name: 'app:my-command')]
class MyCommand implements SignalableCommandInterface
{
    private ?OutputInterface $output = null;

    public function __invoke(OutputInterface $output): int
    {
        $this->output = $output;

        // ...
    }

    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
    {
        $this->output?->writeln(\sprintf('Received signal %d.', $signal));

        return false;
    }
}
```

This PR adds two new optional parameters to `SignalableCommandInterface::handleSignal()`: `?InputInterface $input = null` and `?OutputInterface $output = null`.

This improves the developer experience by removing the need to store these objects as properties solely so they can be accessed from `handleSignal()`.
