### PR TITLE
[SecurityBundle] Let the LDAP and non-LDAP variants of an authenticator share a firewall

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
@@ -35,7 +35,21 @@ trait LdapFactoryTrait
     public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): string
     {
         $key = str_replace('-', '_', $this->getKey());
+        $definitions = $container->getDefinitions();
         $authenticatorId = parent::createAuthenticator($container, $firewallName, $config, $userProviderId);
+
+        // the parent factory registers its authenticator under the id its non-LDAP variant uses as
+        // well, so move the decorated one aside and hand the id back, to let both variants be
+        // configured on the same firewall
+        $decoratedId = 'security.authenticator.'.$key.'.'.$firewallName.'.inner';
+        $container->setDefinition($decoratedId, $container->getDefinition($authenticatorId));
+        $container->removeDefinition($authenticatorId);
+
+        if (isset($definitions[$authenticatorId])) {
+            $container->setDefinition($authenticatorId, $definitions[$authenticatorId]);
+        }
+
+        $authenticatorId = $decoratedId;
 
         $container->setDefinition('security.listener.'.$key.'.'.$firewallName, new Definition(CheckLdapCredentialsListener::class))
             ->addTag('kernel.event_subscriber', ['dispatcher' => 'security.event_dispatcher.'.$firewallName])

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Ldap\Ldap;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\InMemoryUserChecker;
@@ -43,6 +44,30 @@ use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 class SecurityExtensionTest extends TestCase
 {
     use ExpectDeprecationTrait;
+
+    public function testLdapAndNonLdapVariantsOfTheSameAuthenticatorCanShareAFirewall()
+    {
+        $container = $this->getRawContainer();
+        $container->register('Symfony\\Component\\Ldap\\Ldap', Ldap::class)->addTag('ldap');
+        $container->loadFromExtension('security', [
+            'providers' => ['default' => ['id' => 'foo']],
+            'firewalls' => [
+                'main' => [
+                    'entry_point' => 'form_login',
+                    'form_login' => ['check_path' => '/login_check'],
+                    'form_login_ldap' => ['service' => 'Symfony\\Component\\Ldap\\Ldap', 'check_path' => '/login_check_ldap'],
+                ],
+            ],
+        ]);
+        $container->compile();
+
+        $plain = $container->getDefinition('security.authenticator.form_login.main');
+        $this->assertSame('/login_check', $plain->getArgument(4)['check_path']);
+
+        $decorated = $container->getDefinition('security.authenticator.form_login_ldap.main')->getArgument(0);
+        $this->assertSame('security.authenticator.form_login_ldap.main.inner', (string) $decorated);
+        $this->assertSame('/login_check_ldap', $container->getDefinition((string) $decorated)->getArgument(4)['check_path']);
+    }
 
     public function testInvalidCheckPath()
     {
@@ -934,6 +959,7 @@ class SecurityExtensionTest extends TestCase
         $container->loadFromExtension('security', [
             'firewalls' => [
                 'main' => [
+                    'entry_point' => 'form_login',
                     'custom_listener' => true,
                 ],
             ],
@@ -1017,7 +1043,8 @@ class SecurityExtensionTest extends TestCase
                     'migrate_from' => 'legacy',
                 ],
             ],
-            'firewalls' => ['main' => ['http_basic' => true]],
+            'firewalls' => ['main' => [
+                'entry_point' => 'form_login', 'http_basic' => true]],
         ]);
 
         $container->compile();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`LdapFactoryTrait` decorates the authenticator built by its parent factory, and that factory always registers it under a fixed id: `security.authenticator.form_login.<firewall>` for `FormLoginFactory`, and the equivalent for `JsonLoginFactory` and `HttpBasicFactory`. That is the same id the non-LDAP variant of the factory uses.

Configuring both variants on one firewall therefore makes the second one overwrite the first. Both are still registered with the authenticator manager, but they point at a single service carrying whichever configuration was written last. Compiling a firewall with

```yaml
main:
    entry_point: form_login
    form_login:
        check_path: /login_check
    form_login_ldap:
        service: Symfony\Component\Ldap\Ldap
        check_path: /login_check_ldap
```

gives `security.authenticator.form_login.main` a `check_path` of `/login_check_ldap`, so the plain `form_login` authenticator silently listens on the LDAP check path, and the LDAP decorator wraps that same service.

The decorated authenticator now gets its own id, `security.authenticator.<key>.<firewall>.inner`, and the original id is handed back to the factory that registered it, whichever order the two factories run in.

Spotted by @stof while reviewing #51231.
