### PR TITLE
[Console] Fix two ValueError crashes on multibyte / multi-column widths

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -37,7 +37,7 @@ class TextDescriptor extends Descriptor
         }
 
         $totalWidth = $options['total_width'] ?? Helper::width($argument->getName());
-        $spacingWidth = $totalWidth - \strlen($argument->getName());
+        $spacingWidth = $totalWidth - Helper::width($argument->getName());
 
         $this->writeText(\sprintf('  <info>%s</info>  %s%s%s',
             $argument->getName(),

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -544,7 +544,7 @@ final class ProgressBar
                 $display = str_repeat($bar->getBarCharacter(), $completeBars);
                 if ($completeBars < $bar->getBarWidth()) {
                     $emptyBars = $bar->getBarWidth() - $completeBars - Helper::length(Helper::removeDecoration($output->getFormatter(), $bar->getProgressCharacter()));
-                    $display .= $bar->getProgressCharacter().str_repeat($bar->getEmptyBarCharacter(), $emptyBars);
+                    $display .= $bar->getProgressCharacter().str_repeat($bar->getEmptyBarCharacter(), max(0, $emptyBars));
                 }
 
                 return $display;

--- a/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Console\Tests\Descriptor;
 
 use Symfony\Component\Console\Descriptor\TextDescriptor;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorApplication2;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorApplicationMbString;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString;
@@ -32,6 +34,14 @@ class TextDescriptorTest extends AbstractDescriptorTestCase
             ObjectsProvider::getApplications(),
             ['application_mbstring' => new DescriptorApplicationMbString()]
         ));
+    }
+
+    public function testDescribeInputArgumentWithMultibyteName()
+    {
+        $output = new BufferedOutput();
+        (new TextDescriptor())->describe($output, new InputArgument('路径', InputArgument::REQUIRED), ['raw_output' => true]);
+
+        $this->assertStringContainsString('路径', $output->fetch());
     }
 
     public function testDescribeApplicationWithFilteredNamespace()

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
@@ -7,7 +7,7 @@
   descriptor:åèä \<argument_name\>
 
 <comment>Arguments:</comment>
-  <info>argument_åèä</info>   
+  <info>argument_åèä</info>      
 
 <comment>Options:</comment>
   <info>-o, --option_åèä</info>  

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -1117,6 +1117,17 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $bar->finish();
     }
 
+    public function testMultiCharProgressCharacterNearCompletion()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 28, 0);
+        $bar->setProgressCharacter('=>');
+        $bar->start();
+        $bar->setProgress(27);
+
+        rewind($output->getStream());
+        $this->assertStringContainsString(' 27/28 [============================>]  96%', stream_get_contents($output->getStream()));
+    }
+
     /**
      * @dataProvider provideFormat
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR fixes two `ValueError: str_repeat(): Argument #2 ($times) must be greater than or equal to 0` crashes in the Console component. Both are caused by the same underlying mistake: computing a padding/width from the **byte length** of a string while comparing it against a value expressed in **display width** (columns). When a string's display width is smaller than its byte length (multibyte characters) or a character occupies more than one column, the intermediate count goes negative and `str_repeat()` throws.

### 1. `TextDescriptor::describeInputArgument()`

```php
$totalWidth = $options['total_width'] ?? Helper::width($argument->getName());
$spacingWidth = $totalWidth - \strlen($argument->getName()); // ← byte length
```

`$totalWidth` is a **display width** (`Helper::width()` → `mb_strwidth()`), but the padding subtracts the **byte length** (`\strlen()`). For an argument name whose display width is smaller than its byte length, the two are inconsistent:

* If that argument is the widest column, `$spacingWidth` becomes **negative** and `str_repeat(' ', $spacingWidth)` throws. Example: describing an argument named `路径` (display width `4`, byte length `6`) with no wider option present → `$spacingWidth = 4 - 6 = -2` → crash.
* Otherwise the description column is simply **misaligned** (indented too far left by `strlen − width` spaces).

Every sibling method already uses display width: `describeInputOption()` uses `$totalWidth - Helper::width($synopsis)`, and `describeInputDefinition()` derives `total_width` from `Helper::width()`. This line was left as `\strlen()` — an oversight from the `Helper::strlen() → Helper::width()` migration. The fix aligns it:

```php
$spacingWidth = $totalWidth - Helper::width($argument->getName());
```

### 2. `ProgressBar` – the `bar` placeholder

```php
$emptyBars = $bar->getBarWidth() - $completeBars - Helper::length(Helper::removeDecoration($output->getFormatter(), $bar->getProgressCharacter()));
$display .= $bar->getProgressCharacter().str_repeat($bar->getEmptyBarCharacter(), $emptyBars);
```

`$emptyBars` is never clamped. As the bar approaches 100 %, `$completeBars` reaches `barWidth - 1`, so `$emptyBars = 1 - length(progressCharacter)`. The progress character is a **public API** (`setProgressCharacter()`) and may be more than one column wide, in which case `$emptyBars` goes negative and `str_repeat()` throws.

Reproduction:

```php
$bar = new ProgressBar($output, 28);
$bar->setProgressCharacter('=>'); // 2 columns
$bar->setProgress(27);            // completeBars = 27, emptyBars = 28 - 27 - 2 = -1  → ValueError
```

Fixed by clamping:

```php
$display .= $bar->getProgressCharacter().str_repeat($bar->getEmptyBarCharacter(), max(0, $emptyBars));
```

### Tests

* Added `ProgressBarTest::testMultiCharProgressCharacterNearCompletion()`.
* Added `TextDescriptorTest::testDescribeInputArgumentWithMultibyteName()`.
* Updated the `command_mbstring.txt` fixture: the multibyte argument column is now correctly aligned with the options column (the only change is the padding of that one line).

Both new tests fail with the described `ValueError` on the current code and pass with the fix.
