### PR TITLE
[HttpClient] Make `UnknownSizeStream` compatible with `psr/http-message` 1.0

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/Fixtures/UnknownSizeStream.php
+++ b/src/Symfony/Component/HttpClient/Tests/Fixtures/UnknownSizeStream.php
@@ -39,7 +39,7 @@ class UnknownSizeStream implements StreamInterface
         return $this->seekable;
     }
 
-    public function seek(int $offset, int $whence = \SEEK_SET): void
+    public function seek($offset, $whence = \SEEK_SET): void
     {
         if (!$this->seekable) {
             throw new \RuntimeException('Stream is not seekable.');
@@ -83,7 +83,7 @@ class UnknownSizeStream implements StreamInterface
         return false;
     }
 
-    public function write(string $string): int
+    public function write($string): int
     {
         throw new \RuntimeException('Stream is not writable.');
     }
@@ -93,7 +93,7 @@ class UnknownSizeStream implements StreamInterface
         return true;
     }
 
-    public function read(int $length): string
+    public function read($length): string
     {
         return $this->inner->read($length);
     }
@@ -103,7 +103,7 @@ class UnknownSizeStream implements StreamInterface
         return $this->inner->getContents();
     }
 
-    public function getMetadata(?string $key = null): mixed
+    public function getMetadata($key = null): mixed
     {
         return $this->inner->getMetadata($key);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

low-deps tests require `psr/http-message` 1.0 which has no argument types, so the `UnknownSizeStream` class added by #64934 makes them fail: https://github.com/symfony/symfony/actions/runs/29845005119/job/88683251536#step:9:10487