### PR TITLE
[Validator] Allow `Traverse` to be inherited

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -331,6 +331,10 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             $this->setGroupSequenceProvider(true);
         }
 
+        if (TraversalStrategy::IMPLICIT === $this->traversalStrategy) {
+            $this->traversalStrategy = $source->getTraversalStrategy();
+        }
+
         foreach ($source->getConstraints() as $constraint) {
             $this->addConstraint(clone $constraint);
         }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -16,17 +16,20 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Constraints\Composite;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\GroupDefinitionException;
 use Symfony\Component\Validator\Mapping\CascadingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\TraversalStrategy;
 use Symfony\Component\Validator\Tests\Fixtures\CascadingEntity;
 use Symfony\Component\Validator\Tests\Fixtures\CascadingEntityIntersection;
 use Symfony\Component\Validator\Tests\Fixtures\CascadingEntityUnion;
 use Symfony\Component\Validator\Tests\Fixtures\ClassConstraint;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
+use Symfony\Component\Validator\Tests\Fixtures\CustomArrayObject;
 use Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderChildEntity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\EntityParent;
@@ -318,6 +321,27 @@ class ClassMetadataTest extends TestCase
         $metadata->mergeConstraints($parent);
 
         $this->assertTrue($metadata->isGroupSequenceProvider());
+    }
+
+    public function testMergeConstraintsMergesTraversalStrategy()
+    {
+        $traversable = new ClassMetadata(CustomArrayObject::class);
+        $traversable->addConstraint(new Traverse(false));
+
+        $this->metadata->mergeConstraints($traversable);
+
+        $this->assertSame(TraversalStrategy::NONE, $this->metadata->getTraversalStrategy());
+    }
+
+    public function testMergeConstraintsDoesNotOverrideExplicitTraversalStrategy()
+    {
+        $traversable = new ClassMetadata(CustomArrayObject::class);
+        $traversable->addConstraint(new Traverse(false));
+
+        $this->metadata->addConstraint(new Traverse());
+        $this->metadata->mergeConstraints($traversable);
+
+        $this->assertSame(TraversalStrategy::TRAVERSE, $this->metadata->getTraversalStrategy());
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -16,10 +16,12 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Validator\Mapping\TraversalStrategy;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
@@ -80,6 +82,25 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         ];
 
         $this->assertEquals($constraints, $metadata->getConstraints());
+    }
+
+    public function testMergeParentTraversalStrategy()
+    {
+        $loader = new class implements LoaderInterface {
+            public function loadClassMetadata(ClassMetadata $metadata): bool
+            {
+                if (EntityParent::class === $metadata->getClassName()) {
+                    $metadata->addConstraint(new Traverse(false));
+                }
+
+                return true;
+            }
+        };
+
+        $factory = new LazyLoadingMetadataFactory($loader);
+        $metadata = $factory->getMetadataFor(self::CLASS_NAME);
+
+        $this->assertSame(TraversalStrategy::NONE, $metadata->getTraversalStrategy());
     }
 
     public function testCachedMetadata()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64927 (when merged up to 7.4)
| License       | MIT

Constraints are inherited so `Traverse` should be too.