### PR TITLE
[PropertyInfo] Fix union with mixed handling in PhpStanTypeHelper

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -412,6 +412,8 @@ class PhpStanExtractorTest extends TestCase
             ['e', [new Type(Type::BUILTIN_TYPE_OBJECT, true, Dummy::class, false, [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, [], [new Type(Type::BUILTIN_TYPE_STRING)])], [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, [new Type(Type::BUILTIN_TYPE_INT)], [new Type(Type::BUILTIN_TYPE_OBJECT, false, \Traversable::class, true, [], [new Type(Type::BUILTIN_TYPE_OBJECT, false, DefaultValue::class)])])]), new Type(Type::BUILTIN_TYPE_OBJECT, false, ParentDummy::class)]],
             ['f', null],
             ['g', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, [], [new Type(Type::BUILTIN_TYPE_STRING), new Type(Type::BUILTIN_TYPE_INT)])]],
+            ['h', null],
+            ['i', null],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyUnionType.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyUnionType.php
@@ -53,4 +53,14 @@ class DummyUnionType
      * @var non-empty-array<string|int>
      */
     public $g;
+
+    /**
+     * @var string|mixed
+     */
+    public $h;
+
+    /**
+     * @var mixed|null
+     */
+    public $i;
 }

--- a/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpStanTypeHelper.php
@@ -107,6 +107,10 @@ final class PhpStanTypeHelper
                     // It's safer to fall back to other extractors here, as resolving const types correctly is not easy at the moment
                     return [];
                 }
+                if ($type instanceof IdentifierTypeNode && 'mixed' === $type->name) {
+                    // a union that contains "mixed" is equivalent to "mixed", so it accepts any value
+                    return [];
+                }
                 foreach ($this->extractTypes($type, $nameScope) as $subType) {
                     $types[] = $subType;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64657
| License       | MIT

#63342 fixed the handling of unions containing `mixed` (`mixed|null`, `string|mixed`, ...) in `PhpDocTypeHelper` (the `phpdocumentor/reflection-docblock` path), so that such a union resolves to "unknown" instead of dropping `mixed` and keeping only the other members.

The same bug remains in `PhpStanTypeHelper` (the `phpstan/phpdoc-parser` path), which is the default extractor in most modern projects. A `mixed|null` PHPDoc collapses to `null` only, because `mixed` on its own already extracts to `[]` and the union loop just skips it:

```php
class MyClass
{
    private $myProperty;

    /** @return mixed|null */
    public function getMyProperty() { return $this->myProperty; }

    /** @param mixed|null $myProperty */
    public function setMyProperty($myProperty) { $this->myProperty = $myProperty; }
}
```

`PropertyInfo::getTypes()` returns `null` (the `null` type) for `myProperty`, and deserializing `{"myProperty": 5}` throws:

> The type of the "myProperty" attribute for class "MyClass" must be one of "null" ("int" given).

This is exactly what the reporter of #64657 hit, on `property-info` 6.4.34 (which already contains #63342): they were on the PhpStan path, which #63342 did not cover.

This PR mirrors #63342 in `PhpStanTypeHelper`: a union that contains `mixed` is equivalent to `mixed`, so it falls back to "unknown". Plain unions (`string|int`) and nullable types (`int|null`) are unaffected.

---

Note: the `fabbot`/CS check reports a pre-existing issue unrelated to this change (a type-less `@param $omittedTagType` in the `PhpStanOmittedParamTagTypeDocBlock` test fixture, which is intentional there to check the extractor tolerates a missing type). I left it untouched to avoid altering unrelated test scaffolding, but happy to include the CS fix here if you prefer.
