### PR TITLE
 Handle PHP 8.6 removing function arguments in error messages

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/RemotePackageStorageTest.php
@@ -52,7 +52,7 @@ class RemotePackageStorageTest extends TestCase
         $entry = ImportMapEntry::createRemote('foo', ImportMapType::JS, '/does/not/matter', '1.0.0', 'module_specifier', false);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('file_put_contents('.$vendorDir.'/module_specifier/module_specifier.index.js): Failed to open stream: Permission denied');
+        $this->expectExceptionMessageMatches('#^file_put_contents\(('.$vendorDir.'/module_specifier/module_specifier.index.js)?\): Failed to open stream: Permission denied$#');
 
         try {
             $storage->save($entry, 'any content');

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -128,7 +128,7 @@ class ErrorHandlerTest extends TestCase
     public function testFailureCall()
     {
         $this->expectException(\ErrorException::class);
-        $this->expectExceptionMessageMatches('/^fopen\(unknown\.txt\): [Ff]ailed to open stream: No such file or directory$/');
+        $this->expectExceptionMessageMatches('/^fopen\((unknown\.txt)?\): Failed to open stream: No such file or directory$/');
 
         ErrorHandler::call('fopen', 'unknown.txt', 'r');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Following https://github.com/php/php-src/pull/22792