### PR TITLE
[Mailer] Add TurboSMTP bridge

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -63,6 +63,7 @@
         "scaleway-mailer": "src/Symfony/Component/Mailer/Bridge/Scaleway",
         "sendgrid-mailer": "src/Symfony/Component/Mailer/Bridge/Sendgrid",
         "sweego-mailer": "src/Symfony/Component/Mailer/Bridge/Sweego",
+        "turbo-smtp-mailer": "src/Symfony/Component/Mailer/Bridge/TurboSmtp",
         "messenger": {
             "prefixes": [{ "from": "src/Symfony/Component/Messenger", "to": "", "excludes": ["Bridge"] }]
         },

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3082,6 +3082,7 @@ class FrameworkExtension extends Extension
             MailerBridge\Sendgrid\Transport\SendgridTransportFactory::class => ['symfony/sendgrid-mailer', 'mailer.transport_factory.sendgrid'],
             MailerBridge\Amazon\Transport\SesTransportFactory::class => ['symfony/amazon-mailer', 'mailer.transport_factory.amazon'],
             MailerBridge\Sweego\Transport\SweegoTransportFactory::class => ['symfony/sweego-mailer', 'mailer.transport_factory.sweego'],
+            MailerBridge\TurboSmtp\Transport\TurboSmtpTransportFactory::class => ['symfony/turbo-smtp-mailer', 'mailer.transport_factory.turbosmtp'],
         ];
 
         foreach ($classToServices as $class => [$package, $service]) {
@@ -3158,6 +3159,7 @@ class FrameworkExtension extends Extension
                 MailerBridge\Resend\Webhook\ResendRequestParser::class => ['symfony/resend-mailer', 'mailer.webhook.request_parser.resend'],
                 MailerBridge\Sendgrid\Webhook\SendgridRequestParser::class => ['symfony/sendgrid-mailer', 'mailer.webhook.request_parser.sendgrid'],
                 MailerBridge\Sweego\Webhook\SweegoRequestParser::class => ['symfony/sweego-mailer', 'mailer.webhook.request_parser.sweego'],
+                MailerBridge\TurboSmtp\Webhook\TurboSmtpRequestParser::class => ['symfony/turbo-smtp-mailer', 'mailer.webhook.request_parser.turbosmtp'],
             ];
 
             foreach ($webhookRequestParsers as $class => [$package, $service]) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -31,6 +31,7 @@ use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoTransportFactory;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpTransportFactory;
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\NativeTransportFactory;
 use Symfony\Component\Mailer\Transport\NullTransportFactory;
@@ -73,6 +74,7 @@ return static function (ContainerConfigurator $container) {
         'sendmail' => SendmailTransportFactory::class,
         'smtp' => EsmtpTransportFactory::class,
         'sweego' => SweegoTransportFactory::class,
+        'turbosmtp' => TurboSmtpTransportFactory::class,
     ];
 
     foreach ($factories as $name => $class) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_webhook.php
