### PR TITLE
[Validator] Fix missing Tagalog (tl) translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -568,7 +568,7 @@
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Ang halagang ito ay hindi wastong cron expression.</target>
+                <target>Ang halagang ito ay hindi wastong cron expression.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64688
| License       | MIT

Removes the `needs-review-translation` state from the Tagalog translation of "This value is not a valid cron expression." (id 146) in `validators.tl.xlf`. The existing translation is accurate and consistent with the file's established terminology (`wastong` for "valid"), so it just needed sign-off rather than a re-translation.
