### PR TITLE
[Yaml] Fix parsing and dumping of NaN

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -147,6 +147,8 @@ class Inline
                 return 'false';
             case \is_int($value):
                 return $value;
+            case \is_float($value) && is_nan($value):
+                return '.NaN';
             case is_numeric($value) && false === strpbrk($value, "\f\n\r\t\v"):
                 $locale = setlocale(\LC_NUMERIC, 0);
                 if (false !== $locale) {
@@ -794,8 +796,9 @@ class Inline
 
                         return '0x' === $scalar[0].$scalar[1] ? hexdec($scalar) : (float) $scalar;
                     case '.inf' === $scalarLower:
-                    case '.nan' === $scalarLower:
                         return -log(0);
+                    case '.nan' === $scalarLower:
+                        return \NAN;
                     case '-.inf' === $scalarLower:
                         return log(0);
                     case Parser::preg_match('/^(-|\+)?[0-9][0-9_]*(\.[0-9_]+)?$/', $scalar):

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -365,7 +365,7 @@ syck: |
 
 
 ---
-test: Literal perserves newlines
+test: Literal preserves newlines
 todo: true
 spec: 2.13
 yaml: |
@@ -521,6 +521,8 @@ php: |
 # FIX: spec shows parens around -inf and NaN
 test: Floating point
 spec: 2.20
+# dump_skip: assertSame() cannot compare NaN (NAN !== NAN); NaN round-trip is covered by InlineTest.
+dump_skip: true
 yaml: |
   canonical: 1.23015e+3
   exponential: 12.3015e+02
@@ -532,7 +534,7 @@ php: |
     'canonical' => 1230.15,
     'exponential' => 1230.15,
     'negative infinity' => log(0),
-    'not a number' => -log(0),
+    'not a number' => NAN,
     'float as whole number' => (float) 1
   ]
 ---
@@ -1511,6 +1513,8 @@ php: |
    ]
 ---
 test: Float
+# dump_skip: assertSame() cannot compare NaN (NAN !== NAN); NaN round-trip is covered by InlineTest.
+dump_skip: true
 yaml: |
    canonical: 1.23015e+3
    exponential: 12.3015e+02
@@ -1521,7 +1525,7 @@ php: |
     'canonical' => 1230.15,
     'exponential' => 1230.15,
     'negative infinity' => log(0),
-    'not a number' => -log(0)
+    'not a number' => NAN
   ]
 ---
 test: Timestamp

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -35,6 +35,22 @@ class InlineTest extends TestCase
     }
 
     /**
+     * @testWith [".nan"]
+     *           [".NaN"]
+     *           [".NAN"]
+     */
+    public function testParseNan(string $yaml)
+    {
+        $this->assertNan(Inline::parse($yaml));
+    }
+
+    public function testDumpNan()
+    {
+        $this->assertSame('.NaN', Inline::dump(\NAN));
+        $this->assertNan(Inline::parse(Inline::dump(\NAN)));
+    }
+
+    /**
      * @dataProvider getTestsForParseWithMapObjects
      */
     public function testParseWithMapObjects($yaml, $value, $flags = Yaml::PARSE_OBJECT_FOR_MAP)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Yaml::parse('.nan')` returns `+INF` instead of `NAN`.

`.nan`, `.NaN` and `.NAN` shared the `.inf` `case` in `Inline::evaluateScalar()` and fell through to `return -log(0)` (positive infinity). So any YAML `.nan` scalar is silently parsed as `+INF`; downstream `is_nan()` guards never fire and the value compares/serializes as infinity rather than Not-a-Number.

The dump side was broken too: dumping a float `NAN` produced the literal `NAN` (plus a PHP *"unexpected NAN value was coerced to string"* warning) instead of the YAML `.NaN` literal, so `NAN` did not round-trip.

This PR:
- parses `.nan` / `.NaN` / `.NAN` to `NAN`;
- dumps a float `NAN` as `.NaN` (no warning);
- gives `NAN` a clean `parse(dump())` round-trip.

Before:
```php
Yaml::parse('x: .nan');   // ['x' => INF]        (is_nan() === false)
Yaml::dump(['x' => NAN]); // "x: NAN\n"  + 2 PHP warnings
```
After:
```php
Yaml::parse('x: .nan');   // ['x' => NAN]        (is_nan() === true)
Yaml::dump(['x' => NAN]); // "x: .NaN\n"
```

The two `YtsSpecificationExamples` docs that already contained `not a number: .NaN` have their PHP expectation updated from `-log(0)` to `NAN`, and are marked `dump_skip` on the dump side because `assertSame()` cannot compare NaN (`NAN !== NAN`) — the round-trip is covered explicitly by the new `InlineTest::testDumpNan`.