@@ -35,6 +35,8 @@ use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverte
 use Symfony\Component\Mailer\Bridge\Sendgrid\Webhook\SendgridRequestParser;
 use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sweego\Webhook\SweegoRequestParser;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\RemoteEvent\TurboSmtpPayloadConverter;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Webhook\TurboSmtpRequestParser;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -97,5 +99,10 @@ return static function (ContainerConfigurator $container) {
         ->set('mailer.webhook.request_parser.mailchimp', MailchimpRequestParser::class)
             ->args([service('mailer.payload_converter.mailchimp')])
         ->alias(MailchimpRequestParser::class, 'mailer.webhook.request_parser.mailchimp')
+
+        ->set('mailer.payload_converter.turbosmtp', TurboSmtpPayloadConverter::class)
+        ->set('mailer.webhook.request_parser.turbosmtp', TurboSmtpRequestParser::class)
+            ->args([service('mailer.payload_converter.turbosmtp')])
+        ->alias(TurboSmtpRequestParser::class, 'mailer.webhook.request_parser.turbosmtp')
     ;
 };

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/.gitignore
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/README.md
@@ -1,0 +1,93 @@
+TurboSMTP Bridge
+================
+
+Provides TurboSMTP integration for Symfony Mailer.
+
+Configuration example:
+
+```env
+# SMTP
+MAILER_DSN=turbosmtp+smtp://KEY:SECRET@default
+
+# SMTP (EU region)
+MAILER_DSN=turbosmtp+smtp://KEY:SECRET@pro.eu.turbo-smtp.com
+
+# API
+MAILER_DSN=turbosmtp+api://KEY:SECRET@default
+
+# API (EU region)
+MAILER_DSN=turbosmtp+api://KEY:SECRET@api.eu.turbo-smtp.com
+```
+
+where:
+ - `KEY` is your TurboSMTP Consumer Key
+ - `SECRET` is your TurboSMTP Consumer Secret
+
+Use the `default` host to send through the non-EU endpoint
+(`api.turbo-smtp.com` for the API, `pro.turbo-smtp.com` for SMTP). EU accounts
+must set the corresponding EU host (`api.eu.turbo-smtp.com` or
+`pro.eu.turbo-smtp.com`).
+
+Webhook
+-------
+
+Configure the TurboSMTP Event Webhook in your TurboSMTP dashboard, under
+Settings > Notifications, to point at your application, then create a route:
+
+```yaml
+framework:
+    webhook:
+        routing:
+            turbosmtp:
+                service: mailer.webhook.request_parser.turbosmtp
+                secret: '%env(TURBOSMTP_WEBHOOK_SECRET)%' # optional, see below
+```
+
+And a consumer:
+
+```php
+use Symfony\Component\RemoteEvent\Attribute\AsRemoteEventConsumer;
+use Symfony\Component\RemoteEvent\Consumer\ConsumerInterface;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+
+#[AsRemoteEventConsumer(name: 'turbosmtp')]
+class TurboSmtpConsumer implements ConsumerInterface
+{
+    public function consume(RemoteEvent $event): void
+    {
+        if ($event instanceof MailerDeliveryEvent) {
+            // handle processed, delivered, deferred, bounce and dropped events
+        } elseif ($event instanceof MailerEngagementEvent) {
+            // handle open, click, unsubscribe and spam events
+        }
+    }
+}
+```
+
+TurboSMTP does not sign its webhook requests. Authenticating them is optional:
+if a route `secret` is set, requests are expected to carry matching HTTP Basic
+credentials, otherwise no check is performed. To enable it, set HTTP Basic
+credentials on the webhook URL in your TurboSMTP dashboard
+(`https://USERNAME:PASSWORD@example.com/webhook/turbosmtp`) and configure the
+same `USERNAME:PASSWORD` pair as the route secret. Requests whose credentials
+do not match are then rejected with a 403.
+
+Sponsor
+-------
+
+This package is looking for a [backer][1].
+
+Help Symfony by [sponsoring][3] its development!
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)
+
+[1]: https://symfony.com/backers
+[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/RemoteEvent/TurboSmtpPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/RemoteEvent/TurboSmtpPayloadConverter.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\RemoteEvent;
+
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\RemoteEvent\PayloadConverterInterface;
+
+/**
+ * @author Dominik Spitzli <dominik@spitzli.dev>
+ */
+final class TurboSmtpPayloadConverter implements PayloadConverterInterface
+{
+    public function convert(array $payload): AbstractMailerEvent
+    {
+        $status = strtolower($payload['status']);
+
+        if (\in_array($status, ['processed', 'delivered', 'deferred', 'bounce', 'bounced', 'dropped'], true)) {
+            $name = match ($status) {
+                'processed' => MailerDeliveryEvent::RECEIVED,
+                'delivered' => MailerDeliveryEvent::DELIVERED,
+                'deferred' => MailerDeliveryEvent::DEFERRED,
+                'bounce', 'bounced' => MailerDeliveryEvent::BOUNCE,
+                'dropped' => MailerDeliveryEvent::DROPPED,
+            };
+            $event = new MailerDeliveryEvent($name, (string) $payload['mid'], $payload);
+
+            // deferrals carry a plain string, drops and bounces an object holding the response of the receiving server
+            $reason = $payload['reason'] ?? '';
+            $event->setReason(\is_array($reason) ? ($reason['response'] ?? '') : $reason);
+        } else {
+            $name = match ($status) {
+                'open', 'opened' => MailerEngagementEvent::OPEN,
+                'click', 'clicked' => MailerEngagementEvent::CLICK,
+                'unsubscribe', 'unsubscribed' => MailerEngagementEvent::UNSUBSCRIBE,
+                'report', 'spam', 'spam report', 'spamreport' => MailerEngagementEvent::SPAM,
+                default => throw new ParseException(\sprintf('Unsupported event "%s".', $payload['status'])),
+            };
+            $event = new MailerEngagementEvent($name, (string) $payload['mid'], $payload);
+        }
+
+        $timestamp = $payload['Timestamp'] ?? $payload['timestamp'] ?? '';
+
+        if (!$date = \DateTimeImmutable::createFromFormat('U', $timestamp)) {
+            throw new ParseException(\sprintf('Invalid date "%s".', $timestamp));
+        }
+
+        $event->setDate($date);
+        $event->setRecipientEmail($payload['email']);
+
+        return $event;
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Transport/TurboSmtpApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Transport/TurboSmtpApiTransportTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpApiTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class TurboSmtpApiTransportTest extends TestCase
+{
+    #[DataProvider('getTransportData')]
+    public function testToString(TurboSmtpApiTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): array
+    {
+        return [
+            [
+                new TurboSmtpApiTransport('KEY', 'SECRET'),
+                'turbosmtp+api://api.turbo-smtp.com',
+            ],
+            [
+                (new TurboSmtpApiTransport('KEY', 'SECRET'))->setHost('api.eu.turbo-smtp.com'),
+                'turbosmtp+api://api.eu.turbo-smtp.com',
+            ],
+            [
+                (new TurboSmtpApiTransport('KEY', 'SECRET'))->setHost('example.com')->setPort(99),
+                'turbosmtp+api://example.com:99',
+            ],
+        ];
+    }
+
+    public function testSend()
+    {
+        $email = new Email();
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->to(new Address('bar@example.com', 'Mr. Recipient'))
+            ->bcc('baz@example.com')
+            ->subject('An email')
+            ->text('Test email body')
+            ->html('<html lang="en"><body><p>Test email body</p></body></html>')
+            ->replyTo(new Address('bar2@example.com', 'Mr. Recipient'));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.turbo-smtp.com/api/v2/mail/send', $url);
+
+            $headers = implode("\n", $options['headers']);
+            $this->assertStringContainsString('consumerKey: KEY', $headers);
+            $this->assertStringContainsString('consumerSecret: SECRET', $headers);
+
+            $body = json_decode($options['body'], true);
+            $this->assertStringContainsString('foo@example.com', $body['from']);
+            $this->assertStringContainsString('bar@example.com', $body['to']);
+            $this->assertSame('An email', $body['subject']);
+            $this->assertSame('Test email body', $body['content']);
+            $this->assertStringContainsString('Test email body', $body['html_content']);
+            $this->assertSame('baz@example.com', $body['bcc']);
+            $this->assertStringContainsString('bar2@example.com', $body['custom_headers']['Reply-To']);
+
+            return new JsonMockResponse(['message' => 'OK', 'mid' => 42], ['http_code' => 200]);
+        });
+
+        $transport = new TurboSmtpApiTransport('KEY', 'SECRET', $client);
+        $message = $transport->send($email);
+
+        $this->assertSame('42', $message->getMessageId());
+    }
+
+    public function testCustomHeader()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('foo', 'bar');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new TurboSmtpApiTransport('KEY', 'SECRET');
+        $method = new \ReflectionMethod(TurboSmtpApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('custom_headers', $payload);
+        $this->assertArrayHasKey('foo', $payload['custom_headers']);
+        $this->assertSame('bar', $payload['custom_headers']['foo']);
+    }
+
+    public function testReplyTo()
+    {
+        $email = new Email();
+        $email->from('from@example.com')
+            ->to('to@example.com')
+            ->replyTo('replyto@example.com')
+            ->text('content');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new TurboSmtpApiTransport('KEY', 'SECRET');
+        $method = new \ReflectionMethod(TurboSmtpApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertStringContainsString('replyto@example.com', $payload['custom_headers']['Reply-To']);
+    }
+
+    public function testSendWithAttachments()
+    {
+        $email = new Email();
+        $email->from('from@example.com')
+            ->to('to@example.com')
+            ->subject('An email')
+            ->text('content')
+            ->addPart(new DataPart('the pdf bytes', 'report.pdf', 'application/pdf'))
+            ->addPart((new DataPart('the gif bytes', 'logo.gif', 'image/gif'))->asInline());
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+
+            $this->assertCount(2, $body['attachments']);
+
+            $this->assertSame('report.pdf', $body['attachments'][0]['name']);
+            $this->assertSame('application/pdf', $body['attachments'][0]['type']);
+            $this->assertSame('the pdf bytes', base64_decode($body['attachments'][0]['content']));
+
+            $this->assertSame('logo.gif', $body['attachments'][1]['name']);
+            $this->assertSame('image/gif', $body['attachments'][1]['type']);
+            $this->assertSame('the gif bytes', base64_decode($body['attachments'][1]['content']));
+
+            return new JsonMockResponse(['message' => 'OK', 'mid' => 42], ['http_code' => 200]);
+        });
+
+        (new TurboSmtpApiTransport('KEY', 'SECRET', $client))->send($email);
+    }
+
+    public function testSendWithoutAttachmentsOmitsTheKey()
+    {
+        $email = new Email();
+        $email->from('from@example.com')->to('to@example.com')->subject('An email')->text('content');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new TurboSmtpApiTransport('KEY', 'SECRET');
+        $method = new \ReflectionMethod(TurboSmtpApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayNotHasKey('attachments', $payload);
+    }
+
+    public function testInlineImageSetsContentIdAndQualifiesTheCidWithTheSenderDomain()
+    {
+        $email = new Email();
+        $email->from('sender@example.com')
+            ->to('to@example.com')
+            ->subject('An email')
+            ->html('<p><img src="cid:logo.gif"></p>')
+            ->addPart((new DataPart('the gif bytes', 'logo.gif', 'image/gif'))->asInline());
+        $envelope = new Envelope(new Address('sender@example.com'), [new Address('to@example.com')]);
+
+        $transport = new TurboSmtpApiTransport('KEY', 'SECRET');
+        $method = new \ReflectionMethod(TurboSmtpApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        // The inline part carries a bare content_id; TurboSMTP appends the sender domain itself.
+        $this->assertSame('logo.gif', $payload['attachments'][0]['content_id']);
+        // The cid: reference in the HTML is qualified with the sender domain so it resolves inline.
+        $this->assertStringContainsString('src="cid:logo.gif@example.com"', $payload['html_content']);
+    }
+
+    public function testSendReportsTheErrorsReturnedByTheApi()
+    {
+        $email = new Email();
+        $email->from('from@example.com')->to('to@example.com')->subject('An email')->text('content');
+
+        $client = new MockHttpClient(new JsonMockResponse(
+            ['message' => 'error', 'errors' => ['recipient address is not valid', 'quota exceeded']],
+            ['http_code' => 400],
+        ));
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: recipient address is not valid, quota exceeded (code 400).');
+
+        (new TurboSmtpApiTransport('KEY', 'SECRET', $client))->send($email);
+    }
+
+    public function testTechnicalHeadersAreNotForwarded()
+    {
+        $email = new Email();
+        $email->from('from@example.com')->to('to@example.com')->text('content');
+        $email->getHeaders()->addTextHeader('X-Custom', 'kept');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new TurboSmtpApiTransport('KEY', 'SECRET');
+        $method = new \ReflectionMethod(TurboSmtpApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame(['X-Custom' => 'kept'], $payload['custom_headers']);
+    }
+
+    public function testEnvelopeSenderAndRecipients()
+    {
+        $email = new Email();
+        $email->from('from@example.com')
+            ->to('to@example.com')
+            ->cc('cc@example.com')
+            ->bcc('bcc@example.com')
+            ->text('content');
+        $envelope = new Envelope(new Address('envelopefrom@example.com'), [new Address('envelopeto@example.com'), new Address('cc@example.com'), new Address('bcc@example.com')]);
+
+        $transport = new TurboSmtpApiTransport('KEY', 'SECRET');
+        $method = new \ReflectionMethod(TurboSmtpApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertStringContainsString('envelopefrom@example.com', $payload['from']);
+        $this->assertStringContainsString('envelopeto@example.com', $payload['to']);
+        $this->assertStringContainsString('cc@example.com', $payload['cc']);
+        $this->assertStringContainsString('bcc@example.com', $payload['bcc']);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Transport/TurboSmtpSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Transport/TurboSmtpSmtpTransportTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpSmtpTransport;
+
+class TurboSmtpSmtpTransportTest extends TestCase
+{
+    #[DataProvider('getTransportData')]
+    public function testToString(TurboSmtpSmtpTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): iterable
+    {
+        yield [
+            new TurboSmtpSmtpTransport('pro.turbo-smtp.com', 'KEY', 'SECRET'),
+            'smtp://pro.turbo-smtp.com:587',
+        ];
+
+        yield [
+            new TurboSmtpSmtpTransport('pro.eu.turbo-smtp.com', 'KEY', 'SECRET'),
+            'smtp://pro.eu.turbo-smtp.com:587',
+        ];
+    }
+
+    public function testCredentials()
+    {
+        $transport = new TurboSmtpSmtpTransport('pro.turbo-smtp.com', 'KEY', 'SECRET');
+
+        $this->assertSame('KEY', $transport->getUsername());
+        $this->assertSame('SECRET', $transport->getPassword());
+    }
+
+    public function testSubmissionPortIsNotWrappedInImplicitTls()
+    {
+        $transport = new TurboSmtpSmtpTransport('pro.turbo-smtp.com', 'KEY', 'SECRET');
+
+        $this->assertFalse($transport->getStream()->isTLS());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Transport/TurboSmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Transport/TurboSmtpTransportFactoryTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Tests\Transport;
+
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpApiTransport;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpSmtpTransport;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpTransportFactory;
+use Symfony\Component\Mailer\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Mailer\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+class TurboSmtpTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new TurboSmtpTransportFactory(null, new MockHttpClient(), new NullLogger());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('turbosmtp+api', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('turbosmtp', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('turbosmtp+smtp', 'default'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        $logger = new NullLogger();
+
+        yield [
+            new Dsn('turbosmtp+api', 'default', self::USER, self::PASSWORD),
+            new TurboSmtpApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, $logger),
+        ];
+
+        yield [
+            new Dsn('turbosmtp+api', 'api.eu.turbo-smtp.com', self::USER, self::PASSWORD),
+            (new TurboSmtpApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, $logger))->setHost('api.eu.turbo-smtp.com'),
+        ];
+
+        yield [
+            new Dsn('turbosmtp+api', 'example.com', self::USER, self::PASSWORD, 8080),
+            (new TurboSmtpApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
+        ];
+
+        yield [
+            new Dsn('turbosmtp+smtp', 'default', self::USER, self::PASSWORD),
+            new TurboSmtpSmtpTransport('pro.turbo-smtp.com', self::USER, self::PASSWORD, null, $logger),
+        ];
+
+        yield [
+            new Dsn('turbosmtp+smtp', 'pro.eu.turbo-smtp.com', self::USER, self::PASSWORD),
+            new TurboSmtpSmtpTransport('pro.eu.turbo-smtp.com', self::USER, self::PASSWORD, null, $logger),
+        ];
+
+        yield [
+            new Dsn('turbosmtp', 'default', self::USER, self::PASSWORD),
+            new TurboSmtpSmtpTransport('pro.turbo-smtp.com', self::USER, self::PASSWORD, null, $logger),
+        ];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield [
+            new Dsn('turbosmtp+foo', 'default', self::USER, self::PASSWORD),
+            'The "turbosmtp+foo" scheme is not supported; supported schemes for mailer "turbosmtp" are: "turbosmtp", "turbosmtp+api", "turbosmtp+smtp".',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('turbosmtp+api', 'default')];
+        yield [new Dsn('turbosmtp+api', 'default', self::USER)];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/bounced.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/bounced.json
@@ -1,0 +1,1 @@
+{"id":"5943788914","mid":"5520611178","status":"BOUNCED","email":"bad@world.com","subject":"An email","timestamp":1576709778,"reason":"550 mailbox unavailable"}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/bounced.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/bounced.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, '5520611178', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('bad@world.com');
+$wh->setReason('550 mailbox unavailable');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709778));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/clicked.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/clicked.json
@@ -1,0 +1,1 @@
+{"id":"5520611177","mid":"5520611177","Timestamp":1576709779,"subject":"An email","email":"reader@world.com","status":"CLICKED","useragent":"Mozilla/5.0","ip":"156.218.154.17","url":"https://serversmtp.com"}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/clicked.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/clicked.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, '5520611177', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('reader@world.com');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709779));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/deferred.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/deferred.json
@@ -1,0 +1,1 @@
+{"id":"5943788913","mid":"5520611177","status":"DEFERRED","email":"hello@world.com","subject":"An email","timestamp":1576709776,"reason":"400 try again later","attempt":2}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/deferred.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/deferred.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DEFERRED, '5520611177', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('hello@world.com');
+$wh->setReason('400 try again later');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709776));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/delivered.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/delivered.json
@@ -1,0 +1,1 @@
+{"id":"5943788912","mid":"5520611177","status":"DELIVERED","email":"hello@world.com","subject":"An email","timestamp":1576709777}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/delivered.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/delivered.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, '5520611177', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('hello@world.com');
+$wh->setReason('');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709777));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/dropped.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/dropped.json
@@ -1,0 +1,1 @@
+{"id":"5943799537","mid":"5520621607","status":"DROPPED","email":"complainer@world.com","subject":null,"timestamp":1576710200,"reason":{"0":"Dropped due to complaining recipient","response":"Dropped due to complaining recipient"}}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/dropped.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/dropped.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DROPPED, '5520621607', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('complainer@world.com');
+$wh->setReason('Dropped due to complaining recipient');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576710200));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/opened.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/opened.json
@@ -1,0 +1,1 @@
+{"id":"5943788916","mid":"5520611177","status":"OPENED","email":"reader@world.com","subject":"An email","timestamp":1576709778,"useragent":"Mozilla/5.0","ip":"40.101.136.165"}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/opened.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/opened.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, '5520611177', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('reader@world.com');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709778));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/processed.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/processed.json
@@ -1,0 +1,1 @@
+{"id":"5943788911","mid":"5520611177","status":"PROCESSED","email":"hello@world.com","subject":"An email","timestamp":1576709776}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/processed.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/processed.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::RECEIVED, '5520611177', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('hello@world.com');
+$wh->setReason('');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709776));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/report.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/report.json
@@ -1,0 +1,1 @@
+{"id":"5943788915","mid":"5520611177","status":"REPORT","email":"reader@world.com","subject":"An email","timestamp":1576709780}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/report.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/report.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::SPAM, '5520611177', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('reader@world.com');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709780));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/unsubscribed.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/unsubscribed.json
@@ -1,0 +1,1 @@
+{"id":"5943788917","mid":"5520611177","status":"UNSUBSCRIBED","email":"reader@world.com","subject":"An email","timestamp":1576709781}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/unsubscribed.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/Fixtures/unsubscribed.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
+
+$wh = new MailerEngagementEvent(MailerEngagementEvent::UNSUBSCRIBE, '5520611177', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh->setRecipientEmail('reader@world.com');
+$wh->setDate(DateTimeImmutable::createFromFormat('U', 1576709781));
+
+return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/TurboSmtpRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Tests/Webhook/TurboSmtpRequestParserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Tests\Webhook;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\RemoteEvent\TurboSmtpPayloadConverter;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Webhook\TurboSmtpRequestParser;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
+
+class TurboSmtpRequestParserTest extends AbstractRequestParserTestCase
+{
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new TurboSmtpRequestParser(new TurboSmtpPayloadConverter());
+    }
+
+    protected function getSecret(): string
+    {
+        return 'symfony:top-secret';
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Authorization' => 'Basic '.base64_encode('symfony:top-secret'),
+        ], $payload);
+    }
+
+    public function testRejectMissingCredentials()
+    {
+        $parser = new TurboSmtpRequestParser(new TurboSmtpPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivered.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, 'symfony:top-secret');
+    }
+
+    public function testRejectWrongSecret()
+    {
+        $parser = new TurboSmtpRequestParser(new TurboSmtpPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivered.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Authorization' => 'Basic '.base64_encode('symfony:wrong-secret'),
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, 'symfony:top-secret');
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Transport/TurboSmtpApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Transport/TurboSmtpApiTransport.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Dominik Spitzli <dominik@spitzli.dev>
+ */
+final class TurboSmtpApiTransport extends AbstractApiTransport
+{
+    private const HOST = 'api.turbo-smtp.com';
+
+    public function __construct(
+        #[\SensitiveParameter] private readonly string $key,
+        #[\SensitiveParameter] private readonly string $secret,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($client, $dispatcher, $logger);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('turbosmtp+api://%s', $this->getEndpoint());
+    }
+
+    protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+    {
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/v2/mail/send', [
+            'headers' => [
+                'consumerKey' => $this->key,
+                'consumerSecret' => $this->secret,
+            ],
+            'json' => $this->getPayload($email, $envelope),
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+            $result = $response->toArray(false);
+        } catch (DecodingExceptionInterface) {
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $response->getStatusCode()), $response);
+        } catch (TransportExceptionInterface $e) {
+            throw new HttpTransportException('Could not reach the remote TurboSMTP server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            $errors = $result['errors'] ?? null;
+            $reason = \is_array($errors) ? implode(', ', $errors) : ($errors ?? $result['message'] ?? $response->getContent(false));
+
+            throw new HttpTransportException('Unable to send an email: '.$reason.\sprintf(' (code %d).', $statusCode), $response);
+        }
+
+        if (isset($result['mid'])) {
+            $sentMessage->setMessageId((string) $result['mid']);
+        }
+
+        return $response;
+    }
+
+    private function getPayload(Email $email, Envelope $envelope): array
+    {
+        $payload = [
+            'from' => $envelope->getSender()->toString(),
+            'to' => implode(',', $this->stringifyAddresses($this->getRecipients($email, $envelope))),
+            'subject' => $email->getSubject(),
+        ];
+
+        if ($text = $email->getTextBody()) {
+            $payload['content'] = $text;
+        }
+
+        if ($html = $email->getHtmlBody()) {
+            $payload['html_content'] = $html;
+        }
+
+        if ($cc = $email->getCc()) {
+            $payload['cc'] = implode(',', $this->stringifyAddresses($cc));
+        }
+
+        if ($bcc = $email->getBcc()) {
+            $payload['bcc'] = implode(',', $this->stringifyAddresses($bcc));
+        }
+
+        if ($replyTo = $email->getReplyTo()) {
+            $payload['custom_headers']['Reply-To'] = implode(',', $this->stringifyAddresses($replyTo));
+        }
+
+        if ($attachments = $this->getAttachments($email)) {
+            $payload['attachments'] = $attachments;
+
+            if (isset($payload['html_content'])) {
+                $payload['html_content'] = $this->qualifyInlineCids($payload['html_content'], $attachments, $envelope->getSender()->getAddress());
+            }
+        }
+
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'reply-to', 'content-type', 'content-transfer-encoding', 'mime-version', 'dkim-signature', 'received', 'message-id', 'date'], true)) {
+                continue;
+            }
+
+            $payload['custom_headers'][$header->getName()] = $header->getBodyAsString();
+        }
+
+        return $payload;
+    }
+
+    private function getAttachments(Email $email): array
+    {
+        $attachments = [];
+        foreach ($email->getAttachments() as $attachment) {
+            $headers = $attachment->getPreparedHeaders();
+            $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
+
+            $item = [
+                'name' => $filename,
+                'type' => $headers->get('Content-Type')->getBody(),
+                'content' => base64_encode($attachment->getBody()),
+            ];
+
+            if ('inline' === $headers->getHeaderBody('Content-Disposition')) {
+                $item['content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
+            }
+
+            $attachments[] = $item;
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * Qualifies inline `cid:` references with the sender domain.
+     *
+     * TurboSMTP builds each inline part's Content-ID as `<content_id@sender-domain>`, so a bare
+     * `cid:the-id` reference in the HTML only resolves once it carries the same domain. Otherwise
+     * the image is delivered as a normal attachment instead of rendering inline.
+     */
+    private function qualifyInlineCids(string $html, array $attachments, string $sender): string
+    {
+        $domain = substr(strrchr($sender, '@') ?: '@', 1);
+        if ('' === $domain) {
+            return $html;
+        }
+
+        foreach ($attachments as $attachment) {
+            $cid = $attachment['content_id'] ?? null;
+            if (null === $cid || str_contains($cid, '@')) {
+                continue;
+            }
+
+            $html = preg_replace('/cid:'.preg_quote($cid, '/').'(?![\w.@-])/', 'cid:'.$cid.'@'.$domain, $html) ?? $html;
+        }
+
+        return $html;
+    }
+
+    private function getEndpoint(): string
+    {
+        return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Transport/TurboSmtpSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Transport/TurboSmtpSmtpTransport.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+
+/**
+ * @author Dominik Spitzli <dominik@spitzli.dev>
+ */
+final class TurboSmtpSmtpTransport extends EsmtpTransport
+{
+    public function __construct(string $host, #[\SensitiveParameter] string $username, #[\SensitiveParameter] string $password, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null)
+    {
+        parent::__construct($host, 587, false, $dispatcher, $logger);
+
+        $this->setUsername($username);
+        $this->setPassword($password);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Transport/TurboSmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Transport/TurboSmtpTransportFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Transport;
+
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+/**
+ * @author Dominik Spitzli <dominik@spitzli.dev>
+ */
+final class TurboSmtpTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+        $user = $this->getUser($dsn);
+        $password = $this->getPassword($dsn);
+
+        if ('turbosmtp+api' === $scheme) {
+            $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+
+            return (new TurboSmtpApiTransport($user, $password, $this->client, $this->dispatcher, $this->logger))
+                ->setHost($host)
+                ->setPort($dsn->getPort());
+        }
+
+        if ('turbosmtp+smtp' === $scheme || 'turbosmtp' === $scheme) {
+            $host = 'default' === $dsn->getHost() ? 'pro.turbo-smtp.com' : $dsn->getHost();
+
+            return new TurboSmtpSmtpTransport($host, $user, $password, $this->dispatcher, $this->logger);
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'turbosmtp', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['turbosmtp', 'turbosmtp+api', 'turbosmtp+smtp'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Webhook/TurboSmtpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/Webhook/TurboSmtpRequestParser.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\TurboSmtp\Webhook;
+
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\RemoteEvent\TurboSmtpPayloadConverter;
+use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+/**
+ * @author Dominik Spitzli <dominik@spitzli.dev>
+ */
+final class TurboSmtpRequestParser extends AbstractRequestParser
+{
+    public function __construct(
+        private readonly TurboSmtpPayloadConverter $converter,
+    ) {
+    }
+
+    protected function getRequestMatcher(): RequestMatcherInterface
+    {
+        return new ChainRequestMatcher([
+            new MethodRequestMatcher('POST'),
+            new IsJsonRequestMatcher(),
+        ]);
+    }
+
+    protected function doParse(Request $request, #[\SensitiveParameter] string $secret): AbstractMailerEvent
+    {
+        if ($secret && !hash_equals('Basic '.base64_encode($secret), $request->headers->get('Authorization', ''))) {
+            throw new RejectWebhookException(403, 'Invalid credentials.');
+        }
+
+        $payload = $request->toArray();
+
+        if (!isset($payload['status'], $payload['mid'], $payload['email'])
+            || !isset($payload['Timestamp']) && !isset($payload['timestamp'])
+        ) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        try {
+            return $this->converter->convert($payload);
+        } catch (ParseException $e) {
+            throw new RejectWebhookException(406, $e->getMessage(), $e);
+        }
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/turbo-smtp-mailer",
+    "type": "symfony-mailer-bridge",
+    "description": "Symfony TurboSMTP Mailer Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dominik Spitzli",
+            "email": "dominik@spitzli.dev"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "psr/event-dispatcher": "^1",
+        "symfony/mailer": "^7.4|^8.0"
+    },
+    "require-dev": {
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/webhook": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\TurboSmtp\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Mailer/Bridge/TurboSmtp/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/TurboSmtp/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony TurboSMTP Mailer Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
@@ -100,6 +100,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Sweego\Transport\SweegoTransportFactory::class,
             'package' => 'symfony/sweego-mailer',
         ],
+        'turbosmtp' => [
+            'class' => Bridge\TurboSmtp\Transport\TurboSmtpTransportFactory::class,
+            'package' => 'symfony/turbo-smtp-mailer',
+        ],
     ];
 
     public function __construct(Dsn $dsn, ?string $name = null, array $supported = [])

--- a/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoTransportFactory;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpTransportFactory;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
 
@@ -63,6 +64,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             SendgridTransportFactory::class => false,
             SesTransportFactory::class => false,
             SweegoTransportFactory::class => false,
+            TurboSmtpTransportFactory::class => false,
         ]);
     }
 
@@ -98,6 +100,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['sendgrid', 'symfony/sendgrid-mailer'];
         yield ['ses', 'symfony/amazon-mailer'];
         yield ['sweego', 'symfony/sweego-mailer'];
+        yield ['turbosmtp', 'symfony/turbo-smtp-mailer'];
     }
 
     #[DataProvider('messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider')]

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -33,6 +33,7 @@ use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sweego\Transport\SweegoTransportFactory;
+use Symfony\Component\Mailer\Bridge\TurboSmtp\Transport\TurboSmtpTransportFactory;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -74,6 +75,7 @@ final class Transport
         SendgridTransportFactory::class,
         SesTransportFactory::class,
         SweegoTransportFactory::class,
+        TurboSmtpTransportFactory::class,
     ];
 
     public static function fromDsn(#[\SensitiveParameter] string $dsn, ?EventDispatcherInterface $dispatcher = null, ?HttpClientInterface $client = null, ?LoggerInterface $logger = null): TransportInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds a Mailer bridge for [TurboSMTP](https://serversmtp.com/), an email delivery
service that exposes both an SMTP relay and a REST API, plus event webhooks for
delivery and engagement tracking.

The package is `symfony/turbo-smtp-mailer`.

### Choosing a transport

Three DSN schemes are registered:

```dotenv
# SMTP, submission port 587 with STARTTLS
MAILER_DSN=turbosmtp+smtp://KEY:SECRET@default

# same thing, shorter
MAILER_DSN=turbosmtp://KEY:SECRET@default

# HTTP API, POST to /api/v2/mail/send
MAILER_DSN=turbosmtp+api://KEY:SECRET@default
```

`turbosmtp` is an alias for `turbosmtp+smtp`. Pick the SMTP transport unless
outbound SMTP is blocked, which is common on PaaS hosts, in which case
`turbosmtp+api` sends over plain HTTPS instead. The API transport also reports
the provider side error messages returned in the `errors` array of a failed
response, and sets the message id from the `mid` field of a successful one.

### Regions

The host part of the DSN selects the endpoint. `default` resolves to the non EU
endpoints, `pro.turbo-smtp.com` for SMTP and `api.turbo-smtp.com` for the API.
Accounts hosted in the EU must name the EU host explicitly:

```dotenv
MAILER_DSN=turbosmtp+smtp://KEY:SECRET@pro.eu.turbo-smtp.com
MAILER_DSN=turbosmtp+api://KEY:SECRET@api.eu.turbo-smtp.com
```

An account only works against the region it was created in, so a wrong host
shows up as an authentication failure rather than as a routing error.

### Credentials

Both transports authenticate with the Consumer Key and Consumer Secret pair
issued by the TurboSMTP dashboard, not with the account email and password. The
SMTP transport sends the key as the SMTP username and the secret as the SMTP
password, which is what the provider documents for `pro.turbo-smtp.com`.

### Webhooks

The bridge ships a request parser and a payload converter for the TurboSMTP
Event Webhook. Configure the webhook URL in the dashboard under
Settings > Notifications, then route it:

```yaml
framework:
    webhook:
        routing:
            turbosmtp:
                service: mailer.webhook.request_parser.turbosmtp
                secret: '%env(TURBOSMTP_WEBHOOK_SECRET)%' # optional
```

All nine documented statuses are mapped onto the standard remote events.
`PROCESSED`, `DELIVERED`, `DEFERRED`, `BOUNCED` and `DROPPED` become a
`MailerDeliveryEvent`, `OPENED`, `CLICKED`, `UNSUBSCRIBED` and `REPORT` become a
`MailerEngagementEvent`. For drops and bounces TurboSMTP nests the receiving
server answer in a `reason` object, and the converter unwraps its `response` key
into the event reason.

TurboSMTP does not sign its webhook requests. Authentication is therefore
optional and, when a route `secret` is configured, done with HTTP Basic: put
`https://USER:PASS@example.com/webhook/turbosmtp` in the dashboard and set
`USER:PASS` as the route secret. Requests that do not match are rejected with a
403, and malformed or unknown payloads with a 406. Leaving the secret empty
disables the check.

### Documentation

A symfony-docs PR should cover:

 * the new row in the mailer third party transports table: package
   `symfony/turbo-smtp-mailer`, webhook support yes;
 * the three DSN schemes, that `turbosmtp` aliases `turbosmtp+smtp`, and when to
   prefer the API transport;
 * the `default` host versus the EU hosts, and that the region is a property of
   the account;
 * that the DSN user and password are the Consumer Key and Consumer Secret from
   the dashboard;
 * the webhook routing snippet, the consumer example, the list of mapped events,
   and the fact that the route secret is optional and checked as HTTP Basic
   credentials.
