### PR TITLE
[Cache] Initialize PhpArrayAdapter before classifying keys in deleteItems()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -177,22 +177,24 @@ class PhpArrayAdapter implements AdapterInterface, CacheInterface, PruneableInte
 
     public function deleteItems(array $keys): bool
     {
-        $deleted = true;
-        $fallbackKeys = [];
-
         foreach ($keys as $key) {
             if (!\is_string($key)) {
                 throw new InvalidArgumentException(\sprintf('Cache key must be string, "%s" given.', get_debug_type($key)));
             }
+        }
+        if (!isset($this->values)) {
+            $this->initialize();
+        }
 
+        $deleted = true;
+        $fallbackKeys = [];
+
+        foreach ($keys as $key) {
             if (isset($this->keys[$key])) {
                 $deleted = false;
             } else {
                 $fallbackKeys[] = $key;
             }
-        }
-        if (!isset($this->values)) {
-            $this->initialize();
         }
 
         if ($fallbackKeys) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
@@ -145,6 +146,22 @@ class PhpArrayAdapterTest extends AdapterTestCase
         $values = eval(substr(file_get_contents(self::$file), 6));
 
         $this->assertSame($expected, $values, 'Warm up should create a PHP file that OPCache can load in memory');
+    }
+
+    public function testDeleteItemsOnUninitializedAdapter()
+    {
+        // A stored (read-only) key must be handled the same way whether the
+        // adapter has been initialized yet or not, and identically to deleteItem().
+        (new PhpArrayAdapter(self::$file, new NullAdapter()))->warmUp(['foo' => 'stored-value']);
+
+        $fallback = new ArrayAdapter();
+        $fallback->save($fallback->getItem('foo')->set('fallback-value'));
+
+        // Fresh, not-yet-initialized instance; deleteItems() is the first call.
+        $adapter = new PhpArrayAdapter(self::$file, $fallback);
+
+        $this->assertFalse($adapter->deleteItems(['foo']), 'A stored key cannot be deleted.');
+        $this->assertTrue($fallback->hasItem('foo'), 'A stored key must not be deleted from the fallback pool.');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PhpArrayAdapter::deleteItems()` classifies each key as either *stored* (read-only, living in the warmed PHP file) or *fallback* (delegated to the fallback pool) by reading `$this->keys` — **but it does so before calling `initialize()`**, which is the method that actually populates `$this->keys` from the file.

```php
public function deleteItems(array $keys): bool
{
    $deleted = true;
    $fallbackKeys = [];

    foreach ($keys as $key) {
        // ...
        if (isset($this->keys[$key])) {   // ← $this->keys is not initialized yet
            $deleted = false;
        } else {
            $fallbackKeys[] = $key;
        }
    }
    if (!isset($this->values)) {
        $this->initialize();              // ← too late
    }
    // ...
}
```

On a not-yet-initialized adapter `$this->keys` is empty, so **every stored key is misclassified as a fallback key**. `deleteItem()` (and every other method) calls `initialize()` first, so the two delete methods disagree.

### Observable effect

When `deleteItems()` is the **first** call on a fresh instance and the key is stored/read-only, compared to the equivalent `deleteItem()`:

```php
$adapter = new PhpArrayAdapter($file, $fallbackPool); // $file has a stored key 'foo'

$adapter->deleteItem('foo');    // returns false, fallback pool untouched  (correct)
$adapter->deleteItems(['foo']); // returns TRUE, and deletes 'foo' from the fallback pool  (wrong)
```

So `deleteItems()`:
* returns `true` for a read-only key that cannot actually be deleted (should be `false`), and
* forwards that key to the fallback pool, wrongly deleting an unrelated same-named entry there.

Once the adapter has been initialized by any prior operation, the bug disappears — it only bites when `deleteItems()` is the first call.

### Fix

Hoist the existing `initialize()` guard above the loop, exactly as `deleteItem()`, `hasItem()`, `save()`, etc. already do. With the fix, `deleteItem()` and `deleteItems()` produce identical results (verified for stored keys, fallback-only keys, and mixed batches, on both cold and warm instances).

A regression test is added (the `testDeleteItems*` inherited from the integration suite are skipped for this read-only adapter, so this path was previously unasserted). It fails on the current code and passes with the fix.
