### PR TITLE
[Messenger] Add support for serialized type name aliases in `#[AsMessage]` attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -771,7 +771,10 @@ class FrameworkExtension extends Extension
             ->addTag('container.excluded', ['source' => 'because it\'s a validation constraint']);
         $container->registerAttributeForAutoconfiguration(AsMessage::class, static function (ChildDefinition $definition, AsMessage $attribute): void {
             $definition->addTag('container.excluded', ['source' => 'because it\'s a messenger message']);
-            $definition->addTag('messenger.message', ['serializedTypeName' => $attribute->serializedTypeName]);
+            $definition->addTag('messenger.message', [
+                'serializedTypeName' => $attribute->serializedTypeName,
+                'serializedTypeNameAliases' => $attribute->serializedTypeNameAliases ?? [],
+            ]);
         });
         $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
             $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine entity']);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -75,6 +75,7 @@ use Symfony\Component\JsonPath\FunctionReturnType;
 use Symfony\Component\JsonPath\JsonPathCrawlerInterface;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Messenger\Attribute\AsMessage;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
@@ -1094,6 +1095,27 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertEquals($expectedFactories, $container->getDefinition('messenger.transport_factory')->getArgument(0)->getValues());
         $this->assertTrue($container->hasDefinition('messenger.listener.reset_services'));
         $this->assertSame('messenger.listener.reset_services', (string) $container->getDefinition('console.command.messenger_consume_messages')->getArgument(5));
+    }
+
+    public function testMessengerAsMessageAttributeIsForwardedToTheTag()
+    {
+        if (!property_exists(AsMessage::class, 'serializedTypeNameAliases')) {
+            $this->markTestSkipped('symfony/messenger 8.2 is required.');
+        }
+
+        $container = $this->createContainerFromFile('messenger', [], true, false);
+        $container->compile();
+
+        $configurators = $container->getAttributeAutoconfigurators()[AsMessage::class] ?? [];
+        $this->assertCount(1, $configurators);
+
+        $definition = new ChildDefinition('');
+        $configurators[0]($definition, new AsMessage(serializedTypeName: 'my.type', serializedTypeNameAliases: ['my.legacy.type']));
+
+        $this->assertSame(
+            [['serializedTypeName' => 'my.type', 'serializedTypeNameAliases' => ['my.legacy.type']]],
+            $definition->getTag('messenger.message')
+        );
     }
 
     public function testMessengerWithoutConsole()

--- a/src/Symfony/Component/Messenger/Attribute/AsMessage.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessage.php
@@ -28,6 +28,12 @@ class AsMessage
          * The serialized type to use when sending or receiving the message.
          */
         public ?string $serializedTypeName = null,
+        /**
+         * Alternate serialized type names that also decode to this message.
+         *
+         * @var string[]
+         */
+        public array $serializedTypeNameAliases = [],
     ) {
     }
 }

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
+
 8.1
 ---
 

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -426,16 +426,36 @@ class MessengerPass implements CompilerPassInterface
         foreach ($taggedIds as $id => $tags) {
             $class = $container->getDefinition($id)->getClass();
             foreach ($tags as $tag) {
+                $aliases = $tag['serializedTypeNameAliases'] ?? [];
+
+                if (!\is_array($aliases)) {
+                    throw new RuntimeException(\sprintf('The "serializedTypeNameAliases" attribute of the "messenger.message" tag of class "%s" must be an array of strings, "%s" given.', $class, get_debug_type($aliases)));
+                }
+
                 if (!isset($tag['serializedTypeName'])) {
+                    if ($aliases) {
+                        throw new RuntimeException(\sprintf('A serialized type name must be set on class "%s" to use serialized type name aliases.', $class));
+                    }
+
                     continue;
                 }
-                if ($tag['serializedTypeName'] !== $class && isset($messageClasses[$tag['serializedTypeName']])) {
-                    throw new RuntimeException(\sprintf('The serialized type name "%s" set on class "%s" is the name of another message class, which uses it as its own serialized type.', $tag['serializedTypeName'], $class));
+
+                // the aliases come first so that the canonical name wins once the map is flipped for encoding
+                foreach ([...$aliases, $tag['serializedTypeName']] as $typeName) {
+                    if ($typeName !== $class && isset($messageClasses[$typeName])) {
+                        throw new RuntimeException(\sprintf('The serialized type name "%s" set on class "%s" is the name of another message class, which uses it as its own serialized type.', $typeName, $class));
+                    }
+
+                    if (isset($typeToClassMap[$typeName])) {
+                        if ($typeToClassMap[$typeName] === $class) {
+                            throw new RuntimeException(\sprintf('The serialized type name "%s" is listed more than once on class "%s".', $typeName, $class));
+                        }
+
+                        throw new RuntimeException(\sprintf('The serialized type name "%s" is already mapped to class "%s", cannot map it to "%s" as well. Each serialized type must be unique.', $typeName, $typeToClassMap[$typeName], $class));
+                    }
+
+                    $typeToClassMap[$typeName] = $class;
                 }
-                if (isset($typeToClassMap[$tag['serializedTypeName']])) {
-                    throw new RuntimeException(\sprintf('The serialized type name "%s" is already mapped to class "%s", cannot map it to "%s" as well. Each serialized type must be unique.', $tag['serializedTypeName'], $typeToClassMap[$tag['serializedTypeName']], $class));
-                }
-                $typeToClassMap[$tag['serializedTypeName']] = $class;
             }
         }
 

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -1078,6 +1078,156 @@ class MessengerPassTest extends TestCase
         );
     }
 
