### PR TITLE
[Security] Add an OIDC Authorization Code Flow authenticator

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
  * Add support for decorating custom authentication failure and success handlers
  * Add role hierarchy graph to the profiler security panel
+ * Add `oidc_login` firewall authenticator for the OpenID Connect Authorization Code Flow, along with an `oidc` user provider for the users it builds from the OIDC claims
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -63,6 +63,8 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                 $config['discovery']['enforce_key_usage_verification'],
             ]);
 
+            $tokenHandlerDefinition->addTag('kernel.reset', ['method' => 'reset']);
+
             return;
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcUserInfoTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcUserInfoTokenHandlerFactory.php
@@ -51,6 +51,8 @@ class OidcUserInfoTokenHandlerFactory implements TokenHandlerFactoryInterface
                     "$id.oidc_configuration",
                 ]
             );
+
+            $tokenHandlerDefinition->addTag('kernel.reset', ['method' => 'reset']);
         }
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
+
+use Jose\Component\Core\Algorithm;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * OidcLoginFactory creates services for OpenID Connect Authorization Code Flow authentication.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ *
+ * @internal
+ */
+class OidcLoginFactory extends AbstractFactory
+{
+    public const PRIORITY = -25;
+
+    /**
+     * @psalm-suppress ParamNameMismatch
+     */
+    public function addConfiguration(NodeDefinition $node): void
+    {
+        parent::addConfiguration($node);
+
+        \assert($node instanceof ArrayNodeDefinition);
+
+        $node->children()
+            ->scalarNode('provider_uri')
+                ->isRequired()
+                ->validate()
+                    ->ifTrue(static function ($v): bool {
+                        // An environment variable is an empty string at this point, so it cannot
+                        // be checked here; OidcDiscovery checks the resolved value at runtime.
+                        // Declaring the node ->cannotBeEmpty() is what would make the Config
+                        // component reject environment variables outright, next to a validator.
+                        if ('' === (string) $v) {
+                            return false;
+                        }
+
+                        return !OidcDiscovery::isSecureUrl((string) $v);
+                    })
+                    ->thenInvalid('The OIDC "provider_uri" must use HTTPS (got %s): the authorization code, the PKCE verifier and the tokens it is exchanged for are only confidential over TLS. Use HTTPS, or a loopback host (localhost, 127.0.0.1, ::1) or a name reserved for testing (*.localhost, *.test) for local development.')
+                ->end()
+                ->info('The OIDC Issuer URL (e.g. "https://accounts.example.com"). Used for .well-known/openid-configuration discovery.')
+            ->end()
+            ->scalarNode('client_id')
+                ->isRequired()
+                ->cannotBeEmpty()
+                ->info('The OIDC client identifier.')
+            ->end()
+            ->scalarNode('client_secret')
+                ->isRequired()
+                ->cannotBeEmpty()
+                ->info('The OIDC client secret.')
+            ->end()
+            ->arrayNode('scope')
+                ->beforeNormalization()->castToArray()->end()
+                ->scalarPrototype()->end()
+                ->defaultValue(['openid'])
+                ->info('The scopes of the authorization request, as a list or as a space-separated string. "openid" is always requested, as OIDC requires it; add e.g. "profile" or "email" to get the matching claims from the UserInfo endpoint, and map them onto your own user with a user provider.')
+            ->end()
+            ->scalarNode('check_path')
+                ->cannotBeEmpty()
+                ->defaultValue('/oidc/callback')
+                ->info('The firewall path where the OIDC provider redirects after authentication. Must match a redirect URI registered with the provider. A route is declared for this path by the "security.authenticator.oidc_login.route_loader" service, which the application must import (see the OIDC login documentation), as it does for the logout routes. A route name is accepted too, in which case no route is declared for it.')
+            ->end()
+            ->integerNode('discovery_cache_ttl')
+                ->defaultValue(3600)
+                ->min(0)
+                ->info('TTL in seconds for caching the OIDC discovery configuration.')
+            ->end()
+            ->integerNode('allowed_time_drift')
+                ->defaultValue(0)
+                ->min(0)
+                ->info('Allowed clock skew in seconds when validating ID token time claims.')
+            ->end()
+        ;
+    }
+
+    public function getKey(): string
+    {
+        return 'oidc-login';
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
+    }
+
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): string
+    {
+        if (!ContainerBuilder::willBeAvailable('symfony/http-client', HttpClientInterface::class, ['symfony/security-bundle'])) {
+            throw new LogicException('You cannot use the "oidc-login" authenticator since the HttpClient component is not installed. Try running "composer require symfony/http-client".');
+        }
+
+        if (!ContainerBuilder::willBeAvailable('web-token/jwt-library', Algorithm::class, ['symfony/security-bundle'])) {
+            throw new LogicException('You cannot use the "oidc-login" authenticator since "web-token/jwt-library" is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        if (!$container->hasDefinition('security.authenticator.oidc_login')) {
+            $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/../../Resources/config'));
+            $loader->load('security_authenticator_oidc_login.php');
+        }
+
+        $discoveryId = 'security.authenticator.oidc_login.discovery.'.$firewallName;
+        $container
+            ->setDefinition($discoveryId, new ChildDefinition('security.authenticator.oidc_login.discovery'))
+            // the discovery URL is built from the issuer by OidcDiscovery, which is the only
+            // place a "provider_uri" coming from an environment variable can be normalized
+            ->replaceArgument(3, $config['provider_uri'])
+            ->replaceArgument(4, $config['discovery_cache_ttl'])
+            ->addTag('kernel.reset', ['method' => 'reset'])
+        ;
+
+        $idTokenId = 'security.authenticator.oidc_login.id_token.'.$firewallName;
+        $container
+            ->setDefinition($idTokenId, (new ChildDefinition('security.authenticator.oidc_login.id_token'))
+                ->replaceArgument(1, $config['allowed_time_drift'])
+            )
+        ;
+
+        $oidcClientId = 'security.authenticator.oidc_login.client.'.$firewallName;
+        $container
+            ->setDefinition($oidcClientId, new ChildDefinition('security.authenticator.oidc_login.client'))
+            ->replaceArgument(1, new Reference($discoveryId))
+            ->replaceArgument(2, $config['client_id'])
+            ->replaceArgument(3, $config['client_secret'])
+        ;
+
+        $authenticatorId = 'security.authenticator.oidc_login.'.$firewallName;
+        $options = array_intersect_key($config, $this->options);
+        $options['firewall_name'] = $firewallName;
+        $options['scope'] = $config['scope'];
+
+        $container
+            ->setDefinition($authenticatorId, new ChildDefinition('security.authenticator.oidc_login'))
+            ->replaceArgument(1, new Reference($userProviderId))
+            ->replaceArgument(2, new Reference($oidcClientId))
+            ->replaceArgument(3, new Reference($discoveryId))
+            ->replaceArgument(4, new Reference($idTokenId))
+            ->replaceArgument(5, $config['client_id'])
+            ->replaceArgument(6, new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
+            ->replaceArgument(7, new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
+            ->replaceArgument(8, $options)
+        ;
+
+        $callbackUris = $container->hasParameter('security.oidc_login.callback_uris') ? (array) $container->getParameter('security.oidc_login.callback_uris') : [];
+        // a "check_path" holding a route name instead of a path gets no route declared
+        // for it; the parameter is always set, as the route loader is wired on it
+        if ('/' === $config['check_path'][0]) {
+            $callbackUris[$firewallName] = $config['check_path'];
+        }
+        $container->setParameter('security.oidc_login.callback_uris', $callbackUris);
+
+        return $authenticatorId;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/OidcFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/OidcFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * OidcFactory creates services for the OIDC user provider.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+class OidcFactory implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, string $id, array $config): void
+    {
+        $container->setDefinition($id, new ChildDefinition('security.user.provider.oidc'));
+    }
+
+    public function getKey(): string
+    {
+        return 'oidc';
+    }
+
+    public function addConfiguration(NodeDefinition $builder): void
+    {
+        \assert($builder instanceof ArrayNodeDefinition);
+
+        $builder
+            ->beforeNormalization()
+                ->ifTrue(static fn ($v) => null === $v || (\is_array($v) && [] === $v))
+                ->then(static fn () => ['enabled' => true])
+            ->end()
+        ;
+
+        $builder
+            ->children()
+                ->booleanNode('enabled')->defaultTrue()->info('Internal marker; the OIDC provider has no configuration options.')->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -44,6 +44,7 @@ use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\InMemoryUserChecker;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\MissingUserProvider;
+use Symfony\Component\Security\Core\User\OidcUserProvider;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
 use Symfony\Component\Security\Csrf\DelegatingCsrfTokenManager;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -272,6 +273,9 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('security.user.provider.in_memory', InMemoryUserProvider::class)
+            ->abstract()
+
+        ->set('security.user.provider.oidc', OidcUserProvider::class)
             ->abstract()
 
         ->set('security.user.provider.ldap', LdapUserProvider::class)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\SecurityBundle\Routing\OidcLoginRouteLoader;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('security.authenticator.oidc_login', OidcLoginAuthenticator::class)
+            ->abstract()
+            ->args([
+                service('security.http_utils'),
+                abstract_arg('user provider'),
+                abstract_arg('OIDC client'),
+                abstract_arg('OIDC discovery'),
+                abstract_arg('ID token'),
+                abstract_arg('client ID'),
+                abstract_arg('authentication success handler'),
+                abstract_arg('authentication failure handler'),
+                abstract_arg('options'),
+            ])
+
+        ->set('security.authenticator.oidc_login.id_token', OidcIdToken::class)
+            ->abstract()
+            ->args([
+                service('clock'),
+                0,
+            ])
+
+        ->set('security.authenticator.oidc_login.discovery', OidcDiscovery::class)
+            ->abstract()
+            ->args([
+                service('http_client'),
+                service('cache.app'),
+                // relative to the issuer below, which OidcDiscovery normalizes at runtime
+                '.well-known/openid-configuration',
+                abstract_arg('issuer'),
+                abstract_arg('cache TTL'),
+                // the cache key is derived from the configuration URL; these endpoints must be
+                // announced and must not downgrade to plain HTTP the transport of the discovery document
+                null,
+                ['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'],
+            ])
+
+        ->set('security.authenticator.oidc_login.client', OidcConfidentialClient::class)
+            ->abstract()
+            ->args([
+                service('http_client'),
+                abstract_arg('OIDC discovery'),
+                abstract_arg('client ID'),
+                abstract_arg('client secret'),
+            ])
+
+        ->set('security.authenticator.oidc_login.route_loader', OidcLoginRouteLoader::class)
+            ->args([
+                '%security.oidc_login.callback_uris%',
+                'security.oidc_login.callback_uris',
+            ])
+            ->tag('routing.route_loader')
+    ;
+};

--- a/src/Symfony/Bundle/SecurityBundle/Routing/OidcLoginRouteLoader.php
+++ b/src/Symfony/Bundle/SecurityBundle/Routing/OidcLoginRouteLoader.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Routing;
+
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Registers a route for each oidc_login firewall callback path, so the provider's
+ * redirect lands on a matched route and is handled by the firewall instead of
+ * returning a 404 from the router.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcLoginRouteLoader
+{
+    /**
+     * @param array<string, string> $callbackUris  Callback URIs indexed by the corresponding firewall name
+     * @param string                $parameterName Name of the container parameter containing {@see $callbackUris} value
+     */
+    public function __construct(
+        private readonly array $callbackUris,
+        private readonly string $parameterName,
+    ) {
+    }
+
+    public function __invoke(): RouteCollection
+    {
+        $collection = new RouteCollection();
+        $collection->addResource(new ContainerParametersResource([$this->parameterName => $this->callbackUris]));
+
+        $routeNames = [];
+        foreach ($this->callbackUris as $firewallName => $callbackPath) {
+            $routeName = '_oidc_login_callback_'.$firewallName;
+
+            if (isset($routeNames[$callbackPath])) {
+                $collection->addAlias($routeName, $routeNames[$callbackPath]);
+            } else {
+                $routeNames[$callbackPath] = $routeName;
+                $collection->add($routeName, new Route($callbackPath));
+            }
+        }
+
+        return $collection;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -40,11 +40,13 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLogin
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginLdapFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginLinkFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginThrottlingFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\OidcLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RememberMeFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RemoteUserFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\X509Factory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\InMemoryFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\LdapFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\OidcFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -78,6 +80,7 @@ class SecurityBundle extends Bundle
         $extension->addAuthenticatorFactory(new CustomAuthenticatorFactory());
         $extension->addAuthenticatorFactory(new LoginThrottlingFactory());
         $extension->addAuthenticatorFactory(new LoginLinkFactory());
+        $extension->addAuthenticatorFactory(new OidcLoginFactory());
         $extension->addAuthenticatorFactory(new AccessTokenFactory([
             new ServiceTokenHandlerFactory(),
             new OidcUserInfoTokenHandlerFactory(),
@@ -88,6 +91,7 @@ class SecurityBundle extends Bundle
 
         $extension->addUserProviderFactory(new InMemoryFactory());
         $extension->addUserProviderFactory(new LdapFactory());
+        $extension->addUserProviderFactory(new OidcFactory());
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
         $container->addCompilerPass(new AddSecurityVotersPass());
         $container->addCompilerPass(new AddSessionDomainConstraintPass());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -178,6 +178,10 @@ class AccessTokenFactoryTest extends TestCase
             'index_7' => 0,
         ];
         $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
+
+        // Assert that the handler does NOT have the kernel.reset tag when discovery is NOT enabled
+        $tags = $container->getDefinition('security.access_token_handler.firewall1')->getTags();
+        $this->assertArrayNotHasKey('kernel.reset', $tags);
     }
 
     public function testOidcTokenHandlerConfigurationWithEncryption()
@@ -314,6 +318,11 @@ class AccessTokenFactoryTest extends TestCase
         ];
         $this->assertEquals($expectedArgs, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
         $this->assertEquals($expectedCalls, $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
+
+        // Assert that the handler has the kernel.reset tag when discovery is enabled
+        $tags = $container->getDefinition('security.access_token_handler.firewall1')->getTags();
+        $this->assertArrayHasKey('kernel.reset', $tags);
+        $this->assertSame(['method' => 'reset'], $tags['kernel.reset'][0]);
     }
 
     public function testOidcTokenHandlerConfigurationWithMultipleDiscoveryBaseUri()
@@ -373,6 +382,11 @@ class AccessTokenFactoryTest extends TestCase
         ];
         $this->assertEquals($expectedArgs, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
         $this->assertEquals($expectedCalls, $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
+
+        // Assert that the handler has the kernel.reset tag when discovery is enabled
+        $tags = $container->getDefinition('security.access_token_handler.firewall1')->getTags();
+        $this->assertArrayHasKey('kernel.reset', $tags);
+        $this->assertSame(['method' => 'reset'], $tags['kernel.reset'][0]);
     }
 
     #[DataProvider('provideEnforceKeyUsageVerification')]
@@ -487,6 +501,10 @@ class AccessTokenFactoryTest extends TestCase
         }
 
         $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
+
+        // Assert that the handler does NOT have the kernel.reset tag when discovery is NOT enabled
+        $tags = $container->getDefinition('security.access_token_handler.firewall1')->getTags();
+        $this->assertArrayNotHasKey('kernel.reset', $tags);
     }
 
     public static function getOidcUserInfoConfiguration(): iterable
@@ -535,6 +553,11 @@ class AccessTokenFactoryTest extends TestCase
         ];
         $this->assertEquals($expectedArgs, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
         $this->assertEquals($expectedCalls, $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
+
+        // Assert that the handler has the kernel.reset tag when discovery is enabled
+        $tags = $container->getDefinition('security.access_token_handler.firewall1')->getTags();
+        $this->assertArrayHasKey('kernel.reset', $tags);
+        $this->assertSame(['method' => 'reset'], $tags['kernel.reset'][0]);
     }
 
     public function testMultipleTokenHandlersSet()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -1,0 +1,362 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Factory;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\OidcLoginFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class OidcLoginFactoryTest extends TestCase
+{
+    public function testBasicServiceConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login'));
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.main'));
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.discovery.main'));
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.client.main'));
+
+        // the discovery service and the client id are injected directly, not fetched through the OIDC client
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $authenticator->getArgument(3));
+        $this->assertSame('my-client-id', $authenticator->getArgument(5));
+
+        // the endpoints checked against the transport of the discovery document stay wired: the
+        // per-firewall child definition only replaces the issuer and the cache TTL, so it
+        // inherits this argument from the abstract definition
+        $discovery = $container->getDefinition('security.authenticator.oidc_login.discovery');
+        $this->assertSame(['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'], $discovery->getArgument(6));
+
+        // the per-firewall discovery definition carries the kernel.reset tag with method reset
+        $discoveryMain = $container->getDefinition('security.authenticator.oidc_login.discovery.main');
+        $this->assertSame(['kernel.reset' => [['method' => 'reset']]], $discoveryMain->getTags());
+    }
+
+    public function testFirewallUserProviderIsInjected()
+    {
+        // the user provider loads the user, so that the token stored in the session can be
+        // refreshed by the very same provider on the next request
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'security.user.provider.concrete.oidc');
+
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+        $this->assertEquals(new Reference('security.user.provider.concrete.oidc'), $authenticator->getArgument(1));
+    }
+
+    public function testScopeDefaultsToOpenid()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame(['openid'], $finalizedConfig['scope']);
+    }
+
+    public function testScopeIsInjectedIntoTheAuthenticatorOptions()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            // a single string is accepted, so that an environment variable can carry every scope
+            'scope' => 'openid profile email',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $options = $container->getDefinition('security.authenticator.oidc_login.main')->getArgument(8);
+        $this->assertSame(['openid profile email'], $options['scope']);
+    }
+
+    public function testGetKey()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->assertSame('oidc-login', $factory->getKey());
+    }
+
+    public function testGetPriority()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->assertSame(-25, $factory->getPriority());
+    }
+
+    public function testRequiredOptions()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig([
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+    }
+
+    public function testCheckPathDefaultsToCallback()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame('/oidc/callback', $finalizedConfig['check_path']);
+    }
+
+    public function testDiscoveryCacheTtlDefaultsToAnHour()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame(3600, $finalizedConfig['discovery_cache_ttl']);
+    }
+
+    public function testAllowedTimeDriftDefaultsToZero()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame(0, $finalizedConfig['allowed_time_drift']);
+    }
+
+    public function testProviderUriIsInjectedAsTheDiscoveryIssuer()
+    {
+        // the value is passed as it is configured: an environment variable is still a
+        // placeholder here, so OidcDiscovery is what trims it and builds the discovery URL
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com/',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $discovery = $container->getDefinition('security.authenticator.oidc_login.discovery.main');
+        $this->assertSame('https://provider.example.com/', $discovery->getArgument(3));
+        // the configuration URL is left to the parent definition, relative to the issuer
+        $this->assertArrayNotHasKey('index_2', $discovery->getArguments());
+    }
+
+    public function testDiscoveryCacheTtlIsInjectedIntoTheDiscoveryService()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'discovery_cache_ttl' => 60,
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $this->assertSame(60, $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(4));
+    }
+
+    public function testAllowedTimeDriftIsInjectedIntoTheIdTokenService()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'allowed_time_drift' => 60,
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $idToken = $container->getDefinition('security.authenticator.oidc_login.id_token.main');
+        $this->assertSame(60, $idToken->getArgument(1));
+
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.id_token.main'), $authenticator->getArgument(4));
+    }
+
+    #[DataProvider('provideNegativeTtls')]
+    public function testRejectsNegativeTtls(string $option)
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            $option => -1,
+        ], $factory);
+    }
+
+    public static function provideNegativeTtls(): iterable
+    {
+        yield 'discovery cache TTL' => ['discovery_cache_ttl'];
+        yield 'allowed time drift' => ['allowed_time_drift'];
+    }
+
+    public function testCallbackRouteIsRegistered()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.route_loader'));
+        $this->assertSame(['main' => '/oidc/callback'], $container->getParameter('security.oidc_login.callback_uris'));
+    }
+
+    public function testCallbackRouteNameIsNotRegistered()
+    {
+        // check_path may be a route name, in which case no route is declared for it
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => 'oidc_callback_route',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.route_loader'));
+        $this->assertSame('oidc_callback_route', $finalizedConfig['check_path']);
+        // no route is declared for a route name, but the parameter the route loader
+        // is wired on must exist
+        $this->assertSame([], $container->getParameter('security.oidc_login.callback_uris'));
+    }
+
+    public function testRejectsNonHttpsProviderUri()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $this->processConfig([
+            'provider_uri' => 'http://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+    }
+
+    public function testAcceptsAnUppercaseSchemeInTheProviderUri()
+    {
+        // a URI scheme is case-insensitive, and parse_url() returns it as it is written
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'HTTPS://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame('HTTPS://provider.example.com', $finalizedConfig['provider_uri']);
+    }
+
+    /**
+     * @param string $providerUri a loopback host or a name reserved for testing (RFC 2606, RFC 6761)
+     */
+    #[DataProvider('provideLocalDevelopmentProviderUris')]
+    public function testAllowsHttpProviderUriForLocalDevelopment(string $providerUri)
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => $providerUri,
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame($providerUri, $finalizedConfig['provider_uri']);
+    }
+
+    public static function provideLocalDevelopmentProviderUris(): iterable
+    {
+        yield 'localhost' => ['http://localhost:8080'];
+        yield 'IPv4 loopback' => ['http://127.0.0.1:8080'];
+        yield 'IPv6 loopback' => ['http://[::1]:8080'];
+        yield 'localhost subdomain' => ['http://keycloak.localhost'];
+        yield 'test TLD' => ['http://keycloak.test'];
+    }
+
+    private function processConfig(array $config, OidcLoginFactory $factory): array
+    {
+        $nodeDefinition = new ArrayNodeDefinition('oidc-login');
+        $factory->addConfiguration($nodeDefinition);
+
+        $node = $nodeDefinition->getNode();
+        $normalizedConfig = $node->normalize($config);
+
+        return $node->finalize($normalizedConfig);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/UserProvider/OidcFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/UserProvider/OidcFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\UserProvider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\OidcFactory;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class OidcFactoryTest extends TestCase
+{
+    public function testGetKey()
+    {
+        $this->assertSame('oidc', (new OidcFactory())->getKey());
+    }
+
+    public function testCreateRegistersChildOfBuiltinProvider()
+    {
+        $container = new ContainerBuilder();
+
+        (new OidcFactory())->create($container, 'security.user.provider.concrete.oidc_users', []);
+
+        $this->assertTrue($container->hasDefinition('security.user.provider.concrete.oidc_users'));
+        $definition = $container->getDefinition('security.user.provider.concrete.oidc_users');
+        $this->assertInstanceOf(ChildDefinition::class, $definition);
+        $this->assertSame('security.user.provider.oidc', $definition->getParent());
+    }
+
+    public function testAddConfigurationDefaultsEmptyToEnabled()
+    {
+        $factory = new OidcFactory();
+        $treeBuilder = new TreeBuilder('oidc');
+        $factory->addConfiguration($treeBuilder->getRootNode());
+
+        $config = (new Processor())->process($treeBuilder->buildTree(), [null]);
+
+        $this->assertSame(['enabled' => true], $config);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveReferencesToAliasesPass;
+use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -246,7 +247,7 @@ class SecurityExtensionTest extends TestCase
         ]);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Unrecognized option "some_other" under "security.providers.my_app_provider". Available options are "chain", "custom", "id", "ldap", "memory".');
+        $this->expectExceptionMessage('Unrecognized option "some_other" under "security.providers.my_app_provider". Available options are "chain", "custom", "id", "ldap", "memory", "oidc".');
 
         $container->compile();
     }
@@ -1449,6 +1450,63 @@ class SecurityExtensionTest extends TestCase
         $securityHelperAuthenticatorLocator = $container->getDefinition($container->getDefinition('security.helper')->getArgument(1)['main']);
         $this->assertArrayHasKey(TestAuthenticator::class, $authenticatorMap = $securityHelperAuthenticatorLocator->getArgument(0), 'When programmatically authenticating a user, authenticators’ name must be their original ID.');
         $this->assertSame(TestAuthenticator::class, (string) $authenticatorMap[TestAuthenticator::class]->getValues()[0], 'When programmatically authenticating a user, original authenticators must be used.');
+    }
+
+    public function testOidcLoginAcceptsEnvironmentVariables()
+    {
+        // "provider_uri" carries a validator, so declaring it ->cannotBeEmpty() would make
+        // the Config component reject environment variables on it altogether. The scheme of
+        // the resolved value is checked at runtime by OidcDiscovery instead.
+        $container = $this->getRawContainer();
+        // the pass that validates configuration against env placeholders is an
+        // optimization pass, which getRawContainer() replaces: put it back, otherwise
+        // the env vars are simply skipped and this test guards nothing
+        $container->getCompilerPassConfig()->setOptimizationPasses([
+            new ValidateEnvPlaceholdersPass(),
+            new ResolveChildDefinitionsPass(),
+        ]);
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => '%env(OIDC_PROVIDER_URI)%',
+                        'client_id' => '%env(OIDC_CLIENT_ID)%',
+                        'client_secret' => '%env(OIDC_CLIENT_SECRET)%',
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.main'));
+    }
+
+    public function testOidcLoginUsesTheFirewallUserProvider()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'oidc' => ['oidc' => null],
+                'in_memory' => ['memory' => null],
+            ],
+            'firewalls' => [
+                'main' => [
+                    'provider' => 'oidc',
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_secret' => 'my-client-secret',
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+        $this->assertSame('security.user.provider.concrete.oidc', (string) $authenticator->getArgument(1));
     }
 
     protected function getRawContainer()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Routing/OidcLoginRouteLoaderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Routing/OidcLoginRouteLoaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Routing\OidcLoginRouteLoader;
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class OidcLoginRouteLoaderTest extends TestCase
+{
+    public function testLoad()
+    {
+        $paths = [
+            'main' => '/callback',
+            'admin' => '/callback',
+        ];
+
+        $loader = new OidcLoginRouteLoader($paths, 'parameterName');
+        $collection = $loader();
+
+        self::assertInstanceOf(RouteCollection::class, $collection);
+        self::assertCount(1, $collection);
+        self::assertEquals(new Route('/callback'), $collection->get('_oidc_login_callback_main'));
+        self::assertCount(1, $collection->getAliases());
+        self::assertEquals('_oidc_login_callback_main', $collection->getAlias('_oidc_login_callback_admin')->getId());
+
+        $resources = $collection->getResources();
+        self::assertCount(1, $resources);
+
+        $resource = reset($resources);
+        self::assertInstanceOf(ContainerParametersResource::class, $resource);
+        self::assertSame(['parameterName' => $paths], $resource->getParameters());
+    }
+}

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Allow using wildcards as placeholders in the keys of the `RoleHierarchy` map
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `acceptSignatureHash()` and `verifySignatureHash()`
+ * Add `OidcUser::fromClaims()` to build a user from the claims returned by an OIDC provider
+ * Add `OidcUserProvider`, which builds the OIDC users of the `oidc_login` authenticator from those claims
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Core/Tests/User/OidcUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/OidcUserProviderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\User;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\OidcUser;
+use Symfony\Component\Security\Core\User\OidcUserProvider;
+
+class OidcUserProviderTest extends TestCase
+{
+    public function testLoadUserFromTheClaims()
+    {
+        $provider = new OidcUserProvider();
+
+        $user = $provider->loadUserByIdentifier('user-42', [
+            'sub' => 'user-42',
+            'email' => 'test@example.com',
+            'preferred_username' => 'john',
+            'department' => 'engineering',
+        ]);
+
+        $this->assertInstanceOf(OidcUser::class, $user);
+        $this->assertSame('user-42', $user->getUserIdentifier());
+        $this->assertSame('test@example.com', $user->getEmail());
+        $this->assertSame('john', $user->getPreferredUsername());
+        $this->assertSame(['department' => 'engineering'], $user->getAdditionalClaims());
+    }
+
+    public function testLoadUserWithoutClaims()
+    {
+        $provider = new OidcUserProvider();
+
+        // the user is built from the claims collected during authentication, so there is
+        // nothing to load from an identifier alone (e.g. impersonation, or a firewall
+        // pairing this provider with another authenticator)
+        $this->expectException(UserNotFoundException::class);
+
+        $provider->loadUserByIdentifier('user-42');
+    }
+
+    public function testLoadUserWithNonStringSub()
+    {
+        $provider = new OidcUserProvider();
+
+        $this->expectException(UserNotFoundException::class);
+
+        $provider->loadUserByIdentifier('user-42', ['sub' => ['nested']]);
+    }
+
+    #[DataProvider('providePrivilegedClaims')]
+    public function testLoadUserDoesNotMapPrivilegedClaims(string $claim, mixed $value)
+    {
+        // the OIDC provider must not be able to grant roles or define the security
+        // identity through the claims it returns (privilege escalation)
+        $provider = new OidcUserProvider();
+
+        $user = $provider->loadUserByIdentifier('user-42', ['sub' => 'user-42', $claim => $value]);
+
+        $this->assertSame(['ROLE_USER'], $user->getRoles());
+        $this->assertSame('user-42', $user->getUserIdentifier());
+        $this->assertSame([], $user->getAdditionalClaims());
+    }
+
+    public static function providePrivilegedClaims(): iterable
+    {
+        yield 'roles' => ['roles', ['ROLE_ADMIN']];
+        yield 'camel-cased roles' => ['Roles', ['ROLE_ADMIN']];
+        yield 'user identifier' => ['user_identifier', 'spoofed-identity'];
+        yield 'camel-cased user identifier' => ['userIdentifier', 'spoofed-identity'];
+    }
+
+    public function testRefreshUserReturnsSameUser()
+    {
+        $provider = new OidcUserProvider();
+        $user = new OidcUser(userIdentifier: 'user-42', sub: 'user-42');
+
+        $this->assertSame($user, $provider->refreshUser($user));
+    }
+
+    public function testRefreshUnsupportedUser()
+    {
+        $provider = new OidcUserProvider();
+
+        $this->expectException(UnsupportedUserException::class);
+
+        $provider->refreshUser(new InMemoryUser('john', 'pass'));
+    }
+
+    public function testSupportsClass()
+    {
+        $provider = new OidcUserProvider();
+
+        $this->assertTrue($provider->supportsClass(OidcUser::class));
+        $this->assertFalse($provider->supportsClass(InMemoryUser::class));
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/User/OidcUserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/OidcUserTest.php
@@ -24,6 +24,74 @@ class OidcUserTest extends TestCase
         new OidcUser();
     }
 
+    public function testFromClaims()
+    {
+        $user = OidcUser::fromClaims([
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+            'preferred_username' => 'john.doe',
+            'email' => 'john.doe@example.com',
+            'email_verified' => 'true',
+            'updated_at' => 1669628917,
+            'custom_id' => 12345,
+            'nickname' => '',
+        ]);
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $user->getUserIdentifier());
+        $this->assertSame('john.doe', $user->getPreferredUsername());
+        $this->assertSame('john.doe@example.com', $user->getEmail());
+        $this->assertTrue($user->getEmailVerified());
+        $this->assertEquals((new \DateTimeImmutable())->setTimestamp(1669628917), $user->getUpdatedAt());
+        $this->assertNull($user->getNickname());
+        $this->assertSame(['customId' => 12345], $user->getAdditionalClaims());
+        $this->assertSame(['ROLE_USER'], $user->getRoles());
+    }
+
+    public function testFromClaimsGrantsTheRolesItIsGiven()
+    {
+        // this is how a user provider maps the claims of its choice onto roles
+        $user = OidcUser::fromClaims(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f', 'roles' => ['ROLE_ADMIN']]);
+
+        $this->assertSame(['ROLE_ADMIN'], $user->getRoles());
+    }
+
+    public function testFromClaimsIgnoresMistypedClaims()
+    {
+        $user = OidcUser::fromClaims([
+            'sub' => 'valid-sub-123',
+            'name' => ['formatted' => 'John Doe'],
+            'updated_at' => '2024-01-01T00:00:00Z',
+            'address' => 'not-a-struct',
+            'email_verified' => ['yes'],
+            'roles' => 'ROLE_ADMIN',
+        ]);
+
+        $this->assertSame('valid-sub-123', $user->getSub());
+        $this->assertNull($user->getName());
+        $this->assertNull($user->getUpdatedAt());
+        $this->assertNull($user->getAddress());
+        $this->assertNull($user->getEmailVerified());
+        $this->assertSame(['ROLE_USER'], $user->getRoles());
+    }
+
+    public function testFromClaimsAcceptsNumericStringUpdatedAt()
+    {
+        $user = OidcUser::fromClaims([
+            'sub' => 'valid-sub-123',
+            'updated_at' => '1700000000',
+            'custom' => ['a' => 1],
+        ]);
+
+        $this->assertSame(1700000000, $user->getUpdatedAt()?->getTimestamp());
+        $this->assertSame(['custom' => ['a' => 1]], $user->getAdditionalClaims());
+    }
+
+    public function testFromClaimsKeepsTheCalledClass()
+    {
+        $user = TestOidcUser::fromClaims(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']);
+
+        $this->assertInstanceOf(TestOidcUser::class, $user);
+    }
+
     public function testCreateFullUserWithAdditionalClaimsUsingPositionalParameters()
     {
         $this->assertEquals(new OidcUser(
@@ -171,4 +239,8 @@ class OidcUserTest extends TestCase
             12345
         ));
     }
+}
+
+class TestOidcUser extends OidcUser
+{
 }

--- a/src/Symfony/Component/Security/Core/User/OidcUser.php
+++ b/src/Symfony/Component/Security/Core/User/OidcUser.php
@@ -11,8 +11,11 @@
 
 namespace Symfony\Component\Security\Core\User;
 
+use function Symfony\Component\String\u;
+
 /**
- * UserInterface implementation used by the access-token security workflow with an OIDC server.
+ * UserInterface implementation used by the security workflows with an OIDC server:
+ * the "oidc_login" authenticator and the access-token OIDC handlers.
  */
 class OidcUser implements UserInterface
 {
@@ -52,6 +55,64 @@ class OidcUser implements UserInterface
         }
 
         $this->additionalClaims = $additionalClaims['additionalClaims'] ?? $additionalClaims;
+    }
+
+    /**
+     * Builds a user from the claims returned by an OIDC provider.
+     *
+     * Claim names are camel-cased onto the constructor arguments, and the ones matching
+     * no argument become additional claims. Every claim is mapped this way, so a "roles"
+     * claim does grant the roles it holds: only pass claims you decided to trust, either
+     * because you verified where they come from or because you mapped them yourself.
+     * Claims whose value does not match the type of their constructor argument are ignored,
+     * so that a misbehaving provider cannot break authentication with a TypeError.
+     *
+     * @param array<string, mixed> $claims
+     */
+    public static function fromClaims(array $claims): static
+    {
+        if (!\function_exists('Symfony\Component\String\u')) {
+            throw new \LogicException(\sprintf('You cannot use "%s()" since the String component is not installed. Try running "composer require symfony/string".', __METHOD__));
+        }
+
+        foreach ($claims as $claim => $value) {
+            unset($claims[$claim]);
+            if ('' === $value || null === $value) {
+                continue;
+            }
+            $claim = u($claim)->camel()->toString();
+
+            // drop the claims whose value cannot fit their typed constructor argument:
+            // a TypeError would escape the authentication flow as a 500 response
+            $fits = match ($claim) {
+                'roles', 'address', 'additionalClaims' => \is_array($value),
+                'emailVerified', 'phoneNumberVerified' => \is_scalar($value),
+                'updatedAt' => is_numeric($value),
+                'userIdentifier', 'sub', 'name', 'givenName', 'familyName', 'middleName', 'nickname', 'preferredUsername', 'profile', 'picture', 'website', 'email', 'gender', 'birthdate', 'zoneinfo', 'locale', 'phoneNumber' => \is_scalar($value) || $value instanceof \Stringable,
+                default => true,
+            };
+
+            if ($fits) {
+                $claims[$claim] = $value;
+            }
+        }
+
+        if (isset($claims['updatedAt'])) {
+            $claims['updatedAt'] = (new \DateTimeImmutable())->setTimestamp((int) $claims['updatedAt']);
+        }
+
+        if (isset($claims['emailVerified'])) {
+            $claims['emailVerified'] = (bool) $claims['emailVerified'];
+        }
+
+        if (isset($claims['phoneNumberVerified'])) {
+            $claims['phoneNumberVerified'] = (bool) $claims['phoneNumberVerified'];
+        }
+
+        // a subclass that changes the constructor signature breaks this factory anyway,
+        // and late static binding is what lets it keep its own type here
+        // @phpstan-ignore new.static
+        return new static(...$claims);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/User/OidcUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/OidcUserProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+
+/**
+ * User provider for the OIDC users built from the claims returned by an OIDC provider.
+ *
+ * OIDC users are self-contained: the user is built from the claims collected during
+ * authentication, and returned as-is when the session is refreshed, without any
+ * external lookup.
+ *
+ * The claims cannot define the security identity nor grant roles: the identifier comes
+ * from the verified "sub" claim, and roles default to ROLE_USER. Use your own user
+ * provider to map claims onto roles, or to load the users from your own storage.
+ *
+ * This user provider cannot be used with the "switch_user" feature or any other feature that
+ * loads a user by its identifier alone (e.g. impersonation), as it requires the claims
+ * collected during authentication. Use your own user provider instead.
+ *
+ * @implements AttributesBasedUserProviderInterface<OidcUser>
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcUserProvider implements AttributesBasedUserProviderInterface
+{
+    /**
+     * @param array $attributes The claims collected by the OIDC authenticator
+     */
+    public function loadUserByIdentifier(string $identifier, array $attributes = []): OidcUser
+    {
+        if (!\is_string($attributes['sub'] ?? null) || '' === $attributes['sub']) {
+            $exception = new UserNotFoundException(\sprintf('The "%s" provider cannot load a user by its identifier alone: OIDC users are built from the claims collected during authentication.', self::class));
+            $exception->setUserIdentifier($identifier);
+
+            throw $exception;
+        }
+
+        return OidcUser::fromClaims($this->filterPrivilegedClaims($attributes));
+    }
+
+    public function refreshUser(UserInterface $user): OidcUser
+    {
+        if (!$user instanceof OidcUser) {
+            throw new UnsupportedUserException(\sprintf('Instances of "%s" are not supported.', $user::class));
+        }
+
+        return $user;
+    }
+
+    public function supportsClass(string $class): bool
+    {
+        return OidcUser::class === $class;
+    }
+
+    /**
+     * Drops any claim that would be mapped onto a security-sensitive OidcUser
+     * constructor argument, so the provider cannot populate "roles" or override
+     * the "userIdentifier" through the claims it returns (privilege escalation).
+     *
+     * The claim name is reduced to its letters and digits, lower-cased, to also
+     * catch the separator and case variants that {@see OidcUser::fromClaims()}
+     * would camel-case onto those arguments. Kept free of the optional
+     * symfony/string dependency on purpose.
+     *
+     * @param array<string, mixed> $claims
+     *
+     * @return array<string, mixed>
+     */
+    private function filterPrivilegedClaims(array $claims): array
+    {
+        foreach (array_keys($claims) as $claim) {
+            $normalized = strtolower((string) preg_replace('/[^a-zA-Z0-9]++/', '', (string) $claim));
+            if ('roles' === $normalized || 'useridentifier' === $normalized) {
+                unset($claims[$claim]);
+            }
+        }
+
+        return $claims;
+    }
+}

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -32,14 +32,16 @@ use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\InvalidSignatureE
 use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\MissingClaimException;
 use Symfony\Component\Security\Http\Authenticator\FallbackUserLoader;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * The token handler decodes and validates the token, and retrieves the user identifier from it.
  */
-final class OidcTokenHandler implements AccessTokenHandlerInterface
+final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterface
 {
     use OidcTrait;
     private ?JWKSet $decryptionKeyset = null;
@@ -54,6 +56,11 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
      * @var HttpClientInterface[]
      */
     private array $discoveryClients = [];
+
+    /**
+     * @var OidcDiscovery[]
+     */
+    private array $discoveries = [];
 
     public function __construct(
         private AlgorithmManager $signatureAlgorithm,
@@ -89,6 +96,15 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
         $this->discoveryClients = \is_array($client) ? $client : [$client];
         $this->oidcConfigurationCacheKey = $oidcConfigurationCacheKey;
         $this->enforceKeyUsageVerification = $enforceKeyUsageVerification;
+
+        // the discovery documents get their own cache entries: $oidcConfigurationCacheKey
+        // keeps holding the JWKS, whose lifetime is driven by the JWKS response headers
+        $discoveries = [];
+        foreach ($this->discoveryClients as $i => $discoveryClient) {
+            // the keys are kept aligned with $discoveryClients, which computeDiscoveryKeys() indexes back into
+            $discoveries[$i] = new OidcDiscovery($discoveryClient, $cache, cacheKey: $oidcConfigurationCacheKey.'.document.'.$i, checkedEndpoints: ['jwks_uri']);
+        }
+        $this->discoveries = $discoveries;
     }
 
     public function getUserBadgeFrom(string $accessToken): UserBadge
@@ -144,27 +160,27 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
      */
     public function computeDiscoveryKeys(ItemInterface $item): array
     {
-        $clients = $this->discoveryClients;
-        if (!$clients) {
+        if (!$this->discoveries) {
             throw new \LogicException('No OIDC discovery client configured.');
         }
         $logger = $this->logger;
         try {
             $discoveredKeys = [];
             $minTtl = null;
-            $configResponses = [];
             $jwkSetResponses = [];
 
-            foreach ($clients as $client) {
-                $configResponses[] = [$client, $client->request('GET', '.well-known/openid-configuration', ['max_redirects' => 0])];
+            // the ".well-known" requests are sent first, so that they travel concurrently:
+            // the responses are lazy, and only consumed by getConfiguration() below
+            foreach ($this->discoveries as $discovery) {
+                $discovery->prefetch();
             }
 
-            foreach ($configResponses as [$client, $response]) {
-                $config = $response->toArray();
+            foreach ($this->discoveries as $i => $discovery) {
+                // the scheme was checked against the URL that served the document before
+                // the configuration was cached, so only the announcement is enforced here
+                $jwksUri = self::checkDiscoveredEndpoint($discovery->getConfiguration()['jwks_uri'] ?? null, 'jwks_uri', null);
 
-                $jwksUri = self::checkDiscoveredEndpoint($config['jwks_uri'] ?? null, 'jwks_uri', $response->getInfo('url'));
-
-                $jwkSetResponses[] = $client->request('GET', $jwksUri);
+                $jwkSetResponses[] = $this->discoveryClients[$i]->request('GET', $jwksUri);
             }
 
             foreach ($jwkSetResponses as $response) {
@@ -329,6 +345,13 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
             $this->logger?->debug('The token decryption failed. Skipping as not mandatory.');
 
             return $accessToken;
+        }
+    }
+
+    public function reset(): void
+    {
+        foreach ($this->discoveries as $discovery) {
+            $discovery->reset();
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTrait.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTrait.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Security\Http\AccessToken\Oidc;
 
 use Symfony\Component\Security\Core\User\OidcUser;
 
-use function Symfony\Component\String\u;
-
 /**
  * Creates {@see OidcUser} from claims and validates the endpoints advertised by the discovery document.
  *
@@ -24,31 +22,7 @@ trait OidcTrait
 {
     private function createUser(array $claims): OidcUser
     {
-        if (!\function_exists('Symfony\Component\String\u')) {
-            throw new \LogicException('You cannot use the "OidcUserInfoTokenHandler" since the String component is not installed. Try running "composer require symfony/string".');
-        }
-
-        foreach ($claims as $claim => $value) {
-            unset($claims[$claim]);
-            if ('' === $value || null === $value) {
-                continue;
-            }
-            $claims[u($claim)->camel()->toString()] = $value;
-        }
-
-        if (isset($claims['updatedAt']) && '' !== $claims['updatedAt']) {
-            $claims['updatedAt'] = (new \DateTimeImmutable())->setTimestamp($claims['updatedAt']);
-        }
-
-        if (\array_key_exists('emailVerified', $claims) && null !== $claims['emailVerified'] && '' !== $claims['emailVerified']) {
-            $claims['emailVerified'] = (bool) $claims['emailVerified'];
-        }
-
-        if (\array_key_exists('phoneNumberVerified', $claims) && null !== $claims['phoneNumberVerified'] && '' !== $claims['phoneNumberVerified']) {
-            $claims['phoneNumberVerified'] = (bool) $claims['phoneNumberVerified'];
-        }
-
-        return new OidcUser(...$claims);
+        return OidcUser::fromClaims($claims);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
@@ -11,25 +11,25 @@
 
 namespace Symfony\Component\Security\Http\AccessToken\Oidc;
 
-use Psr\Cache\CacheItemInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\MissingClaimException;
 use Symfony\Component\Security\Http\Authenticator\FallbackUserLoader;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * The token handler validates the token on the OIDC server and retrieves the user identifier.
  */
-final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
+final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface, ResetInterface
 {
     use OidcTrait;
 
-    private ?CacheInterface $discoveryCache = null;
-    private ?string $oidcConfigurationCacheKey = null;
+    private ?OidcDiscovery $discovery = null;
 
     public function __construct(
         private HttpClientInterface $client,
@@ -40,40 +40,24 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
 
     public function enableDiscovery(CacheInterface $cache, string $oidcConfigurationCacheKey): void
     {
-        $this->discoveryCache = $cache;
-        $this->oidcConfigurationCacheKey = $oidcConfigurationCacheKey;
+        // no TTL: the cache pool decides, as it did before this delegated to OidcDiscovery.
+        // ".document" keeps the key clear of the entries previous releases wrote under the
+        // bare one, in formats of their own: they expire with the pool, unread.
+        $this->discovery = new OidcDiscovery($this->client, $cache, cacheTtl: null, cacheKey: $oidcConfigurationCacheKey.'.document', checkedEndpoints: ['userinfo_endpoint']);
     }
 
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
         $userInfoEndpoint = '';
 
-        if (null !== $this->discoveryCache) {
+        if (null !== $this->discovery) {
             try {
                 // Call OIDC discovery to retrieve userinfo endpoint
                 // OIDC configuration is stored in cache
-                $discover = function (CacheItemInterface $item, bool &$save): array {
-                    $response = $this->client->request('GET', '.well-known/openid-configuration', ['max_redirects' => 0]);
-                    $config = $response->toArray();
-                    $discoveryUrl = $response->getInfo('url');
+                $oidcConfiguration = $this->discovery->getConfiguration();
 
-                    self::checkDiscoveredEndpoint($config['userinfo_endpoint'] ?? null, 'userinfo_endpoint', $discoveryUrl);
-
-                    // A cached configuration does not tell which URL served it, so store only what has been checked against that URL
-                    $save = null !== $discoveryUrl && '' !== $discoveryUrl;
-
-                    return $config;
-                };
-
-                $oidcConfiguration = $this->discoveryCache->get($this->oidcConfigurationCacheKey, $discover);
-
-                if (!\is_array($oidcConfiguration)) {
-                    // Raw JSON was cached before the discovered endpoints were checked, refresh it to get it checked
-                    $this->discoveryCache->delete($this->oidcConfigurationCacheKey);
-                    $oidcConfiguration = $this->discoveryCache->get($this->oidcConfigurationCacheKey, $discover);
-                }
-
-                // The endpoint was checked against the discovery URL before the configuration was stored
+                // The scheme was checked against the URL that served the document before
+                // the configuration was cached, so only the announcement is enforced here
                 $userInfoEndpoint = self::checkDiscoveredEndpoint($oidcConfiguration['userinfo_endpoint'] ?? null, 'userinfo_endpoint', null);
             } catch (\Throwable $e) {
                 $this->logger?->error('An error occurred while requesting OIDC configuration.', [
@@ -110,5 +94,10 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
 
             throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
         }
+    }
+
+    public function reset(): void
+    {
+        $this->discovery?->reset();
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Base HTTP client for OpenID Connect protocol operations.
+ *
+ * Concrete subclasses decide how the client authenticates at the token endpoint
+ * (RFC 6749 §2.3): confidential clients send a secret, public clients rely on PKCE,
+ * other profiles use signed JWTs (OIDC Core §9).
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth OIDC Core 1.0 §3.1
+ * @see https://datatracker.ietf.org/doc/html/rfc6749                      OAuth 2.0 (RFC 6749)
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+abstract class OidcClient
+{
+    public function __construct(
+        protected readonly HttpClientInterface $httpClient,
+        protected readonly OidcDiscovery $discovery,
+        protected readonly string $clientId,
+    ) {
+    }
+
+    /**
+     * Exchanges an authorization code for tokens at the token endpoint.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws AuthenticationException If the token endpoint is missing, cannot be reached or returns an invalid response
+     */
+    public function exchangeCode(string $code, string $redirectUri, ?string $codeVerifier = null): array
+    {
+        $tokenEndpoint = $this->discovery->getSecureEndpoint('token_endpoint');
+
+        $body = [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $redirectUri,
+            'client_id' => $this->clientId,
+        ];
+
+        if (null !== $codeVerifier) {
+            $body['code_verifier'] = $codeVerifier;
+        }
+
+        $options = $this->applyClientAuthentication($body, []);
+
+        try {
+            return $this->httpClient->request('POST', $tokenEndpoint, $options)->toArray();
+        } catch (HttpClientExceptionInterface $e) {
+            throw new AuthenticationException(\sprintf('The OIDC token endpoint request failed: "%s"', $e->getMessage()), previous: $e);
+        }
+    }
+
+    /**
+     * Fetches the user's claims from the OIDC provider's UserInfo endpoint.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws AuthenticationException If the userinfo endpoint is missing, cannot be reached or returns an invalid response
+     */
+    public function fetchUserInfo(string $accessToken): array
+    {
+        $userInfoEndpoint = $this->discovery->getSecureEndpoint('userinfo_endpoint');
+
+        try {
+            return $this->httpClient->request('GET', $userInfoEndpoint, [
+                'auth_bearer' => $accessToken,
+            ])->toArray();
+        } catch (HttpClientExceptionInterface $e) {
+            throw new AuthenticationException(\sprintf('The OIDC userinfo endpoint request failed: "%s"', $e->getMessage()), previous: $e);
+        }
+    }
+
+    /**
+     * Applies the client authentication scheme to the token endpoint request.
+     *
+     * Subclasses return the final HttpClient options array (typically shaped as
+     * `['body' => ..., 'auth_basic' => ...]`), starting from the given request body.
+     *
+     * @param array<string, mixed> $body    The token request body being built
+     * @param array<string, mixed> $options The HttpClient options being built
+     *
+     * @return array<string, mixed> The final HttpClient options
+     */
+    abstract protected function applyClientAuthentication(array $body, array $options): array;
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcConfidentialClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcConfidentialClient.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * OIDC client for confidential clients (holding a client secret).
+ *
+ * Authenticates at the token endpoint using `client_secret_post` (secret in the
+ * request body), per RFC 6749 §2.3.1.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+class OidcConfidentialClient extends OidcClient
+{
+    public function __construct(
+        HttpClientInterface $httpClient,
+        OidcDiscovery $discovery,
+        string $clientId,
+        #[\SensitiveParameter] private readonly string $clientSecret,
+    ) {
+        parent::__construct($httpClient, $discovery, $clientId);
+    }
+
+    protected function applyClientAuthentication(array $body, array $options): array
+    {
+        $body['client_secret'] = $this->clientSecret;
+        $options['body'] = $body;
+
+        return $options;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Jose\Component\Checker\AudienceChecker;
+use Jose\Component\Checker\ClaimCheckerManager;
+use Jose\Component\Checker\ExpirationTimeChecker;
+use Jose\Component\Checker\InvalidClaimException;
+use Jose\Component\Checker\IssuedAtChecker;
+use Jose\Component\Checker\IssuerChecker;
+use Jose\Component\Checker\MissingMandatoryClaimException;
+use Jose\Component\Checker\NotBeforeChecker;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Decodes and validates OIDC ID tokens using the web-token (JOSE) library,
+ * reusing the same claim checkers as the OIDC access-token handlers.
+ *
+ * The signature is not verified: the ID token is received directly from the
+ * token endpoint over TLS, where signature verification MAY be skipped
+ * (OIDC Core 1.0, Section 3.1.3.7, item 6).
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcIdToken
+{
+    /**
+     * @param ClockInterface $clock The caller provides the clock (any PSR-20 implementation):
+     *                              symfony/clock is not a dependency of this component, so no
+     *                              default can be instantiated here
+     */
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly int $allowedTimeDrift = 0,
+    ) {
+    }
+
+    /**
+     * Decodes the claims of a JWT without verifying its signature.
+     *
+     * @return array<string, mixed> The decoded claims
+     *
+     * @throws AuthenticationException If the token cannot be decoded
+     */
+    public function decode(string $jwt): array
+    {
+        if (!class_exists(JWSSerializerManager::class)) {
+            throw new \LogicException('You cannot decode OIDC ID tokens since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        try {
+            $payload = (new JWSSerializerManager([new CompactSerializer()]))->unserialize($jwt)->getPayload();
+        } catch (\InvalidArgumentException) {
+            throw new AuthenticationException('Invalid ID token format.');
+        }
+
+        try {
+            $claims = json_decode($payload ?? '', true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            throw new AuthenticationException('Invalid ID token payload.');
+        }
+
+        if (!\is_array($claims)) {
+            throw new AuthenticationException('Invalid ID token payload.');
+        }
+
+        return $claims;
+    }
+
+    /**
+     * Validates ID token claims per OIDC Core 1.0, Section 3.1.3.7.
+     *
+     * @throws AuthenticationException If any claim validation fails
+     */
+    public function validateClaims(array $claims, string $expectedIssuer, string $expectedAudience, ?string $expectedNonce = null): void
+    {
+        if (!class_exists(ClaimCheckerManager::class)) {
+            throw new \LogicException('You cannot validate OIDC ID tokens since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        try {
+            (new ClaimCheckerManager([
+                new IssuerChecker([$expectedIssuer]),
+                new AudienceChecker($expectedAudience),
+                new IssuedAtChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
+                new NotBeforeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
+                new ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
+            ]))->check($claims, ['iss', 'aud', 'exp', 'iat']);
+        } catch (InvalidClaimException|MissingMandatoryClaimException $e) {
+            throw new AuthenticationException(\sprintf('Invalid ID token: "%s"', $e->getMessage()), previous: $e);
+        }
+
+        // "azp" is only checked when present: OIDC Core 1.0, Section 3.1.3.7 items 3 to 5
+        // are SHOULD, and the AudienceChecker above already ensures the client_id is one
+        // of the audiences.
+        if (isset($claims['azp']) && !hash_equals($expectedAudience, (string) $claims['azp'])) {
+            throw new AuthenticationException('ID token "azp" claim does not match the expected client_id.');
+        }
+
+        if (null !== $expectedNonce && (!isset($claims['nonce']) || !hash_equals($expectedNonce, (string) $claims['nonce']))) {
+            throw new AuthenticationException('ID token nonce does not match.');
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -1,0 +1,363 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+/**
+ * Authenticator for the OpenID Connect Authorization Code Flow.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcLoginAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface, InteractiveAuthenticatorInterface
+{
+    private const MAX_CONCURRENT_ATTEMPTS = 5;
+
+    private array $options;
+
+    public function __construct(
+        private readonly HttpUtils $httpUtils,
+        private readonly UserProviderInterface $userProvider,
+        private readonly OidcClient $oidcClient,
+        private readonly OidcDiscovery $discovery,
+        private readonly OidcIdToken $idToken,
+        private readonly string $clientId,
+        private readonly AuthenticationSuccessHandlerInterface $successHandler,
+        private readonly AuthenticationFailureHandlerInterface $failureHandler,
+        array $options,
+    ) {
+        $this->options = array_merge([
+            'check_path' => '/oidc/callback',
+            'firewall_name' => 'main',
+            'scope' => ['openid'],
+        ], $options);
+    }
+
+    public function supports(Request $request): bool
+    {
+        // every request on the callback path is handled here: the route declared for it
+        // carries no controller, so one passing through would end up reported as a routing
+        // error instead of the authentication failure it is
+        return $this->httpUtils->checkRequestPath($request, $this->options['check_path']);
+    }
+
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
+    {
+        $session = $this->getSession($request);
+        $prefix = $this->getSessionPrefix();
+
+        // both resolved before anything is stored in the session, so that a provider
+        // announcing no usable authorization endpoint, or a "check_path" given as a route
+        // name with no URL generator to resolve it, does not leave any attempt behind
+        $authorizationEndpoint = $this->discovery->getSecureEndpoint('authorization_endpoint');
+        $redirectUri = $this->httpUtils->generateUri($request, $this->options['check_path']);
+
+        $state = bin2hex(random_bytes(32));
+        $nonce = bin2hex(random_bytes(32));
+        $codeVerifier = $this->generateCodeVerifier();
+
+        // each pending attempt lives under its own session key, carrying the state, so
+        // that concurrent logins started from several tabs write distinct entries instead
+        // of rewriting a shared one; the count is capped, oldest attempts dropped first,
+        // so that an unauthenticated visitor cannot grow the session unbounded
+        // (spring-security's unbounded per-state storage was CVE-2021-22119)
+        $attemptKeys = $this->getAttemptKeys($session);
+        while (\count($attemptKeys) >= self::MAX_CONCURRENT_ATTEMPTS) {
+            $session->remove(array_shift($attemptKeys));
+        }
+
+        $session->set($prefix.'attempt.'.$state, [
+            'nonce' => $nonce,
+            'code_verifier' => $codeVerifier,
+            'redirect_uri' => $redirectUri,
+        ]);
+
+        $params = [
+            'response_type' => 'code',
+            'client_id' => $this->clientId,
+            'redirect_uri' => $redirectUri,
+            'scope' => implode(' ', $this->getScopes()),
+            'state' => $state,
+            'nonce' => $nonce,
+            'code_challenge' => rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '='),
+            'code_challenge_method' => 'S256',
+        ];
+
+        $authorizationUrl = $authorizationEndpoint
+            .(str_contains($authorizationEndpoint, '?') ? '&' : '?')
+            .http_build_query($params, '', '&', \PHP_QUERY_RFC3986);
+
+        return new RedirectResponse($authorizationUrl);
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $session = $this->getSession($request);
+        $prefix = $this->getSessionPrefix();
+
+        // the "state" is validated first: an unauthenticated request would otherwise get an
+        // attacker-supplied "error_description" stored in the session, through the exception
+        // the failure handler keeps there (the provider echoes "state" back on errors too,
+        // as RFC 6749, Section 4.1.2.1 requires)
+        $state = $request->query->get('state');
+        if (!\is_string($state) || '' === $state) {
+            throw new AuthenticationException('Invalid OIDC state parameter.');
+        }
+
+        // the attempt is looked up with hash_equals() over the stored keys, so the
+        // attacker-supplied value is never used as a session key, and an unknown state
+        // fails with the same message as an empty session (no oracle, no login CSRF)
+        $expectedKey = $prefix.'attempt.'.$state;
+        $matchedKey = null;
+
+        foreach ($this->getAttemptKeys($session) as $key) {
+            if (hash_equals($key, $expectedKey)) {
+                $matchedKey = $key;
+                break;
+            }
+        }
+
+        if (null === $matchedKey) {
+            throw new AuthenticationException('Invalid OIDC state parameter.');
+        }
+
+        // the matched attempt is consumed right away, whatever the outcome: a replayed
+        // callback fails on the state check, and the other pending attempts survive
+        $attempt = $session->get($matchedKey);
+        $session->remove($matchedKey);
+
+        $nonce = \is_array($attempt) ? $attempt['nonce'] ?? null : null;
+        $codeVerifier = \is_array($attempt) ? $attempt['code_verifier'] ?? null : null;
+        $redirectUri = \is_array($attempt) ? $attempt['redirect_uri'] ?? null : null;
+
+        $this->checkForProviderError($request);
+
+        $code = $request->query->get('code');
+        if (null === $code) {
+            throw new AuthenticationException('Missing authorization code in OIDC callback.');
+        }
+
+        // the nonce is mandatory in this flow, since start() always sends one: requiring it
+        // here means the check of the "nonce" claim in the ID token can never be skipped
+        if (!\is_string($nonce) || '' === $nonce) {
+            throw new AuthenticationException('Missing OIDC nonce in session.');
+        }
+
+        // same for the PKCE verifier: exchanging the code without it would downgrade PKCE
+        if (!\is_string($codeVerifier) || '' === $codeVerifier) {
+            throw new AuthenticationException('Missing PKCE code verifier in session.');
+        }
+
+        // and the redirect URI resolved when the flow started: RFC 6749, Section 4.1.3
+        // requires the token request to carry the very value the authorization request
+        // used, so it is replayed from the attempt instead of being recomputed from the
+        // callback request, whose host is not necessarily the one the flow started on
+        if (!\is_string($redirectUri) || '' === $redirectUri) {
+            throw new AuthenticationException('Missing OIDC redirect URI in session.');
+        }
+
+        $tokenData = $this->exchangeAuthorizationCode($redirectUri, $code, $codeVerifier);
+
+        $idTokenClaims = $this->idToken->decode($tokenData['id_token']);
+        $this->idToken->validateClaims(
+            $idTokenClaims,
+            $this->discovery->getConfiguration()['issuer'] ?? '',
+            $this->clientId,
+            $nonce,
+        );
+
+        $claims = $this->fetchUserClaims($tokenData['access_token'], $idTokenClaims);
+
+        // The user is loaded by the firewall's user provider, from the verified "sub"
+        // claim and with every claim passed as badge attributes: a provider implementing
+        // AttributesBasedUserProviderInterface receives them, which is where mapping
+        // claims onto roles belongs. The built-in "oidc" provider builds a self-contained
+        // OidcUser, without letting a claim define the identity or grant any role.
+        $passport = new SelfValidatingPassport(
+            new UserBadge($claims['sub'], $this->userProvider->loadUserByIdentifier(...), $claims),
+        );
+        $passport->setAttribute('oidc_token_data', $tokenData);
+
+        return $passport;
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        $token = new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+
+        $tokenData = $passport->getAttribute('oidc_token_data');
+        if (\is_array($tokenData)) {
+            $token->setAttribute('oidc_id_token', $tokenData['id_token'] ?? null);
+            $token->setAttribute('oidc_access_token', $tokenData['access_token'] ?? null);
+        }
+
+        return $token;
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        // each pending attempt carries a nonce and a PKCE verifier, which have no
+        // place in an authenticated session; a callback for one of them would
+        // re-authenticate anyway, the state check just fails it earlier
+        $session = $this->getSession($request);
+        foreach ($this->getAttemptKeys($session) as $key) {
+            $session->remove($key);
+        }
+
+        return $this->successHandler->onAuthenticationSuccess($request, $token);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        return $this->failureHandler->onAuthenticationFailure($request, $exception);
+    }
+
+    public function isInteractive(): bool
+    {
+        return true;
+    }
+
+    private function checkForProviderError(Request $request): void
+    {
+        $error = $request->query->get('error');
+        if (null !== $error) {
+            $description = $request->query->get('error_description', $error);
+
+            // only the matched attempt was consumed: a provider error for one tab
+            // must not cancel the logins pending in the others
+            throw new AuthenticationException(\sprintf('OIDC provider returned an error: "%s"', $description));
+        }
+    }
+
+    /**
+     * Exchanges the authorization code for tokens and ensures the token endpoint
+     * returned an ID and access token.
+     *
+     * @return array<string, mixed>
+     */
+    private function exchangeAuthorizationCode(string $redirectUri, string $code, string $codeVerifier): array
+    {
+        $tokenData = $this->oidcClient->exchangeCode($code, $redirectUri, $codeVerifier);
+
+        if (!\is_string($tokenData['id_token'] ?? null) || '' === $tokenData['id_token']) {
+            throw new AuthenticationException('The token endpoint response does not contain a valid "id_token".');
+        }
+        if (!\is_string($tokenData['access_token'] ?? null) || '' === $tokenData['access_token']) {
+            throw new AuthenticationException('The token endpoint response does not contain a valid "access_token".');
+        }
+
+        return $tokenData;
+    }
+
+    /**
+     * Fetches user claims from the UserInfo endpoint and enforces the OIDC Core
+     * 1.0, Section 5.3.2 rule that its "sub" matches the ID token "sub".
+     *
+     * @param array<string, mixed> $idTokenClaims
+     *
+     * @return array<string, mixed>
+     */
+    private function fetchUserClaims(string $accessToken, array $idTokenClaims): array
+    {
+        $claims = $this->oidcClient->fetchUserInfo($accessToken);
+
+        if (!\is_string($claims['sub'] ?? null) || '' === $claims['sub']) {
+            throw new AuthenticationException('The "sub" claim is missing or invalid in the OIDC response.');
+        }
+
+        if (!\is_string($idTokenClaims['sub'] ?? null) || !hash_equals($idTokenClaims['sub'], $claims['sub'])) {
+            throw new AuthenticationException('The "sub" claim from the UserInfo endpoint does not match the ID token.');
+        }
+
+        return $claims;
+    }
+
+    /**
+     * Returns the scopes of the authorization request, always including "openid",
+     * which OIDC Core 1.0, Section 3.1.2.1 requires for the request to return an
+     * ID token. Each configured value may hold several space-separated scopes, so
+     * that an environment variable can carry them all.
+     *
+     * @return list<string>
+     */
+    private function getScopes(): array
+    {
+        $scopes = ['openid'];
+        foreach ((array) $this->options['scope'] as $scope) {
+            foreach (preg_split('/\s+/', (string) $scope, -1, \PREG_SPLIT_NO_EMPTY) as $value) {
+                $scopes[] = $value;
+            }
+        }
+
+        return array_values(array_unique($scopes));
+    }
+
+    private function generateCodeVerifier(): string
+    {
+        // A 32-byte (256-bit) verifier, hex-encoded to 64 characters, as recommended
+        // by RFC 7636 Appendix B. The S256 challenge below is the only base64url step.
+        return bin2hex(random_bytes(32));
+    }
+
+    private function getSession(Request $request): SessionInterface
+    {
+        if (!$request->hasSession()) {
+            throw new \LogicException('The "oidc_login" authenticator stores the OIDC "state", "nonce" and PKCE code verifier in the session, which this request has none of: it cannot be used with the session disabled, nor on a stateless firewall.');
+        }
+
+        return $request->getSession();
+    }
+
+    /**
+     * Returns the session keys of the pending attempts, oldest first.
+     *
+     * @return list<string>
+     */
+    private function getAttemptKeys(SessionInterface $session): array
+    {
+        $attemptPrefix = $this->getSessionPrefix().'attempt.';
+
+        $keys = [];
+        foreach (array_keys($session->all()) as $key) {
+            // a numeric session attribute name comes back as an int key
+            if (str_starts_with((string) $key, $attemptPrefix)) {
+                $keys[] = (string) $key;
+            }
+        }
+
+        return $keys;
+    }
+
+    private function getSessionPrefix(): string
+    {
+        return '_security.oidc_login.'.$this->options['firewall_name'].'.';
+    }
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -16,6 +16,9 @@ CHANGELOG
  * Configure the decorated handler of `CustomAuthenticationSuccessHandler` and `CustomAuthenticationFailureHandler` when they are called instead of when they are built, so that a single handler can be shared by several authenticators
  * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()` to add extra query parameters covered by the link signature
  * Expose the verified extra parameters via the `_login_link_parameters` request attribute when consuming a login link
+ * Add `OidcLoginAuthenticator` for the OpenID Connect Authorization Code Flow (interactive login via OIDC provider)
+ * Add `OidcClient` and `OidcDiscovery` protocol classes
+ * Cache the discovery document of the `oidc` access token handler for one hour, where it was fetched again on every refresh of the JWKS
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Oidc/OidcDiscovery.php
+++ b/src/Symfony/Component/Security/Http/Oidc/OidcDiscovery.php
@@ -1,0 +1,309 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Oidc;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Fetches and caches the OpenID Connect discovery configuration.
+ *
+ * It lives outside the authenticator namespace on purpose: resolving the endpoints
+ * of a provider is a protocol concern shared by every OIDC authentication mechanism,
+ * not something specific to the Authorization Code Flow.
+ *
+ * @see https://openid.net/specs/openid-connect-discovery-1_0.html
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcDiscovery implements ResetInterface
+{
+    // Discovery documents are small. This limits untrusted data retained by the cache.
+    private const MAX_CONFIGURATION_SIZE = 1024 * 1024;
+
+    private readonly ?string $issuer;
+    private readonly string $openIdConfigurationUrl;
+    private ?ResponseInterface $response = null;
+    private ?array $configuration = null;
+
+    /**
+     * @param string       $openIdConfigurationUrl Absolute, or relative to $issuer when one is given,
+     *                                             or to the HTTP client "base_uri"
+     * @param string|null  $issuer                 The expected issuer, or null to skip the check of OIDC Discovery 1.0, Section 4.3
+     * @param int|null     $cacheTtl               The cache entry lifetime, or null to leave it to the cache pool
+     * @param string|null  $cacheKey               The cache key, or null to derive it from the configuration URL
+     * @param list<string> $checkedEndpoints       Endpoints that must be announced and must not downgrade to plain
+     *                                             HTTP the transport that carried the discovery document, checked
+     *                                             before the document is cached
+     */
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly CacheInterface $cache,
+        string $openIdConfigurationUrl = '.well-known/openid-configuration',
+        ?string $issuer = null,
+        private readonly ?int $cacheTtl = 3600,
+        private readonly ?string $cacheKey = null,
+        private readonly array $checkedEndpoints = [],
+    ) {
+        // The trailing slash is trimmed here, and the configuration URL built from the
+        // issuer, because an issuer coming from an environment variable is an unresolved
+        // placeholder while the container compiles: trimming it there leaves the resolved
+        // value untouched, and the discovery URL ends up carrying a double slash.
+        $this->issuer = null !== $issuer ? rtrim($issuer, '/') : null;
+        // OIDC Discovery 1.0, Section 4.1: the well-known path is appended to the issuer
+        $this->openIdConfigurationUrl = null !== $this->issuer && !preg_match('#^https?://#i', $openIdConfigurationUrl)
+            ? $this->issuer.'/'.ltrim($openIdConfigurationUrl, '/')
+            : $openIdConfigurationUrl;
+    }
+
+    /**
+     * @return array<string, mixed> The raw discovery document
+     *
+     * @throws AuthenticationException If the discovery document cannot be fetched or announces another issuer
+     */
+    public function getConfiguration(): array
+    {
+        // Checked outside the cache callback so it also applies to warm entries, and
+        // here rather than only in the configuration of the firewall because a
+        // "provider_uri" coming from an environment variable is unknown until runtime.
+        if (null !== $this->issuer && !self::isSecureUrl($this->issuer)) {
+            throw new AuthenticationException(\sprintf('The OIDC issuer "%s" must use HTTPS: the authorization code, the PKCE verifier and the tokens it is exchanged for are only confidential over TLS.', $this->issuer));
+        }
+
+        // the decoded document is memoized for the lifetime of the instance (one per
+        // request on classic runtimes, reset between requests in worker mode), so
+        // repeated endpoint reads within one authentication do not re-read the cache
+        // nor re-decode, and a zero cache TTL costs a single HTTP request per
+        // authentication instead of one per read
+        if (null !== $this->configuration) {
+            return $this->configuration;
+        }
+
+        $value = $this->cache->get($this->getCacheKey(), function (ItemInterface $item, bool &$save): array {
+            if (null !== $this->cacheTtl) {
+                $item->expiresAfter($this->cacheTtl);
+            }
+
+            // the request may have been sent by prefetch() already, and is consumed once
+            $response = $this->response ?? $this->request();
+            $this->response = null;
+
+            try {
+                // decoding here rejects a malformed document before it reaches the cache,
+                // where it would otherwise fail on every read until the entry expires
+                $payload = $this->getConfigurationPayload($response);
+                $configuration = $this->decode($payload);
+            } catch (HttpClientExceptionInterface $e) {
+                throw $this->cannotFetch($e);
+            }
+
+            // OpenID Connect Discovery 1.0, Section 4.3: the "issuer" returned MUST be
+            // identical to the issuer used to build the discovery URL. Validating it
+            // prevents a tampered discovery document from redefining the expected issuer.
+            // A trailing slash is ignored on both sides: providers do announce issuers
+            // ending with one (Authentik does), and it carries no security meaning since
+            // the origin and the path are otherwise identical.
+            if (null !== $this->issuer
+                && rtrim((string) ($configuration['issuer'] ?? ''), '/') !== $this->issuer
+            ) {
+                throw new AuthenticationException(\sprintf('The OIDC provider announced the issuer "%s", which does not match the configured issuer "%s".', $configuration['issuer'] ?? '', $this->issuer));
+            }
+
+            // checked before the document is stored, so that a document sending its
+            // clients to plain HTTP is never cached, and a cached configuration does
+            // not tell which URL served it, so store only when that URL is known
+            $url = $response->getInfo('url');
+            $url = \is_string($url) ? $url : '';
+            foreach ($this->checkedEndpoints as $endpoint) {
+                self::checkEndpointScheme($configuration[$endpoint] ?? null, $endpoint, $url);
+            }
+            $save = '' !== $url;
+
+            // the raw payload is cached next to the URL that served it, rather than the
+            // decoded document, so that the whole document survives the round trip unchanged
+            return ['url' => $url, 'payload' => $payload];
+        });
+
+        // a request sent by prefetch() is dropped when another process warmed the entry
+        // in between, instead of being consumed the next time the document is read
+        $this->response = null;
+
+        return $this->configuration = $this->decode($value['payload'] ?? '');
+    }
+
+    /**
+     * Sends the discovery request, without waiting for its response, when the document is
+     * not cached yet.
+     *
+     * Calling it on several instances before reading any of them lets their requests travel
+     * concurrently, since the response is only consumed by {@see getConfiguration()}.
+     */
+    public function prefetch(): void
+    {
+        if (null !== $this->response || null !== $this->configuration) {
+            return;
+        }
+
+        $this->cache->get($this->getCacheKey(), function (ItemInterface $item, bool &$save): string {
+            // the document is not cached: its request is sent and left for
+            // getConfiguration() to consume, so nothing is computed nor stored here
+            $save = false;
+            $this->response = $this->request();
+
+            return '';
+        });
+    }
+
+    public function reset(): void
+    {
+        $this->configuration = null;
+        $this->response = null;
+    }
+
+    /**
+     * Returns an endpoint announced by the discovery document, checking that it provides
+     * the transport security the ID token relies on.
+     *
+     * The document is fetched from the provider, so a tampered or misconfigured one must
+     * not be able to downgrade a request to plain HTTP: enforcing HTTPS on the configured
+     * issuer would be pointless if the endpoints it announces were used as they are.
+     *
+     * @throws AuthenticationException If the endpoint is not announced, or does not use HTTPS
+     */
+    public function getSecureEndpoint(string $endpoint): string
+    {
+        $url = $this->getConfiguration()[$endpoint] ?? null;
+
+        if (!\is_string($url) || '' === $url) {
+            throw new AuthenticationException(\sprintf('The OIDC provider does not announce any "%s".', $endpoint));
+        }
+
+        // The token endpoint carries the authorization code and the PKCE verifier one way,
+        // and returns the ID and access tokens the other, so its transport must be secure even
+        // for the loopback and test-domain issuers allowed during local development. A public
+        // client sends no secret there, and still needs this.
+        if (!self::isSecureUrl($url) || ('token_endpoint' === $endpoint && 'https' !== strtolower((string) parse_url($url, \PHP_URL_SCHEME)))) {
+            throw new AuthenticationException(\sprintf('The "%s" announced by the OIDC provider must use HTTPS (got "%s"): the authorization code, the PKCE verifier and the tokens it is exchanged for are only confidential over TLS.', $endpoint, $url));
+        }
+
+        return $url;
+    }
+
+    /**
+     * Tells whether the given URL provides the transport security the OIDC flow relies on.
+     *
+     * The authorization code, the PKCE verifier and the tokens it is exchanged for are only
+     * confidential over TLS, so HTTPS is mandatory, loopback hosts and the names reserved for
+     * testing excepted, for local development.
+     */
+    public static function isSecureUrl(string $url): bool
+    {
+        // parse_url() returns the scheme as it is written, and a scheme is case-insensitive
+        if ('https' === strtolower((string) parse_url($url, \PHP_URL_SCHEME))) {
+            return true;
+        }
+
+        // parse_url() keeps the square brackets around IPv6 hosts
+        $host = strtolower(trim((string) parse_url($url, \PHP_URL_HOST), '[]'));
+
+        if (\in_array($host, ['localhost', '127.0.0.1', '::1'], true)) {
+            return true;
+        }
+
+        // special-use domain names reserved for testing: RFC 2606 §2, RFC 6761 §6.2 and §6.3
+        return str_ends_with($host, '.localhost') || str_ends_with($host, '.test');
+    }
+
+    private function request(): ResponseInterface
+    {
+        try {
+            // redirects are not followed: the endpoints announced by the document are
+            // checked against the URL it was requested from, which a redirect would change
+            $response = $this->httpClient->request('GET', $this->openIdConfigurationUrl, ['max_redirects' => 0]);
+            $response->getHeaders(); // triggers the exception on a 3xx, 4xx or 5xx status
+
+            return $response;
+        } catch (HttpClientExceptionInterface $e) {
+            throw $this->cannotFetch($e);
+        }
+    }
+
+    /**
+     * The discovery specification requires the endpoints it advertises to use the "https"
+     * scheme: they are rejected when they downgrade the transport that carried the document.
+     */
+    private static function checkEndpointScheme(mixed $endpoint, string $key, string $discoveryUrl): void
+    {
+        if (!\is_string($endpoint) || '' === $endpoint) {
+            throw new AuthenticationException(\sprintf('The "%s" is missing from the OIDC discovery document.', $key));
+        }
+
+        $scheme = parse_url($endpoint, \PHP_URL_SCHEME);
+
+        if ($scheme && 'https' !== strtolower($scheme) && str_starts_with($discoveryUrl, 'https://')) {
+            throw new AuthenticationException(\sprintf('The "%s" found in the OIDC discovery document must use the "https" scheme, "%s" given.', $key, $scheme));
+        }
+    }
+
+    private function getConfigurationPayload(ResponseInterface $response): string
+    {
+        $payload = '';
+        foreach ($this->httpClient->stream($response) as $chunk) {
+            $payload .= $chunk->getContent();
+            if (self::MAX_CONFIGURATION_SIZE < \strlen($payload)) {
+                $response->cancel();
+
+                throw new AuthenticationException('The OIDC discovery document exceeds the maximum size of 1 MiB.');
+            }
+        }
+
+        return $payload;
+    }
+
+    private function cannotFetch(\Throwable $e): AuthenticationException
+    {
+        return new AuthenticationException(\sprintf('The OIDC discovery document could not be fetched from "%s": "%s"', $this->openIdConfigurationUrl, $e->getMessage()), previous: $e);
+    }
+
+    /**
+     * Decodes a JSON payload and ensures it is a JSON object.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws AuthenticationException
+     */
+    private function decode(string $payload): array
+    {
+        try {
+            $configuration = json_decode($payload, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw $this->cannotFetch(new \JsonException(\sprintf('Invalid JSON: "%s"', $e->getMessage()), $e->getCode(), $e));
+        }
+
+        // a valid JSON payload may still hold a scalar, which none of the readers expect
+        if (!\is_array($configuration)) {
+            throw $this->cannotFetch(new \JsonException('The document is not a JSON object.'));
+        }
+
+        return $configuration;
+    }
+
+    private function getCacheKey(): string
+    {
+        return $this->cacheKey ?? 'oidc_discovery.'.hash('xxh128', $this->openIdConfigurationUrl);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -336,6 +336,45 @@ class OidcTokenHandlerTest extends TestCase
         $this->assertTrue($cache->hasItem('oidc_config'));
     }
 
+    public function testDiscoveryDocumentsOfEveryClientAreRequestedBeforeTheirJwks()
+    {
+        // the responses are lazy, so requesting every ".well-known" document before consuming
+        // any of them is what lets those round trips happen concurrently
+        $requestedUrls = [];
+        $httpClients = [];
+        foreach ([1, 2] as $provider) {
+            $httpClients[] = new MockHttpClient(static function ($method, $url) use (&$requestedUrls, $provider): JsonMockResponse {
+                $requestedUrls[] = $url;
+
+                if (str_contains($url, 'openid-configuration')) {
+                    return new JsonMockResponse(['jwks_uri' => \sprintf('https://provider%d.example.com/jwks.json', $provider)]);
+                }
+
+                return new JsonMockResponse(['keys' => [array_merge((1 === $provider ? self::getJWK() : self::getSecondJWK())->all(), ['use' => 'sig'])]]);
+            }, \sprintf('https://provider%d.example.com/', $provider));
+        }
+
+        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com']);
+        $handler->enableDiscovery(new ArrayAdapter(), $httpClients, 'oidc_config');
+
+        $time = time();
+        $handler->getUserBadgeFrom(self::buildJWSWithKey(json_encode([
+            'iat' => $time,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'user-from-provider1',
+        ]), self::getJWK()));
+
+        $this->assertSame([
+            'https://provider1.example.com/.well-known/openid-configuration',
+            'https://provider2.example.com/.well-known/openid-configuration',
+            'https://provider1.example.com/jwks.json',
+            'https://provider2.example.com/jwks.json',
+        ], $requestedUrls);
+    }
+
     private static function buildJWSWithKey(string $payload, JWK $jwk): string
     {
         return (new CompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([
@@ -385,6 +424,51 @@ class OidcTokenHandlerTest extends TestCase
         $this->assertSame(2, $requestCount);
         $this->assertSame('user-cache-control', $handler->getUserBadgeFrom($token)->getUserIdentifier());
         $this->assertSame(2, $requestCount);
+    }
+
+    public function testResetForcesANewDiscoveryOnTheNextAuthentication()
+    {
+        $requestedUrls = [];
+        $httpClient = new MockHttpClient(static function ($method, $url) use (&$requestedUrls): JsonMockResponse {
+            $requestedUrls[] = $url;
+
+            if (str_contains($url, 'openid-configuration')) {
+                return new JsonMockResponse(['jwks_uri' => 'https://www.example.com/jwks.json']);
+            }
+
+            return new JsonMockResponse(['keys' => [array_merge(self::getJWK()->all(), ['use' => 'sig'])]]);
+        });
+        $countConfigurationRequests = static function () use (&$requestedUrls): int {
+            return \count(array_filter($requestedUrls, static fn (string $url): bool => str_contains($url, 'openid-configuration')));
+        };
+
+        $time = time();
+        $token = self::buildJWS(json_encode([
+            'iat' => $time,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'user-reset',
+        ]));
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com']);
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_config');
+
+        $handler->getUserBadgeFrom($token);
+        $this->assertSame(1, $countConfigurationRequests());
+
+        // expired JWKS and document entries alone recompute the keys from the memoized document
+        $cache->deleteItems(['oidc_config', 'oidc_config.document.0']);
+        $handler->getUserBadgeFrom($token);
+        $this->assertSame(1, $countConfigurationRequests());
+
+        // after reset(), recomputing the keys fetches the discovery document again
+        $handler->reset();
+        $cache->deleteItems(['oidc_config', 'oidc_config.document.0']);
+        $handler->getUserBadgeFrom($token);
+        $this->assertSame(2, $countConfigurationRequests());
     }
 
     public function testDiscoveryCachesJwksAccordingToExpires()

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
@@ -15,9 +15,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\Chunk\DataChunk;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OidcUser;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcUserInfoTokenHandler;
@@ -175,8 +177,9 @@ class OidcUserInfoTokenHandlerTest extends TestCase
 
     public function testDiscoveryIsNotCachedWhenTheDiscoveryUrlIsUnknown()
     {
+        $payload = json_encode(['userinfo_endpoint' => 'https://oidc.example.com/userinfo']);
+
         $configResponse = $this->createStub(ResponseInterface::class);
-        $configResponse->method('toArray')->willReturn(['userinfo_endpoint' => 'https://oidc.example.com/userinfo']);
         $configResponse->method('getInfo')->willReturn(null);
 
         $userInfoResponse = $this->createStub(ResponseInterface::class);
@@ -189,13 +192,57 @@ class OidcUserInfoTokenHandlerTest extends TestCase
 
             return '.well-known/openid-configuration' === $url ? $configResponse : $userInfoResponse;
         });
+        $clientMock->method('stream')->willReturnCallback(static fn (ResponseInterface $response) => new ResponseStream((static function () use ($response, $payload) {
+            yield $response => new DataChunk(0, $payload);
+        })()));
 
+        $cache = new ArrayAdapter();
         $handler = new OidcUserInfoTokenHandler($clientMock);
-        $handler->enableDiscovery(new ArrayAdapter(), 'oidc_config');
+        $handler->enableDiscovery($cache, 'oidc_config');
 
         $handler->getUserBadgeFrom('a-secret-token');
         $handler->getUserBadgeFrom('a-secret-token');
 
+        // the instance memoizes the document, so the second authentication does not
+        // re-request it; not knowing the URL that served it still keeps it out of the cache
+        $this->assertFalse($cache->getItem('oidc_config.document')->isHit());
+        $this->assertSame([
+            '.well-known/openid-configuration',
+            'https://oidc.example.com/userinfo',
+            'https://oidc.example.com/userinfo',
+        ], $requestedUrls);
+    }
+
+    public function testResetForcesANewDiscoveryOnTheNextAuthentication()
+    {
+        $payload = json_encode(['userinfo_endpoint' => 'https://oidc.example.com/userinfo']);
+
+        $configResponse = $this->createStub(ResponseInterface::class);
+        $configResponse->method('getInfo')->willReturn(null);
+
+        $userInfoResponse = $this->createStub(ResponseInterface::class);
+        $userInfoResponse->method('toArray')->willReturn(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']);
+
+        $requestedUrls = [];
+        $clientMock = $this->createStub(HttpClientInterface::class);
+        $clientMock->method('request')->willReturnCallback(static function (string $method, string $url) use (&$requestedUrls, $configResponse, $userInfoResponse) {
+            $requestedUrls[] = $url;
+
+            return '.well-known/openid-configuration' === $url ? $configResponse : $userInfoResponse;
+        });
+        $clientMock->method('stream')->willReturnCallback(static fn (ResponseInterface $response) => new ResponseStream((static function () use ($response, $payload) {
+            yield $response => new DataChunk(0, $payload);
+        })()));
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcUserInfoTokenHandler($clientMock);
+        $handler->enableDiscovery($cache, 'oidc_config');
+
+        $handler->getUserBadgeFrom('a-secret-token');
+        $handler->reset();
+        $handler->getUserBadgeFrom('a-secret-token');
+
+        // After reset(), the next authentication should request the discovery document again
         $this->assertSame([
             '.well-known/openid-configuration',
             'https://oidc.example.com/userinfo',
@@ -204,11 +251,13 @@ class OidcUserInfoTokenHandlerTest extends TestCase
         ], $requestedUrls);
     }
 
-    public function testDiscoveryRefreshesAConfigurationCachedAsRawJson()
+    #[DataProvider('provideLegacyConfigurationCacheEntries')]
+    public function testDiscoveryIgnoresTheEntriesTheReplacedCodeCached(string|array $legacyEntry)
     {
+        // the bare key holds what previous releases cached there, in formats of their
+        // own, unchecked: the document is read and stored under a key of its own instead
         $cache = new ArrayAdapter();
-        // an entry written before the discovered endpoints were checked
-        $cache->get('oidc_config', static fn () => json_encode(['userinfo_endpoint' => 'http://169.254.169.254/latest/meta-data/']));
+        $cache->get('oidc_config', static fn () => $legacyEntry);
 
         $userInfoResponse = new JsonMockResponse(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']);
         $httpClient = new MockHttpClient([
@@ -223,7 +272,14 @@ class OidcUserInfoTokenHandlerTest extends TestCase
 
         $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
         $this->assertSame('https://oidc.example.com/userinfo', $userInfoResponse->getRequestUrl());
-        $this->assertIsArray($cache->getItem('oidc_config')->get());
+        $this->assertSame($legacyEntry, $cache->getItem('oidc_config')->get());
+        $this->assertIsArray($cache->getItem('oidc_config.document')->get());
+    }
+
+    public static function provideLegacyConfigurationCacheEntries(): iterable
+    {
+        yield 'the decoded document' => [['userinfo_endpoint' => 'http://169.254.169.254/latest/meta-data/']];
+        yield 'the raw JSON' => [json_encode(['userinfo_endpoint' => 'http://169.254.169.254/latest/meta-data/'])];
     }
 
     public function testDiscoveryRejectsMissingUserInfoEndpoint()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+class OidcConfidentialClientTest extends TestCase
+{
+    private OidcDiscovery $discovery;
+    private HttpClientInterface $httpClient;
+
+    protected function setUp(): void
+    {
+        $this->discovery = $this->createDiscovery([
+            'token_endpoint' => 'https://provider.example.com/token',
+            'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+            'issuer' => 'https://provider.example.com',
+        ]);
+
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function createDiscovery(array $configuration): OidcDiscovery
+    {
+        return new OidcDiscovery(
+            new MockHttpClient(static fn (): MockResponse => new JsonMockResponse($configuration)),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+    }
+
+    public function testExchangeCodeWithClientSecretPost()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => 'id-token-abc',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://provider.example.com/token', $this->callback(function (array $options) {
+                $this->assertSame('authorization_code', $options['body']['grant_type']);
+                $this->assertSame('auth-code', $options['body']['code']);
+                $this->assertSame('https://app.example.com/callback', $options['body']['redirect_uri']);
+                $this->assertSame('test-client-id', $options['body']['client_id']);
+                $this->assertSame('test-client-secret', $options['body']['client_secret']);
+                $this->assertArrayNotHasKey('auth_basic', $options);
+
+                return true;
+            }))
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $tokens = $client->exchangeCode('auth-code', 'https://app.example.com/callback');
+
+        $this->assertSame('access-123', $tokens['access_token']);
+        $this->assertSame('id-token-abc', $tokens['id_token']);
+    }
+
+    public function testExchangeCodeWithCodeVerifier()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => 'id-token-abc',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://provider.example.com/token', $this->callback(function (array $options) {
+                $this->assertSame('my-code-verifier', $options['body']['code_verifier']);
+
+                return true;
+            }))
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $client->exchangeCode('auth-code', 'https://app.example.com/callback', 'my-code-verifier');
+    }
+
+    public function testFetchUserInfo()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sub' => '123',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', 'https://provider.example.com/userinfo', [
+                'auth_bearer' => 'access-token',
+            ])
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $claims = $client->fetchUserInfo('access-token');
+
+        $this->assertSame('123', $claims['sub']);
+        $this->assertSame('test@example.com', $claims['email']);
+    }
+
+    public function testFetchUserInfoThrowsWhenEndpointMissing()
+    {
+        $discovery = $this->createDiscovery([
+            'token_endpoint' => 'https://provider.example.com/token',
+        ]);
+
+        $client = new OidcConfidentialClient($this->httpClient, $discovery, 'test-client-id', 'test-client-secret');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not announce any "userinfo_endpoint"');
+
+        $client->fetchUserInfo('access-token');
+    }
+
+    public function testExchangeCodeThrowsWhenEndpointMissing()
+    {
+        $discovery = $this->createDiscovery([
+            'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+        ]);
+
+        $client = new OidcConfidentialClient($this->httpClient, $discovery, 'test-client-id', 'test-client-secret');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not announce any "token_endpoint"');
+
+        $client->exchangeCode('auth-code', 'https://app.example.com/callback');
+    }
+
+    public function testExchangeCodeRejectsAnInsecureTokenEndpoint()
+    {
+        // the ID token signature is not verified because the token endpoint is reached over
+        // TLS: a discovery document announcing a plain HTTP endpoint takes that away
+        $discovery = $this->createDiscovery(['token_endpoint' => 'http://provider.example.com/token']);
+
+        $this->httpClient->expects($this->never())->method('request');
+
+        $client = new OidcConfidentialClient($this->httpClient, $discovery, 'test-client-id', 'test-client-secret');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $client->exchangeCode('auth-code', 'https://app.example.com/callback');
+    }
+
+    public function testFetchUserInfoRejectsAnInsecureUserInfoEndpoint()
+    {
+        $discovery = $this->createDiscovery(['userinfo_endpoint' => 'http://provider.example.com/userinfo']);
+
+        $this->httpClient->expects($this->never())->method('request');
+
+        $client = new OidcConfidentialClient($this->httpClient, $discovery, 'test-client-id', 'test-client-secret');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $client->fetchUserInfo('access-token');
+    }
+
+    public function testExchangeCodeConvertsTransportErrorsToAuthenticationException()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willThrowException(new TransportException('Connection refused.'));
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC token endpoint request failed');
+
+        $this->createClient()->exchangeCode('auth-code', 'https://app.example.com/callback');
+    }
+
+    public function testFetchUserInfoConvertsTransportErrorsToAuthenticationException()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willThrowException(new TransportException('Connection refused.'));
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC userinfo endpoint request failed');
+
+        $this->createClient()->fetchUserInfo('access-token');
+    }
+
+    private function createClient(): OidcConfidentialClient
+    {
+        return new OidcConfidentialClient(
+            httpClient: $this->httpClient,
+            discovery: $this->discovery,
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+        );
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcIdTokenTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcIdTokenTest.php
@@ -1,0 +1,344 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+
+#[RequiresPhpExtension('openssl')]
+class OidcIdTokenTest extends TestCase
+{
+    public function testDecode()
+    {
+        $jwt = $this->buildJwt(['sub' => 'user-42', 'email' => 'test@example.com']);
+
+        $claims = $this->createIdToken()->decode($jwt);
+
+        $this->assertSame('user-42', $claims['sub']);
+        $this->assertSame('test@example.com', $claims['email']);
+    }
+
+    public function testDecodeInvalidFormat()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token format');
+
+        $this->createIdToken()->decode('not-a-jwt');
+    }
+
+    public function testDecodeInvalidBase64()
+    {
+        $this->expectException(AuthenticationException::class);
+
+        $this->createIdToken()->decode('header.!!!invalid!!!.signature');
+    }
+
+    public function testDecodeInvalidJson()
+    {
+        $header = base64_encode('{"alg":"RS256"}');
+        $payload = rtrim(strtr(base64_encode('not-json'), '+/', '-_'), '=');
+        $signature = base64_encode('sig');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token payload');
+
+        $this->createIdToken()->decode($header.'.'.$payload.'.'.$signature);
+    }
+
+    public function testValidateClaims()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+            'nonce' => 'expected-nonce',
+        ];
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id', 'expected-nonce');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsWithArrayAudience()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => ['other-client', 'my-client-id'],
+            'azp' => 'my-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsAllowsMultipleAudiencesWithoutAzp()
+    {
+        // OIDC Core 1.0, Section 3.1.3.7 item 3 is a SHOULD, and the audience is already
+        // checked, so a missing "azp" claim must not reject the token
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => ['other-client', 'my-client-id'],
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsWrongAzp()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'azp' => 'another-client',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('azp');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsWithoutNonce()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsWrongIssuer()
+    {
+        $claims = [
+            'iss' => 'https://evil.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsMissingIssuer()
+    {
+        $claims = [
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsWrongAudience()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'wrong-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsExpired()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() - 3600,
+            'iat' => time(),
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsMissingExp()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'iat' => time(),
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsMissingIssuedAt()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    #[DataProvider('provideFutureTimeClaims')]
+    public function testValidateClaimsRejectsFutureTimeClaims(string $claim)
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => 1750003600,
+            'iat' => 1749999999,
+        ];
+        $claims[$claim] = 1750000001;
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        (new OidcIdToken(new MockClock('@1750000000')))->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public static function provideFutureTimeClaims(): iterable
+    {
+        yield 'issued at' => ['iat'];
+        yield 'not before' => ['nbf'];
+    }
+
+    public function testValidateClaimsAllowsTimeDrift()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => 1750003600,
+            'iat' => 1750000001,
+            'nbf' => 1750000001,
+        ];
+
+        (new OidcIdToken(new MockClock('@1750000000'), 2))->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsWrongNonce()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+            'nonce' => 'wrong-nonce',
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('nonce');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id', 'expected-nonce');
+    }
+
+    public function testValidateClaimsMissingNonceWhenExpected()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('nonce');
+
+        $this->createIdToken()->validateClaims($claims, 'https://provider.example.com', 'my-client-id', 'expected-nonce');
+    }
+
+    public function testValidateClaimsUsesTheInjectedClock()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => 1750000000,
+            'iat' => 1749990000,
+        ];
+
+        // the token is still valid one second before it expires...
+        (new OidcIdToken(new MockClock('@1749999999')))->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The token expired');
+
+        // ...and expired one second after
+        (new OidcIdToken(new MockClock('@1750000001')))->validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    private function createIdToken(): OidcIdToken
+    {
+        // any PSR-20 clock does: decode() never reads it
+        return new OidcIdToken(new MockClock());
+    }
+
+    private function buildJwt(array $claims = []): string
+    {
+        return (new CompactSerializer())->serialize(
+            (new JWSBuilder(new AlgorithmManager([new ES256()])))
+                ->withPayload(json_encode($claims))
+                ->addSignature(self::getJWK(), ['alg' => 'ES256'])
+                ->build()
+        );
+    }
+
+    private static function getJWK(): JWK
+    {
+        // tip: use https://mkjwk.org/ to generate a JWK
+        return new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+            'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+            'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -1,0 +1,1027 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\AttributesBasedUserProviderInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\OidcUserProvider;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+#[AllowMockObjectsWithoutExpectations]
+class OidcLoginAuthenticatorTest extends TestCase
+{
+    private OidcClient $oidcClient;
+    private OidcDiscovery $discovery;
+    private AuthenticationSuccessHandlerInterface $successHandler;
+    private AuthenticationFailureHandlerInterface $failureHandler;
+
+    protected function setUp(): void
+    {
+        $this->discovery = $this->createDiscovery([
+            'authorization_endpoint' => 'https://provider.example.com/authorize',
+            'token_endpoint' => 'https://provider.example.com/token',
+            'issuer' => 'https://provider.example.com',
+            'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+        ]);
+
+        $this->oidcClient = $this->createMock(OidcClient::class);
+
+        $this->successHandler = $this->createStub(AuthenticationSuccessHandlerInterface::class);
+        $this->failureHandler = $this->createStub(AuthenticationFailureHandlerInterface::class);
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function createDiscovery(array $configuration): OidcDiscovery
+    {
+        return new OidcDiscovery(
+            new MockHttpClient(static fn (): MockResponse => new JsonMockResponse($configuration)),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+    }
+
+    public function testSupportsCallbackWithCode()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertTrue($authenticator->supports(Request::create('/oidc/callback?code=abc&state=xyz')));
+    }
+
+    public function testSupportsCallbackWithError()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertTrue($authenticator->supports(Request::create('/oidc/callback?error=access_denied')));
+    }
+
+    public function testDoesNotSupportWrongPath()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertFalse($authenticator->supports(Request::create('/other-path?code=abc')));
+    }
+
+    public function testSupportsTheCallbackPathWithoutAnyParameter()
+    {
+        // the route declared for the callback path carries no controller, so a request
+        // getting past the authenticator would be reported as a routing error
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertTrue($authenticator->supports(Request::create('/oidc/callback')));
+    }
+
+    public function testAuthenticateRejectsACallbackWithoutAnyParameter()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRequiresASession()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('stores the OIDC "state", "nonce" and PKCE code verifier in the session');
+
+        $authenticator->authenticate(Request::create('/oidc/callback?code=abc&state=xyz'));
+    }
+
+    public function testStartRequiresASession()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('nor on a stateless firewall');
+
+        $authenticator->start(Request::create('/protected'));
+    }
+
+    public function testAuthenticate()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('fetchUserInfo')
+            ->with('access-123')
+            ->willReturn([
+                'sub' => 'user-42',
+                'email' => 'test@example.com',
+                'name' => 'Test User',
+            ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+
+        $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
+        $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+        // no remember-me: it would re-establish a session without contacting the IdP,
+        // and the OIDC user provider cannot reload a user by its identifier alone
+        $this->assertFalse($passport->hasBadge(RememberMeBadge::class));
+        $this->assertSame('access-123', $passport->getAttribute('oidc_token_data')['access_token']);
+    }
+
+    public function testAuthenticateDoesNotGrantRolesFromClaims()
+    {
+        // a "roles" claim returned by the provider must not be mass-assigned onto the
+        // OidcUser roles: the login flow always yields the default ROLE_USER
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'user-42',
+            'roles' => ['ROLE_ADMIN', 'ROLE_SUPER_ADMIN'],
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+
+        $this->assertSame(['ROLE_USER'], $passport->getUser()->getRoles());
+    }
+
+    public function testAuthenticateIgnoresProviderSuppliedIdentifierClaim()
+    {
+        // a provider "userIdentifier" claim must not override the identity derived
+        // from the verified "sub"
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'user-42',
+            'userIdentifier' => 'spoofed-identity',
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+
+        $this->assertSame('user-42', $passport->getUser()->getUserIdentifier());
+        $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    public function testAuthenticateLoadsTheUserFromTheFirewallUserProvider()
+    {
+        // the firewall's user provider is what loads the user, and mapping claims onto
+        // roles is what it is for: it receives the verified identifier and every claim,
+        // including the ones the built-in OIDC provider refuses to map by itself
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'user-42',
+            'email' => 'test@example.com',
+            'roles' => ['admin'],
+        ]);
+
+        $userProvider = new class implements AttributesBasedUserProviderInterface {
+            public array $claims = [];
+
+            public function loadUserByIdentifier(string $identifier, array $attributes = []): UserInterface
+            {
+                $this->claims = $attributes;
+
+                return new InMemoryUser($identifier, null, array_map(static fn (string $role): string => 'ROLE_'.strtoupper($role), $attributes['roles'] ?? []));
+            }
+
+            public function refreshUser(UserInterface $user): UserInterface
+            {
+                throw new UnsupportedUserException();
+            }
+
+            public function supportsClass(string $class): bool
+            {
+                return InMemoryUser::class === $class;
+            }
+        };
+
+        $authenticator = $this->createAuthenticator(userProvider: $userProvider);
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $user = $authenticator->authenticate($request)->getUser();
+
+        $this->assertInstanceOf(InMemoryUser::class, $user);
+        $this->assertSame('user-42', $user->getUserIdentifier());
+        $this->assertSame(['ROLE_ADMIN'], $user->getRoles());
+        $this->assertSame('test@example.com', $userProvider->claims['email']);
+    }
+
+    public function testAuthenticateWithInvalidState()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest('valid-state', 'nonce');
+        $request->query->set('state', 'wrong-state');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsEmptyStateWhenNoneStored()
+    {
+        // login CSRF: an attacker-crafted callback with an empty "state" must not pass
+        // when the victim's session holds no state (empty === empty would otherwise match)
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?code=attacker-code&state=');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateWithProviderError()
+    {
+        // the provider echoes the "state" back on an error response too (RFC 6749,
+        // Section 4.1.2.1), which is what makes validating it first harmless
+        $state = bin2hex(random_bytes(16));
+
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?error=access_denied&error_description=User+denied+access&state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.attempt.'.$state, [
+            'nonce' => 'nonce',
+            'code_verifier' => 'verifier',
+        ]);
+        $request->setSession($session);
+
+        try {
+            $authenticator->authenticate($request);
+            $this->fail(\sprintf('Expected an "%s" to be thrown.', AuthenticationException::class));
+        } catch (AuthenticationException $e) {
+            $this->assertSame('OIDC provider returned an error: "User denied access"', $e->getMessage());
+        }
+
+        // the matched attempt was the only one, so the whole entry is removed
+        $this->assertNull($session->get('_security.oidc_login.main.attempt.'.$state));
+    }
+
+    public function testAuthenticateValidatesTheStateBeforeTheProviderError()
+    {
+        // an unauthenticated request must not be able to get its own "error_description"
+        // into the exception the failure handler stores in the victim's session
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?error=access_denied&error_description=Forged+message');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingClaim()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['email' => 'test@example.com']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('"sub" claim');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsNonStringUserInfoSub()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => ['x']]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('"sub" claim');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsUserInfoSubMismatch()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]); // sub => user-42
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'someone-else',
+            'email' => 'test@example.com',
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not match the ID token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingAccessToken()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'id_token' => $idToken,
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('access_token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateClearsSession()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+        $authenticator->authenticate($request);
+
+        $session = $request->getSession();
+        $this->assertNull($session->get('_security.oidc_login.main.attempt.'.$state));
+    }
+
+    public function testOnAuthenticationSuccessClearsPendingAttempts()
+    {
+        $state1 = bin2hex(random_bytes(16));
+        $state2 = bin2hex(random_bytes(16));
+        $state3 = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state1, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+        $token = $authenticator->createToken($passport, 'main');
+
+        $session = $request->getSession();
+        $prefix = '_security.oidc_login.main.';
+
+        // pending attempts from other tabs
+        $session->set($prefix.'attempt.'.$state2, ['nonce' => bin2hex(random_bytes(16)), 'code_verifier' => bin2hex(random_bytes(32))]);
+        $session->set($prefix.'attempt.'.$state3, ['nonce' => bin2hex(random_bytes(16)), 'code_verifier' => bin2hex(random_bytes(32))]);
+
+        $response = new RedirectResponse('https://example.com/success');
+        $this->successHandler->method('onAuthenticationSuccess')->willReturn($response);
+
+        $result = $authenticator->onAuthenticationSuccess($request, $token, 'main');
+
+        $this->assertSame($response, $result);
+
+        $attemptKeys = array_filter(array_keys($session->all()), static fn (string $key): bool => str_starts_with($key, $prefix.'attempt.'));
+        $this->assertCount(0, $attemptKeys);
+    }
+
+    public function testStartRedirectsToProvider()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/protected');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $response = $authenticator->start($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $location = $response->getTargetUrl();
+        $this->assertStringStartsWith('https://provider.example.com/authorize?', $location);
+
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+        $this->assertSame('code', $params['response_type']);
+        $this->assertSame('test-client-id', $params['client_id']);
+        $this->assertSame('openid', $params['scope']);
+        $this->assertNotEmpty($params['state']);
+        $this->assertNotEmpty($params['nonce']);
+        $this->assertNotEmpty($params['code_challenge']);
+        $this->assertSame('S256', $params['code_challenge_method']);
+    }
+
+    #[DataProvider('provideScopes')]
+    public function testStartRequestsTheConfiguredScopes(array|string $scope, string $expectedScope)
+    {
+        $authenticator = $this->createAuthenticator(['scope' => $scope]);
+        $request = Request::create('/protected');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $params = [];
+        parse_str(parse_url($authenticator->start($request)->getTargetUrl(), \PHP_URL_QUERY), $params);
+
+        $this->assertSame($expectedScope, $params['scope']);
+    }
+
+    public static function provideScopes(): iterable
+    {
+        yield 'a list' => [['profile', 'email'], 'openid profile email'];
+        // an environment variable carries them all in a single value
+        yield 'a space-separated string' => [['profile email'], 'openid profile email'];
+        yield 'openid on its own' => [['openid'], 'openid'];
+        yield 'openid is never requested twice' => [['openid', 'profile'], 'openid profile'];
+    }
+
+    public function testStartThrowsWhenAuthorizationEndpointIsMissing()
+    {
+        $this->discovery = $this->createDiscovery([
+            'issuer' => 'https://provider.example.com',
+            'token_endpoint' => 'https://provider.example.com/token',
+        ]);
+
+        $request = Request::create('/protected');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not announce any "authorization_endpoint"');
+
+        $this->createAuthenticator()->start($request);
+    }
+
+    public function testStartRejectsAnInsecureAuthorizationEndpoint()
+    {
+        $this->discovery = $this->createDiscovery([
+            'issuer' => 'https://provider.example.com',
+            'authorization_endpoint' => 'http://provider.example.com/authorize',
+        ]);
+
+        $request = Request::create('/protected');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        try {
+            $this->createAuthenticator()->start($request);
+            $this->fail(\sprintf('Expected an "%s" to be thrown.', AuthenticationException::class));
+        } catch (AuthenticationException $e) {
+            $this->assertStringContainsString('must use HTTPS', $e->getMessage());
+        }
+
+        // the endpoint is resolved first, so no attempt was left behind in the session
+        $this->assertSame([], array_filter(array_keys($session->all()), static fn (string $key): bool => str_starts_with($key, '_security.oidc_login.main.attempt.')));
+    }
+
+    public function testStartStoresStateNonceAndCodeVerifierInSession()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/protected');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $response = $authenticator->start($request);
+        $location = $response->getTargetUrl();
+
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+
+        $attempt = $session->get('_security.oidc_login.main.attempt.'.$params['state']);
+        $this->assertIsArray($attempt);
+        $this->assertSame($params['nonce'], $attempt['nonce']);
+        $this->assertNotNull($attempt['code_verifier']);
+        // the very redirect URI sent to the provider is the one kept for the token request
+        $this->assertSame($params['redirect_uri'], $attempt['redirect_uri']);
+    }
+
+    public function testAuthenticatePassesCodeVerifierToExchangeCode()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->with('auth-code', $this->anything(), 'my-verifier')
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce, 'my-verifier');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testTheStoredRedirectUriIsReusedAtTheTokenExchange()
+    {
+        // RFC 6749, Section 4.1.3: the token request must carry the very redirect URI the
+        // authorization request used, so the callback request never gets to recompute it
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->with('auth-code', 'https://app.example.com/oidc/callback', $this->anything())
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.attempt.'.$state, [
+            'nonce' => $nonce,
+            'code_verifier' => 'my-verifier',
+            'redirect_uri' => 'https://app.example.com/oidc/callback',
+        ]);
+        $request->setSession($session);
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingIdToken()
+    {
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('id_token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsNonStringIdToken()
+    {
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'id_token' => ['x'],
+            'access_token' => 'access-123',
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('id_token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsNonStringAccessToken()
+    {
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'id_token' => $idToken,
+            'access_token' => ['x'],
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('access_token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingAuthorizationCode()
+    {
+        $state = bin2hex(random_bytes(16));
+
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.attempt.'.$state, [
+            'nonce' => 'nonce',
+            'code_verifier' => 'verifier',
+        ]);
+        $request->setSession($session);
+
+        try {
+            $authenticator->authenticate($request);
+            $this->fail(\sprintf('Expected an "%s" to be thrown.', AuthenticationException::class));
+        } catch (AuthenticationException $e) {
+            $this->assertSame('Missing authorization code in OIDC callback.', $e->getMessage());
+        }
+
+        // The matched attempt is consumed even though there's no code
+        $this->assertNull($session->get('_security.oidc_login.main.attempt.'.$state));
+    }
+
+    public function testCreateTokenStoresOidcTokens()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+        $passport = $authenticator->authenticate($request);
+
+        $token = $authenticator->createToken($passport, 'main');
+
+        $this->assertSame($idToken, $token->getAttribute('oidc_id_token'));
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testSessionClearedEvenWhenExchangeCodeFails()
+    {
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willThrowException(new \RuntimeException('Token exchange failed'));
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce, 'verifier');
+
+        try {
+            $authenticator->authenticate($request);
+        } catch (\RuntimeException) {
+        }
+
+        $session = $request->getSession();
+        // The matched attempt was already consumed before the exchange, so it's gone
+        $this->assertNull($session->get('_security.oidc_login.main.attempt.'.$state));
+    }
+
+    public function testConcurrentLoginsPreserveSeparateAttempts()
+    {
+        // Two tabs starting a login concurrently must not overwrite each other's state/nonce/verifier
+        $state1 = bin2hex(random_bytes(16));
+        $state2 = bin2hex(random_bytes(16));
+        $nonce1 = bin2hex(random_bytes(16));
+        $nonce2 = bin2hex(random_bytes(16));
+        $codeVerifier1 = bin2hex(random_bytes(32));
+        $codeVerifier2 = bin2hex(random_bytes(32));
+
+        $authenticator = $this->createAuthenticator();
+        $session = new Session(new MockArraySessionStorage());
+        $prefix = '_security.oidc_login.main.';
+
+        // Simulate two start() calls on the same session
+        $session->set($prefix.'attempt.'.$state1, ['nonce' => $nonce1, 'code_verifier' => $codeVerifier1, 'redirect_uri' => 'http://localhost/oidc/callback']);
+        $session->set($prefix.'attempt.'.$state2, ['nonce' => $nonce2, 'code_verifier' => $codeVerifier2, 'redirect_uri' => 'http://localhost/oidc/callback']);
+
+        // First callback succeeds with its own state and nonce
+        $idToken1 = $this->buildIdToken(['nonce' => $nonce1]);
+        $this->oidcClient->method('exchangeCode')->willReturnOnConsecutiveCalls(
+            ['access_token' => 'access-123', 'id_token' => $idToken1],
+            ['access_token' => 'access-456', 'id_token' => $this->buildIdToken(['nonce' => $nonce2])]
+        );
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $request1 = Request::create('/oidc/callback?code=auth-code-1&state='.$state1);
+        $request1->setSession($session);
+
+        $passport1 = $authenticator->authenticate($request1);
+        $this->assertSame('user-42', $passport1->getBadge(UserBadge::class)->getUserIdentifier());
+
+        $this->assertNull($session->get($prefix.'attempt.'.$state1));
+        $attempt2 = $session->get($prefix.'attempt.'.$state2);
+        $this->assertSame($nonce2, $attempt2['nonce']);
+        $this->assertSame($codeVerifier2, $attempt2['code_verifier']);
+    }
+
+    public function testFifoCapRemovesOldestAttempts()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/protected');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+        $prefix = '_security.oidc_login.main.';
+
+        // Collect states from 6 start() calls (MAX_CONCURRENT_ATTEMPTS + 1)
+        $states = [];
+        for ($i = 0; $i < 6; ++$i) {
+            $response = $authenticator->start($request);
+            parse_str(parse_url($response->getTargetUrl(), \PHP_URL_QUERY), $params);
+            $states[] = $params['state'];
+        }
+
+        // Session should only have MAX_CONCURRENT_ATTEMPTS (5) attempts
+        $attemptKeys = array_filter(array_keys($session->all()), static fn (string $key): bool => str_starts_with($key, $prefix.'attempt.'));
+        $this->assertCount(5, $attemptKeys);
+
+        $this->assertNull($session->get($prefix.'attempt.'.$states[0]));
+
+        $request2 = Request::create('/oidc/callback?code=auth-code&state='.$states[0]);
+        $request2->setSession($session);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state parameter.');
+
+        $authenticator->authenticate($request2);
+    }
+
+    public function testReplayProtectionFailsOnConsumedAttempt()
+    {
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+
+        $session = new Session(new MockArraySessionStorage());
+        $prefix = '_security.oidc_login.main.';
+        $session->set($prefix.'attempt.'.$state, [
+            'nonce' => $nonce,
+            'code_verifier' => bin2hex(random_bytes(32)),
+            'redirect_uri' => 'http://localhost/oidc/callback',
+        ]);
+
+        $request1 = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $request1->setSession($session);
+
+        $authenticator->authenticate($request1);
+
+        $request2 = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $request2->setSession($session);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state parameter.');
+
+        $authenticator->authenticate($request2);
+    }
+
+    public function testMissingNonceInAttemptFails()
+    {
+        $state = bin2hex(random_bytes(16));
+
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.attempt.'.$state, [
+            'nonce' => '',
+            'code_verifier' => 'verifier',
+        ]);
+        $request->setSession($session);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Missing OIDC nonce in session.');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testProviderErrorPreservesOtherAttempts()
+    {
+        $state1 = bin2hex(random_bytes(16));
+        $state2 = bin2hex(random_bytes(16));
+
+        $authenticator = $this->createAuthenticator();
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.attempt.'.$state1, ['nonce' => 'nonce-1', 'code_verifier' => 'verifier-1']);
+        $session->set('_security.oidc_login.main.attempt.'.$state2, ['nonce' => 'nonce-2', 'code_verifier' => 'verifier-2']);
+
+        $request1 = Request::create('/oidc/callback?error=access_denied&state='.$state1);
+        $request1->setSession($session);
+
+        try {
+            $authenticator->authenticate($request1);
+            $this->fail('Expected AuthenticationException to be thrown.');
+        } catch (AuthenticationException $e) {
+            $this->assertStringContainsString('OIDC provider returned an error', $e->getMessage());
+        }
+
+        $this->assertNull($session->get('_security.oidc_login.main.attempt.'.$state1));
+        $this->assertIsArray($session->get('_security.oidc_login.main.attempt.'.$state2));
+    }
+
+    public function testInvalidStateErrorMessageSameForEmptySessionAndUnknownState()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        // an empty session and an unknown state must fail with the very same message,
+        // so the response does not reveal whether a login was pending
+        $request1 = Request::create('/oidc/callback?code=attacker-code&state=forged');
+        $request1->setSession(new Session(new MockArraySessionStorage()));
+
+        try {
+            $authenticator->authenticate($request1);
+            $this->fail('Expected AuthenticationException to be thrown.');
+        } catch (AuthenticationException $e) {
+            $this->assertSame('Invalid OIDC state parameter.', $e->getMessage());
+        }
+
+        $request2 = Request::create('/oidc/callback?code=attacker-code&state=forged');
+        $session2 = new Session(new MockArraySessionStorage());
+        $session2->set('_security.oidc_login.main.attempt.some-other-state', ['nonce' => 'nonce', 'code_verifier' => 'verifier']);
+        $request2->setSession($session2);
+
+        try {
+            $authenticator->authenticate($request2);
+            $this->fail('Expected AuthenticationException to be thrown.');
+        } catch (AuthenticationException $e) {
+            $this->assertSame('Invalid OIDC state parameter.', $e->getMessage());
+        }
+    }
+
+    public function testMissingCodeVerifierInAttemptFails()
+    {
+        $state = bin2hex(random_bytes(16));
+
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.attempt.'.$state, [
+            'nonce' => 'nonce',
+            'code_verifier' => '',
+        ]);
+        $request->setSession($session);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Missing PKCE code verifier in session.');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testMissingRedirectUriInAttemptFails()
+    {
+        $state = bin2hex(random_bytes(16));
+
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.attempt.'.$state, [
+            'nonce' => 'nonce',
+            'code_verifier' => 'verifier',
+            'redirect_uri' => '',
+        ]);
+        $request->setSession($session);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Missing OIDC redirect URI in session.');
+
+        $authenticator->authenticate($request);
+    }
+
+    private function createCallbackRequest(string $state, string $nonce, ?string $codeVerifier = null): Request
+    {
+        $request = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $prefix = '_security.oidc_login.main.';
+        $session->set($prefix.'attempt.'.$state, [
+            'nonce' => $nonce,
+            'code_verifier' => $codeVerifier ?? bin2hex(random_bytes(32)),
+            'redirect_uri' => 'http://localhost/oidc/callback',
+        ]);
+
+        return $request;
+    }
+
+    private function buildIdToken(array $extraClaims = []): string
+    {
+        $header = rtrim(strtr(base64_encode(json_encode(['alg' => 'RS256', 'typ' => 'JWT'])), '+/', '-_'), '=');
+        $claims = array_merge([
+            'iss' => 'https://provider.example.com',
+            'aud' => 'test-client-id',
+            'sub' => 'user-42',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ], $extraClaims);
+        $payload = rtrim(strtr(base64_encode(json_encode($claims)), '+/', '-_'), '=');
+        $signature = rtrim(strtr(base64_encode('fake-signature'), '+/', '-_'), '=');
+
+        return $header.'.'.$payload.'.'.$signature;
+    }
+
+    private function createAuthenticator(array $options = [], ?UserProviderInterface $userProvider = null): OidcLoginAuthenticator
+    {
+        return new OidcLoginAuthenticator(
+            new HttpUtils(),
+            $userProvider ?? new OidcUserProvider(),
+            $this->oidcClient,
+            $this->discovery,
+            new OidcIdToken(new Clock()),
+            'test-client-id',
+            $this->successHandler,
+            $this->failureHandler,
+            $options,
+        );
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Oidc/OidcDiscoveryTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Oidc/OidcDiscoveryTest.php
@@ -1,0 +1,526 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Oidc;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class OidcDiscoveryTest extends TestCase
+{
+    private const URL = 'https://provider.example.com/.well-known/openid-configuration';
+    private const ISSUER = 'https://provider.example.com';
+    private const CONFIGURATION = [
+        'issuer' => self::ISSUER,
+        'authorization_endpoint' => 'https://provider.example.com/authorize',
+        'token_endpoint' => 'https://provider.example.com/token',
+    ];
+
+    public function testGetConfigurationFetchesAndDecodesTheDocument()
+    {
+        $requests = 0;
+        $httpClient = new MockHttpClient(function (string $method, string $url) use (&$requests): MockResponse {
+            ++$requests;
+            $this->assertSame('GET', $method);
+            $this->assertSame(self::URL, $url);
+
+            return new JsonMockResponse(self::CONFIGURATION);
+        });
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+        // the second read is served by the cache
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+        $this->assertSame(1, $requests);
+    }
+
+    public function testGetConfigurationRejectsIssuerMismatch()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['issuer' => 'https://attacker.example.com']));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not match the configured issuer');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationAcceptsAnAnnouncedIssuerWithATrailingSlash()
+    {
+        // providers do announce an issuer ending with a slash (Authentik does), while the
+        // configured one is normalized without it: the check must not reject them
+        $httpClient = new MockHttpClient(new JsonMockResponse(['issuer' => self::ISSUER.'/']));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->assertSame(['issuer' => self::ISSUER.'/'], $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationAcceptsAnExpectedIssuerWithATrailingSlash()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['issuer' => self::ISSUER]));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER.'/');
+
+        $this->assertSame(['issuer' => self::ISSUER], $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationRejectsAnInsecureIssuer()
+    {
+        // the firewall configuration cannot check a "provider_uri" coming from an
+        // environment variable, so the resolved value is checked here instead
+        $httpClient = new MockHttpClient(static fn () => throw new \LogicException('The provider must not be contacted.'));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), 'http://provider.example.com/.well-known/openid-configuration', 'http://provider.example.com');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationAcceptsAnIssuerWithAnUppercaseScheme()
+    {
+        // parse_url() returns the scheme as it is written, and a scheme is case-insensitive
+        $httpClient = new MockHttpClient(new JsonMockResponse(['issuer' => 'HTTPS://provider.example.com']));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, 'HTTPS://provider.example.com');
+
+        $this->assertSame(['issuer' => 'HTTPS://provider.example.com'], $discovery->getConfiguration());
+    }
+
+    /**
+     * @param string $issuer a loopback host or a name reserved for testing (RFC 2606, RFC 6761)
+     */
+    #[DataProvider('provideLocalDevelopmentIssuers')]
+    public function testGetConfigurationAllowsInsecureIssuersForLocalDevelopment(string $issuer)
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['issuer' => $issuer]));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), $issuer.'/.well-known/openid-configuration', $issuer);
+
+        $this->assertSame(['issuer' => $issuer], $discovery->getConfiguration());
+    }
+
+    public static function provideLocalDevelopmentIssuers(): iterable
+    {
+        yield 'localhost' => ['http://localhost:8080'];
+        yield 'IPv4 loopback' => ['http://127.0.0.1:8080'];
+        yield 'IPv6 loopback' => ['http://[::1]:8080'];
+        yield 'localhost subdomain' => ['http://keycloak.localhost'];
+        yield 'test TLD' => ['http://keycloak.test'];
+    }
+
+    public function testGetConfigurationSkipsTheIssuerCheckWhenNoIssuerIsExpected()
+    {
+        // the access-token handlers have no client to issuer mapping, so they opt out
+        $httpClient = new MockHttpClient(new JsonMockResponse(['issuer' => 'https://somewhere.example.com']));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL);
+
+        $this->assertSame(['issuer' => 'https://somewhere.example.com'], $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationUsesARelativeUrlByDefault()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): MockResponse {
+            $this->assertSame(self::URL, $url);
+
+            return new JsonMockResponse(self::CONFIGURATION);
+        }, 'https://provider.example.com/');
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter());
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+    }
+
+    public function testPrefetchSendsTheRequestThatGetConfigurationConsumes()
+    {
+        // several documents are fetched concurrently by prefetching them all before reading
+        // any of them, which is what OidcTokenHandler does with its discovery clients
+        $httpClient = new MockHttpClient(new JsonMockResponse(self::CONFIGURATION));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+        $discovery->prefetch();
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+        // the prefetched response is reused, and prefetching stored nothing in the cache
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testPrefetchSendsNothingWhenTheDocumentIsCached()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(self::CONFIGURATION));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+        $discovery->getConfiguration();
+
+        $discovery->prefetch();
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testPrefetchDropsItsRequestWhenTheEntryIsWarmedInBetween()
+    {
+        // another process may store the document between the prefetch and the read: the
+        // response is then useless, and must not be consumed the next time the entry
+        // expires, hours later, on the same long-running instance
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['issuer' => self::ISSUER, 'token_endpoint' => 'https://provider.example.com/prefetched']),
+            new JsonMockResponse(['issuer' => self::ISSUER, 'token_endpoint' => 'https://provider.example.com/fresh']),
+        ]);
+
+        $cache = new ArrayAdapter();
+        $discovery = new OidcDiscovery($httpClient, $cache, self::URL, self::ISSUER, cacheKey: 'the.key');
+        $discovery->prefetch();
+
+        $cache->save($cache->getItem('the.key')->set(['url' => self::URL, 'payload' => json_encode(['issuer' => self::ISSUER, 'token_endpoint' => 'https://provider.example.com/warmed'])]));
+        $this->assertSame('https://provider.example.com/warmed', $discovery->getConfiguration()['token_endpoint']);
+
+        $cache->deleteItem('the.key');
+        // the memoized document survives the deleted entry until reset()
+        $this->assertSame('https://provider.example.com/warmed', $discovery->getConfiguration()['token_endpoint']);
+
+        // after reset(), the dropped prefetch response must not be consumed: the
+        // expired entry triggers a new request instead
+        $discovery->reset();
+        $this->assertSame('https://provider.example.com/fresh', $discovery->getConfiguration()['token_endpoint']);
+    }
+
+    public function testGetSecureEndpointReturnsTheAnnouncedEndpoint()
+    {
+        $discovery = new OidcDiscovery(new MockHttpClient(new JsonMockResponse(self::CONFIGURATION)), new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->assertSame('https://provider.example.com/token', $discovery->getSecureEndpoint('token_endpoint'));
+    }
+
+    public function testGetSecureEndpointRejectsAnEndpointThatIsNotAnnounced()
+    {
+        $discovery = new OidcDiscovery(new MockHttpClient(new JsonMockResponse(self::CONFIGURATION)), new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not announce any "userinfo_endpoint"');
+
+        $discovery->getSecureEndpoint('userinfo_endpoint');
+    }
+
+    public function testGetSecureEndpointRejectsAnInsecureEndpoint()
+    {
+        // requiring HTTPS on the configured issuer is worth nothing if the endpoints it
+        // announces are used as they are: a tampered or misconfigured discovery document
+        // would otherwise downgrade the requests carrying the code and the tokens
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'issuer' => self::ISSUER,
+            'token_endpoint' => 'http://provider.example.com/token',
+        ]));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $discovery->getSecureEndpoint('token_endpoint');
+    }
+
+    public function testGetSecureEndpointAllowsALoopbackAuthorizationEndpointForLocalDevelopment()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'issuer' => 'http://localhost:8080',
+            'authorization_endpoint' => 'http://localhost:8080/authorize',
+        ]));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), 'http://localhost:8080/.well-known/openid-configuration', 'http://localhost:8080');
+
+        $this->assertSame('http://localhost:8080/authorize', $discovery->getSecureEndpoint('authorization_endpoint'));
+    }
+
+    public function testGetSecureEndpointRejectsALoopbackTokenEndpoint()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'issuer' => 'http://localhost:8080',
+            'token_endpoint' => 'http://localhost:8080/token',
+        ]));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), 'http://localhost:8080/.well-known/openid-configuration', 'http://localhost:8080');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $discovery->getSecureEndpoint('token_endpoint');
+    }
+
+    public function testGetConfigurationAppendsARelativeUrlToTheIssuer()
+    {
+        // an issuer coming from an environment variable is a placeholder while the container
+        // compiles, so its trailing slash can only be trimmed here: appending the well-known
+        // path to "https://provider.example.com/" would otherwise carry a double slash
+        $httpClient = new MockHttpClient(function (string $method, string $url): MockResponse {
+            $this->assertSame(self::URL, $url);
+
+            return new JsonMockResponse(self::CONFIGURATION);
+        });
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), issuer: self::ISSUER.'/');
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationConvertsTransportErrorsToAuthenticationException()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('', ['http_code' => 500]));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC discovery document could not be fetched');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationRejectsAnErrorResponseWhoseBodyIsValidJson()
+    {
+        // an error response whose body happens to decode leaves no JSON failure to fall back on,
+        // so the HTTP status itself has to be what rejects the document
+        $httpClient = new MockHttpClient(new JsonMockResponse(self::CONFIGURATION, ['http_code' => 500]));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC discovery document could not be fetched');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationDoesNotCacheAMalformedDocument()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('not json', ['response_headers' => ['content-type' => 'application/json']]),
+            new JsonMockResponse(self::CONFIGURATION),
+        ]);
+
+        $discovery = new OidcDiscovery($httpClient, $cache = new ArrayAdapter(), self::URL, self::ISSUER);
+
+        try {
+            $discovery->getConfiguration();
+            $this->fail(\sprintf('Expected an "%s" to be thrown.', AuthenticationException::class));
+        } catch (AuthenticationException) {
+        }
+
+        // the malformed payload was not stored, so the next read hits the provider again
+        // instead of replaying the failure until the entry expires
+        $this->assertNotContains(serialize('not json'), $cache->getValues());
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationRejectsAnOversizedDocument()
+    {
+        $httpClient = new MockHttpClient(new MockResponse(str_repeat(' ', 1024 * 1024 + 1)));
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('exceeds the maximum size');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationCachesTheRawPayload()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(self::CONFIGURATION));
+
+        $discovery = new OidcDiscovery($httpClient, $cache = new ArrayAdapter(), self::URL, self::ISSUER);
+        $discovery->getConfiguration();
+
+        // the payload is stored as-is, next to the URL that served it: the URL tells the
+        // endpoint checks what transport carried the document, even on a warm cache
+        $this->assertSame([['url' => self::URL, 'payload' => json_encode(self::CONFIGURATION)]], array_map(unserialize(...), array_values($cache->getValues())));
+    }
+
+    public function testGetConfigurationUsesTheGivenCacheKey()
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->with('the.custom.key')
+            ->willReturn(['url' => self::URL, 'payload' => json_encode(self::CONFIGURATION)]);
+
+        $discovery = new OidcDiscovery($this->createStub(HttpClientInterface::class), $cache, self::URL, self::ISSUER, cacheKey: 'the.custom.key');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationDerivesTheCacheKeyFromTheUrl()
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->with('oidc_discovery.'.hash('xxh128', self::URL))
+            ->willReturn(['url' => self::URL, 'payload' => json_encode(self::CONFIGURATION)]);
+
+        $discovery = new OidcDiscovery($this->createStub(HttpClientInterface::class), $cache, self::URL, self::ISSUER);
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationLeavesTheLifetimeToThePoolWhenTtlIsNull()
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->never())->method('expiresAfter');
+
+        $discovery = new OidcDiscovery(
+            new MockHttpClient(new JsonMockResponse(self::CONFIGURATION)),
+            $this->cacheRunningCallback($item),
+            self::URL,
+            self::ISSUER,
+            cacheTtl: null,
+        );
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationAppliesTheGivenTtl()
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->once())->method('expiresAfter')->with(60);
+
+        $discovery = new OidcDiscovery(
+            new MockHttpClient(new JsonMockResponse(self::CONFIGURATION)),
+            $this->cacheRunningCallback($item),
+            self::URL,
+            self::ISSUER,
+            60,
+        );
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationRejectsAScalarJsonResponse()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('123'));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The document is not a JSON object');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationRejectsAForeignCacheEntry()
+    {
+        // whatever another writer left under the key is refused, never served as a document
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->never())->method('request');
+
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')->willReturn('"scalar"');
+
+        $discovery = new OidcDiscovery($httpClient, $cache, self::URL, self::ISSUER);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('could not be fetched');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationMemoizesTheDecodedDocument()
+    {
+        // a single login callback reads the cache and json_decode()s the document 3 times:
+        // once for the issuer check, once for the token_endpoint, once for the userinfo_endpoint,
+        // and start() adds one more for the authorization_endpoint. With memoization, a single
+        // HTTP request is sent even when the cache TTL is 0 (expiresAfter(0) stores nothing).
+        $requests = 0;
+        $httpClient = new MockHttpClient(function (string $method, string $url) use (&$requests): MockResponse {
+            ++$requests;
+            $this->assertSame('GET', $method);
+            $this->assertSame(self::URL, $url);
+
+            return new JsonMockResponse(self::CONFIGURATION);
+        });
+
+        // a cache that never stores (TTL 0)
+        $cache = $this->createStub(CacheInterface::class);
+        $item = $this->createStub(ItemInterface::class);
+        $cache->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            $save = false;
+
+            return $callback($item, $save);
+        });
+
+        $discovery = new OidcDiscovery($httpClient, $cache, self::URL, self::ISSUER);
+
+        // first read: getConfiguration()
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+        // second read: getSecureEndpoint('authorization_endpoint')
+        $discovery->getSecureEndpoint('authorization_endpoint');
+        // third read: getSecureEndpoint('token_endpoint')
+        $discovery->getSecureEndpoint('token_endpoint');
+
+        // only one HTTP request was made thanks to memoization
+        $this->assertSame(1, $requests);
+    }
+
+    public function testResetClearsTheMemoizedDocument()
+    {
+        // after reset(), the next read goes back to the cache/HTTP path
+        $requests = 0;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requests): MockResponse {
+            ++$requests;
+
+            return new JsonMockResponse(self::CONFIGURATION);
+        });
+
+        // a cache that never stores (TTL 0)
+        $cache = $this->createStub(CacheInterface::class);
+        $item = $this->createStub(ItemInterface::class);
+        $cache->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            $save = false;
+
+            return $callback($item, $save);
+        });
+
+        $discovery = new OidcDiscovery($httpClient, $cache, self::URL, self::ISSUER);
+
+        // first read
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+        $this->assertSame(1, $requests);
+
+        // reset the memo
+        $discovery->reset();
+
+        // second read: should hit the cache/HTTP path again
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+        $this->assertSame(2, $requests);
+    }
+
+    private function cacheRunningCallback(ItemInterface $item): CacheInterface
+    {
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item) {
+            $save = true;
+
+            return $callback($item, $save);
+        });
+
+        return $cache;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | https://github.com/symfony/symfony/issues/50896
| License       | MIT

## TL;DR

This PR adds OIDC Authorization Code Flow natively to Symfony. This is the 1st PR of a series that aims to cover a large set (close to "all") of options described across various RFCs.

### Common use case: 

```mermaid
sequenceDiagram
    participant User
    participant App as Service Provider <br> (Symfony App)
    participant IdP as Identity Provider <br> (OIDC Provider)

    User->>App: Access protected resource
    App->>App: Generate state, nonce and PKCE verifier, <br> bound to the session
    App->>IdP: OIDC Authorization Request <br> (client_id, response_type=code, scope, redirect_uri, <br> state, nonce, S256 code_challenge)
    IdP->>User: Redirects to the login page
    User->>IdP: Enter credentials
    IdP->>IdP: Validate credentials
    IdP->>IdP: Generate ID token + Access token
    IdP-->>App: Redirection with <br> Authorization code in query string
    App->>App: Validate state against the session
    App->>IdP: Exchange code for tokens <br> (client_id + code_verifier + the client secret)
    IdP-->>App: ID token + Access token
    rect rgba(201, 150, 255, 0.55)
    App->>App: Validate the ID token claims <br> (iss, aud, exp, iat, nbf, nonce, azp) <br> within allowed_time_drift
    end
    App->>IdP: Fetch the claims from the UserInfo endpoint
    IdP-->>App: User claims
    App->>App: The UserInfo sub must match the ID token sub <br> (OIDC Core 1.0 section 5.3.2)
    rect rgba(150, 201, 255, 0.48)
    App->>App: Extract user claims (roles default to ROLE_USER)
    App->>App: Create Passport with the user badge (claims)
    App->>App: Do the authentication process
    end
    rect rgba(150, 255, 201, 0.49)
    App->>App: Create Security Token object <br> with ID token and Access token in it
    end
    App-->>User: Redirect to protected resource
```

## OIDC in Symfony today

Symfony already supports OpenID Connect for **stateless, resource-server authentication** — the API/machine-to-machine case where the client already holds a token. The `access_token` authenticator, together with the OIDC token handlers, validates a Bearer token from the request and maps it to a user:

- **`OidcTokenHandler`** — validates a signed (JWS, optionally encrypted JWE) ID/access token locally against the provider's keys, using the `web-token` (JOSE) library and its claim checkers;
- **`OidcUserInfoTokenHandler`** — resolves the user by calling the provider's UserInfo endpoint.

Both build an `OidcUser` from the resulting claims (via `OidcTrait`).

## What's missing today

There is no built-in support for the **interactive end-user login flow** — the "Log in with…" experience that web applications actually need:

> a user opens a protected page → is redirected to the Identity Provider → authenticates there → is redirected back, and the application opens a session.

This is the OIDC **Authorization Code Flow**. The existing token handlers don't cover it: they validate a token the client already obtained, they don't drive the browser redirect → callback → code-exchange sequence or establish the session. Today this gap is filled by third-party bundles (e.g. [drenso/symfony-oidc](https://github.com/Drenso/symfony-oidc)).

## What this PR adds

A first-class `oidc_login` firewall authenticator that implements the Authorization Code Flow:

```yaml
security:
    providers:
        oidc:
            oidc: ~
    firewalls:
        main:
            provider: oidc
            oidc_login:
                provider_uri:        '%env(OIDC_PROVIDER_URI)%'
                # identifies this app to the provider. Required: it's a mandatory param of the authorization request (OIDC Core 1.0 §3.1.2.1), and it's
                # also the value the ID token "aud" claim is validated against.
                client_id:           '%env(OIDC_CLIENT_ID)%'
                # authenticates this app at the token endpoint when the authorization
                # code is exchanged for tokens (RFC 6749 §2.3.1). Required as of this PR, 
                # which only supports confidential clients. It becomes optional for public clients, which will be supported in a following PR.
                client_secret:       '%env(OIDC_CLIENT_SECRET)%'
                scope:               ['openid', 'profile', 'email']
                check_path:          /oidc/callback
                discovery_cache_ttl: 3600
                allowed_time_drift:  0
```

The user is loaded by the firewall's user provider, from the verified `sub` claim and with every claim passed as badge attributes. The `oidc` provider above builds a self-contained `OidcUser` from them; any other provider (an entity one, for instance) receives the same claims and can map them onto its own user, which is where roles are granted.

The callback route is declared by a route loader that the application imports, exactly like the logout routes are today:

```yaml
# config/routes/security.yaml
_oidc_login_callbacks:
    resource: security.authenticator.oidc_login.route_loader
    type: service
```

Without it, the provider's redirect reaches the router before the firewall and gets a 404. This import belongs in the `symfony/security-bundle` recipe, next to the existing `_security_logout` one, so a companion PR on `symfony/recipes` is needed before this lands.

**The flow and the classes that implement it:**

- **`OidcLoginAuthenticator`** — the entry point redirects to the provider's authorization endpoint (`response_type=code`, `openid` scope, `state`, `nonce`, S256 PKCE, the latter unconditionally). On the callback it validates `state`, exchanges the authorization code for tokens, validates the ID token, fetches the user's claims, and lets the firewall open the session.
- **`OidcClient` / `OidcConfidentialClient`** — token-endpoint exchange and UserInfo retrieval (`client_secret_post`). `OidcClient` is abstract and delegates client authentication to its subclass; only the confidential subclass is wired here, so `client_secret` is a required option. Public clients, which hold no secret and authenticate with `client_id` plus PKCE alone (`token_endpoint_auth_method=none`), are not supported yet: that is precisely the extension point this split exists for.
- **`OidcDiscovery`** — resolves the authorization, token and userinfo endpoints (and the issuer) from `.well-known/openid-configuration`, so no manual endpoint wiring is needed. The document is cached, with a `discovery_cache_ttl` firewall option (default 3600 seconds) to tune how long.
- **`OidcLoginRouteLoader`**: registers the callback route for `check_path` automatically, so the provider redirect is handled even though it reaches the app before the firewall in the request pipeline.
- **`OidcIdToken`** — ID-token claim validation that **reuses the same `web-token` JOSE claim checkers as the existing token handlers** (`iss` / `aud` / `exp` / `iat` / `nbf`, with an `allowed_time_drift` tolerance), plus the OIDC-specific `nonce` and `azp` rules.
- **`OidcUserProvider`** and the `oidc` user provider.
- **`OidcLoginFactory`** — registers and wires the `oidc_login` firewall key.

It **reuses the existing `OidcUser` and `OidcTrait`** — no new user model is introduced.

**Secure by default:**

- `state` (CSRF) and `nonce` (replay) are generated, session-bound, and validated;
- PKCE is always on, with the S256 challenge method (RFC 9700 §2.1.1). It cannot be turned off and no other method can be selected here: making PKCE configurable and its methods pluggable is the follow-up PR listed below, not part of this one;
- ID-token claims are validated (OIDC Core 1.0 §3.1.3.7), including the `iat` and `nbf` time claims with a configurable `allowed_time_drift` tolerance, and the UserInfo `sub` must match the ID token (§5.3.2);
- signature verification is intentionally skipped because the ID token is fetched directly from the token endpoint over TLS, where it is allowed (OIDC Core 1.0 §3.1.3.7 item 6); this relies on TLS being verified on that connection, and opt-in JWKS-based signature verification is planned as a follow-up (see Future steps);
- `provider_uri` is required to be HTTPS (loopback hosts excepted for local dev), so the TLS guarantee that justifies skipping signature verification actually holds. It is checked when the container compiles for a literal value, and by `OidcDiscovery` at runtime, which is the only place a value coming from an environment variable can be checked;
- the discovery document's announced `issuer` must match the configured one (OIDC Discovery 1.0 §4.3), so a tampered `.well-known` cannot redefine the issuer. A trailing slash is ignored on both sides, since providers do announce one (Authentik does) and it carries no security meaning;
- the `authorization_endpoint`, `token_endpoint` and `userinfo_endpoint` announced by the discovery document must use HTTPS too, so a tampered or misconfigured document cannot downgrade the requests carrying the code and the tokens. The issuer, the authorization endpoint and the userinfo endpoint keep the loopback and reserved-test-domain exemption that makes local development possible, but the `token_endpoint` does not: it is where the client secret is posted, so plain HTTP is refused there even on `localhost`. A local IdP therefore has to serve its token endpoint over TLS;
- the provider cannot escalate privileges through claims: a `roles` (or user-identifier) claim returned by the provider is not mass-assigned onto the `OidcUser`; the identity comes only from the verified `sub`, and roles default to `ROLE_USER`. Provider-driven roles are opt-in through a user provider of your own, which receives every claim and can map them (`OidcUser::fromClaims()` builds the user from claims, roles included).

**Specifications:** OIDC Core 1.0 §3.1, OIDC Discovery 1.0, [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749), [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) (PKCE), [RFC 9700](https://datatracker.ietf.org/doc/html/rfc9700).

## Tested with

- [Keycloak](https://github.com/keycloak/keycloak) ✅ 
- [Authelia](https://github.com/authelia/authelia) ✅ 
- [Microsoft Entra ID](https://learn.microsoft.com/fr-fr/entra/identity/) ✅ 
- [Gravitee](https://documentation.gravitee.io/am) ✅
- [Authentik](https://github.com/goauthentik/authentik) ✅
- [Google](https://developers.google.com/identity/openid-connect/openid-connect) ✅

A runnable demo wiring several of these providers at once (one firewall each, local Docker IdPs) lives in [welcoMattic/oidc-login-demo](https://github.com/welcoMattic/oidc-login-demo). Authentik is what surfaced the trailing-slash issuer problem: its issuer ends with a slash, which no configuration value could satisfy before it was fixed here.

## Following PRs

Each item below is **already implemented** and open as a stacked pull request on my fork, split out of this one to keep every PR reviewable. They are chained, each targeting the previous one, so the links also give the intended review order. Please check the relevant PR before asking for something to be implemented later: it very likely already exists there.

- **PKCE (Proof Key for Code Exchange) configuration & pluggable methods** ([welcoMattic/symfony#15](https://github.com/welcoMattic/symfony/pull/15)): make PKCE toggleable and its challenge method configurable, with pluggable `PkceMethodInterface` implementations (built-in `S256` and `plain`).
- **Authorization-request customization** ([welcoMattic/symfony#16](https://github.com/welcoMattic/symfony/pull/16)): add `prompt`, `max_age` (also enforced against the ID-token `auth_time`), and a free-form bag for any extra authorization-request parameter.
- **Claims source & user-identifier mapping** ([welcoMattic/symfony#17](https://github.com/welcoMattic/symfony/pull/17)): allow sourcing claims from UserInfo or the ID token, map the user identifier to any claim, and enforce the UserInfo/ID-token `sub` match (OIDC §5.3.2).
- **Token-endpoint client authentication** ([welcoMattic/symfony#18](https://github.com/welcoMattic/symfony/pull/18)): support both `client_secret_post` and `client_secret_basic` at the token endpoint.
- **RP-Initiated Logout** ([welcoMattic/symfony#19](https://github.com/welcoMattic/symfony/pull/19)): redirect to the provider's `end_session_endpoint` on logout, falling back to a local logout when it's not advertised.
- **Entry-point tuning** ([welcoMattic/symfony#20](https://github.com/welcoMattic/symfony/pull/20)): optionally redirect straight to the provider instead of a custom login path.
- **Public clients** ([welcoMattic/symfony#21](https://github.com/welcoMattic/symfony/pull/21)): `token_endpoint_auth_method=none` for clients that hold no secret (CLI tools, mobile and native apps e.g using NativePHP), with PKCE made mandatory for them since it is the only thing binding the authorization code to the client.
- **ID-token signature verification** ([welcoMattic/symfony#22](https://github.com/welcoMattic/symfony/pull/22)): JWKS-based verification of the ID token signature, on by default, with an `algorithms` allowlist that can never contain `none`, so a forged or unsigned token is rejected even when the token-endpoint connection does not verify TLS. This answers the review concern about the authenticator and `OidcTokenHandler` disagreeing on whether signatures matter.

## Future steps

Larger items to keep in mind (from @Spomky review feedback):

- **Multiple providers per firewall**: let a single firewall offer several OIDC providers at once, instead of today's one-provider-per-firewall. Needs a provider-keyed config, per-provider discovery/client and session namespacing, callback disambiguation (per-provider `check_path` or the provider encoded in `state`), and a provider-aware entry point.
- **Configurable `response_type` (hybrid flows)**: support `id_token`, `code id_token`, `code token`, etc., so the authenticator can already hold an ID token and/or access token and skip an extra call to the provider. Because the ID token then arrives via the front channel, this comes with JWKS-based ID-token signature verification.
- **`response_mode=form_post`**: return the authorization response as a POST body instead of query parameters, to avoid leaking code/token into logs and browser history.
- **Request Objects**: pass authorization parameters as a signed request object (by value or via `request_uri`), preventing tampering and leaks; the `request_uri` variant requires exposing an extra endpoint.
- **`session_state` handling**: track `session_state` so session-based and provider-initiated logout can be handled correctly.
- **Dynamic client registration (RFC 7591)**: build on the existing generic/confidential `OidcClient` split to register clients with the provider dynamically.

cc @chalasr, you might be interested in this one 😉 

