### PR TITLE
[AssetMapper] Resolve each importmap entry only once

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapGenerator.php
@@ -92,14 +92,15 @@ class ImportMapGenerator
         }
 
         $allEntries = [];
+        $resolvedAssets = [];
         foreach ($this->importMapConfigReader->getEntries() as $rootEntry) {
             $allEntries[$rootEntry->importName] = $rootEntry;
-            $allEntries = $this->addImplicitEntries($rootEntry, $allEntries);
+            $allEntries = $this->addImplicitEntries($rootEntry, $allEntries, $resolvedAssets);
         }
 
         $rawImportMapData = [];
         foreach ($allEntries as $entry) {
-            $asset = $this->findAsset($entry->path);
+            $asset = $resolvedAssets[$entry->importName] ?? $this->findAsset($entry->path);
             if (!$asset) {
                 throw $this->createMissingImportMapAssetException($entry);
             }
@@ -154,10 +155,11 @@ class ImportMapGenerator
      * and adds them to the importmap.
      *
      * @param array<string, ImportMapEntry> $currentImportEntries
+     * @param array<string, MappedAsset>    $resolvedAssets       Filled with the asset of each expanded entry
      *
      * @return array<string, ImportMapEntry>
      */
-    private function addImplicitEntries(ImportMapEntry $entry, array $currentImportEntries): array
+    private function addImplicitEntries(ImportMapEntry $entry, array $currentImportEntries, array &$resolvedAssets): array
     {
         // only process import dependencies for JS files
         if (ImportMapType::JS !== $entry->type) {
@@ -168,6 +170,7 @@ class ImportMapGenerator
             // should only be possible at this point for root importmap.php entries
             throw $this->createMissingImportMapAssetException($entry);
         }
+        $resolvedAssets[$entry->importName] = $asset;
 
         foreach ($asset->getJavaScriptImports() as $javaScriptImport) {
             $importName = $javaScriptImport->importName;
@@ -198,7 +201,7 @@ class ImportMapGenerator
 
             // unless there was some missing importmap entry, recurse
             if ($nextEntry) {
-                $currentImportEntries = $this->addImplicitEntries($nextEntry, $currentImportEntries);
+                $currentImportEntries = $this->addImplicitEntries($nextEntry, $currentImportEntries, $resolvedAssets);
             }
         }
 

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -743,6 +743,27 @@ class ImportMapGeneratorTest extends TestCase
         $this->assertEquals($entrypointData, $manager->findEagerEntrypointImports('foo'));
     }
 
+    public function testGetRawImportMapDataResolvesEachEntryOnce()
+    {
+        $manager = $this->createImportMapGenerator();
+        $this->mockImportMap([
+            self::createLocalEntry('app', path: 'app.js'),
+            self::createLocalEntry('admin', path: 'admin.js'),
+        ]);
+
+        $resolvedAssets = [];
+        $this->mockAssetMapper([
+            new MappedAsset('app.js', publicPath: '/assets/app-d1g3st.js'),
+            new MappedAsset('admin.js', publicPath: '/assets/admin-d1g3st.js'),
+        ], $resolvedAssets);
+
+        $this->assertSame([
+            'app' => ['path' => '/assets/app-d1g3st.js', 'type' => 'js'],
+            'admin' => ['path' => '/assets/admin-d1g3st.js', 'type' => 'js'],
+        ], $manager->getRawImportMapData());
+        $this->assertSame(['app.js' => 1, 'admin.js' => 1], $resolvedAssets);
+    }
+
     private function createImportMapGenerator(): ImportMapGenerator
     {
         $this->compiledConfigReader ??= $this->createStub(CompiledAssetMapperConfigReader::class);
@@ -789,11 +810,13 @@ class ImportMapGeneratorTest extends TestCase
     /**
      * @param MappedAsset[] $mappedAssets
      */
-    private function mockAssetMapper(array $mappedAssets): void
+    private function mockAssetMapper(array $mappedAssets, array &$resolvedAssets = []): void
     {
         $this->assetMapper
             ->method('getAsset')
-            ->willReturnCallback(static function (string $logicalPath) use ($mappedAssets) {
+            ->willReturnCallback(static function (string $logicalPath) use ($mappedAssets, &$resolvedAssets) {
+                $resolvedAssets[$logicalPath] = ($resolvedAssets[$logicalPath] ?? 0) + 1;
+
                 foreach ($mappedAssets as $asset) {
                     if ($asset->logicalPath === $logicalPath) {
                         return $asset;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Follows #64966, refs #64959
| License       | MIT

`getRawImportMapData()` resolves every entry twice. `addImplicitEntries()` calls `findAsset($entry->path)` while expanding the entry, and the loop that builds the raw data calls `findAsset()` again on the same entry to read its public path. The asset found during expansion is now carried over, so the second lookup only happens for entries that were never expanded, which are the non JS ones.

Each lookup costs a `MappedAssetFactory` call, and in debug mode a `ConfigCache::isFresh()` that re-stats the asset's whole transitive resource list. On the application reported in #64959, 780 entries meant 780 avoidable resolutions per render.

This is the remaining half of #64959. The first half, the traversal that re-walked bare-imported subtrees, was fixed in #64966. That report also suggested memoizing inside `CachedMappedAssetFactory`; this removes the duplicated calls at the source instead, so nothing extra is retained in memory.

### Merge-up note

#64966 is in 6.4 and touches the same two methods, so this will conflict. The resolution is small:

`$expandedEntries` and `$resolvedAssets` are the same set of keys, so they collapse into one array. Keep `$resolvedAssets`, and let the guard use it:

```php
if (isset($resolvedAssets[$entry->importName])) {
    return $currentImportEntries;
}

if (!$asset = $this->findAsset($entry->path)) {
    throw $this->createMissingImportMapAssetException($entry);
}
$resolvedAssets[$entry->importName] = $asset;
```

The two counts asserted by the tests from #64966 then drop from 2 to 1, since the final loop no longer re-resolves:

```
testGetRawImportMapDataExpandsBareImportedEntriesOnce:        $resolvedAssets['shared.js'] === 1
testGetRawImportMapDataDoesNotExpandInterRootBareImportsTwice: $resolvedAssets['admin.js'] === 1
```

I ran that combined state locally: 396 tests, green.
