### PR TITLE
[EventDispatcher] Clear wrappedListeners in TraceableEventDispatcher::reset()

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -233,6 +233,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
     public function reset()
     {
         $this->callStack = null;
+        $this->wrappedListeners = [];
         $this->orphanedEvents = [];
         $this->currentRequestHash = '';
         $this->dispatchDepth = [];

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -455,6 +455,24 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertSame([], $tdispatcher->getCalledListeners());
     }
 
+    public function testResetDuringDispatchClearsWrappedListeners()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', static function () {});
+        // postProcess() returns early after a mid-dispatch reset, so reset() itself must clear wrappedListeners
+        $tdispatcher->addListener('foo', static function () use ($tdispatcher) {
+            $tdispatcher->reset();
+        });
+
+        for ($i = 0; $i < 5; ++$i) {
+            $tdispatcher->dispatch(new Event(), 'foo');
+        }
+
+        $p = (new \ReflectionObject($tdispatcher))->getProperty('wrappedListeners');
+
+        $this->assertSame([], $p->getValue($tdispatcher));
+    }
+
     public function testCallStackIsNotLeakingWhenListenerIsRemovedBetweenDispatches()
     {
         $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TraceableEventDispatcher::reset()` clears every internal accumulator
(`callStack`, `orphanedEvents`, `dispatchDepth`, `calledListenerInfos`,
`calledOriginalListeners`) but leaves `$wrappedListeners` untouched. In the
normal request lifecycle it doesn't matter, because `postProcess()` calls
`unset($this->wrappedListeners[$eventName])` at the end of every dispatch.

But if `reset()` is invoked **mid-dispatch** (e.g. from a listener), it sets
`$callStack = null`, and `postProcess()` returns early on
`null === $this->callStack` — never reaching the `unset(...)` line. Every
subsequent dispatch keeps appending `WrappedListener` instances to
`wrappedListeners[$eventName][]`, unbounded.

This isn't purely theoretical. A Messenger worker running in debug mode can
end up calling `services_resetter->reset()` from a `WorkerRunningEvent`
listener to bound `TraceableAdapter::$calls` accumulation during long idle
stretches between messages — a common workaround. That reset propagates to
all `kernel.reset` services, including `TraceableEventDispatcher`, and
triggers the leak.

### Reproducer

Minimal, standalone (composer.json only needs `symfony/event-dispatcher` +
`symfony/stopwatch`):

```php
use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
use Symfony\Component\EventDispatcher\EventDispatcher;
use Symfony\Component\Stopwatch\Stopwatch;

$dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
$dispatcher->addListener('test.event', static fn () => null);
$dispatcher->addListener('test.event', static function () use (\$dispatcher) {
    $dispatcher->reset();
});

for ($i = 0; $i < 1000; ++$i) {
    $dispatcher->dispatch(new stdClass(), 'test.event');
}

$r = new ReflectionObject($dispatcher);
$p = $r->getProperty('wrappedListeners');
$p->setAccessible(true);
$wrapped = $p->getValue($dispatcher);
echo count($wrapped['test.event'] ?? []); // Before: 2000 — After: 0
```

Before the fix: `wrappedListeners[test.event]` grows to 2000
(2 listeners × 1000 dispatches), leaking ~900 KB of `WrappedListener`
objects. After the fix: it stays at 0.

### Fix

One-line change in `reset()`: also clear `$wrappedListeners`. Same class,
same lifecycle, no BC break. Covered by a new unit test that fails on `6.4`
without the fix and passes with it.