+    public function testItRegistersTypeMappingWithSerializedTypeNameAliases()
+    {
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MyMessage', 'App\Message\MyMessage')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', [
+                'serializedTypeName' => 'my.custom.type',
+                'serializedTypeNameAliases' => ['my.legacy.type', 'MyMessage'],
+            ])
+        ;
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame(
+            [
+                'my.legacy.type' => 'App\Message\MyMessage',
+                'MyMessage' => 'App\Message\MyMessage',
+                'my.custom.type' => 'App\Message\MyMessage',
+            ],
+            $container->getDefinition('messenger.transport.symfony_serializer')->getArgument(3)
+        );
+    }
+
+    public function testItThrowsExceptionOnDuplicateSerializedTypeNameAlias()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The serialized type name "my.duplicate.type" is already mapped to class "App\Message\MessageA", cannot map it to "App\Message\MessageB" as well.');
+
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MessageA', 'App\Message\MessageA')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', ['serializedTypeName' => 'my.duplicate.type'])
+        ;
+        $container
+            ->register('App\Message\MessageB', 'App\Message\MessageB')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', [
+                'serializedTypeName' => 'type.b',
+                'serializedTypeNameAliases' => ['my.duplicate.type'],
+            ])
+        ;
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testItThrowsExceptionOnAliasShadowingAnotherMessageClass()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The serialized type name "App\Message\MessageA" set on class "App\Message\MessageB" is the name of another message class, which uses it as its own serialized type.');
+
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MessageA', 'App\Message\MessageA')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', [])
+        ;
+        $container
+            ->register('App\Message\MessageB', 'App\Message\MessageB')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', [
+                'serializedTypeName' => 'type.b',
+                'serializedTypeNameAliases' => ['App\Message\MessageA'],
+            ])
+        ;
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testItAllowsAMessageToAliasItsOwnClassName()
+    {
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MyMessage', 'App\Message\MyMessage')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', [
+                'serializedTypeName' => 'my.custom.type',
+                'serializedTypeNameAliases' => ['App\Message\MyMessage'],
+            ])
+        ;
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame(
+            [
+                'App\Message\MyMessage' => 'App\Message\MyMessage',
+                'my.custom.type' => 'App\Message\MyMessage',
+            ],
+            $container->getDefinition('messenger.transport.symfony_serializer')->getArgument(3)
+        );
+    }
+
+    public function testItThrowsExceptionOnNonArraySerializedTypeNameAliases()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "serializedTypeNameAliases" attribute of the "messenger.message" tag of class "App\Message\MyMessage" must be an array of strings, "string" given.');
+
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MyMessage', 'App\Message\MyMessage')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', [
+                'serializedTypeName' => 'my.custom.type',
+                'serializedTypeNameAliases' => 'my.legacy.type',
+            ])
+        ;
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testItThrowsExceptionOnSerializedTypeNameAliasesWithoutSerializedTypeName()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('A serialized type name must be set on class "App\Message\MyMessage" to use serialized type name aliases.');
+
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MyMessage', 'App\Message\MyMessage')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', ['serializedTypeNameAliases' => ['my.legacy.type']])
+        ;
+
+        (new MessengerPass())->process($container);
+    }
+
     public function testItIgnoresMessageTagWithoutSerializedTypeName()
     {
         $container = $this->getContainerBuilder('message_bus');

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -297,6 +297,22 @@ class SerializerTest extends TestCase
         $this->assertSame('Hello', $decodedEnvelope->getMessage()->getMessage());
     }
 
