### PR TITLE
[Messenger] Allow message groups on standard SQS queues

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Allow message group IDs on standard queues
+
 7.4
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -468,6 +468,23 @@ class ConnectionTest extends TestCase
         $connection->reject($id);
     }
 
+    public function testSendWithMessageGroupIdOnStandardQueue()
+    {
+        $queueUrl = 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue';
+        $client = $this->createMock(SqsClient::class);
+        $client->expects($this->once())->method('sendMessage')->with([
+            'QueueUrl' => $queueUrl,
+            'MessageBody' => 'body',
+            'MessageAttributes' => [],
+            'MessageSystemAttributes' => [],
+            'DelaySeconds' => 30,
+            'MessageGroupId' => 'group',
+        ]);
+
+        $connection = new Connection(['queue_name' => 'queue', 'auto_setup' => false], $client, $queueUrl);
+        $connection->send('body', [], 30, 'group', 'deduplication');
+    }
+
     public function testKeepaliveWithTooSmallTtl()
     {
         $client = $this->createMock(SqsClient::class);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -407,6 +407,8 @@ class Connection
             $parameters['MessageGroupId'] = $messageGroupId ?? __METHOD__;
             $parameters['MessageDeduplicationId'] = $messageDeduplicationId ?? sha1(json_encode(['body' => $body, 'headers' => $headers]));
             unset($parameters['DelaySeconds']);
+        } elseif (null !== $messageGroupId) {
+            $parameters['MessageGroupId'] = $messageGroupId;
         }
 
         $this->client->sendMessage($parameters);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | No existing issue
| License       | MIT

Allow Amazon SQS message groups to be used with standard queues.

AWS supports fair queue scheduling on standard queues when producers provide `MessageGroupId`. This forwards an explicitly provided group ID while preserving existing FIFO behavior.

For standard queues, `DelaySeconds` remains set and `MessageDeduplicationId` remains omitted.

Tests cover forwarding `MessageGroupId` on a standard queue while retaining `DelaySeconds` and omitting `MessageDeduplicationId`.