### PR TITLE
[HttpKernel] Fix XML config for bundles extending `AbstractBundle`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php
@@ -58,4 +58,9 @@ abstract class AbstractBundle extends Bundle implements ConfigurableExtensionInt
 
         return $this->path;
     }
+
+    public function getXMLNamespace(): ?string
+    {
+        return null;
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleExtension.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleExtension.php
@@ -64,4 +64,10 @@ class BundleExtension extends Extension implements PrependExtensionInterface
 
         $this->executeConfiguratorCallback($container, $callback, $this->subject);
     }
+
+    public function getNamespace(): string
+    {
+        return ($this->subject instanceof AbstractBundle ? $this->subject->getXMLNamespace() : null)
+            ?? parent::getNamespace();
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/AbstractBundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/AbstractBundleTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Bundle;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpKernel\Tests\Fixtures\AcmeBarBundle\AcmeBarBundle;
+use Symfony\Component\HttpKernel\Tests\Fixtures\AcmeFooBundle\AcmeFooBundle;
+
+class AbstractBundleTest extends TestCase
+{
+    public function testExtensionNamespaceDefaultsToTheExtensionNamespace()
+    {
+        $bundle = new AcmeFooBundle();
+
+        self::assertSame('http://example.org/schema/dic/acme_foo', $bundle->getContainerExtension()->getNamespace());
+    }
+
+    public function testExtensionNamespaceIsForwardedFromBundle()
+    {
+        $bundle = new AcmeBarBundle();
+
+        self::assertSame('http://acme.example/schema/dic/acme_bar', $bundle->getContainerExtension()->getNamespace());
+    }
+
+    public function testConfigurationIsLoadedFromXmlUsingTheBundleNamespace()
+    {
+        $bundle = new AcmeBarBundle();
+
+        $container = new ContainerBuilder(new ParameterBag([
+            'kernel.environment' => 'test',
+            'kernel.build_dir' => sys_get_temp_dir(),
+        ]));
+        $container->registerExtension($bundle->getContainerExtension());
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Fixtures/AcmeBarBundle/Resources/config'));
+        $loader->load('config.xml');
+
+        $container->compile();
+
+        self::assertTrue($container->hasParameter('acme_bar.config'));
+        self::assertSame(['foo' => 'hello'], $container->getParameter('acme_bar.config'));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/AcmeBarBundle/AcmeBarBundle.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/AcmeBarBundle/AcmeBarBundle.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\AcmeBarBundle;
+
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+
+class AcmeBarBundle extends AbstractBundle
+{
+    public function getXMLNamespace(): ?string
+    {
+        return 'http://acme.example/schema/dic/acme_bar';
+    }
+
+    public function configure(DefinitionConfigurator $definition): void
+    {
+        $definition->rootNode()
+            ->children()
+                ->scalarNode('foo')->defaultValue('bar')->end()
+            ->end()
+        ;
+    }
+
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $container->parameters()
+            ->set('acme_bar.config', $config)
+        ;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/AcmeBarBundle/Resources/config/config.xml
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/AcmeBarBundle/Resources/config/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:acme-bar="http://acme.example/schema/dic/acme_bar">
+
+    <acme-bar:config foo="hello"/>
+
+</container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a bundle extends `AbstractBundle`, configuring it via XML fails with:

> There is no extension able to load the configuration for "`<bundle alias>`" (in ".../config.xml"). Looked for namespace "`<custom namespace>`", found "`http://example.org/schema/dic/<bundle alias>`".

This happens because `BundleExtension` does not forward the bundle's XML namespace. As a result, it always reports the default `http://example.org/schema/dic/<bundle alias>` instead of the namespace declared by the bundle.