### PR TITLE
[Translation] Add a Plural-Forms header to the PoFileDumper output

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Preserve the XLIFF `<source>` element when loading and dumping a file, instead of overwriting it with the message key
+ * Add a locale-aware `Plural-Forms` header to the output of `PoFileDumper`
 
 8.1
 ---

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -27,6 +27,7 @@ class PoFileDumper extends FileDumper
         $output .= '"Content-Type: text/plain; charset=UTF-8\n"'."\n";
         $output .= '"Content-Transfer-Encoding: 8bit\n"'."\n";
         $output .= '"Language: '.$messages->getLocale().'\n"'."\n";
+        $output .= '"Plural-Forms: '.$this->getPluralFormsHeader($messages->getLocale()).'\n"'."\n";
         $output .= "\n";
 
         $newLine = false;
@@ -63,6 +64,107 @@ class PoFileDumper extends FileDumper
         }
 
         return $output;
+    }
+
+    /**
+     * Returns the gettext "Plural-Forms" value matching the plural rule Symfony applies for the given
+     * locale (see TranslatorTrait::getPluralizationRule()), so the header stays consistent by
+     * construction with the msgstr indexes this dumper writes. It mirrors that method group by group,
+     * including its single-form default for locales without a specific rule (e.g. ja, ko, zh).
+     */
+    private function getPluralFormsHeader(string $locale): string
+    {
+        $locale = 'pt_BR' !== $locale && 'en_US_POSIX' !== $locale && \strlen($locale) > 3
+            ? substr($locale, 0, strrpos($locale, '_'))
+            : $locale;
+
+        return match ($locale) {
+            'af',
+            'bn',
+            'bg',
+            'ca',
+            'da',
+            'de',
+            'el',
+            'en',
+            'en_US_POSIX',
+            'eo',
+            'es',
+            'et',
+            'eu',
+            'fa',
+            'fi',
+            'fo',
+            'fur',
+            'fy',
+            'gl',
+            'gu',
+            'ha',
+            'he',
+            'hu',
+            'is',
+            'it',
+            'ku',
+            'lb',
+            'ml',
+            'mn',
+            'mr',
+            'nah',
+            'nb',
+            'ne',
+            'nl',
+            'nn',
+            'no',
+            'oc',
+            'om',
+            'or',
+            'pa',
+            'pap',
+            'ps',
+            'pt',
+            'so',
+            'sq',
+            'sv',
+            'sw',
+            'ta',
+            'te',
+            'tk',
+            'ur',
+            'zu' => 'nplurals=2; plural=(n != 1);',
+            'am',
+            'bh',
+            'fil',
+            'fr',
+            'gun',
+            'hi',
+            'hy',
+            'ln',
+            'mg',
+            'nso',
+            'pt_BR',
+            'ti',
+            'wa' => 'nplurals=2; plural=(n > 1);',
+            'be',
+            'bs',
+            'hr',
+            'ru',
+            'sh',
+            'sr',
+            'uk' => 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);',
+            'cs',
+            'sk' => 'nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);',
+            'ga' => 'nplurals=3; plural=(n==1 ? 0 : n==2 ? 1 : 2);',
+            'lt' => 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);',
+            'sl' => 'nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);',
+            'mk' => 'nplurals=2; plural=(n%10==1 ? 0 : 1);',
+            'mt' => 'nplurals=4; plural=(n==1 ? 0 : n==0 || (n%100>1 && n%100<11) ? 1 : n%100>10 && n%100<20 ? 2 : 3);',
+            'lv' => 'nplurals=3; plural=(n==0 ? 0 : n%10==1 && n%100!=11 ? 1 : 2);',
+            'pl' => 'nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);',
+            'cy' => 'nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n==8 || n==11 ? 2 : 3);',
+            'ro' => 'nplurals=3; plural=(n==1 ? 0 : n==0 || (n%100>0 && n%100<20) ? 1 : 2);',
+            'ar' => 'nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);',
+            default => 'nplurals=1; plural=0;',
+        };
     }
 
     private function getStandardRules(string $id): array

--- a/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Tests\Dumper;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\Dumper\PoFileDumper;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -57,5 +58,45 @@ class PoFileDumperTest extends TestCase
         $dumper = new PoFileDumper();
 
         $this->assertStringEqualsFile(__DIR__.'/../Fixtures/plurals.po', $dumper->formatCatalogue($catalogue, 'messages'));
