### PR TITLE
[TwigBridge] prevent implicit string casts for translatable message objects

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -94,7 +94,7 @@
             {% set embed_label_classes = parent_label_class|split(' ')|filter(class => class in ['checkbox-inline', 'radio-inline']) %}
             {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ embed_label_classes|join(' '))|trim}) -%}
         {% endif %}
-        {%- if label is null or label == '' -%}
+        {%- if label is null or label is same as('') -%}
             {%- if label_format is not empty -%}
                 {%- set label = label_format|replace({
                     '%name%': name,

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -279,7 +279,7 @@
 {%- endblock form_label -%}
 
 {%- block form_label_content -%}
-    {%- if label is null or label == '' -%}
+    {%- if label is null or label is same as('') -%}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({
                 '%name%': name,

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -261,7 +261,7 @@
         {% set embed_label_classes = parent_label_class|split(' ')|filter(class => class in ['checkbox-inline', 'radio-inline']) %}
         {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ embed_label_classes|join(' '))|trim}) -%}
     {% endif %}
-    {% if label is null or label == '' %}
+    {% if label is null or label is same as('') %}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({
                 '%name%': name,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

With the `==` operator any `TranslatableMessage` instance is cast to `string` first triggering a deprecation (see https://github.com/symfony/symfony/actions/runs/29821288589/job/88604266586#step:9:312).