### PR TITLE
[Messenger][AmazonSqs] Fix fatal on shutdown when the in-flight receive cannot be resumed

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\Sqs\Result\GetQueueUrlResult;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
@@ -20,9 +21,14 @@ use AsyncAws\Sqs\ValueObject\Message;
 use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 class ConnectionTest extends TestCase
 {
@@ -289,6 +295,103 @@ class ConnectionTest extends TestCase
 
         $connection = new Connection(['queue_name' => 'queue', 'account' => 123, 'auto_setup' => false], $client);
         $connection->get();
+    }
+
+    public function testDestructDoesNotThrowWhenTheInFlightReceiveCannotBeResumed()
+    {
+        $httpClient = $this->createPollingClientThatCannotResume();
+        $client = new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => 'key', 'accessKeySecret' => 'secret'], null, $httpClient);
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, 'https://sqs.eu-west-1.amazonaws.com/123456789012/queue');
+
+        $this->assertNull($connection->get());
+
+        unset($connection);
+
+        $this->assertTrue($httpClient->response->getInfo('canceled'));
+    }
+
+    public function testResetDiscardsTheInFlightReceiveThatCannotBeResumed()
+    {
+        $httpClient = $this->createPollingClientThatCannotResume();
+        $client = new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => 'key', 'accessKeySecret' => 'secret'], null, $httpClient);
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, 'https://sqs.eu-west-1.amazonaws.com/123456789012/queue');
+
+        $this->assertNull($connection->get());
+
+        $connection->reset();
+
+        $this->assertTrue($httpClient->response->getInfo('canceled'));
+    }
+
+    public function testDestructDoesNotThrowOnNetworkFailure()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('', ['error' => 'Connection timed out']));
+        $client = new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => 'key', 'accessKeySecret' => 'secret'], null, $httpClient);
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, 'https://sqs.eu-west-1.amazonaws.com/123456789012/queue');
+
+        try {
+            $connection->get();
+            $this->fail('The receive should have failed.');
+        } catch (NetworkException) {
+        }
+
+        unset($connection);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testResetDiscardsTheFailedResponseOnNetworkFailure()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('', ['error' => 'Connection timed out']));
+        $client = new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => 'key', 'accessKeySecret' => 'secret'], null, $httpClient);
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, 'https://sqs.eu-west-1.amazonaws.com/123456789012/queue');
+
+        try {
+            $connection->get();
+            $this->fail('The receive should have failed.');
+        } catch (NetworkException) {
+        }
+
+        $connection->reset();
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Simulates an in-flight ReceiveMessage long-poll: the first stream() call times out,
+     * leaving the response pending, and any later attempt to resume it throws, like
+     * HttpClient decorators do when the underlying response was already consumed.
+     */
+    private function createPollingClientThatCannotResume(): HttpClientInterface
+    {
+        return new class implements HttpClientInterface {
+            public ?MockResponse $response = null;
+            private int $streamCalls = 0;
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                return $this->response = new MockResponse();
+            }
+
+            public function stream($responses, ?float $timeout = null): ResponseStreamInterface
+            {
+                if (++$this->streamCalls > 1) {
+                    throw new \LogicException('Instance of "Symfony\Component\HttpClient\Response\CurlResponse" is already consumed and cannot be managed by "Symfony\Component\HttpClient\Response\AsyncResponse". A decorated client should not call any of the response\'s methods in its "request()" method.');
+                }
+
+                $response = $this->response;
+                $timeoutChunk = new ErrorChunk(0, 'Idle timeout reached');
+
+                return new ResponseStream((static function () use ($response, $timeoutChunk) {
+                    yield $response => $timeoutChunk;
+                })());
+            }
+
+            public function withOptions(array $options): static
+            {
+                return $this;
+            }
+        };
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -77,7 +77,11 @@ class Connection
 
     public function __destruct()
     {
-        $this->reset();
+        try {
+            $this->reset();
+        } catch (\Throwable) {
+            // requeuing in-transit messages on shutdown is best effort and must not throw from a destructor
+        }
     }
 
     /**
@@ -373,10 +377,17 @@ class Connection
     public function reset(): void
     {
         if (null !== $this->currentResponse) {
-            // fetch current response in order to requeue in transit messages
-            if (!$this->fetchMessage()) {
-                $this->currentResponse->cancel();
+            try {
+                // fetch current response in order to requeue in transit messages
+                if (!$this->fetchMessage()) {
+                    $this->currentResponse->cancel();
+                    $this->currentResponse = null;
+                }
+            } catch (\Throwable) {
+                // discard the in-flight response that cannot be reused so the connection stays usable
+                $response = $this->currentResponse;
                 $this->currentResponse = null;
+                $response->cancel();
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50342
| License       | MIT

`messenger:consume` workers using the SQS transport intermittently die with an uncatchable fatal error on shutdown instead of exiting cleanly:

```
PHP Fatal error: Uncaught LogicException: Instance of "Symfony\Component\HttpClient\Response\CurlResponse"
is already consumed and cannot be managed by "Symfony\Component\HttpClient\RetryableHttpClient".
A decorated client should not call any of the response's methods in its "request()" method.
```

`Connection::__destruct()` → `reset()` resolves the pending long-poll `ReceiveMessage` response one last time in order to requeue in-transit messages. When that in-flight response is in a state the HTTP client refuses to resume, the exception escapes the destructor during script shutdown, where nothing can catch it: the worker dies with a fatal error (masking the real exit status), and the in-transit messages are never requeued (`changeMessageVisibility` is skipped), so they stay invisible until the queue's visibility timeout expires. See the reports on #50342 (reported on 5.4, still present on 6.4/7.x).

There are at least two ways to end up in this state in production:

1. **A network failure while polling**: the first resolve throws a `NetworkException`; the destructor then resolves the same poisoned response again and the exception is rethrown from the destructor. This is the scenario #64819 addresses.
2. **No prior failure at all**: the worker stops (e.g. `--time-limit`, SIGTERM on deploy) with a pending long poll, and the final resolve trips `AsyncResponse`'s "already consumed" guard, which throws a plain `LogicException`. This is what we observe in production (~100 fatal events over 2.5 months on ECS workers; `RetryableHttpClient` shows up in the message because async-aws wraps the default HTTP client in one when no client is injected — which is always the case for transports created from a DSN). A `LogicException` implements neither `TransportExceptionInterface` (so async-aws does not convert it into a `NetworkException`) nor `AsyncAws\Core\Exception\Exception`, so catching only AsyncAws exceptions is not enough.

This PR makes the shutdown path robust against both:

- `reset()`: if the in-flight response cannot be fetched, discard it (clear + cancel) whatever the failure is, so the connection ends up in a clean, reusable state and buffered messages still get requeued;
- `__destruct()`: never let anything escape — requeuing on shutdown is best effort, and an exception thrown from a destructor during shutdown is uncatchable by design.

Alternative to #64819, which covers scenario 1 but not scenario 2 (its `catch` only matches AsyncAws exceptions and misses the `LogicException`). The added tests cover both scenarios and fail without the fix:

```
1) testDestructDoesNotThrowWhenTheInFlightReceiveCannotBeResumed
LogicException: Instance of "..CurlResponse" is already consumed and cannot be managed by "..AsyncResponse".
2) testResetDiscardsTheInFlightReceiveThatCannotBeResumed
LogicException: Instance of "..CurlResponse" is already consumed and cannot be managed by "..AsyncResponse".
3) testDestructDoesNotThrowOnNetworkFailure
AsyncAws\Core\Exception\Http\NetworkException: Could not contact remote server.
4) testResetDiscardsTheFailedResponseOnNetworkFailure
AsyncAws\Core\Exception\Http\NetworkException: Could not contact remote server.
```
