### PR TITLE
[Cache] Fix "Class Relay\Relay not found" for RedisCluster/RedisArray with tcp_keepalive

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTcpKeepaliveTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTcpKeepaliveTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Traits;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Traits\RedisTrait;
+
+/**
+ * @requires extension redis
+ */
+class RedisTraitTcpKeepaliveTest extends TestCase
+{
+    // RedisArray connects lazily, so the tcp_keepalive setOption() runs without a server.
+    public function testCreateConnectionForRedisArrayWithTcpKeepalive()
+    {
+        $mock = new class {
+            use RedisTrait;
+        };
+
+        $connection = $mock::createConnection('redis:?host[127.0.0.1:6379]&host[127.0.0.1:6380]', ['tcp_keepalive' => 60]);
+
+        self::assertInstanceOf(\RedisArray::class, $connection);
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -343,11 +343,11 @@ trait RedisTrait
                 throw new InvalidArgumentException('Redis connection failed: '.$e->getMessage());
             }
 
-            if (0 < $params['tcp_keepalive'] && (!$isRedisExt || \defined('Redis::OPT_TCP_KEEPALIVE'))) {
-                $redis->setOption($isRedisExt ? \Redis::OPT_TCP_KEEPALIVE : Relay::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
+            if (0 < $params['tcp_keepalive']) {
+                $redis->setOption(\Redis::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
             }
         } elseif (is_a($class, \RedisCluster::class, true)) {
-            $initializer = static function () use ($isRedisExt, $class, $params, $hosts) {
+            $initializer = static function () use ($class, $params, $hosts) {
                 foreach ($hosts as $i => $host) {
                     $hosts[$i] = match ($host['scheme']) {
                         'tcp' => $host['host'].':'.$host['port'],
@@ -362,8 +362,8 @@ trait RedisTrait
                     throw new InvalidArgumentException('Redis connection failed: '.$e->getMessage());
                 }
 
-                if (0 < $params['tcp_keepalive'] && (!$isRedisExt || \defined('Redis::OPT_TCP_KEEPALIVE'))) {
-                    $redis->setOption($isRedisExt ? \Redis::OPT_TCP_KEEPALIVE : Relay::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
+                if (0 < $params['tcp_keepalive']) {
+                    $redis->setOption(\Redis::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
                 }
                 $redis->setOption(\RedisCluster::OPT_SLAVE_FAILOVER, match ($params['failover']) {
                     'error' => \RedisCluster::FAILOVER_ERROR,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64956
| License       | MIT

`RedisTrait::createConnection()` fatals with `Error: Class "Relay\Relay" not found` when **all** of these hold:

- the connection is a **`\RedisCluster`** (`redis_cluster=1`) or **`\RedisArray`** (multiple hosts), using the **phpredis** extension;
- `tcp_keepalive > 0`;
- the **`relay` extension is not installed**.

### Root cause

- The `\RedisArray` and `\RedisCluster` branches resolve the keepalive option with `$isRedisExt ? \Redis::OPT_TCP_KEEPALIVE : Relay::OPT_TCP_KEEPALIVE`.
- `$isRedisExt` is `is_a($class, \Redis::class, true)`, which is **`false`** for `\RedisCluster`/`\RedisArray` — neither extends `\Redis`.
- So the ternary takes the `else` branch and dereferences `Relay::OPT_TCP_KEEPALIVE`, loading the `Relay\Relay` class even though this is a phpredis connection and relay is absent → fatal.
- The ternary assumes "not `\Redis` ⇒ Relay", which only holds in the single-node `if ($isRedisExt || $isRelayExt)` path.

### Fix

- Use `\Redis::OPT_TCP_KEEPALIVE` in both the `\RedisArray` and `\RedisCluster` branches.
- `\RedisCluster`/`\RedisArray` don't declare their own `OPT_TCP_KEEPALIVE` (so `\RedisCluster::OPT_TCP_KEEPALIVE` would itself be an undefined-constant fatal), but `setOption()` dispatches on the shared integer value — `\Redis::OPT_TCP_KEEPALIVE` is correct for all three phpredis classes.
- Dropped the `(!$isRedisExt || \defined('Redis::OPT_TCP_KEEPALIVE'))` guard in these two branches. `$isRedisExt` is always `false` here, so the `!$isRedisExt` clause short-circuited the `||` and made the `\defined()` check dead — and these branches are only reachable with `ext-redis` loaded (Symfony 6.4 needs PHP ≥ 8.1 ⇒ phpredis ≥ 5.x), where `Redis::OPT_TCP_KEEPALIVE` always exists. This matches the adjacent unguarded `\RedisCluster::OPT_SLAVE_FAILOVER` call. (`$isRedisExt` is consequently no longer imported into the `\RedisCluster` initializer.)
- The single-node branch (inside `if ($isRedisExt || $isRelayExt)`) is **left untouched** — its ternary still needs `Relay::OPT_TCP_KEEPALIVE` for genuine relay connections.

### No behavior change for relay users

- **These branches only ever hold phpredis objects.** Relay is handled earlier by `if ($isRedisExt || $isRelayExt)` (single node) or, on 7.x+, by the dedicated `RelayCluster` branch (which keeps `Relay::OPT_TCP_KEEPALIVE`). `is_a($class, \RedisArray/\RedisCluster::class, true)` is false for relay classes, so relay never reaches the changed lines.
- **The values are identical anyway:** `Relay::OPT_TCP_KEEPALIVE === \Redis::OPT_TCP_KEEPALIVE === 6`. The fix only removes the dependency on the `Relay\Relay` class being loaded.

### Test

- Added a regression test on the lazy `\RedisArray` path — it reaches the keepalive `setOption()` without contacting a server, reproducing the fatal deterministically (fails without this fix) whenever the relay extension is absent.
- It lives in a **separate `RedisTraitTcpKeepaliveTest`** rather than in `RedisTraitTest` on purpose: `RedisTraitTest::setUpBeforeClass()` skips the whole class unless a live Redis is reachable, so the test would be skipped in exactly the relay-absent, server-less setup that triggers the bug (e.g. the `minimal-exts` Windows CI job, which has phpredis but no relay and no server). As a standalone `@requires extension redis` test it runs there and genuinely guards the regression, while server-backed cases stay in `RedisTraitTest`.

### Workaround (existing releases)

- Set `tcp_keepalive: 0` (the default), which skips the affected branch.
