### PR TITLE
[Messenger] Do not wrap the Doctrine transport keepalive in a transaction

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -309,87 +309,41 @@ class ConnectionTest extends TestCase
 
         $connection = new Connection(['redeliver_timeout' => 30, 'table_name' => 'messenger_messages'], $driverConnection);
 
-        $queryBuilder->expects($this->once())
-            ->method('update')
-            ->with('messenger_messages')
-            ->willReturnSelf();
+        $queryBuilder->expects($this->once())->method('update')->with('messenger_messages')->willReturnSelf();
+        $queryBuilder->expects($this->once())->method('set')->with('delivered_at', '?')->willReturnSelf();
+        $queryBuilder->expects($this->once())->method('where')->with('id = ?')->willReturnSelf();
+        $queryBuilder->expects($this->once())->method('getSQL')->willReturn('UPDATE');
 
-        $queryBuilder->expects($this->once())
-            ->method('set')
-            ->with('delivered_at', '?')
-            ->willReturnSelf();
+        $driverConnection->expects($this->once())->method('createQueryBuilder')->willReturn($queryBuilder);
+        $driverConnection->expects($this->once())->method('executeStatement')->with('UPDATE');
 
-        $queryBuilder->expects($this->once())
-            ->method('where')
-            ->with('id = ?')
-            ->willReturnSelf();
-
-        $driverConnection->expects($this->once())
-            ->method('beginTransaction');
-
-        $driverConnection->expects($this->once())
-            ->method('createQueryBuilder')
-            ->willReturn($queryBuilder);
-
-        $queryBuilder->expects($this->once())
-            ->method('getSQL')
-            ->willReturn('UPDATE');
-
-        $driverConnection->expects($this->once())
-            ->method('executeStatement')
-            ->with('UPDATE')
-            ->willReturn(1);
-
-        $driverConnection->expects($this->once())
-            ->method('commit');
+        // the keepalive runs from a signal handler that can interrupt the connection between a
+        // driver call and its nesting-level update, where a transaction corrupts that state
+        $driverConnection->expects($this->never())->method('beginTransaction');
+        $driverConnection->expects($this->never())->method('commit');
+        $driverConnection->expects($this->never())->method('rollBack');
 
         $connection->keepalive('1');
     }
 
-    public function testKeepaliveRollback()
+    public function testKeepaliveWrapsFailuresInTransportException()
     {
-        $queryBuilder = $this->getQueryBuilderMock();
+        $queryBuilder = $this->createStub(QueryBuilder::class);
+        $queryBuilder->method('update')->willReturnSelf();
+        $queryBuilder->method('set')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('getSQL')->willReturn('UPDATE');
+
         $driverConnection = $this->getDBALConnection(true);
+        $driverConnection->method('createQueryBuilder')->willReturn($queryBuilder);
+        $driverConnection->method('executeStatement')->willThrowException(new \RuntimeException('No connection.'));
+
+        $driverConnection->expects($this->never())->method('rollBack');
 
         $connection = new Connection(['redeliver_timeout' => 30, 'table_name' => 'messenger_messages'], $driverConnection);
 
-        $queryBuilder->expects($this->once())
-            ->method('update')
-            ->with('messenger_messages')
-            ->willReturnSelf();
-
-        $queryBuilder->expects($this->once())
-            ->method('set')
-            ->with('delivered_at', '?')
-            ->willReturnSelf();
-
-        $queryBuilder->expects($this->once())
-            ->method('where')
-            ->with('id = ?')
-            ->willReturnSelf();
-
-        $driverConnection->expects($this->once())
-            ->method('beginTransaction');
-
-        $driverConnection->expects($this->once())
-            ->method('createQueryBuilder')
-            ->willReturn($queryBuilder);
-
-        $queryBuilder->expects($this->once())
-            ->method('getSQL')
-            ->willReturn('UPDATE');
-
-        $driverConnection->expects($this->once())
-            ->method('executeStatement')
-            ->willThrowException($this->createStub(DBALException::class));
-
-        $driverConnection->expects($this->never())
-            ->method('commit');
-
-        $driverConnection->expects($this->once())
-            ->method('rollBack');
-
         $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('No connection.');
 
         $connection->keepalive('1');
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -50,6 +50,30 @@ class DoctrineIntegrationTest extends TestCase
         $this->assertEquals(['type' => DummyMessage::class], $encoded['headers']);
     }
 
