### PR TITLE
[AssetMapper] Avoid re-expanding bare importmap entries

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
@@ -92,9 +92,10 @@ class ImportMapGenerator
         }
 
         $allEntries = [];
+        $expandedEntries = [];
         foreach ($this->importMapConfigReader->getEntries() as $rootEntry) {
             $allEntries[$rootEntry->importName] = $rootEntry;
-            $allEntries = $this->addImplicitEntries($rootEntry, $allEntries);
+            $allEntries = $this->addImplicitEntries($rootEntry, $allEntries, $expandedEntries);
         }
 
         $rawImportMapData = [];
@@ -157,12 +158,17 @@ class ImportMapGenerator
      *
      * @return array<string, ImportMapEntry>
      */
-    private function addImplicitEntries(ImportMapEntry $entry, array $currentImportEntries): array
+    private function addImplicitEntries(ImportMapEntry $entry, array $currentImportEntries, array &$expandedEntries): array
     {
         // only process import dependencies for JS files
         if (ImportMapType::JS !== $entry->type) {
             return $currentImportEntries;
         }
+
+        if (isset($expandedEntries[$entry->importName])) {
+            return $currentImportEntries;
+        }
+        $expandedEntries[$entry->importName] = true;
 
         if (!$asset = $this->findAsset($entry->path)) {
             // should only be possible at this point for root importmap.php entries
@@ -198,7 +204,7 @@ class ImportMapGenerator
 
             // unless there was some missing importmap entry, recurse
             if ($nextEntry) {
-                $currentImportEntries = $this->addImplicitEntries($nextEntry, $currentImportEntries);
+                $currentImportEntries = $this->addImplicitEntries($nextEntry, $currentImportEntries, $expandedEntries);
             }
         }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -571,6 +571,87 @@ class ImportMapGeneratorTest extends TestCase
         ];
     }
 
