### PR TITLE
[Form] Keep unchecked empty-value checkboxes false on PATCH

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransfo
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CheckboxType extends AbstractType
@@ -63,6 +64,13 @@ class CheckboxType extends AbstractType
         ]);
 
         $resolver->setAllowedTypes('false_values', 'array');
+        $resolver->setNormalizer('false_values', static function (Options $options, array $falseValues): array {
+            if ('' === $options['value'] && !\in_array('0', $falseValues, true)) {
+                $falseValues[] = '0';
+            }
+
+            return $falseValues;
+        });
     }
 
     public function getBlockPrefix(): string

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class CheckboxTypeTest extends BaseTypeTestCase
@@ -126,6 +128,19 @@ class CheckboxTypeTest extends BaseTypeTestCase
 
         $this->assertFalse($form->getData());
         $this->assertNull($form->getViewData());
+    }
+
+    public function testSubmitNestedWithEmptyValueAndFalseUncheckedWithClearMissingFalse()
+    {
+        $form = $this->factory
+            ->create(FormType::class, ['check' => true])
+            ->add('check', CheckboxType::class, ['value' => ''])
+        ;
+
+        $form->submit(['check' => '0'], false);
+
+        $this->assertFalse($form->get('check')->getData());
+        $this->assertNull($form->get('check')->getViewData());
     }
 
     public function testSubmitWithEmptyValueAndTrueChecked()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #17899
| License       | MIT

When a nested checkbox uses an empty string as its checked value, submitting a PATCH payload with `"0"` should be able to represent an unchecked value. Without this, the child checkbox treats the submitted string as checked because it is not one of the default false values.

This keeps the change scoped to empty-value checkboxes by adding `"0"` to the resolved false values only when `value` is `""`.

## Test verification (RED -> GREEN)

RED (upstream `6.4` + regression test only):
```text
Failed asserting that true is false.
FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

GREEN (patched branch):
```text
OK (1 test, 2 assertions)
```

Fix reverted -> RED:
```text
Failed asserting that true is false.
FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

CheckboxType test suite:
```text
OK (40 tests, 65 assertions)
```

ChoiceType test suite:
```text
OK (209 tests, 714 assertions)
```

Form component suite:
```text
OK, but incomplete, skipped, or risky tests!
Tests: 4749, Assertions: 9404, Skipped: 356, Incomplete: 7.
```

Additional local checks:
```text
PHP-CS-Fixer dry-run: Found 0 of 3 files that can be fixed.
codespell: clean on changed files.
git diff --check: clean.
```
