### PR TITLE
[PropertyInfo] Ignore mutators with several required parameters

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -315,19 +315,25 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             try {
                 $method = new \ReflectionMethod($class, $methodName);
                 if ($method->isStatic()) {
+                    $method = null;
+
                     continue;
                 }
 
                 if (self::ACCESSOR === $type && \in_array((string) $method->getReturnType(), ['void', 'never'], true)) {
+                    $method = null;
+
                     continue;
                 }
 
                 if (
                     (self::ACCESSOR === $type && !$method->getNumberOfRequiredParameters())
-                    || (self::MUTATOR === $type && $method->getNumberOfParameters() >= 1)
+                    || (self::MUTATOR === $type && $method->getNumberOfParameters() >= 1 && $method->getNumberOfRequiredParameters() <= 1)
                 ) {
                     break;
                 }
+
+                $method = null;
             } catch (\ReflectionException) {
                 // Try the next prefix if the method doesn't exist
             }

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -286,19 +286,25 @@ final class PhpStanExtractor implements PropertyTypeExtractorInterface, Construc
             try {
                 $method = new \ReflectionMethod($class, $methodName);
                 if ($method->isStatic()) {
+                    $method = null;
+
                     continue;
                 }
 
                 if (self::ACCESSOR === $type && \in_array((string) $method->getReturnType(), ['void', 'never'], true)) {
+                    $method = null;
+
                     continue;
                 }
 
                 if (
                     (self::ACCESSOR === $type && !$method->getNumberOfRequiredParameters())
-                    || (self::MUTATOR === $type && $method->getNumberOfParameters() >= 1)
+                    || (self::MUTATOR === $type && $method->getNumberOfParameters() >= 1 && $method->getNumberOfRequiredParameters() <= 1)
                 ) {
                     break;
                 }
+
+                $method = null;
             } catch (\ReflectionException) {
                 // Try the next prefix if the method doesn't exist
             }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -690,8 +690,9 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                         continue;
                     }
 
-                    // Parameter can be optional to allow things like: method(?array $foo = null)
-                    if ($reflectionMethod->getNumberOfParameters() >= 1) {
+                    // Parameter can be optional to allow things like: method(?array $foo = null),
+                    // but at most one parameter may be required, matching the write-access rules
+                    if ($reflectionMethod->getNumberOfParameters() >= 1 && $reflectionMethod->getNumberOfRequiredParameters() <= 1) {
                         return [$reflectionMethod, $prefix];
                     }
                 } catch (\ReflectionException) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -16,6 +16,8 @@ use phpDocumentor\Reflection\PseudoTypes\IntMaskOf;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDocDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\RejectedCandidateDocDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyCollection;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildOfParentUsingTrait;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Extractor\ChildOfParentWithPromotedSelfDocBlock;
@@ -46,6 +48,17 @@ class PhpDocExtractorTest extends TestCase
     protected function setUp(): void
     {
         $this->extractor = new PhpDocExtractor();
+    }
+
+    public function testAdderWithSeveralRequiredParametersIsIgnored()
+    {
+        $this->assertNull($this->extractor->getTypes(MultiParameterAdderDocDummy::class, 'link'));
+    }
+
+    public function testRejectedCandidateMethodsAreIgnored()
+    {
+        $this->assertNull($this->extractor->getTypes(RejectedCandidateDocDummy::class, 'foo'));
+        $this->assertNull($this->extractor->getTypes(RejectedCandidateDocDummy::class, 'bar'));
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\Clazz;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithoutDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDocDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\RejectedCandidateDocDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyCollection;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyGeneric;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\IFace;
@@ -45,6 +47,17 @@ class PhpStanExtractorTest extends TestCase
     {
         $this->extractor = new PhpStanExtractor();
         $this->phpDocExtractor = new PhpDocExtractor();
+    }
+
+    public function testAdderWithSeveralRequiredParametersIsIgnored()
+    {
+        $this->assertNull($this->extractor->getTypes(MultiParameterAdderDocDummy::class, 'link'));
+    }
+
+    public function testRejectedCandidateMethodsAreIgnored()
+    {
+        $this->assertNull($this->extractor->getTypes(RejectedCandidateDocDummy::class, 'foo'));
+        $this->assertNull($this->extractor->getTypes(RejectedCandidateDocDummy::class, 'bar'));
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -20,6 +20,9 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\AsymmetricVisibility;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended;
@@ -317,6 +320,16 @@ class ReflectionExtractorTest extends TestCase
             ['nothing', null],
             ['collection', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Traversable'), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Countable')]],
         ];
+    }
+
+    public function testExtractTypeFromPropertyDeclarationWhenAdderRequiresSeveralParameters()
+    {
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, true, MultiParameterAdderValue::class)], $this->extractor->getTypes(MultiParameterAdderDummy::class, 'link'));
+    }
+
+    public function testIsNotWritableWhenAdderRequiresSeveralParameters()
+    {
+        $this->assertFalse($this->extractor->isWritable(MultiParameterAdderParentDummy::class, 'link'));
     }
 
     public function testReadonlyPropertiesAreNotWriteable()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/MultiParameterAdderDocDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/MultiParameterAdderDocDummy.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class MultiParameterAdderDocDummy
+{
+    public $link;
+
+    /**
+     * @param \stdClass                $request
+     * @param MultiParameterAdderValue $link
+     */
+    public function addLink($request, $link)
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/MultiParameterAdderDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/MultiParameterAdderDummy.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class MultiParameterAdderDummy extends MultiParameterAdderParentDummy
+{
+    public ?MultiParameterAdderValue $link = null;
+}
+
+class MultiParameterAdderParentDummy
+{
+    public function addLink(\stdClass $request, MultiParameterAdderValue $link): void
+    {
+    }
+}
+
+class MultiParameterAdderValue
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/RejectedCandidateDocDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/RejectedCandidateDocDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class RejectedCandidateDocDummy
+{
+    public $foo;
+    public $bar;
+
+    /**
+     * @param string $foo
+     */
+    public static function setFoo($foo): void
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getBar(): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64922
| License       | MIT

`ReflectionExtractor::getTypes()` consults mutators before the property declaration, and `getMutatorMethod()` accepted any non-static `add`/`remove`/`set`-prefixed method with at least one parameter, blindly using its first parameter as the value type. Methods are resolved anywhere in the class hierarchy at any visibility, so a `link` property on a class extending `AbstractController` picked up the protected `addLink(Request $request, LinkInterface $link)` helper: the extracted type became `Request[]|null` instead of the declared `?Link`, breaking Serializer denormalization and LiveComponent hydration.

The fix caps mutator candidates at one required parameter, which is exactly the acceptance rule the write path (`isMethodAccessible()`) has always enforced. It applies to any such mutator, declared or inherited, and to removers and setters as well. `isWritable()` now returns `false` where the only candidate mutator could never be called with a single value, matching what `getWriteInfo()` already reported.

The same unguarded predicate existed in `PhpDocExtractor` and `PhpStanExtractor` for docblock-based extraction and is fixed identically. Doing so surfaced a second flaw in their shared candidate loop: a rejected candidate (too many required parameters, static, or a `void`/`never` accessor) leaked into the result when no later prefix matched, so its docblock was still trusted. Rejected candidates are now discarded, covered by tests for each case in both extractors.
