### PR TITLE
[Cache] Convert Traits/ValueWrapper.php to utf-8

### DIFF
--- a/src/Symfony/Component/Cache/Traits/ValueWrapper.php
+++ b/src/Symfony/Component/Cache/Traits/ValueWrapper.php
@@ -16,7 +16,7 @@
  *
  * @internal
  */
-class ©
+class Â©
 {
     private const EXPIRY_OFFSET = 1648206727;
     private const INT32_MAX = 2147483647;


### PR DESCRIPTION
I ran `iconv -f ISO-8859-1 -t UTF-8 ValueWrapper.php > ValueWrapper.php` on this file to convert it from native encoding.

This fixes a Debian lintian error: https://udd.debian.org/lintian-tag/national-encoding

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes/no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | 
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
