### PR TITLE
[Messenger] Do not reject unknown types when no message requires signing

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
@@ -175,6 +175,63 @@ class SigningSerializerTest extends TestCase
         $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
     }
 
+    public function testDecodeDoesNotRejectUnknownTypeWhenNoMessageTypeRequiresSignature()
+    {
+        $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {
+            public function getMessageType(array $encodedEnvelope): ?string
+            {
+                return null;
+            }
+
+            public function decode(array $encodedEnvelope): Envelope
+            {
+                return new Envelope(new DummyMessage('hello'));
+            }
+
+            public function encode(Envelope $envelope): array
+            {
+                return ['body' => 'irrelevant'];
+            }
+        };
+
+        $serializer = new SigningSerializer($inner, 'secret-key', []);
+
+        $decoded = $serializer->decode(['body' => 'irrelevant']);
+
+        $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
+    }
+
+    public function testDecodePassesHeadersThroughWhenNoMessageTypeRequiresSignature()
+    {
+        $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {
+            public array $receivedHeaders = [];
+
+            public function getMessageType(array $encodedEnvelope): ?string
+            {
+                return null;
+            }
+
+            public function decode(array $encodedEnvelope): Envelope
+            {
+                $this->receivedHeaders = $encodedEnvelope['headers'] ?? [];
+
+                return new Envelope(new DummyMessage('hello'));
+            }
+
+            public function encode(Envelope $envelope): array
+            {
+                return ['body' => 'irrelevant'];
+            }
+        };
+
+        $serializer = new SigningSerializer($inner, 'secret-key', []);
+
+        $decoded = $serializer->decode(['body' => 'irrelevant', 'headers' => ['Body-Sign' => 'not-a-valid-signature', 'Sign-Algo' => 'sha256']]);
+
+        $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
+        $this->assertSame(['Body-Sign' => 'not-a-valid-signature', 'Sign-Algo' => 'sha256'], $inner->receivedHeaders);
+    }
+
     public function testDecodeRejectsMessageWithoutSignatureWhenTypeAwareInnerSerializerCannotDetermineType()
     {
         $inner = new class implements SerializerInterface, MessageTypeAwareSerializerInterface {

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
@@ -45,6 +45,11 @@ final class SigningSerializer implements SerializerInterface
 
     public function decode(array $encodedEnvelope): Envelope
     {
+        // no message type requires signing: act as a pass-through for the inner serializer
+        if (!$this->signedMessageTypes) {
+            return $this->inner->decode($encodedEnvelope);
+        }
+
         $headers = $encodedEnvelope['headers'] ?? [];
         $sign = $headers['Body-Sign'] ?? null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64906
| License       | MIT

When no message type is configured as signed, `SigningSerializer` should behave as a pass-through decoder. This keeps BC for transports that are decorated with the signing serializer but do not actually require any message signatures.

The stricter path is unchanged when at least one signed message type is configured: unknown message types are still rejected before the inner serializer can decode them.

## Test verification (RED -> GREEN)

RED on `upstream/7.4` with only the regression test:

```text
1) Symfony\Component\Messenger\Tests\Transport\Serialization\SigningSerializerTest::testDecodeDoesNotRejectUnknownTypeWhenNoMessageTypeRequiresSignature
Symfony\Component\Messenger\Exception\InvalidMessageSignatureException: The message could not be verified and its type could not be determined; refusing to decode it.

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

GREEN with the fix:

```text
OK (1 test, 1 assertion)
OK (13 tests, 20 assertions)
OK, but some tests were skipped!
Tests: 512, Assertions: 1489, Skipped: 1.
```
