### PR TITLE
[Security] Update a stale comment

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -59,7 +59,7 @@ final class AccessDecisionManager implements AccessDecisionManagerInterface
             $accessDecision = null;
         }
 
-        // Special case for AccessListener, do not remove the right side of the condition before 6.0
+        // Special case for AccessListener, which passes all attributes of the matched access_control rule at once
         if (\count($attributes) > 1 && !$allowMultipleAttributes) {
             throw new InvalidArgumentException(\sprintf('Passing more than one Security attribute to "%s()" is not supported.', __METHOD__));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The comment above the multi-attribute check in `AccessDecisionManager::decide()` still said *"do not remove the right side of the condition before 6.0"*. That instruction was consumed long ago (the deprecation layer was dropped in 5.0), and the right side is not removable anyway: `AccessListener` passes `$allowMultipleAttributes = true` to submit all attributes of the matched `access_control` rule in a single `decide()` call.

This PR replaces the stale instruction with the actual reason for the special case.