### PR TITLE
[HttpClient] Do not stream empty PSR-18 request bodies

### DIFF
--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -236,7 +236,7 @@ final class HttplugClient implements ClientInterface, HttpAsyncClient, RequestFa
                 $headers['Content-Length'] = [$size];
             }
 
-            if (0 === $size) {
+            if (0 === $size || (0 > $size && !$body->isSeekable() && $body->eof())) {
                 $body = '';
             } elseif (0 < $size && $size < 1 << 21) {
                 if ($body->isSeekable()) {

--- a/src/Symfony/Component/HttpClient/Psr18Client.php
+++ b/src/Symfony/Component/HttpClient/Psr18Client.php
@@ -100,7 +100,7 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
                 $headers['Content-Length'] = [$size];
             }
 
-            if (0 === $size) {
+            if (0 === $size || (0 > $size && !$body->isSeekable() && $body->eof())) {
                 $body = '';
             } elseif (0 < $size && $size < 1 << 21) {
                 if ($body->isSeekable()) {

--- a/src/Symfony/Component/HttpClient/Tests/Fixtures/UnknownSizeStream.php
+++ b/src/Symfony/Component/HttpClient/Tests/Fixtures/UnknownSizeStream.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Fixtures;
+
+use Nyholm\Psr7\Stream;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * A stream that doesn't know its size, as allowed by PSR-7 and exhibited by
+ * pipe-backed streams (e.g. "php://input") or by Guzzle's Pump/CachingStream.
+ */
+class UnknownSizeStream implements StreamInterface
+{
+    private StreamInterface $inner;
+
+    public function __construct(
+        string $content,
+        private bool $seekable = true,
+    ) {
+        $this->inner = Stream::create($content);
+    }
+
+    public function getSize(): ?int
+    {
+        return null;
+    }
+
+    public function isSeekable(): bool
+    {
+        return $this->seekable;
+    }
+
+    public function seek(int $offset, int $whence = \SEEK_SET): void
+    {
+        if (!$this->seekable) {
+            throw new \RuntimeException('Stream is not seekable.');
+        }
+
+        $this->inner->seek($offset, $whence);
+    }
+
+    public function rewind(): void
+    {
+        $this->seek(0);
+    }
+
+    public function __toString(): string
+    {
+        return $this->inner->__toString();
+    }
+
+    public function close(): void
+    {
+        $this->inner->close();
+    }
+
+    public function detach(): mixed
+    {
+        return $this->inner->detach();
+    }
+
+    public function tell(): int
+    {
+        return $this->inner->tell();
+    }
+
+    public function eof(): bool
+    {
+        return $this->inner->eof();
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+
+    public function write(string $string): int
+    {
+        throw new \RuntimeException('Stream is not writable.');
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function read(int $length): string
+    {
+        return $this->inner->read($length);
+    }
+
+    public function getContents(): string
+    {
+        return $this->inner->getContents();
+    }
+
+    public function getMetadata(?string $key = null): mixed
+    {
+        return $this->inner->getMetadata($key);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttplugClientTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpClient\HttplugClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Tests\Fixtures\UnknownSizeStream;
 use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class HttplugClientTest extends TestCase
@@ -117,6 +118,20 @@ class HttplugClientTest extends TestCase
         $body = json_decode((string) $response->getBody(), true);
 
         $this->assertSame(['foo' => '0123456789', 'REQUEST_METHOD' => 'POST'], $body);
+    }
+
+    public function testRequestWithEmptyUnknownSizeBodyDoesNotPassAStreamingBody()
+    {
+        $client = new HttplugClient(new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
+            $this->assertSame('TRACE', $method);
+            $this->assertSame('', $options['body']);
+
+            return new MockResponse();
+        }));
+        $body = new UnknownSizeStream('', seekable: false);
+        $body->getContents();
+
+        $client->sendRequest($client->createRequest('TRACE', 'http://localhost')->withBody($body));
     }
 
     public function testNetworkException()

--- a/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Psr18ClientTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpClient\Psr18Client;
 use Symfony\Component\HttpClient\Psr18NetworkException;
 use Symfony\Component\HttpClient\Psr18RequestException;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Tests\Fixtures\UnknownSizeStream;
 use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class Psr18ClientTest extends TestCase
@@ -57,6 +58,46 @@ class Psr18ClientTest extends TestCase
         $body = json_decode((string) $response->getBody(), true);
 
         $this->assertSame(['foo' => '0123456789', 'REQUEST_METHOD' => 'POST'], $body);
+    }
+
+    public function testRequestWithEmptyUnknownSizeBodyDoesNotPassAStreamingBody()
+    {
+        $factory = new Psr17Factory();
+        $body = new UnknownSizeStream('', seekable: false);
+        $body->getContents();
+        $client = new Psr18Client(new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
+            $this->assertSame('TRACE', $method);
+            $this->assertSame('', $options['body']);
+
+            return new MockResponse();
+        }), $factory, $factory);
+
+        $client->sendRequest($factory->createRequest('TRACE', 'http://localhost')->withBody($body));
+    }
+
+    public function testRequestWithConsumedSeekableUnknownSizeBodyIsRestreamed()
+    {
+        $factory = new Psr17Factory();
+        $body = new UnknownSizeStream('IMPORTANT-PAYLOAD');
+        $body->getContents();
+        $this->assertTrue($body->eof());
+        $client = new Psr18Client(new MockHttpClient(function (string $method, string $url, array $options) use (&$sentBody): MockResponse {
+            $sentBody = $options['body'];
+
+            if (!\is_string($sentBody)) {
+                $received = '';
+                while ('' !== $chunk = $sentBody()) {
+                    $received .= $chunk;
+                }
+                $sentBody = $received;
+            }
+
+            return new MockResponse();
+        }), $factory, $factory);
+
+        $client->sendRequest($factory->createRequest('POST', 'http://localhost')->withBody($body));
+
+        $this->assertSame('IMPORTANT-PAYLOAD', $sentBody);
     }
 
     public function testNetworkException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64901
| License       | MIT

`Psr18Client` used a streaming request body whenever the PSR-7 body size was unknown. Empty PSR-7 bodies can also have an unknown size, which made HttpClient see a non-empty `body` option and add `Content-Type: application/x-www-form-urlencoded` for non-POST requests.

This keeps unknown-size bodies streaming only when the stream is not already at EOF.

## Test verification (RED -> GREEN)

RED (upstream `7.4` + regression test only):
```text
Failed asserting that Closure Object is identical to ''.
FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
```

GREEN (patched branch):
```text
OK (1 test, 3 assertions)
```

Fix reverted -> RED:
```text
Failed asserting that Closure Object is identical to ''.
FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
```

PSR-18 test suite:
```text
OK (9 tests, 21 assertions)
```
