### PR TITLE
[Messenger] Strip trace from nested exceptions in ErrorDetailsStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
@@ -43,6 +43,9 @@ final class ErrorDetailsStamp implements StampInterface
         if (!$throwable instanceof RecoverableExceptionInterface && class_exists(FlattenException::class)) {
             $flattenException = FlattenException::createFromThrowable($throwable);
             $flattenException->setTrace([], $throwable->getFile(), $throwable->getLine());
+            foreach ($flattenException->getAllPrevious() as $previous) {
+                $previous->setTrace([], $previous->getFile(), $previous->getLine());
+            }
         }
 
         return new self($throwable::class, $throwable->getCode(), $throwable->getMessage(), $flattenException);

--- a/src/Symfony/Component/Messenger/Tests/Stamp/ErrorDetailsStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/ErrorDetailsStampTest.php
@@ -55,6 +55,28 @@ class ErrorDetailsStampTest extends TestCase
         $this->assertEquals($flattenException, $stamp->getFlattenException());
     }
 
+    public function testStripsTraceFromNestedExceptions()
+    {
+        $deepestException = new \Exception('I am the deepest');
+        $nestedException = new \Exception('I am nested', 0, $deepestException);
+        $exception = new \Exception('I am on top', 0, $nestedException);
+
+        $stamp = ErrorDetailsStamp::create($exception);
+        $flattenException = $stamp->getFlattenException();
+
+        $this->assertNotNull($flattenException);
+        $nested = $flattenException->getPrevious();
+        $this->assertNotNull($nested);
+        $deepest = $nested->getPrevious();
+        $this->assertNotNull($deepest);
+
+        $this->assertCount(1, $flattenException->getTrace());
+        $this->assertCount(1, $nested->getTrace());
+        $this->assertCount(1, $deepest->getTrace());
+        $this->assertNotSame('', $nested->getTraceAsString());
+        $this->assertNotSame('', $deepest->getTraceAsString());
+    }
+
     public function testDeserialization()
     {
         $exception = new \Exception('exception message');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follow-up to #63288, relates to #44943
| License       | MIT

#63288 reduced the serialized size of `ErrorDetailsStamp` by stripping the structured trace from the `FlattenException`, while keeping `traceAsString`:

```php
$flattenException = FlattenException::createFromThrowable($throwable);
$flattenException->setTrace([], $throwable->getFile(), $throwable->getLine());
```

However, `FlattenException::createFromThrowable()` builds the exception chain recursively and sets a full trace on **every** nested exception, while `create()` calls `setTrace([], ...)` only on the top-level one. Handler failures are almost always wrapped exceptions (the real cause is nested), so the nested traces still bloat the serialized stamp. This is the same payload-size problem #63288 addressed, originally reported in #44943 for size-limited transports such as SQS or Beanstalk.

This applies the same strip to the whole chain via `getAllPrevious()`, keeping `traceAsString` on every level (unchanged, as intended by #63288).

In a local reproduction (a two-level nested exception with ~13 trace frames each), the serialized `ErrorDetailsStamp` shrinks from ~14 KB to ~8 KB; real-world chains are deeper.

FYI: @nicolas-grekas @HypeMC 