### PR TITLE
[Mailer] Wrap AsyncAws NetworkException into HttpTransportException in the SES transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -142,4 +142,21 @@ class SesHttpAsyncAwsTransportTest extends TestCase
         $this->expectExceptionMessage('Unable to send an email: i\'m a teapot (code 418).');
         $transport->send($mail);
     }
+
+    public function testSendThrowsTransportExceptionOnNetworkFailure()
+    {
+        $client = new MockHttpClient(static fn (): ResponseInterface => new MockResponse('', ['error' => 'Connection timed out']));
+
+        $transport = new SesHttpAsyncAwsTransport(new SesClient(Configuration::create([]), new NullProvider(), $client));
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Could not reach the remote Amazon server.');
+        $transport->send($mail);
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mailer\Bridge\Amazon\Transport;
 
 use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Ses\Input\SendEmailRequest;
 use AsyncAws\Ses\SesClient;
 use AsyncAws\Ses\ValueObject\Destination;
@@ -64,6 +65,8 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
             $exception->appendDebug($e->getResponse()->getInfo('debug') ?? '');
 
             throw $exception;
+        } catch (NetworkException $e) {
+            throw new HttpTransportException('Could not reach the remote Amazon server.', $response, 0, $e);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`SesHttpAsyncAwsTransport::doSend()` wraps AsyncAws failures with `catch (HttpException $e)`. `AsyncAws\Core\Exception\Http\HttpException` is an interface implemented only by `ClientException`, `ServerException` and `RedirectionException`, that is only when SES answered with a 3xx/4xx/5xx status.

When the request never reaches SES, `Response::resolve()` stores a `NetworkException` instead. That class implements the AsyncAws root exception interface but not `HttpException`, so it walks straight through the catch and escapes as a raw AsyncAws exception, where the Mailer contract documents a `TransportException`.

Before:

```
AsyncAws\Core\Exception\Http\NetworkException: Could not contact remote server.
```

After:

```
Symfony\Component\Mailer\Exception\HttpTransportException: Could not reach the remote Amazon server.
```

with the original exception kept as `getPrevious()`.

`NetworkException` carries no response, no AWS code and no AWS message, so widening the existing catch would break its body. It needs its own catch, which is also what the other bridges do: `MandrillHttpTransport`, `MandrillApiTransport`, `MailgunApiTransport` and `MailgunHttpTransport` all throw `HttpTransportException('Could not reach the remote <vendor> server.', $response, 0, $e)` for the same situation.

Same class of bug as #64820, which fixes the Messenger AmazonSqs bridge.
