### PR TITLE
[ErrorHandler] Fix fatal error without args triggering an error when calling `getTraceFromString`

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Error/FatalError.php
+++ b/src/Symfony/Component/ErrorHandler/Error/FatalError.php
@@ -26,8 +26,9 @@ class FatalError extends \Error
 
         if (null !== $trace) {
             if (!$traceArgs) {
-                foreach ($trace as &$frame) {
-                    unset($frame['args'], $frame['this'], $frame);
+                foreach ($trace as $index => $frame) {
+                    unset($frame['args'], $frame['this']);
+                    $trace[$index] = $frame;
                 }
             }
         } elseif (null !== $traceOffset) {

--- a/src/Symfony/Component/ErrorHandler/Tests/Error/FatalErrorTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Error/FatalErrorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler\Tests\Error;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorHandler\Error\FatalError;
+
+class FatalErrorTest extends TestCase
+{
+    public function testGetTraceWithoutTraceArgs()
+    {
+        $originalExceptionWithTrace = (static fn () => new \Exception('Whoops!'))();
+        $originalExceptionTrace = array_map(static function ($frame) {
+            $frame['args'] ??= ['foo'];
+
+            return $frame;
+        }, $originalExceptionWithTrace->getTrace());
+        $fatalException = new FatalError(
+            message: 'Whoops!',
+            code: 10,
+            error: [
+                'type' => \E_ERROR,
+                'message' => 'Whoops!',
+                'file' => '/path/to/file.php',
+                'line' => 10,
+            ],
+            traceOffset: null,
+            traceArgs: false,
+            trace: $originalExceptionTrace,
+        );
+
+        $expectedTrace = array_reduce($originalExceptionTrace, function ($carry, $frame) {
+            $this->assertArrayHasKey('args', $frame);
+
+            unset($frame['args']);
+            $carry[] = $frame;
+
+            return $carry;
+        }, []);
+
+        $this->assertGreaterThan(0, \count($expectedTrace));
+        $this->assertSame($expectedTrace, $fatalException->getTrace());
+    }
+
+    public function testGetTraceAsStringDoesNotTriggerWarning()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $originalExceptionWithTrace = (static fn () => new \Exception('Whoops!'))();
+        $originalExceptionTrace = array_map(static function ($frame) {
+            $frame['args'] ??= ['foo'];
+
+            return $frame;
+        }, $originalExceptionWithTrace->getTrace());
+        $fatalException = new FatalError(
+            message: 'Whoops!',
+            code: 10,
+            error: [
+                'type' => \E_ERROR,
+                'message' => 'Whoops!',
+                'file' => '/path/to/file.php',
+                'line' => 10,
+            ],
+            traceOffset: null,
+            traceArgs: false,
+            trace: $originalExceptionTrace,
+        );
+        set_error_handler(fn (int $errno, string $errstr) => $this->fail('Error handler should not be called. Received error: '.$errstr));
+
+        try {
+            $fatalException->getTraceAsString();
+        } finally {
+            restore_error_handler();
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Hey, Symfony team,  Tim from the Laravel team here 👋 

When a fatal exception is created and `$traceArgs = false`, the trace's frames are looped over and some keys in the array are unset, e.g., `args`.

The loop uses the technique of passing the frame by reference, I assume for memory / performance reasons.

Later, the trace is then set on the error via reflection.

Something about this flow is is triggering [this warning](https://github.com/php/php-src/blob/f17c2203883ddf53adfcb33d85523d11429729ab/Zend/zend_exceptions.c#L598) when you later call `$fatalError->getTraceFromString()`.

To be honest, I actually cannot explain why this is happening; Looking at things in PHP land, everything seems like it should be fine. The only thing I can boil it down to is the frame being captured by reference. Changing that does seem to fix the issue.

I've modified the loop to not pass by reference. I've also unset the dangling variables created in the `foreach` loop, hoping in low-memory situations a little cleanup might help.

The test shows the issue in isolation, however I hit the issue when I passed the fatal error to Symfony's `FlattenException` class, which calls the `getTraceFromString` method. This lead a fatal error, such as an OOM, to the throw another exception. In fatal error situations, I figure the last thing we want is to trigger or throw additional errors / exceptions.

Although the tests verify the problem, they have a bit going on, so if you'd like oto verify the problem manually, you can run the following minimal reproduction:

```php
<?php

use Symfony\Component\ErrorHandler\Error\FatalError;

require_once __DIR__.'/vendor/autoload.php';

ini_set('zend.exception_ignore_args', 0);

$originalExceptionWithTrace = (fn () => new Exception('Whoops!'))();

$fatalException = new FatalError(
    message: 'Whoops!',
    code: 0,
    error: [
        'type' => E_ERROR,
        'message' => 'Whoops!',
        'file' => '/path/to/file.php',
        'line' => 1,
    ],
    traceOffset: null,
    traceArgs: false,
    trace: $originalExceptionWithTrace->getTrace(),
);

$fatalException->getTraceAsString();
```

Output:

```
Warning: Expected array for frame 0 in /path/to/file.php on line 25
```

p.s., thank you for all your work on Symfony ❤️ 