+    }
+
+    #[DataProvider('pluralFormsProvider')]
+    public function testPluralFormsHeaderIsDerivedFromLocale(string $locale, string $expectedPluralForms)
+    {
+        $catalogue = new MessageCatalogue($locale);
+        $catalogue->add(['foo' => 'bar']);
+
+        $output = (new PoFileDumper())->formatCatalogue($catalogue, 'messages');
+
+        $this->assertStringContainsString('"Plural-Forms: '.$expectedPluralForms.'\n"', $output);
+    }
+
+    /**
+     * One representative per plural-rule group of TranslatorTrait::getPluralizationRule(), so every
+     * branch of the mapping is pinned. Locales within the same group share the same formula.
+     */
+    public static function pluralFormsProvider(): array
+    {
+        return [
+            'english-like (two forms)' => ['en', 'nplurals=2; plural=(n != 1);'],
+            'french-like (two forms, n > 1)' => ['fr', 'nplurals=2; plural=(n > 1);'],
+            'russian-like (three forms)' => ['ru', 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);'],
+            'czech-like (three forms)' => ['cs', 'nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);'],
+            'irish (three forms)' => ['ga', 'nplurals=3; plural=(n==1 ? 0 : n==2 ? 1 : 2);'],
+            'lithuanian (three forms)' => ['lt', 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);'],
+            'slovenian (four forms)' => ['sl', 'nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);'],
+            'macedonian (two forms)' => ['mk', 'nplurals=2; plural=(n%10==1 ? 0 : 1);'],
+            'maltese (four forms)' => ['mt', 'nplurals=4; plural=(n==1 ? 0 : n==0 || (n%100>1 && n%100<11) ? 1 : n%100>10 && n%100<20 ? 2 : 3);'],
+            'latvian (three forms)' => ['lv', 'nplurals=3; plural=(n==0 ? 0 : n%10==1 && n%100!=11 ? 1 : 2);'],
+            'polish (three forms)' => ['pl', 'nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);'],
+            'welsh (four forms)' => ['cy', 'nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n==8 || n==11 ? 2 : 3);'],
+            'romanian (three forms)' => ['ro', 'nplurals=3; plural=(n==1 ? 0 : n==0 || (n%100>0 && n%100<20) ? 1 : 2);'],
+            'arabic (six forms)' => ['ar', 'nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);'],
+            'japanese (single form default)' => ['ja', 'nplurals=1; plural=0;'],
+            'french region is stripped to its prefix' => ['fr_FR', 'nplurals=2; plural=(n > 1);'],
+            'pt_BR is not stripped to pt' => ['pt_BR', 'nplurals=2; plural=(n > 1);'],
+            'en_US_POSIX is kept as-is' => ['en_US_POSIX', 'nplurals=2; plural=(n != 1);'],
+            'unknown locale falls back to a single form' => ['xx', 'nplurals=1; plural=0;'],
+        ];
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Fixtures/plurals.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/plurals.po
@@ -3,6 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "foo"
 msgid_plural "foos"

--- a/src/Symfony/Component/Translation/Tests/Fixtures/resources.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/resources.po
@@ -3,6 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "foo"
 msgstr "bar"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Related to #64585
| License       | MIT

`PoFileDumper` writes `msgid_plural` / `msgstr[N]` entries but no `Plural-Forms` header, so `msgfmt -c` fatally rejects any dumped catalogue that contains plural entries (one of the side issues @nicolas-grekas spotted in #64585).

This adds a locale-aware `Plural-Forms` header. Rather than a hardcoded formula, `getPluralFormsHeader()` mirrors `TranslatorTrait::getPluralizationRule()` group by group (with the same locale-prefix handling, e.g. `pt_BR` vs `pt`), so the header stays consistent by construction with the msgstr indexes the dumper writes:

```
"Language: fr\n"
"Plural-Forms: nplurals=2; plural=(n > 1);\n"
```

Each mapped formula was checked to select the exact same index as `getPluralizationRule()` for every `n`. A data-provider test pins one representative per plural-rule group, plus the single-form, prefix-stripping and unknown-locale cases.

Note that nothing detects drift if a locale is later added to `getPluralizationRule()` and not here: the two lists have to be kept in step by hand.

One point worth confirming: for the locales that fall into `getPluralizationRule()`'s default arm (ja, ko, zh, ...), I used `nplurals=1; plural=0;` rather than the generic two-form formula, since that is what makes those locales consistent by construction (and turns `ja` into a real single-form locale as requested). Happy to switch to the generic two-form default if you prefer.