### PR TITLE
[Filesystem] Handle PHP 8.6 removing function arguments in error messages

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1863,7 +1863,7 @@ class FilesystemTest extends FilesystemTestCase
     public function testReadNonExistentFile()
     {
         $this->expectException(IOException::class);
-        $this->expectExceptionMessageMatches(\sprintf('#^Failed to read file ".+%1$sTests/invalid"\\: file_get_contents\\(.+%1$sTests/invalid\\)\\: Failed to open stream\\: No such file or directory$#', preg_quote(\DIRECTORY_SEPARATOR)));
+        $this->expectExceptionMessageMatches(\sprintf('#^Failed to read file ".+%1$sTests/invalid"\\: file_get_contents\\((.+%1$sTests/invalid)?\\)\\: Failed to open stream\\: No such file or directory$#', preg_quote(\DIRECTORY_SEPARATOR)));
 
         $this->filesystem->readFile(__DIR__.'/invalid');
     }
@@ -1885,7 +1885,7 @@ class FilesystemTest extends FilesystemTestCase
         chmod($filename, 0o000);
 
         $this->expectException(IOException::class);
-        $this->expectExceptionMessageMatches('#^Failed to read file ".+/unreadable.txt"\\: file_get_contents\\(.+/unreadable.txt\\)\\: Failed to open stream\\: Permission denied$#');
+        $this->expectExceptionMessageMatches('#^Failed to read file ".+/unreadable.txt"\\: file_get_contents\\((.+/unreadable.txt)?\\)\\: Failed to open stream\\: Permission denied$#');
 
         $this->filesystem->readFile($filename);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Same as #64930 but for 7.4.