### PR TITLE
Forward message groups on standard SQS queues

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -468,6 +468,23 @@ class ConnectionTest extends TestCase
         $connection->reject($id);
     }
 
+    public function testSendWithMessageGroupIdOnStandardQueue()
+    {
+        $queueUrl = 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue';
+        $client = $this->createMock(SqsClient::class);
+        $client->expects($this->once())->method('sendMessage')->with([
+            'QueueUrl' => $queueUrl,
+            'MessageBody' => 'body',
+            'MessageAttributes' => [],
+            'MessageSystemAttributes' => [],
+            'DelaySeconds' => 30,
+            'MessageGroupId' => 'group',
+        ]);
+
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, $queueUrl);
+        $connection->send('body', [], 30, 'group', 'deduplication');
+    }
+
     public function testKeepaliveWithTooSmallTtl()
     {
         $client = $this->createMock(SqsClient::class);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -407,6 +407,8 @@ class Connection
             $parameters['MessageGroupId'] = $messageGroupId ?? __METHOD__;
             $parameters['MessageDeduplicationId'] = $messageDeduplicationId ?? sha1(json_encode(['body' => $body, 'headers' => $headers]));
             unset($parameters['DelaySeconds']);
+        } elseif (null !== $messageGroupId) {
+            $parameters['MessageGroupId'] = $messageGroupId;
         }
 
         $this->client->sendMessage($parameters);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | No existing issue
| License       | MIT

## Description

Allow Amazon SQS message groups to be used with Standard queues.

AWS supports fair queue scheduling on Standard queues when producers provide `MessageGroupId`. Preserve existing FIFO behavior while forwarding an explicitly provided group ID for Standard queues.

Standard queues continue to:
- Retain `DelaySeconds`
- Omit `MessageDeduplicationId`

## Tests

- Added regression coverage for Standard queue message group parameters.
- PHP syntax checks pass.
- PHPUnit could not run locally because PHP 8.3 is below the repository requirement.