+    public function testKeepaliveRenewsTheLease()
+    {
+        $this->connection->send('{"message": "Hi"}', ['type' => DummyMessage::class]);
+        $encoded = $this->connection->get();
+        $this->driverConnection->executeStatement('UPDATE messenger_messages SET delivered_at = ? WHERE id = ?', ['2000-01-01 00:00:00', $encoded['id']]);
+
+        $this->connection->keepalive($encoded['id']);
+
+        $this->assertNotSame('2000-01-01 00:00:00', $this->driverConnection->fetchOne('SELECT delivered_at FROM messenger_messages WHERE id = ?', [$encoded['id']]));
+    }
+
+    public function testKeepaliveWhileTheConnectionIsInATransaction()
+    {
+        $this->connection->send('{"message": "Hi"}', ['type' => DummyMessage::class]);
+        $encoded = $this->connection->get();
+        $this->driverConnection->executeStatement('UPDATE messenger_messages SET delivered_at = ? WHERE id = ?', ['2000-01-01 00:00:00', $encoded['id']]);
+
+        $this->driverConnection->beginTransaction();
+        $this->connection->keepalive($encoded['id']);
+        $this->driverConnection->commit();
+
+        $this->assertNotSame('2000-01-01 00:00:00', $this->driverConnection->fetchOne('SELECT delivered_at FROM messenger_messages WHERE id = ?', [$encoded['id']]));
+    }
+
     public function testSendWithDelay()
     {
         $this->connection->send('{"message": "Hi i am delayed"}', ['type' => DummyMessage::class], 600000);

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlKeepaliveIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrinePostgreSqlKeepaliveIntegrationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\Transport;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection as DBALConnection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Tools\DsnParser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
+
+/**
+ * Reproduces the messenger:consume --keepalive SIGALRM race: keepalive is
+ * delivered by a signal handler that pcntl async signals can run between any
+ * two opcodes, including inside a transport transaction's commit, after the
+ * driver-level COMMIT has completed but before DBAL decrements its
+ * transaction nesting counter. A keepalive touching the transport connection
+ * in that window issues SAVEPOINT against an idle session, corrupts the
+ * counter, and fails the interrupted send even though its INSERT committed.
+ *
+ * The driver middleware below raises SIGALRM to the current process right
+ * after the armed driver-level COMMIT returns, which is by construction
+ * inside that window.
+ */
+#[RequiresPhpExtension('pdo_pgsql')]
+#[RequiresPhpExtension('pcntl')]
+#[RequiresPhpExtension('posix')]
+#[Group('integration')]
+class DoctrinePostgreSqlKeepaliveIntegrationTest extends TestCase
+{
+    private DBALConnection $driverConnection;
+    private Connection $connection;
+    private \stdClass $alarm;
+
+    protected function setUp(): void
+    {
+        if (!$host = getenv('POSTGRES_HOST')) {
+            $this->markTestSkipped('Missing POSTGRES_HOST env variable');
+        }
+
+        $this->alarm = new \stdClass();
+        $this->alarm->armed = false;
+
+        $url = "pdo-pgsql://postgres:password@$host";
+        $params = (new DsnParser())->parse($url);
+        $config = new Configuration();
+        if (class_exists(DefaultSchemaManagerFactory::class)) {
+            $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+        }
+        $config->setMiddlewares([$this->createAlarmOnCommitMiddleware($this->alarm)]);
+
+        $this->driverConnection = DriverManager::getConnection($params, $config);
+        $this->connection = new Connection(['table_name' => 'keepalive_queue_table'], $this->driverConnection);
+        $this->connection->setup();
+    }
+
+    protected function tearDown(): void
+    {
+        if (\function_exists('pcntl_signal')) {
+            pcntl_signal(\SIGALRM, \SIG_DFL);
+        }
+
+        if (!isset($this->driverConnection)) {
+            return;
+        }
+        $this->driverConnection->createSchemaManager()->dropTable('keepalive_queue_table');
+        $this->driverConnection->close();
+    }
+
+    public function testKeepaliveInterruptingASendCommitLeavesTheSendIntact()
+    {
+        $inFlightId = $this->connection->send('{"message": "in-flight"}', []);
+
+        // What ConsumeMessagesCommand::handleSignal() runs when the keepalive alarm fires
+        $connection = $this->connection;
+        pcntl_async_signals(true);
+        pcntl_signal(\SIGALRM, static function () use ($connection, $inFlightId): void {
+            $connection->keepalive($inFlightId);
+        });
+
+        $this->alarm->armed = true;
+        $victimId = $this->connection->send('{"message": "victim"}', []);
+
+        $this->assertSame(1, (int) $this->driverConnection->fetchOne('SELECT COUNT(*) FROM keepalive_queue_table WHERE id = ?', [$victimId]), 'The interrupted send must store the message exactly once.');
+        $this->assertNotNull($this->driverConnection->fetchOne('SELECT delivered_at FROM keepalive_queue_table WHERE id = ?', [$inFlightId]), 'The keepalive must have renewed the delivered_at lease.');
+        $this->assertFalse($this->driverConnection->isTransactionActive(), 'The transport connection must come out of the interrupted send with a clean transaction state.');
+    }
+
+    private function createAlarmOnCommitMiddleware(\stdClass $alarm): Middleware
+    {
+        return new class($alarm) implements Middleware {
+            public function __construct(private \stdClass $alarm)
+            {
+            }
+
+            public function wrap(Driver $driver): Driver
+            {
+                return new class($driver, $this->alarm) extends AbstractDriverMiddleware {
+                    public function __construct(Driver $driver, private \stdClass $alarm)
+                    {
+                        parent::__construct($driver);
+                    }
+
+                    public function connect(#[\SensitiveParameter] array $params): Driver\Connection
+                    {
+                        return new class(parent::connect($params), $this->alarm) extends AbstractConnectionMiddleware {
+                            public function __construct(Driver\Connection $connection, private \stdClass $alarm)
+                            {
+                                parent::__construct($connection);
+                            }
+
+                            public function commit(): void
+                            {
+                                parent::commit();
+
+                                if ($this->alarm->armed) {
+                                    $this->alarm->armed = false;
+                                    posix_kill(posix_getpid(), \SIGALRM);
+                                    usleep(1); // an opcode boundary, so the async signal handler runs before commit() returns to DBAL
+                                }
+                            }
+                        };
+                    }
+                };
+            }
+        };
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -271,23 +271,21 @@ class Connection implements ResetInterface
             throw new TransportException(\sprintf('Doctrine redeliver_timeout (%ds) cannot be smaller than the keepalive interval (%ds).', $this->configuration['redeliver_timeout'], $seconds));
         }
 
-        $this->driverConnection->beginTransaction();
+        // No transaction here: the keepalive runs from a SIGALRM handler that can interrupt the
+        // connection between the driver call and the nesting-level update, where beginTransaction()
+        // would issue a SAVEPOINT against an idle session and corrupt the nesting state.
         try {
             $queryBuilder = $this->driverConnection->createQueryBuilder()
                 ->update($this->configuration['table_name'])
                 ->set('delivered_at', '?')
                 ->where('id = ?');
-            $now = new \DateTimeImmutable('UTC');
             $this->executeStatement($queryBuilder->getSQL(), [
-                $now,
+                new \DateTimeImmutable('UTC'),
                 $id,
             ], [
                 Types::DATETIME_IMMUTABLE,
             ]);
-
-            $this->driverConnection->commit();
         } catch (\Throwable $e) {
-            $this->driverConnection->rollBack();
             throw new TransportException($e->getMessage(), 0, $e);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64912
| License       | MIT

DBAL increments its transaction nesting counter *before* the driver call and decrements it only in the `finally` block, so between those two points the counter reads 1 while the session is already idle.

`pcntl_async_signals(true)` lets the keepalive `SIGALRM` handler run at any opcode boundary, including inside that window. Landing there, `Connection::keepalive()` called `beginTransaction()`, which saw level 1, treated it as nested and issued `SAVEPOINT` against an idle session. PostgreSQL rejects that with 25P01, the counter stays poisoned, and the interrupted `send()` unwinds into a `rollBack()` that throws `There is no active transaction` and masks the original error, while its INSERT has already committed. The message is in the table and the sender reports failure, so the retry listener duplicates it.

A single `UPDATE` never needed a transaction, so the wrapper is simply removed.

Approach changed during review. The first version routed the keepalive to a second DBAL connection built from `$this->driverConnection->getParams()`. That fixed the race but introduced two regressions, both measured:

* in-memory SQLite lost keepalive entirely, because `DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true])` opens a new, empty database, so every tick threw `no such table: messenger_messages`. That is the default DSN of this bridge's own `DoctrineIntegrationTest`;
* with a file-backed SQLite database and an open write transaction on the transport connection, the second connection blocked on the write lock for the full driver busy timeout: 59.1 s against 0.0 s on the base branch, inside a signal handler, so the whole worker froze.

Dropping the transaction avoids both, keeps using the existing `executeStatement()` helper with its auto-setup retry, needs no second connection, and does not depend on `Connection::getParams()`, which DBAL marks `@internal`.

Tests:

* `ConnectionTest::testKeepalive` and `::testKeepaliveWrapsFailuresInTransportException` assert that the lease is renewed and that the connection's transaction methods are never touched. Both fail on the base branch;
* `DoctrineIntegrationTest::testKeepaliveRenewsTheLease` and `::testKeepaliveWhileTheConnectionIsInATransaction` run against a real connection. These pass on the base branch too: they protect the behaviour rather than prove the fix;
* `DoctrinePostgreSqlKeepaliveIntegrationTest` is the only real reproduction of the race. Its driver middleware raises `SIGALRM` right after the armed driver-level COMMIT returns, which is by construction inside the poisoned window. It needs `POSTGRES_HOST` and runs in the integration job.
