### PR TITLE
[Serializer] Do not read subclass discriminator attributes from base objects

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -794,12 +794,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         if (null !== $this->classDiscriminatorResolver) {
-            $class = \is_object($classOrObject) ? $classOrObject::class : $classOrObject;
             if (null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject)) {
                 $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
             }
 
-            if (null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForClass($class)) {
+            // A class name can be denormalized into any of the mapped classes, so their attributes
+            // are all allowed. The class of an object is known and the others cannot be read from it.
+            if (!\is_object($classOrObject) && null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForClass($classOrObject)) {
                 $attributes = [];
                 foreach ($discriminatorMapping->getTypesMapping() as $mappedClass) {
                     $attributes[] = parent::getAllowedAttributes($mappedClass, $context, $attributesAsString);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
@@ -1454,6 +1455,48 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame($nested, $obj->nested);
         $this->assertSame('foo', $obj->nested->getValue());
     }
+
+    /**
+     * @dataProvider provideDiscriminatorMapGroups
+     */
+    public function testNormalizeConcreteDiscriminatorMapClassKeepsOwnAttributesOnly(array $groups)
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+        $context = [AbstractNormalizer::GROUPS => $groups];
+
+        $this->assertSame([
+            'foo' => ObjectNormalizerDiscriminatorBase::FOO,
+            'type' => ObjectNormalizerDiscriminatorBase::TYPE,
+        ], $normalizer->normalize(new ObjectNormalizerDiscriminatorBase(), null, $context));
+
+        $this->assertSame([
+            'bar' => ObjectNormalizerDiscriminatorSub::BAR,
+            'foo' => ObjectNormalizerDiscriminatorBase::FOO,
+            'type' => ObjectNormalizerDiscriminatorSub::TYPE,
+        ], $normalizer->normalize(new ObjectNormalizerDiscriminatorSub(), null, $context));
+    }
+
+    public static function provideDiscriminatorMapGroups(): iterable
+    {
+        yield 'wildcard group' => [['*']];
+        yield 'no group' => [[]];
+    }
+
+    public function testDenormalizeConcreteDiscriminatorMapBaseClassAllowsMappedAttributes()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $denormalized = $normalizer->denormalize(
+            ['type' => ObjectNormalizerDiscriminatorSub::TYPE, 'foo' => 'FOO', 'bar' => 'BAR'],
+            ObjectNormalizerDiscriminatorBase::class,
+            null,
+            [AbstractNormalizer::GROUPS => ['*']]
+        );
+
+        $this->assertInstanceOf(ObjectNormalizerDiscriminatorSub::class, $denormalized);
+        $this->assertSame('FOO', $denormalized->foo);
+        $this->assertSame('BAR', $denormalized->bar);
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy
@@ -1817,7 +1860,7 @@ class ObjectWithAccessorishMethods
     }
 }
 
-#[\Symfony\Component\Serializer\Attribute\DiscriminatorMap(
+#[DiscriminatorMap(
     typeProperty: 'type',
     mapping: [
         'type_a' => DiscriminatorDummyTypeA::class,
@@ -2162,4 +2205,31 @@ class ObjectWithMetadata
 class ObjectTypedDummy
 {
     public string $name;
+}
+
+#[DiscriminatorMap(
+    typeProperty: 'type',
+    mapping: [
+        ObjectNormalizerDiscriminatorBase::TYPE => ObjectNormalizerDiscriminatorBase::class,
+        ObjectNormalizerDiscriminatorSub::TYPE => ObjectNormalizerDiscriminatorSub::class,
+    ],
+)]
+class ObjectNormalizerDiscriminatorBase
+{
+    public const TYPE = 'base';
+    public const FOO = 'foo';
+    public const BAZ = 'baz';
+
+    public string $foo = self::FOO;
+
+    #[Ignore]
+    public string $baz = self::BAZ;
+}
+
+class ObjectNormalizerDiscriminatorSub extends ObjectNormalizerDiscriminatorBase
+{
+    public const TYPE = 'sub';
+    public const BAR = 'bar';
+
+    public string $bar = self::BAR;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64960
| License       | MIT

`AbstractObjectNormalizer::getAllowedAttributes()` merged the attributes of every class of a discriminator map, even when it was given an object to normalize. Normalizing an instance of a class that is itself part of the map then tried to read a property that only exists on another mapped class, and failed with a `NoSuchPropertyException`.

The merge is only needed when the argument is a class name: denormalization does not know the target class before the type property is read. It is now skipped for objects, whose class is already known.

Post-review changes: the condition was simplified, two unrelated docblock changes were reverted, and the tests now also check that normalizing a subclass still returns all its attributes and that denormalizing through the base class still accepts the subclass attributes.
