### PR TITLE
[Console] Reduce buffer reallocations in FileInputHelper paste detection

### DIFF
--- a/src/Symfony/Component/Console/Helper/FileInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/FileInputHelper.php
@@ -104,39 +104,56 @@ final class FileInputHelper
         $buffer = '';
         $inPaste = false;
         $pasteBuffer = '';
+        $scanned = 0;
 
-        while (!feof($inputStream)) {
+        while (true) {
             $inputHelper->waitForInput();
-            $char = fread($inputStream, 1);
+            $chunk = fread($inputStream, 8192);
 
-            if (false === $char || '' === $char) {
+            if (false === $chunk || '' === $chunk) {
                 if ('' === $buffer && '' === $pasteBuffer) {
                     throw new MissingInputException('Aborted.');
                 }
                 break;
             }
 
-            $buffer .= $char;
+            $buffer .= $chunk;
 
             if (\strlen($buffer) > self::MAX_PASTE_BYTES) {
                 throw new InvalidFileException(\sprintf('Pasted input exceeds the maximum allowed size of %d bytes.', self::MAX_PASTE_BYTES));
             }
 
-            if (!$inPaste && str_ends_with($buffer, self::PASTE_START)) {
+            // Scan whole reads at once; appending byte by byte is quadratic for large pastes.
+            if (!$inPaste) {
+                // Look back so a marker split across two reads is still matched.
+                $pasteStart = strpos($buffer, self::PASTE_START, max(0, $scanned - \strlen(self::PASTE_START) + 1));
+                $newline = $scanned + strcspn($buffer, "\r\n", $scanned);
+                $hasNewline = $newline < \strlen($buffer);
+
+                if (false === $pasteStart || ($hasNewline && $newline <= $pasteStart + \strlen(self::PASTE_START) - 1)) {
+                    if ($hasNewline) {
+                        $buffer = substr($buffer, 0, $newline);
+                        break;
+                    }
+
+                    $scanned = \strlen($buffer);
+                    continue;
+                }
+
                 $inPaste = true;
-                $buffer = substr($buffer, 0, -\strlen(self::PASTE_START));
-                continue;
+                $buffer = substr($buffer, 0, $pasteStart).substr($buffer, $pasteStart + \strlen(self::PASTE_START));
+                $scanned = $pasteStart;
             }
 
-            if ($inPaste && str_ends_with($buffer, self::PASTE_END)) {
-                $pasteBuffer = substr($buffer, 0, -\strlen(self::PASTE_END));
+            $pasteEnd = strpos($buffer, self::PASTE_END, max(0, $scanned - \strlen(self::PASTE_END) + 1));
+
+            if (false !== $pasteEnd) {
+                $pasteBuffer = substr($buffer, 0, $pasteEnd);
+                $buffer = substr($buffer, 0, $pasteEnd + \strlen(self::PASTE_END));
                 break;
             }
 
-            if (!$inPaste && ("\n" === $char || "\r" === $char)) {
-                $buffer = rtrim($buffer, "\r\n");
-                break;
-            }
+            $scanned = \strlen($buffer);
         }
 
         if ('' !== $pasteBuffer) {

--- a/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Exception\InvalidFileException;
+use Symfony\Component\Console\Exception\MissingInputException;
 use Symfony\Component\Console\Helper\FileInputHelper;
 use Symfony\Component\Console\Helper\TerminalInputHelper;
 use Symfony\Component\Console\Input\File\InputFile;
@@ -21,6 +22,15 @@ use Symfony\Component\Console\Question\FileQuestion;
 
 class FileInputHelperTest extends TestCase
 {
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            @unlink($file);
+        }
+    }
+
     public function testDisplayFileEscapesFormatterMetaCharactersInPath()
     {
         $name = 'sf_console_<error>bad<error>_'.bin2hex(random_bytes(4)).'.txt';
@@ -29,20 +39,76 @@ class FileInputHelperTest extends TestCase
         if (false === @file_put_contents($path, 'x')) {
             $this->markTestSkipped('Filesystem does not allow "<" / ">" in filenames.');
         }
+        $this->tempFiles[] = $path;
 
-        try {
-            $file = new InputFile($path);
-            $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $file = new InputFile($path);
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
 
-            (new FileInputHelper())->displayFile($output, $file);
+        (new FileInputHelper())->displayFile($output, $file);
 
-            $display = $output->fetch();
-            $this->assertStringContainsString('<error>bad<error>', $display);
-            $this->assertStringNotContainsString("\e[37;41m", $display);
-            $this->assertStringNotContainsString("\e[39;49m", $display);
-        } finally {
-            @unlink($path);
-        }
+        $display = $output->fetch();
+        $this->assertStringContainsString('<error>bad<error>', $display);
+        $this->assertStringNotContainsString("\e[37;41m", $display);
+        $this->assertStringNotContainsString("\e[39;49m", $display);
+    }
+
+    public function testReadWithPasteDetectionReturnsPathFromLineInput()
+    {
+        $path = $this->createTempFile();
+
+        $this->assertSame($path, $this->readWithPasteDetection($this->streamOf($path."\n"))->getPathname());
+    }
+
+    public function testReadWithPasteDetectionReturnsPathWhenInputEndsWithoutNewline()
+    {
+        $path = $this->createTempFile();
+
+        $this->assertSame($path, $this->readWithPasteDetection($this->streamOf($path))->getPathname());
+    }
+
+    public function testReadWithPasteDetectionStopsAtNewlineBeforePasteStart()
+    {
+        $path = $this->createTempFile();
+
+        // A newline ends the line even when a paste-start marker appears later in the stream.
+        $input = $path."\n".$this->pasteMarker('PASTE_START').'ignored'.$this->pasteMarker('PASTE_END');
+
+        $this->assertSame($path, $this->readWithPasteDetection($this->streamOf($input))->getPathname());
+    }
+
+    public function testReadWithPasteDetectionReassemblesPasteSpanningMultipleReadChunks()
+    {
+        $start = $this->pasteMarker('PASTE_START');
+        $path = $this->createTempFile();
+
+        // Pad so the path straddles the 8192-byte read boundary: part lands in the first
+        // fread() call, the rest in the second.
+        $input = $start.str_repeat(' ', 8192 - \strlen($start) - 5).$path.$this->pasteMarker('PASTE_END');
+
+        $this->assertSame($path, $this->readWithPasteDetection($this->streamOf($input))->getPathname());
+    }
+
+    public function testReadWithPasteDetectionMatchesPasteStartSplitAcrossReadChunks()
+    {
+        $start = $this->pasteMarker('PASTE_START');
+        $path = $this->createTempFile();
+
+        // Worst case for the boundary look-back: only PASTE_START's last byte lands in the second read.
+        $input = str_repeat(' ', 8192 - (\strlen($start) - 1)).$start.$path.$this->pasteMarker('PASTE_END');
+
+        $this->assertSame($path, $this->readWithPasteDetection($this->streamOf($input))->getPathname());
+    }
+
+    public function testReadWithPasteDetectionMatchesPasteEndSplitAcrossReadChunks()
+    {
+        $start = $this->pasteMarker('PASTE_START');
+        $end = $this->pasteMarker('PASTE_END');
+        $path = $this->createTempFile();
+
+        // Worst case for the boundary look-back: only PASTE_END's last byte lands in the second read.
+        $input = $start.str_repeat(' ', 8192 - (\strlen($end) - 1) - \strlen($start) - \strlen($path)).$path.$end;
+
+        $this->assertSame($path, $this->readWithPasteDetection($this->streamOf($input))->getPathname());
     }
 
     public function testDisplayFileStripsTerminalControlCharactersFromName()
@@ -126,15 +192,71 @@ class FileInputHelperTest extends TestCase
     {
         $cap = (new \ReflectionClassConstant(FileInputHelper::class, 'MAX_PASTE_BYTES'))->getValue();
 
-        $stream = fopen('php://memory', 'r+');
-        $chunk = str_repeat('A', 64 * 1024);
-        $written = 0;
-        while ($written <= $cap) {
-            $written += fwrite($stream, $chunk);
+        $this->expectException(InvalidFileException::class);
+        $this->expectExceptionMessage('Pasted input exceeds the maximum allowed size');
+
+        $this->readWithPasteDetection($this->streamOf(str_repeat('A', $cap + 1)));
+    }
+
+    public function testReadWithPasteDetectionAbortsOnEmptyInput()
+    {
+        $this->expectException(MissingInputException::class);
+        $this->expectExceptionMessage('Aborted.');
+
+        $this->readWithPasteDetection($this->streamOf(''));
+    }
+
+    public function testReadWithPasteDetectionRejectsEmptyLine()
+    {
+        $this->expectException(MissingInputException::class);
+        $this->expectExceptionMessage('No file input provided.');
+
+        $this->readWithPasteDetection($this->streamOf("\n"));
+    }
+
+    public function testReadWithPasteDetectionIgnoresInputTypedAfterAnEmptyPaste()
+    {
+        $path = $this->createTempFile();
+        $input = $this->pasteMarker('PASTE_START').$this->pasteMarker('PASTE_END').$path."\n";
+
+        try {
+            $this->readWithPasteDetection($this->streamOf($input));
+            $this->fail('Expected an InvalidFileException.');
+        } catch (InvalidFileException $e) {
+            $this->assertStringNotContainsString($path, $e->getMessage());
         }
+    }
+
+    private function createTempFile(): string
+    {
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'sf_console_'.bin2hex(random_bytes(4)).'.txt';
+        file_put_contents($path, 'x');
+
+        return $this->tempFiles[] = $path;
+    }
+
+    private function pasteMarker(string $name): string
+    {
+        return (new \ReflectionClassConstant(FileInputHelper::class, $name))->getValue();
+    }
+
+    /**
+     * @return resource
+     */
+    private function streamOf(string $contents)
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $contents);
         rewind($stream);
 
-        $helper = new FileInputHelper();
+        return $stream;
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function readWithPasteDetection($stream): InputFile
+    {
         $method = (new \ReflectionClass(FileInputHelper::class))->getMethod('readWithPasteDetection');
 
         $terminalReflection = new \ReflectionClass(TerminalInputHelper::class);
@@ -143,13 +265,6 @@ class FileInputHelperTest extends TestCase
             $terminalReflection->getProperty($name)->setValue($inputHelper, $value);
         }
 
-        $this->expectException(InvalidFileException::class);
-        $this->expectExceptionMessage('Pasted input exceeds the maximum allowed size');
-
-        try {
-            $method->invoke($helper, $stream, new BufferedOutput(), new FileQuestion('?'), $inputHelper);
-        } finally {
-            fclose($stream);
-        }
+        return $method->invoke(new FileInputHelper(), $stream, new BufferedOutput(), new FileQuestion('?'), $inputHelper);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Continuation of https://github.com/symfony/symfony/pull/64709

The excessive syscalls were eliminated, but excessive allocation still happens in the tests in php-src: https://github.com/php/php-src/actions/runs/29464682224/job/87515398317

Current culprit: reading input one byte at a time (`$buffer .= $char`), which reallocates the buffer per byte, quadratic under ASAN's allocator. Now it appends each 8192-byte read whole and finds the paste markers/newline with strpos/strcspn, keeping a small look-back so a marker split across two reads is still matched.

The first commit re-applies #64709 on 8.1, as fabpot asked. The second one replaces the per-byte scan.

Measured, counting appends and the bytes an allocator that copies on every realloc has to move:

| payload | appends before | appends after | bytes recopied before | bytes recopied after |
| ------- | -------------- | ------------- | --------------------- | -------------------- |
| 256 KB  | 262,140        | 32            | 34,356,985,926        | 4,063,046            |
| 1 MB    | 1,048,572      | 128           | 549,744,803,910       | 66,583,814           |
| 4 MB    | 4,194,300      | 512           | 8,796,048,982,086     | 1,071,641,606        |

So the appends drop by the 8192-byte chunk size. The growth itself stays quadratic in both states, which is why the title says "reduce" and not "fix"; the 16 MB cap is what bounds it. Visible in the suite: `testReadWithPasteDetectionAbortsBeyondMaxBytes` goes from 4.159 s to 0.108 s.

New tests added:
1. `testReadWithPasteDetectionReturnsPathFromLineInput` - a typed path ending in \n returns that path.
2. `testReadWithPasteDetectionReturnsPathWhenInputEndsWithoutNewline` - a path terminated by EOF (no newline) still returns that path.
3. `testReadWithPasteDetectionStopsAtNewlineBeforePasteStart` - a newline ends the line even when a paste marker appears later (verifies the newline-wins priority).
4. `testReadWithPasteDetectionMatchesPasteStartSplitAcrossReadChunks` - PASTE_START split across the 8192-byte read boundary is still detected (exercises the look-back).
5. `testReadWithPasteDetectionMatchesPasteEndSplitAcrossReadChunks` - PASTE_END split across the boundary is still detected (exercises the look-back).
6. `testReadWithPasteDetectionAbortsOnEmptyInput` - an empty stream throws MissingInputException('Aborted.').
7. `testReadWithPasteDetectionRejectsEmptyLine` - a bare `\n` throws MissingInputException('No file input provided.').

Added during review:

* the buffer is now truncated at the end marker. Without it, bytes typed after an empty or whitespace-only paste stayed in the buffer and leaked into the resulting path: `PASTE_START . PASTE_END . "/tmp/f.txt\n"` reported `File "<ESC>[201~/tmp/f.txt" does not exist.` where 8.1 reports `File "<ESC>[201~" does not exist.`;
* `testReadWithPasteDetectionIgnoresInputTypedAfterAnEmptyPaste`, which passes on 8.1, fails without the truncation and passes with it.
