### PR TITLE
[HttpKernel] Add milliseconds to logs’ `timestamp_rfc3339`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -162,14 +162,16 @@ class Logger extends AbstractLogger implements DebugLoggerInterface
         $request = $this->requestStack->getCurrentRequest();
         $key = $request ? spl_object_id($request) : '';
 
+        $now = new \DateTimeImmutable();
+
         $this->logs[$key][] = [
             'channel' => null,
             'context' => $context,
             'message' => $message,
             'priority' => self::PRIORITIES[$level],
             'priorityName' => $level,
-            'timestamp' => time(),
-            'timestamp_rfc3339' => date(\DATE_RFC3339_EXTENDED),
+            'timestamp' => $now->getTimestamp(),
+            'timestamp_rfc3339' => $now->format(\DATE_RFC3339_EXTENDED),
         ];
 
         $this->errorCount[$key] ??= 0;

--- a/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Log/LoggerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Log\Logger;
 
 /**
@@ -202,6 +203,32 @@ class LoggerTest extends TestCase
         }
 
         ini_set('error_log', $oldErrorLog);
+    }
+
+    public function testRecordedTimestampsHaveMillisecondPrecision()
+    {
+        $logger = new Logger(LogLevel::DEBUG, $this->tmpFile, null, new RequestStack(), true);
+
+        // Log away from the second boundary: a time truncated to the second
+        // would then fall before the measured window.
+        do {
+            usleep(100);
+            $subSecond = fmod(microtime(true), 1);
+        } while (0.002 > $subSecond || 0.9 < $subSecond);
+
+        $before = microtime(true);
+        $logger->debug('test');
+        $after = microtime(true);
+
+        ['timestamp' => $timestamp, 'timestamp_rfc3339' => $rfc3339] = $logger->getLogs()[0];
+        $recorded = \DateTimeImmutable::createFromFormat(\DATE_RFC3339_EXTENDED, $rfc3339);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $recorded);
+        $this->assertSame($timestamp, $recorded->getTimestamp());
+
+        // the recorded time is truncated to the millisecond, so it can sit just below $before
+        $this->assertGreaterThan($before - 0.001, (float) $recorded->format('U.v'));
+        $this->assertLessThanOrEqual($after, (float) $recorded->format('U.v'));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

I missed this note in #47483:

> `date()` will always generate [<samp>000</samp> milliseconds] since it takes an `int` parameter, whereas `DateTimeInterface::format()` does support [milliseconds] if an object of type `DateTimeInterface` was created with [milliseconds].

https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters

The profiler was already asking for this: `logger.html.twig` renders `log.timestamp|date('H:i:s.v')` with `fractionalSecondDigits: 3`, and every entry was being fed `.000`. It also makes the two `DebugLoggerInterface` implementations agree, since `Monolog\Processor\DebugProcessor` already emitted real milliseconds.

Added during review:

* `LoggerTest::testRecordedTimestampsHaveMillisecondPrecision`. The test waits until the call lands away from a second boundary, so a second-truncated value is always strictly below the measured lower bound and the failure is deterministic rather than probabilistic. On the base branch it fails 10 times out of 10 with `Failed asserting that 1785147863000 is equal to 1785147863514 or is greater than 1785147863514`; the failing value always ends in `000`. The guard spins at most 100 ms, and only when the call lands in the last 100 ms of a second.

Two things worth recording for the merger.

**A second, unadvertised change.** `'timestamp' => time()` becomes `$now->getTimestamp()`. Before, the two fields were read from two independent clock calls and could straddle a second boundary, leaving `timestamp` and `timestamp_rfc3339` one second apart. With the reads artificially widened to 1.2 ms this reproduces 5 times out of 8; in the real code the gap is a few array writes, so no user will have seen it. Both fields now derive from a single instant.

**`ClockMock` no longer applies to this path.** `ClockMock` shims `time()`, `microtime()`, `date()` and friends per namespace, but it does not intercept `new \DateTimeImmutable()`, so a frozen clock is ignored by `Logger::record()` where it used to be honoured. Nothing registers `ClockMock` for `Symfony\Component\HttpKernel\Log` today, so no test changes behaviour. Restoring it would mean

```php
$now = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', microtime(true)))
    ->setTimezone(new \DateTimeZone(date_default_timezone_get()));
```

which is uglier than the one-liner and is not needed by the test above, so this keeps `new \DateTimeImmutable()`.
