### PR TITLE
[Form] Add zero as false value for empty checkboxes

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `0` as a default `false_values` value for `CheckboxType` and `RadioType` when `value` is an empty string
  * Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled
 
 8.1

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -16,10 +16,15 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransfo
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CheckboxType extends AbstractType
 {
+    private const DEFAULT_FALSE_VALUES = [null];
+    private const EMPTY_VALUE = '';
+    private const EMPTY_VALUE_FALSE_VALUES = [null, '0'];
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Unlike in other types, where the data is NULL by default, it
@@ -48,7 +53,13 @@ class CheckboxType extends AbstractType
             'value' => '1',
             'empty_data' => $emptyData,
             'compound' => false,
-            'false_values' => [null],
+            'false_values' => static function (Options $options): array {
+                if (self::EMPTY_VALUE === $options['value']) {
+                    return self::EMPTY_VALUE_FALSE_VALUES;
+                }
+
+                return self::DEFAULT_FALSE_VALUES;
+            },
             'invalid_message' => 'The checkbox has an invalid value.',
             'is_empty_callback' => static fn ($modelData): bool => false === $modelData,
         ]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -14,11 +14,15 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\RadioType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class CheckboxTypeTest extends BaseTypeTestCase
 {
     public const TESTED_TYPE = CheckboxType::class;
+    private const DEFAULT_FALSE_VALUES = [null];
+    private const EMPTY_VALUE = '';
+    private const ZERO_VALUE = '0';
 
     public function testDataIsFalseByDefault()
     {
@@ -139,6 +143,40 @@ class CheckboxTypeTest extends BaseTypeTestCase
 
         $this->assertTrue($form->getData());
         $this->assertSame('', $form->getViewData());
+    }
+
+    public function testSubmitZeroWithEmptyValueUnchecked()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'value' => self::EMPTY_VALUE,
+        ]);
+        $form->submit(self::ZERO_VALUE);
+
+        $this->assertFalse($form->getData());
+        $this->assertNull($form->getViewData());
+    }
+
+    public function testExplicitFalseValuesOverrideEmptyValueDefault()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'value' => self::EMPTY_VALUE,
+            'false_values' => self::DEFAULT_FALSE_VALUES,
+        ]);
+        $form->submit(self::ZERO_VALUE);
+
+        $this->assertTrue($form->getData());
+        $this->assertSame(self::EMPTY_VALUE, $form->getViewData());
+    }
+
+    public function testRadioTypeSubmitZeroWithEmptyValueUnchecked()
+    {
+        $form = $this->factory->create(RadioType::class, null, [
+            'value' => self::EMPTY_VALUE,
+        ]);
+        $form->submit(self::ZERO_VALUE);
+
+        $this->assertFalse($form->getData());
+        $this->assertNull($form->getViewData());
     }
 
     #[DataProvider('provideCustomModelTransformerData')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

When a checkbox or radio button uses an empty string as its submitted value, this makes the default `false_values` option also treat submitted `"0"` as false.

The default remains `[null]` for all other values, and explicitly configured `false_values` still wins. This keeps the current behavior reachable while allowing API clients to submit `"0"` for empty-value checkboxes and radio buttons.

This follows the feature shape proposed in symfony/symfony#64936.

## Test verification (RED -> GREEN)

RED (`8.2` with the new tests only, before the implementation):
```text
Failed asserting that true is false.
FAILURES!
Tests: 3, Assertions: 4, Failures: 2.
```

GREEN (patched branch, targeted tests):
```text
OK (3 tests, 6 assertions)
```

CheckboxType and ChoiceType tests:
```text
OK (262 tests, 821 assertions)
```

Form component suite:
```text
OK, but there were issues!
Tests: 4941, Assertions: 10284, Skipped: 375, Incomplete: 7.
```

Additional checks:
```text
git diff --check: clean
php -l src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php: no syntax errors
```
