### PR TITLE
 Do not expose the `BundleAdapter` class in the `kernel.bundles` parameter

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/BundleAdapter.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleAdapter.php
@@ -67,4 +67,9 @@ final class BundleAdapter implements BundleInterface
     {
         $this->bundle->setContainer($container);
     }
+
+    public function getInnerBundle(): BaseBundleInterface
+    {
+        return $this->bundle;
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -231,6 +231,9 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
         ];
 
         foreach ($this->bundles as $name => $bundle) {
+            if ($bundle instanceof BundleAdapter) {
+                $parameters['kernel.bundles'][$name] = $bundle->getInnerBundle()::class;
+            }
             $parameters['kernel.bundles_metadata'][$name]['namespace'] = $bundle->getNamespace();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`KernelTrait::getKernelParameters()` builds the `kernel.bundles` parameter, which is a mapping from bundle names to bundle classes.

Starting in 8.1, the `HttpKernel` (in `\Symfony\Component\HttpKernel\Kernel::initializeBundles`) wraps an internal `BundleAdapter` helper class around bundle instances that already implement the new `Symfony\Component\DependencyInjection\Kernel\BundleInterface` interface.

That leads to `BundleAdapter` being exposed as the supposed bundle class in that kernel parameter.

I am not sure about the guarantees made regarding the `kernel.bundles` parameter and what downstream clients may expect to find there. But at least in DoctrineBundle, this parameter serves as a starting point to derive mapping information, for which the bundle class name is required:

https://github.com/doctrine/DoctrineBundle/blob/940ff32c627be92234362614f413fe041d83a5ce/src/DependencyInjection/DoctrineExtension.php#L164-L171

Not sure if this PR is the right fix, but I'd say `BundleAdapter` as a temporary (?), internal class should never be exposed in `kernel.bundles`.

It might be that DoctrineBundle (and other bundles alike) were wrong when taking the bundle class name from that parameter in the first place. However, not fixing it here might cause a lot of confusion and breakage across all those places once people start migrating to the new bundle base class.