### PR TITLE
[Messenger] Fix ack/reject failing when the Redis stream entry is already deleted

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -361,6 +361,37 @@ class ConnectionTest extends TestCase
         $connection->ack('1');
     }
 
+    public function testDeleteAfterAckDoesNotFailWhenAlreadyDeleted()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->exactly(1))->method('xack')
+            ->with('queue', 'symfony', ['1'])
+            ->willReturn(1);
+        $redis->expects($this->exactly(1))->method('xdel')
+            ->with('queue', ['1'])
+            ->willReturn(0);
+
+        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
+        $connection->ack('1');
+    }
+
+    public function testAckThrowsWhenNotAcknowledged()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->exactly(1))->method('xack')
+            ->with('queue', 'symfony', ['1'])
+            ->willReturn(0);
+        $redis->expects($this->never())->method('xdel');
+
+        $connection = Connection::fromDsn('redis://localhost/queue', [], $redis);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not acknowledge redis message "1".');
+        $connection->ack('1');
+    }
+
     public function testDeleteAfterReject()
     {
         $redis = $this->createRedisMock();
@@ -373,6 +404,37 @@ class ConnectionTest extends TestCase
             ->willReturn(1);
 
         $connection = Connection::fromDsn('redis://localhost/queue?delete_after_reject=true', [], $redis);
+        $connection->reject('1');
+    }
+
+    public function testDeleteAfterRejectDoesNotFailWhenAlreadyDeleted()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->exactly(1))->method('xack')
+            ->with('queue', 'symfony', ['1'])
+            ->willReturn(1);
+        $redis->expects($this->exactly(1))->method('xdel')
+            ->with('queue', ['1'])
+            ->willReturn(0);
+
+        $connection = Connection::fromDsn('redis://localhost/queue?delete_after_reject=true', [], $redis);
+        $connection->reject('1');
+    }
+
+    public function testRejectThrowsWhenNotInPendingList()
+    {
+        $redis = $this->createRedisMock();
+
+        $redis->expects($this->exactly(1))->method('xack')
+            ->with('queue', 'symfony', ['1'])
+            ->willReturn(0);
+        $redis->expects($this->never())->method('xdel');
+
+        $connection = Connection::fromDsn('redis://localhost/queue?delete_after_reject=true', [], $redis);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Could not reject redis message "1".');
         $connection->reject('1');
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -541,8 +541,10 @@ class Connection
 
         try {
             $acknowledged = $redis->xack($this->stream, $this->group, [$id]);
-            if ($this->deleteAfterAck) {
-                $acknowledged = $redis->xdel($this->stream, [$id]);
+
+            // the ack decides the outcome: the entry may already be gone from the stream (e.g. trimmed), deleting it is best effort
+            if ($acknowledged && $this->deleteAfterAck && false === $redis->xdel($this->stream, [$id])) {
+                $redis->clearLastError();
             }
         } catch (\RedisException|\Relay\Exception $e) {
             throw new TransportException($e->getMessage(), 0, $e);
@@ -563,19 +565,21 @@ class Connection
         $redis = $this->getRedis();
 
         try {
-            $deleted = $redis->xack($this->stream, $this->group, [$id]);
-            if ($this->deleteAfterReject) {
-                $deleted = $redis->xdel($this->stream, [$id]) && $deleted;
+            $rejected = $redis->xack($this->stream, $this->group, [$id]);
+
+            // same as in ack(): the entry may already be gone from the stream, deleting it is best effort
+            if ($rejected && $this->deleteAfterReject && false === $redis->xdel($this->stream, [$id])) {
+                $redis->clearLastError();
             }
         } catch (\RedisException|\Relay\Exception $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
 
-        if (!$deleted) {
+        if (!$rejected) {
             if ($error = $redis->getLastError() ?: null) {
                 $redis->clearLastError();
             }
-            throw new TransportException($error ?? \sprintf('Could not delete message "%s" from the redis stream.', $id));
+            throw new TransportException($error ?? \sprintf('Could not reject redis message "%s".', $id));
         }
 
         unset($this->inflightIds[$id]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53406, related to #64925
| License       | MIT

With `delete_after_ack` (the default since 6.0), Redis `Connection::ack()` replaced the `XACK` result with the optional `XDEL` result. Per Redis Streams semantics, trimming or deleting an entry does not remove it from a consumer group's PEL, so a message can be acknowledged successfully while `XDEL` returns `0` because the entry is already gone, e.g. trimmed by `stream_max_entries` (`XADD ... MAXLEN ~`), removed by an external `XTRIM`/`XDEL`, or deleted through another consumer group. The falsy `XDEL` result then made `ack()` throw `TransportException: Could not acknowledge redis message`, killing `messenger:consume` even though the acknowledgement succeeded.

`reject()` had the same bug through `delete_after_reject` (also `true` by default), crashing the worker on the failure/retry path with `Could not delete message`.

This ties the outcome of `ack()`/`reject()` to `XACK` and makes the deletion best effort:
- the entry is only deleted after a successful `XACK` (deleting an entry that could not be acknowledged might destroy a message owned by another consumer);
- `XDEL` returning `0` is not a failure; an `XDEL` error reply (`false`) is ignored as well, and its `lastError` is cleared so it cannot leak into a later error message.

Behavior notes:
- `XACK` returning `0` still throws; this is why this PR does not fix #64925: its reproduction (two workers sharing the same consumer name) fails on `XACK` itself, and keeping that loud signals the misconfiguration (consumer names must be unique).
- Previously, a failed `XACK` combined with a successful `XDEL` was silently reported as success in both methods; it now throws, and the deletion is not attempted.
- The `reject()` exception message changes from `Could not delete message "%s" from the redis stream.` to `Could not reject redis message "%s".`, matching what the failure now means.

