### PR TITLE
[String] Fix AsciiSlugger::getLocale() TypeError with no locale set

### DIFF
--- a/src/Symfony/Component/String/Slugger/AsciiSlugger.php
+++ b/src/Symfony/Component/String/Slugger/AsciiSlugger.php
@@ -84,7 +84,7 @@ class AsciiSlugger implements SluggerInterface, LocaleAwareInterface
 
     public function getLocale(): string
     {
-        return $this->defaultLocale;
+        return $this->defaultLocale ?? '';
     }
 
     /**

--- a/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
+++ b/src/Symfony/Component/String/Tests/Slugger/AsciiSluggerTest.php
@@ -121,4 +121,14 @@ class AsciiSluggerTest extends TestCase
 
         $this->assertSame('a-and-a-go-to', (string) $slugger->slug('a 😺, 🐈‍⬛, and a 🦁 go to 🏞️... 😍 🎉 💛', '-'));
     }
+
+    public function testGetLocaleDefaultsToEmptyString()
+    {
+        $slugger = new AsciiSlugger();
+
+        $this->assertSame('', $slugger->getLocale());
+
+        $slugger->setLocale('en');
+        $this->assertSame('en', $slugger->getLocale());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`AsciiSlugger::getLocale()` is typed `: string` (via `LocaleAwareInterface`) but returns the nullable `$defaultLocale` property, so calling it on a slugger created without a locale throws a `TypeError`.

Returning `''` when no locale is set matches what `slug()` already does. It skips locale-specific transliteration and keys the symbols map on `$locale ?? ''`.

`Translator::getLocale()` falls back to `\Locale::getDefault()`, but `slug()` applies no locale by default, so returning one would report a locale the slugger never uses and would need `ext-intl`, which this component does not require.
