### PR TITLE
 Update deps in the static-analysis jobs when a PR changes composer.json

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -49,8 +49,16 @@ jobs:
       - name: Switch to PR
         run: |
           git checkout composer.json
+          base_sha=$(git rev-parse HEAD)
           git fetch --depth=1 origin '+${{ github.event.pull_request.head.sha }}'
           git checkout -m FETCH_HEAD
+
+          # update dependencies when the PR changes composer.json so that packages it adds are resolvable
+          if ! git diff --quiet "$base_sha" HEAD -- composer.json; then
+            export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
+            composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
+            composer require --no-progress --ansi --no-plugins psalm/phar:@stable phpunit/phpunit:^11.5 php-http/discovery psr/event-dispatcher mongodb/mongodb jetbrains/phpstorm-stubs
+          fi
 
       - name: Psalm
         run: ./vendor/bin/psalm.phar --no-progress || ./vendor/bin/psalm.phar --output-format=github --no-progress
@@ -89,8 +97,16 @@ jobs:
       - name: Switch to PR
         run: |
           git checkout composer.json
+          base_sha=$(git rev-parse HEAD)
           git fetch --depth=1 origin '+${{ github.event.pull_request.head.sha }}'
           git checkout -m FETCH_HEAD
+
+          # update dependencies when the PR changes composer.json so that packages it adds are resolvable
+          if ! git diff --quiet "$base_sha" HEAD -- composer.json; then
+            export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
+            composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
+            composer require --no-progress --ansi --no-plugins phpstan/phpstan:@stable phpstan/phpstan-deprecation-rules:@stable phpunit/phpunit:^11.5 php-http/discovery psr/event-dispatcher mongodb/mongodb
+          fi
 
       - name: PHPStan
         run: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a PR changes the composer.json file, SA tools need to run composer up to get accurate sources to analyze.