### PR TITLE
[AssetMapper] Reset the mapped asset factory between requests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -70,6 +70,7 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.debug'),
             ])
             ->decorate('asset_mapper.mapped_asset_factory')
+            ->tag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore'])
 
         ->set('asset_mapper.repository', AssetMapperRepository::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2518,6 +2518,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $container = $this->createContainerFromFile('asset_mapper_without_assets');
 
         $this->assertTrue($container->has('asset_mapper'));
+        $this->assertSame([['method' => 'reset', 'on_invalid' => 'ignore']], $container->getDefinition('asset_mapper.cached_mapped_asset_factory')->getTag('kernel.reset'));
         $this->assertFalse($container->has('asset_mapper.asset_package'));
         $this->assertFalse($container->has('assets.packages'));
         $this->assertFalse($container->has('assets._default_package'));

--- a/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/CachedMappedAssetFactory.php
@@ -58,6 +58,13 @@ class CachedMappedAssetFactory implements MappedAssetFactoryInterface
         return $mappedAsset;
     }
 
+    public function reset(): void
+    {
+        if (\is_callable([$this->innerFactory, 'reset'])) {
+            $this->innerFactory->reset();
+        }
+    }
+
     private function getCacheFilePath(string $logicalPath, string $sourcePath): string
     {
         return $this->cacheDir.'/'.hash('xxh128', $logicalPath.':'.$sourcePath).'.php';

--- a/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
+++ b/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php
@@ -71,6 +71,12 @@ class MappedAssetFactory implements MappedAssetFactoryInterface
         return $this->assetsCache[$logicalPath];
     }
 
+    public function reset(): void
+    {
+        $this->assetsCache = [];
+        $this->assetsBeingCreated = [];
+    }
+
     /**
      * Returns an array of "string digest" and "bool predigested".
      *

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/CachedMappedAssetFactoryTest.php
@@ -171,6 +171,41 @@ class CachedMappedAssetFactoryTest extends TestCase
         $this->assertInstanceOf(FileExistenceResource::class, $configCacheMetadata[5]);
     }
 
+    public function testResetIsForwardedToTheInnerFactory()
+    {
+        $innerFactory = new class implements MappedAssetFactoryInterface {
+            public int $resetCount = 0;
+
+            public function createMappedAsset(string $logicalPath, string $sourcePath): ?MappedAsset
+            {
+                return null;
+            }
+
+            public function reset(): void
+            {
+                ++$this->resetCount;
+            }
+        };
+
+        (new CachedMappedAssetFactory($innerFactory, $this->cacheDir, true))->reset();
+
+        $this->assertSame(1, $innerFactory->resetCount);
+    }
+
+    public function testResetAcceptsAnInnerFactoryWithoutResetMethod()
+    {
+        $innerFactory = new class implements MappedAssetFactoryInterface {
+            public function createMappedAsset(string $logicalPath, string $sourcePath): ?MappedAsset
+            {
+                return null;
+            }
+        };
+
+        $this->expectNotToPerformAssertions();
+
+        (new CachedMappedAssetFactory($innerFactory, $this->cacheDir, true))->reset();
+    }
+
     private function loadConfigCacheMetadataFor(MappedAsset $mappedAsset): array
     {
         $cachedPath = $this->getConfigCachePath($mappedAsset).'.meta';

--- a/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Factory/MappedAssetFactoryTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\AssetMapper\Factory\MappedAssetFactory;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\AssetMapper\Path\PublicAssetsPathResolverInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 class MappedAssetFactoryTest extends TestCase
 {
@@ -144,6 +145,25 @@ class MappedAssetFactoryTest extends TestCase
         $asset = $assetMapper->createMappedAsset('lodash.js', __DIR__.'/../Fixtures/assets/vendor/lodash/lodash.index.js');
         $this->assertSame('lodash.js', $asset->logicalPath);
         $this->assertFalse($asset->isVendor);
+    }
+
+    public function testResetForgetsTheContentOfAlreadyBuiltAssets()
+    {
+        $sourcePath = sys_get_temp_dir().'/asset_mapper_reset_'.uniqid('', true).'/file.css';
+        (new Filesystem())->dumpFile($sourcePath, 'body { color: red; }');
+
+        try {
+            $factory = $this->createFactory();
+            $digest = $factory->createMappedAsset('file.css', $sourcePath)->digest;
+
+            (new Filesystem())->dumpFile($sourcePath, 'body { color: blue; }');
+            $this->assertSame($digest, $factory->createMappedAsset('file.css', $sourcePath)->digest);
+
+            $factory->reset();
+            $this->assertNotSame($digest, $factory->createMappedAsset('file.css', $sourcePath)->digest);
+        } finally {
+            (new Filesystem())->remove(\dirname($sourcePath));
+        }
     }
 
     private function createFactory(?AssetCompilerInterface $extraCompiler = null, ?string $vendorDir = self::DEFAULT_FIXTURES): MappedAssetFactory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`MappedAssetFactory` keeps every asset it builds in `$assetsCache` for the life of the service, and nothing ever clears it. Under a long-running worker (FrankenPHP, RoadRunner) that cache outlives the request: once an asset has been built in a process, editing its source file has no effect. The decorator checks the on-disk cache, finds it stale, asks the inner factory again, and gets the same object back with the old digest and the old content.

It does not stop there. The decorator then writes that stale asset back to the on-disk cache with fresh resource timestamps, so the next process reads the stale version too. Restarting the worker does not help, and only editing the file again changes anything, which immediately poisons the cache once more.

Simulating a worker with the real factory classes, in debug mode, editing the source between requests:

```
worker booted with a warm asset cache
  boot    digest=79f8c104e001
  edit 1  digest=08b7e475e5e0  <- picked up
  edit 2  digest=08b7e475e5e0  <- stale
  edit 3  digest=08b7e475e5e0  <- stale
  a fresh process now sees digest=08b7e475e5e0

worker booted with a cold asset cache
  boot    digest=79f8c104e001
  edit 1  digest=79f8c104e001  <- stale
  edit 2  digest=79f8c104e001  <- stale
  edit 3  digest=79f8c104e001  <- stale
  a fresh process now sees digest=79f8c104e001
```

With the reset firing between requests, every edit is picked up in both cases and the on-disk cache stays correct.

`reset()` now clears the built-asset cache, and the cached decorator forwards `reset()` to the factory it decorates. FrameworkBundle tags the service with `kernel.reset`, using `on_invalid: ignore` as HttpClient and Security already do, so it stays compatible with component versions that do not have the method.

This only shows up in dev under a worker runtime: without one, every request is a fresh process, and in production assets do not change. Production pays nothing for the reset, since `importmap()` reads the compiled config and public paths come from `manifest.json`, so the cleared cache is hardly populated there.

`MappedAssetFactoryTest::testResetForgetsTheContentOfAlreadyBuiltAssets` covers the bug: it builds an asset, rewrites the source file, checks the digest is still the stale one, then resets and checks the digest changes.
