### PR TITLE
[HttpClient] Replace the native "dechunk" stream filter with a pure PHP implementation

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient;
 
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\Dechunker;
 use Symfony\Component\HttpClient\Response\StreamableInterface;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Component\Mime\MimeTypes;
@@ -510,14 +511,15 @@ trait HttpClientTrait
 
     private static function dechunk(string $body): string
     {
-        $h = fopen('php://temp', 'w+');
-        stream_filter_append($h, 'dechunk', \STREAM_FILTER_WRITE);
-        fwrite($h, $body);
-        $body = stream_get_contents($h, -1, 0);
-        rewind($h);
-        ftruncate($h, 0);
+        $dechunker = new Dechunker();
 
-        if (fwrite($h, '-') && '' !== stream_get_contents($h, -1, 0)) {
+        try {
+            $body = $dechunker->dechunk($body);
+        } catch (TransportException) {
+            $dechunker = null;
+        }
+
+        if (!$dechunker?->isFinished()) {
             throw new TransportException('Request body has broken chunked encoding.');
         }
 

--- a/src/Symfony/Component/HttpClient/Internal/Dechunker.php
+++ b/src/Symfony/Component/HttpClient/Internal/Dechunker.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Symfony\Component\HttpClient\Exception\TransportException;
+
+/**
+ * A pure PHP alternative to the native "dechunk" stream filter.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+final class Dechunker
+{
+    private const STATE_SIZE = 0;
+    private const STATE_SIZE_EXT = 1;
+    private const STATE_SIZE_LF = 2;
+    private const STATE_DATA = 3;
+    private const STATE_DATA_CR = 4;
+    private const STATE_DATA_LF = 5;
+    private const STATE_TRAILER = 6;
+
+    private int $state = self::STATE_SIZE;
+    private string $size = '';
+    private int $remaining = 0;
+
+    public function isFinished(): bool
+    {
+        return self::STATE_TRAILER === $this->state;
+    }
+
+    /**
+     * @throws TransportException When the chunked encoding is malformed
+     */
+    public function dechunk(string $data): string
+    {
+        $out = '';
+        $offset = 0;
+        $len = \strlen($data);
+
+        while ($offset < $len) {
+            switch ($this->state) {
+                case self::STATE_SIZE:
+                    if (0 < $spn = strspn($data, '0123456789ABCDEFabcdef', $offset)) {
+                        $this->size = ltrim($this->size.substr($data, $offset, $spn), '0') ?: '0';
+                        $offset += $spn;
+
+                        if (2 * \PHP_INT_SIZE - 1 < \strlen($this->size)) {
+                            throw new TransportException('Malformed chunked body: chunk size is too big.');
+                        }
+                        break;
+                    }
+
+                    if ('' === $this->size) {
+                        throw new TransportException('Malformed chunked body: invalid chunk size.');
+                    }
+
+                    $this->state = self::STATE_SIZE_EXT;
+                    // no break
+                case self::STATE_SIZE_EXT:
+                    if ($len === $offset += strcspn($data, "\r\n", $offset)) {
+                        break;
+                    }
+
+                    if ("\r" === $data[$offset]) {
+                        ++$offset;
+                    }
+
+                    $this->state = self::STATE_SIZE_LF;
+                    break;
+
+                case self::STATE_SIZE_LF:
+                    if ("\n" !== $data[$offset]) {
+                        throw new TransportException('Malformed chunked body: invalid line ending after chunk size.');
+                    }
+
+                    ++$offset;
+                    $this->state = ($this->remaining = (int) hexdec($this->size)) ? self::STATE_DATA : self::STATE_TRAILER;
+                    $this->size = '';
+                    break;
+
+                case self::STATE_DATA:
+                    $out .= $chunk = substr($data, $offset, $this->remaining);
+                    $offset += \strlen($chunk);
+
+                    if (0 === $this->remaining -= \strlen($chunk)) {
+                        $this->state = self::STATE_DATA_CR;
+                    }
+                    break;
+
+                case self::STATE_DATA_CR:
+                    if ("\r" === $data[$offset]) {
+                        ++$offset;
+                    }
+
+                    $this->state = self::STATE_DATA_LF;
+                    break;
+
+                case self::STATE_DATA_LF:
+                    if ("\n" !== $data[$offset]) {
+                        throw new TransportException('Malformed chunked body: invalid line ending after chunk data.');
+                    }
+
+                    ++$offset;
+                    $this->state = self::STATE_SIZE;
+                    break;
+
+                case self::STATE_TRAILER:
+                    // Trailer fields and anything else after the terminal chunk are ignored
+                    return $out;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\Canary;
 use Symfony\Component\HttpClient\Internal\ClientState;
+use Symfony\Component\HttpClient\Internal\Dechunker;
 use Symfony\Component\HttpClient\Internal\NativeClientState;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -38,11 +39,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
     private ?\Closure $onProgress;
     private ?int $remaining = null;
 
-    /**
-     * @var resource|null
-     */
-    private $buffer;
-
+    private ?Dechunker $dechunker;
     private NativeClientState $multi;
     private float $pauseExpiry = 0.0;
 
@@ -62,9 +59,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
         $this->onProgress = $onProgress ? $onProgress(...) : null;
         $this->inflate = !isset($options['normalized_headers']['accept-encoding']);
         $this->shouldBuffer = $options['buffer'] ?? true;
-
-        // Temporary resource to dechunk the response stream
-        $this->buffer = fopen('php://temp', 'w+');
+        $this->dechunker = new Dechunker();
 
         $info['original_url'] = implode('', $info['url']);
         $info['user_data'] = $options['user_data'];
@@ -93,7 +88,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
             $info['url'] = implode('', $info['url']);
             unset($info['size_body'], $info['request_header']);
 
-            if (null === $this->buffer) {
+            if (null === $this->dechunker) {
                 $this->finalInfo = $info;
             }
         }
@@ -179,11 +174,9 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
         stream_set_blocking($h, false);
         unset($this->context, $this->resolver);
 
-        // Create dechunk buffers
         if (isset($this->headers['content-length'])) {
             $this->remaining = (int) $this->headers['content-length'][0];
         } elseif ('chunked' === ($this->headers['transfer-encoding'][0] ?? null)) {
-            stream_filter_append($this->buffer, 'dechunk', \STREAM_FILTER_WRITE);
             $this->remaining = -1;
         } else {
             $this->remaining = -2;
@@ -200,14 +193,14 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
 
         $host = parse_url($this->info['redirect_url'] ?? $this->url, \PHP_URL_HOST);
         $this->multi->lastTimeout = null;
-        $this->multi->openHandles[$this->id] = [&$this->pauseExpiry, $h, $this->buffer, $this->onProgress, &$this->remaining, &$this->info, $host];
+        $this->multi->openHandles[$this->id] = [&$this->pauseExpiry, $h, -1 === $this->remaining ? $this->dechunker : null, $this->onProgress, &$this->remaining, &$this->info, $host];
         $this->multi->hosts[$host] = 1 + ($this->multi->hosts[$host] ?? 0);
     }
 
     private function close(): void
     {
         $this->canary->cancel();
-        $this->handle = $this->buffer = $this->inflate = $this->onProgress = null;
+        $this->handle = $this->dechunker = $this->inflate = $this->onProgress = null;
     }
 
     private static function schedule(self $response, array &$runningResponses): void
@@ -218,7 +211,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
 
         $runningResponses[$i][1][$response->id] = $response;
 
-        if (null === $response->buffer) {
+        if (null === $response->dechunker) {
             // Response already completed
             $response->multi->handlesActivity[$response->id][] = null;
             $response->multi->handlesActivity[$response->id][] = null !== $response->info['error'] ? new TransportException($response->info['error']) : null;
@@ -230,7 +223,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
      */
     private static function perform(ClientState $multi, ?array $responses = null): void
     {
-        foreach ($multi->openHandles as $i => [$pauseExpiry, $h, $buffer, $onProgress]) {
+        foreach ($multi->openHandles as $i => [$pauseExpiry, $h, $dechunker, $onProgress]) {
             if ($pauseExpiry) {
                 if (hrtime(true) / 1E9 < $pauseExpiry) {
                     continue;
@@ -244,38 +237,34 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
             $info = &$multi->openHandles[$i][5];
             $e = null;
 
-            // Read incoming buffer and write it to the dechunk one
+            // Read incoming buffer and dechunk it when needed
             try {
                 if ($remaining && '' !== $data = (string) fread($h, 0 > $remaining ? 16372 : $remaining)) {
-                    fwrite($buffer, $data);
                     $hasActivity = true;
                     $multi->sleep = false;
 
                     if (-1 !== $remaining) {
                         $remaining -= \strlen($data);
+                    } else {
+                        $data = $dechunker->dechunk($data);
+                    }
+
+                    if ('' !== $data) {
+                        $multi->handlesActivity[$i][] = $data;
                     }
                 }
             } catch (\Throwable $e) {
                 $hasActivity = $onProgress = false;
             }
 
-            if (!$hasActivity) {
-                if ($onProgress) {
-                    try {
-                        // Notify the progress callback so that it can e.g. cancel
-                        // the request if the stream is inactive for too long
-                        $info['total_time'] = microtime(true) - $info['start_time'];
-                        $onProgress();
-                    } catch (\Throwable $e) {
-                        // no-op
-                    }
-                }
-            } elseif ('' !== $data = stream_get_contents($buffer, -1, 0)) {
-                rewind($buffer);
-                ftruncate($buffer, 0);
-
-                if (null === $e) {
-                    $multi->handlesActivity[$i][] = $data;
+            if (!$hasActivity && $onProgress) {
+                try {
+                    // Notify the progress callback so that it can e.g. cancel
+                    // the request if the stream is inactive for too long
+                    $info['total_time'] = microtime(true) - $info['start_time'];
+                    $onProgress();
+                } catch (\Throwable $e) {
+                    // no-op
                 }
             }
 
@@ -295,7 +284,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
                 if (null === $e) {
                     if (0 < $remaining) {
                         $e = new TransportException(\sprintf('Transfer closed with %s bytes remaining to read.', $remaining));
-                    } elseif (-1 === $remaining && fwrite($buffer, '-') && '' !== stream_get_contents($buffer, -1, 0)) {
+                    } elseif (-1 === $remaining && !$dechunker->isFinished()) {
                         $e = new TransportException('Transfer closed with outstanding data remaining from chunked response.');
                     }
                 }
@@ -317,7 +306,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
         $maxHosts = $multi->maxHostConnections;
 
         foreach ($responses as $i => $response) {
-            if (null !== $response->remaining || null === $response->buffer) {
+            if (null !== $response->remaining || null === $response->dechunker) {
                 continue;
             }
 

--- a/src/Symfony/Component/HttpClient/Tests/Internal/DechunkerTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Internal/DechunkerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Internal;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\Dechunker;
+
+class DechunkerTest extends TestCase
+{
+    /**
+     * @dataProvider provideValidChunkedData
+     */
+    public function testDechunk(string $expected, string $chunked)
+    {
+        $dechunker = new Dechunker();
+
+        $this->assertSame($expected, $dechunker->dechunk($chunked));
+        $this->assertTrue($dechunker->isFinished());
+    }
+
+    /**
+     * @dataProvider provideValidChunkedData
+     */
+    public function testDechunkByteByByte(string $expected, string $chunked)
+    {
+        $dechunker = new Dechunker();
+        $out = '';
+
+        foreach (str_split($chunked) as $byte) {
+            $out .= $dechunker->dechunk($byte);
+        }
+
+        $this->assertSame($expected, $out);
+        $this->assertTrue($dechunker->isFinished());
+    }
+
+    public static function provideValidChunkedData(): iterable
+    {
+        yield 'single chunk' => ['hello world', "b\r\nhello world\r\n0\r\n\r\n"];
+        yield 'multiple chunks' => ['Symfony is awesome!', "8\r\nSymfony \r\n5\r\nis aw\r\n6\r\nesome!\r\n0\r\n\r\n"];
+        yield 'uppercase hex and leading zeros' => ['hello world', "0B\r\nhello world\r\n000\r\n\r\n"];
+        yield 'chunk extensions' => ['hello world', "b;foo=bar\r\nhello world\r\n0;baz\r\n\r\n"];
+        yield 'bare LF line endings' => ['hello world', "b\nhello world\n0\n"];
+        yield 'trailer fields' => ['hello world', "b\r\nhello world\r\n0\r\nX-Trailer: value\r\n\r\n"];
+        yield 'data after terminal chunk is ignored' => ['hello world', "b\r\nhello world\r\n0\r\n\r\nignored"];
+        yield 'CRLF inside chunk data' => ["\r\n\r\n", "4\r\n\r\n\r\n\r\n0\r\n\r\n"];
+        yield 'empty body' => ['', "0\r\n\r\n"];
+    }
+
+    /**
+     * @dataProvider provideTruncatedChunkedData
+     */
+    public function testTruncatedData(string $chunked)
+    {
+        $dechunker = new Dechunker();
+        $dechunker->dechunk($chunked);
+
+        $this->assertFalse($dechunker->isFinished());
+    }
+
+    public static function provideTruncatedChunkedData(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'partial size' => ['b'];
+        yield 'partial data' => ["b\r\nhel"];
+        yield 'missing terminal chunk' => ["b\r\nhello world\r\n"];
+        yield 'partial terminal chunk' => ["b\r\nhello world\r\n0"];
+    }
+
+    /**
+     * @dataProvider provideInvalidChunkedData
+     */
+    public function testInvalidData(string $chunked)
+    {
+        $dechunker = new Dechunker();
+
+        $this->expectException(TransportException::class);
+        $dechunker->dechunk($chunked);
+    }
+
+    public static function provideInvalidChunkedData(): iterable
+    {
+        yield 'invalid size' => ["x\r\nhello\r\n"];
+        yield 'empty size line' => ["\r\nhello\r\n"];
+        yield 'missing LF after size' => ["5\rXhello"];
+        yield 'missing line ending after data' => ["1\r\naX"];
+        yield 'CR but no LF after data' => ["1\r\na\rX"];
+        yield 'size overflow' => ["123456789abcdef01\r\n"];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The native `dechunk` stream filter is likely going to be deprecated in a future version of PHP. This PR removes our reliance on it by introducing `Internal\Dechunker`, a pure PHP incremental decoder for chunked transfer encoding, and uses it to decode chunked request bodies in `HttpClientTrait` and chunked responses in `NativeResponse`.

The decoder mirrors the state machine of the native filter, including its tolerances: bare LF line endings, chunk extensions, leading zeros in chunk sizes, and ignored trailer fields. Parity was verified by fuzzing it against the native filter with randomly generated chunked bodies split at random read boundaries, producing byte-identical output.

Two behavior improvements come with the switch:
- a malformed chunked response now fails with a `TransportException` at the first malformed byte, while the native filter used to switch to passthrough mode, streaming raw chunked data to the consumer and failing only at EOF;
- `NativeResponse` no longer needs its `php://temp` buffer, removing a write/read round-trip per network read for all responses.