### PR TITLE
[Cache] Remove obsolete `return` instruction from classes constructors

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis5Proxy.php
@@ -33,7 +33,7 @@ class Redis5Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 
     public function __construct()
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
     }
 
     public function _prefix($key)

--- a/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/Redis6Proxy.php
@@ -36,7 +36,7 @@ class Redis6Proxy extends \Redis implements ResetInterface, LazyObjectInterface
 
     public function __construct($options = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
     }
 
     public function _compress($value): string

--- a/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster5Proxy.php
@@ -33,7 +33,7 @@ class RedisCluster5Proxy extends \RedisCluster implements ResetInterface, LazyOb
 
     public function __construct($name, $seeds = null, $timeout = null, $read_timeout = null, $persistent = null, #[\SensitiveParameter] $auth = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
     }
 
     public function _masters()

--- a/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisCluster6Proxy.php
@@ -36,7 +36,7 @@ class RedisCluster6Proxy extends \RedisCluster implements ResetInterface, LazyOb
 
     public function __construct($name, $seeds = null, $timeout = 0, $read_timeout = 0, $persistent = false, #[\SensitiveParameter] $auth = null, $context = null)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
     }
 
     public function _compress($value): string

--- a/src/Symfony/Component/Cache/Traits/RelayProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RelayProxy.php
@@ -72,7 +72,7 @@ class RelayProxy extends \Relay\Relay implements ResetInterface, LazyObjectInter
 
     public function __construct($host = null, $port = 6379, $connect_timeout = 0.0, $command_timeout = 0.0, #[\SensitiveParameter] $context = [], $database = 0)
     {
-        return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
+        ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->__construct(...\func_get_args());
     }
 
     public function connect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0, #[\SensitiveParameter] $context = [], $database = 0): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A `return` instruction has no effect in a class constructor, the object instance is always returned. A deprecation has been added for this in PHP 8.6, see https://github.com/php/php-src/pull/21982 .

The proposed change will not change the component behaviour, but it will prevent deprecations (e.g. `Deprecated: Returning a value from a constructor is deprecated at Redis6Proxy.php line 39`) to be triggered when the classes are loaded.
