### PR TITLE
[Dotenv] Allow multiple underscores at start

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -26,7 +26,7 @@ use Symfony\Component\Process\Process;
  */
 final class Dotenv
 {
-    public const VARNAME_REGEX = '(?i:_?[A-Z][A-Z0-9_]*+)';
+    public const VARNAME_REGEX = '(?i:_*[A-Z][A-Z0-9_]*+)';
     public const STATE_VARNAME = 0;
     public const STATE_VALUE = 1;
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -189,6 +189,7 @@ class DotenvTest extends TestCase
             // underscores
             ['_FOO=BAR', ['_FOO' => 'BAR']],
             ['_FOO_BAR=FOOBAR', ['_FOO_BAR' => 'FOOBAR']],
+            ['__FOO_BAR=FOOBAR', ['__FOO_BAR' => 'FOOBAR']],
         ];
 
         if ('\\' !== \DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

#52928 already fixed the issue, that environment variables with a leading underscore cause an error, but the fix still restricted them to a single underscore at the start.

Recently I had a project, where I needed to have some vite environment variables inside the same .env file that's loaded by symfony.
Vite internal environment variables start with two underscores, like `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS`.

I did not create an issue, because I think this is a reasonably small fix.