+    public function testGetRawImportMapDataExpandsBareImportedEntriesOnce()
+    {
+        $manager = $this->createImportMapGenerator();
+        $this->mockImportMap([
+            self::createLocalEntry('app', path: 'app.js'),
+            self::createLocalEntry('module-a', path: 'module-a.js'),
+            self::createLocalEntry('module-b', path: 'module-b.js'),
+            self::createLocalEntry('shared', path: 'shared.js'),
+        ]);
+
+        $mappedAssets = [
+            new MappedAsset(
+                'app.js',
+                publicPath: '/assets/app-d1g3st.js',
+                javaScriptImports: [
+                    new JavaScriptImport('module-a', assetLogicalPath: 'module-a.js', assetSourcePath: '/path/to/module-a.js', isLazy: false),
+                    new JavaScriptImport('module-b', assetLogicalPath: 'module-b.js', assetSourcePath: '/path/to/module-b.js', isLazy: false),
+                ],
+            ),
+            new MappedAsset(
+                'module-a.js',
+                publicPath: '/assets/module-a-d1g3st.js',
+                javaScriptImports: [
+                    new JavaScriptImport('shared', assetLogicalPath: 'shared.js', assetSourcePath: '/path/to/shared.js', isLazy: false),
+                ],
+            ),
+            new MappedAsset(
+                'module-b.js',
+                publicPath: '/assets/module-b-d1g3st.js',
+                javaScriptImports: [
+                    new JavaScriptImport('shared', assetLogicalPath: 'shared.js', assetSourcePath: '/path/to/shared.js', isLazy: false),
+                ],
+            ),
+            new MappedAsset(
+                'shared.js',
+                publicPath: '/assets/shared-d1g3st.js',
+            ),
+        ];
+        $resolvedAssets = [];
+        $this->mockAssetMapper($mappedAssets, $resolvedAssets);
+
+        $this->assertSame([
+            'app' => ['path' => '/assets/app-d1g3st.js', 'type' => 'js'],
+            'module-a' => ['path' => '/assets/module-a-d1g3st.js', 'type' => 'js'],
+            'module-b' => ['path' => '/assets/module-b-d1g3st.js', 'type' => 'js'],
+            'shared' => ['path' => '/assets/shared-d1g3st.js', 'type' => 'js'],
+        ], $manager->getRawImportMapData());
+        $this->assertSame(2, $resolvedAssets['shared.js']);
+    }
+
+    public function testGetRawImportMapDataDoesNotExpandInterRootBareImportsTwice()
+    {
+        $manager = $this->createImportMapGenerator();
+        $this->mockImportMap([
+            self::createLocalEntry('app', path: 'app.js'),
+            self::createLocalEntry('admin', path: 'admin.js'),
+        ]);
+
+        $mappedAssets = [
+            new MappedAsset(
+                'app.js',
+                publicPath: '/assets/app-d1g3st.js',
+                javaScriptImports: [
+                    new JavaScriptImport('admin', assetLogicalPath: 'admin.js', assetSourcePath: '/path/to/admin.js', isLazy: false),
+                ],
+            ),
+            new MappedAsset(
+                'admin.js',
+                publicPath: '/assets/admin-d1g3st.js',
+            ),
+        ];
+        $resolvedAssets = [];
+        $this->mockAssetMapper($mappedAssets, $resolvedAssets);
+
+        $this->assertSame([
+            'app' => ['path' => '/assets/app-d1g3st.js', 'type' => 'js'],
+            'admin' => ['path' => '/assets/admin-d1g3st.js', 'type' => 'js'],
+        ], $manager->getRawImportMapData());
+        $this->assertSame(2, $resolvedAssets['admin.js']);
+    }
+
     public function testGetRawImportDataUsesCacheFile()
     {
         $this->compiledConfigReader = $this->createMock(CompiledAssetMapperConfigReader::class);
@@ -734,9 +815,15 @@ class ImportMapGeneratorTest extends TestCase
 
     private function mockImportMap(array $importMapEntries): void
     {
+        $importMapEntries = new ImportMapEntries($importMapEntries);
+
         $this->configReader
             ->method('getEntries')
-            ->willReturn(new ImportMapEntries($importMapEntries))
+            ->willReturn($importMapEntries)
+        ;
+        $this->configReader
+            ->method('findRootImportMapEntry')
+            ->willReturnCallback(static fn (string $moduleName): ?ImportMapEntry => $importMapEntries->has($moduleName) ? $importMapEntries->get($moduleName) : null)
         ;
     }
 
@@ -754,13 +841,16 @@ class ImportMapGeneratorTest extends TestCase
     }
 
     /**
-     * @param MappedAsset[] $mappedAssets
+     * @param MappedAsset[]      $mappedAssets
+     * @param array<string, int> $resolvedAssets Filled with the number of times each logical path was resolved
      */
-    private function mockAssetMapper(array $mappedAssets): void
+    private function mockAssetMapper(array $mappedAssets, array &$resolvedAssets = []): void
     {
         $this->assetMapper
             ->method('getAsset')
-            ->willReturnCallback(static function (string $logicalPath) use ($mappedAssets) {
+            ->willReturnCallback(static function (string $logicalPath) use ($mappedAssets, &$resolvedAssets) {
+                $resolvedAssets[$logicalPath] = ($resolvedAssets[$logicalPath] ?? 0) + 1;
+
                 foreach ($mappedAssets as $asset) {
                     if ($asset->logicalPath === $logicalPath) {
                         return $asset;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64959
| License       | MIT

`ImportMapGenerator::getRawImportMapData()` walked the same importmap entries many times over. The dedup guard in `addImplicitEntries()` relies on entries being recorded in the accumulator, but an entry reached through a bare specifier is never recorded there: `JavaScriptImportPathCompiler` only sets `addImplicitlyToImportMap` for relative imports. So every bare import re-entered the traversal and re-walked its whole subtree, from another root or from another path in the same root. On an application with a few hundred bare-name entries this turned a few hundred asset resolutions into tens of thousands.

Entries that have already been expanded are now tracked explicitly, so each one is expanded once. The resulting import map is unchanged.

Post-review changes: the memoization and reset work was moved out to #64972, and the two regression tests now share the existing `mockAssetMapper()` helper instead of duplicating it.