+    public function testTypeToClassMapAliasesDecodeToSameClassWhileEncodeUsesCanonicalName()
+    {
+        $serializer = new Serializer(typeToClassMap: [
+            'legacy.type' => DummyMessage::class,
+            'current.type' => DummyMessage::class,
+        ]);
+
+        foreach (['legacy.type', 'current.type'] as $type) {
+            $decoded = $serializer->decode(['body' => '{"message":"Hello"}', 'headers' => ['type' => $type]]);
+            $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
+        }
+
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('Hello')));
+        $this->assertSame('current.type', $encoded['headers']['type']);
+    }
+
     public function testEncodeDecodeWithTypeToClassMap()
     {
         $serializer = new Serializer(typeToClassMap: ['custom.type' => DummyMessage::class]);

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -45,7 +45,10 @@ class Serializer implements SerializerInterface, MessageTypeAwareSerializerInter
     private array $classToTypeMap = [];
 
     /**
-     * @param array<string, class-string> $typeToClassMap
+     * @param array<string, class-string> $typeToClassMap Several type names may point to the same class, so that
+     *                                                    messages already sent under an old name keep decoding. The
+     *                                                    map is flipped to pick the type name to encode with, so the
+     *                                                    last name listed for a class is the one that gets sent
      */
     public function __construct(
         ?SymfonySerializerInterface $serializer = null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Adds `serializedTypeNameAliases` to `#[AsMessage]`, so a message can be decoded from names it was sent under in the past:

```php
#[AsMessage(serializedTypeName: 'order.created', serializedTypeNameAliases: ['App\Message\OrderCreated'])]
class OrderCreated {}
```

Messages already sitting in a transport under the old name keep decoding, while new ones are sent under the canonical name. Aliases apply to decoding only, so during a rolling deploy consumers still need to be updated before producers.

`Serializer` is untouched. `decode()` already falls back to `$typeToClassMap[$type] ?? $type`, and `MessengerPass` registers the aliases ahead of the canonical name so that the canonical one survives the `array_flip()` used for encoding.

Added during review:

* an alias can no longer take the name of another message class. The uniqueness check only looked at names explicitly registered in the map, but a message with no `serializedTypeName` is sent under its own class name, and that name never enters the map. So this used to compile cleanly:

  ```php
  #[AsMessage]                                                                  // sent as its FQCN
  class LegacyOrderCreated {}
  #[AsMessage(serializedTypeName: 'ship.it', serializedTypeNameAliases: ['LegacyOrderCreated'])]
  class Shipped {}
  ```

  and `LegacyOrderCreated` then encoded as itself and decoded back as `Shipped`. With `SigningSerializer` it was worse: the type resolves through the same map, so a forged unsigned message on the shadowed name was accepted, where the same application without the alias answers `Message "LegacyOrderCreated" requires a signature but none was found.` A class listing its own class name as an alias stays legal, which is the normal way to keep reading messages sent before a `serializedTypeName` was introduced;

* a `serializedTypeNameAliases` tag attribute that is not an array now names the class instead of failing with `Error: Only arrays and Traversables can be unpacked, string given`;

* listing the same name twice on one class now says so, rather than reporting that the name is already mapped to the class it is being mapped to;

* the ordering rule is documented where it is relied on: on `Serializer::$typeToClassMap`, which is public API and can be built by hand, and in `MessengerPass` where the order is created. It was previously recorded only in a comment inside a test;

* `FrameworkExtensionTestCase::testMessengerAsMessageAttributeIsForwardedToTheTag` covers the attribute-to-tag closure, which had no test at all. A typo in the tag key used to leave the whole suite green.

The check applies to aliases only. The same hole exists for `serializedTypeName` itself and predates this feature, so it is fixed separately on 8.1 in #64978 and will arrive here through the merge-up; the two will want unifying into one loop at that point.
