### PR TITLE
[Dotenv] Don't parse external env var values when resolving .env references

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -676,10 +676,16 @@ final class Dotenv
             $loadedVars = array_flip(explode(',', $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? ''));
             unset($loadedVars['']);
 
-            foreach ($values as $name => $_) {
+            foreach ($values as $name => $value) {
                 $alreadyExternal = isset($_ENV[$name]) || isset($_SERVER[$name]) && !str_starts_with($name, 'HTTP_');
-                if (!isset($this->overriddenValues[$name]) && $alreadyExternal) {
-                    $this->overriddenValues[$name] = $_ENV[$name] ?? $_SERVER[$name];
+                if (!isset($this->overriddenValues[$name])) {
+                    if ($alreadyExternal) {
+                        $this->overriddenValues[$name] = $_ENV[$name] ?? $_SERVER[$name];
+                    } elseif ($this->isSelfReferencing($name, $value) && false !== $external = getenv($name, true)) {
+                        // the OS provides the value but neither $_ENV nor $_SERVER is populated;
+                        // $localOnly skips the request-scoped SAPI env and its HTTP_* vars
+                        $this->overriddenValues[$name] = $external;
+                    }
                 }
                 if (isset($loadedVars[$name]) || $overrideExistingVars || !$alreadyExternal) {
                     $this->loadedRawVars[$name] = true;
@@ -688,6 +694,15 @@ final class Dotenv
 
             $this->populate($values, $overrideExistingVars);
         }
+    }
+
+    /**
+     * Tells whether a raw value references the variable it defines
+     * (e.g. MY_VAR="${MY_VAR:-default}").
+     */
+    private function isSelfReferencing(string $name, string $value): bool
+    {
+        return str_contains($value, '$') && preg_match('/\$\{?'.preg_quote($name, '/').'(?![A-Za-z0-9_])/', $value);
     }
 
     /**
@@ -752,12 +767,11 @@ final class Dotenv
 
         try {
             // Detect variables that were originally defined as self-referencing
-            // (e.g. MY_VAR="${MY_VAR:-default}") so their own raw value is hidden
-            // during resolution, allowing the default to trigger correctly.
+            // so their own raw value is hidden during resolution, allowing the
+            // external value or the default to trigger correctly.
             $selfReferencingVars = [];
             foreach ($rawVars as $name => $_) {
-                $value = $_ENV[$name] ?? '';
-                if (str_contains($value, '$') && preg_match('/\$\{?'.preg_quote($name, '/').'(?![A-Za-z0-9_])/', $value)) {
+                if ($this->isSelfReferencing($name, $_ENV[$name] ?? '')) {
                     $selfReferencingVars[$name] = true;
                 }
             }

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -604,19 +604,27 @@ final class Dotenv
             }
 
             $name = $matches['name'];
+            $isExternal = false;
             if (isset($loadedVars[$name]) && isset($this->values[$name])) {
                 $value = $this->values[$name];
             } elseif (isset($_ENV[$name])) {
                 $value = $_ENV[$name];
+                $isExternal = true;
             } elseif (isset($_SERVER[$name]) && !str_starts_with($name, 'HTTP_')) {
                 $value = $_SERVER[$name];
+                $isExternal = true;
             } elseif (isset($this->values[$name])) {
                 $value = $this->values[$name];
             } else {
                 $value = (string) getenv($name);
+                $isExternal = true;
             }
 
             if ('' !== $value && !isset($loadedVars[$name])) {
+                if ($isExternal) {
+                    // unlike values parsed from a .env file, external ones are not escaped yet
+                    $value = str_replace('\\', '\\\\', $value);
+                }
                 $value = str_replace('$', "\x00", $value);
             }
 
@@ -787,7 +795,7 @@ final class Dotenv
                         $envBackup = $_ENV[$name] ?? null;
                         $serverBackup = $_SERVER[$name] ?? null;
                         if (isset($this->overriddenValues[$name])) {
-                            $_ENV[$name] = str_replace('$', "\x00", $this->overriddenValues[$name]);
+                            $_ENV[$name] = str_replace(['\\\\', '$'], ['\\\\\\\\', "\x00"], $this->overriddenValues[$name]);
                             $_SERVER[$name] = $_ENV[$name];
                         } else {
                             unset($_ENV[$name], $_SERVER[$name]);

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -333,6 +333,125 @@ class DotenvTest extends TestCase
         }
     }
 
+    /**
+     * @testWith [false]
+     *           [true]
+     */
+    public function testLoadDoesNotTruncateExternalEnvVarOnlyPresentInGetenvOnSelfReference(bool $usePutenv)
+    {
+        unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('SYMFONY_DOTENV_VARS');
+
+        // Mimics `variables_order` lacking both "E" and "S": the OS-provided
+        // env var is only reachable through getenv().
+        putenv('EXT_VAR=secret$word');
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $path = tempnam($tmpdir, 'sf-');
+        file_put_contents($path, "EXT_VAR=\${EXT_VAR}\n");
+
+        $dotenv = new Dotenv();
+
+        try {
+            $dotenv->usePutenv($usePutenv)->load($path);
+            $this->assertSame('secret$word', $_ENV['EXT_VAR']);
+            $this->assertSame('secret$word', $_SERVER['EXT_VAR']);
+            if ($usePutenv) {
+                $this->assertSame('secret$word', getenv('EXT_VAR'));
+            }
+        } finally {
+            unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('EXT_VAR');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
+    /**
+     * @testWith [false]
+     *           [true]
+     */
+    public function testLoadResolvesSelfReferencingDefaultWhenNoExternalEnvVarExists(bool $usePutenv)
+    {
+        unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('EXT_VAR');
+        putenv('SYMFONY_DOTENV_VARS');
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $path = tempnam($tmpdir, 'sf-');
+        file_put_contents($path, "EXT_VAR=\${EXT_VAR:-default}\n");
+
+        try {
+            (new Dotenv())->usePutenv($usePutenv)->load($path);
+            $this->assertSame('default', $_ENV['EXT_VAR']);
+            $this->assertSame('default', $_SERVER['EXT_VAR']);
+            if ($usePutenv) {
+                $this->assertSame('default', getenv('EXT_VAR'));
+            }
+        } finally {
+            unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('EXT_VAR');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
+    /**
+     * @testWith [false]
+     *           [true]
+     */
+    public function testLoadPrefersExternalEnvVarOnlyPresentInGetenvOverSelfReferencingDefault(bool $usePutenv)
+    {
+        unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('SYMFONY_DOTENV_VARS');
+        putenv('EXT_VAR=external');
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $path = tempnam($tmpdir, 'sf-');
+        file_put_contents($path, "EXT_VAR=\${EXT_VAR:-default}\n");
+
+        try {
+            (new Dotenv())->usePutenv($usePutenv)->load($path);
+            $this->assertSame('external', $_ENV['EXT_VAR']);
+            $this->assertSame('external', $_SERVER['EXT_VAR']);
+        } finally {
+            unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('EXT_VAR');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
+    /**
+     * @testWith [false]
+     *           [true]
+     */
+    public function testLoadDoesNotExecuteShellSyntaxFromExternalEnvVarOnlyPresentInGetenv(bool $usePutenv)
+    {
+        unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('SYMFONY_DOTENV_VARS');
+        putenv('EXT_VAR=value$(id)');
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $path = tempnam($tmpdir, 'sf-');
+        file_put_contents($path, "EXT_VAR=\${EXT_VAR}\n");
+
+        try {
+            (new Dotenv())->usePutenv($usePutenv)->load($path);
+            $this->assertSame('value$(id)', $_ENV['EXT_VAR']);
+            $this->assertSame('value$(id)', $_SERVER['EXT_VAR']);
+        } finally {
+            unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('EXT_VAR');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
     public function testOverloadDoesNotExecuteShellSyntaxFromExternalEnvOnSelfReference()
     {
         unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -452,6 +452,49 @@ class DotenvTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider provideBackslashedExternalEnvVars
+     */
+    public function testPreservesBackslashesOfExternalEnvVar(string $external, bool $onlyInGetenv, bool $selfReference)
+    {
+        unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['REF_VAR'], $_SERVER['REF_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('SYMFONY_DOTENV_VARS');
+
+        if ($onlyInGetenv) {
+            putenv("EXT_VAR=$external");
+        } else {
+            $_ENV['EXT_VAR'] = $_SERVER['EXT_VAR'] = $external;
+        }
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+        $path = tempnam($tmpdir, 'sf-');
+        $name = $selfReference ? 'EXT_VAR' : 'REF_VAR';
+        file_put_contents($path, "$name=pre\${EXT_VAR}post\n");
+
+        try {
+            $dotenv = new Dotenv();
+            $onlyInGetenv ? $dotenv->load($path) : $dotenv->overload($path);
+            $this->assertSame("pre{$external}post", $_ENV[$name]);
+            $this->assertSame("pre{$external}post", $_SERVER[$name]);
+        } finally {
+            unset($_ENV['EXT_VAR'], $_SERVER['EXT_VAR'], $_ENV['REF_VAR'], $_SERVER['REF_VAR'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);
+            putenv('EXT_VAR');
+            putenv('SYMFONY_DOTENV_VARS');
+            unlink($path);
+            @rmdir($tmpdir);
+        }
+    }
+
+    public static function provideBackslashedExternalEnvVars(): iterable
+    {
+        foreach (['a\\b', 'a\\\\b', 'a\\\\\\b', 'a\\\\\\\\b', 'a\\\\', '\\\\a', 'a\\\\$b'] as $external) {
+            foreach ([true, false] as $onlyInGetenv) {
+                yield [$external, $onlyInGetenv, true];
+                yield [$external, $onlyInGetenv, false];
+            }
+        }
+    }
+
     public function testOverloadDoesNotExecuteShellSyntaxFromExternalEnvOnSelfReference()
     {
         unset($_ENV['FOO'], $_SERVER['FOO'], $_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64774
| License       | MIT

Follow up to #64386. An external env var value should reach the app unparsed, whatever `.env` does with it. Two ways it did not.

**1. Values reachable only via `getenv()`**

When `variables_order` lacks both `E` and `S`, an OS-provided var is only reachable through `getenv()`. `doLoad()` recorded the pre-existing external value only when it was in `$_ENV`/`$_SERVER`, so `resolveLoadedVars()` had nothing to substitute a self-reference with and fell back to the raw `getenv()` value at the tail of `resolveVariables()`. Since the variable is listed in `SYMFONY_DOTENV_VARS`, that value skipped escaping and got parsed again on the next resolution pass.

With `TEST=${TEST}` in `.env`:

| `getenv('TEST')` | before | before, `usePutenv()` | after |
| --- | --- | --- | --- |
| `fake$value` | `fake` | `''` | `fake$value` |
| `x$FOO`, with `FOO=bar` in `.env` | `xbar` | `''` | `x$FOO` |
| `value$(id)` | output of `id` | `''` | `value$(id)` |
| `x${FOO` | `FormatException` | `''` | `x${FOO` |

The third row is why this is more than a truncation fix: the extra pass reaches `resolveCommands()`, which runs the value through a shell. It takes a self-referencing entry in `.env` plus control of the matching external value.

The new lookup passes `$localOnly` so `getenv()` stays on the process environment. Without it, `getenv()` also reads the request-scoped SAPI environment, where `HTTP_*` entries come from client headers, which is exactly what the `!str_starts_with($name, 'HTTP_')` check right above it refuses to trust.

**2. Backslashes**

Substituting an external value escaped `$` but not `\`, while the final pass unescapes both, so one level of backslashes was lost. This one is not specific to `getenv()`: it reproduces with `$_SERVER` and `overload()`, on both the self-referencing and the indirect form.

| `.env` | external value | before | after |
| --- | --- | --- | --- |
| `TEST=pre${TEST}post` | `a\\b` | `prea\bpost` | `prea\\bpost` |
| `OTHER=${TEST}` | `a\\b` | `a\b` | `a\\b` |
