### PR TITLE
[HttpFoundation] Throw when IpUtils::isPrivateIp() receives a non-canonical IP address

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -231,9 +231,15 @@ class IpUtils
 
     /**
      * Checks if an IPv4 or IPv6 address is contained in the list of private IP subnets.
+     *
+     * @throws \ValueError When $requestIp is not a valid IP address
      */
     public static function isPrivateIp(string $requestIp): bool
     {
+        if (!filter_var($requestIp, \FILTER_VALIDATE_IP)) {
+            throw new \ValueError(\sprintf('"%s" is not a valid IP address.', $requestIp));
+        }
+
         return self::checkIp($requestIp, self::PRIVATE_SUBNETS);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -211,6 +211,30 @@ class IpUtilsTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider getIsPrivateIpInvalidData
+     */
+    public function testIsPrivateIpThrowsOnNonCanonicalIp(string $ip)
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage(\sprintf('"%s" is not a valid IP address.', $ip));
+
+        IpUtils::isPrivateIp($ip);
+    }
+
+    public static function getIsPrivateIpInvalidData(): array
+    {
+        return [
+            'decimal' => ['2130706433'],
+            'hexadecimal' => ['0x7f000001'],
+            'leading zero' => ['010.0.0.1'],
+            'short form' => ['127.1'],
+            'zone id' => ['fe80::1%eth0'],
+            'not an IP' => ['not-an-ip'],
+            'empty string' => [''],
+        ];
+    }
+
     public function testCacheSizeLimit()
     {
         $ref = new \ReflectionClass(IpUtils::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64896
| License       | MIT

Implements the plan agreed by @nicolas-grekas in #64896, targeted at 6.4 as a hardening.

`IpUtils::isPrivateIp()` used to return `false` for strings that are not valid IP addresses (`2130706433`, `0x7f000001`, `010.0.0.1`, `127.1`, zone IDs like `fe80::1%eth0`, ...). "Not private" then reads as "public" for input the method does not even understand, which is a footgun for allow-list / SSRF style checks.

Rather than normalizing those forms (attempted in #64939, closed, because picking octal vs decimal semantics for leading zeros silently widens what deployed allow-lists match, the exact ambiguity behind CVE-2021-29921 / CVE-2021-28918), `isPrivateIp()` now throws a `ValueError` for input that is not a canonical IP address, so callers get an honest answer: normalize or resolve the value first.

```php
IpUtils::isPrivateIp('127.0.0.1');   // true, unchanged
IpUtils::isPrivateIp('::1');         // true, unchanged
IpUtils::isPrivateIp('0x7f000001');  // before: false, now: ValueError
```

`checkIp()` / `checkIp4()` / `checkIp6()` keep their current strict, fail-closed behavior, so matching is unaffected: none of the inputs that now throw could ever match a private subnet. Canonical inputs are unaffected. There are no internal callers of `isPrivateIp()` in the codebase.
